### PR TITLE
feat(uneqsrc): displayed L1 neighbor data is not lock-tick

### DIFF
--- a/docs/UNEQUAL_RADIUS_TICK_NOT_L1_NEIGHBOR_DATUM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNEQUAL_RADIUS_TICK_NOT_L1_NEIGHBOR_DATUM_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,208 @@
+---
+claim_id: unequal_radius_tick_not_l1_neighbor_datum_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the lex-first unequal-radius breaker, whether displayed L1 neighbor data equals the lock-tick 4-tuple is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py
+---
+
+# Unequal-Radius Lock-Tick Is Not A Displayed L1 Neighbor Datum (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the uneqrad lex-first unequal-radius breaker
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))` at
+`v = (−3,−3,−1)`. Occupied slots carry
+`t = (1, 1, 3, 2)` on `(+x, +y, +z, −z)`. Whether any displayed L1
+neighbor datum on those four sites equals that 4-tuple is reported.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py`](../scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment uneqrec: `M_2` Record does not supply `t`. That residual is one
+common `M_2` lock on every occupied neighbor. The residual here is not
+leftover of uneqrec (one `M_2` lock). New residual: on this star, none of
+the displayed L1 neighbor data — `n`, Bloch from occupancy, `k`,
+formation-count of the union — equals the 4-tuple `t`. That names the
+extra as not a theorem of displayed L1.
+
+`U`, `v`, and `t` are the uneqrad lex-first breaker. Occupancy `σ` is the
+6-bit nearest-neighbor indicator of `U` at `v`. The four occupied
+neighbors are `+x`, `+y`, `+z`, and `−z`. Comparators are the displayed
+L1 lists at those four sites only.
+
+**Theorem 1.** `t` is not equal to any of those four-site L1 lists.
+
+**Theorem 2.** Therefore `t` is not a theorem of displayed L1 on this
+star.
+
+**Theorem 3.** Displayed, not adopted. Do not write `t` into L1 or
+Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+Only records are readable. A readout value is determined by record content
+alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither lock-ticks nor any displayed L1 neighbor list
+as a supplier of `t`. Lattice names cubic sites and six-neighbor
+adjacency; it does not name the 4-tuple `t`. Record locks one admissible
+local possibility in `M_2(C)` and supplies no integer formation-count of
+a union. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "On the uneqrad lex-first star the occupied lock-tick 4-tuple equals none of the displayed four-site L1 lists (occupancy bits, n from each neighbor six-star, Bloch from occupancy, k, formation-count of U). So t is not a theorem of displayed L1 on this star. Displayed, not adopted."
+trace_class: negative_route_pruning
+target_claim_id: unequal_radius_tick_not_l1_neighbor_datum
+target_blocker_text: "whether displayed L1 neighbor data equals the lock-tick 4-tuple on the lex-first unequal-radius breaker"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "independent audit of the four-site list comparison on this star; do not write t into L1 or Admissibility or attach L1"
+conditional_surface_status: "exact on the uneqrad lex-first 6-star; t equals none of the displayed L1 lists; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `B_r(c) = { x ∈ Z^3 : ‖x − c‖_1 ≤ r }`. The host is the uneqrad
+lex-first breaker
+
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))`,
+radii `(2, 1, 3)`,
+`v = (−3,−3,−1)`.
+
+Slots are the six directions
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+A neighbor `w = v + e` is occupied when `w ∈ U`. Occupancy and ticks are
+
+`σ = (1, 0, 1, 0, 1, 1)`,
+`t = (1, ·, 1, ·, 3, 2)`.
+
+So `v ∉ U` and the four occupied neighbors carry mixed clocks `{1, 1, 3, 2}`.
+The occupied 4-tuple, in slot order `(+x, +y, +z, −z)`, is
+
+`t_occ = (1, 1, 3, 2)`.
+
+The four occupied sites are
+
+`w_{+x} = (−2, −3, −1)`,
+`w_{+y} = (−3, −2, −1)`,
+`w_{+z} = (−3, −3, 0)`,
+`w_{−z} = (−3, −3, −2)`.
+
+Displayed L1 comparators at those four neighbors:
+
+- occupancy bits (all 1): `σ_occ = (1, 1, 1, 1)`;
+- `n_μ` from the six-star of each neighbor if defined, with dipole
+  `d_μ(w) = occ(w + e_μ) − occ(w − e_μ)` and `n(w) = d(w)/3` when
+  defined from that six-star:
+  `n_occ = ((0, 1/3, 0), (1/3, 0, 0), (1/3, 1/3, 1/3), (1/3, 1/3, 0))`;
+- Bloch `I_2/2` (Bloch vector `(0, 0, 0)` at each occupied site) or the
+  occupancy map `(1, 1, 1, 1)`;
+- `k(w)` the occupied-NN count of the six-star at `w`:
+  `k_occ = (3, 3, 3, 2)`;
+- Formation-count of `U` is one integer `|U| = 81`, not a 4-tuple.
+
+These lists are occupancy geometry of `U` on the six-neighbor graph.
+They are not Record content and not an Admissibility rule.
+
+## Theorem 1 — `t` is not equal to any of those four-site L1 lists
+
+Direct comparison on this star:
+
+`t_occ = (1, 1, 3, 2)`,
+
+`σ_occ = (1, 1, 1, 1) ≠ t_occ`,
+
+`n_occ` is a 4-tuple of 3-vectors, not the integer 4-tuple `t_occ`,
+
+Bloch `I_2/2` is four copies of `(0, 0, 0)`, not `t_occ`,
+
+the occupancy map is `(1, 1, 1, 1) ≠ t_occ`,
+
+`k_occ = (3, 3, 3, 2) ≠ t_occ`,
+
+and the formation-count of the union is the single integer `81`, not a
+4-tuple.
+
+So `t` is not equal to any of those four-site L1 lists.
+
+## Theorem 2 — `t` is not a theorem of displayed L1 on this star
+
+The displayed L1 menu on this star is occupancy bits, `n` from each
+neighbor six-star, Bloch from occupancy, `k`, and the formation-count of
+`U`. Theorem 1 says none of those objects equals `t_occ`. Therefore `t`
+is not a theorem of displayed L1 on this star.
+
+This is not leftover of uneqrec (one `M_2` lock). uneqrec showed that the
+same `M_2` projector on every occupied neighbor cannot send one Bloch
+vector to both `1` and `3`. The present comparison does not use that
+lock. It uses only the named L1 neighbor lists.
+
+## Theorem 3 — displayed, not adopted
+
+The four-site comparison is displayed star data. It is not the
+framework's fixed Lattice, Record, or Admissibility content.
+Displayed, not adopted. Do not write `t` into L1 or Admissibility.
+Do not attach L1. Occupancy-only formation is not attached. Qubit remains
+`M_2(C)`. No approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the uneqrad lex-first unequal-radius breaker,
+  the occupied lock-tick 4-tuple equals none of the displayed four-site
+  L1 lists. Therefore `t` is not a theorem of displayed L1 on this star.
+- **What is displayed only.** The lists `σ_occ`, `n_occ`, Bloch from
+  occupancy, `k_occ`, and `|U|` are one rival table. They are not
+  adopted.
+- **What is not claimed.** No writing of `t` into L1 or Admissibility;
+  no attachment of L1; no axiom edit; no formation rate; no lattice-wide
+  dynamics; no leftover of uneqrec (one `M_2` lock); no compiler no-go.
+- **Mutation controls.** A rebuilt `t_occ` other than `(1, 1, 3, 2)`
+  fails. A rebuilt list among occupancy, `n`, Bloch, `k`, or
+  formation-count that equals `t_occ` fails. A note that writes `t` into
+  L1 or Admissibility, attaches L1, or authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the uneqrad lex-first host, the occupancy,
+the lock-ticks, the four-site L1 lists, the current premise boundary,
+and the mutation controls. It writes no cache and authors no audit
+verdict. It scores the uneqrad star only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18657,6 +18657,10 @@
   "u_integration_reading_blind_and_dictionary_blind_on_corner_transfer_bounded_note_2026-06-12": {
    "deps_hash": "311d6b921eb1",
    "out_degree": 3
+  },
+  "unequal_radius_tick_not_l1_neighbor_datum_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unification_basin_failure_note": {
    "deps_hash": "c90c9ba91199",

--- a/logs/runner-cache/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.txt
+++ b/logs/runner-cache/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py
+runner_sha256: 737af173afdd5fc62c82afb5d68d75fbe9eb89207d3f324e7f62c22f4297ce63
+input_fingerprint_sha256: 5e479c41ec4e92f1606bd860cfd5d87616c007a462e293eaf6ee60a6b2fbc7ad
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+unequal-radius tick not L1 neighbor datum
+AUDIT_INPUT_PATHS:
+  docs/UNEQUAL_RADIUS_TICK_NOT_L1_NEIGHBOR_DATUM_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+seeds=((-2, -2, -2), (-2, -2, -1), (-2, -2, 1))
+radii=(2, 1, 3)
+v=(-3, -3, -1)
+unread=True
+sigma=(1, 0, 1, 0, 1, 1)
+ticks=(1, None, 1, None, 3, 2)
+occupied_sites=((-2, -3, -1), (-3, -2, -1), (-3, -3, 0), (-3, -3, -2))
+t_occ=(1, 1, 3, 2)
+sigma_occ=(1, 1, 1, 1)
+n_dipole=((0, 1, 0), (1, 0, 0), (1, 1, 1), (1, 1, 0))
+n_frac=(((0, 1), (1, 3), (0, 1)), ((1, 3), (0, 1), (0, 1)), ((1, 3), (1, 3), (1, 3)), ((1, 3), (1, 3), (0, 1)))
+k_occ=(3, 3, 3, 2)
+bloch_I2_over_2=((0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0))
+bloch_occupancy_map=(1, 1, 1, 1)
+formation_count=81
+any_displayed_list_equals_t=False
+t_is_theorem_of_displayed_L1=False
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-record-qubit
+PASS: host-lex-first-breaker | sigma=(1, 0, 1, 0, 1, 1) ticks=(1, None, 1, None, 3, 2)
+PASS: theorem-1-t-not-occupancy-bits | sigma_occ=(1, 1, 1, 1)
+PASS: theorem-1-t-not-n-from-six-star | n_dipole=((0, 1, 0), (1, 0, 0), (1, 1, 1), (1, 1, 0))
+PASS: theorem-1-t-not-bloch-from-occupancy | bloch_i2=((0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0)) bloch_occ_map=(1, 1, 1, 1)
+PASS: theorem-1-t-not-k | k_occ=(3, 3, 3, 2)
+PASS: theorem-1-t-not-formation-count | formation_count=81
+PASS: theorem-1-t-not-equal-any-four-site-l1-list
+PASS: theorem-2-not-theorem-of-displayed-l1
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqrec
+PASS: admissibility-record-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: scored occupancy bits, n, Bloch from occupancy, k, and formation-count against t_occ
+per_site: scored only the uneqrad lex-first star at v
+per_mode: no spectral calculation; displayed L1 lists only
+per_block: 3-ball unequal-radius host only; no fourth ball
+lattice_wide: checked and not executed — one finite 6-star, not a lattice-wide rule
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py
+++ b/scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Displayed L1 neighbor data versus t on the uneqrad lex-first star.
+
+U, v, t are the uneqrad lex-first breaker. Occupied slots carry
+t=(1,1,3,2) on (+x,+y,+z,-z). Occupancy bits, n from each neighbor
+six-star, Bloch from occupancy, k, and the formation-count of U are
+compared with that 4-tuple. None equals t, so t is not a theorem of
+displayed L1 on this star. Displayed, not adopted.
+No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/UNEQUAL_RADIUS_TICK_NOT_L1_NEIGHBOR_DATUM_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNEQUAL_RADIUS_TICK_NOT_L1_NEIGHBOR_DATUM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Vec3 = tuple[int, int, int]
+Frac3 = tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (0, 1, 0),
+    (0, 0, 1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the lex-first unequal-radius breaker, '
+    "whether displayed L1 neighbor data equals the lock-tick 4-tuple "
+    'is reported. Displayed, not adopted."'
+)
+SEEDS: tuple[Point, Point, Point] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, -2, 1),
+)
+RADII = (2, 1, 3)
+V: Point = (-3, -3, -1)
+EXPECTED_SIGMA: Coloring = (1, 0, 1, 0, 1, 1)
+EXPECTED_TICKS: Tick = (1, None, 1, None, 3, 2)
+EXPECTED_T_OCC: tuple[int, ...] = (1, 1, 3, 2)
+EXPECTED_SIGMA_OCC: tuple[int, ...] = (1, 1, 1, 1)
+EXPECTED_K_OCC: tuple[int, ...] = (3, 3, 3, 2)
+EXPECTED_N_DIPOLE: tuple[Vec3, ...] = (
+    (0, 1, 0),
+    (1, 0, 0),
+    (1, 1, 1),
+    (1, 1, 0),
+)
+EXPECTED_N_FRAC: tuple[Frac3, ...] = (
+    ((0, 1), (1, 3), (0, 1)),
+    ((1, 3), (0, 1), (0, 1)),
+    ((1, 3), (1, 3), (1, 3)),
+    ((1, 3), (1, 3), (0, 1)),
+)
+EXPECTED_FORMATION_COUNT = 81
+I2_OVER_2_BLOCH = (0, 0, 0)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def in_union(point: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]) -> bool:
+    return any(l1(point, seed) <= radius for seed, radius in zip(seeds, radii))
+
+
+def occupancy_ticks(
+    seeds: tuple[Point, ...], radii: tuple[int, ...], site: Point
+) -> tuple[Coloring, Tick]:
+    sigma: list[int] = []
+    ticks: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if in_union(neighbor, seeds, radii):
+            sigma.append(1)
+            ticks.append(min(l1(neighbor, seed) for seed in seeds))
+        else:
+            sigma.append(0)
+            ticks.append(None)
+    return tuple(sigma), tuple(ticks)
+
+
+def occupied_tuple(values: tuple[object, ...], sigma: Coloring) -> tuple[object, ...]:
+    return tuple(value for bit, value in zip(sigma, values) if bit == 1)
+
+
+def six_star_occupancy(
+    site: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]
+) -> Coloring:
+    return tuple(int(in_union(add(site, direction), seeds, radii)) for direction in DIRS)
+
+
+def dipole(star: Coloring) -> Vec3:
+    return (
+        star[0] - star[1],
+        star[2] - star[3],
+        star[4] - star[5],
+    )
+
+
+def n_from_dipole(dip: Vec3) -> Frac3:
+    return tuple((component, 3) if component != 0 else (0, 1) for component in dip)
+
+
+def formation_count(seeds: tuple[Point, ...], radii: tuple[int, ...]) -> int:
+    seen: set[Point] = set()
+    for seed, radius in zip(seeds, radii):
+        span = range(-radius, radius + 1)
+        for dx in span:
+            for dy in span:
+                for dz in span:
+                    point = add(seed, (dx, dy, dz))
+                    if l1(point, seed) <= radius:
+                        seen.add(point)
+    return len(seen)
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    sigma, ticks = occupancy_ticks(SEEDS, RADII, V)
+    unread = not in_union(V, SEEDS, RADII)
+    occupied_sites = tuple(
+        add(V, DIRS[index]) for index, bit in enumerate(sigma) if bit == 1
+    )
+    t_occ = tuple(clock for clock in occupied_tuple(ticks, sigma))
+    sigma_occ = tuple(1 for _ in occupied_sites)
+    stars = tuple(six_star_occupancy(site, SEEDS, RADII) for site in occupied_sites)
+    k_occ = tuple(sum(star) for star in stars)
+    dipoles = tuple(dipole(star) for star in stars)
+    n_frac = tuple(n_from_dipole(dip) for dip in dipoles)
+    bloch_i2 = tuple(I2_OVER_2_BLOCH for _ in occupied_sites)
+    bloch_occ_map = sigma_occ
+    union_count = formation_count(SEEDS, RADII)
+    n_equals_t = n_frac == t_occ
+    lists_equal_t = any(
+        candidate == t_occ
+        for candidate in (sigma_occ, k_occ, bloch_occ_map, bloch_i2, union_count)
+    ) or n_equals_t
+    t_is_displayed_l1_theorem = lists_equal_t
+
+    print("unequal-radius tick not L1 neighbor datum")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"seeds={SEEDS}")
+    print(f"radii={RADII}")
+    print(f"v={V}")
+    print(f"unread={unread}")
+    print(f"sigma={sigma}")
+    print(f"ticks={ticks}")
+    print(f"occupied_sites={occupied_sites}")
+    print(f"t_occ={t_occ}")
+    print(f"sigma_occ={sigma_occ}")
+    print(f"n_dipole={dipoles}")
+    print(f"n_frac={n_frac}")
+    print(f"k_occ={k_occ}")
+    print(f"bloch_I2_over_2={bloch_i2}")
+    print(f"bloch_occupancy_map={bloch_occ_map}")
+    print(f"formation_count={union_count}")
+    print(f"any_displayed_list_equals_t={lists_equal_t}")
+    print(f"t_is_theorem_of_displayed_L1={t_is_displayed_l1_theorem}")
+
+    expected_paths = (
+        "docs/UNEQUAL_RADIUS_TICK_NOT_L1_NEIGHBOR_DATUM_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content"
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-record-qubit",
+        record_lock in axiom
+        and record_lock in note
+        and record_content in axiom
+        and record_content in note
+        and unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "host-lex-first-breaker",
+        unread
+        and sigma == EXPECTED_SIGMA
+        and ticks == EXPECTED_TICKS
+        and occupied_sites
+        == ((-2, -3, -1), (-3, -2, -1), (-3, -3, 0), (-3, -3, -2))
+        and len(set(RADII)) > 1
+        and "`v = (−3,−3,−1)`" in note
+        and "radii `(2, 1, 3)`" in note
+        and "`σ = (1, 0, 1, 0, 1, 1)`" in note
+        and "`t = (1, ·, 1, ·, 3, 2)`" in note
+        and "`t_occ = (1, 1, 3, 2)`" in note,
+        f"sigma={sigma} ticks={ticks}",
+    )
+    checks.check(
+        "theorem-1-t-not-occupancy-bits",
+        t_occ == EXPECTED_T_OCC
+        and sigma_occ == EXPECTED_SIGMA_OCC
+        and sigma_occ != t_occ
+        and "`σ_occ = (1, 1, 1, 1)`" in note
+        and "occupancy bits (all 1)" in note,
+        f"sigma_occ={sigma_occ}",
+    )
+    checks.check(
+        "theorem-1-t-not-n-from-six-star",
+        dipoles == EXPECTED_N_DIPOLE
+        and n_frac == EXPECTED_N_FRAC
+        and n_frac != t_occ
+        and not n_equals_t
+        and "`n_occ = ((0, 1/3, 0), (1/3, 0, 0), (1/3, 1/3, 1/3), (1/3, 1/3, 0))`"
+        in note
+        and "n_μ from the six-star of each neighbor" in note_flat.replace("`", ""),
+        f"n_dipole={dipoles}",
+    )
+    checks.check(
+        "theorem-1-t-not-bloch-from-occupancy",
+        bloch_i2 == (I2_OVER_2_BLOCH,) * 4
+        and bloch_occ_map == EXPECTED_SIGMA_OCC
+        and bloch_i2 != t_occ
+        and bloch_occ_map != t_occ
+        and "Bloch `I_2/2`" in note
+        and "occupancy map `(1, 1, 1, 1)`" in note,
+        f"bloch_i2={bloch_i2} bloch_occ_map={bloch_occ_map}",
+    )
+    checks.check(
+        "theorem-1-t-not-k",
+        k_occ == EXPECTED_K_OCC
+        and k_occ != t_occ
+        and "`k_occ = (3, 3, 3, 2)`" in note,
+        f"k_occ={k_occ}",
+    )
+    checks.check(
+        "theorem-1-t-not-formation-count",
+        union_count == EXPECTED_FORMATION_COUNT
+        and union_count != t_occ
+        and not isinstance(union_count, tuple)
+        and "`|U| = 81`" in note
+        and "Formation-count of `U` is one integer" in note,
+        f"formation_count={union_count}",
+    )
+    checks.check(
+        "theorem-1-t-not-equal-any-four-site-l1-list",
+        not lists_equal_t
+        and "t` is not equal to any of those four-site L1 lists" in note,
+    )
+    checks.check(
+        "theorem-2-not-theorem-of-displayed-l1",
+        t_is_displayed_l1_theorem is False
+        and "Therefore `t` is not a theorem of displayed L1 on this" in note
+        and "not a theorem of displayed L1" in note_flat,
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write `t` into L1 or Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqrec",
+        "not leftover of uneqrec" in note_flat
+        and "one `M_2` lock" in note
+        and "uneqrec" in note,
+    )
+    checks.check(
+        "admissibility-record-unedited",
+        covariance_clause in axiom_flat
+        and record_lock in axiom
+        and "lock-tick" not in axiom
+        and "unequal-radius" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print(
+        "per_element: scored occupancy bits, n, Bloch from occupancy, "
+        "k, and formation-count against t_occ"
+    )
+    print("per_site: scored only the uneqrad lex-first star at v")
+    print("per_mode: no spectral calculation; displayed L1 lists only")
+    print("per_block: 3-ball unequal-radius host only; no fourth ball")
+    print(
+        "lattice_wide: checked and not executed — one finite 6-star, "
+        "not a lattice-wide rule"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the uneqrad star t_occ=(1,1,3,2). Occupancy bits, n, Bloch, k=(3,3,3,2), and |U|=81 all differ from t. t is not a theorem of displayed L1. Displayed, not adopted. No axiom edit.

## Runner

`scripts/unequal_radius_tick_not_l1_neighbor_datum_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.