### PR TITLE
feat(ticklab): lock-ticks stay 2 and do not shrink Stab

### DIFF
--- a/docs/SKEW_THREE_SEED_LOCK_TICK_STAB_PAIR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SKEW_THREE_SEED_LOCK_TICK_STAB_PAIR_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,295 @@
+---
+claim_id: skew_three_seed_lock_tick_stab_pair_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the off-axis three-ball star at v=(-1,1,1), whether lock-ticks shrink Stab enough for a Stab-invariant pair member is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py
+---
+
+# Lock-Ticks Versus Occupancy Stabilizer On The Off-Axis Three-Seed Star (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the unread six-neighbor star at `v = (−1,1,1)` on
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`. Occupied nearest neighbors
+carry a lock-tick `t(w) = min_s |w − s|_1`. Local data are `(σ, t)`.
+Score the star at `v` only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py`](../scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment maskstab `#pending` reported that every weight-4 occupancy has
+`N_stab_ok = 0`. Occupancy alone cannot host a fair pair. The residual
+here is not leftover of staborb (no times) or delsgn (distant seeds). It
+is the lock-tick object on the same displayed three-ball star.
+
+On this star, occupancy is the 6-bit nearest-neighbor occupancy `σ` of
+`U` at `v`. Each occupied neighbor `w` also carries
+
+`t(w) = min{ |w|_1, |w − (2,0,0)|_1, |w − (1,2,1)|_1 }`.
+
+Empty slots have no tick. Local data are `(σ, t)`. `G+` acts on slots.
+The occupancy stabilizer and the lock-tick stabilizer are
+
+`Stab(σ) = { g in G+ : g · σ = σ }`,
+
+`Stab(σ,t) = { g in G+ : g · σ = σ and t(g · μ) = t(μ) on occupied slots }`.
+
+Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+Direct listing against `U` gives
+
+`σ = (1, 0, 1, 1, 0, 1)`.
+
+**Theorem 1.** On the four occupied slots the lock-ticks are
+
+`t(+x) = 2`, `t(+y) = 2`, `t(−y) = 2`, `t(−z) = 2`.
+
+`|Stab(σ)| = 2`. `|Stab(σ,t)| = 2`. The occupancy swapper survives.
+
+**Theorem 2.** `N_tick_ok = 0`: none of the four July-3 pair members with
+support `σ` is invariant under `Stab(σ,t)`. The implication “if `|Stab(σ,t)| = 1` then
+`N_tick_ok = N_pair_support`” holds vacuously here because
+`|Stab(σ,t)| = 2`. On this `σ`, `N_pair_support = 4`.
+
+**Theorem 3.** Displayed, not adopted. Do not write ticks into
+Admissibility. Do not write any such `c` into Admissibility. Do not
+attach L1. Do not add a 4th ball. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither `Stab(σ,t)` nor any lock-tick, nor any July-3
+pair member, as the framework's fixed rule. The covariance clause is the
+reason a local labeling on the orbit of `(σ, t)` must be stabilizer-invariant.
+Formation site and rate remain outside the axiom memo. Qubit remains
+`M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact ℓ¹ lock-ticks on one unread six-neighbor star, occupancy and lock-tick stabilizer orders, and a 48-member pair invariance census. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: skew_three_seed_lock_tick_stab_pair
+target_blocker_text: "on the off-axis three-ball star at v=(-1,1,1), whether lock-ticks shrink Stab enough for a Stab-invariant pair member"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of t on the four occupied slots, |Stab(σ)|, |Stab(σ,t)|, swapper survival, and N_tick_ok; do not write ticks into Admissibility, attach L1, or add a 4th ball"
+conditional_surface_status: "exact on the star at v=(-1,1,1); t=(2,·,2,2,·,2) on occupied slots; |Stab(σ)|=2; |Stab(σ,t)|=2; occupancy swapper survives; N_tick_ok=0; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0 = (0,0,0)`, `p = (2,0,0)`, and `q = (1,2,1)`. The closed ℓ¹
+ball of radius two is
+
+`B_2(c) = { x ∈ Z^3 : |x − c|_1 ≤ 2 }`.
+
+The locked set is the already-given union
+
+`U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1))`.
+
+The three balls each have 25 sites. Pairwise overlaps are 7, 4, and 4,
+and the triple overlap has 2 sites, so `|U| = 62`. The unread site is
+
+`v = (−1,1,1)`.
+
+Then `|v|_1 = 3`, `|v − p|_1 = 5`, and `|v − q|_1 = 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` | lock-tick |
+|---|---|---|---|
+| `+x` | `(0,1,1)` | yes | `2` |
+| `−x` | `(−2,1,1)` | no | none |
+| `+y` | `(−1,2,1)` | yes | `2` |
+| `−y` | `(−1,0,1)` | yes | `2` |
+| `+z` | `(−1,1,2)` | no | none |
+| `−z` | `(−1,1,0)` | yes | `2` |
+
+Occupancy at `v`:
+
+`σ = (1, 0, 1, 1, 0, 1)`.
+
+On occupied slots the lock-tick is the minimum ℓ¹ distance to a seed.
+Empty slots have no tick. The displayed tick tuple, with a dot on empty
+slots, is
+
+`t = (2, ·, 2, 2, ·, 2)`.
+
+Support of a 6-tuple is the set of slots with a nonzero letter. Occupancy
+`σ` is already that indicator.
+
+`G+` is the 24 determinant-`+1` signed permutation matrices of the three
+axes. A matrix `g` permutes the six axis directions: the letter (or bit,
+or tick) at slot `μ` moves to slot `gμ`. The two stabilizers are as
+named above.
+
+The July-3 `k = 3` chiral pair is the unique pair of `G+` orbits of
+handed fully-mixed 6-tuples on the three-letter alphabet `{0,1,2}` with
+`0` empty. Fully mixed means every axis is bi-colored and each letter is
+used twice. The pair is reconstructed by enumerating the 24 proper
+rotations on `{0,1,2}^6`; it has 48 members (two orbits of size 24).
+Letters `{1,2}` are the two nonzero condition letters; they may be
+written `{+, −}` when displaying a 6-tuple.
+
+`N_pair_support` is the number of pair members whose support equals `σ`.
+On this `σ` that number is 4. `N_tick_ok` is the number of those members
+`c` with `g · c = c` for every `g` in `Stab(σ,t)`.
+
+If `|Stab(σ,t)| < |Stab(σ)|`, lock-ticks may admit a pair member that
+occupancy alone refused. That comparison is the residual.
+
+## Theorem 1 — lock-ticks and the two stabilizers
+
+The four occupied neighbors and their lock-ticks are
+
+| slot | `w` | `|w|_1` | `|w − p|_1` | `|w − q|_1` | `t(w)` |
+|---|---|---:|---:|---:|---:|
+| `+x` | `(0,1,1)` | 2 | 4 | 2 | 2 |
+| `+y` | `(−1,2,1)` | 4 | 6 | 2 | 2 |
+| `−y` | `(−1,0,1)` | 2 | 4 | 4 | 2 |
+| `−z` | `(−1,1,0)` | 2 | 4 | 4 | 2 |
+
+So
+
+`t(+x) = 2`, `t(+y) = 2`, `t(−y) = 2`, `t(−z) = 2`.
+
+Enumerating the 24 proper rotations on the occupancy 6-tuple gives
+
+`|Stab(σ)| = 2`.
+
+A generating list is
+
+1. the identity `id : (x, y, z) ↦ (x, y, z)`, which fixes every slot;
+2. the order-2 occupancy swapper `s : (x, y, z) ↦ (−z, −y, −x)`, whose
+   slot permutation is
+
+   `+x ↔ −z`, `−x ↔ +z`, `+y ↔ −y`.
+
+Those two matrices generate `Stab(σ)` and exhaust it. The swapper
+preserves the occupied set `{+x, +y, −y, −z}` and swaps the two empty
+slots.
+
+Because every occupied lock-tick equals `2`, the identity
+`t(s · μ) = t(μ)` holds on occupied slots. Therefore `s` lies in
+`Stab(σ,t)`, the occupancy swapper survives, and
+
+`|Stab(σ,t)| = 2`.
+
+Lock-ticks do not shrink the occupancy stabilizer on this star.
+`|Stab(σ,t)| < |Stab(σ)|` is false here.
+
+Scoring only the star at `v`. This is not leftover of staborb (no times)
+and not leftover of delsgn (distant seeds).
+
+## Theorem 2 — lock-tick-invariant pair members
+
+The July-3 pair is reconstructed by partitioning `{0,1,2}^6` into 57
+`G+` orbits and retaining the unique pair of orbits exchanged by spatial
+inversion. Exactly four pair members have support equal to `σ`:
+
+| member `{0,1,2}` | displayed `{+,0,−}` |
+|---|---|
+| `(1, 0, 1, 2, 0, 2)` | `(+,0,+,−,0,−)` |
+| `(1, 0, 2, 1, 0, 2)` | `(+,0,−,+,0,−)` |
+| `(2, 0, 1, 2, 0, 1)` | `(−,0,+,−,0,+)` |
+| `(2, 0, 2, 1, 0, 1)` | `(−,0,−,+,0,+)` |
+
+So `N_pair_support = 4`.
+
+For `c` among those four, `g · c = c` for every `g` in `Stab(σ,t)` if
+and only if `s · c = c`, because `Stab(σ,t) = {id, s}`. The slot
+permutation of `s` requires `c(+x) = c(−z)` and `c(+y) = c(−y)`. Every
+July-3 pair member is fully mixed, so the `y`-axis is bi-colored:
+
+`c(+y) ≠ c(−y)`.
+
+Therefore no support-matched pair member is fixed by `s`, and
+
+`N_tick_ok = 0`.
+
+If `|Stab(σ,t)| = 1` then `N_tick_ok = N_pair_support`. That implication
+is recorded. It is not triggered: `|Stab(σ,t)| = 2`. On this `σ`,
+`N_pair_support = 4`.
+
+Lock-ticks do not shrink `Stab` enough for a Stab-invariant pair member
+on this star.
+
+## Theorem 3 — displayed, not adopted
+
+The lock-ticks, the two stabilizer orders, swapper survival, and the
+count `N_tick_ok = 0` are displayed member data. They are not the
+framework's fixed Admissibility rule. This note does not write ticks into
+Admissibility. Do not write ticks into Admissibility. Do not write any
+such `c` into Admissibility. Do not attach L1. Do not add a 4th ball.
+Occupancy-only formation is not attached. Qubit remains `M_2(C)`. No
+approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On this unread star, the four occupied lock-ticks
+  are all `2`, `|Stab(σ)| = 2`, `|Stab(σ,t)| = 2`, the occupancy swapper
+  survives, `N_pair_support = 4`, and `N_tick_ok = 0`.
+- **What is displayed only.** The ticks, the two stabilizers, and the
+  invariance count are one rival table. They are not adopted.
+- **What is not claimed.** No attachment of ticks or any pair member to
+  Admissibility; no attachment of occupancy-only formation; no axiom
+  edit; no formation rate; no lattice-wide dynamics; no fourth
+  equal-radius ball; no leftover of staborb (no times); no leftover of
+  delsgn (distant seeds); no compiler no-go.
+- **Mutation controls.** A rebuilt `σ` other than `(1, 0, 1, 1, 0, 1)`
+  fails. A rebuilt occupied tick other than `2` fails. `|Stab(σ,t)| = 1`
+  would trigger `N_tick_ok = N_pair_support` and fail the unshrunk
+  report. A note that writes ticks into Admissibility, attaches L1, or
+  authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, occupancy `σ`, the
+lock-ticks on occupied slots, the 24 proper cube rotations acting on
+slots, `Stab(σ)`, `Stab(σ,t)`, swapper survival, the reconstructed
+July-3 pair, `N_pair_support`, `N_tick_ok`, the current premise boundary,
+and the mutation controls. It writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17033,6 +17033,10 @@
   "sixth_family_sheared_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "skew_three_seed_lock_tick_stab_pair_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "slab_boundary_eta_globally_zero_per_edge_nonuniversal_no_fractional_carrier_bounded_note_2026-06-12": {
    "deps_hash": "9defae253834",

--- a/logs/runner-cache/skew_three_seed_lock_tick_stab_pair_2026_08_15.txt
+++ b/logs/runner-cache/skew_three_seed_lock_tick_stab_pair_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py
+runner_sha256: f3cf39fe3f515691189ac9c694b40d277af2e9c533ba5ee77876d9ff45b51a1d
+input_fingerprint_sha256: f257be46d49c8e77f5c7615dea3c06d72afe7260227efc8b0a4dfbd8d565e54b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+lock-tick stabilizer vs July-3 pair members
+AUDIT_INPUT_PATHS:
+  docs/SKEW_THREE_SEED_LOCK_TICK_STAB_PAIR_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+U_card=62
+v_in_U=False
+sigma=(1, 0, 1, 1, 0, 1)
+ticks=(2,·,2,2,·,2)
+occupied_ticks=+x=2,+y=2,−y=2,−z=2
+G_plus=24
+stab_order=2
+stab_tick_order=2
+swapper_survives=True
+N_pair=48
+N_pair_support=4
+support_members=(1, 0, 1, 2, 0, 2),(1, 0, 2, 1, 0, 2),(2, 0, 1, 2, 0, 1),(2, 0, 2, 1, 0, 1)
+support_members_letters=(+,0,+,−,0,−),(+,0,−,+,0,−),(−,0,+,−,0,+),(−,0,−,+,0,+)
+N_tick_ok=0
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: g-plus-order | proper=24
+PASS: center-unread
+PASS: u-geometry
+PASS: occupancy-sigma | sigma=(1, 0, 1, 1, 0, 1)
+PASS: theorem-1-ticks | ticks=(2,·,2,2,·,2)
+PASS: theorem-1-stab | stab=2 stab_tick=2 swapper=True
+PASS: theorem-2-tick-ok | N_tick_ok=0 N_pair_support=4
+PASS: swapper-forces-y-bicolor-obstruction
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-prior
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: |Stab(σ)|, |Stab(σ,t)|, N_tick_ok are exact integers
+per_site: only the unread star center v is scored
+per_mode: no spectral calculation
+per_block: the six-neighbor star at v only
+lattice_wide: checked and not executed
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py
+++ b/scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Lock-ticks versus occupancy stabilizer on one unread star.
+
+U = B_2(0) ∪ B_2((2,0,0)) ∪ B_2((1,2,1)). Score only the unread star at
+v = (−1, 1, 1). Occupied neighbors carry t(w) = min_s |w − s|_1. Local
+data are (σ, t). Count |Stab(σ)|, |Stab(σ,t)|, swapper survival, and
+N_tick_ok. Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SKEW_THREE_SEED_LOCK_TICK_STAB_PAIR_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SKEW_THREE_SEED_LOCK_TICK_STAB_PAIR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+SLOT_NAME = ("+x", "−x", "+y", "−y", "+z", "−z")
+V: Point = (-1, 1, 1)
+SEEDS: tuple[Point, ...] = ((0, 0, 0), (2, 0, 0), (1, 2, 1))
+IDENTITY: Matrix = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+SWAPPER: Matrix = ((0, 0, -1), (0, -1, 0), (-1, 0, 0))
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def ball(center: Point, radius: int = 2) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        if l1(offset) <= radius:
+            sites.add(add(center, offset))
+    return frozenset(sites)
+
+
+def locked_union(seeds: tuple[Point, ...] = SEEDS) -> frozenset[Point]:
+    occupied: frozenset[Point] = frozenset()
+    for seed in seeds:
+        occupied = occupied | ball(seed)
+    return occupied
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def lock_tick(point: Point, seeds: tuple[Point, ...] = SEEDS) -> int:
+    return min(l1(sub(point, seed)) for seed in seeds)
+
+
+def tick_tuple(site: Point, occupied: frozenset[Point]) -> Tick:
+    records: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if neighbor in occupied:
+            records.append(lock_tick(neighbor))
+        else:
+            records.append(None)
+    return tuple(records)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(letter != 0) for letter in coloring)
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: Point) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | Tick) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def all_colorings(letters: int = 3) -> list[Coloring]:
+    return list(itertools.product(range(letters), repeat=len(DIRS)))
+
+
+def direct_orbits(perms: list[tuple[int, ...]]) -> list[set[Coloring]]:
+    unseen = set(all_colorings())
+    orbits: list[set[Coloring]] = []
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        orbits.append(orbit)
+        unseen -= orbit
+    return orbits
+
+
+def fully_mixed(coloring: Coloring) -> bool:
+    axis_bicolored = all(
+        coloring[2 * axis] != coloring[2 * axis + 1] for axis in range(3)
+    )
+    counts = sorted(coloring.count(letter) for letter in range(3))
+    return axis_bicolored and counts == [2, 2, 2]
+
+
+def format_letters(coloring: Coloring) -> str:
+    return "(" + ",".join(LETTER[letter] for letter in coloring) + ")"
+
+
+def format_ticks(ticks: Tick) -> str:
+    parts = ["·" if value is None else str(value) for value in ticks]
+    return "(" + ",".join(parts) + ")"
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    occupied = locked_union()
+    sigma = occupancy_tuple(V, occupied)
+    ticks = tick_tuple(V, occupied)
+    rotations = proper_rotations()
+    perms = [direction_perm(matrix) for matrix in rotations]
+    stab_occ_mats = tuple(
+        matrix
+        for matrix in rotations
+        if act_col(direction_perm(matrix), sigma) == sigma
+    )
+    stab_tick_mats = tuple(
+        matrix
+        for matrix in rotations
+        if act_col(direction_perm(matrix), sigma) == sigma
+        and act_col(direction_perm(matrix), ticks) == ticks
+    )
+    stab_tick_perms = [direction_perm(matrix) for matrix in stab_tick_mats]
+    inversion: Matrix = ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+    p_perm = direction_perm(inversion)
+    orbits = direct_orbits(perms)
+    orbit_id = {
+        coloring: index for index, orbit in enumerate(orbits) for coloring in orbit
+    }
+    chiral_ids: set[int] = set()
+    for coloring in all_colorings():
+        if orbit_id[act_col(p_perm, coloring)] != orbit_id[coloring]:
+            chiral_ids.add(orbit_id[coloring])
+    pair = set().union(*(orbits[index] for index in sorted(chiral_ids)))
+    support_members = tuple(
+        sorted(coloring for coloring in pair if support(coloring) == sigma)
+    )
+    tick_ok = tuple(
+        coloring
+        for coloring in support_members
+        if all(act_col(perm, coloring) == coloring for perm in stab_tick_perms)
+    )
+    n_stab = len(stab_occ_mats)
+    n_stab_tick = len(stab_tick_mats)
+    n_pair_support = len(support_members)
+    n_tick_ok = len(tick_ok)
+    swapper_survives = SWAPPER in stab_tick_mats
+    occupied_ticks = tuple(
+        ticks[index] for index, bit in enumerate(sigma) if bit == 1
+    )
+
+    print("lock-tick stabilizer vs July-3 pair members")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"sigma={sigma}")
+    print(f"ticks={format_ticks(ticks)}")
+    print(
+        "occupied_ticks="
+        + ",".join(
+            f"{SLOT_NAME[index]}={ticks[index]}"
+            for index, bit in enumerate(sigma)
+            if bit == 1
+        )
+    )
+    print(f"G_plus={len(rotations)}")
+    print(f"stab_order={n_stab}")
+    print(f"stab_tick_order={n_stab_tick}")
+    print(f"swapper_survives={swapper_survives}")
+    print(f"N_pair={len(pair)}")
+    print(f"N_pair_support={n_pair_support}")
+    print("support_members=" + ",".join(str(item) for item in support_members))
+    print(
+        "support_members_letters="
+        + ",".join(format_letters(item) for item in support_members)
+    )
+    print(f"N_tick_ok={n_tick_ok}")
+
+    expected_paths = (
+        "docs/SKEW_THREE_SEED_LOCK_TICK_STAB_PAIR_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+
+    balls = tuple(ball(seed) for seed in SEEDS)
+    pairwise = (
+        len(balls[0] & balls[1]),
+        len(balls[0] & balls[2]),
+        len(balls[1] & balls[2]),
+    )
+    triple = len(balls[0] & balls[1] & balls[2])
+    checks.check(
+        "g-plus-order",
+        len(rotations) == 24 and len(set(rotations)) == 24 and det3(SWAPPER) == 1,
+        f"proper={len(rotations)}",
+    )
+    checks.check(
+        "center-unread",
+        V not in occupied
+        and l1(V) == 3
+        and l1(sub(V, (2, 0, 0))) == 5
+        and l1(sub(V, (1, 2, 1))) == 3,
+    )
+    checks.check(
+        "u-geometry",
+        all(len(item) == 25 for item in balls)
+        and pairwise == (7, 4, 4)
+        and triple == 2
+        and len(occupied) == 62,
+    )
+    checks.check(
+        "occupancy-sigma",
+        sigma == (1, 0, 1, 1, 0, 1)
+        and "(1, 0, 1, 1, 0, 1)" in note,
+        f"sigma={sigma}",
+    )
+    checks.check(
+        "theorem-1-ticks",
+        ticks == (2, None, 2, 2, None, 2)
+        and occupied_ticks == (2, 2, 2, 2)
+        and "`t(+x) = 2`" in note
+        and "`t(+y) = 2`" in note
+        and "`t(−y) = 2`" in note
+        and "`t(−z) = 2`" in note
+        and "Empty slots have no tick" in note,
+        f"ticks={format_ticks(ticks)}",
+    )
+    checks.check(
+        "theorem-1-stab",
+        n_stab == 2
+        and n_stab_tick == 2
+        and IDENTITY in stab_occ_mats
+        and SWAPPER in stab_occ_mats
+        and set(stab_occ_mats) == {IDENTITY, SWAPPER}
+        and set(stab_tick_mats) == {IDENTITY, SWAPPER}
+        and swapper_survives
+        and "|Stab(σ)| = 2" in note
+        and "|Stab(σ,t)| = 2" in note
+        and "the occupancy swapper survives" in note
+        and "s : (x, y, z) ↦ (−z, −y, −x)" in note,
+        f"stab={n_stab} stab_tick={n_stab_tick} swapper={swapper_survives}",
+    )
+    implication_ok = n_stab_tick != 1 or n_tick_ok == n_pair_support
+    checks.check(
+        "theorem-2-tick-ok",
+        n_tick_ok == 0
+        and implication_ok
+        and n_stab_tick == 2
+        and n_pair_support == 4
+        and support_members
+        == (
+            (1, 0, 1, 2, 0, 2),
+            (1, 0, 2, 1, 0, 2),
+            (2, 0, 1, 2, 0, 1),
+            (2, 0, 2, 1, 0, 1),
+        )
+        and all(fully_mixed(item) for item in support_members)
+        and "N_tick_ok = 0" in note
+        and "N_pair_support = 4" in note
+        and "if `|Stab(σ,t)| = 1` then" in note
+        and "`N_tick_ok = N_pair_support`" in note,
+        f"N_tick_ok={n_tick_ok} N_pair_support={n_pair_support}",
+    )
+    swap_perm = direction_perm(SWAPPER)
+    checks.check(
+        "swapper-forces-y-bicolor-obstruction",
+        swap_perm[2] == 3
+        and swap_perm[3] == 2
+        and swap_perm[0] == 5
+        and all(item[2] != item[3] for item in support_members)
+        and all(act_col(swap_perm, item) != item for item in support_members)
+        and act_col(swap_perm, ticks) == ticks,
+    )
+
+    claim_scope = (
+        'claim_scope: "On the off-axis three-ball star at v=(-1,1,1), '
+        "whether lock-ticks shrink Stab enough for a Stab-invariant pair "
+        'member is reported. Displayed, not adopted."'
+    )
+    checks.check("claim-scope", claim_scope in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write ticks into Admissibility" in note
+        and "Do not write any such `c` into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "Do not add a 4th ball" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-prior",
+        "not leftover of staborb" in note_flat
+        and "no times" in note_flat
+        and "not leftover of delsgn" in note_flat
+        and "distant seeds" in note_flat,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "Stab(σ,t)" not in axiom
+        and "N_tick_ok" not in axiom
+        and "lock-tick" not in axiom
+        and "B_2((1,2,1))" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: |Stab(σ)|, |Stab(σ,t)|, N_tick_ok are exact integers")
+    print("per_site: only the unread star center v is scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: the six-neighbor star at v only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the displayed three-ball star, t=+x=+y=-y=-z=2. |Stab(sigma,t)|=|Stab(sigma)|=2. The occupancy swapper survives. N_tick_ok=0. Displayed, not adopted. No axiom edit. No 4th ball.

## Runner

`scripts/skew_three_seed_lock_tick_stab_pair_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.