### PR TITLE
feat(minkocc): occupancy hop costs stay diamond

### DIFF
--- a/docs/OCCUPANCY_HOP_COST_MINKOWSKI_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OCCUPANCY_HOP_COST_MINKOWSKI_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,329 @@
+---
+claim_id: occupancy_hop_cost_minkowski_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_3(0), whether G+-equivariant occupancy-dependent hop costs can match Minkowski better than ℓ¹ is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/occupancy_hop_cost_minkowski_2026_08_15.py
+---
+
+# Occupancy-Only Hop Costs Stay Diamond On The Radius-3 Ball
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact one-seed front on `B_3(0)` whose 6-NN hop cost may depend on
+the occupancy of the arrival site, restricted to `G+`-equivariant maps
+`c:{0,1}^6→{1,2}`. Displayed comparison to the Minkowski sample
+`x^2+y^2+z^2 = c t^2`. No physical clock, boost, or Wick map is selected.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/occupancy_hop_cost_minkowski_2026_08_15.py`](../scripts/occupancy_hop_cost_minkowski_2026_08_15.py)
+
+## Result Up Front
+
+Lattice names nearest-neighbor adjacency on `Z^3` and proper cubic rotations
+about each site. Admissibility says the local rule is determined by
+nearest-neighbor conditions. A leftover after constant cube-covariant hop
+costs is therefore still NN-determined: the cost of a hop into `v` may depend
+on the 6-bit occupancy `σ` of `N(v)`.
+
+Grow a one-seed front from the origin on the induced graph of the integer
+ball `B_3(0)={v∈Z^3 : |v|_1 ≤ 3}`. Arrival time is the first time the front
+reaches a site; each hop into `v` costs `c(σ)∈{1,2}`, where `σ` is read from
+already-arrived neighbors of `v`. The map `c` is required to be
+`G+`-equivariant.
+
+For constant `c=1` the front is ordinary graph distance, so isochrones are
+`ℓ¹` spheres. On the sphere `|v|_1=3` the 6 axis sites have `|v|_2^2=9` and
+the 8 body-diagonal sites have `|v|_2^2=3`. The Minkowski sample
+`|v|_2^2 = c t^2` would require those two classes to share a common ratio
+`t^2/|v|_2^2`. They do not: both arrive at `t=3`, so the ratios are `1` and
+`3`.
+
+Every `G+`-equivariant `c:{0,1}^6→{1,2}` is scored, including every cost that
+depends only on the weight of `σ` and every cost that depends only on whether
+the arrival axis is already occupied. In all `1024` equivariant maps the axis
+tips still arrive no later, per Euclidean radius, than the body-diagonal
+tips: `t(3,0,0)^2 / 9 ≤ t(1,1,1)^2 / 3`. No map reverses that order. Therefore
+occupancy-only hop costs stay diamond.
+
+The comparison is displayed, not adopted. Do not write a cost into
+Admissibility. Do not attach a named arrival kernel.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences supply the six-neighbor graph, the proper-cube covariance, and
+the license to let a displayed hop cost depend on nearest-neighbor occupancy.
+They do not name a hop-cost, a first-arrival clock, a null cone, a boost, or a
+Wick map. This note does not edit them.
+
+Record is unused. The current Record boundary remains:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The scored domain is only `B_3(0)`. No larger ball is grown.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Constant-c=1 ell^1 isochrones, the axis/body Euclidean mismatch at ell^1=3, and the 1024-map G+ occupancy census on B_3(0) are finite exact statements. Minkowski light is a displayed comparator, not an adopted law."
+trace_class: negative_route_pruning
+target_claim_id: occupancy_hop_cost_minkowski
+target_blocker_text: "score whether G+-equivariant occupancy-dependent 6-NN hop-costs on a one-seed B_3(0) front can match a Minkowski sample better than ell^1"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Do not attach a named arrival kernel; a later route that wants isotropic c must change the hop set, drop G+ equivariance, enlarge the cost alphabet, or add structure that is not occupancy-only on B_3(0)."
+conditional_surface_status: "exact for G+-equivariant occupancy hop-costs in {1,2} on the induced B_3(0) one-seed front; no adopted clock or axiom edit"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`, and
+
+`A = {±e_1, ±e_2, ±e_3}`.
+
+A proper cube matrix is a `3×3` monomial signed-permutation matrix with
+exactly one nonzero entry `±1` in each row and column and determinant `+1`.
+The proper cube group `G+` is the set of all such matrices. It has order `24`
+and acts on occupancy configurations `σ∈{0,1}^A` by permuting the six
+neighbor slots.
+
+The comparison domain is
+
+`B_3(0) = {v∈Z^3 : |v|_1 ≤ 3}`.
+
+It has `63` sites. The induced 6-NN graph is used; sites with `|v|_1=4` are
+never occupied. The seed is the origin. Occupancy of an arrival site `v` is
+the 6-bit pattern of which neighbors in `A` have already arrived. A hop into
+`v` costs `c(σ)∈{1,2}`. First arrival is the one-seed front time, which is the
+minimum path cost among paths whose hop costs are evaluated against the
+already-arrived set.
+
+`G+`-equivariance means `c(gσ)=c(σ)` for every `g∈G+`. The action has ten
+orbits on `{0,1}^6`, so there are `2^{10}=1024` equivariant maps to `{1,2}`.
+Two named subfamilies are included in that census:
+
+- weight-only maps, `c(σ)=f(|σ|)`;
+- arrival-axis maps, `c` depending on whether the far neighbor along the
+  incoming hop is already occupied.
+
+The taxicab and Euclidean quadratic forms are the displayed comparators
+
+`|v|_1 = |v_1|+|v_2|+|v_3|`,
+
+`|v|_2^2 = v_1^2+v_2^2+v_3^2`.
+
+The Minkowski sample is the displayed relation `|v|_2^2 = c t^2`, or
+equivalently constancy of `t^2/|v|_2^2` on a nonzero sample.
+
+## Theorem 1 — Constant Cost Recovers ℓ¹ Isochrones
+
+If `c` is the constant function `1`, every hop costs `1`. The one-seed front
+on the induced ball is ordinary graph distance, so
+
+`t(v)=|v|_1`
+
+on `B_3(0)`. Isochrones are `ℓ¹` spheres.
+
+On the sphere `|v|_1=3` there are `6` axis sites `(±3,0,0)` and permutations,
+each with `|v|_2^2=9`, and `8` body-diagonal sites `(±1,±1,±1)`, each with
+`|v|_2^2=3`. All fourteen sites arrive at `t=3`. The displayed ratios are
+
+`t(3,0,0)^2 / 9 = 1`, `t(1,1,1)^2 / 3 = 3`.
+
+That is the `ℓ¹` versus Euclidean mismatch on this sample. It is not a
+leftover of a constant direction-only hop cost: the same numbers appear here
+as the occupancy-independent baseline against which occupancy-dependent maps
+are scored.
+
+## Theorem 2 — Occupancy-Only Maps Stay Diamond
+
+Let `c:{0,1}^6→{1,2}` be `G+`-equivariant. Grow the one-seed front on
+`B_3(0)` and write `t_axis=t(3,0,0)` and `t_body=t(1,1,1)`. Cube covariance
+forces these values to be constant on the `6` axis tips and on the `8` body
+tips respectively.
+
+The Euclidean-radius comparison is the exact integer inequality
+
+`t_axis^2 · 3 ≤ t_body^2 · 9`,
+
+which says that the axis sites still arrive no later than the body diagonals
+at the same Euclidean radius (smaller or equal `t^2/|v|_2^2`).
+
+The `1024` maps produce only the six ordered pairs
+
+`(t_axis,t_body) ∈ {(3,3),(3,4),(3,5),(6,4),(6,5),(6,6)}`.
+
+Each pair satisfies the inequality. The first reversing map in lexicographic
+orbit order does not exist. Weight-only maps produce the same six pairs.
+Arrival-axis maps produce only `(3,3)` and `(6,6)`.
+
+On the induced ball the unique in-ball neighbor of `(3,0,0)` is `(2,0,0)`, so
+every axis-tip hop has weight `1` and `t_axis=3 c(wt=1)`. Body-diagonal sites
+can see up to three already-arrived face-adjacent neighbors, so occupancy can
+split the raw times. Even the most body-favoring pair `(6,4)` still has
+
+`6^2 / 9 = 4 < 16/3 = 4^2 / 3`.
+
+Axes remain the fast Euclidean directions. Therefore occupancy-only hop costs
+stay diamond.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The Minkowski sample and the occupancy hop-cost are displayed comparison
+objects. They are not written into Lattice or Admissibility. No cost law is
+adopted. No arrival kernel is attached. A Wick map is not selected.
+
+Displayed, not adopted. Do not write a cost into Admissibility.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| quote current Lattice nearest-neighbor and proper-cube wording | source-bound |
+| quote current Admissibility covariance and NN-condition wording | source-bound |
+| enumerate `G+` and the ten occupancy orbits | closed by finite listing |
+| constant `c=1` recovers `t=|v|_1` on `B_3(0)` | closed by the one-seed front |
+| report the `|v|_1=3` axis/body Euclidean mismatch | closed: `|v|_2^2=9` versus `|v|_2^2=3` |
+| census every `G+`-equivariant `c` to `{1,2}` | closed: `1024` maps, six pairs |
+| axis still no later per Euclidean radius, or name the first reversal | closed: no reversal |
+| write a cost into Admissibility | outside the claim |
+| attach a named arrival kernel | outside the claim |
+| edit Lattice or Admissibility | `hypothetical_axiom_status: no edit` |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a physical light law is not a proof leaf because it is
+expressly not part of the target.
+
+## Imports And Non-Claims
+
+Only the current axiom memo is imported. Occupancy is the one-seed arrived
+set on the induced `B_3(0)` graph, not a new spatial patch and not a Record
+content map. The Minkowski sample is a displayed comparator on that finite
+ball.
+
+The theorem does not say that isotropic light is impossible in every later
+construction. It says that `G+`-equivariant occupancy-dependent hop-costs
+with values in `{1,2}` on this one-seed front stay diamond.
+
+## Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It isolates occupancy dependence of a still-NN hop cost as the leftover after constant cube-covariant costs, and scores it on `B_3(0)`. |
+| V2 | Current main names nearest-neighbor conditions but does not score occupancy hop-costs against the displayed Minkowski sample. |
+| V3 | Group order, orbit count, the `63`-site ball, and the `1024`-map census are independently finite and exact. |
+| V4 | The result is more than a restatement of constant hop-costs because occupancy is allowed to vary with the arrival 6-tuple. |
+| V5 | The comparisons remain displayed; the note does not install Minkowski structure or a clock. |
+
+## No-Go Discipline Gate
+
+The negative claim is restricted to `G+`-equivariant occupancy hop-costs in
+`{1,2}` on the one-seed front in `B_3(0)`, and to the displayed Minkowski
+sample on the `ℓ¹=3` axis/body sites. No global impossibility of isotropic
+light is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| constant occupancy-blind cost | `c=1` | executed; `t=|v|_1`; mismatch `1` versus `3` |
+| weight-only occupancy cost | `c=f(|σ|)` in `{1,2}` | executed; six pairs; diamond order holds |
+| arrival-axis occupancy cost | cost from the far-axis bit | executed; pairs `(3,3)` and `(6,6)` only |
+| every `G+`-equivariant `c` | `1024` maps `{0,1}^6→{1,2}` | executed; no Euclidean-radius reversal |
+| drop `G+` equivariance | unequal costs on one orbit | lives only after dropping cube covariance |
+| larger hop set | add face diagonals or longer steps | different member; not 6-NN |
+| enlarge the cost alphabet | values outside `{1,2}` | different object; not scored |
+| write a cost into Admissibility | enlarge the axiom | forbidden; `no edit` |
+
+### N2 — wall independence
+
+Cube covariance, the six-neighbor hop set, the `{1,2}` occupancy cost type,
+the one-seed front, and the displayed Minkowski sample are distinct inputs.
+The note claims no complete wall collection beyond this scored class.
+
+### N3 — hidden-condition scan
+
+The hop set, the group `G+`, occupancy of already-arrived neighbors, the
+induced `B_3(0)` domain, layer-synchronous front arrival, and the
+Euclidean-radius predicate are declared. A Wick map, a boost, and an axiom
+edit are not silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies nearest-neighbor adjacency, proper cubic
+rotations, and an Admissibility rule determined by nearest-neighbor
+conditions. It does not name Minkowski light. The residual scored here is
+occupancy dependence of an NN hop-cost, not leftover constancy of a
+direction-only member.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | ten occupancy orbits and the named axis/body tips | no continuum spacetime classification |
+| per site | one-seed front arrival on `B_3(0)` | no Record content map |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | `B_3(0)` only | no larger spatial patch |
+| lattice wide | checked and not executed | no global light-law derivation |
+
+### N6 — live partial-closure paths
+
+A later construction may change the hop set, drop cube covariance, enlarge
+the cost alphabet, or add structure that is not an occupancy-only 6-NN hop
+cost on `B_3(0)`. Those are different objects. They are not scored here and
+are not filled by writing a cost into Admissibility.
+
+### N7 — hostile steelman
+
+**Steelman:** Making singleton hops expensive and crowded arrivals cheap
+should fill body diagonals first and restore a Euclidean sphere.
+
+**Answer:** That law is included. It produces `(t_axis,t_body)=(6,4)`, which
+splits the raw `|v|_1=3` sphere. The Euclidean-radius order still holds,
+`4 < 16/3`, so axes remain faster per Euclidean radius. Occupancy-only hop
+costs stay diamond.
+
+### N8 — cross-cycle echo
+
+This note does not attach a named arrival kernel and does not treat the
+comparison as leftover character of a constant direction-only hop-cost. It
+scores occupancy dependence on the arrival 6-tuple, which that constant-cost
+census did not run.
+
+**Gate disposition:** PASS for constant-`c=1` `ℓ¹` isochrones, the
+`|v|_1=3` Euclidean mismatch, and the occupancy census with no
+Euclidean-radius reversal. FAIL / DO NOT SHIP for “Minkowski is adopted,”
+“Admissibility now contains a hop-cost,” “a Wick map is selected,” or
+“occupancy-only costs match the Minkowski sample better than `ℓ¹`.”
+
+## Primary Runner
+
+The primary runner enumerates `G+` and the occupancy orbits, grows the
+one-seed front on `B_3(0)` for every equivariant cost, checks the constant-`c`
+isochrones and the axis/body mismatch, and confirms that no scored map
+reverses the Euclidean-radius diamond order. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13425,6 +13425,10 @@
   "occupancy_atom_is_the_outcome_dictionary_flow_selects_equipartition_bounded_note_2026-06-12": {
    "deps_hash": "61b6add32af6",
    "out_degree": 3
+  },
+  "occupancy_hop_cost_minkowski_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "occupancy_nonexclusivity_mixture_bound_note_2026-06-09": {
    "deps_hash": "188680808cab",

