### PR TITLE
feat(uneqlaw): unequal-radius tick rule commutes with all 24

### DIFF
--- a/docs/UNEQUAL_RADIUS_TICK_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNEQUAL_RADIUS_TICK_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,213 @@
+---
+claim_id: unequal_radius_tick_rule_equivariance_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the G+ orbit of the lex-first unequal-radius breaker, whether a tick-ok pair member is cube-equivariant is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py
+---
+
+# Unequal-Radius Tick-Ok Pair Member on the Breaker Orbit (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the `G+` orbit of the uneqrad lex-first unequal-radius breaker
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))` at
+`v = (−3,−3,−1)`, with the lex-first `Stab(σ,t)`-ok July-3 pair member.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py`](../scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment uneqrad names a breaker where `|Stab(σ,t)| = 1` and
+`N_tick_ok = 4`. That census is one star. The residual here is not leftover
+of uneqrad (one star) or deleq (different map). Rotate the three balls,
+radii, and star together under `G+`. How many of the 24 proper cube
+rotations send this host to a weight-4 unread star whose
+`Stab(σ_g, t_g)`-ok set contains the rotated 6-tuple `g·c`?
+
+`G+` is the 24 proper cube rotations about the origin. It acts on seeds,
+radii (radii travel with their seeds), `v`, and the six slots
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+Empty slots have no tick. Local data are `(σ, t)`. Pair members are the
+July-3 6-slot 3-letter colorings whose `G+` orbit is sent to a different
+orbit by spatial inversion. The `Stab(σ,t)`-ok set is the pair members
+with support `σ` that are invariant under `Stab(σ,t)`.
+
+**Theorem 1.** `N_commute = 24` and `N_commute / 24 = 24/24`. Every
+`g` in `G+` sends this host to a weight-4 unread star, and that image's
+`Stab(σ_g, t_g)`-ok set contains `g·c`.
+
+**Theorem 2.** Whether N_commute = 24. N_commute = 24 holds. On this
+orbit, tick-ok membership of the lex-first pair member is cube-equivariant
+as a set membership. This does not write radii or ticks into
+Admissibility.
+
+**Theorem 3.** Displayed, not adopted. Do not write radii into Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither `N_commute` nor any unequal-radius 3-ball
+union, nor any lock-tick labeling, as the framework's fixed rule. The
+covariance clause is the reason a local labeling on the orbit of
+`(σ, t, c)` must be checked under `G+`. Formation site and rate remain
+outside the axiom memo. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact G+ orbit of the uneqrad lex-first unequal-radius breaker: N_commute and the 24/24 ratio are exact. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: unequal_radius_tick_rule_equivariance
+target_blocker_text: "on the G+ orbit of the lex-first unequal-radius breaker, whether a tick-ok pair member is cube-equivariant"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_commute on this orbit; do not write radii into Admissibility or attach L1"
+conditional_surface_status: "exact on the 24-element G+ orbit of the displayed host; N_commute=24; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `B_r(c) = { x ∈ Z^3 : ‖x − c‖_1 ≤ r }`. The host is the uneqrad
+lex-first breaker
+
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))`,
+radii `(2, 1, 3)`,
+`v = (−3,−3,−1)`.
+
+Occupancy `σ` is the 6-bit nearest-neighbor indicator of `U` at `v`.
+On an occupied neighbor `w` of `v`,
+
+`t(w) = min_i ‖w − s_i‖_1`.
+
+Direct distances give `v ∉ U`,
+
+`σ = (1, 0, 1, 0, 1, 1)`,
+`t = (1, ·, 1, ·, 3, 2)`,
+
+`|Stab(σ)| = 2`, `|Stab(σ,t)| = 1`, and `N_tick_ok = 4`. The four
+tick-ok pair members are
+
+`(1, 0, 2, 0, 1, 2)`, `(1, 0, 2, 0, 2, 1)`,
+`(2, 0, 1, 0, 1, 2)`, `(2, 0, 1, 0, 2, 1)`.
+
+The lex-first member is
+
+`c = (1, 0, 2, 0, 1, 2)`.
+
+For `g` in `G+`, the image host is the three balls with seeds `g·s_i`,
+the same radii traveling with those seeds, and unread site `g·v`. Slots
+move by the induced permutation of the six directions. The image
+occupancy and ticks are `σ_g = g·σ` and `t_g = g·t` because ℓ¹ is
+preserved by proper cube rotations. The rotated 6-tuple is `g·c`.
+
+`N_commute` is the number of `g` that send this host to a weight-4 unread
+star whose `Stab(σ_g, t_g)`-ok set contains `g·c`. The 24 image hosts
+remain inside the uneqrad box (centers in `[-2,2]^3`, `‖v‖_∞ ≤ 4`) and
+remain breakers (`|Stab(σ_g, t_g)| = 1 < |Stab(σ_g)| = 2`). This is a
+different map from deleq's claim-delta sign product.
+
+## Theorem 1 — `N_commute / 24`
+
+The runner rebuilds `U`, `v`, `(σ, t)`, the July-3 pair, and the
+lex-first tick-ok member `c`, then applies each of the 24 proper cube
+rotations to seeds, radii, `v`, and slots.
+
+Every image is unread and has weight 4. Because `|Stab(σ_g, t_g)| = 1`,
+the image tick-ok set is the four pair members with support `σ_g`. The
+July-3 pair is a union of `G+` orbits, so `g·c` remains a pair member,
+and `support(g·c) = g·σ = σ_g`. Hence `g·c` lies in the image tick-ok
+set for every `g`. Therefore
+
+`N_commute = 24`, `N_commute / 24 = 24/24`.
+
+The identity is one such `g`. The occupancy swapper
+`s : (x, y, z) ↦ (y, x, −z)` is another: it sends `c` to
+`(2, 0, 1, 0, 2, 1)`, which is tick-ok on the image star at
+`g·v = (−3,−3,1)`.
+
+## Theorem 2 — whether `N_commute = 24`
+
+Whether N_commute = 24. N_commute = 24 holds. On this orbit a
+tick-ok pair member remains tick-ok after every proper cube rotation of
+the host. The scored rule is set membership of `g·c` in the image
+tick-ok set, not a unique product-of-ticks labeling and not deleq's
+sign-product map. If `N_commute` had not been 24, unequal-radius ticks
+would not be a cube-covariant Admissibility rule. That negative clause
+is not triggered. The count is still displayed member data, not the
+framework's fixed rule.
+
+## Theorem 3 — displayed, not adopted
+
+`N_commute = 24` and `N_commute / 24 = 24/24` are displayed orbit data.
+They are not the framework's fixed Admissibility rule. This note does
+not write radii into Admissibility. Do not write radii into
+Admissibility. Do not attach L1. Occupancy-only formation is not
+attached. Qubit remains `M_2(C)`. No approved primitive is added. No
+axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the `G+` orbit of the uneqrad lex-first
+  unequal-radius breaker, with lex-first tick-ok pair member
+  `c = (1, 0, 2, 0, 1, 2)`, every image is a weight-4 unread star and
+  `N_commute = 24`.
+- **What is displayed only.** The radii, the ticks, the pair member, and
+  the commute count are one rival table. They are not adopted.
+- **What is not claimed.** No attachment of radii or ticks to
+  Admissibility; no attachment of occupancy-only formation; no axiom
+  edit; no formation rate; no lattice-wide dynamics; no leftover of
+  uneqrad (one star) or deleq (different map); no compiler no-go.
+- **Mutation controls.** A rebuilt `N_commute ≠ 24` fails. A rebuilt
+  lex-first `c` other than `(1, 0, 2, 0, 1, 2)` fails. A note that
+  writes radii into Admissibility, attaches L1, or authors an audit
+  verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the uneqrad lex-first host, the lock-ticks,
+the 24 proper cube rotations, the lex-first tick-ok pair member, the
+image weight-4 unread stars, `N_commute`, the current premise boundary,
+and the mutation controls. It writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18657,6 +18657,10 @@
   "u_integration_reading_blind_and_dictionary_blind_on_corner_transfer_bounded_note_2026-06-12": {
    "deps_hash": "311d6b921eb1",
    "out_degree": 3
+  },
+  "unequal_radius_tick_rule_equivariance_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unification_basin_failure_note": {
    "deps_hash": "c90c9ba91199",

--- a/logs/runner-cache/unequal_radius_tick_rule_equivariance_2026_08_15.txt
+++ b/logs/runner-cache/unequal_radius_tick_rule_equivariance_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py
+runner_sha256: 9a374f49e0d2885c2d75fa158a6134a8c5bfbe0824f9eb3c86e49d8049d1fc8b
+input_fingerprint_sha256: d923af68ebb7862cbe397bc35e66da7b9bdf30ee00c188df6d842e37dc0f6b3d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+unequal-radius tick-rule cube-equivariance
+AUDIT_INPUT_PATHS:
+  docs/UNEQUAL_RADIUS_TICK_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+G_plus=24
+seeds=((-2, -2, -2), (-2, -2, -1), (-2, -2, 1))
+radii=(2, 1, 3)
+v=(-3, -3, -1)
+sigma=(1, 0, 1, 0, 1, 1)
+ticks=(1, None, 1, None, 3, 2)
+stab_sigma=2
+stab_sigma_t=1
+N_tick_ok=4
+lex_first_c=(1, 0, 2, 0, 1, 2)
+N_unread=24
+N_weight4=24
+N_breaker=24
+N_box=24
+N_commute=24
+N_commute_over_24=24/24
+N_commute_eq_24=True
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: g-plus-order | proper=24
+PASS: host-lex-first-breaker | sigma=(1, 0, 1, 0, 1, 1) ticks=(1, None, 1, None, 3, 2) stab=(2,1)
+PASS: lex-first-tick-ok | c=(1, 0, 2, 0, 1, 2) N_tick_ok=4
+PASS: theorem-1-n-commute | N_commute=24
+PASS: theorem-2-commute-is-24 | eq24=True
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqrad-deleq
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: N_commute is the exact count of the 24 proper cube rotations whose image is a weight-4 unread star containing g·c
+per_site: scored only the G+ orbit of the uneqrad lex-first unequal-radius breaker at v
+per_mode: no spectral calculation; occupancy and lock-ticks only
+per_block: 3-ball unequal-radius host orbit only; no fourth ball
+lattice_wide: checked and not executed — one finite G+ orbit, not a lattice-wide rule
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py
+++ b/scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Unequal-radius tick-ok pair-member cube-equivariance on one orbit.
+
+U, v are the uneqrad lex-first breaker. c is the lex-first Stab(σ,t)-ok
+July-3 pair member. G+ acts on seeds, radii (travel with seeds), v, and
+slots. N_commute counts the proper cube rotations that send this host to
+a weight-4 unread star whose Stab(σ_g, t_g)-ok set contains g·c.
+Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/UNEQUAL_RADIUS_TICK_RULE_EQUIVARIANCE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNEQUAL_RADIUS_TICK_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+EMPTY = 0
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the G+ orbit of the lex-first unequal-radius breaker, '
+    "whether a tick-ok pair member is cube-equivariant is reported. "
+    'Displayed, not adopted."'
+)
+SWAPPER: Matrix = ((0, 1, 0), (1, 0, 0), (0, 0, -1))
+SEEDS: tuple[Point, Point, Point] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, -2, 1),
+)
+RADII = (2, 1, 3)
+V: Point = (-3, -3, -1)
+EXPECTED_SIGMA: Coloring = (1, 0, 1, 0, 1, 1)
+EXPECTED_TICKS: Tick = (1, None, 1, None, 3, 2)
+EXPECTED_C: Coloring = (1, 0, 2, 0, 1, 2)
+EXPECTED_MEMBERS: tuple[Coloring, ...] = (
+    (1, 0, 2, 0, 1, 2),
+    (1, 0, 2, 0, 2, 1),
+    (2, 0, 1, 0, 1, 2),
+    (2, 0, 1, 0, 2, 1),
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: Point) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | Tick) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(letter != EMPTY) for letter in coloring)
+
+
+def in_union(point: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]) -> bool:
+    return any(l1(point, seed) <= radius for seed, radius in zip(seeds, radii))
+
+
+def occupancy_ticks(
+    seeds: tuple[Point, ...], radii: tuple[int, ...], site: Point
+) -> tuple[Coloring, Tick]:
+    sigma: list[int] = []
+    ticks: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if in_union(neighbor, seeds, radii):
+            sigma.append(1)
+            ticks.append(min(l1(neighbor, seed) for seed in seeds))
+        else:
+            sigma.append(0)
+            ticks.append(None)
+    return tuple(sigma), tuple(ticks)
+
+
+def stab_orders(
+    sigma: Coloring, ticks: Tick, perms: list[tuple[int, ...]]
+) -> tuple[int, int]:
+    n_stab = 0
+    n_stab_tick = 0
+    for perm in perms:
+        if act_col(perm, sigma) == sigma:
+            n_stab += 1
+            if act_col(perm, ticks) == ticks:
+                n_stab_tick += 1
+    return n_stab, n_stab_tick
+
+
+def july3_pair(perms: list[tuple[int, ...]]) -> frozenset[Coloring]:
+    unseen = set(itertools.product(range(3), repeat=6))
+    inversion = direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+    pair: set[Coloring] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def tick_ok(
+    sigma: Coloring,
+    ticks: Tick,
+    perms: list[tuple[int, ...]],
+    pair: frozenset[Coloring],
+) -> tuple[Coloring, ...]:
+    stab_tick_perms = [
+        perm
+        for perm in perms
+        if act_col(perm, sigma) == sigma and act_col(perm, ticks) == ticks
+    ]
+    members = tuple(sorted(item for item in pair if support(item) == sigma))
+    return tuple(
+        item
+        for item in members
+        if all(act_col(perm, item) == item for perm in stab_tick_perms)
+    )
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def score_orbit(
+    rotations: tuple[Matrix, ...],
+    perms: list[tuple[int, ...]],
+    pair: frozenset[Coloring],
+    coloring: Coloring,
+) -> dict:
+    n_unread = 0
+    n_weight4 = 0
+    n_breaker = 0
+    n_commute = 0
+    n_box = 0
+    images: list[tuple] = []
+    for matrix, perm in zip(rotations, perms):
+        seeds = tuple(mat_vec(matrix, seed) for seed in SEEDS)
+        site = mat_vec(matrix, V)
+        unread = not in_union(site, seeds, RADII)
+        sigma, ticks = occupancy_ticks(seeds, RADII, site)
+        n_stab, n_stab_tick = stab_orders(sigma, ticks, perms)
+        ok = tick_ok(sigma, ticks, perms, pair)
+        rotated = act_col(perm, coloring)
+        weight4 = sum(sigma) == 4
+        breaker = unread and weight4 and n_stab_tick < n_stab
+        inbox = all(all(abs(coord) <= 2 for coord in seed) for seed in seeds) and all(
+            abs(coord) <= 4 for coord in site
+        )
+        commute = unread and weight4 and rotated in ok
+        n_unread += int(unread)
+        n_weight4 += int(weight4)
+        n_breaker += int(breaker)
+        n_commute += int(commute)
+        n_box += int(inbox)
+        images.append((site, sigma, ticks, n_stab, n_stab_tick, rotated, commute))
+    return {
+        "n_unread": n_unread,
+        "n_weight4": n_weight4,
+        "n_breaker": n_breaker,
+        "n_commute": n_commute,
+        "n_box": n_box,
+        "images": images,
+    }
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    rotations = proper_rotations()
+    perms = [direction_perm(matrix) for matrix in rotations]
+    pair = july3_pair(perms)
+    sigma, ticks = occupancy_ticks(SEEDS, RADII, V)
+    n_stab, n_stab_tick = stab_orders(sigma, ticks, perms)
+    ok = tick_ok(sigma, ticks, perms, pair)
+    coloring = ok[0] if ok else None
+    orbit = score_orbit(rotations, perms, pair, coloring) if coloring is not None else {
+        "n_unread": 0,
+        "n_weight4": 0,
+        "n_breaker": 0,
+        "n_commute": 0,
+        "n_box": 0,
+        "images": [],
+    }
+    n_commute = orbit["n_commute"]
+
+    print("unequal-radius tick-rule cube-equivariance")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"G_plus={len(rotations)}")
+    print(f"seeds={SEEDS}")
+    print(f"radii={RADII}")
+    print(f"v={V}")
+    print(f"sigma={sigma}")
+    print(f"ticks={ticks}")
+    print(f"stab_sigma={n_stab}")
+    print(f"stab_sigma_t={n_stab_tick}")
+    print(f"N_tick_ok={len(ok)}")
+    print(f"lex_first_c={coloring}")
+    print(f"N_unread={orbit['n_unread']}")
+    print(f"N_weight4={orbit['n_weight4']}")
+    print(f"N_breaker={orbit['n_breaker']}")
+    print(f"N_box={orbit['n_box']}")
+    print(f"N_commute={n_commute}")
+    print(f"N_commute_over_24={n_commute}/24")
+    print(f"N_commute_eq_24={n_commute == 24}")
+
+    expected_paths = (
+        "docs/UNEQUAL_RADIUS_TICK_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "g-plus-order",
+        len(rotations) == 24
+        and len(set(rotations)) == 24
+        and det3(SWAPPER) == 1
+        and SWAPPER in rotations,
+        f"proper={len(rotations)}",
+    )
+    checks.check(
+        "host-lex-first-breaker",
+        sigma == EXPECTED_SIGMA
+        and ticks == EXPECTED_TICKS
+        and n_stab == 2
+        and n_stab_tick == 1
+        and not in_union(V, SEEDS, RADII)
+        and len(set(RADII)) > 1
+        and "`v = (−3,−3,−1)`" in note
+        and "radii `(2, 1, 3)`" in note
+        and "`σ = (1, 0, 1, 0, 1, 1)`" in note
+        and "`t = (1, ·, 1, ·, 3, 2)`" in note
+        and "|Stab(σ,t)| = 1" in note,
+        f"sigma={sigma} ticks={ticks} stab=({n_stab},{n_stab_tick})",
+    )
+    checks.check(
+        "lex-first-tick-ok",
+        ok == EXPECTED_MEMBERS
+        and coloring == EXPECTED_C
+        and "N_tick_ok = 4" in note
+        and "`c = (1, 0, 2, 0, 1, 2)`" in note,
+        f"c={coloring} N_tick_ok={len(ok)}",
+    )
+    checks.check(
+        "theorem-1-n-commute",
+        n_commute == 24
+        and orbit["n_unread"] == 24
+        and orbit["n_weight4"] == 24
+        and orbit["n_breaker"] == 24
+        and orbit["n_box"] == 24
+        and "N_commute = 24" in note
+        and "N_commute / 24 = 24/24" in note,
+        f"N_commute={n_commute}",
+    )
+    checks.check(
+        "theorem-2-commute-is-24",
+        n_commute == 24
+        and "N_commute = 24" in note
+        and "Whether N_commute = 24" in note
+        and "N_commute = 24 holds" in note,
+        f"eq24={n_commute == 24}",
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write radii into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqrad-deleq",
+        "not leftover of uneqrad" in note_flat
+        and "one star" in note
+        and "deleq" in note
+        and "different map" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "N_commute" not in axiom
+        and "unequal-radius" not in axiom
+        and "tick-ok" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print(
+        "per_element: N_commute is the exact count of the 24 proper cube "
+        "rotations whose image is a weight-4 unread star containing g·c"
+    )
+    print(
+        "per_site: scored only the G+ orbit of the uneqrad lex-first "
+        "unequal-radius breaker at v"
+    )
+    print("per_mode: no spectral calculation; occupancy and lock-ticks only")
+    print("per_block: 3-ball unequal-radius host orbit only; no fourth ball")
+    print(
+        "lattice_wide: checked and not executed — one finite G+ orbit, "
+        "not a lattice-wide rule"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the G+ orbit of the uneqrad lex-first breaker, N_commute=24/24. Every rotation sends the host to a weight-4 unread star whose Stab-ok set contains g·c. Displayed, not adopted. Radii not written into Admissibility. No axiom edit.

## Runner

`scripts/unequal_radius_tick_rule_equivariance_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.