### PR TITLE
feat(uneqaxis): occupancy names the full axis; one bit kills Stab

### DIFF
--- a/docs/WEIGHT4_FULL_AXIS_ONE_BIT_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/WEIGHT4_FULL_AXIS_ONE_BIT_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,253 @@
+---
+claim_id: weight4_full_axis_one_bit_extra_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the 15 weight-4 occupancy masks, whether occupancy names a unique full axis whose one-bit age extra kills Stab is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/weight4_full_axis_one_bit_extra_2026_08_15.py
+---
+
+# Occupancy Names The Full Axis; The Extra Is One Age Bit (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 15 weight-4 occupancy masks on the 6-NN star. A mask
+empties a whole axis or two perpendicular slots. On the 12 that empty
+two perpendicular slots, occupancy names the unique full axis and a
+single older/newer bit on that axis is the extra that kills every
+occupancy stabilizer swapping those two ends. Score the 15 weight-4
+masks. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/weight4_full_axis_one_bit_extra_2026_08_15.py`](../scripts/weight4_full_axis_one_bit_extra_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment uneqbit #6680: one comparison on the unique full axis shrinks
+`Stab`. That extra was scored on one star. The residual here is not leftover
+of uneqbit (one star). New residual: on all 12 weight-4 masks that empty
+two perpendicular slots, occupancy names the unique full axis. The extra
+is only which end of that axis is older.
+
+`N_perp = 12` empty two perpendicular slots and have a unique full axis
+(both ends occupied). `N_axis = 3` empty a whole axis (no pair support).
+The 3 masks that empty a whole axis have 10→no pair support.
+
+**Theorem 1.** `N_perp = 12` empty two perpendicular slots and have a
+unique full axis (both ends occupied). `N_axis = 3` empty a whole axis
+(no pair support).
+
+**Theorem 2.** On each of the 12, occupancy names the full axis. A single bit on that axis (which end is older) kills every occupancy stabilizer that swaps those two ends. On the uneqrad mask
+`σ = (1, 0, 1, 0, 1, 1)` the unique full axis is `z` and the bit
+`b = [t(−z) < t(+z)]` already gives `|Stab(σ)| = 2`, `|Stab(σ,b)| = 1`.
+The pattern is the same for all 12.
+
+**Theorem 3.** Displayed, not adopted. Do not write the bit into Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither a unique full axis nor the one-bit age extra
+on that axis as the framework's fixed rule. The covariance clause is the
+reason a local labeling on the orbit of `(σ, b)` must be
+stabilizer-invariant. Formation site and rate remain outside the axiom
+memo. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact census of the 15 weight-4 occupancy masks: N_perp=12, N_axis=3, unique full axis on each of the 12, one-bit age extra killing the end-swapping occupancy stabilizer, uneqrad mask report, and 10→no pair support on the 3 axis masks. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: weight4_full_axis_one_bit_extra
+target_blocker_text: "on the 15 weight-4 occupancy masks, whether occupancy names a unique full axis whose one-bit age extra kills Stab"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_perp, N_axis, the unique full axis on each of the 12, the one-bit extra, and no pair support on the 3 axis masks; do not write the bit into Admissibility or attach L1"
+conditional_surface_status: "exact on the 15 weight-4 occupancy masks; N_perp=12; N_axis=3; uneqrad unique full axis z; |Stab(σ)|=2; |Stab(σ,b)|=1 on each of the 12; 10→no pair support on the 3 axis masks; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Slots are the six nearest-neighbor directions in order
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+A weight-4 occupancy mask is a 6-bit string of weight 4. There are
+exactly `C(6,4) = 15` such masks. Each mask empties exactly two slots.
+Those two slots lie on one axis or on two perpendicular axes.
+
+An axis is full when both of its ends are occupied. `G+` is the 24
+proper cube rotations acting on the six slots.
+
+`Stab(σ) = { g in G+ : g · σ = σ }`.
+
+July-3 pair members are the 6-slot 3-letter colorings whose `G+` orbit
+is sent to a different orbit by spatial inversion. `N_pair_support` is
+the number of pair members with a given occupancy support.
+
+The uneqrad lex-first breaker is the host
+
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))`,
+radii `(2, 1, 3)`,
+`v = (−3,−3,−1)`,
+
+with occupancy and lock-ticks
+
+`σ = (1, 0, 1, 0, 1, 1)`,
+`t = (1, ·, 1, ·, 3, 2)`.
+
+On that mask the unique full axis is `z`. The displayed bit is
+
+`b = 1` if `t(−z) < t(+z)`, else `0`.
+
+`Stab(σ,b) = { g in G+ : g · σ = σ and b(g · t) = b(t) }`.
+
+Score the 15 weight-4 masks. The uneqrad host is used only to name the
+uneqrad mask and its displayed bit.
+
+## Theorem 1 — `N_perp = 12` and `N_axis = 3`
+
+The 15 masks split by the two emptied slots.
+
+| `σ` | emptied slots | class | unique full axis | `|Stab(σ)|` | `N_pair_support` |
+| --- | --- | --- | --- | --- | --- |
+| `(0, 0, 1, 1, 1, 1)` | `+x,−x` | axis | none | 8 | 0 |
+| `(0, 1, 0, 1, 1, 1)` | `+x,+y` | perp | `z` | 2 | 4 |
+| `(0, 1, 1, 0, 1, 1)` | `+x,−y` | perp | `z` | 2 | 4 |
+| `(0, 1, 1, 1, 0, 1)` | `+x,+z` | perp | `y` | 2 | 4 |
+| `(0, 1, 1, 1, 1, 0)` | `+x,−z` | perp | `y` | 2 | 4 |
+| `(1, 0, 0, 1, 1, 1)` | `−x,+y` | perp | `z` | 2 | 4 |
+| `(1, 0, 1, 0, 1, 1)` | `−x,−y` | perp | `z` | 2 | 4 |
+| `(1, 0, 1, 1, 0, 1)` | `−x,+z` | perp | `y` | 2 | 4 |
+| `(1, 0, 1, 1, 1, 0)` | `−x,−z` | perp | `y` | 2 | 4 |
+| `(1, 1, 0, 0, 1, 1)` | `+y,−y` | axis | none | 8 | 0 |
+| `(1, 1, 0, 1, 0, 1)` | `+y,+z` | perp | `x` | 2 | 4 |
+| `(1, 1, 0, 1, 1, 0)` | `+y,−z` | perp | `x` | 2 | 4 |
+| `(1, 1, 1, 0, 0, 1)` | `−y,+z` | perp | `x` | 2 | 4 |
+| `(1, 1, 1, 0, 1, 0)` | `−y,−z` | perp | `x` | 2 | 4 |
+| `(1, 1, 1, 1, 0, 0)` | `+z,−z` | axis | none | 8 | 0 |
+
+`N_perp = 12`. Each of those 12 empties two perpendicular slots, so
+exactly one axis has both ends occupied: occupancy names the unique
+full axis.
+
+`N_axis = 3`. Each of those 3 empties a whole axis, so two axes are
+full and no unique full axis is named. The 3 masks that empty a whole
+axis have 10→no pair support: each has `N_pair_support = 0`.
+
+## Theorem 2 — one bit on the named axis kills the end-swapping stabilizer
+
+On each of the 12, `Stab(σ)` has order 2. The non-identity element
+swaps the two ends of the unique full axis (and swaps the two remaining
+occupied slots). Occupancy therefore names the axis; it does not name
+which end of that axis is older.
+
+A single bit on that axis — which end is older — is reversed by every
+occupancy stabilizer that swaps those two ends. Hence that bit kills
+every such stabilizer, and
+
+`|Stab(σ,b)| = 1`
+
+on each of the 12. The pattern is the same for all 12.
+
+The uneqrad mask is the perp row
+
+`σ = (1, 0, 1, 0, 1, 1)`,
+
+which empties `−x` and `−y` and names unique full axis `z`. Occupied
+neighbors and ticks on the uneqrad lex-first host are
+
+- `+x = (−2,−3,−1)` has `t = 1`,
+- `+y = (−3,−2,−1)` has `t = 1`,
+- `+z = (−3,−3,0)` has `t = 3`,
+- `−z = (−3,−3,−2)` has `t = 2`.
+
+Hence `t(−z) = 2 < 3 = t(+z)`, so `b = 1`. The occupancy swapper is
+
+`s : (x, y, z) ↦ (y, x, −z)`,
+
+which swaps `+x ↔ +y` and `+z ↔ −z`. That map preserves `σ` and
+reverses the `z` bit, so the occupancy swapper is excluded and
+
+`|Stab(σ)| = 2`, `|Stab(σ,b)| = 1`
+
+on the uneqrad mask. The same occupancy-named axis plus one-bit extra
+holds on the other 11 perp masks.
+
+## Theorem 3 — displayed, not adopted
+
+The 15-mask census, the unique full axis on each of the 12, the one-bit
+age extra, the uneqrad report, and 10→no pair support on the 3 axis
+masks are displayed member data. They are not the framework's fixed
+Admissibility rule. This note does not write the bit into Admissibility.
+Do not write the bit into Admissibility. Do not attach L1.
+Occupancy-only formation is not attached. Qubit remains `M_2(C)`. No
+approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the 15 weight-4 occupancy masks, `N_perp = 12`
+  and `N_axis = 3`. Occupancy names a unique full axis on each of the
+  12. A single bit on that axis (which end is older) kills every
+  occupancy stabilizer that swaps those two ends, so `|Stab(σ,b)| = 1`
+  on each of the 12. The uneqrad mask names axis `z` with `b = 1` and
+  `|Stab(σ)| = 2`. The 3 axis masks have 10→no pair support.
+- **What is displayed only.** The one-bit age extra and the two
+  stabilizers are one rival table. They are not adopted.
+- **What is not claimed.** No attachment of the bit, radii, integer
+  `t`, or a unique full axis to Admissibility; no attachment of
+  occupancy-only formation; no axiom edit; no formation rate; no
+  leftover of uneqbit (one star); no compiler no-go.
+- **Mutation controls.** A rebuilt `N_perp ≠ 12` or `N_axis ≠ 3` fails.
+  A rebuilt perp mask without a unique full axis fails. A rebuilt
+  end-swapping occupancy stabilizer that preserves the bit fails. A
+  rebuilt uneqrad mask that is not `(1, 0, 1, 0, 1, 1)` or a rebuilt
+  `b ≠ 1` fails. A rebuilt axis mask with pair support fails. A note
+  that writes the bit into Admissibility, attaches L1, or authors an
+  audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the 15 weight-4 occupancy masks, the 24
+proper cube rotations, unique-full-axis naming on each of the 12, the
+one-bit extra that kills every end-swapping occupancy stabilizer, the
+uneqrad mask and its displayed bit, July-3 pair support on the 3 axis
+masks, the current premise boundary, and the mutation controls. It
+scores the 15 weight-4 masks. It writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -19325,6 +19325,10 @@
   "weak_field_optical_metric_ansatz_diagnostic_bounded_theorem_note_2026-06-09": {
    "deps_hash": "83ad60d045c1",
    "out_degree": 4
+  },
+  "weight4_full_axis_one_bit_extra_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "weighting_exact_algebra_cycle905_support_note_2026-08-08": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/weight4_full_axis_one_bit_extra_2026_08_15.txt
+++ b/logs/runner-cache/weight4_full_axis_one_bit_extra_2026_08_15.txt
@@ -1,0 +1,72 @@
+===== runner cache v1 =====
+runner: scripts/weight4_full_axis_one_bit_extra_2026_08_15.py
+runner_sha256: f30a57fecfd21a324971855aae2b1d8e71bcd56b7453e91e2b1878a0dc5068a7
+input_fingerprint_sha256: 53579b4e05ab3733f2c8e38e0d29aef26a0a5a5c728e4e13646e81361e049672
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+weight-4 occupancy unique full axis one-bit extra
+AUDIT_INPUT_PATHS:
+  docs/WEIGHT4_FULL_AXIS_ONE_BIT_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+G_plus=24
+N_masks=15
+N_perp=12
+N_axis=3
+N_pair=48
+uneq_unread=True
+uneq_sigma=(1, 0, 1, 0, 1, 1)
+uneq_ticks=(1, None, 1, None, 3, 2)
+uneq_full_axis=z
+uneq_b=1
+|Stab(uneq)|=2
+|Stab(uneq,b)|=1
+swapper_excluded=True
+perp_rows:
+  (0, 1, 0, 1, 1, 1) full=z |Stab|=2 Nps=4
+  (0, 1, 1, 0, 1, 1) full=z |Stab|=2 Nps=4
+  (0, 1, 1, 1, 0, 1) full=y |Stab|=2 Nps=4
+  (0, 1, 1, 1, 1, 0) full=y |Stab|=2 Nps=4
+  (1, 0, 0, 1, 1, 1) full=z |Stab|=2 Nps=4
+  (1, 0, 1, 0, 1, 1) full=z |Stab|=2 Nps=4
+  (1, 0, 1, 1, 0, 1) full=y |Stab|=2 Nps=4
+  (1, 0, 1, 1, 1, 0) full=y |Stab|=2 Nps=4
+  (1, 1, 0, 1, 0, 1) full=x |Stab|=2 Nps=4
+  (1, 1, 0, 1, 1, 0) full=x |Stab|=2 Nps=4
+  (1, 1, 1, 0, 0, 1) full=x |Stab|=2 Nps=4
+  (1, 1, 1, 0, 1, 0) full=x |Stab|=2 Nps=4
+axis_rows:
+  (0, 0, 1, 1, 1, 1) |Stab|=8 Nps=0
+  (1, 1, 0, 0, 1, 1) |Stab|=8 Nps=0
+  (1, 1, 1, 1, 0, 0) |Stab|=8 Nps=0
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: g-plus-order | proper=24
+PASS: theorem-1-split | N_perp=12 N_axis=3
+PASS: theorem-1-unique-full-axis
+PASS: theorem-1-axis-no-pair-support | N_pair=48
+PASS: theorem-2-bit-kills-swapper
+PASS: theorem-2-uneqrad-mask | sigma=(1, 0, 1, 0, 1, 1) axis=2 b=1
+PASS: theorem-2-uneqrad-swapper | swap_bit=0
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqbit
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: N_perp, N_axis, |Stab(σ)|, |Stab(σ,b)| are exact integers
+per_site: 15 weight-4 occupancy masks; uneqrad mask named only
+per_mode: no spectral calculation
+per_block: 6-NN star masks only
+lattice_wide: checked and not executed
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/weight4_full_axis_one_bit_extra_2026_08_15.py
+++ b/scripts/weight4_full_axis_one_bit_extra_2026_08_15.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Occupancy names the unique full axis; the extra is one age bit.
+
+Score all 15 weight-4 occupancy masks. N_perp=12 empty two perpendicular
+slots and have a unique full axis. N_axis=3 empty a whole axis and have
+no pair support. On each of the 12, a single older/newer bit on the
+named axis kills every occupancy stabilizer that swaps those two ends.
+Report that for the uneqrad mask; the pattern is the same for all 12.
+Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/WEIGHT4_FULL_AXIS_ONE_BIT_EXTRA_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/WEIGHT4_FULL_AXIS_ONE_BIT_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+AXIS_NAME = ("x", "y", "z")
+SLOT_PLUS_Z = 4
+SLOT_MINUS_Z = 5
+EMPTY = 0
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the 15 weight-4 occupancy masks, whether occupancy '
+    "names a unique full axis whose one-bit age extra kills Stab is "
+    'reported. Displayed, not adopted."'
+)
+UNEQ_SEEDS: tuple[Point, Point, Point] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, -2, 1),
+)
+UNEQ_RADII = (2, 1, 3)
+UNEQ_V: Point = (-3, -3, -1)
+UNEQ_SIGMA: Coloring = (1, 0, 1, 0, 1, 1)
+UNEQ_TICKS: Tick = (1, None, 1, None, 3, 2)
+SWAPPER: Matrix = ((0, 1, 0), (1, 0, 0), (0, 0, -1))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: Point, radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        if abs(offset[0]) + abs(offset[1]) + abs(offset[2]) <= radius:
+            sites.append(add(center, offset))
+    return tuple(sites)
+
+
+def in_union(point: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]) -> bool:
+    return any(l1(point, seed) <= radius for seed, radius in zip(seeds, radii))
+
+
+def sigma_ticks(
+    site: Point, seeds: tuple[Point, ...], radii: tuple[int, ...]
+) -> tuple[Coloring, Tick]:
+    occupied = {
+        add(seed, offset)
+        for seed, radius in zip(seeds, radii)
+        for offset in ball((0, 0, 0), radius)
+    }
+    sigma_bits: list[int] = []
+    ticks_bits: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if neighbor in occupied:
+            sigma_bits.append(1)
+            ticks_bits.append(min(l1(neighbor, seed) for seed in seeds))
+        else:
+            sigma_bits.append(0)
+            ticks_bits.append(None)
+    return tuple(sigma_bits), tuple(ticks_bits)
+
+
+def weight4_masks() -> tuple[Coloring, ...]:
+    return tuple(
+        bits
+        for bits in itertools.product((0, 1), repeat=6)
+        if sum(bits) == 4
+    )
+
+
+def empty_slots(sigma: Coloring) -> tuple[int, int]:
+    emptied = tuple(index for index, bit in enumerate(sigma) if bit == 0)
+    if len(emptied) != 2:
+        raise AssertionError(f"expected two empty slots, got {emptied}")
+    return (emptied[0], emptied[1])
+
+
+def same_axis(left: int, right: int) -> bool:
+    return any({left, right} == set(axis) for axis in AXES)
+
+
+def full_axes(sigma: Coloring) -> tuple[int, ...]:
+    return tuple(
+        axis_index
+        for axis_index, (plus, minus) in enumerate(AXES)
+        if sigma[plus] == 1 and sigma[minus] == 1
+    )
+
+
+def unique_full_axis(sigma: Coloring) -> int | None:
+    named = full_axes(sigma)
+    if len(named) == 1:
+        return named[0]
+    return None
+
+
+def bit_on_axis(ticks: Tick, axis_index: int) -> int:
+    plus, minus = AXES[axis_index]
+    minus_tick = ticks[minus]
+    plus_tick = ticks[plus]
+    if minus_tick is not None and plus_tick is not None and minus_tick < plus_tick:
+        return 1
+    return 0
+
+
+def display_ticks(sigma: Coloring, axis_index: int) -> Tick:
+    plus, minus = AXES[axis_index]
+    ticks: list[int | None] = [None] * 6
+    for slot, bit in enumerate(sigma):
+        if bit == 0:
+            continue
+        if slot == minus:
+            ticks[slot] = 1
+        elif slot == plus:
+            ticks[slot] = 2
+        else:
+            ticks[slot] = 0
+    return tuple(ticks)
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: Point) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | Tick) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def stab_perms(sigma: Coloring, perms: list[tuple[int, ...]]) -> list[tuple[int, ...]]:
+    return [perm for perm in perms if act_col(perm, sigma) == sigma]
+
+
+def swaps_axis_ends(perm: tuple[int, ...], axis_index: int) -> bool:
+    plus, minus = AXES[axis_index]
+    return perm[plus] == minus and perm[minus] == plus
+
+
+def july3_pair(perms: list[tuple[int, ...]]) -> frozenset[Coloring]:
+    unseen = set(itertools.product(range(3), repeat=6))
+    inversion = direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+    pair: set[Coloring] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(letter != EMPTY) for letter in coloring)
+
+
+def n_pair_support(sigma: Coloring, pair: frozenset[Coloring]) -> int:
+    return sum(1 for item in pair if support(item) == sigma)
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    rotations = proper_rotations()
+    perms = [direction_perm(matrix) for matrix in rotations]
+    pair = july3_pair(perms)
+    masks = weight4_masks()
+
+    perp: list[Coloring] = []
+    axis_masks: list[Coloring] = []
+    named_ok = True
+    bit_kills = True
+    stab_orders_ok = True
+    pair_axis_zero = True
+    for sigma in masks:
+        emptied = empty_slots(sigma)
+        named = unique_full_axis(sigma)
+        stab = stab_perms(sigma, perms)
+        n_ps = n_pair_support(sigma, pair)
+        if same_axis(*emptied):
+            axis_masks.append(sigma)
+            if named is not None or n_ps != 0 or len(stab) != 8:
+                pair_axis_zero = False
+        else:
+            perp.append(sigma)
+            if named is None or len(full_axes(sigma)) != 1:
+                named_ok = False
+                continue
+            plus, minus = AXES[named]
+            if len(stab) != 2:
+                stab_orders_ok = False
+            non_id = [perm for perm in stab if perm != tuple(range(6))]
+            if len(non_id) != 1 or not swaps_axis_ends(non_id[0], named):
+                bit_kills = False
+            ticks = display_ticks(sigma, named)
+            bit = bit_on_axis(ticks, named)
+            n_stab_bit = 0
+            for perm in stab:
+                if bit_on_axis(act_col(perm, ticks), named) == bit:
+                    n_stab_bit += 1
+            if n_stab_bit != 1 or bit != 1:
+                bit_kills = False
+
+    uneq_unread = not in_union(UNEQ_V, UNEQ_SEEDS, UNEQ_RADII)
+    uneq_sigma, uneq_ticks = sigma_ticks(UNEQ_V, UNEQ_SEEDS, UNEQ_RADII)
+    uneq_named = unique_full_axis(uneq_sigma)
+    uneq_bit = (
+        bit_on_axis(uneq_ticks, uneq_named) if uneq_named is not None else None
+    )
+    uneq_stab = stab_perms(uneq_sigma, perms)
+    n_uneq_bit = 0
+    if uneq_named is not None:
+        for perm in uneq_stab:
+            if bit_on_axis(act_col(perm, uneq_ticks), uneq_named) == uneq_bit:
+                n_uneq_bit += 1
+    swap_perm = direction_perm(SWAPPER)
+    swap_ticks = act_col(swap_perm, uneq_ticks)
+    swap_bit = (
+        bit_on_axis(swap_ticks, uneq_named) if uneq_named is not None else None
+    )
+
+    print("weight-4 occupancy unique full axis one-bit extra")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"G_plus={len(rotations)}")
+    print(f"N_masks={len(masks)}")
+    print(f"N_perp={len(perp)}")
+    print(f"N_axis={len(axis_masks)}")
+    print(f"N_pair={len(pair)}")
+    print(f"uneq_unread={uneq_unread}")
+    print(f"uneq_sigma={uneq_sigma}")
+    print(f"uneq_ticks={uneq_ticks}")
+    print(f"uneq_full_axis={None if uneq_named is None else AXIS_NAME[uneq_named]}")
+    print(f"uneq_b={uneq_bit}")
+    print(f"|Stab(uneq)|={len(uneq_stab)}")
+    print(f"|Stab(uneq,b)|={n_uneq_bit}")
+    print(f"swapper_excluded={swap_bit != uneq_bit}")
+    print("perp_rows:")
+    for sigma in perp:
+        named = unique_full_axis(sigma)
+        axis = AXIS_NAME[named] if named is not None else None
+        print(f"  {sigma} full={axis} |Stab|={len(stab_perms(sigma, perms))} Nps={n_pair_support(sigma, pair)}")
+    print("axis_rows:")
+    for sigma in axis_masks:
+        print(f"  {sigma} |Stab|={len(stab_perms(sigma, perms))} Nps={n_pair_support(sigma, pair)}")
+
+    expected_paths = (
+        "docs/WEIGHT4_FULL_AXIS_ONE_BIT_EXTRA_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "g-plus-order",
+        len(rotations) == 24
+        and len(set(rotations)) == 24
+        and det3(SWAPPER) == 1
+        and SWAPPER in rotations,
+        f"proper={len(rotations)}",
+    )
+    checks.check(
+        "theorem-1-split",
+        len(masks) == 15
+        and len(perp) == 12
+        and len(axis_masks) == 3
+        and "N_perp = 12" in note
+        and "N_axis = 3" in note
+        and "C(6,4) = 15" in note,
+        f"N_perp={len(perp)} N_axis={len(axis_masks)}",
+    )
+    checks.check(
+        "theorem-1-unique-full-axis",
+        named_ok
+        and all(unique_full_axis(sigma) is not None for sigma in perp)
+        and all(unique_full_axis(sigma) is None for sigma in axis_masks)
+        and "unique full axis" in note
+        and "both ends occupied" in note,
+    )
+    checks.check(
+        "theorem-1-axis-no-pair-support",
+        pair_axis_zero
+        and all(n_pair_support(sigma, pair) == 0 for sigma in axis_masks)
+        and "10→no pair support" in note
+        and "N_pair_support = 0" in note,
+        f"N_pair={len(pair)}",
+    )
+    checks.check(
+        "theorem-2-bit-kills-swapper",
+        bit_kills
+        and stab_orders_ok
+        and "pattern is the same for all 12" in note
+        and "which end is older" in note
+        and "kills every occupancy stabilizer that swaps those two ends" in note,
+    )
+    checks.check(
+        "theorem-2-uneqrad-mask",
+        uneq_unread
+        and uneq_sigma == UNEQ_SIGMA
+        and uneq_ticks == UNEQ_TICKS
+        and uneq_named == 2
+        and uneq_bit == 1
+        and len(uneq_stab) == 2
+        and n_uneq_bit == 1
+        and "`σ = (1, 0, 1, 0, 1, 1)`" in note
+        and "`t = (1, ·, 1, ·, 3, 2)`" in note
+        and "unique full axis is `z`" in note
+        and "`b = 1`" in note
+        and "|Stab(σ)| = 2" in note
+        and "|Stab(σ,b)| = 1" in note,
+        f"sigma={uneq_sigma} axis={uneq_named} b={uneq_bit}",
+    )
+    checks.check(
+        "theorem-2-uneqrad-swapper",
+        act_col(swap_perm, UNEQ_SIGMA) == UNEQ_SIGMA
+        and swap_bit != uneq_bit
+        and swap_bit == 0
+        and swap_perm[4] == 5
+        and "s : (x, y, z) ↦ (y, x, −z)" in note
+        and "occupancy swapper is excluded" in note,
+        f"swap_bit={swap_bit}",
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write the bit into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqbit",
+        "not leftover of uneqbit" in note_flat
+        and "one star" in note
+        and "uneqbit #6680" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "Stab(σ,b)" not in axiom
+        and "N_perp" not in axiom
+        and "lock-tick" not in axiom
+        and "unequal-radius" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: N_perp, N_axis, |Stab(σ)|, |Stab(σ,b)| are exact integers")
+    print("per_site: 15 weight-4 occupancy masks; uneqrad mask named only")
+    print("per_mode: no spectral calculation")
+    print("per_block: 6-NN star masks only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

N_perp=12 have a unique full axis named by occupancy. N_axis=3 have no pair support. One older/newer bit on that axis gives |Stab(sigma,b)|=1 on all 12. Displayed, not adopted. No axiom edit.

## Runner

`scripts/weight4_full_axis_one_bit_extra_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.