### PR TITLE
feat(delloc): claim-delta sign product is not NN-determined

### DIFF
--- a/docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,316 @@
+---
+claim_id: skew_three_seed_delta_sign_product_locality_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On stars at unread v=(-1,1,1), whether the claim-delta sign-product 6-tuple is a function of the 6-NN occupancy alone is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py
+---
+
+# Skew Three-Seed Claim-Delta Sign-Product Is Not NN-Determined
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** stars at the single unread site `v=(-1,1,1)` for finite unions of
+radius-2 taxicab balls. The 6-NN occupancy and the claim-delta sign-product
+6-tuple are compared on that star only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py`](../scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py)
+
+The product is **displayed, not adopted**. It is not written into
+Admissibility. L1 is not attached. No fourth ball is used.
+
+## Result Up Front
+
+Admissibility requires a law-level distribution that is determined by
+nearest-neighbor conditions. A July pair member names the product of signs of
+the nonzero coordinates of the claim-delta `δ=w-s*(w)`, where `s*(w)` is the
+nearest occupied site of a finite seed union `U`. That product can be scored
+on the six neighbors of an unread site. The residual answered here is only
+whether that 6-tuple is a function of the 6-NN occupancy at `v` alone.
+
+It is not. On the declared three-seed union `U0` the occupancy and the
+6-tuple are reported, and `s*(w)` is not always a neighbor of `v`. A second
+three-seed union `U1` with centers in `[-2,2]^3` keeps the same occupancy at
+`v` and changes the 6-tuple. The product therefore names distant seed
+placement, which is extra structure beyond the star occupancy.
+
+This is not a leftover-character membership claim for the product, and it is
+not an equivariance claim for a different map. Those residuals are untouched.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite taxicab-ball unions, 6-NN occupancy, and lex-first nearest-site sign products are exact listings; the product is displayed and is not adopted as Admissibility content."
+trace_class: negative_route_pruning
+target_claim_id: admissibility_nn_determined_law
+target_blocker_text: "Admissibility requires a law-level distribution that is NN-determined; the claim-delta sign-product 6-tuple is not such a distribution."
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Leave the product displayed. Do not write it into Admissibility. Do not attach L1. Continue the NN-determined-law residual on a different object."
+conditional_surface_status: "exact for stars at unread v=(-1,1,1) on finite unions of radius-2 taxicab balls; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Record is quoted only as the unread-site boundary:
+
+A site with no record cannot be read.
+
+No axiom sentence is edited. The product is not inserted into Admissibility.
+The axiom already names an NN-determined law-level distribution; a 6-tuple
+that fails to be a function of the 6-NN occupancy cannot fill that role.
+
+## Exact Objects
+
+Write `0=(0,0,0)`, `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The
+closed taxicab ball of radius 2 is
+
+`B_2(c)={x∈Z^3 : ||x-c||_1 ≤ 2}`.
+
+Each such ball has 25 sites. A three-seed union is a union of three such
+balls. The declared starting union is
+
+`U0 = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`.
+
+The scored site is the unread point `v=(-1,1,1)`. Its six neighbors, in the
+fixed order `+e_1,-e_1,+e_2,-e_2,+e_3,-e_3`, are
+
+```text
+N(v) = ((0,1,1), (-2,1,1), (-1,2,1), (-1,0,1), (-1,1,2), (-1,1,0)).
+```
+
+Stars are scored at `v` only.
+
+For a finite nonempty `U⊂Z^3` and a query site `w`, the nearest occupied
+site `s*(w)` is the lexicographically first site of `U` at minimal taxicab
+distance from `w`. The claim-delta is `δ(w)=w-s*(w)`. The sign product
+`π(δ)` is the product of the signs of the nonzero coordinates of `δ`. The
+empty product, used when `δ=(0,0,0)`, is `+1`.
+
+The 6-NN occupancy and the claim-delta sign-product 6-tuple are
+
+```text
+σ(U)_i = 1 if N(v)_i ∈ U else 0,
+c(U)_i = π(δ(N(v)_i)).
+```
+
+## Theorem 1 — Occupancy And Product On U0
+
+The site `v` is unread on `U0`: `||v-0||_1=3`, `||v-(2,0,0)||_1=5`, and
+`||v-(1,2,1)||_1=3`. The union has 62 sites.
+
+Direct listing of the six neighbors against the three balls gives
+
+```text
+σ(U0) = (1, 0, 1, 1, 0, 1).
+```
+
+The occupied neighbors are `(0,1,1)`, `(-1,2,1)`, `(-1,0,1)`, and
+`(-1,1,0)`. For each of those, `s*(w)=w` and `π((0,0,0))=+1`.
+
+The two unoccupied neighbors are not decided by a neighbor of `v` alone:
+
+| `w` | `s*(w)` | `δ` | `π(δ)` | `s*(w)∈N(v)` |
+|---|---|---|---|---|
+| `(0,1,1)` | `(0,1,1)` | `(0,0,0)` | `+1` | yes |
+| `(-2,1,1)` | `(-2,0,0)` | `(0,1,1)` | `+1` | no |
+| `(-1,2,1)` | `(-1,2,1)` | `(0,0,0)` | `+1` | yes |
+| `(-1,0,1)` | `(-1,0,1)` | `(0,0,0)` | `+1` | yes |
+| `(-1,1,2)` | `(-1,0,1)` | `(0,1,1)` | `+1` | yes |
+| `(-1,1,0)` | `(-1,1,0)` | `(0,0,0)` | `+1` | yes |
+
+So
+
+```text
+c(U0) = (1, 1, 1, 1, 1, 1),
+```
+
+and `s*(w)` is not always a neighbor of `v`. The unoccupied neighbor
+`w=(-2,1,1)` is nearest to `(-2,0,0)`, which lies in `B_2(0)` and is not
+one of the six neighbors of `v`.
+
+## Theorem 2 — Same Occupancy, Different Product
+
+Let
+
+`U1 = B_2(0) ∪ B_2((1,2,1)) ∪ B_2((1,2,2))`.
+
+This is a three-seed union. Its centers lie in `[-2,2]^3`. It is not `U0`.
+The site `v` remains unread: `||v-(1,2,2)||_1=4`. No fourth ball is added.
+
+The six-neighbor occupancy is unchanged:
+
+```text
+σ(U1) = (1, 0, 1, 1, 0, 1) = σ(U0).
+```
+
+The claim-delta 6-tuple changes. The unoccupied neighbor `w=(-1,1,2)` has
+no site of `U0` at distance 1, and the lex-first distance-2 site in `U0` is
+`(-1,0,1)`, giving `δ=(0,1,1)` and `π=+1`. On `U1` the same `w` has two
+distance-1 sites, `(0,1,2)` and `(-1,2,2)`, both in `B_2((1,2,2))`. The
+lex-first of those is `(-1,2,2)`, so `δ=(0,-1,0)` and `π=-1`. The other five
+coordinates of `c` stay `+1`. Therefore
+
+```text
+c(U1) = (1, 1, 1, 1, -1, 1) ≠ c(U0).
+```
+
+A function of the 6-NN occupancy alone cannot take two values on one
+occupancy. The product is not NN-determined on this family. The changed
+coordinate is decided by the third seed `(1,2,2)`, which is not a neighbor
+of `v`.
+
+The primary runner exhausts every three-center union whose centers lie in
+`[-2,2]^3` and confirms that this disagreement is not an isolated listing
+error: many other same-occupancy triples change `c`. Existence of one
+witness is the theorem.
+
+## Theorem 3 — Displayed, Not Adopted
+
+Theorem 2 is a geometric diagnostic. It is not a new Admissibility clause
+and it is not a law-level distribution. The product is displayed, not
+adopted.
+
+Do not write the product into Admissibility. The axiom already requires an
+NN-determined law-level `μ`. A 6-tuple that varies at fixed 6-NN occupancy
+cannot be that `μ`.
+
+Do not attach L1. The note does not promote the product to leftover
+character, does not settle leftover-character membership of the product, and
+does not settle equivariance of a different map.
+
+No fourth ball is introduced to restore locality. Adding a further seed
+would be a different family, not a repair of the three-seed residual.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice and Admissibility premises | quoted; no edit |
+| unread site `v=(-1,1,1)` | `v∉U0` and `v∉U1` |
+| 6-NN occupancy on `U0` | exact listing `σ=(1,0,1,1,0,1)` |
+| claim-delta 6-tuple on `U0` | exact listing `c=(1,1,1,1,1,1)` |
+| `s*` not always a neighbor of `v` | `s*((-2,1,1))=(-2,0,0)` |
+| same-occupancy disagreement | `U1` with `c=(1,1,1,1,-1,1)` |
+| product written into Admissibility | refused |
+| L1 attached | refused |
+| fourth ball | not used |
+| leftover-character membership of the product | not this residual |
+| equivariance of a different map | not this residual |
+| stars scored away from `v` | not executed |
+
+## Boundary And Imports
+
+The only imported geometry is the cubic lattice with taxicab balls and
+nearest-neighbor adjacency. The only imported axiom sentences are the
+quoted Lattice, Admissibility, and unread-site Record lines. No kernel
+values, formation process, rate, leftover-character membership test, or
+equivariance map is imported.
+
+The July pair member is used only as the definition of the displayed
+product. Membership of that pair and equivariance of any other map remain
+separate residuals.
+
+## No-Go Discipline Gate
+
+The negative content is narrow: on stars at unread `v=(-1,1,1)`, the
+claim-delta sign-product 6-tuple is not a function of the 6-NN occupancy
+alone, among three-seed radius-2 unions. No compiler impossibility is
+claimed. No replacement law is derived.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| keep `U0` | report `σ` and `c` | Theorem 1; `s*` is not always a neighbor of `v` |
+| move the third seed inside `[-2,2]^3` | hold `σ` fixed | Theorem 2 witness `U1` |
+| write the product into Admissibility | treat `c` as the NN-determined `μ` | refused; `c` is not NN-determined |
+| attach L1 | reuse leftover-character membership | refused; different residual |
+| add a fourth ball | enlarge the seed family | refused; different family |
+| leftover-character membership | ask whether the product is leftover character | not executed |
+| equivariance of a different map | ask whether another map is equivariant | not executed |
+| score another star | change `v` | not executed |
+
+### N2 — wall independence
+
+Distant-seed naming of `s*` and the missing NN-determined law-level `μ` are
+distinct residuals. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+Radius 2, three seeds, lex-first nearest site, empty-product `+1`, the
+fixed neighbor order, and the single unread site `v` are declared. No
+fourth seed, no leftover-character test, and no Admissibility edit is
+smuggled in.
+
+### N4 — source residual matching
+
+The current Admissibility sentence requires NN-determination of a law-level
+distribution. The residual matched here is whether the displayed product
+meets that NN-determination demand on the declared stars. It does not.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | named sites of `N(v)` and named `s*` values | no alphabet classification |
+| per site | stars at unread `v` only | no other site scored |
+| per mode | no mode calculation | no spectral claim |
+| per block | three-seed unions `U0` and `U1` | no four-seed family |
+| lattice wide | checked and not executed | no lattice-wide law |
+
+### N6 — live partial-closure paths
+
+Live routes are a different NN-determined object for the Admissibility
+distribution, and the untouched leftover-character and equivariance
+residuals. The displayed product is not one of those routes.
+
+### N7 — hostile steelman
+
+**Steelman:** Once the six neighbors of `v` are known, the nearest occupied
+site of a radius-2 three-seed union should be a neighbor of `v` or else
+should be fixed by that occupancy, so the sign product should be
+NN-determined.
+
+**Answer:** On `U0` the unoccupied neighbor `(-2,1,1)` is nearest to
+`(-2,0,0)`, which is not a neighbor of `v`. Holding the occupancy fixed
+and moving the third seed to `(1,2,2)` flips the sign product at
+`(-1,1,2)`. Occupancy of `N(v)` does not name the distant seed.
+
+### N8 — cross-cycle echo
+
+This note does not close leftover-character membership of the product and
+does not close equivariance of a different map. It reports only the
+NN-determination failure of the displayed 6-tuple on the declared stars.
+
+**Gate disposition:** PASS for the finite occupancy listings, the `U1`
+disagreement, and the refusal to adopt the product. FAIL / DO NOT SHIP for
+“the product is NN-determined,” “write the product into Admissibility,”
+“attach L1,” or “a fourth ball restores the law.”
+
+## Primary Runner
+
+The companion runner rebuilds `U0` and `U1` from the three centers, scores
+only the star at `v`, checks the Theorem 1 listings, exhibits the Theorem 2
+disagreement, exhausts three-center unions in `[-2,2]^3` far enough to
+confirm a same-occupancy sign change, and checks that the note keeps the
+product displayed rather than adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17033,6 +17033,10 @@
   "sixth_family_sheared_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "skew_three_seed_delta_sign_product_locality_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
    "deps_hash": "9defae253834",

