### PR TITLE
feat(uneqrec): M2 Records do not supply lock-ticks

### DIFF
--- a/docs/UNEQUAL_RADIUS_TICK_FROM_NEIGHBOR_RECORD_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNEQUAL_RADIUS_TICK_FROM_NEIGHBOR_RECORD_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,204 @@
+---
+claim_id: unequal_radius_tick_from_neighbor_record_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the lex-first unequal-radius breaker, whether neighbor Records valued in M_2 supply the lock-tick field is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py
+---
+
+# Neighbor Records And The Unequal-Radius Lock-Tick Field (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the uneqrad lex-first unequal-radius breaker
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))` at
+`v = (−3,−3,−1)`. For each occupied neighbor the displayed Record clock is
+the ℓ¹-to-nearest-seed value (L1 formation-count). Whether that 6-star
+content rebuilds the lock-tick field, and whether Record valued in `M_2`
+supplies it, is reported. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py`](../scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment uneqext names the lock-tick field `t` as an extra versus
+occupancy. That extra is not leftover of delloc (product rule) or uneqext
+(extra vs occupancy). The residual here is whether each occupied neighbor's
+Record, whose only displayed clock is the L1 formation-count (equivalently
+ℓ¹-to-nearest-seed), can rebuild `t` at the 6-star only, without naming
+distant seeds or radii.
+
+`U, v` are the uneqrad lex-first breaker. Occupancy `σ` is the 6-bit
+nearest-neighbor indicator of `U` at `v`. On an occupied neighbor `w`,
+
+`t(w) = min_i ‖w − s_i‖_1`.
+
+Empty slots have no clock. Local input at `v` is the 6-tuple of
+`(occupied?, clock-or-none)`.
+
+**Theorem 1.** That 6-tuple equals `(σ,t)` on this star. It is not occupancy
+alone.
+
+**Theorem 2.** Rebuilding `t` from neighbor Records uses the seed-distance
+clocks. Those clocks are not a function of the qubit state on `M_2` at `w`
+(L1 Bloch is an occupancy function). So Record-as-`M_2` does not supply
+`t`. Naming seed-distance as Record content is the same extra.
+
+**Theorem 3.** Displayed, not adopted. Do not write a clock into Record or
+Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+Only records are readable. A readout value is determined by record content
+alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither lock-ticks nor seed-distance clocks as the
+framework's fixed rule. Record locks one admissible local possibility in
+`M_2(C)` and supplies no integer formation-count. The displayed neighbor
+clocks are one rival table, not current Record content. Qubit remains
+`M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "On the uneqrad lex-first star the displayed neighbor-Record 6-tuple equals (σ,t) and is not occupancy alone. The same M_2 lock on every occupied neighbor has one Bloch vector, so Record-as-M_2 does not supply t. Displayed, not adopted."
+trace_class: negative_route_pruning
+target_claim_id: unequal_radius_tick_from_neighbor_record
+target_blocker_text: "whether neighbor Records valued in M_2 supply the lock-tick field on the lex-first unequal-radius breaker"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "independent audit of the 6-tuple identity and the M_2 non-supply on this star; do not write a clock into Record or Admissibility or attach L1"
+conditional_surface_status: "exact on the uneqrad lex-first 6-star; Record-as-M_2 does not supply t; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `B_r(c) = { x ∈ Z^3 : ‖x − c‖_1 ≤ r }`. The host is the uneqrad
+lex-first breaker
+
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))`,
+radii `(2, 1, 3)`,
+`v = (−3,−3,−1)`.
+
+Slots are the six directions
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+A neighbor `w = v + e` is occupied when `w ∈ U`. Occupancy and ticks are
+
+`σ = (1, 0, 1, 0, 1, 1)`,
+`t = (1, ·, 1, ·, 3, 2)`.
+
+So `v ∉ U` and the four occupied neighbors carry mixed clocks `{1, 1, 3, 2}`.
+
+The displayed Record table on the star is: occupied neighbors carry a Record
+whose only displayed clock is `t(w)`; empty neighbors carry no Record and
+cannot be read. The local input is the 6-tuple of `(occupied?, clock-or-none)`
+
+`ρ = ((1, 1), (0, ·), (1, 1), (0, ·), (1, 3), (1, 2))`.
+
+The one-site possibility domain is `M_2(C)`. The displayed lock used to
+test Record-as-`M_2` is the same rank-1 projector
+
+`P = ((1, 0), (0, 0))`
+
+on every occupied neighbor. Its Bloch vector is `(0, 0, 1)`. L1 Bloch is an
+occupancy function: `1` when a Record is present and `0` when the site has
+no Record. That occupancy function is `σ`, not `t`.
+
+## Theorem 1 — the 6-tuple equals `(σ,t)` and is not occupancy alone
+
+Direct ℓ¹ distances on the six neighbors rebuild `σ` and `t` above. The
+displayed Record 6-tuple is obtained by writing `(1, t(w))` on an occupied
+slot and `(0, ·)` on an empty slot. That 6-tuple equals `(σ,t)` on this
+star:
+
+`ρ = ((1, 1), (0, ·), (1, 1), (0, ·), (1, 3), (1, 2))`.
+
+It is not occupancy alone. Occupancy is the bit string
+`σ = (1, 0, 1, 0, 1, 1)`. The four occupied slots are indistinguishable
+under `σ`, while their clocks are `1, 1, 3, 2`. In particular the `+z`
+clock `3` and the `−z` clock `2` differ from the `+x` and `+y` clocks
+`1`. The 6-tuple therefore carries the uneqext extra, not occupancy
+alone.
+
+## Theorem 2 — Record-as-`M_2` does not supply `t`
+
+Rebuilding `t` from neighbor Records uses the seed-distance clocks. Those
+clocks are not a function of the qubit state on `M_2` at `w`.
+
+On this star every occupied neighbor may lock the same `M_2` possibility
+`P`. The four occupied Bloch vectors are then identical, `(0, 0, 1)`,
+while the clocks remain `1, 1, 3, 2`. L1 Bloch is an occupancy function:
+it returns `1` on each occupied neighbor and `0` on each empty neighbor,
+which is exactly `σ`. A function of the `M_2` lock, or of that occupancy
+function, cannot send the same lock to both `1` and `3`.
+
+So Record-as-`M_2` does not supply `t`. Naming seed-distance as Record
+content is the same extra already named by uneqext versus occupancy. The
+delloc product rule is a different map and is not used.
+
+## Theorem 3 — displayed, not adopted
+
+The 6-tuple identity and the `M_2` non-supply are displayed star data.
+They are not the framework's fixed Record or Admissibility content.
+Displayed, not adopted. Do not write a clock into Record or Admissibility.
+Do not attach L1. Occupancy-only formation is not attached. Qubit remains
+`M_2(C)`. No approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the uneqrad lex-first unequal-radius breaker, the
+  displayed neighbor-Record 6-tuple equals `(σ,t)` and is not occupancy
+  alone. The same `M_2` lock on every occupied neighbor has one Bloch
+  vector, so Record-as-`M_2` does not supply `t`.
+- **What is displayed only.** The seed-distance clocks, the 6-tuple, and
+  the chosen projector `P` are one rival table. They are not adopted.
+- **What is not claimed.** No clock written into Record or Admissibility;
+  no attachment of L1; no axiom edit; no formation rate; no lattice-wide
+  dynamics; no leftover of delloc (product rule) or uneqext (extra vs
+  occupancy); no compiler no-go.
+- **Mutation controls.** A rebuilt 6-tuple other than `(σ,t)` fails. A
+  rebuilt mixed-clock witness that collapses to occupancy alone fails. A
+  note that writes a clock into Record or Admissibility, attaches L1, or
+  authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the uneqrad lex-first host, the occupancy,
+the lock-ticks, the displayed neighbor-Record 6-tuple, the common `M_2`
+lock and Bloch occupancy function, the current premise boundary, and the
+mutation controls. It writes no cache and authors no audit verdict.
+It scores the uneqrad star only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18657,6 +18657,10 @@
   "u_integration_reading_blind_and_dictionary_blind_on_corner_transfer_bounded_note_2026-06-12": {
    "deps_hash": "311d6b921eb1",
    "out_degree": 3
+  },
+  "unequal_radius_tick_from_neighbor_record_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unification_basin_failure_note": {
    "deps_hash": "c90c9ba91199",

--- a/logs/runner-cache/unequal_radius_tick_from_neighbor_record_2026_08_15.txt
+++ b/logs/runner-cache/unequal_radius_tick_from_neighbor_record_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py
+runner_sha256: 9f35031f3d8c451d95247a93cdb7e31ed474d90af68935312e50affe84c2c80f
+input_fingerprint_sha256: 90e817aadc75d34cab9652b79d50eb7e06ec912294a7c56584c08cb376d2f86b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+unequal-radius tick from neighbor Record
+AUDIT_INPUT_PATHS:
+  docs/UNEQUAL_RADIUS_TICK_FROM_NEIGHBOR_RECORD_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+seeds=((-2, -2, -2), (-2, -2, -1), (-2, -2, 1))
+radii=(2, 1, 3)
+v=(-3, -3, -1)
+unread=True
+sigma=(1, 0, 1, 0, 1, 1)
+ticks=(1, None, 1, None, 3, 2)
+record_6tuple=((1, 1), (0, None), (1, 1), (0, None), (1, 3), (1, 2))
+equals_sigma_t=True
+occupancy_alone=False
+occupied_clocks=(1, 1, 3, 2)
+common_projector=((1, 0), (0, 0))
+common_bloch=(0, 0, 1)
+l1_bloch_occupancy=(1, 0, 1, 0, 1, 1)
+clocks_not_function_of_M2=True
+Record_as_M2_supplies_t=False
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-record-qubit
+PASS: host-lex-first-breaker | sigma=(1, 0, 1, 0, 1, 1) ticks=(1, None, 1, None, 3, 2)
+PASS: theorem-1-six-tuple-equals-sigma-t | rho=((1, 1), (0, None), (1, 1), (0, None), (1, 3), (1, 2))
+PASS: theorem-1-not-occupancy-alone | occupied_clocks=(1, 1, 3, 2)
+PASS: theorem-2-clocks-not-m2-function | bloch=(0, 0, 1) bloch_occ=(1, 0, 1, 0, 1, 1)
+PASS: theorem-2-record-as-m2-does-not-supply-t
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-delloc-uneqext
+PASS: admissibility-record-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: scored the displayed (occupied?, clock-or-none) 6-tuple against (σ,t) and against one common M_2 lock
+per_site: scored only the uneqrad lex-first star at v
+per_mode: no spectral calculation; occupancy, ticks, and M_2 lock only
+per_block: 3-ball unequal-radius host only; no fourth ball
+lattice_wide: checked and not executed — one finite 6-star, not a lattice-wide rule
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py
+++ b/scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Neighbor-Record clocks versus M_2 on the uneqrad lex-first star.
+
+U, v are the uneqrad lex-first breaker. Occupied neighbors display the
+ℓ¹-to-nearest-seed clock t(w). The 6-tuple of (occupied?, clock-or-none)
+is compared with (σ, t). The same M_2 lock on every occupied neighbor
+shows that Record-as-M_2 does not supply t. Displayed, not adopted.
+No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/UNEQUAL_RADIUS_TICK_FROM_NEIGHBOR_RECORD_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNEQUAL_RADIUS_TICK_FROM_NEIGHBOR_RECORD_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+RecordSlot = tuple[int, int | None]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the lex-first unequal-radius breaker, '
+    "whether neighbor Records valued in M_2 supply the lock-tick field "
+    'is reported. Displayed, not adopted."'
+)
+SEEDS: tuple[Point, Point, Point] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, -2, 1),
+)
+RADII = (2, 1, 3)
+V: Point = (-3, -3, -1)
+EXPECTED_SIGMA: Coloring = (1, 0, 1, 0, 1, 1)
+EXPECTED_TICKS: Tick = (1, None, 1, None, 3, 2)
+EXPECTED_RECORD: tuple[RecordSlot, ...] = (
+    (1, 1),
+    (0, None),
+    (1, 1),
+    (0, None),
+    (1, 3),
+    (1, 2),
+)
+COMMON_PROJECTOR = ((1, 0), (0, 0))
+COMMON_BLOCH = (0, 0, 1)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def in_union(point: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]) -> bool:
+    return any(l1(point, seed) <= radius for seed, radius in zip(seeds, radii))
+
+
+def occupancy_ticks(
+    seeds: tuple[Point, ...], radii: tuple[int, ...], site: Point
+) -> tuple[Coloring, Tick]:
+    sigma: list[int] = []
+    ticks: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if in_union(neighbor, seeds, radii):
+            sigma.append(1)
+            ticks.append(min(l1(neighbor, seed) for seed in seeds))
+        else:
+            sigma.append(0)
+            ticks.append(None)
+    return tuple(sigma), tuple(ticks)
+
+
+def record_tuple(sigma: Coloring, ticks: Tick) -> tuple[RecordSlot, ...]:
+    return tuple((occupied, clock) for occupied, clock in zip(sigma, ticks))
+
+
+def bloch_of_projector(projector: tuple[tuple[int, int], tuple[int, int]]) -> tuple[int, int, int]:
+    a, b = projector[0]
+    c, d = projector[1]
+    # P = (I + r·σ)/2  ⇒  r = (2 Re P_01, 2 Im P_01, P_00 − P_11)
+    return (b + c, 0, a - d)
+
+
+def l1_bloch_occupancy(sigma: Coloring) -> Coloring:
+    # L1 Bloch is an occupancy function: present Record ↦ 1, unread ↦ 0.
+    return tuple(int(bit == 1) for bit in sigma)
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    sigma, ticks = occupancy_ticks(SEEDS, RADII, V)
+    displayed = record_tuple(sigma, ticks)
+    unread = not in_union(V, SEEDS, RADII)
+    occupied_clocks = tuple(clock for bit, clock in zip(sigma, ticks) if bit == 1)
+    bloch = bloch_of_projector(COMMON_PROJECTOR)
+    bloch_occ = l1_bloch_occupancy(sigma)
+    same_m2_on_occupied = len(set(occupied_clocks)) > 1 and bloch == COMMON_BLOCH
+    clocks_not_m2_function = same_m2_on_occupied and bloch_occ == sigma
+    record_as_m2_supplies_t = False if clocks_not_m2_function else None
+    occupancy_alone = displayed == tuple((bit, 1 if bit else None) for bit in sigma)
+
+    print("unequal-radius tick from neighbor Record")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"seeds={SEEDS}")
+    print(f"radii={RADII}")
+    print(f"v={V}")
+    print(f"unread={unread}")
+    print(f"sigma={sigma}")
+    print(f"ticks={ticks}")
+    print(f"record_6tuple={displayed}")
+    print(f"equals_sigma_t={displayed == record_tuple(sigma, ticks)}")
+    print(f"occupancy_alone={occupancy_alone}")
+    print(f"occupied_clocks={occupied_clocks}")
+    print(f"common_projector={COMMON_PROJECTOR}")
+    print(f"common_bloch={bloch}")
+    print(f"l1_bloch_occupancy={bloch_occ}")
+    print(f"clocks_not_function_of_M2={clocks_not_m2_function}")
+    print(f"Record_as_M2_supplies_t={record_as_m2_supplies_t}")
+
+    expected_paths = (
+        "docs/UNEQUAL_RADIUS_TICK_FROM_NEIGHBOR_RECORD_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content"
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-record-qubit",
+        record_lock in axiom
+        and record_lock in note
+        and record_content in axiom
+        and record_content in note
+        and unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "host-lex-first-breaker",
+        unread
+        and sigma == EXPECTED_SIGMA
+        and ticks == EXPECTED_TICKS
+        and len(set(RADII)) > 1
+        and "`v = (−3,−3,−1)`" in note
+        and "radii `(2, 1, 3)`" in note
+        and "`σ = (1, 0, 1, 0, 1, 1)`" in note
+        and "`t = (1, ·, 1, ·, 3, 2)`" in note,
+        f"sigma={sigma} ticks={ticks}",
+    )
+    checks.check(
+        "theorem-1-six-tuple-equals-sigma-t",
+        displayed == EXPECTED_RECORD
+        and displayed == record_tuple(EXPECTED_SIGMA, EXPECTED_TICKS)
+        and "That 6-tuple equals `(σ,t)` on this star" in note
+        and "`ρ = ((1, 1), (0, ·), (1, 1), (0, ·), (1, 3), (1, 2))`" in note,
+        f"rho={displayed}",
+    )
+    checks.check(
+        "theorem-1-not-occupancy-alone",
+        not occupancy_alone
+        and set(occupied_clocks) == {1, 2, 3}
+        and "It is not occupancy alone" in note
+        and "not occupancy alone" in note_flat,
+        f"occupied_clocks={occupied_clocks}",
+    )
+    checks.check(
+        "theorem-2-clocks-not-m2-function",
+        clocks_not_m2_function
+        and bloch == COMMON_BLOCH
+        and bloch_occ == sigma
+        and occupied_clocks == (1, 1, 3, 2)
+        and "Those clocks are not a function of the qubit state on `M_2` at `w`"
+        in note
+        and "L1 Bloch is an occupancy function" in note,
+        f"bloch={bloch} bloch_occ={bloch_occ}",
+    )
+    checks.check(
+        "theorem-2-record-as-m2-does-not-supply-t",
+        record_as_m2_supplies_t is False
+        and "So Record-as-`M_2` does not supply" in note
+        and "Naming seed-distance as Record content is the same extra" in note,
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write a clock into Record or Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-delloc-uneqext",
+        "not leftover of delloc" in note_flat
+        and "product rule" in note
+        and "uneqext" in note
+        and "extra vs occupancy" in note,
+    )
+    checks.check(
+        "admissibility-record-unedited",
+        covariance_clause in axiom_flat
+        and record_lock in axiom
+        and "lock-tick" not in axiom
+        and "seed-distance" not in axiom
+        and "unequal-radius" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print(
+        "per_element: scored the displayed (occupied?, clock-or-none) "
+        "6-tuple against (σ,t) and against one common M_2 lock"
+    )
+    print("per_site: scored only the uneqrad lex-first star at v")
+    print("per_mode: no spectral calculation; occupancy, ticks, and M_2 lock only")
+    print("per_block: 3-ball unequal-radius host only; no fourth ball")
+    print(
+        "lattice_wide: checked and not executed — one finite 6-star, "
+        "not a lattice-wide rule"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the uneqrad star the neighbor-Record 6-tuple is (sigma,t), not occupancy alone. The same M2 lock can sit on every occupied neighbor, so Record-as-M2 does not supply t. Seed-distance as Record content is the same extra. Displayed, not adopted. No axiom edit.

## Runner

`scripts/unequal_radius_tick_from_neighbor_record_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.