### PR TITLE
feat(uneqk): k equals t on 27 of 2000 mixed-t stars

### DIFF
--- a/docs/UNEQUAL_RADIUS_K_EQUALS_TICK_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNEQUAL_RADIUS_K_EQUALS_TICK_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,159 @@
+---
+claim_id: unequal_radius_k_equals_tick_census_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On a prefix of mixed-t unequal-radius weight-4 stars, whether occupied-NN count equals lock-tick is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unequal_radius_k_equals_tick_census_2026_08_15.py
+---
+
+# Occupied-NN Count Versus Lock-Tick On Mixed-t Unequal-Radius Stars
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** a 2000-star prefix of unread weight-4 stars with not-all-equal
+occupied lock-ticks in the uneqrad three-ball box. Occupied-NN count is
+compared with lock-tick on occupied slots only. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unequal_radius_k_equals_tick_census_2026_08_15.py`](../scripts/unequal_radius_k_equals_tick_census_2026_08_15.py)
+
+## Result Up Front
+
+The uneqrad box is the family of unions
+`U = B_{r_1}(s_1) ∪ B_{r_2}(s_2) ∪ B_{r_3}(s_3)` with distinct centers
+`s_i ∈ [−2,2]^3` and radii `r_i ∈ {1,2,3}` not all equal. An unread site
+`v ∉ U` with `‖v‖_∞ ≤ 4` carries a six-star occupancy `σ` and lock-ticks
+`t(w) = min_i ‖w − s_i‖_1` on occupied neighbors. This note scores only
+weight-4 stars whose occupied ticks are not all equal.
+
+On each occupied neighbor `w`, write `k(w)` for the number of nearest
+neighbors of `w` that lie in `U`. Compare the occupied 4-tuples `k` and `t`.
+
+The prefix has `N_prefix = 2000` mixed-t stars and `N_eq = 27` equalities.
+So `N_eq` is not 0: occupied-NN count equals lock-tick on some scored stars
+and fails on the rest. The lex-first disagreement is recorded below. The
+already uneqsrc breaker is a later disagreement on the same prefix. The
+census is not leftover of uneqsrc (one star).
+
+Displayed, not adopted. Do not write `k` as `t` into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). This note
+authors no axiom edit.
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names a nearest-neighbor rule for the content law. It does not
+name a radius triple, a seed-distance clock, or an identification of
+occupied-NN count with lock-tick. Record locks one admissible possibility at
+a formed site and supplies no clock field. Unread `v` has no record.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite prefix counts N_prefix and N_eq, the lex-first k versus t disagreement, and the already uneqsrc disagreement are exact listings in a declared box; no Admissibility identification of k with t is derived."
+trace_class: negative_route_pruning
+target_claim_id: lock_tick_from_occupied_nn_count
+target_blocker_text: "occupied-NN count is not a derived lock-tick law on mixed-t unequal-radius weight-4 stars"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Keep k and t as separately displayed 4-tuples. Do not adopt k as t."
+conditional_surface_status: "exact for the declared 2000-star mixed-t prefix in the uneqrad box"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Centers run over combinations of three distinct points of `[−2,2]^3` in
+lexicographic order. Radii run over the 24 triples in `{1,2,3}^3` that are
+not all equal. Sites `v` run over `[−4,4]^3` in lexicographic order. A star
+is scored when `v ∉ U`, `wt(σ) = 4`, and the occupied 4-tuple `t` is not a
+constant. The prefix is the first 2000 such stars, or the whole family if
+shorter.
+
+Directions are `(+x, −x, +y, −y, +z, −z)`. Occupied slots are the four
+neighbors of `v` that lie in `U`. On those slots,
+
+- `t_μ = min_i ‖v + e_μ − s_i‖_1`,
+- `k_μ` is the occupied-NN count of that neighbor inside `U`.
+
+Equality means `k = t` as occupied 4-tuples.
+
+## Theorem 1 — Prefix Counts
+
+The mixed-t family reaches the cap, so `N_prefix = 2000`. Of those stars,
+`N_eq = 27` have `k = t` on the occupied slots.
+
+The first equality is star 342:
+
+- centers `((−2,−2,−2), (−2,−2,−1), (−2,1,1))`,
+- radii `(2, 2, 1)`,
+- `v = (−2,0,0)`,
+- `σ = (0, 0, 1, 1, 1, 1)`,
+- `k = t = (1, 2, 1, 2)`.
+
+That coincidence is a listing, not a law. The other 1973 scored stars have
+`k ≠ t`.
+
+## Theorem 2 — `N_eq` Is Not Zero; Disagreements Recorded
+
+Because `N_eq` is not 0, occupied-NN count equals lock-tick on a nonempty
+subset of the prefix. It is not the case that the prefix has no `k = t`
+star.
+
+The lex-first disagreement is star 1:
+
+- centers `((−2,−2,−2), (−2,−2,−1), (−2,−2,0))`,
+- radii `(2, 1, 2)`,
+- `v = (−3,−3,−1)`,
+- `σ = (1, 0, 1, 0, 1, 1)`,
+- `t = (1, 1, 2, 2)`,
+- `k = (3, 3, 2, 2)`.
+
+The already uneqsrc star is star 21 of the same prefix:
+
+- centers `((−2,−2,−2), (−2,−2,−1), (−2,−2,1))`,
+- radii `(2, 1, 3)`,
+- `v = (−3,−3,−1)`,
+- `σ = (1, 0, 1, 0, 1, 1)`,
+- `t = (1, 1, 3, 2)`,
+- `k = (3, 3, 3, 2)`.
+
+That is the leftover uneqsrc pair `k = (3, 3, 3, 2)` versus `t = (1, 1, 3, 2)`.
+The present census is not leftover of uneqsrc: it scores a 2000-star prefix,
+not one star.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The counts, the first equality, and both recorded disagreements are
+displayed finite listings. Do not write `k` as `t` into Admissibility. The
+27 coincidences do not promote occupied-NN count to a lock-tick rule. Do
+not attach L1. No fourth ball is added. The axiom memo is unedited.
+
+## Claim Scope
+
+claim_scope: "On a prefix of mixed-t unequal-radius weight-4 stars, whether occupied-NN count equals lock-tick is reported. Displayed, not adopted."

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18657,6 +18657,10 @@
   "u_integration_reading_blind_and_dictionary_blind_on_corner_transfer_bounded_note_2026-06-12": {
    "deps_hash": "311d6b921eb1",
    "out_degree": 3
+  },
+  "unequal_radius_k_equals_tick_census_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unification_basin_failure_note": {
    "deps_hash": "c90c9ba91199",

--- a/logs/runner-cache/unequal_radius_k_equals_tick_census_2026_08_15.txt
+++ b/logs/runner-cache/unequal_radius_k_equals_tick_census_2026_08_15.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/unequal_radius_k_equals_tick_census_2026_08_15.py
+runner_sha256: dff7ca8d264b7cf32680576b1a459e8ec2c4d8f1238c20c11cf0a2eb9de966bf
+input_fingerprint_sha256: 9f3e94fe9fd540b9c526c76caa5c6f09aa30c14262f7b2bf926567c62e4a6beb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 2.09
+status: ok
+----- stdout -----
+unequal-radius k-equals-tick census
+AUDIT_INPUT_PATHS:
+  docs/UNEQUAL_RADIUS_K_EQUALS_TICK_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+N_prefix=2000
+N_eq=27
+N_eq_is_zero=False
+lex_first_disagreement: seeds=((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)) radii=(2, 1, 2) v=(-3, -3, -1) t=(1, 1, 2, 2) k=(3, 3, 2, 2)
+uneqsrc: index=21 t=(1, 1, 3, 2) k=(3, 3, 3, 2) equal=False
+lex_first_equality: index=342 t=(1, 2, 1, 2) k=(1, 2, 1, 2)
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-record-qubit
+PASS: theorem-1-n-prefix | N_prefix=2000
+PASS: theorem-1-n-eq | N_eq=27
+PASS: theorem-2-n-eq-not-zero | N_eq_is_zero=False
+PASS: theorem-2-lex-first-disagreement | first_ne=(((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -3, -1))
+PASS: uneqsrc-disagreement-recorded | uneqsrc_index=21
+PASS: first-equality-on-prefix | first_eq_index=342
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqsrc
+PASS: admissibility-record-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: scored occupied-NN count k against occupied lock-tick t
+per_site: scored a 2000-star mixed-t unread weight-4 prefix
+per_mode: no spectral calculation; occupancy geometry only
+per_block: 3-ball unequal-radius host only; no fourth ball
+lattice_wide: checked and not executed — finite prefix in the uneqrad box, not a lattice-wide rule
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unequal_radius_k_equals_tick_census_2026_08_15.py
+++ b/scripts/unequal_radius_k_equals_tick_census_2026_08_15.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Census: occupied-NN count k versus lock-tick t on mixed-t stars.
+
+Same box as uneqrad. Score a 2000-star prefix of unread weight-4
+stars whose occupied lock-ticks are not all equal. Compare the
+occupied 4-tuple k of occupied-NN counts inside U with t.
+Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from itertools import combinations, product
+from pathlib import Path
+from typing import Iterator
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/UNEQUAL_RADIUS_K_EQUALS_TICK_CENSUS_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNEQUAL_RADIUS_K_EQUALS_TICK_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int, ...]
+StarRec = dict[str, object]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On a prefix of mixed-t unequal-radius weight-4 stars, '
+    "whether occupied-NN count equals lock-tick is reported. "
+    'Displayed, not adopted."'
+)
+PREFIX_CAP = 2000
+CENTER_BOX = 2
+SITE_BOX = 4
+RADII_MENU = (1, 2, 3)
+UNEQSRC_SEEDS: tuple[Point, ...] = ((-2, -2, -2), (-2, -2, -1), (-2, -2, 1))
+UNEQSRC_RADII = (2, 1, 3)
+UNEQSRC_V: Point = (-3, -3, -1)
+EXPECTED_UNEQSRC_T = (1, 1, 3, 2)
+EXPECTED_UNEQSRC_K = (3, 3, 3, 2)
+EXPECTED_N_PREFIX = 2000
+EXPECTED_N_EQ = 27
+EXPECTED_FIRST_NE_SEEDS: tuple[Point, ...] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, -2, 0),
+)
+EXPECTED_FIRST_NE_RADII = (2, 1, 2)
+EXPECTED_FIRST_NE_V: Point = (-3, -3, -1)
+EXPECTED_FIRST_NE_SIGMA: Coloring = (1, 0, 1, 0, 1, 1)
+EXPECTED_FIRST_NE_T = (1, 1, 2, 2)
+EXPECTED_FIRST_NE_K = (3, 3, 2, 2)
+EXPECTED_FIRST_EQ_SEEDS: tuple[Point, ...] = (
+    (-2, -2, -2),
+    (-2, -2, -1),
+    (-2, 1, 1),
+)
+EXPECTED_FIRST_EQ_RADII = (2, 2, 1)
+EXPECTED_FIRST_EQ_V: Point = (-2, 0, 0)
+EXPECTED_FIRST_EQ_T = (1, 2, 1, 2)
+EXPECTED_FIRST_EQ_K = (1, 2, 1, 2)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def box_points(half: int) -> tuple[Point, ...]:
+    span = range(-half, half + 1)
+    return tuple(product(span, repeat=3))
+
+
+def radii_options() -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        radii
+        for radii in product(RADII_MENU, repeat=3)
+        if len(set(radii)) > 1
+    )
+
+
+def build_union(seeds: tuple[Point, ...], radii: tuple[int, ...]) -> set[Point]:
+    union: set[Point] = set()
+    for seed, radius in zip(seeds, radii, strict=True):
+        span = range(-radius, radius + 1)
+        sx, sy, sz = seed
+        for dx in span:
+            for dy in span:
+                for dz in span:
+                    if abs(dx) + abs(dy) + abs(dz) <= radius:
+                        union.add((sx + dx, sy + dy, sz + dz))
+    return union
+
+
+def occupied_star(
+    site: Point, union: set[Point], seeds: tuple[Point, ...]
+) -> tuple[Coloring, Tick, tuple[Point, ...]]:
+    sigma: list[int] = []
+    ticks: list[int] = []
+    occupied: list[Point] = []
+    contained = union.__contains__
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if contained(neighbor):
+            sigma.append(1)
+            ticks.append(min(l1(neighbor, seed) for seed in seeds))
+            occupied.append(neighbor)
+        else:
+            sigma.append(0)
+    return tuple(sigma), tuple(ticks), tuple(occupied)
+
+
+def occupied_nn_counts(occupied: tuple[Point, ...], union: set[Point]) -> Tick:
+    contained = union.__contains__
+    return tuple(
+        sum(1 for direction in DIRS if contained(add(neighbor, direction)))
+        for neighbor in occupied
+    )
+
+
+def mixed_tick_stars(limit: int) -> Iterator[StarRec]:
+    centers = box_points(CENTER_BOX)
+    sites = box_points(SITE_BOX)
+    yielded = 0
+    for seeds in combinations(centers, 3):
+        for radii in radii_options():
+            union = build_union(seeds, radii)
+            contained = union.__contains__
+            for site in sites:
+                if contained(site):
+                    continue
+                sigma, ticks, occupied = occupied_star(site, union, seeds)
+                if len(occupied) != 4:
+                    continue
+                if ticks[0] == ticks[1] == ticks[2] == ticks[3]:
+                    continue
+                counts = occupied_nn_counts(occupied, union)
+                yielded += 1
+                yield {
+                    "index": yielded,
+                    "seeds": seeds,
+                    "radii": radii,
+                    "v": site,
+                    "sigma": sigma,
+                    "t": ticks,
+                    "k": counts,
+                    "equal": counts == ticks,
+                }
+                if yielded >= limit:
+                    return
+
+
+def score_prefix(limit: int = PREFIX_CAP) -> dict[str, object]:
+    n_eq = 0
+    first_ne: StarRec | None = None
+    first_eq: StarRec | None = None
+    uneqsrc: StarRec | None = None
+    last: StarRec | None = None
+    for record in mixed_tick_stars(limit):
+        last = record
+        if record["equal"]:
+            n_eq += 1
+            if first_eq is None:
+                first_eq = record
+        elif first_ne is None:
+            first_ne = record
+        if (
+            record["seeds"] == UNEQSRC_SEEDS
+            and record["radii"] == UNEQSRC_RADII
+            and record["v"] == UNEQSRC_V
+        ):
+            uneqsrc = record
+    n_prefix = 0 if last is None else int(last["index"])
+    return {
+        "n_prefix": n_prefix,
+        "n_eq": n_eq,
+        "n_eq_is_zero": n_eq == 0,
+        "first_disagreement": first_ne,
+        "first_equality": first_eq,
+        "uneqsrc": uneqsrc,
+    }
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def fmt_tuple(values: object) -> str:
+    if not isinstance(values, tuple):
+        return str(values)
+    inner = ", ".join(
+        fmt_tuple(item) if isinstance(item, tuple) else str(item) for item in values
+    )
+    return f"({inner})"
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    scored = score_prefix()
+    n_prefix = int(scored["n_prefix"])
+    n_eq = int(scored["n_eq"])
+    first_ne = scored["first_disagreement"]
+    first_eq = scored["first_equality"]
+    uneqsrc = scored["uneqsrc"]
+    assert isinstance(first_ne, dict)
+    assert isinstance(first_eq, dict)
+    assert isinstance(uneqsrc, dict)
+
+    print("unequal-radius k-equals-tick census")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"N_prefix={n_prefix}")
+    print(f"N_eq={n_eq}")
+    print(f"N_eq_is_zero={bool(scored['n_eq_is_zero'])}")
+    print(
+        "lex_first_disagreement: "
+        f"seeds={fmt_tuple(first_ne['seeds'])} "
+        f"radii={fmt_tuple(first_ne['radii'])} "
+        f"v={fmt_tuple(first_ne['v'])} "
+        f"t={fmt_tuple(first_ne['t'])} "
+        f"k={fmt_tuple(first_ne['k'])}"
+    )
+    print(
+        "uneqsrc: "
+        f"index={uneqsrc['index']} "
+        f"t={fmt_tuple(uneqsrc['t'])} "
+        f"k={fmt_tuple(uneqsrc['k'])} "
+        f"equal={uneqsrc['equal']}"
+    )
+    print(
+        "lex_first_equality: "
+        f"index={first_eq['index']} "
+        f"t={fmt_tuple(first_eq['t'])} "
+        f"k={fmt_tuple(first_eq['k'])}"
+    )
+
+    expected_paths = (
+        "docs/UNEQUAL_RADIUS_K_EQUALS_TICK_CENSUS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content"
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-record-qubit",
+        record_lock in axiom
+        and record_lock in note
+        and record_content in axiom
+        and record_content in note
+        and unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "theorem-1-n-prefix",
+        n_prefix == EXPECTED_N_PREFIX
+        and n_prefix == PREFIX_CAP
+        and "`N_prefix = 2000`" in note,
+        f"N_prefix={n_prefix}",
+    )
+    checks.check(
+        "theorem-1-n-eq",
+        n_eq == EXPECTED_N_EQ and "`N_eq = 27`" in note,
+        f"N_eq={n_eq}",
+    )
+    checks.check(
+        "theorem-2-n-eq-not-zero",
+        scored["n_eq_is_zero"] is False
+        and n_eq > 0
+        and "N_eq` is not 0" in note
+        and "k` never equals `t`" not in note_flat.replace(" ", ""),
+        f"N_eq_is_zero={scored['n_eq_is_zero']}",
+    )
+    checks.check(
+        "theorem-2-lex-first-disagreement",
+        first_ne["seeds"] == EXPECTED_FIRST_NE_SEEDS
+        and first_ne["radii"] == EXPECTED_FIRST_NE_RADII
+        and first_ne["v"] == EXPECTED_FIRST_NE_V
+        and first_ne["sigma"] == EXPECTED_FIRST_NE_SIGMA
+        and first_ne["t"] == EXPECTED_FIRST_NE_T
+        and first_ne["k"] == EXPECTED_FIRST_NE_K
+        and first_ne["equal"] is False
+        and first_ne["index"] == 1
+        and "`t = (1, 1, 2, 2)`" in note
+        and "`k = (3, 3, 2, 2)`" in note
+        and "radii `(2, 1, 2)`" in note
+        and "`v = (−3,−3,−1)`" in note,
+        f"first_ne={first_ne['seeds'], first_ne['radii'], first_ne['v']}",
+    )
+    checks.check(
+        "uneqsrc-disagreement-recorded",
+        uneqsrc["t"] == EXPECTED_UNEQSRC_T
+        and uneqsrc["k"] == EXPECTED_UNEQSRC_K
+        and uneqsrc["equal"] is False
+        and uneqsrc["index"] == 21
+        and "`t = (1, 1, 3, 2)`" in note
+        and "`k = (3, 3, 3, 2)`" in note
+        and "already uneqsrc" in note_flat,
+        f"uneqsrc_index={uneqsrc['index']}",
+    )
+    checks.check(
+        "first-equality-on-prefix",
+        first_eq["seeds"] == EXPECTED_FIRST_EQ_SEEDS
+        and first_eq["radii"] == EXPECTED_FIRST_EQ_RADII
+        and first_eq["v"] == EXPECTED_FIRST_EQ_V
+        and first_eq["t"] == EXPECTED_FIRST_EQ_T
+        and first_eq["k"] == EXPECTED_FIRST_EQ_K
+        and first_eq["equal"] is True
+        and first_eq["index"] == 342
+        and "`k = t = (1, 2, 1, 2)`" in note,
+        f"first_eq_index={first_eq['index']}",
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write `k` as `t` into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqsrc",
+        "not leftover of uneqsrc" in note_flat
+        and "one star" in note
+        and "uneqsrc" in note,
+    )
+    checks.check(
+        "admissibility-record-unedited",
+        covariance_clause in axiom_flat
+        and record_lock in axiom
+        and "lock-tick" not in axiom
+        and "unequal-radius" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: scored occupied-NN count k against occupied lock-tick t")
+    print("per_site: scored a 2000-star mixed-t unread weight-4 prefix")
+    print("per_mode: no spectral calculation; occupancy geometry only")
+    print("per_block: 3-ball unequal-radius host only; no fourth ball")
+    print(
+        "lattice_wide: checked and not executed — finite prefix in the "
+        "uneqrad box, not a lattice-wide rule"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Prefix of 2000 mixed-t weight-4 stars: N_eq=27. Lex-first disagreement t=(1,1,2,2) vs k=(3,3,2,2). First equality at star 342: k=t=(1,2,1,2). k is not a law for t. Displayed, not adopted. No axiom edit.

## Runner

`scripts/unequal_radius_k_equals_tick_census_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.