### PR TITLE
feat(uneqbit): one opposite-pair tick bit shrinks Stab; N_bit_ok=4

### DIFF
--- a/docs/UNEQUAL_RADIUS_ONE_BIT_TICK_STAB_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNEQUAL_RADIUS_ONE_BIT_TICK_STAB_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,212 @@
+---
+claim_id: unequal_radius_one_bit_tick_stab_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the lex-first unequal-radius breaker, whether the single comparison t(−z)<t(+z) shrinks Stab is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py
+---
+
+# One Opposite-Pair Tick Bit Versus Occupancy Stab (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the uneqrad lex-first unequal-radius breaker
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))` at
+`v = (−3,−3,−1)`. Occupancy `σ` is the 6-NN indicator. The lock-tick
+field is `t(w) = min_i ‖w − s_i‖_1` on occupied neighbors. The scored
+datum is the single opposite-pair bit `b = [t(−z) < t(+z)]`. Score this
+star only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py`](../scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment uneqord: the full older/newer order shrinks `Stab` to 1. That
+extra is the full pairwise order. The residual here is not leftover of
+uneqord (full order). New residual: the occupancy swapper only reverses
+`−z ≺ +z`. Does the single bit `b = [t(−z) < t(+z)]` already give
+`|Stab(σ,b)| = 1` and `N_bit_ok = 4`?
+
+`U, v, σ, t` are the uneqrad lex-first breaker.
+
+**Theorem 1.** `b = 1`. `|Stab(σ)| = 2`, `|Stab(σ,b)| = 1`. The
+occupancy swapper is excluded.
+
+**Theorem 2.** `N_bit_ok = 4`. The four July-3 pair members with this
+support are all `Stab(σ,b)`-invariant because `|Stab(σ,b)| = 1`, so
+`N_bit_ok = N_ord_ok = 4`.
+
+**Theorem 3.** Displayed, not adopted. Do not write b into Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither `Stab(σ,b)` nor the opposite-pair bit
+`b = [t(−z) < t(+z)]`, nor the full pairwise order, as the framework's
+fixed rule. The covariance clause is the reason a local labeling on the
+orbit of `(σ, b)` must be stabilizer-invariant. Formation site and rate
+remain outside the axiom memo. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact comparison on the uneqrad lex-first star: the opposite-pair bit b, |Stab(σ)|, |Stab(σ,b)|, swapper exclusion, and N_bit_ok versus N_ord_ok=4 are exact. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: unequal_radius_one_bit_tick_stab
+target_blocker_text: "on the lex-first unequal-radius breaker, whether the single comparison t(−z)<t(+z) shrinks Stab"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of b, |Stab(σ)|, |Stab(σ,b)|, swapper exclusion, and N_bit_ok; do not write b into Admissibility or attach L1"
+conditional_surface_status: "exact on the uneqrad lex-first star; b=1; |Stab(σ)|=2; |Stab(σ,b)|=1; occupancy swapper excluded; N_bit_ok=4; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `B_r(c) = { x ∈ Z^3 : ‖x − c‖_1 ≤ r }`. The uneqrad lex-first
+breaker is
+
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))`,
+radii `(2, 1, 3)`,
+`v = (−3,−3,−1)`.
+
+Occupancy `σ` is the 6-bit nearest-neighbor indicator of `U` at `v`, in
+slot order
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+On an occupied neighbor `w`,
+
+`t(w) = min_i ‖w − s_i‖_1`.
+
+Empty slots have no tick. Direct distances give `v ∉ U`,
+
+`σ = (1, 0, 1, 0, 1, 1)`,
+`t = (1, ·, 1, ·, 3, 2)`.
+
+`G+` is the 24 proper cube rotations acting on the six slots.
+
+`Stab(σ) = { g in G+ : g · σ = σ }`,
+
+`b = 1` if `t(−z) < t(+z)`, else `0`.
+
+`Stab(σ,b) = { g in G+ : g · σ = σ and b(g · t) = b(t) }`.
+
+This keeps only the opposite-pair comparison `t(−z) < t(+z)`. It drops
+the remaining older/newer pairs and the integer distances. Score the
+uneqrad star only.
+
+## Theorem 1 — report `b`, the two stabilizer orders, and the swapper
+
+Occupied neighbors and ticks:
+
+- `+x = (−2,−3,−1)` has `t = 1`,
+- `+y = (−3,−2,−1)` has `t = 1`,
+- `+z = (−3,−3,0)` has `t = 3`,
+- `−z = (−3,−3,−2)` has `t = 2`.
+
+Hence `t(−z) = 2 < 3 = t(+z)`, so `b = 1`.
+
+The occupancy stabilizer is `{id, s}` with
+
+`s : (x, y, z) ↦ (y, x, −z)`,
+
+which swaps `+x ↔ +y` and `+z ↔ −z`. That map preserves `σ`. It sends
+`t(+z) = 3` to `t(−z) = 2` and `t(−z) = 2` to `t(+z) = 3`, so the image
+field has `t'(−z) = 3 > 2 = t'(+z)` and `b(s · t) = 0 ≠ b(t)`. The
+occupancy swapper only reverses `−z ≺ +z`; the single bit already
+detects that reversal. Therefore the occupancy swapper is excluded, and
+
+`|Stab(σ)| = 2`, `|Stab(σ,b)| = 1`.
+
+The single opposite-pair comparison, without the full order, already
+shrinks occupancy `Stab` on this star.
+
+## Theorem 2 — `N_bit_ok` versus `N_ord_ok = 4`
+
+July-3 pair members are the 6-slot 3-letter colorings whose `G+` orbit
+is sent to a different orbit by spatial inversion. Restricting to
+support `σ` gives four members
+
+`(1, 0, 2, 0, 1, 2)`, `(1, 0, 2, 0, 2, 1)`,
+`(2, 0, 1, 0, 1, 2)`, `(2, 0, 1, 0, 2, 1)`,
+
+so `N_pair_support = 4`. Because `|Stab(σ,b)| = 1`, every such member is
+invariant under `Stab(σ,b)`. Hence
+
+`N_bit_ok = 4`.
+
+On this star `N_ord_ok = 4` for the same four members under
+`Stab(σ,≺)`. The thinner extra still leaves `N_bit_ok = N_ord_ok = 4`.
+
+## Theorem 3 — displayed, not adopted
+
+The displayed bit, the two stabilizer orders, swapper exclusion,
+`N_bit_ok = 4`, and `N_ord_ok = 4` are displayed member data. They are
+not the framework's fixed Admissibility rule. This note does not write
+b into Admissibility. Do not write b into Admissibility. Do not attach
+L1. Occupancy-only formation is not attached. Qubit remains `M_2(C)`.
+No approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the uneqrad lex-first unequal-radius breaker,
+  `b = 1`. `|Stab(σ)| = 2`, `|Stab(σ,b)| = 1`. The occupancy swapper is
+  excluded. `N_bit_ok = 4`, equal to `N_ord_ok = 4`.
+- **What is displayed only.** The opposite-pair bit and the two
+  stabilizers are one rival table. They are not adopted.
+- **What is not claimed.** No attachment of `b`, radii, integer `t`, or
+  the full order to Admissibility; no attachment of occupancy-only
+  formation; no axiom edit; no formation rate; no lattice-wide
+  dynamics; no leftover of uneqord (full order); no compiler no-go.
+- **Mutation controls.** A rebuilt `b ≠ 1` fails. A rebuilt
+  `|Stab(σ)| ≠ 2` or `|Stab(σ,b)| ≠ 1` fails. A rebuilt occupancy
+  swapper that preserves `b` fails. A rebuilt `N_bit_ok ≠ 4` fails. A
+  note that writes b into Admissibility, attaches L1, or authors an
+  audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the uneqrad lex-first host, the occupancy,
+the integer ticks, the opposite-pair bit, the 24 proper cube rotations,
+`Stab(σ)`, `Stab(σ,b)`, occupancy-swapper exclusion, `N_bit_ok` against
+`N_ord_ok = 4`, the current premise boundary, and the mutation
+controls. It scores the uneqrad star only. It writes no cache and
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18657,6 +18657,10 @@
   "u_integration_reading_blind_and_dictionary_blind_on_corner_transfer_bounded_note_2026-06-12": {
    "deps_hash": "311d6b921eb1",
    "out_degree": 3
+  },
+  "unequal_radius_one_bit_tick_stab_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unification_basin_failure_note": {
    "deps_hash": "c90c9ba91199",

--- a/logs/runner-cache/unequal_radius_one_bit_tick_stab_2026_08_15.txt
+++ b/logs/runner-cache/unequal_radius_one_bit_tick_stab_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py
+runner_sha256: 8911e0d67548623bfb2905304c6a5612bd4b32008e9792bd6337cb0d6af66f98
+input_fingerprint_sha256: f932693b17d11caf948dea414a33fa03597dc6381397831f53d6213929368532
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+unequal-radius one-bit lock-tick occupancy Stab
+AUDIT_INPUT_PATHS:
+  docs/UNEQUAL_RADIUS_ONE_BIT_TICK_STAB_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+G_plus=24
+uneq_unread=True
+uneq_sigma=(1, 0, 1, 0, 1, 1)
+uneq_ticks=(1, None, 1, None, 3, 2)
+b=1
+|Stab(sigma)|=2
+|Stab(sigma,t)|=1
+|Stab(sigma,b)|=1
+swapper_excluded=True
+first_breaker=(((-2, -2, -2), (-2, -2, -1), (-2, -2, 1)), (2, 1, 3), (-3, -3, -1))
+N_pair=48
+N_pair_support=4
+N_bit_ok=4
+N_ord_ok=4
+support_members=(1, 0, 2, 0, 1, 2),(1, 0, 2, 0, 2, 1),(2, 0, 1, 0, 1, 2),(2, 0, 1, 0, 2, 1)
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: g-plus-order | proper=24
+PASS: theorem-1-lex-first-breaker | sigma=(1, 0, 1, 0, 1, 1) ticks=(1, None, 1, None, 3, 2)
+PASS: theorem-1-bit | b=1
+PASS: theorem-1-stab-orders | stab=2 bit=1
+PASS: theorem-1-swapper-excluded | swap_bit=0
+PASS: theorem-2-bit-ok | N_bit_ok=4 N_ord_ok=4
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqord
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: |Stab(σ)|, |Stab(σ,b)|, b, N_bit_ok are exact integers
+per_site: uneqrad lex-first unequal-radius breaker only
+per_mode: no spectral calculation
+per_block: 3-ball star only
+lattice_wide: checked and not executed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py
+++ b/scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Opposite-pair lock-tick bit versus occupancy Stab.
+
+U, v, σ, t are the uneqrad lex-first breaker. The scored datum is the
+single bit b = [t(−z) < t(+z)]. Report b, |Stab(σ)|, |Stab(σ,b)|,
+whether the occupancy swapper is excluded, and N_bit_ok versus
+N_ord_ok=4. Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from array import array
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/UNEQUAL_RADIUS_ONE_BIT_TICK_STAB_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNEQUAL_RADIUS_ONE_BIT_TICK_STAB_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+Order = frozenset[tuple[int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+SLOT_PLUS_Z = 4
+SLOT_MINUS_Z = 5
+EMPTY = 0
+SHIFT = 5
+STRIDE = 11
+GRID = STRIDE * STRIDE * STRIDE
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the lex-first unequal-radius breaker, whether the '
+    "single comparison t(−z)<t(+z) shrinks Stab is reported. Displayed, "
+    'not adopted."'
+)
+UNEQ_SEEDS: tuple[Point, Point, Point] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, -2, 1),
+)
+UNEQ_RADII = (2, 1, 3)
+UNEQ_V: Point = (-3, -3, -1)
+EXPECTED_SIGMA: Coloring = (1, 0, 1, 0, 1, 1)
+EXPECTED_TICKS: Tick = (1, None, 1, None, 3, 2)
+EXPECTED_BIT = 1
+SWAPPER: Matrix = ((0, 1, 0), (1, 0, 0), (0, 0, -1))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: Point, radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        if abs(offset[0]) + abs(offset[1]) + abs(offset[2]) <= radius:
+            sites.append(add(center, offset))
+    return tuple(sites)
+
+
+def enc(point: Point) -> int:
+    return (point[0] + SHIFT) + STRIDE * (
+        (point[1] + SHIFT) + STRIDE * (point[2] + SHIFT)
+    )
+
+
+def in_union(point: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]) -> bool:
+    return any(l1(point, seed) <= radius for seed, radius in zip(seeds, radii))
+
+
+def sigma_ticks(
+    site: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]
+) -> tuple[Coloring, Tick]:
+    occupied = {
+        add(seed, offset)
+        for seed, radius in zip(seeds, radii)
+        for offset in ball((0, 0, 0), radius)
+    }
+    sigma_bits: list[int] = []
+    ticks_bits: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if neighbor in occupied:
+            sigma_bits.append(1)
+            ticks_bits.append(min(l1(neighbor, seed) for seed in seeds))
+        else:
+            sigma_bits.append(0)
+            ticks_bits.append(None)
+    return tuple(sigma_bits), tuple(ticks_bits)
+
+
+def bit_from_ticks(ticks: Tick) -> int:
+    minus_z = ticks[SLOT_MINUS_Z]
+    plus_z = ticks[SLOT_PLUS_Z]
+    if minus_z is not None and plus_z is not None and minus_z < plus_z:
+        return 1
+    return 0
+
+
+def order_from_ticks(ticks: Tick) -> Order:
+    pairs: list[tuple[int, int]] = []
+    occupied = [index for index, tick in enumerate(ticks) if tick is not None]
+    for left, right in itertools.permutations(occupied, 2):
+        left_tick = ticks[left]
+        right_tick = ticks[right]
+        if left_tick is not None and right_tick is not None and left_tick < right_tick:
+            pairs.append((left, right))
+    return frozenset(pairs)
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: Point) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | Tick) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def preserves_order(perm: tuple[int, ...], order: Order) -> bool:
+    mapped = frozenset((perm[left], perm[right]) for left, right in order)
+    return mapped == order
+
+
+def stab_orders(
+    sigma: Coloring, ticks: Tick, perms: list[tuple[int, ...]]
+) -> tuple[int, int, int]:
+    bit = bit_from_ticks(ticks)
+    n_stab = 0
+    n_stab_tick = 0
+    n_stab_bit = 0
+    for perm in perms:
+        if act_col(perm, sigma) != sigma:
+            continue
+        n_stab += 1
+        image_ticks = act_col(perm, ticks)
+        if image_ticks == ticks:
+            n_stab_tick += 1
+        if bit_from_ticks(image_ticks) == bit:
+            n_stab_bit += 1
+    return n_stab, n_stab_tick, n_stab_bit
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def july3_pair(perms: list[tuple[int, ...]]) -> frozenset[Coloring]:
+    unseen = set(itertools.product(range(3), repeat=6))
+    inversion = direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+    pair: set[Coloring] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(letter != EMPTY) for letter in coloring)
+
+
+def n_ok(
+    sigma: Coloring,
+    perms: list[tuple[int, ...]],
+    pair: frozenset[Coloring],
+    stab_filter,
+) -> tuple[int, int, tuple[Coloring, ...]]:
+    stab_perms = [perm for perm in perms if stab_filter(perm)]
+    members = tuple(sorted(item for item in pair if support(item) == sigma))
+    ok = tuple(
+        item
+        for item in members
+        if all(act_col(perm, item) == item for perm in stab_perms)
+    )
+    return len(members), len(ok), members
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def first_breaker(perms: list[tuple[int, ...]]) -> tuple | None:
+    seed_box = tuple(itertools.product(range(-2, 3), repeat=3))
+    v_box = tuple(itertools.product(range(-4, 5), repeat=3))
+    radii_opts = tuple(
+        radii
+        for radii in itertools.product((1, 2, 3), repeat=3)
+        if not (radii[0] == radii[1] == radii[2])
+    )
+    ball_enc = {
+        (seed, radius): tuple(enc(site) for site in ball(seed, radius))
+        for seed in seed_box
+        for radius in (1, 2, 3)
+    }
+    v_enc = tuple(enc(site) for site in v_box)
+    neighbor_enc = tuple(
+        tuple(enc(add(site, direction)) for direction in DIRS) for site in v_box
+    )
+    neighbor_pts = tuple(
+        tuple(add(site, direction) for direction in DIRS) for site in v_box
+    )
+    mark = array("I", [0]) * GRID
+    generation = 0
+    for s1, s2, s3 in itertools.combinations(seed_box, 3):
+        seeds = (s1, s2, s3)
+        for radii in radii_opts:
+            generation += 1
+            for seed, radius in zip(seeds, radii):
+                for index in ball_enc[(seed, radius)]:
+                    mark[index] = generation
+            for v_index, site in enumerate(v_box):
+                if mark[v_enc[v_index]] == generation:
+                    continue
+                sigma_bits: list[int] = []
+                ticks_bits: list[int | None] = []
+                occupied_ticks: list[int] = []
+                for slot, w_enc in enumerate(neighbor_enc[v_index]):
+                    if mark[w_enc] == generation:
+                        sigma_bits.append(1)
+                        tick = min(
+                            l1(neighbor_pts[v_index][slot], seed) for seed in seeds
+                        )
+                        ticks_bits.append(tick)
+                        occupied_ticks.append(tick)
+                    else:
+                        sigma_bits.append(0)
+                        ticks_bits.append(None)
+                if len(occupied_ticks) != 4:
+                    continue
+                sigma = tuple(sigma_bits)
+                ticks = tuple(ticks_bits)
+                n_stab, n_stab_tick, _n_stab_bit = stab_orders(sigma, ticks, perms)
+                if n_stab_tick < n_stab:
+                    return (seeds, radii, site, sigma, ticks, n_stab, n_stab_tick)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    rotations = proper_rotations()
+    perms = [direction_perm(matrix) for matrix in rotations]
+
+    uneq_unread = not in_union(UNEQ_V, UNEQ_SEEDS, UNEQ_RADII)
+    uneq_sigma, uneq_ticks = sigma_ticks(UNEQ_V, UNEQ_SEEDS, UNEQ_RADII)
+    bit = bit_from_ticks(uneq_ticks)
+    order = order_from_ticks(uneq_ticks)
+    n_stab, n_stab_tick, n_stab_bit = stab_orders(uneq_sigma, uneq_ticks, perms)
+    breaker = first_breaker(perms)
+    pair = july3_pair(perms)
+    n_pair_support, n_bit_ok, members = n_ok(
+        uneq_sigma,
+        perms,
+        pair,
+        lambda perm: act_col(perm, uneq_sigma) == uneq_sigma
+        and bit_from_ticks(act_col(perm, uneq_ticks)) == bit,
+    )
+    _n_pair_ord, n_ord_ok, _ord_members = n_ok(
+        uneq_sigma,
+        perms,
+        pair,
+        lambda perm: act_col(perm, uneq_sigma) == uneq_sigma
+        and preserves_order(perm, order),
+    )
+    swap_perm = direction_perm(SWAPPER)
+    swap_ticks = act_col(swap_perm, uneq_ticks)
+    swap_bit = bit_from_ticks(swap_ticks)
+
+    print("unequal-radius one-bit lock-tick occupancy Stab")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"G_plus={len(rotations)}")
+    print(f"uneq_unread={uneq_unread}")
+    print(f"uneq_sigma={uneq_sigma}")
+    print(f"uneq_ticks={uneq_ticks}")
+    print(f"b={bit}")
+    print(f"|Stab(sigma)|={n_stab}")
+    print(f"|Stab(sigma,t)|={n_stab_tick}")
+    print(f"|Stab(sigma,b)|={n_stab_bit}")
+    print(f"swapper_excluded={swap_bit != bit}")
+    print(f"first_breaker={None if breaker is None else breaker[:3]}")
+    print(f"N_pair={len(pair)}")
+    print(f"N_pair_support={n_pair_support}")
+    print(f"N_bit_ok={n_bit_ok}")
+    print(f"N_ord_ok={n_ord_ok}")
+    print("support_members=" + ",".join(str(item) for item in members))
+
+    expected_paths = (
+        "docs/UNEQUAL_RADIUS_ONE_BIT_TICK_STAB_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "g-plus-order",
+        len(rotations) == 24
+        and len(set(rotations)) == 24
+        and det3(SWAPPER) == 1
+        and SWAPPER in rotations,
+        f"proper={len(rotations)}",
+    )
+    checks.check(
+        "theorem-1-lex-first-breaker",
+        uneq_unread
+        and uneq_sigma == EXPECTED_SIGMA
+        and uneq_ticks == EXPECTED_TICKS
+        and breaker is not None
+        and breaker[:3] == (UNEQ_SEEDS, UNEQ_RADII, UNEQ_V)
+        and breaker[3:5] == (EXPECTED_SIGMA, EXPECTED_TICKS)
+        and "`σ = (1, 0, 1, 0, 1, 1)`" in note
+        and "`t = (1, ·, 1, ·, 3, 2)`" in note
+        and "radii `(2, 1, 3)`" in note
+        and "`v = (−3,−3,−1)`" in note,
+        f"sigma={uneq_sigma} ticks={uneq_ticks}",
+    )
+    checks.check(
+        "theorem-1-bit",
+        bit == EXPECTED_BIT
+        and uneq_ticks[SLOT_MINUS_Z] is not None
+        and uneq_ticks[SLOT_PLUS_Z] is not None
+        and uneq_ticks[SLOT_MINUS_Z] < uneq_ticks[SLOT_PLUS_Z]
+        and "`b = 1`" in note
+        and "t(−z) = 2 < 3 = t(+z)" in note,
+        f"b={bit}",
+    )
+    checks.check(
+        "theorem-1-stab-orders",
+        n_stab == 2
+        and n_stab_bit == 1
+        and "|Stab(σ)| = 2" in note
+        and "|Stab(σ,b)| = 1" in note,
+        f"stab={n_stab} bit={n_stab_bit}",
+    )
+    checks.check(
+        "theorem-1-swapper-excluded",
+        act_col(swap_perm, EXPECTED_SIGMA) == EXPECTED_SIGMA
+        and swap_bit != bit
+        and swap_bit == 0
+        and swap_perm[0] == 2
+        and swap_perm[4] == 5
+        and "s : (x, y, z) ↦ (y, x, −z)" in note
+        and "occupancy swapper is excluded" in note
+        and "only reverses" in note
+        and "−z ≺ +z" in note,
+        f"swap_bit={swap_bit}",
+    )
+    checks.check(
+        "theorem-2-bit-ok",
+        n_bit_ok == 4
+        and n_ord_ok == 4
+        and n_pair_support == 4
+        and members
+        == (
+            (1, 0, 2, 0, 1, 2),
+            (1, 0, 2, 0, 2, 1),
+            (2, 0, 1, 0, 1, 2),
+            (2, 0, 1, 0, 2, 1),
+        )
+        and "N_bit_ok = 4" in note
+        and "N_ord_ok = 4" in note
+        and "N_pair_support = 4" in note,
+        f"N_bit_ok={n_bit_ok} N_ord_ok={n_ord_ok}",
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write b into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqord",
+        "not leftover of uneqord" in note_flat
+        and "full order" in note
+        and "single bit" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "Stab(σ,b)" not in axiom
+        and "N_bit_ok" not in axiom
+        and "lock-tick" not in axiom
+        and "unequal-radius" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: |Stab(σ)|, |Stab(σ,b)|, b, N_bit_ok are exact integers")
+    print("per_site: uneqrad lex-first unequal-radius breaker only")
+    print("per_mode: no spectral calculation")
+    print("per_block: 3-ball star only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the uneqrad breaker, b=[t(-z)<t(+z)]=1. |Stab(sigma,b)|=1. Occupancy swapper flips the bit. N_bit_ok=4=N_ord_ok. Displayed, not adopted. No axiom edit.

## Runner

`scripts/unequal_radius_one_bit_tick_stab_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.