--- a/logs/runner-cache/skew_three_seed_delta_sign_product_locality_2026_08_15.txt
+++ b/logs/runner-cache/skew_three_seed_delta_sign_product_locality_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py
+runner_sha256: 3cc691013f8565e493841d1e38f69ec5868f92b26cede199b2cfbbda0bcda10b
+input_fingerprint_sha256: b822fc0a77109ed048bb87dcf1670b6ee86382c8247de68610a6809742387ecd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.04
+status: ok
+----- stdout -----
+Skew three-seed claim-delta sign-product locality
+AUDIT_INPUT_PATHS:
+  docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+scope: stars at unread v=(-1,1,1) only; displayed, not adopted
+PASS: audit-input-paths-static-literals
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: source-distribution-sentence-current
+PASS: source-unread-site-sentence-current
+PASS: note-quotes-admissibility-nn-law
+PASS: theorem1-v-unread-on-u0
+PASS: theorem1-sigma-u0  ((1, 0, 1, 1, 0, 1))
+PASS: theorem1-c-u0  ((1, 1, 1, 1, 1, 1))
+PASS: theorem1-sstar-not-always-neighbor  ((-2, 0, 0))
+PASS: theorem1-u0-has-three-centers
+PASS: theorem1-empty-product-is-plus-one
+PASS: theorem2-u1-distinct
+PASS: theorem2-v-unread-on-u1
+PASS: theorem2-same-sigma
+PASS: theorem2-c-disagrees  ((1, 1, 1, 1, -1, 1))
+PASS: theorem2-centers-in-box
+PASS: theorem2-disagreement-from-distant-seed  ((-1, 2, 2))
+PASS: theorem2-box-census-finds-disagreement  (same_sigma>=2545 disagreements>=391)
+PASS: product-not-nn-determined
+PASS: note-claim-scope
+PASS: theorem3-displayed-not-adopted
+PASS: theorem3-not-written-into-admissibility
+PASS: theorem3-l1-not-attached
+PASS: no-fourth-ball
+PASS: stars-scored-at-v-only
+PASS: not-leftover-char-or-skeweq
+PASS: forbidden-phrases-absent
+PASS: hypothetical-axiom-no-edit
+PASS: note-reports-computed-tuples
+PASS: axiom-file-unedited-marker
+per_element: six neighbors of unread v and their lex-first nearest sites
+per_site: stars scored at v only
+per_mode: checked and not executed
+per_block: three-seed unions U0 and U1; no fourth ball
+lattice_wide: checked and not executed — product displayed, not adopted
+TOTAL: PASS=31 FAIL=0
+
+----- stderr -----
+