--- a/logs/runner-cache/occupancy_hop_cost_minkowski_2026_08_15.txt
+++ b/logs/runner-cache/occupancy_hop_cost_minkowski_2026_08_15.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/occupancy_hop_cost_minkowski_2026_08_15.py
+runner_sha256: 1202e1261ec7f88ca5b83d666cbe71feb9a33b6a0c97661722da715a6c6dc04c
+input_fingerprint_sha256: a29e6d03460e8b6f5673676dbbc7b9f53925316d3e67d393ef76c8ae0eceae88
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.37
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/OCCUPANCY_HOP_COST_MINKOWSKI_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: current Lattice and Admissibility wording are source-bound; Minkowski light is a displayed comparator
+construction: one-seed front on B_3(0) with G+-equivariant occupancy hop-costs in {1,2}
+negative_scope: occupancy-only hop-costs stay diamond on B_3(0); no axiom edit and no adopted cost
+PASS: audit-inputs declared inputs are exactly the source note and the axiom memo
+PASS: source-lattice current cubic nearest-neighbor and proper-cube wording is pinned
+PASS: source-admissibility current covariance and local-condition wording is pinned
+PASS: source-no-minkowski-in-axioms the axiom memo does not name Minkowski, a hop-cost, or a Wick map
+PASS: group-order the proper cube group has 24 matrices of determinant +1
+PASS: ball-census B_3(0) has 63 integer sites; the ell^1=3 sphere has 6 axis and 8 body-diagonal sites
+PASS: occupancy-orbits G+ has ten orbits on {0,1}^6, so 1024 equivariant maps to {1,2}
+PASS: constant-isochrones constant c=1 gives first arrival equal to ell^1 on B_3(0)
+PASS: ell1-euclidean-mismatch at ell^1=3 the 6 axis sites have |v|_2^2=9 and the 8 body sites have |v|_2^2=3
+PASS: weight-family-diamond every weight-only cost in {1,2} keeps the axis/body Euclidean-radius order
+PASS: arrival-axis-family-diamond every arrival-axis occupancy cost in {1,2} keeps equal axis and body arrival
+PASS: equivariant-census-diamond every G+-equivariant c:{0,1}^6->{1,2} keeps the Euclidean-radius diamond order
+N_B3=63 N_orbits=10 N_equivariant=1024 first_reversal=None
+axis_body_pairs=[(3, 3), (3, 4), (3, 5), (6, 4), (6, 5), (6, 6)]
+PASS: note-contract machine fields, displayed-not-adopted boundary, N1-N8, and forbidden-phrase hygiene hold
+per_element: six axis tips, eight body-diagonal tips, and every G+ occupancy orbit are executed
+per_site: one-seed first arrival is scored on the induced B_3(0) graph
+per_mode: checked and not executed — no spectral claim occurs
+per_block: B_3(0) is the only comparison domain
+lattice_wide: checked and not executed — no axiom edit and no adopted hop-cost
+TOTAL: PASS=13 FAIL=0
+
+----- stderr -----
+

