### PR TITLE
feat(bitenc): age-bit axis encoding commutes 288 of 576

### DIFF
--- a/docs/FULL_AXIS_AGE_BIT_ENCODING_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/FULL_AXIS_AGE_BIT_ENCODING_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,233 @@
+---
+claim_id: full_axis_age_bit_encoding_equivariance_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the 12 perpendicular weight-4 masks, whether encoding the age bit as opposite letters on the full axis yields a G+-equivariant pair labeling is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py
+---
+
+# Age-Bit Encoding On The Occupancy-Named Full Axis Under G+ (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 12 perpendicular weight-4 occupancy masks on the 6-NN star.
+For each mask `σ` and each older-end bit `b ∈ {0,1}` on the unique full
+axis, `f(σ,b)` writes opposite letters on that axis according to `b`
+(older end `−`, younger `+`) and takes the unique, or else lex-first,
+completion of the other two occupied slots to a July-3 pair member.
+Score those 12 masks and `G+`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py`](../scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment bitlaw: the lex-first pair member of `support(σ)` is independent
+of `b`, so `f(σ,0)=f(σ,1)` and `N_commute=144/576`. That residual is not
+leftover of bitlaw (lex-first ignored `b`). New residual: define `f(σ,b)`
+by writing opposite letters on the occupancy-named full axis according to
+`b` (older end `−`, younger `+`), then the unique or lex-first completion
+to a July-3 pair member. Then recompute `N_commute/576`.
+
+**Theorem 1.** A pair completion exists for both bits on each of the 12.
+No `(σ, b)` has a unique completion: each has exactly two. The rule
+therefore takes the lex-first of those two. `N_complete / 24 = 24/24`.
+
+**Theorem 2.** `N_commute / 576 = 288/576`. Whether `N_commute=576`: it is
+not. Encoding the age bit as opposite letters on the full axis does not
+yield a `G+`-equivariant pair labeling.
+
+**Theorem 3.** Displayed, not adopted. Do not write `f` into Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither `f` nor any full-axis opposite-letter encoding
+of the age bit as the framework's fixed rule. The covariance clause is the
+reason a local labeling on the orbit of `(σ, b)` must be checked under
+`G+`. Formation site and rate remain outside the axiom memo. Qubit
+remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact census of the 12 perpendicular weight-4 masks times two age bits: N_complete=24 of 24, and times the 24 proper cube rotations: N_commute=288 of 576. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: full_axis_age_bit_encoding_equivariance
+target_blocker_text: "on the 12 perpendicular weight-4 masks, whether encoding the age bit as opposite letters on the full axis yields a G+-equivariant pair labeling"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_complete and N_commute on the 12 masks; do not write f into Admissibility or attach L1"
+conditional_surface_status: "exact on the 12 perpendicular weight-4 masks; N_complete=24 of 24; N_commute=288 of 576; not the full 576; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Slots are the six nearest-neighbor directions in order
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+A weight-4 occupancy mask is a 6-bit string of weight 4. A mask is
+perpendicular when the two emptied slots lie on two distinct axes. There
+are exactly 12 such masks. Each has a unique full axis: both ends of one
+axis are occupied.
+
+`G+` is the 24 proper cube rotations acting on the six slots.
+
+July-3 pair members are the 6-slot 3-letter colorings on `{0, +, −}`
+whose `G+` orbit is sent to a different orbit by spatial inversion.
+Letter order is `0 < + < −`. There are 48 such members. Each of the 12
+masks is the support of exactly four of them.
+
+`b = 1` means `t(−axis) < t(+axis)`. Set `c(−axis)=−`, `c(+axis)=+` if
+`b=1`, and the swap if `b=0`. Empty slots are `0`. Complete the other
+two occupied slots to a pair member if unique; else take the lex-first
+among completions.
+
+Displayed ticks realizing `(σ, b)` put the older end of the unique full
+axis at tick 1 and the newer end at tick 2 when `b = 1`, and the reverse
+when `b = 0`. Occupied slots off that axis carry tick 0. Empty slots
+carry no tick. The transported bit is the older-end bit of `g · t` on
+the unique full axis of `g · σ`. The commute identity is
+
+`f(g · σ, b_g) = g · f(σ,b)`.
+
+Score the 12 masks and `G+`. The completion denominator is `12 × 2 = 24`.
+The commute denominator is `12 × 2 × 24 = 576`.
+
+## Theorem 1 — pair completion exists for both bits; `N_complete / 24 = 24/24`
+
+| `σ` | unique full axis | both bits | `f(σ,0)` | `f(σ,1)` | completions each bit |
+| --- | --- | --- | --- | --- | --- |
+| `(0, 1, 0, 1, 1, 1)` | `z` | yes | `(0, +, 0, −, −, +)` | `(0, +, 0, −, +, −)` | 2 |
+| `(0, 1, 1, 0, 1, 1)` | `z` | yes | `(0, +, −, 0, −, +)` | `(0, +, −, 0, +, −)` | 2 |
+| `(0, 1, 1, 1, 0, 1)` | `y` | yes | `(0, +, −, +, 0, −)` | `(0, +, +, −, 0, −)` | 2 |
+| `(0, 1, 1, 1, 1, 0)` | `y` | yes | `(0, +, −, +, −, 0)` | `(0, +, +, −, −, 0)` | 2 |
+| `(1, 0, 0, 1, 1, 1)` | `z` | yes | `(+, 0, 0, −, −, +)` | `(+, 0, 0, −, +, −)` | 2 |
+| `(1, 0, 1, 0, 1, 1)` | `z` | yes | `(+, 0, −, 0, −, +)` | `(+, 0, −, 0, +, −)` | 2 |
+| `(1, 0, 1, 1, 0, 1)` | `y` | yes | `(+, 0, −, +, 0, −)` | `(+, 0, +, −, 0, −)` | 2 |
+| `(1, 0, 1, 1, 1, 0)` | `y` | yes | `(+, 0, −, +, −, 0)` | `(+, 0, +, −, −, 0)` | 2 |
+| `(1, 1, 0, 1, 0, 1)` | `x` | yes | `(−, +, 0, +, 0, −)` | `(+, −, 0, +, 0, −)` | 2 |
+| `(1, 1, 0, 1, 1, 0)` | `x` | yes | `(−, +, 0, +, −, 0)` | `(+, −, 0, +, −, 0)` | 2 |
+| `(1, 1, 1, 0, 0, 1)` | `x` | yes | `(−, +, +, 0, 0, −)` | `(+, −, +, 0, 0, −)` | 2 |
+| `(1, 1, 1, 0, 1, 0)` | `x` | yes | `(−, +, +, 0, −, 0)` | `(+, −, +, 0, −, 0)` | 2 |
+
+`N_complete = 24`. A pair completion exists for both bits on each of
+the 12, so `N_complete / 24 = 24/24`. No completion is unique. The
+lex-first of the two completions is used, and `f(σ,0) ≠ f(σ,1)` on
+every mask: the opposite-letter write on the full axis depends on `b`.
+
+## Theorem 2 — `N_commute / 576 = 288/576`; not the full 576
+
+Whether `N_commute=576`. It is not. `N_commute = 288` of the 576
+triples `(σ, b, g)`. Each of the 12 masks contributes 24 commuting
+`(b, g)` pairs of 48, so `N_commute / 576 = 288/576`. Encoding the age
+bit as opposite letters on the full axis is not a `G+`-equivariant
+pair labeling.
+
+A commuting witness on `σ = (0, 1, 0, 1, 1, 1)`, `b = 0`,
+`f(σ,b) = (0, +, 0, −, −, +)` is
+
+`g : (x, y, z) ↦ (−x, −y, z)`,
+
+which sends the pair to `σ_g = (1, 0, 1, 0, 1, 1)`, `b_g = 0`, and both
+sides equal `(+, 0, −, 0, −, +)`.
+
+A failing witness on the same `(σ, b)` is
+
+`g : (x, y, z) ↦ (−y, x, z)`,
+
+which sends the pair to `σ_g = (1, 0, 0, 1, 1, 1)`, `b_g = 0`, with
+
+`f(σ_g, b_g) = (+, 0, 0, −, −, +)`
+and
+`g · f(σ,b) = (−, 0, 0, +, −, +)`.
+
+The full-axis letters travel with `b`. The lex-first choice among the
+two completions of the remaining occupied slots does not.
+
+This is a labeling residual, not leftover of bitlaw (lex-first ignored
+`b`). Bitlaw scored the occupancy-only lex-first section and found
+`N_commute=144/576` because `f(σ,0)=f(σ,1)`. The present `f` depends on
+`b` and raises the commute count to `288/576`. It still is not the
+full 576.
+
+## Theorem 3 — displayed, not adopted
+
+The 24-pair completion census, `N_complete = 24`, the 576-triple
+census, `N_commute = 288`, the 288/576 ratio, the failing rotate of the
+lex-first completion, and the conclusion that the opposite-letter
+encoding is not a `G+`-equivariant pair labeling are displayed member
+data. They are not the framework's fixed Admissibility rule. This note
+does not write `f` into Admissibility.
+Do not write `f` into Admissibility. Do not attach L1.
+Occupancy-only formation is not attached. Qubit remains `M_2(C)`. No
+approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the 12 perpendicular weight-4 masks, a pair
+  completion exists for both bits, `N_complete = 24` of `12 × 2 = 24`,
+  and `N_commute = 288` of `12 × 2 × 24 = 576`. Encoding the age bit as
+  opposite letters on the full axis does not yield a `G+`-equivariant
+  pair labeling. Each `(σ, b)` has two completions, so `f` is the
+  lex-first, and `f(σ,0) ≠ f(σ,1)`.
+- **What is displayed only.** The rule `f` and the commute count are
+  one rival table. They are not adopted.
+- **What is not claimed.** No attachment of `f`, the age bit, opposite
+  letters, or a unique full axis to Admissibility; no attachment of
+  occupancy-only formation; no axiom edit; no formation rate; no leftover
+  of bitlaw (lex-first ignored `b`); no compiler no-go.
+- **Mutation controls.** A rebuilt `N_complete ≠ 24` fails. A rebuilt
+  `N_commute ≠ 288` fails. A rebuilt denominator other than 576 fails.
+  A rebuilt `N_commute = 576` fails the Theorem 2 report. A rebuilt
+  perp mask without a pair completion for both bits fails. A note that
+  writes `f` into Admissibility, attaches L1, or authors an audit
+  verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the 12 perpendicular weight-4 occupancy
+masks, the 24 proper cube rotations, July-3 pair members on
+`{0, +, −}`, the opposite-letter write on the unique full axis, the
+lex-first pair completion `f(σ,b)`, `N_complete / 24`, the transported
+bit `b_g`, the 576-triple commute count, the current premise boundary,
+and the mutation controls. It scores the 12 masks and `G+`. It writes
+no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -5281,6 +5281,10 @@
   "full128_two_rail_fixed_law_compositional_induction_bounded_theorem_note_2026-07-24": {
    "deps_hash": "39bd4d637769",
    "out_degree": 2
+  },
+  "full_axis_age_bit_encoding_equivariance_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "full_physical_epr_companion_input_substitution_cycle799_bounded_theorem_note_2026-07-30": {
    "deps_hash": "39b252a4b556",

--- a/logs/runner-cache/full_axis_age_bit_encoding_equivariance_2026_08_15.txt
+++ b/logs/runner-cache/full_axis_age_bit_encoding_equivariance_2026_08_15.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py
+runner_sha256: db249859c9569d34233c572c3cdd352f0d460c0c73ca9006cf4fce730836812b
+input_fingerprint_sha256: 6aac4cdb88e163e568c82b9c38bbe5765e979c9e9783bb6fb3867a4bd3e3d9a2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+full-axis age-bit encoding G+ equivariance
+AUDIT_INPUT_PATHS:
+  docs/FULL_AXIS_AGE_BIT_ENCODING_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+G_plus=24
+N_perp=12
+N_pair=48
+N_complete=24
+N_complete_over_24=24/24
+N_denom=576
+N_commute=288
+N_commute_over_denom=288/576
+N_commute_eq_576=False
+f_independent_of_b=False
+perp_rows:
+  (0, 1, 0, 1, 1, 1) full=z both=True n_comp=2,2 f0=(0, +, 0, −, −, +) f1=(0, +, 0, −, +, −) commute=24/48
+  (0, 1, 1, 0, 1, 1) full=z both=True n_comp=2,2 f0=(0, +, −, 0, −, +) f1=(0, +, −, 0, +, −) commute=24/48
+  (0, 1, 1, 1, 0, 1) full=y both=True n_comp=2,2 f0=(0, +, −, +, 0, −) f1=(0, +, +, −, 0, −) commute=24/48
+  (0, 1, 1, 1, 1, 0) full=y both=True n_comp=2,2 f0=(0, +, −, +, −, 0) f1=(0, +, +, −, −, 0) commute=24/48
+  (1, 0, 0, 1, 1, 1) full=z both=True n_comp=2,2 f0=(+, 0, 0, −, −, +) f1=(+, 0, 0, −, +, −) commute=24/48
+  (1, 0, 1, 0, 1, 1) full=z both=True n_comp=2,2 f0=(+, 0, −, 0, −, +) f1=(+, 0, −, 0, +, −) commute=24/48
+  (1, 0, 1, 1, 0, 1) full=y both=True n_comp=2,2 f0=(+, 0, −, +, 0, −) f1=(+, 0, +, −, 0, −) commute=24/48
+  (1, 0, 1, 1, 1, 0) full=y both=True n_comp=2,2 f0=(+, 0, −, +, −, 0) f1=(+, 0, +, −, −, 0) commute=24/48
+  (1, 1, 0, 1, 0, 1) full=x both=True n_comp=2,2 f0=(−, +, 0, +, 0, −) f1=(+, −, 0, +, 0, −) commute=24/48
+  (1, 1, 0, 1, 1, 0) full=x both=True n_comp=2,2 f0=(−, +, 0, +, −, 0) f1=(+, −, 0, +, −, 0) commute=24/48
+  (1, 1, 1, 0, 0, 1) full=x both=True n_comp=2,2 f0=(−, +, +, 0, 0, −) f1=(+, −, +, 0, 0, −) commute=24/48
+  (1, 1, 1, 0, 1, 0) full=x both=True n_comp=2,2 f0=(−, +, +, 0, −, 0) f1=(+, −, +, 0, −, 0) commute=24/48
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: g-plus-order | proper=24
+PASS: twelve-perp-masks | N_perp=12
+PASS: theorem-1-n-complete | N_complete=24/24
+PASS: theorem-2-n-commute | N_commute=288/576
+PASS: fail-witness | lhs=(1, 0, 0, 2, 2, 1) rhs=(2, 0, 0, 1, 2, 1)
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-bitlaw
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: N_complete, N_commute, and f(σ,b) are exact
+per_site: 12 perpendicular weight-4 occupancy masks scored
+per_mode: no spectral calculation
+per_block: 6-NN star masks and G+ only
+lattice_wide: checked and not executed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py
+++ b/scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Age-bit encoding on the occupancy-named full axis under G+.
+
+Score the 12 perpendicular weight-4 occupancy masks. For each mask and
+each older-end bit, write opposite letters on the unique full axis
+(older −, younger +) and take the unique or lex-first July-3 pair
+completion of the other two occupied slots. N_complete counts (σ,b)
+with a completion. N_commute counts the (σ,b,g) triples that satisfy
+f(g·σ, b_g)=g·f(σ,b). Displayed, not adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/FULL_AXIS_AGE_BIT_ENCODING_EQUIVARIANCE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/FULL_AXIS_AGE_BIT_ENCODING_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+AXIS_NAME = ("x", "y", "z")
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER_SHOW = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "On the 12 perpendicular weight-4 masks, whether encoding '
+    "the age bit as opposite letters on the full axis yields a G+-equivariant "
+    'pair labeling is reported. Displayed, not adopted."'
+)
+SWAPPER: Matrix = ((0, 1, 0), (1, 0, 0), (0, 0, -1))
+FAIL_SIGMA: Coloring = (0, 1, 0, 1, 1, 1)
+FAIL_G: Matrix = ((0, -1, 0), (1, 0, 0), (0, 0, 1))
+OK_G: Matrix = ((-1, 0, 0), (0, -1, 0), (0, 0, 1))
+EXPECTED_F: dict[tuple[Coloring, int], Coloring] = {
+    ((0, 1, 0, 1, 1, 1), 0): (0, PLUS, 0, MINUS, MINUS, PLUS),
+    ((0, 1, 0, 1, 1, 1), 1): (0, PLUS, 0, MINUS, PLUS, MINUS),
+    ((0, 1, 1, 0, 1, 1), 0): (0, PLUS, MINUS, 0, MINUS, PLUS),
+    ((0, 1, 1, 0, 1, 1), 1): (0, PLUS, MINUS, 0, PLUS, MINUS),
+    ((0, 1, 1, 1, 0, 1), 0): (0, PLUS, MINUS, PLUS, 0, MINUS),
+    ((0, 1, 1, 1, 0, 1), 1): (0, PLUS, PLUS, MINUS, 0, MINUS),
+    ((0, 1, 1, 1, 1, 0), 0): (0, PLUS, MINUS, PLUS, MINUS, 0),
+    ((0, 1, 1, 1, 1, 0), 1): (0, PLUS, PLUS, MINUS, MINUS, 0),
+    ((1, 0, 0, 1, 1, 1), 0): (PLUS, 0, 0, MINUS, MINUS, PLUS),
+    ((1, 0, 0, 1, 1, 1), 1): (PLUS, 0, 0, MINUS, PLUS, MINUS),
+    ((1, 0, 1, 0, 1, 1), 0): (PLUS, 0, MINUS, 0, MINUS, PLUS),
+    ((1, 0, 1, 0, 1, 1), 1): (PLUS, 0, MINUS, 0, PLUS, MINUS),
+    ((1, 0, 1, 1, 0, 1), 0): (PLUS, 0, MINUS, PLUS, 0, MINUS),
+    ((1, 0, 1, 1, 0, 1), 1): (PLUS, 0, PLUS, MINUS, 0, MINUS),
+    ((1, 0, 1, 1, 1, 0), 0): (PLUS, 0, MINUS, PLUS, MINUS, 0),
+    ((1, 0, 1, 1, 1, 0), 1): (PLUS, 0, PLUS, MINUS, MINUS, 0),
+    ((1, 1, 0, 1, 0, 1), 0): (MINUS, PLUS, 0, PLUS, 0, MINUS),
+    ((1, 1, 0, 1, 0, 1), 1): (PLUS, MINUS, 0, PLUS, 0, MINUS),
+    ((1, 1, 0, 1, 1, 0), 0): (MINUS, PLUS, 0, PLUS, MINUS, 0),
+    ((1, 1, 0, 1, 1, 0), 1): (PLUS, MINUS, 0, PLUS, MINUS, 0),
+    ((1, 1, 1, 0, 0, 1), 0): (MINUS, PLUS, PLUS, 0, 0, MINUS),
+    ((1, 1, 1, 0, 0, 1), 1): (PLUS, MINUS, PLUS, 0, 0, MINUS),
+    ((1, 1, 1, 0, 1, 0), 0): (MINUS, PLUS, PLUS, 0, MINUS, 0),
+    ((1, 1, 1, 0, 1, 0), 1): (PLUS, MINUS, PLUS, 0, MINUS, 0),
+}
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def show_col(coloring: Coloring) -> str:
+    return "(" + ", ".join(LETTER_SHOW[letter] for letter in coloring) + ")"
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | Tick) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def proper_rotations() -> tuple[Matrix, ...]:
+    records: list[Matrix] = []
+    seen: set[Matrix] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if matrix not in seen and det3(matrix) == 1:
+                seen.add(matrix)
+                records.append(matrix)
+    return tuple(records)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(letter != EMPTY) for letter in coloring)
+
+
+def empty_slots(sigma: Coloring) -> tuple[int, int]:
+    emptied = tuple(index for index, bit in enumerate(sigma) if bit == 0)
+    if len(emptied) != 2:
+        raise AssertionError(f"expected two empty slots, got {emptied}")
+    return (emptied[0], emptied[1])
+
+
+def same_axis(left: int, right: int) -> bool:
+    return any({left, right} == set(axis) for axis in AXES)
+
+
+def unique_full_axis(sigma: Coloring) -> int | None:
+    named = tuple(
+        axis_index
+        for axis_index, (plus, minus) in enumerate(AXES)
+        if sigma[plus] == 1 and sigma[minus] == 1
+    )
+    if len(named) == 1:
+        return named[0]
+    return None
+
+
+def weight4_masks() -> tuple[Coloring, ...]:
+    return tuple(bits for bits in itertools.product((0, 1), repeat=6) if sum(bits) == 4)
+
+
+def perp_masks() -> tuple[Coloring, ...]:
+    return tuple(
+        sigma
+        for sigma in weight4_masks()
+        if not same_axis(*empty_slots(sigma))
+    )
+
+
+def display_ticks(sigma: Coloring, axis_index: int, bit: int) -> Tick:
+    plus, minus = AXES[axis_index]
+    ticks: list[int | None] = [None] * 6
+    for slot, occupied in enumerate(sigma):
+        if occupied == 0:
+            continue
+        if slot == minus:
+            ticks[slot] = 1 if bit == 1 else 2
+        elif slot == plus:
+            ticks[slot] = 2 if bit == 1 else 1
+        else:
+            ticks[slot] = 0
+    return tuple(ticks)
+
+
+def bit_on_axis(ticks: Tick, axis_index: int) -> int:
+    plus, minus = AXES[axis_index]
+    minus_tick = ticks[minus]
+    plus_tick = ticks[plus]
+    if minus_tick is not None and plus_tick is not None and minus_tick < plus_tick:
+        return 1
+    return 0
+
+
+def axis_letters(bit: int) -> tuple[int, int]:
+    if bit == 1:
+        return (PLUS, MINUS)
+    return (MINUS, PLUS)
+
+
+def july3_pair(perms: list[tuple[int, ...]]) -> frozenset[Coloring]:
+    unseen = set(itertools.product((EMPTY, PLUS, MINUS), repeat=6))
+    inversion = direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+    pair: set[Coloring] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in perms}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def completions(
+    sigma: Coloring,
+    bit: int,
+    pair: frozenset[Coloring],
+) -> tuple[Coloring, ...]:
+    named = unique_full_axis(sigma)
+    if named is None:
+        return ()
+    plus, minus = AXES[named]
+    plus_letter, minus_letter = axis_letters(bit)
+    matches = [
+        item
+        for item in pair
+        if support(item) == sigma
+        and item[plus] == plus_letter
+        and item[minus] == minus_letter
+    ]
+    return tuple(sorted(matches))
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    rotations = proper_rotations()
+    perms = [direction_perm(matrix) for matrix in rotations]
+    pair = july3_pair(perms)
+    masks = perp_masks()
+    complete_denom = len(masks) * 2
+    commute_denom = len(masks) * 2 * len(rotations)
+
+    rule: dict[tuple[Coloring, int], Coloring] = {}
+    n_comp: dict[tuple[Coloring, int], int] = {}
+    both_ok = True
+    unique_any = False
+    f_indep = False
+    for sigma in masks:
+        named = unique_full_axis(sigma)
+        if named is None:
+            both_ok = False
+            continue
+        for bit in (0, 1):
+            comps = completions(sigma, bit, pair)
+            n_comp[(sigma, bit)] = len(comps)
+            if len(comps) == 1:
+                unique_any = True
+            if not comps:
+                both_ok = False
+                continue
+            rule[(sigma, bit)] = comps[0]
+        if (sigma, 0) in rule and (sigma, 1) in rule:
+            if rule[(sigma, 0)] == rule[(sigma, 1)]:
+                f_indep = True
+
+    n_complete = sum(1 for sigma in masks for bit in (0, 1) if (sigma, bit) in rule)
+    n_commute = 0
+    per_mask: list[int] = []
+    for sigma in masks:
+        named = unique_full_axis(sigma)
+        if named is None:
+            per_mask.append(0)
+            continue
+        mask_commute = 0
+        for bit in (0, 1):
+            if (sigma, bit) not in rule:
+                continue
+            ticks = display_ticks(sigma, named, bit)
+            coloring = rule[(sigma, bit)]
+            for perm in perms:
+                sigma_g = act_col(perm, sigma)
+                named_g = unique_full_axis(sigma_g)
+                if named_g is None:
+                    continue
+                bit_g = bit_on_axis(act_col(perm, ticks), named_g)
+                image = rule.get((sigma_g, bit_g))
+                if image is not None and image == act_col(perm, coloring):
+                    n_commute += 1
+                    mask_commute += 1
+        per_mask.append(mask_commute)
+
+    fail_perm = direction_perm(FAIL_G)
+    fail_named = unique_full_axis(FAIL_SIGMA)
+    fail_ticks = display_ticks(FAIL_SIGMA, fail_named, 0) if fail_named is not None else None
+    fail_sigma_g = act_col(fail_perm, FAIL_SIGMA)
+    fail_named_g = unique_full_axis(fail_sigma_g)
+    fail_bit_g = (
+        bit_on_axis(act_col(fail_perm, fail_ticks), fail_named_g)
+        if fail_ticks is not None and fail_named_g is not None
+        else None
+    )
+    fail_lhs = rule.get((fail_sigma_g, fail_bit_g)) if fail_bit_g is not None else None
+    fail_rhs = act_col(fail_perm, rule[(FAIL_SIGMA, 0)]) if (FAIL_SIGMA, 0) in rule else None
+
+    ok_perm = direction_perm(OK_G)
+    ok_ticks = display_ticks(FAIL_SIGMA, fail_named, 0) if fail_named is not None else None
+    ok_sigma_g = act_col(ok_perm, FAIL_SIGMA)
+    ok_named_g = unique_full_axis(ok_sigma_g)
+    ok_bit_g = (
+        bit_on_axis(act_col(ok_perm, ok_ticks), ok_named_g)
+        if ok_ticks is not None and ok_named_g is not None
+        else None
+    )
+    ok_lhs = rule.get((ok_sigma_g, ok_bit_g)) if ok_bit_g is not None else None
+    ok_rhs = act_col(ok_perm, rule[(FAIL_SIGMA, 0)]) if (FAIL_SIGMA, 0) in rule else None
+
+    print("full-axis age-bit encoding G+ equivariance")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"G_plus={len(rotations)}")
+    print(f"N_perp={len(masks)}")
+    print(f"N_pair={len(pair)}")
+    print(f"N_complete={n_complete}")
+    print(f"N_complete_over_24={n_complete}/{complete_denom}")
+    print(f"N_denom={commute_denom}")
+    print(f"N_commute={n_commute}")
+    print(f"N_commute_over_denom={n_commute}/{commute_denom}")
+    print(f"N_commute_eq_576={n_commute == 576}")
+    print(f"f_independent_of_b={f_indep}")
+    print("perp_rows:")
+    for sigma, count in zip(masks, per_mask):
+        named = unique_full_axis(sigma)
+        axis = AXIS_NAME[named] if named is not None else None
+        f0 = rule.get((sigma, 0))
+        f1 = rule.get((sigma, 1))
+        n0 = n_comp.get((sigma, 0), 0)
+        n1 = n_comp.get((sigma, 1), 0)
+        both = n0 > 0 and n1 > 0
+        print(
+            f"  {sigma} full={axis} both={both} n_comp={n0},{n1} "
+            f"f0={show_col(f0) if f0 is not None else None} "
+            f"f1={show_col(f1) if f1 is not None else None} "
+            f"commute={count}/48"
+        )
+
+    expected_paths = (
+        "docs/FULL_AXIS_AGE_BIT_ENCODING_EQUIVARIANCE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "g-plus-order",
+        len(rotations) == 24
+        and len(set(rotations)) == 24
+        and det3(SWAPPER) == 1
+        and SWAPPER in rotations,
+        f"proper={len(rotations)}",
+    )
+    checks.check(
+        "twelve-perp-masks",
+        len(masks) == 12
+        and all(unique_full_axis(sigma) is not None for sigma in masks)
+        and all((sigma, 0) in rule and (sigma, 1) in rule for sigma in masks)
+        and all(rule[(sigma, bit)] == EXPECTED_F[(sigma, bit)] for sigma in masks for bit in (0, 1))
+        and "12 perpendicular" in note
+        and "`12 × 2 × 24 = 576`" in note,
+        f"N_perp={len(masks)}",
+    )
+    checks.check(
+        "theorem-1-n-complete",
+        both_ok
+        and n_complete == 24
+        and complete_denom == 24
+        and not unique_any
+        and all(n_comp[(sigma, bit)] == 2 for sigma in masks for bit in (0, 1))
+        and all(rule[(sigma, 0)] != rule[(sigma, 1)] for sigma in masks)
+        and not f_indep
+        and "N_complete / 24 = 24/24" in note
+        and "N_complete = 24" in note
+        and "both bits" in note,
+        f"N_complete={n_complete}/{complete_denom}",
+    )
+    checks.check(
+        "theorem-2-n-commute",
+        n_commute == 288
+        and commute_denom == 576
+        and n_commute != 576
+        and per_mask == [24] * 12
+        and "N_commute / 576 = 288/576" in note
+        and "N_commute = 288" in note
+        and "Whether `N_commute=576`" in note
+        and "not the full 576" in note
+        and "not a `G+`-equivariant pair labeling" in note,
+        f"N_commute={n_commute}/{commute_denom}",
+    )
+    checks.check(
+        "fail-witness",
+        fail_lhs == (PLUS, 0, 0, MINUS, MINUS, PLUS)
+        and fail_rhs == (MINUS, 0, 0, PLUS, MINUS, PLUS)
+        and fail_lhs != fail_rhs
+        and fail_bit_g == 0
+        and fail_sigma_g == (1, 0, 0, 1, 1, 1)
+        and ok_lhs == ok_rhs == (PLUS, 0, MINUS, 0, MINUS, PLUS)
+        and "`g : (x, y, z) ↦ (−y, x, z)`" in note
+        and "`f(σ_g, b_g) = (+, 0, 0, −, −, +)`" in note
+        and "`g · f(σ,b) = (−, 0, 0, +, −, +)`" in note,
+        f"lhs={fail_lhs} rhs={fail_rhs}",
+    )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write `f` into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-bitlaw",
+        "not leftover of bitlaw" in note_flat
+        and "lex-first ignored" in note
+        and "N_commute=144/576" in note
+        and "f(σ,0)=f(σ,1)" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "N_commute" not in axiom
+        and "N_complete" not in axiom
+        and "bitlaw" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: N_complete, N_commute, and f(σ,b) are exact")
+    print("per_site: 12 perpendicular weight-4 occupancy masks scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: 6-NN star masks and G+ only")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Pair completions exist for all 24 (sigma,b). Two completions each. Opposite-letter encoding of b on the full axis gives N_commute=288/576. Lex-first of the leftover two slots is not G+ covariant. Displayed, not adopted. No axiom edit.

## Runner

`scripts/full_axis_age_bit_encoding_equivariance_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.