### PR TITLE
feat(bitlaw): lex-first one-bit labeling is not G+ equivariant

### DIFF
--- a/docs/FULL_AXIS_ONE_BIT_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/FULL_AXIS_ONE_BIT_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,240 @@
+---
+claim_id: full_axis_one_bit_rule_equivariance_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the 12 perpendicular weight-4 masks, whether the occupancy-named-axis one-bit pair labeling is G+-equivariant is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py
+---
+
+# Occupancy-Named-Axis One-Bit Pair Labeling Under G+ (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 12 perpendicular weight-4 occupancy masks on the 6-NN star.
+For each mask `σ` and each older-end bit `b ∈ {0,1}` on the unique full
+axis, `f(σ,b)` is the lex-first July-3 pair member with support `σ`
+invariant under `Stab(σ,b)`. Score those 12 masks and `G+`. Displayed,
+not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py`](../scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment uneqaxis: on all 12 perp masks, occupancy names the full axis;
+one age bit kills `Stab`. That census is a 15-mask split. The residual
+here is not leftover of uneqlaw (one host) or uneqaxis (census). New
+residual: the rule `f(σ,b) =` pair-member (lex-first Stab-ok) is
+`G+`-equivariant,
+
+`f(g · σ, b ∘ g^{-1}) = g · f(σ,b)`,
+
+on those 12.
+
+**Theorem 1.** `N_commute / (12 × 2 × 24) = 144/576`. Exactly 144 of the
+576 triples `(σ, b, g)` satisfy `f(g · σ, b_g) = g · f(σ,b)`, where `b_g`
+is the bit transported by `g`.
+
+**Theorem 2.** Whether that count is the full 576. `N_commute = 144` is
+not the full 576. The occupancy-named-axis one-bit pair labeling is not
+cube-covariant as a labeling.
+
+**Theorem 3.** Displayed, not adopted. Do not write `f` into Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither `f` nor any occupancy-named-axis one-bit pair
+labeling as the framework's fixed rule. The covariance clause is the
+reason a local labeling on the orbit of `(σ, b)` must be checked under
+`G+`. Formation site and rate remain outside the axiom memo. Qubit
+remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact census of the 12 perpendicular weight-4 masks times two age bits times the 24 proper cube rotations: N_commute=144 of 576. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: full_axis_one_bit_rule_equivariance
+target_blocker_text: "on the 12 perpendicular weight-4 masks, whether the occupancy-named-axis one-bit pair labeling is G+-equivariant"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_commute on the 12 masks; do not write f into Admissibility or attach L1"
+conditional_surface_status: "exact on the 12 perpendicular weight-4 masks; N_commute=144 of 576; not the full 576; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Slots are the six nearest-neighbor directions in order
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+A weight-4 occupancy mask is a 6-bit string of weight 4. A mask is
+perpendicular when the two emptied slots lie on two distinct axes. There
+are exactly 12 such masks. Each has a unique full axis: both ends of one
+axis are occupied.
+
+`G+` is the 24 proper cube rotations acting on the six slots.
+
+July-3 pair members are the 6-slot 3-letter colorings whose `G+` orbit
+is sent to a different orbit by spatial inversion. There are 48 such
+members. Each of the 12 masks is the support of exactly four of them.
+
+Displayed ticks realizing `(σ, b)` put the older end of the unique full
+axis at tick 1 and the newer end at tick 2 when `b = 1`, and the reverse
+when `b = 0`. Occupied slots off that axis carry tick 0. Empty slots
+carry no tick.
+
+`b = 1` if the minus-end tick is strictly smaller than the plus-end
+tick, else `0`.
+
+`Stab(σ,b) = { g in G+ : g · σ = σ and b(g · t) = b(t) }`.
+
+`f(σ,b)` is the lex-first July-3 pair member with support `σ` invariant
+under `Stab(σ,b)`. On each of the 12, `|Stab(σ,b)| = 1` for both bits,
+so all four pair members with support `σ` are Stab-ok, and `f(σ,0) =
+f(σ,1)` is the lex-first of those four.
+
+For `g` in `G+` the transported bit is
+
+`b_g = b ∘ g^{-1}`,
+
+computed as the older-end bit of `g · t` on the unique full axis of
+`g · σ`. The commute identity is
+
+`f(g · σ, b_g) = g · f(σ,b)`.
+
+Score the 12 masks and `G+`. The denominator is `12 × 2 × 24 = 576`.
+
+## Theorem 1 — `N_commute / (12 × 2 × 24) = 144/576`
+
+| `σ` | unique full axis | `f(σ,0) = f(σ,1)` | commute count of 48 |
+| --- | --- | --- | --- |
+| `(0, 1, 0, 1, 1, 1)` | `z` | `(0, 1, 0, 2, 1, 2)` | 12 |
+| `(0, 1, 1, 0, 1, 1)` | `z` | `(0, 1, 2, 0, 1, 2)` | 12 |
+| `(0, 1, 1, 1, 0, 1)` | `y` | `(0, 1, 1, 2, 0, 2)` | 12 |
+| `(0, 1, 1, 1, 1, 0)` | `y` | `(0, 1, 1, 2, 2, 0)` | 12 |
+| `(1, 0, 0, 1, 1, 1)` | `z` | `(1, 0, 0, 2, 1, 2)` | 12 |
+| `(1, 0, 1, 0, 1, 1)` | `z` | `(1, 0, 2, 0, 1, 2)` | 12 |
+| `(1, 0, 1, 1, 0, 1)` | `y` | `(1, 0, 1, 2, 0, 2)` | 12 |
+| `(1, 0, 1, 1, 1, 0)` | `y` | `(1, 0, 1, 2, 2, 0)` | 12 |
+| `(1, 1, 0, 1, 0, 1)` | `x` | `(1, 2, 0, 1, 0, 2)` | 12 |
+| `(1, 1, 0, 1, 1, 0)` | `x` | `(1, 2, 0, 1, 2, 0)` | 12 |
+| `(1, 1, 1, 0, 0, 1)` | `x` | `(1, 2, 1, 0, 0, 2)` | 12 |
+| `(1, 1, 1, 0, 1, 0)` | `x` | `(1, 2, 1, 0, 2, 0)` | 12 |
+
+`N_commute = 144`. Each of the 12 masks contributes 12 commuting
+`(b, g)` pairs of 48, so `N_commute / (12 × 2 × 24) = 144/576`.
+
+A commuting witness on `σ = (0, 1, 0, 1, 1, 1)`, `b = 0`,
+`f(σ,b) = (0, 1, 0, 2, 1, 2)` is
+
+`g : (x, y, z) ↦ (−x, −y, z)`,
+
+which sends the pair to `σ_g = (1, 0, 1, 0, 1, 1)`, `b_g = 0`, and both
+sides equal `(1, 0, 2, 0, 1, 2)`.
+
+A failing witness on the same `(σ, b)` is
+
+`g : (x, y, z) ↦ (−x, y, −z)`,
+
+which sends the pair to `σ_g = (1, 0, 0, 1, 1, 1)`, `b_g = 1`, with
+
+`f(σ_g, b_g) = (1, 0, 0, 2, 1, 2)`
+and
+`g · f(σ,b) = (1, 0, 0, 2, 2, 1)`.
+
+Lex-first choice on the image support is not the rotate of the lex-first
+choice on the source support.
+
+## Theorem 2 — the count is not the full 576
+
+Whether that count is the full 576. It is not. `N_commute = 144` is not
+the full 576. Because `|Stab(σ,b)| = 1`, `f` does not depend on `b`: it
+is the lex-first pair member of the occupancy support alone. That
+lex-first section of the July-3 pair over the 12 masks does not commute
+with `G+`. The occupancy-named-axis one-bit pair labeling is not
+cube-covariant as a labeling.
+
+This is a labeling residual, not leftover of uneqlaw (one host) or
+uneqaxis (census). Uneqlaw scored tick-ok membership of one rotated
+host. Uneqaxis scored whether occupancy names the axis. Neither scored
+whether the lex-first Stab-ok pair member is a `G+`-equivariant section
+on all 12.
+
+## Theorem 3 — displayed, not adopted
+
+The 576-triple census, `N_commute = 144`, the 144/576 ratio, the
+failing rotate of the lex-first section, and the conclusion that the
+occupancy-named-axis one-bit pair labeling is not cube-covariant as a
+labeling are displayed member data. They are not the framework's fixed
+Admissibility rule. This note does not write `f` into Admissibility.
+Do not write `f` into Admissibility. Do not attach L1.
+Occupancy-only formation is not attached. Qubit remains `M_2(C)`. No
+approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the 12 perpendicular weight-4 masks,
+  `N_commute = 144` of `12 × 2 × 24 = 576`. The occupancy-named-axis
+  one-bit pair labeling is not cube-covariant as a labeling. Each of
+  the 12 has `|Stab(σ,b)| = 1` and four Stab-ok pair members for both
+  bits, so `f(σ,0) = f(σ,1)`.
+- **What is displayed only.** The rule `f` and the commute count are
+  one rival table. They are not adopted.
+- **What is not claimed.** No attachment of `f`, the age bit, or a
+  unique full axis to Admissibility; no attachment of occupancy-only
+  formation; no axiom edit; no formation rate; no leftover of uneqlaw
+  (one host) or uneqaxis (census); no compiler no-go.
+- **Mutation controls.** A rebuilt `N_commute ≠ 144` fails. A rebuilt
+  denominator other than 576 fails. A rebuilt `N_commute = 576` fails
+  the Theorem 2 report. A rebuilt perp mask without a defined `f`
+  fails. A note that writes `f` into Admissibility, attaches L1, or
+  authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the 12 perpendicular weight-4 occupancy
+masks, the 24 proper cube rotations, July-3 pair members, displayed
+ticks for each `(σ, b)`, `Stab(σ,b)`, the lex-first Stab-ok pair
+member `f(σ,b)`, the transported bit `b_g`, the 576-triple commute
+count, the current premise boundary, and the mutation controls. It
+scores the 12 masks and `G+`. It writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -5281,6 +5281,10 @@
   "full128_two_rail_fixed_law_compositional_induction_bounded_theorem_note_2026-07-24": {
    "deps_hash": "39bd4d637769",
    "out_degree": 2
+  },
+  "full_axis_one_bit_rule_equivariance_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "full_physical_epr_companion_input_substitution_cycle799_bounded_theorem_note_2026-07-30": {
    "deps_hash": "39b252a4b556",

--- a/logs/runner-cache/full_axis_one_bit_rule_equivariance_2026_08_15.txt
+++ b/logs/runner-cache/full_axis_one_bit_rule_equivariance_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py
+runner_sha256: 1f5fa9171b204c3ca1ba4268da76824aacd2dbca6627b08e99df3ac6ec138c7e
+input_fingerprint_sha256: a3c755cdb9c5eb10edabe75290318c82234919fe4b5435a4bb04cc228a698107
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+occupancy-named-axis one-bit pair labeling G+ equivariance
+AUDIT_INPUT_PATHS:
+  docs/FULL_AXIS_ONE_BIT_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+G_plus=24
+N_perp=12
+N_pair=48
+N_denom=576
+N_commute=144
+N_commute_over_denom=144/576
+N_commute_eq_576=False
+f_independent_of_b=True
+perp_rows:
+  (0, 1, 0, 1, 1, 1) full=z f=(0, 1, 0, 2, 1, 2) commute=12/48
+  (0, 1, 1, 0, 1, 1) full=z f=(0, 1, 2, 0, 1, 2) commute=12/48
+  (0, 1, 1, 1, 0, 1) full=y f=(0, 1, 1, 2, 0, 2) commute=12/48
+  (0, 1, 1, 1, 1, 0) full=y f=(0, 1, 1, 2, 2, 0) commute=12/48
+  (1, 0, 0, 1, 1, 1) full=z f=(1, 0, 0, 2, 1, 2) commute=12/48
+  (1, 0, 1, 0, 1, 1) full=z f=(1, 0, 2, 0, 1, 2) commute=12/48
+  (1, 0, 1, 1, 0, 1) full=y f=(1, 0, 1, 2, 0, 2) commute=12/48
+  (1, 0, 1, 1, 1, 0) full=y f=(1, 0, 1, 2, 2, 0) commute=12/48
+  (1, 1, 0, 1, 0, 1) full=x f=(1, 2, 0, 1, 0, 2) commute=12/48
+  (1, 1, 0, 1, 1, 0) full=x f=(1, 2, 0, 1, 2, 0) commute=12/48
+  (1, 1, 1, 0, 0, 1) full=x f=(1, 2, 1, 0, 0, 2) commute=12/48
+  (1, 1, 1, 0, 1, 0) full=x f=(1, 2, 1, 0, 2, 0) commute=12/48
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: g-plus-order | proper=24
+PASS: twelve-perp-masks | N_perp=12
+PASS: stab-ok-and-f-defined
+PASS: theorem-1-n-commute | N_commute=144/576
+PASS: theorem-2-not-full-576 | eq576=False
+PASS: fail-witness | lhs=(1, 0, 0, 2, 1, 2) rhs=(1, 0, 0, 2, 2, 1)
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqlaw-uneqaxis
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: N_commute, |Stab(σ,b)|, and f(σ,b) are exact
+per_site: 12 perpendicular weight-4 occupancy masks scored
+per_mode: no spectral calculation
+per_block: 6-NN star masks and G+ only
+lattice_wide: checked and not executed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py
+++ b/scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Occupancy-named-axis one-bit pair labeling under G+.
+
+Score the 12 perpendicular weight-4 occupancy masks. For each mask and
+each older-end bit, f is the lex-first July-3 pair member with that
+support invariant under Stab(σ,b). N_commute counts the (σ,b,g) triples
+that satisfy f(g·σ, b_g)=g·f(σ,b). Displayed, not adopted. No cache
+is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/FULL_AXIS_ONE_BIT_RULE_EQUIVARIANCE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/FULL_AXIS_ONE_BIT_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+AXIS_NAME = ("x", "y", "z")
+EMPTY = 0
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the 12 perpendicular weight-4 masks, whether the '
+    "occupancy-named-axis one-bit pair labeling is G+-equivariant is "
+    'reported. Displayed, not adopted."'
+)
+SWAPPER: Matrix = ((0, 1, 0), (1, 0, 0), (0, 0, -1))
+FAIL_SIGMA: Coloring = (0, 1, 0, 1, 1, 1)
+FAIL_G: Matrix = ((-1, 0, 0), (0, 1, 0), (0, 0, -1))
+EXPECTED_F: dict[Coloring, Coloring] = {
+    (0, 1, 0, 1, 1, 1): (0, 1, 0, 2, 1, 2),
+    (0, 1, 1, 0, 1, 1): (0, 1, 2, 0, 1, 2),
+    (0, 1, 1, 1, 0, 1): (0, 1, 1, 2, 0, 2),
+    (0, 1, 1, 1, 1, 0): (0, 1, 1, 2, 2, 0),
+    (1, 0, 0, 1, 1, 1): (1, 0, 0, 2, 1, 2),
+    (1, 0, 1, 0, 1, 1): (1, 0, 2, 0, 1, 2),
+    (1, 0, 1, 1, 0, 1): (1, 0, 1, 2, 0, 2),
+    (1, 0, 1, 1, 1, 0): (1, 0, 1, 2, 2, 0),
+    (1, 1, 0, 1, 0, 1): (1, 2, 0, 1, 0, 2),
+    (1, 1, 0, 1, 1, 0): (1, 2, 0, 1, 2, 0),
+    (1, 1, 1, 0, 0, 1): (1, 2, 1, 0, 0, 2),
+    (1, 1, 1, 0, 1, 0): (1, 2, 1, 0, 2, 0),
+}
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | Tick) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(letter != EMPTY) for letter in coloring)
+
+
+def empty_slots(sigma: Coloring) -> tuple[int, int]:
+    emptied = tuple(index for index, bit in enumerate(sigma) if bit == 0)
+    if len(emptied) != 2:
+        raise AssertionError(f"expected two empty slots, got {emptied}")
+    return (emptied[0], emptied[1])
+
+
+def same_axis(left: int, right: int) -> bool:
+    return any({left, right} == set(axis) for axis in AXES)
+
+
+def unique_full_axis(sigma: Coloring) -> int | None:
+    named = tuple(
+        axis_index
+        for axis_index, (plus, minus) in enumerate(AXES)
+        if sigma[plus] == 1 and sigma[minus] == 1
+    )
+    if len(named) == 1:
+        return named[0]
+    return None
+
+
+def weight4_masks() -> tuple[Coloring, ...]:
+    return tuple(bits for bits in itertools.product((0, 1), repeat=6) if sum(bits) == 4)
+
+
+def perp_masks() -> tuple[Coloring, ...]:
+    return tuple(
+        sigma
+        for sigma in weight4_masks()
+        if not same_axis(*empty_slots(sigma))
+    )
+
+
+def display_ticks(sigma: Coloring, axis_index: int, bit: int) -> Tick:
+    plus, minus = AXES[axis_index]
+    ticks: list[int | None] = [None] * 6
+    for slot, occupied in enumerate(sigma):
+        if occupied == 0:
+            continue
+        if slot == minus:
+            ticks[slot] = 1 if bit == 1 else 2
+        elif slot == plus:
+            ticks[slot] = 2 if bit == 1 else 1
+        else:
+            ticks[slot] = 0
+    return tuple(ticks)
+
+
+def bit_on_axis(ticks: Tick, axis_index: int) -> int:
+    plus, minus = AXES[axis_index]
+    minus_tick = ticks[minus]
+    plus_tick = ticks[plus]
+    if minus_tick is not None and plus_tick is not None and minus_tick < plus_tick:
+        return 1
+    return 0
+
+
+def july3_pair(perms: list[tuple[int, ...]]) -> frozenset[Coloring]:
+    unseen = set(itertools.product(range(3), repeat=6))
+    inversion = direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+    pair: set[Coloring] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def stab_bit(
+    sigma: Coloring,
+    ticks: Tick,
+    named: int,
+    bit: int,
+    perms: list[tuple[int, ...]],
+) -> list[tuple[int, ...]]:
+    return [
+        perm
+        for perm in perms
+        if act_col(perm, sigma) == sigma
+        and bit_on_axis(act_col(perm, ticks), named) == bit
+    ]
+
+
+def pair_ok(
+    sigma: Coloring,
+    stab: list[tuple[int, ...]],
+    pair: frozenset[Coloring],
+) -> tuple[Coloring, ...]:
+    members = tuple(sorted(item for item in pair if support(item) == sigma))
+    return tuple(
+        item
+        for item in members
+        if all(act_col(perm, item) == item for perm in stab)
+    )
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    rotations = proper_rotations()
+    perms = [direction_perm(matrix) for matrix in rotations]
+    pair = july3_pair(perms)
+    masks = perp_masks()
+    denom = len(masks) * 2 * len(rotations)
+
+    rule: dict[tuple[Coloring, int], Coloring] = {}
+    stab_ok = True
+    f_indep = True
+    for sigma in masks:
+        named = unique_full_axis(sigma)
+        if named is None:
+            stab_ok = False
+            continue
+        for bit in (0, 1):
+            ticks = display_ticks(sigma, named, bit)
+            stab = stab_bit(sigma, ticks, named, bit, perms)
+            ok = pair_ok(sigma, stab, pair)
+            if len(stab) != 1 or len(ok) != 4:
+                stab_ok = False
+            if not ok:
+                continue
+            rule[(sigma, bit)] = ok[0]
+        if (sigma, 0) in rule and (sigma, 1) in rule:
+            if rule[(sigma, 0)] != rule[(sigma, 1)]:
+                f_indep = False
+
+    n_commute = 0
+    per_mask: list[int] = []
+    for sigma in masks:
+        named = unique_full_axis(sigma)
+        if named is None:
+            per_mask.append(0)
+            continue
+        mask_commute = 0
+        for bit in (0, 1):
+            if (sigma, bit) not in rule:
+                continue
+            ticks = display_ticks(sigma, named, bit)
+            coloring = rule[(sigma, bit)]
+            for perm in perms:
+                sigma_g = act_col(perm, sigma)
+                named_g = unique_full_axis(sigma_g)
+                if named_g is None:
+                    continue
+                bit_g = bit_on_axis(act_col(perm, ticks), named_g)
+                image = rule.get((sigma_g, bit_g))
+                if image is not None and image == act_col(perm, coloring):
+                    n_commute += 1
+                    mask_commute += 1
+        per_mask.append(mask_commute)
+
+    fail_perm = direction_perm(FAIL_G)
+    fail_named = unique_full_axis(FAIL_SIGMA)
+    fail_ticks = display_ticks(FAIL_SIGMA, fail_named, 0) if fail_named is not None else None
+    fail_sigma_g = act_col(fail_perm, FAIL_SIGMA)
+    fail_named_g = unique_full_axis(fail_sigma_g)
+    fail_bit_g = (
+        bit_on_axis(act_col(fail_perm, fail_ticks), fail_named_g)
+        if fail_ticks is not None and fail_named_g is not None
+        else None
+    )
+    fail_lhs = rule.get((fail_sigma_g, fail_bit_g)) if fail_bit_g is not None else None
+    fail_rhs = act_col(fail_perm, rule[(FAIL_SIGMA, 0)]) if (FAIL_SIGMA, 0) in rule else None
+
+    print("occupancy-named-axis one-bit pair labeling G+ equivariance")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"G_plus={len(rotations)}")
+    print(f"N_perp={len(masks)}")
+    print(f"N_pair={len(pair)}")
+    print(f"N_denom={denom}")
+    print(f"N_commute={n_commute}")
+    print(f"N_commute_over_denom={n_commute}/{denom}")
+    print(f"N_commute_eq_576={n_commute == 576}")
+    print(f"f_independent_of_b={f_indep}")
+    print("perp_rows:")
+    for sigma, count in zip(masks, per_mask):
+        named = unique_full_axis(sigma)
+        axis = AXIS_NAME[named] if named is not None else None
+        coloring = rule.get((sigma, 0))
+        print(f"  {sigma} full={axis} f={coloring} commute={count}/48")
+
+    expected_paths = (
+        "docs/FULL_AXIS_ONE_BIT_RULE_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "g-plus-order",
+        len(rotations) == 24
+        and len(set(rotations)) == 24
+        and det3(SWAPPER) == 1
+        and SWAPPER in rotations,
+        f"proper={len(rotations)}",
+    )
+    checks.check(
+        "twelve-perp-masks",
+        len(masks) == 12
+        and all(unique_full_axis(sigma) is not None for sigma in masks)
+        and all((sigma, 0) in rule and (sigma, 1) in rule for sigma in masks)
+        and all(rule[(sigma, 0)] == EXPECTED_F[sigma] for sigma in masks)
+        and "12 perpendicular" in note
+        and "`12 × 2 × 24 = 576`" in note,
+        f"N_perp={len(masks)}",
+    )
+    checks.check(
+        "stab-ok-and-f-defined",
+        stab_ok
+        and f_indep
+        and all(rule[(sigma, 0)] == rule[(sigma, 1)] for sigma in masks)
+        and "|Stab(σ,b)| = 1" in note
+        and "f(σ,0) =" in note
+        and "f(σ,1)" in note,
+    )
+    checks.check(
+        "theorem-1-n-commute",
+        n_commute == 144
+        and denom == 576
+        and per_mask == [12] * 12
+        and "N_commute / (12 × 2 × 24) = 144/576" in note
+        and "N_commute = 144" in note,
+        f"N_commute={n_commute}/{denom}",
+    )
+    checks.check(
+        "theorem-2-not-full-576",
+        n_commute != 576
+        and n_commute == 144
+        and "Whether that count is the full 576" in note
+        and "not the full 576" in note
+        and "not cube-covariant as a labeling" in note,
+        f"eq576={n_commute == 576}",
+    )
+    checks.check(
+        "fail-witness",
+        fail_lhs == (1, 0, 0, 2, 1, 2)
+        and fail_rhs == (1, 0, 0, 2, 2, 1)
+        and fail_lhs != fail_rhs
+        and fail_bit_g == 1
+        and fail_sigma_g == (1, 0, 0, 1, 1, 1)
+        and "`g : (x, y, z) ↦ (−x, y, −z)`" in note
+        and "`f(σ_g, b_g) = (1, 0, 0, 2, 1, 2)`" in note
+        and "`g · f(σ,b) = (1, 0, 0, 2, 2, 1)`" in note,
+        f"lhs={fail_lhs} rhs={fail_rhs}",
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write `f` into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqlaw-uneqaxis",
+        "not leftover of uneqlaw" in note_flat
+        and "one host" in note
+        and "uneqaxis" in note
+        and "census" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "N_commute" not in axiom
+        and "Stab(σ,b)" not in axiom
+        and "uneqaxis" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: N_commute, |Stab(σ,b)|, and f(σ,b) are exact")
+    print("per_site: 12 perpendicular weight-4 occupancy masks scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: 6-NN star masks and G+ only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On 12 perp masks, lex-first pair member of support(sigma) ignores b, so f(sigma,0)=f(sigma,1). N_commute=144/576. Witness sigma=(0,1,0,1,1,1). Displayed, not adopted. No axiom edit.

## Runner

`scripts/full_axis_one_bit_rule_equivariance_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.