### PR TITLE
feat(deleq): claim-delta sign product commutes with 3 of 24

### DIFF
--- a/docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,267 @@
+---
+claim_id: skew_three_seed_delta_sign_product_equivariance_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the off-axis three-ball star at v=(-1,1,1), whether the claim-delta sign-product labeling is equivariant under the 24 proper cube rotations is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py
+---
+
+# Claim-Delta Sign-Product Cube Equivariance On The Off-Axis Three-Seed Star (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the unread six-neighbor star at `v = (−1,1,1)` on
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`. The displayed claim-delta
+sign-product rule of delsgn is scored for commutation with the 24
+proper cube rotations acting jointly on slots, seeds, and `δ`. Score
+the star at `v` only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py`](../scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment delsgn rebuilt a complete history tag on this star by the
+product of the signs of the nonzero coordinates of each history-tied
+claim-delta and reported that the completed 6-tuple fires. Investment
+skeweq scored a different map — occupancy `f(n)` — and found that map
+commutes for only `1/24` proper rotations. The residual here is not
+leftover-char of delsgn (membership of that completed 6-tuple in the
+July-3 pair) and not leftover-char of skeweq (different map). It is
+whether *this* product-of-`δ`-signs labeling commutes with `G+` on the
+star at `v`.
+
+Treat `U` as already locked. The site `v = (−1,1,1)` is unread.
+Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+Occupancy mask
+
+`m = (1, 0, 1, 1, 0, 1)`.
+
+Seeds are `S = {0, (2,0,0), (1,2,1)}`. For an occupied neighbor `w`,
+the nearest seed `s*(w)` is a seed of least ℓ¹ distance; ties take the
+lex-first seed. The history kernel `n_hist(w)` is the occupancy dipole
+at `w` computed from occupancy in `B_2(s*(w))` only. If `n_hist(w)`
+has a unique nonzero coordinate, the label is the sign of that
+coordinate. Else `δ = w − s*(w)` and the label is the product of the
+signs of the nonzero coordinates of `δ`. Empty stays `0`. On this
+star that rule produces
+
+`c = (+,0,+,−,0,−)`.
+
+A rotation `g ∈ G+` acts about `v` on slots, on the three seeds, and
+on each claim-delta. Commutation at `g` is the identity
+
+`label(g · w) =` the product rule applied after rotating the seeds
+and `w`.
+
+The commutation count on the six slots is
+
+`N_commute = 3`,
+
+so `3/24`. The identity and the two sign-free 3-cycles of the axes
+commute. Every other proper rotation rebuilds a different 6-tuple.
+In particular `N_commute ≠ 24`, so this firing history tag is not a
+cube-covariant Admissibility rule.
+
+Displayed, not adopted. Do not write the product into Admissibility.
+Do not attach L1. Do not add a 4th ball. Qubit remains `M_2(C)`. No
+axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither the 6-tuple `c` nor the product of
+claim-delta signs as the framework's fixed rule. The covariance clause
+is the test this note applies to that product on this star. Formation
+site and rate remain outside the axiom memo. Qubit remains `M_2(C)`.
+No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact ℓ¹ geometry on one unread six-neighbor star and a 24-element commutation count for one displayed claim-delta sign-product rule. Displayed rule only."
+trace_class: frontier_discovery
+target_claim_id: skew_three_seed_delta_sign_product_equivariance
+target_blocker_text: "on the off-axis three-ball star at v=(-1,1,1), whether the claim-delta sign-product labeling commutes with the 24 proper cube rotations"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_commute; do not write the product into Admissibility, attach L1, or add a 4th ball"
+conditional_surface_status: "exact on the star at v=(-1,1,1); N_commute=3 of 24; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)`, `p = (2,0,0)`, and `q = (1,2,1)`. The closed ℓ¹
+ball of radius two is
+
+`B_2(c) = { x ∈ Z^3 : |x − c|_1 ≤ 2 }`.
+
+The locked set is the already-given union
+
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`.
+
+The three balls each have 25 sites. Pairwise overlaps are 7, 4, and 4,
+and the triple overlap has 2 sites, so `|U| = 62`. The unread site is
+
+`v = (−1,1,1)`.
+
+Then `|v|_1 = 3`, `|v − p|_1 = 5`, and `|v − q|_1 = 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` |
+|---|---|---|
+| `+x` | `(0,1,1)` | yes |
+| `−x` | `(−2,1,1)` | no |
+| `+y` | `(−1,2,1)` | yes |
+| `−y` | `(−1,0,1)` | yes |
+| `+z` | `(−1,1,2)` | no |
+| `−z` | `(−1,1,0)` | yes |
+
+Occupancy mask at `v`:
+
+`m = (1, 0, 1, 1, 0, 1)`.
+
+For occupied `w`, `s*(w)` is a nearest seed of `w` among `S`, lex-first
+if tied. The history occupancy 6-tuple of `w` uses only the indicator
+of `B_2(s*(w))`. That 6-tuple determines the dipole
+
+`d_μ = occ_hist(w + e_μ) − occ_hist(w − e_μ)`, `n_hist = d/3`.
+
+If exactly one component of `n_hist` is nonzero, the label of `w` is
+the sign of that component. Otherwise the claim-delta is
+
+`δ = w − s*(w)`,
+
+and the label is the product of the signs of the nonzero coordinates
+of `δ`. If `|supp δ| = 0`, the empty product is undefined and the
+occupied neighbor stays tied. Empty neighbors of `v` stay `0`.
+
+`G+` is the 24 determinant-`+1` signed permutation matrices of the
+three axes. A matrix `g` acts about `v`: slot `μ` goes to `gμ`, a
+site `x` goes to `v + g(x − v)`, and a vector `δ` goes to `gδ`. The
+rotated seeds are `{ v + g(s − v) : s ∈ S }`. The product rule is
+then rebuilt on the rotated seeds and the image neighbors of `v`.
+Letters move with their slots. Commutation at `g` is
+
+`label(g · w) =` the product rule applied after rotating seeds and `w`
+
+on all six slots. `N_commute` is the number of such `g`.
+
+## Theorem 1 — commutation count on this star
+
+Nearest seeds, history kernels, claim-deltas, and product labels on the
+four occupied neighbors are exact:
+
+| neighbor | `s*(w)` | `n_hist` | hist | `δ = w − s*(w)` | product | label |
+|---|---|---|---|---|---|---|
+| `(0,1,1)` | `(0,0,0)` | `(0, −1/3, −1/3)` | tied | `(0, 1, 1)` | `+` | `+` |
+| `(−1,2,1)` | `(1,2,1)` | `(1/3, 0, 0)` | `+` | `(−2, 0, 0)` | unused | `+` |
+| `(−1,0,1)` | `(0,0,0)` | `(1/3, 0, −1/3)` | tied | `(−1, 0, 1)` | `−` | `−` |
+| `(−1,1,0)` | `(0,0,0)` | `(1/3, −1/3, 0)` | tied | `(−1, 1, 0)` | `−` | `−` |
+
+Empty slots stay `0`. The labeled 6-tuple is therefore
+
+`c = (+,0,+,−,0,−)`.
+
+Enumerating all 24 elements of `G+` and comparing the transported
+labeling with the labeling rebuilt from the rotated seeds and image
+neighbors gives
+
+`N_commute = 3`
+
+out of 24, written `3/24`. The three commuting rotations are the
+identity and the two sign-free 3-cycles of the coordinate axes. Those
+three send every unique-axis kernel to another unique-axis kernel of
+the same sign and send every two-support claim-delta to a two-support
+claim-delta with the same sign product. Every other `g` either flips
+an odd number of support signs, moves the unique-axis letter, or
+changes the lex-first nearest seed on a tied neighbor, and then
+rebuilds a different 6-tuple.
+
+Scoring only the star at `v`. This is not leftover-char of delsgn
+(membership): the completed firing 6-tuple is not re-tested as a
+July-3 pair member. It is not leftover-char of skeweq (different
+map): skeweq scored occupancy `f(n)`, not the product of claim-delta
+signs.
+
+## Theorem 2 — the firing history tag is not cube-equivariant
+
+Because `N_commute ≠ 24`, the displayed claim-delta sign-product rule
+does not commute with every proper cube rotation of this star. This
+firing history tag is not a cube-covariant Admissibility rule.
+
+## Theorem 3 — displayed, not adopted
+
+The product and the commutation count are displayed member data. They
+are not the framework's fixed Admissibility rule. This note does not
+write the product into Admissibility. Do not write the product into
+Admissibility. Do not attach L1. Do not add a 4th ball.
+Occupancy-only formation (the `n ≠ 0` gate) is not attached. Qubit
+remains `M_2(C)`. No approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On this unread star, the displayed claim-delta
+  sign-product rule reproduces `c = (+,0,+,−,0,−)` and commutes with
+  `3` of the `24` proper cube rotations.
+- **What is displayed only.** The product, the letter identification
+  `{+, −}`, and the commutation count are one rival table. They are
+  not adopted.
+- **What is not claimed.** No attachment of the product to
+  Admissibility; no attachment of occupancy-only formation; no axiom
+  edit; no formation rate; no lattice-wide dynamics; no claim that
+  Admissibility selects `c`; no fourth equal-radius ball; no re-test
+  of delsgn pair membership; no occupancy `f(n)` map.
+- **Mutation controls.** A rebuilt `c` other than `(+,0,+,−,0,−)`
+  fails. `N_commute = 24` would fail the non-covariance report. A note
+  that writes the product into Admissibility, attaches L1, or authors
+  an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, nearest seeds,
+history kernels, claim-deltas, the product rule, the 24 proper cube
+rotations acting on slots, seeds, and `δ`, `N_commute`, the current
+premise boundary, and the mutation controls. It writes no cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17033,6 +17033,10 @@
   "sixth_family_sheared_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "skew_three_seed_delta_sign_product_equivariance_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
    "deps_hash": "9defae253834",

--- a/logs/runner-cache/skew_three_seed_delta_sign_product_equivariance_2026_08_15.txt
+++ b/logs/runner-cache/skew_three_seed_delta_sign_product_equivariance_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py
+runner_sha256: 172181ee1c58b174b20a3eb0d070bc0b8c167f6070710e20f4614b96e7d8e9c2
+input_fingerprint_sha256: 63833dd25889c53b5419d23a302850f1dca0acbe58bc02acca3f91e16d9459f5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Qubit, Admissibility, and Record sentences; G+ rebuilt as the 24 proper cube rotations
+construction: U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)), unread v=(-1,1,1)
+negative_scope: displayed claim-delta sign-product rule only; not adopted; L1 not attached; no 4th equal-radius ball
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-covariance Admissibility still requires one proper-cubic covariant rule
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-qubit Qubit remains M_2(C)
+PASS: source-record lock, permanence, content-only readout, and unreadability at absence are pinned
+U_card=62
+v_in_U=False
+occupancy_mask=(1, 0, 1, 1, 0, 1)
+displayed_c=(+,0,+,−,0,−)
+slot dir=(1, 0, 0) w=(0, 1, 1) s*=(0, 0, 0) n_hist=(0,-1/3,-1/3) hist-tied delta=(0, 1, 1) label=+
+slot dir=(-1, 0, 0) w=(-2, 1, 1) s*=None n_hist=empty empty delta=None label=0
+slot dir=(0, 1, 0) w=(-1, 2, 1) s*=(1, 2, 1) n_hist=(1/3,0,0) unique-axis delta=(-2, 0, 0) label=+
+slot dir=(0, -1, 0) w=(-1, 0, 1) s*=(0, 0, 0) n_hist=(1/3,0,-1/3) hist-tied delta=(-1, 0, 1) label=−
+slot dir=(0, 0, 1) w=(-1, 1, 2) s*=None n_hist=empty empty delta=None label=0
+slot dir=(0, 0, -1) w=(-1, 1, 0) s*=(0, 0, 0) n_hist=(1/3,-1/3,0) hist-tied delta=(-1, 1, 0) label=−
+G_plus=24
+N_commute=3
+N_commute_over_24=3/24
+identity_commutes=True
+commuting_rotations=((1, 0, 0), (0, 1, 0), (0, 0, 1)),((0, 1, 0), (0, 0, 1), (1, 0, 0)),((0, 0, 1), (1, 0, 0), (0, 1, 0))
+PASS: g-plus-order finite G+ is exactly the 24 proper cube rotations
+PASS: center-unread the star center v is not already in U
+PASS: u-geometry U is the union of three radius-2 ℓ¹ balls and has 62 sites
+PASS: occupancy-mask occupied nearest neighbors of v are exactly +x,+y,−y,−z
+PASS: theorem-1-product-tuple the product rule rebuilds c=(+,0,+,−,0,−) on this star
+PASS: theorem-1-commute N_commute among the 24 proper rotations is computed and reported
+PASS: theorem-2-covariance whether N_commute=24 is reported as cube-covariance of the history tag
+PASS: claim-scope the note reports the declared displayed claim_scope
+PASS: displayed-not-adopted the product is displayed and is not written into Admissibility
+PASS: l1-not-attached the note does not attach L1 and does not add a fourth ball
+PASS: not-leftover-prior the note is not leftover-char of delsgn membership or skeweq
+PASS: admissibility-unedited the product rule is not written into Admissibility
+PASS: forbidden-phrases the forbidden rhetoric strings are absent from the note and runner
+PASS: no-axiom-edit the only axiom authority is the current memo; no cache or axiom rewrite
+per_element: product labels and N_commute are exact integers
+per_site: only the unread star center v is scored
+per_mode: no spectral calculation
+per_block: the six-neighbor star at v only
+lattice_wide: checked and not executed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py
+++ b/scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Cube equivariance of the claim-delta sign-product rule on one star.
+
+U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1)). Score only the unread star at
+v = (−1, 1, 1). Same s* as delsgn: lex-first nearest seed. Rebuild c by
+the product rule: unique-axis of n_hist when it exists, else the product
+of the signs of the nonzero coordinates of δ = w − s*(w). G+ acts on
+slots, seeds, and δ by rotating about v. Count how many of the 24 proper
+cube rotations satisfy transported labels = the product rule after
+rotating seeds and w. Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_EQUIVARIANCE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Kernel = tuple[Fraction, Fraction, Fraction]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+V: Point = (-1, 1, 1)
+SEEDS: tuple[Point, ...] = ((0, 0, 0), (2, 0, 0), (1, 2, 1))
+C: Coloring = (PLUS, EMPTY, PLUS, MINUS, EMPTY, MINUS)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def ball(center: Point, radius: int = 2) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        site = add(center, offset)
+        if l1(sub(site, center)) <= radius:
+            sites.add(site)
+    return frozenset(sites)
+
+
+def locked_union(seeds: tuple[Point, ...] = SEEDS) -> frozenset[Point]:
+    occupied = frozenset()
+    for seed in seeds:
+        occupied = occupied | ball(seed)
+    return occupied
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def dipole(occ: Coloring) -> Kernel:
+    return (
+        Fraction(occ[0] - occ[1], 3),
+        Fraction(occ[2] - occ[3], 3),
+        Fraction(occ[4] - occ[5], 3),
+    )
+
+
+def unique_nonzero_sign(vec: tuple[object, ...]) -> int | None:
+    support = [index for index, value in enumerate(vec) if value != 0]
+    if len(support) != 1:
+        return None
+    return PLUS if vec[support[0]] > 0 else MINUS
+
+
+def nonzero_sign_product(vec: tuple[object, ...]) -> int | None:
+    product = 1
+    support = 0
+    for value in vec:
+        if value == 0:
+            continue
+        support += 1
+        product *= 1 if value > 0 else -1
+    if support == 0:
+        return None
+    return PLUS if product > 0 else MINUS
+
+
+def nearest_seed(site: Point, seeds: tuple[Point, ...]) -> Point:
+    ranked = sorted((l1(sub(site, seed)), seed) for seed in seeds)
+    return ranked[0][1]
+
+
+def product_label(n_vec: Kernel, delta: Point) -> int | None:
+    hist = unique_nonzero_sign(n_vec)
+    if hist is not None:
+        return hist
+    return nonzero_sign_product(delta)
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: tuple[object, ...] | Point) -> tuple:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def act_about(matrix: Matrix, point: Point, origin: Point = V) -> Point:
+    return add(origin, mat_vec(matrix, sub(point, origin)))
+
+
+def rotate_seeds(matrix: Matrix, seeds: tuple[Point, ...] = SEEDS) -> tuple[Point, ...]:
+    return tuple(act_about(matrix, seed) for seed in seeds)
+
+
+def rotate_labels(matrix: Matrix, labels: Coloring) -> Coloring:
+    out = [EMPTY] * 6
+    for source, direction in enumerate(DIRS):
+        image = DIR_INDEX[mat_vec(matrix, direction)]
+        out[image] = labels[source]
+    return tuple(out)
+
+
+NeighborRow = tuple[Point, Point, Point | None, Kernel | None, Point | None, int | None, int | None]
+
+
+def star_from_seeds(seeds: tuple[Point, ...]) -> tuple[Coloring, tuple[NeighborRow, ...]]:
+    occupied = locked_union(seeds)
+    labels: list[int] = []
+    rows: list[NeighborRow] = []
+    for direction in DIRS:
+        neighbor = add(V, direction)
+        if neighbor not in occupied:
+            labels.append(EMPTY)
+            rows.append((direction, neighbor, None, None, None, None, EMPTY))
+            continue
+        seed_star = nearest_seed(neighbor, seeds)
+        n_vec = dipole(occupancy_tuple(neighbor, ball(seed_star)))
+        delta = sub(neighbor, seed_star)
+        hist_only = unique_nonzero_sign(n_vec)
+        label = product_label(n_vec, delta)
+        if label is None:
+            raise RuntimeError(f"empty product at occupied neighbor {neighbor}")
+        labels.append(label)
+        rows.append((direction, neighbor, seed_star, n_vec, delta, hist_only, label))
+    return tuple(labels), tuple(rows)
+
+
+def commute_count(
+    rotations: tuple[Matrix, ...],
+) -> tuple[int, Coloring, tuple[NeighborRow, ...], tuple[Matrix, ...]]:
+    base, rows = star_from_seeds(SEEDS)
+    commuting: list[Matrix] = []
+    for matrix in rotations:
+        rebuilt, _ = star_from_seeds(rotate_seeds(matrix))
+        if rebuilt == rotate_labels(matrix, base):
+            commuting.append(matrix)
+    return len(commuting), base, rows, tuple(commuting)
+
+
+def format_tuple(coloring: Coloring) -> str:
+    return "(" + ",".join(LETTER[slot] for slot in coloring) + ")"
+
+
+def format_n(n: Kernel | None) -> str:
+    if n is None:
+        return "empty"
+    return "(" + ",".join(str(component) for component in n) + ")"
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Qubit, Admissibility, "
+        "and Record sentences; G+ rebuilt as the 24 proper cube rotations"
+    )
+    print("construction: U=B_2(0)∪B_2((2,0,0))∪B_2((1,2,1)), unread v=(-1,1,1)")
+    print(
+        "negative_scope: displayed claim-delta sign-product rule only; "
+        "not adopted; L1 not attached; no 4th equal-radius ball"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SKEW_THREE_SEED_DELTA_SIGN_PRODUCT_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    covariance_clause = (
+        "one fixed nearest-neighbor admissibility rule, covariant under "
+        "lattice translations and proper cubic rotations"
+    )
+    formation_boundary = "it does not supply the formation site, probability,"
+    qubit_sentence = "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_perm = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in axiom_flat and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-covariance",
+        "Admissibility still requires one proper-cubic covariant rule",
+        covariance_clause in axiom_flat and covariance_clause in note_flat,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in axiom and formation_boundary in note,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit remains M_2(C)",
+        qubit_sentence in axiom and qubit_sentence in note and "Qubit remains `M_2(C)`" in note,
+    )
+    checks.check(
+        "source-record",
+        "lock, permanence, content-only readout, and unreadability at absence are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        )
+        and all(
+            phrase in note
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        ),
+    )
+
+    occupied = locked_union()
+    mask = occupancy_tuple(V, occupied)
+    rotations = proper_rotations()
+    n_commute, displayed, neighbor_rows, commuting = commute_count(rotations)
+    identity = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    cycle_plus = ((0, 1, 0), (0, 0, 1), (1, 0, 0))
+    cycle_minus = ((0, 0, 1), (1, 0, 0), (0, 1, 0))
+    identity_commutes = identity in commuting
+    axis_cycles = {identity, cycle_plus, cycle_minus}
+
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"occupancy_mask={mask}")
+    print(f"displayed_c={format_tuple(displayed)}")
+    for direction, neighbor, seed_star, n_vec, delta, hist_only, label in neighbor_rows:
+        hist_kind = "empty" if seed_star is None else (
+            "unique-axis" if hist_only is not None else "hist-tied"
+        )
+        print(
+            f"slot dir={direction} w={neighbor} s*={seed_star} "
+            f"n_hist={format_n(n_vec)} {hist_kind} delta={delta} "
+            f"label={LETTER[label] if label is not None else 'tied'}"
+        )
+    print(f"G_plus={len(rotations)}")
+    print(f"N_commute={n_commute}")
+    print(f"N_commute_over_24={n_commute}/24")
+    print(f"identity_commutes={identity_commutes}")
+    print("commuting_rotations=" + ",".join(str(matrix) for matrix in commuting))
+
+    balls = tuple(ball(seed) for seed in SEEDS)
+    pairwise = (
+        len(balls[0] & balls[1]),
+        len(balls[0] & balls[2]),
+        len(balls[1] & balls[2]),
+    )
+    triple = len(balls[0] & balls[1] & balls[2])
+
+    checks.check(
+        "g-plus-order",
+        "finite G+ is exactly the 24 proper cube rotations",
+        len(rotations) == 24 and len(set(rotations)) == 24,
+    )
+    checks.check(
+        "center-unread",
+        "the star center v is not already in U",
+        V not in occupied
+        and l1(V) == 3
+        and l1(sub(V, (2, 0, 0))) == 5
+        and l1(sub(V, (1, 2, 1))) == 3,
+        residual=V in occupied,
+    )
+    checks.check(
+        "u-geometry",
+        "U is the union of three radius-2 ℓ¹ balls and has 62 sites",
+        all(len(item) == 25 for item in balls)
+        and pairwise == (7, 4, 4)
+        and triple == 2
+        and len(occupied) == 62,
+    )
+    checks.check(
+        "occupancy-mask",
+        "occupied nearest neighbors of v are exactly +x,+y,−y,−z",
+        mask == (1, 0, 1, 1, 0, 1) and "(1, 0, 1, 1, 0, 1)" in note,
+    )
+    checks.check(
+        "theorem-1-product-tuple",
+        "the product rule rebuilds c=(+,0,+,−,0,−) on this star",
+        displayed == C
+        and neighbor_rows[0][2] == (0, 0, 0)
+        and neighbor_rows[0][4] == (0, 1, 1)
+        and neighbor_rows[0][6] == PLUS
+        and neighbor_rows[2][5] == PLUS
+        and neighbor_rows[2][6] == PLUS
+        and neighbor_rows[3][4] == (-1, 0, 1)
+        and neighbor_rows[3][6] == MINUS
+        and neighbor_rows[5][4] == (-1, 1, 0)
+        and neighbor_rows[5][6] == MINUS
+        and "(+,0,+,−,0,−)" in note,
+        residual=format_tuple(displayed),
+    )
+    checks.check(
+        "theorem-1-commute",
+        "N_commute among the 24 proper rotations is computed and reported",
+        identity_commutes
+        and 0 <= n_commute <= 24
+        and f"N_commute = {n_commute}" in note
+        and f"{n_commute}/24" in note,
+        residual=n_commute,
+    )
+    theorem_2_ok = (
+        (
+            n_commute == 24
+            and "cube-covariant Admissibility rule" in note
+            and "not a cube-covariant Admissibility rule" not in note
+        )
+        or (
+            n_commute != 24
+            and "not a cube-covariant Admissibility rule" in note
+        )
+    )
+    checks.check(
+        "theorem-2-covariance",
+        "whether N_commute=24 is reported as cube-covariance of the history tag",
+        theorem_2_ok and set(commuting) == axis_cycles if n_commute != 24 else theorem_2_ok,
+        residual=n_commute,
+    )
+
+    claim_scope = (
+        'claim_scope: "On the off-axis three-ball star at v=(-1,1,1), '
+        "whether the claim-delta sign-product labeling is equivariant under "
+        'the 24 proper cube rotations is reported. Displayed, not adopted."'
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the declared displayed claim_scope",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the product is displayed and is not written into Admissibility",
+        "Displayed, not adopted" in note
+        and "Do not write the product into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "the note does not attach L1 and does not add a fourth ball",
+        "Do not attach L1" in note
+        and "Do not add a 4th ball" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-prior",
+        "the note is not leftover-char of delsgn membership or skeweq",
+        "not leftover-char of delsgn" in note_flat
+        and "membership" in note_flat
+        and "not leftover-char of skeweq" in note_flat
+        and "different map" in note_flat,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the product rule is not written into Admissibility",
+        covariance_clause in axiom_flat
+        and "(+,0,+,−,0,−)" not in axiom
+        and "sign-product" not in axiom
+        and "B_2((1,2,1))" not in axiom
+        and "n_hist" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the forbidden rhetoric strings are absent from the note and runner",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(phrase not in self_source.split("FORBIDDEN = ", 1)[0] for phrase in FORBIDDEN),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the only axiom authority is the current memo; no cache or axiom rewrite",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: product labels and N_commute are exact integers")
+    print("per_site: only the unread star center v is scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: the six-neighbor star at v only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the off-axis three-ball star at v=(-1,1,1) the product rule rebuilds c=(+,0,+,-,0,-) but N_commute=3/24 (identity and two sign-free axis 3-cycles). Not cube-covariant. Displayed, not adopted. No axiom edit. No 4th ball.

## Runner

`scripts/skew_three_seed_delta_sign_product_equivariance_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.