--- a/scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py
+++ b/scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Exact checks for claim-delta sign-product NN-determination.
+
+The paired note is
+docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md.
+
+Stars are scored at unread v=(-1,1,1) only. The product is displayed, not
+adopted. No cache or axiom surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from itertools import combinations_with_replacement, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_LOCALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+DECLARED_INPUT_PATHS = AUDIT_INPUT_PATHS
+
+Point = tuple[int, int, int]
+V: Point = (-1, 1, 1)
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+NEIGHBORS: tuple[Point, ...] = tuple(
+    (V[0] + shift[0], V[1] + shift[1], V[2] + shift[2]) for shift in SHIFTS
+)
+U0_CENTERS: tuple[Point, ...] = ((0, 0, 0), (2, 0, 0), (1, 2, 1))
+U1_CENTERS: tuple[Point, ...] = ((0, 0, 0), (1, 2, 1), (1, 2, 2))
+BOX: tuple[Point, ...] = tuple(product(range(-2, 3), repeat=3))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def taxicab(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: Point, radius: int = 2) -> frozenset[Point]:
+    sites: set[Point] = set()
+    for dx, dy, dz in product(range(-radius, radius + 1), repeat=3):
+        if abs(dx) + abs(dy) + abs(dz) <= radius:
+            sites.add((center[0] + dx, center[1] + dy, center[2] + dz))
+    return frozenset(sites)
+
+
+def union_of(centers: tuple[Point, ...]) -> frozenset[Point]:
+    occupied: set[Point] = set()
+    for center in centers:
+        occupied |= ball(center)
+    return frozenset(occupied)
+
+
+def occupancy(sites: frozenset[Point]) -> tuple[int, ...]:
+    return tuple(1 if neighbor in sites else 0 for neighbor in NEIGHBORS)
+
+
+def sign_product(delta: Point) -> int:
+    value = 1
+    for coord in delta:
+        if coord > 0:
+            value *= 1
+        elif coord < 0:
+            value *= -1
+    return value
+
+
+def nearest_site(query: Point, sites: frozenset[Point]) -> Point:
+    best: Point | None = None
+    best_distance: int | None = None
+    for site in sites:
+        distance = taxicab(query, site)
+        if (
+            best is None
+            or best_distance is None
+            or distance < best_distance
+            or (distance == best_distance and site < best)
+        ):
+            best = site
+            best_distance = distance
+    if best is None:
+        raise ValueError("nearest site is undefined on the empty set")
+    return best
+
+
+def claim_delta_tuple(sites: frozenset[Point]) -> tuple[int, ...]:
+    values: list[int] = []
+    for neighbor in NEIGHBORS:
+        seed = nearest_site(neighbor, sites)
+        delta = (neighbor[0] - seed[0], neighbor[1] - seed[1], neighbor[2] - seed[2])
+        values.append(sign_product(delta))
+    return tuple(values)
+
+
+def nearest_in_ball(query: Point, center: Point) -> tuple[int, tuple[Point, ...]]:
+    best_distance: int | None = None
+    found: list[Point] = []
+    for site in ball(center):
+        distance = taxicab(query, site)
+        if best_distance is None or distance < best_distance:
+            best_distance = distance
+            found = [site]
+        elif distance == best_distance:
+            found.append(site)
+    if best_distance is None:
+        raise ValueError("empty ball")
+    return best_distance, tuple(found)
+
+
+def merged_sign_product(centers: tuple[Point, ...], neighbor_index: int) -> int:
+    neighbor = NEIGHBORS[neighbor_index]
+    best_distance: int | None = None
+    found: list[Point] = []
+    for center in centers:
+        distance, sites = nearest_in_ball(neighbor, center)
+        if best_distance is None or distance < best_distance:
+            best_distance = distance
+            found = list(sites)
+        elif distance == best_distance:
+            found.extend(sites)
+    seed = min(found)
+    delta = (neighbor[0] - seed[0], neighbor[1] - seed[1], neighbor[2] - seed[2])
+    return sign_product(delta)
+
+
+def audit_input_paths_literal(source: str) -> tuple[str, ...] | None:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS" for target in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        values: list[str] = []
+        for element in node.value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                return None
+            values.append(element.value)
+        return tuple(values)
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = (ROOT / NOTE_REL).read_text(encoding="utf-8")
+    axiom = (ROOT / AXIOM_REL).read_text(encoding="utf-8")
+    runner_source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("Skew three-seed claim-delta sign-product locality")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scope: stars at unread v=(-1,1,1) only; displayed, not adopted")
+
+    literal_paths = audit_input_paths_literal(runner_source)
+    checks.check(
+        "audit-input-paths-static-literals",
+        literal_paths == AUDIT_INPUT_PATHS == DECLARED_INPUT_PATHS,
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    distribution_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    checks.check(
+        "source-distribution-sentence-current",
+        distribution_sentence in normalized_axiom,
+    )
+    checks.check(
+        "source-unread-site-sentence-current",
+        "A site with no record cannot be read." in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-admissibility-nn-law",
+        distribution_sentence in normalized_note,
+    )
+
+    u0 = union_of(U0_CENTERS)
+    u1 = union_of(U1_CENTERS)
+    sigma0 = occupancy(u0)
+    sigma1 = occupancy(u1)
+    c0 = claim_delta_tuple(u0)
+    c1 = claim_delta_tuple(u1)
+    star0 = nearest_site(NEIGHBORS[1], u0)
+    star1 = nearest_site(NEIGHBORS[4], u1)
+
+    checks.check("theorem1-v-unread-on-u0", V not in u0)
+    checks.check(
+        "theorem1-sigma-u0",
+        sigma0 == (1, 0, 1, 1, 0, 1),
+        str(sigma0),
+    )
+    checks.check(
+        "theorem1-c-u0",
+        c0 == (1, 1, 1, 1, 1, 1),
+        str(c0),
+    )
+    checks.check(
+        "theorem1-sstar-not-always-neighbor",
+        star0 == (-2, 0, 0) and star0 not in set(NEIGHBORS),
+        str(star0),
+    )
+    checks.check("theorem1-u0-has-three-centers", len(U0_CENTERS) == 3)
+    checks.check("theorem1-empty-product-is-plus-one", sign_product((0, 0, 0)) == 1)
+
+    checks.check("theorem2-u1-distinct", u1 != u0)
+    checks.check("theorem2-v-unread-on-u1", V not in u1)
+    checks.check("theorem2-same-sigma", sigma1 == sigma0)
+    checks.check("theorem2-c-disagrees", c1 != c0 and c1 == (1, 1, 1, 1, -1, 1), str(c1))
+    checks.check(
+        "theorem2-centers-in-box",
+        all(center in BOX for center in U1_CENTERS) and len(U1_CENTERS) == 3,
+    )
+    checks.check(
+        "theorem2-disagreement-from-distant-seed",
+        star1 == (-1, 2, 2) and star1 not in set(NEIGHBORS),
+        str(star1),
+    )
+
+    occupancy_by_center = {center: occupancy(ball(center)) for center in BOX}
+    disagreement_count = 0
+    same_sigma_count = 0
+    for centers in combinations_with_replacement(BOX, 3):
+        bits = [0] * 6
+        for center in centers:
+            for index, occupied in enumerate(occupancy_by_center[center]):
+                if occupied:
+                    bits[index] = 1
+        if tuple(bits) != sigma0:
+            continue
+        same_sigma_count += 1
+        candidate = tuple(merged_sign_product(centers, index) for index in range(6))
+        if candidate != c0 and union_of(centers) != u0:
+            disagreement_count += 1
+            if disagreement_count >= 1 and same_sigma_count >= 8:
+                # Existence is the theorem; keep the census short.
+                pass
+    checks.check(
+        "theorem2-box-census-finds-disagreement",
+        disagreement_count >= 1,
+        f"same_sigma>={same_sigma_count} disagreements>={disagreement_count}",
+    )
+    checks.check(
+        "product-not-nn-determined",
+        sigma0 == sigma1 and c0 != c1,
+    )
+
+    claim_scope = (
+        "On stars at unread v=(-1,1,1), whether the claim-delta sign-product "
+        "6-tuple is a function of the 6-NN occupancy alone is reported. "
+        "Displayed, not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "theorem3-displayed-not-adopted",
+        "Displayed, not adopted" in note and "displayed, not adopted" in note.lower(),
+    )
+    checks.check(
+        "theorem3-not-written-into-admissibility",
+        "Do not write the product into Admissibility" in note
+        and "The product is not inserted into Admissibility" in note,
+    )
+    checks.check(
+        "theorem3-l1-not-attached",
+        "Do not attach L1" in note and "L1 is not attached" in note,
+    )
+    checks.check(
+        "no-fourth-ball",
+        "No fourth ball" in note
+        and "fourth ball" in normalized_note
+        and len(U0_CENTERS) == 3
+        and len(U1_CENTERS) == 3,
+    )
+    checks.check(
+        "stars-scored-at-v-only",
+        "Stars are scored at `v` only" in note
+        and "On stars at unread v=(-1,1,1)" in note,
+    )
+    checks.check(
+        "not-leftover-char-or-skeweq",
+        "not a leftover-character membership claim for the product" in normalized_note
+        and "not an equivariance claim for a different map" in normalized_note,
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-phrases-absent",
+        all(phrase not in note for phrase in forbidden),
+        ",".join(phrase for phrase in forbidden if phrase in note),
+    )
+    checks.check(
+        "hypothetical-axiom-no-edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "note-reports-computed-tuples",
+        "σ(U0) = (1, 0, 1, 1, 0, 1)" in note
+        and "c(U0) = (1, 1, 1, 1, 1, 1)" in note
+        and "c(U1) = (1, 1, 1, 1, -1, 1)" in note,
+    )
+    checks.check(
+        "axiom-file-unedited-marker",
+        "### Admissibility / Local Constraint" in axiom
+        and "claim-delta" not in axiom
+        and "U0" not in axiom,
+    )
+
+    print("per_element: six neighbors of unread v and their lex-first nearest sites")
+    print("per_site: stars scored at v only")
+    print("per_mode: checked and not executed")
+    print("per_block: three-seed unions U0 and U1; no fourth ball")
+    print("lattice_wide: checked and not executed — product displayed, not adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same 6-NN occupancy at v=(-1,1,1) yields different product 6-tuples: U1=B2(0)∪B2((1,2,1))∪B2((1,2,2)) has c=(1,1,1,1,-1,1)≠c(U0). 391 disagreements in the box. Product names distant seeds. Displayed, not adopted. No axiom edit. No 4th ball.

## Runner

`scripts/skew_three_seed_delta_sign_product_locality_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.