--- a/scripts/occupancy_hop_cost_minkowski_2026_08_15.py
+++ b/scripts/occupancy_hop_cost_minkowski_2026_08_15.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Exact checks for G+-equivariant occupancy hop-costs on B_3(0)."""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/OCCUPANCY_HOP_COST_MINKOWSKI_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Point = tuple[int, int, int]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+AXES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXIS_INDEX: dict[Point, int] = {axis: index for index, axis in enumerate(AXES)}
+ORIGIN: Point = (0, 0, 0)
+AXIS_TIP: Point = (3, 0, 0)
+BODY_TIP: Point = (1, 1, 1)
+RADIUS = 3
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def matrix_det(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def apply_linear(matrix: Matrix, vector: Point) -> Point:
+    return tuple(sum(matrix[i][j] * vector[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def proper_cube_group() -> tuple[Matrix, ...]:
+    group: list[Matrix] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = []
+            for i in range(3):
+                row = [0, 0, 0]
+                row[perm[i]] = signs[i]
+                rows.append(tuple(row))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix_det(matrix) == 1:
+                group.append(matrix)
+    return tuple(group)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1_norm(vector: Point) -> int:
+    return abs(vector[0]) + abs(vector[1]) + abs(vector[2])
+
+
+def l2_sq(vector: Point) -> int:
+    return vector[0] * vector[0] + vector[1] * vector[1] + vector[2] * vector[2]
+
+
+def radius_ball(radius: int) -> tuple[Point, ...]:
+    return tuple(
+        (x, y, z)
+        for x, y, z in product(range(-radius, radius + 1), repeat=3)
+        if l1_norm((x, y, z)) <= radius
+    )
+
+
+def inverse_matrix(matrix: Matrix) -> Matrix:
+    return tuple(tuple(matrix[j][i] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def act_occupancy(matrix: Matrix, bits: int) -> int:
+    inverse = inverse_matrix(matrix)
+    out = 0
+    for index, axis in enumerate(AXES):
+        preimage = apply_linear(inverse, axis)
+        out |= ((bits >> AXIS_INDEX[preimage]) & 1) << index
+    return out
+
+
+def occupancy_orbits(group: tuple[Matrix, ...]) -> tuple[tuple[int, ...], ...]:
+    seen: set[int] = set()
+    orbits: list[tuple[int, ...]] = []
+    for bits in range(64):
+        if bits in seen:
+            continue
+        orbit = {act_occupancy(matrix, bits) for matrix in group}
+        seen |= orbit
+        orbits.append(tuple(sorted(orbit)))
+    return tuple(orbits)
+
+
+def orbit_id_table(orbits: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
+    table = [0] * 64
+    for orbit_id, orbit in enumerate(orbits):
+        for bits in orbit:
+            table[bits] = orbit_id
+    return tuple(table)
+
+
+def occupancy_bits(site: Point, occupied: set[Point]) -> int:
+    bits = 0
+    for index, axis in enumerate(AXES):
+        if add(site, axis) in occupied:
+            bits |= 1 << index
+    return bits
+
+
+def front_arrival(
+    ball: tuple[Point, ...],
+    cost_of: object,
+) -> dict[Point, int]:
+    """One-seed front on the induced B_3 graph; layer-synchronous occupancy."""
+    ball_set = set(ball)
+    arrival: dict[Point, int] = {ORIGIN: 0}
+    settled: set[Point] = set()
+    while True:
+        pending = [site for site in ball if site not in settled and site in arrival]
+        if not pending:
+            break
+        time = min(arrival[site] for site in pending)
+        layer = [site for site in pending if arrival[site] == time]
+        settled.update(layer)
+        for site in layer:
+            for hop in AXES:
+                neighbor = add(site, hop)
+                if neighbor not in ball_set or neighbor in settled:
+                    continue
+                bits = occupancy_bits(neighbor, settled)
+                next_time = time + cost_of(bits, hop)
+                if next_time < arrival.get(neighbor, 10**9):
+                    arrival[neighbor] = next_time
+    return arrival
+
+
+def weight_cost(table: tuple[int, ...]):
+    def cost_of(bits: int, hop: Point) -> int:
+        del hop
+        return table[bin(bits).count("1")]
+
+    return cost_of
+
+
+def orbit_cost(orbit_table: tuple[int, ...], ids: tuple[int, ...]):
+    def cost_of(bits: int, hop: Point) -> int:
+        del hop
+        return orbit_table[ids[bits]]
+
+    return cost_of
+
+
+def arrival_axis_cost(empty_cost: int, occupied_cost: int):
+    """Cost depends on whether the far end of the arrival axis is occupied."""
+
+    def cost_of(bits: int, hop: Point) -> int:
+        opposite = (bits >> AXIS_INDEX[hop]) & 1
+        return occupied_cost if opposite else empty_cost
+
+    return cost_of
+
+
+def axis_body_times(arrival: dict[Point, int], axes: tuple[Point, ...], bodies: tuple[Point, ...]) -> tuple[int, int]:
+    axis_values = {arrival[site] for site in axes}
+    body_values = {arrival[site] for site in bodies}
+    if len(axis_values) != 1 or len(body_values) != 1:
+        raise RuntimeError((axis_values, body_values))
+    return next(iter(axis_values)), next(iter(body_values))
+
+
+def diamond_order(axis_time: int, body_time: int) -> bool:
+    """Axis sites arrive no later per Euclidean radius than body sites."""
+    return axis_time * axis_time * l2_sq(BODY_TIP) <= body_time * body_time * l2_sq(AXIS_TIP)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice and Admissibility wording are source-bound; Minkowski light is a displayed comparator")
+    print("construction: one-seed front on B_3(0) with G+-equivariant occupancy hop-costs in {1,2}")
+    print("negative_scope: occupancy-only hop-costs stay diamond on B_3(0); no axiom edit and no adopted cost")
+
+    checks.check(
+        "audit-inputs",
+        "declared inputs are exactly the source note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/OCCUPANCY_HOP_COST_MINKOWSKI_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    cubic_rotations = "proper cubic rotations about each site"
+    admissibility_cov = "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations."
+    admissibility_law = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor and proper-cube wording is pinned",
+        lattice_sentence in normalized_axiom
+        and cubic_rotations in normalized_axiom
+        and lattice_sentence in note
+        and cubic_rotations in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current covariance and local-condition wording is pinned",
+        admissibility_cov in normalized_axiom
+        and admissibility_law in normalized_axiom
+        and admissibility_cov in normalized_note
+        and admissibility_law in normalized_note,
+    )
+    checks.check(
+        "source-no-minkowski-in-axioms",
+        "the axiom memo does not name Minkowski, a hop-cost, or a Wick map",
+        all(token not in axiom for token in ("Minkowski", "hop-cost", "Wick")),
+    )
+
+    group = proper_cube_group()
+    ball = radius_ball(RADIUS)
+    axes = tuple(site for site in ball if l1_norm(site) == 3 and sorted(abs(coord) for coord in site) == [0, 0, 3])
+    bodies = tuple(site for site in ball if l1_norm(site) == 3 and sorted(abs(coord) for coord in site) == [1, 1, 1])
+    orbits = occupancy_orbits(group)
+    ids = orbit_id_table(orbits)
+
+    checks.check(
+        "group-order",
+        "the proper cube group has 24 matrices of determinant +1",
+        len(group) == 24 and len(set(group)) == 24 and all(matrix_det(matrix) == 1 for matrix in group),
+        residual=len(group),
+    )
+    checks.check(
+        "ball-census",
+        "B_3(0) has 63 integer sites; the ell^1=3 sphere has 6 axis and 8 body-diagonal sites",
+        len(ball) == 63
+        and len(axes) == 6
+        and len(bodies) == 8
+        and AXIS_TIP in axes
+        and BODY_TIP in bodies
+        and l2_sq(AXIS_TIP) == 9
+        and l2_sq(BODY_TIP) == 3,
+        residual=(len(ball), len(axes), len(bodies)),
+    )
+    checks.check(
+        "occupancy-orbits",
+        "G+ has ten orbits on {0,1}^6, so 1024 equivariant maps to {1,2}",
+        len(orbits) == 10
+        and sum(len(orbit) for orbit in orbits) == 64
+        and all(act_occupancy(matrix, bits) in orbits[ids[bits]] for matrix in group for bits in range(64)),
+        residual=len(orbits),
+    )
+
+    constant = front_arrival(ball, weight_cost((1, 1, 1, 1, 1, 1, 1)))
+    axis_const, body_const = axis_body_times(constant, axes, bodies)
+    sphere_ok = all(constant[site] == l1_norm(site) for site in ball)
+    checks.check(
+        "constant-isochrones",
+        "constant c=1 gives first arrival equal to ell^1 on B_3(0)",
+        sphere_ok and axis_const == 3 and body_const == 3 and constant[ORIGIN] == 0,
+        residual=(axis_const, body_const),
+    )
+    checks.check(
+        "ell1-euclidean-mismatch",
+        "at ell^1=3 the 6 axis sites have |v|_2^2=9 and the 8 body sites have |v|_2^2=3",
+        axis_const == body_const == 3
+        and {l2_sq(site) for site in axes} == {9}
+        and {l2_sq(site) for site in bodies} == {3}
+        and (axis_const * axis_const) // 9 != (body_const * body_const) // 3,
+        residual=((axis_const * axis_const) // 9, (body_const * body_const) // 3),
+    )
+
+    weight_pairs = set()
+    weight_diamond = True
+    for mask in range(128):
+        table = tuple(1 + ((mask >> weight) & 1) for weight in range(7))
+        arrival = front_arrival(ball, weight_cost(table))
+        axis_time, body_time = axis_body_times(arrival, axes, bodies)
+        weight_pairs.add((axis_time, body_time))
+        weight_diamond = weight_diamond and diamond_order(axis_time, body_time)
+    checks.check(
+        "weight-family-diamond",
+        "every weight-only cost in {1,2} keeps the axis/body Euclidean-radius order",
+        weight_diamond and weight_pairs == {(3, 3), (3, 4), (3, 5), (6, 4), (6, 5), (6, 6)},
+        residual=sorted(weight_pairs),
+    )
+
+    axis_pairs = set()
+    axis_diamond = True
+    for empty_cost, occupied_cost in product((1, 2), repeat=2):
+        arrival = front_arrival(ball, arrival_axis_cost(empty_cost, occupied_cost))
+        axis_time, body_time = axis_body_times(arrival, axes, bodies)
+        axis_pairs.add((axis_time, body_time))
+        axis_diamond = axis_diamond and diamond_order(axis_time, body_time)
+    checks.check(
+        "arrival-axis-family-diamond",
+        "every arrival-axis occupancy cost in {1,2} keeps equal axis and body arrival",
+        axis_diamond and axis_pairs == {(3, 3), (6, 6)},
+        residual=sorted(axis_pairs),
+    )
+
+    first_reversal = None
+    orbit_pairs = set()
+    for mask in range(1 << len(orbits)):
+        table = tuple(1 + ((mask >> orbit_id) & 1) for orbit_id in range(len(orbits)))
+        arrival = front_arrival(ball, orbit_cost(table, ids))
+        axis_time, body_time = axis_body_times(arrival, axes, bodies)
+        orbit_pairs.add((axis_time, body_time))
+        if not diamond_order(axis_time, body_time) and first_reversal is None:
+            first_reversal = (table, axis_time, body_time)
+    checks.check(
+        "equivariant-census-diamond",
+        "every G+-equivariant c:{0,1}^6->{1,2} keeps the Euclidean-radius diamond order",
+        first_reversal is None
+        and len(orbits) == 10
+        and orbit_pairs == {(3, 3), (3, 4), (3, 5), (6, 4), (6, 5), (6, 6)},
+        residual=first_reversal,
+    )
+    print(f"N_B3={len(ball)} N_orbits={len(orbits)} N_equivariant={1 << len(orbits)} first_reversal={first_reversal}")
+    print(f"axis_body_pairs={sorted(orbit_pairs)}")
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: negative_route_pruning",
+        "reachability_to_target: prunes",
+        'hypothetical_axiom_status: "no edit"',
+        "occupancy-only hop costs stay diamond",
+        "|v|_2^2=9",
+        "|v|_2^2=3",
+        "Displayed, not adopted",
+        "Do not write a cost into Admissibility",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "one-seed front",
+        "B_3(0)",
+    )
+    slash_r = "/" + "r"
+    forbidden = (
+        "G" + "_N",
+        "1" + slash_r,
+        "1" + slash_r + "^2",
+        "Lattice" + "-named",
+        "not a " + "TOE",
+        "new axiom",
+        "we adopt",
+        "runner-cache",
+        "trace_class: direct_blocker_closure",
+        "reachability_to_target: partially_closes",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, displayed-not-adopted boundary, N1-N8, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{i}" in note for i in range(1, 9))
+        and not any(phrase in note for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "Block 12" not in note
+        and "toe-lphys" not in note
+        and "L1" not in note,
+        residual=[phrase for phrase in required if phrase not in note],
+    )
+
+    print("per_element: six axis tips, eight body-diagonal tips, and every G+ occupancy orbit are executed")
+    print("per_site: one-seed first arrival is scored on the induced B_3(0) graph")
+    print("per_mode: checked and not executed — no spectral claim occurs")
+    print("per_block: B_3(0) is the only comparison domain")
+    print("lattice_wide: checked and not executed — no axiom edit and no adopted hop-cost")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

All 1024 G+-equivariant occupancy hop-costs in {1,2} keep t(axis)^2/9 <= t(diagonal)^2/3 on B3(0). No Minkowski reversal. Displayed, not adopted. No axiom edit.

## Runner

`scripts/occupancy_hop_cost_minkowski_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.