### PR TITLE
feat(bitreal): all 12 perp masks are realized as 3-ball stars

### DIFF
--- a/docs/PERP_MASK_THREE_BALL_REALIZATION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PERP_MASK_THREE_BALL_REALIZATION_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,227 @@
+---
+claim_id: perp_mask_three_ball_realization_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 12 perpendicular weight-4 masks, how many are realized as unread 6-NN occupancy of a 3-ball union is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/perp_mask_three_ball_realization_2026_08_15.py
+---
+
+# Perpendicular Weight-4 Mask Three-Ball Realization (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the 12 perpendicular weight-4 occupancy masks on the six-neighbor
+star, and 3-ball unions `U = B_{r1}(s1) ∪ B_{r2}(s2) ∪ B_{r3}(s3)` with
+distinct centers in `[−2,2]³`, radii `ri ∈ {1,2,3}` not all equal, together
+with unread sites `v ∉ U` in the box `‖v‖_∞ ≤ 4`. Score a prefix plus
+existence per mask. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/perp_mask_three_ball_realization_2026_08_15.py`](../scripts/perp_mask_three_ball_realization_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment bitname: `f` is named on all 12 perp masks. Investment bitfire:
+`f` fires on the uneqrad star (one mask). The residual here is not leftover
+of uneqrad (one mask). Among the 12, how many appear as the 6-NN occupancy
+of an unread site on a 3-ball union in the uneqrad box (radii in `{1,2,3}`)?
+
+Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+A weight-4 mask is perpendicular when the two emptied slots lie on two
+distinct axes. There are exactly 12 such masks. Centers are distinct sites
+of `Z^3` in the cube `[−2,2]³`. Radii run over the 24 triples in `{1,2,3}³`
+that are not all equal. Lex order is on the canonical tuple
+`(s1,s2,s3, r1,r2,r3, v)` with `s1 < s2 < s3` in coordinate lex order.
+An unread site is scored only when `wt(σ(U,v)) = 4`. Stop at the first
+realization per mask. Also report the 2000-star prefix.
+
+**Theorem 1.** `N_real = 12`. All 12 perpendicular weight-4 masks are
+realized as unread 6-NN occupancy of a 3-ball union in the uneqrad box.
+
+On the lex-first 2000 weight-4 stars,
+
+`N_prefix = 2000`, `N_prefix_real = 12`.
+
+**Theorem 2.** The lex-first host `(centers, radii, v)` of each realized
+mask is the first unread weight-4 star in the uneqrad enumeration whose
+occupancy equals that mask. Every mask has such a host; none is empty.
+
+**Theorem 3.** Displayed, not adopted. Do not write a host into
+Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither a perpendicular weight-4 occupancy mask nor a
+realizing 3-ball union as the framework's fixed rule. Formation site and
+rate remain outside the axiom memo. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact census of the 12 perpendicular weight-4 occupancy masks as unread 6-NN occupancy of uneqrad 3-ball unions, with a 2000-star prefix and a lex-first host per mask. Displayed counts only."
+trace_class: frontier_discovery
+target_claim_id: perp_mask_three_ball_realization
+target_blocker_text: "among the 12 perpendicular weight-4 masks, how many are realized as unread 6-NN occupancy of a 3-ball union"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of N_real and the lex-first hosts; do not write a host into Admissibility or attach L1"
+conditional_surface_status: "exact on the 12 perpendicular weight-4 masks in the uneqrad box; N_real=12; N_prefix=2000; N_prefix_real=12; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Slots are `(+x, −x, +y, −y, +z, −z)`. Occupancy at an unread site `v`
+relative to a locked set `U` is the 6-bit indicator
+
+`σ(U, v)_μ = 1` if and only if `v + e_μ ∈ U`.
+
+Weight is the number of occupied slots. A weight-4 mask is perpendicular
+when the two emptied slots lie on two distinct axes. The 12 perpendicular
+masks, in lex order, are
+
+`(0, 1, 0, 1, 1, 1)`,
+`(0, 1, 1, 0, 1, 1)`,
+`(0, 1, 1, 1, 0, 1)`,
+`(0, 1, 1, 1, 1, 0)`,
+`(1, 0, 0, 1, 1, 1)`,
+`(1, 0, 1, 0, 1, 1)`,
+`(1, 0, 1, 1, 0, 1)`,
+`(1, 0, 1, 1, 1, 0)`,
+`(1, 1, 0, 1, 0, 1)`,
+`(1, 1, 0, 1, 1, 0)`,
+`(1, 1, 1, 0, 0, 1)`,
+`(1, 1, 1, 0, 1, 0)`.
+
+The three same-axis empty weight-4 masks are not scored.
+
+Write `B_r(c) = { x ∈ Z^3 : ‖x − c‖_1 ≤ r }`. A 3-ball union in the
+uneqrad box is
+
+`U = B_{r1}(s1) ∪ B_{r2}(s2) ∪ B_{r3}(s3)`
+
+with distinct `si` in `[−2,2]³` and `(r1,r2,r3) ∈ {1,2,3}³` not all
+equal. An unread site is `v ∉ U` with `‖v‖_∞ ≤ 4`. A star in the prefix
+is such a `v` with `wt(σ(U,v)) = 4`. A realization of a perpendicular
+mask `σ` is a pair `(U, v)` with `σ(U, v) = σ`. `N_real` is the number
+of the 12 masks that admit at least one such pair. Short-circuit after
+the first hit per mask. `N_prefix` is the number of weight-4 unread
+stars in the lex-first 2000. `N_prefix_real` is how many of the 12
+appear in that prefix.
+
+## Theorem 1 — `N_real = 12`
+
+Every one of the 12 perpendicular weight-4 masks appears as the 6-NN
+occupancy of an unread site on some uneqrad 3-ball union in the box, so
+
+`N_real = 12`.
+
+The census lists all 12. On the lex-first 2000 weight-4 stars the same
+12 already appear:
+
+`N_prefix = 2000`, `N_prefix_real = 12`.
+
+The last first-hit in that prefix is star 1410. This is not leftover of
+uneqrad (one mask): uneqrad scores lock-tick Stab shrink on one breaker
+star; bitfire scores whether `f` fires on that one star. The present
+count is occupancy realization of each of the 12 masks.
+
+## Theorem 2 — lex-first host per mask
+
+The lex-first host is the first `(centers, radii, v)` in the uneqrad
+enumeration whose unread 6-NN occupancy equals the mask. The twelve
+hosts are
+
+| `σ` | lex-first `(centers, radii, v)` |
+|---|---|
+| `(0, 1, 0, 1, 1, 1)` | `(((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-1, -1, -1))` |
+| `(0, 1, 1, 0, 1, 1)` | `(((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-1, -3, -1))` |
+| `(0, 1, 1, 1, 0, 1)` | `(((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 1, 2), (-1, -1, -1))` |
+| `(0, 1, 1, 1, 1, 0)` | `(((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 2, 1), (-1, -1, -2))` |
+| `(1, 0, 0, 1, 1, 1)` | `(((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -1, -1))` |
+| `(1, 0, 1, 0, 1, 1)` | `(((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -3, -1))` |
+| `(1, 0, 1, 1, 0, 1)` | `(((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 1, 2), (-3, -1, -1))` |
+| `(1, 0, 1, 1, 1, 0)` | `(((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 2, 1), (-3, -1, -2))` |
+| `(1, 1, 0, 1, 0, 1)` | `(((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 1, 2), (-1, -1, -1))` |
+| `(1, 1, 0, 1, 1, 0)` | `(((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 2, 1), (-1, -1, -2))` |
+| `(1, 1, 1, 0, 0, 1)` | `(((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 1, 2), (-1, -3, -1))` |
+| `(1, 1, 1, 0, 1, 0)` | `(((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 2, 1), (-1, -3, -2))` |
+
+No mask is unrealized. The first weight-4 star of the box is itself a
+perpendicular mask: `σ = (1, 0, 1, 0, 1, 1)` at
+`((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -3, -1)`.
+
+## Theorem 3 — displayed, not adopted
+
+The count `N_real = 12`, the prefix counts, and the twelve lex-first
+hosts are displayed member data. They are not the framework's fixed
+Admissibility rule. This note does not write a host into Admissibility.
+Do not write a host into Admissibility. Do not attach L1. Occupancy-only
+formation is not attached. Qubit remains `M_2(C)`. No approved primitive
+is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the 12 perpendicular weight-4 occupancy masks,
+  `N_real = 12`. Each mask has a lex-first uneqrad host. The 2000-star
+  prefix already contains all 12, so `N_prefix = 2000` and
+  `N_prefix_real = 12`.
+- **What is displayed only.** The twelve hosts and the two prefix counts
+  are one rival table. They are not adopted.
+- **What is not claimed.** No attachment of a realizing union to
+  Admissibility; no attachment of occupancy-only formation; no axiom
+  edit; no formation rate; no lattice-wide dynamics; no leftover of
+  uneqrad (one mask); no leftover of bitname or bitfire; no compiler
+  no-go.
+- **Mutation controls.** A rebuilt `N_real` other than 12 fails. A
+  rebuilt empty host on any of the 12 masks fails. A rebuilt prefix
+  with `N_prefix_real` other than 12 fails. A note that writes a host
+  into Admissibility, attaches L1, or authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Primary Runner
+
+The primary runner rebuilds the 12 perpendicular weight-4 occupancy
+masks, the uneqrad 3-ball box, the 2000-star prefix, `N_real`, the
+lex-first host of each mask, the current premise boundary, and the
+mutation controls. It scores a prefix plus existence per mask. It
+writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13681,6 +13681,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "perp_mask_three_ball_realization_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/perp_mask_three_ball_realization_2026_08_15.txt
+++ b/logs/runner-cache/perp_mask_three_ball_realization_2026_08_15.txt
@@ -1,0 +1,71 @@
+===== runner cache v1 =====
+runner: scripts/perp_mask_three_ball_realization_2026_08_15.py
+runner_sha256: 680047c0f9bd4954a70014cc6ec8a2d048ede57e17da7828c4e7fa66dfebc91d
+input_fingerprint_sha256: 444da377349d27e6f77e63e50cfaa003202b029088b8ec114b6a2ee1c7280fa1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.62
+status: ok
+----- stdout -----
+perp-mask 3-ball realization
+AUDIT_INPUT_PATHS:
+  docs/PERP_MASK_THREE_BALL_REALIZATION_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+seed_box_card=125
+v_box_card=729
+radii_card=24
+N_perp=12
+N_prefix=2000
+N_prefix_real=12
+N_real=12
+first_star=(((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -3, -1), (1, 0, 1, 0, 1, 1))
+lex_first_hosts:
+  (0, 1, 0, 1, 1, 1) (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-1, -1, -1))
+  (0, 1, 1, 0, 1, 1) (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-1, -3, -1))
+  (0, 1, 1, 1, 0, 1) (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 1, 2), (-1, -1, -1))
+  (0, 1, 1, 1, 1, 0) (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 2, 1), (-1, -1, -2))
+  (1, 0, 0, 1, 1, 1) (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -1, -1))
+  (1, 0, 1, 0, 1, 1) (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -3, -1))
+  (1, 0, 1, 1, 0, 1) (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 1, 2), (-3, -1, -1))
+  (1, 0, 1, 1, 1, 0) (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 2, 1), (-3, -1, -2))
+  (1, 1, 0, 1, 0, 1) (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 1, 2), (-1, -1, -1))
+  (1, 1, 0, 1, 1, 0) (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 2, 1), (-1, -1, -2))
+  (1, 1, 1, 0, 0, 1) (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 1, 2), (-1, -3, -1))
+  (1, 1, 1, 0, 1, 0) (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 2, 1), (-1, -3, -2))
+PASS: audit-input-paths | AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice
+PASS: source-admissibility
+PASS: source-unread-qubit
+PASS: perp-mask-count | N_perp=12
+PASS: theorem-1-n-real | N_real=12
+PASS: prefix-2000 | N_prefix=2000 N_prefix_real=12
+PASS: exists-mask-(0, 1, 0, 1, 1, 1) | (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-1, -1, -1))
+PASS: exists-mask-(0, 1, 1, 0, 1, 1) | (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-1, -3, -1))
+PASS: exists-mask-(0, 1, 1, 1, 0, 1) | (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 1, 2), (-1, -1, -1))
+PASS: exists-mask-(0, 1, 1, 1, 1, 0) | (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 2, 1), (-1, -1, -2))
+PASS: exists-mask-(1, 0, 0, 1, 1, 1) | (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -1, -1))
+PASS: exists-mask-(1, 0, 1, 0, 1, 1) | (((-2, -2, -2), (-2, -2, -1), (-2, -2, 0)), (2, 1, 2), (-3, -3, -1))
+PASS: exists-mask-(1, 0, 1, 1, 0, 1) | (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 1, 2), (-3, -1, -1))
+PASS: exists-mask-(1, 0, 1, 1, 1, 0) | (((-2, -2, -2), (-2, -2, -1), (-2, 0, -2)), (1, 2, 1), (-3, -1, -2))
+PASS: exists-mask-(1, 1, 0, 1, 0, 1) | (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 1, 2), (-1, -1, -1))
+PASS: exists-mask-(1, 1, 0, 1, 1, 0) | (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 2, 1), (-1, -1, -2))
+PASS: exists-mask-(1, 1, 1, 0, 0, 1) | (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 1, 2), (-1, -3, -1))
+PASS: exists-mask-(1, 1, 1, 0, 1, 0) | (((-2, -2, -2), (-2, -2, -1), (0, -2, -2)), (1, 2, 1), (-1, -3, -2))
+PASS: claim-scope
+PASS: displayed-not-adopted
+PASS: l1-not-attached
+PASS: not-leftover-uneqrad
+PASS: admissibility-unedited
+PASS: forbidden-phrases
+PASS: no-axiom-edit
+per_element: N_real, N_prefix, and N_prefix_real are exact integers
+per_site: unread weight-4 uneqrad 3-ball stars in the declared box
+per_mode: no spectral calculation
+per_block: 12 perp masks and 3-ball stars
+lattice_wide: checked and not executed
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/perp_mask_three_ball_realization_2026_08_15.py
+++ b/scripts/perp_mask_three_ball_realization_2026_08_15.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Perp weight-4 mask realization on uneqrad 3-ball unions.
+
+Among the 12 perpendicular weight-4 occupancy masks, count how many
+appear as 6-NN occupancy of an unread site on a 3-ball union in the
+uneqrad box: distinct centers in [-2,2]^3, radii in {1,2,3} not all
+equal, unread v with ||v||_inf <= 4. Stop at the first realization
+per mask. Also report the 2000-star prefix count. Displayed, not
+adopted. No cache is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from array import array
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PERP_MASK_THREE_BALL_REALIZATION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/PERP_MASK_THREE_BALL_REALIZATION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Host = tuple[tuple[Point, Point, Point], tuple[int, int, int], Point]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+PREFIX = 2000
+SHIFT = 5
+STRIDE = 11
+GRID = STRIDE * STRIDE * STRIDE
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    'claim_scope: "Among the 12 perpendicular weight-4 masks, how many '
+    "are realized as unread 6-NN occupancy of a 3-ball union is reported. "
+    'Displayed, not adopted."'
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def ball(center: Point, radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        if abs(offset[0]) + abs(offset[1]) + abs(offset[2]) <= radius:
+            sites.append(add(center, offset))
+    return tuple(sites)
+
+
+def enc(point: Point) -> int:
+    return (point[0] + SHIFT) + STRIDE * (
+        (point[1] + SHIFT) + STRIDE * (point[2] + SHIFT)
+    )
+
+
+def perp_masks() -> tuple[Coloring, ...]:
+    records: list[Coloring] = []
+    for mask in itertools.product((0, 1), repeat=len(DIRS)):
+        if sum(mask) != 4:
+            continue
+        empty = [index for index, bit in enumerate(mask) if bit == 0]
+        axes = {index // 2 for index in empty}
+        if len(axes) == 2:
+            records.append(mask)
+    return tuple(records)
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f" | {detail}" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def realize() -> dict:
+    masks = perp_masks()
+    remaining = set(masks)
+    hosts: dict[Coloring, Host] = {}
+    seed_box = tuple(itertools.product(range(-2, 3), repeat=3))
+    v_box = tuple(itertools.product(range(-4, 5), repeat=3))
+    radii_opts = tuple(
+        radii
+        for radii in itertools.product((1, 2, 3), repeat=3)
+        if not (radii[0] == radii[1] == radii[2])
+    )
+    ball_enc = {
+        (seed, radius): tuple(enc(site) for site in ball(seed, radius))
+        for seed in seed_box
+        for radius in (1, 2, 3)
+    }
+    v_enc = tuple(enc(site) for site in v_box)
+    neighbor_enc = tuple(
+        tuple(enc(add(site, direction)) for direction in DIRS) for site in v_box
+    )
+    mark = array("I", [0]) * GRID
+    generation = 0
+    n_wt4 = 0
+    prefix_seen: set[Coloring] = set()
+    first_star: tuple | None = None
+
+    for s1, s2, s3 in itertools.combinations(seed_box, 3):
+        seeds = (s1, s2, s3)
+        for radii in radii_opts:
+            generation += 1
+            for seed, radius in zip(seeds, radii):
+                for index in ball_enc[(seed, radius)]:
+                    mark[index] = generation
+            for v_index, site in enumerate(v_box):
+                if mark[v_enc[v_index]] == generation:
+                    continue
+                sigma = tuple(
+                    1 if mark[w_enc] == generation else 0
+                    for w_enc in neighbor_enc[v_index]
+                )
+                if sum(sigma) != 4:
+                    continue
+                n_wt4 += 1
+                if first_star is None:
+                    first_star = (seeds, radii, site, sigma)
+                if sigma in remaining:
+                    remaining.remove(sigma)
+                    hosts[sigma] = (seeds, radii, site)
+                if n_wt4 <= PREFIX and sigma in masks:
+                    prefix_seen.add(sigma)
+            if n_wt4 >= PREFIX and not remaining:
+                break
+        else:
+            continue
+        break
+
+    return {
+        "masks": masks,
+        "hosts": hosts,
+        "n_real": len(masks) - len(remaining),
+        "n_wt4": n_wt4,
+        "n_prefix": min(n_wt4, PREFIX),
+        "n_prefix_real": len(prefix_seen),
+        "first_star": first_star,
+        "seed_count": len(seed_box),
+        "v_count": len(v_box),
+        "radii_count": len(radii_opts),
+        "remaining": remaining,
+    }
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+    data = realize()
+    masks = data["masks"]
+    hosts = data["hosts"]
+    n_real = data["n_real"]
+    n_prefix = data["n_prefix"]
+    n_prefix_real = data["n_prefix_real"]
+
+    print("perp-mask 3-ball realization")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"seed_box_card={data['seed_count']}")
+    print(f"v_box_card={data['v_count']}")
+    print(f"radii_card={data['radii_count']}")
+    print(f"N_perp={len(masks)}")
+    print(f"N_prefix={n_prefix}")
+    print(f"N_prefix_real={n_prefix_real}")
+    print(f"N_real={n_real}")
+    print(f"first_star={data['first_star']}")
+    print("lex_first_hosts:")
+    for sigma in masks:
+        print(f"  {sigma} {hosts.get(sigma)}")
+
+    expected_paths = (
+        "docs/PERP_MASK_THREE_BALL_REALIZATION_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-input-paths",
+        AUDIT_INPUT_PATHS == expected_paths
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    covariance_clause = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations."
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    unread_sentence = "A site with no record cannot be read."
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    checks.check(
+        "source-lattice",
+        lattice_sentence in axiom_flat and lattice_sentence in note_flat,
+    )
+    checks.check(
+        "source-admissibility",
+        covariance_clause in axiom_flat
+        and admissibility_sentence in axiom_flat
+        and covariance_clause in note_flat
+        and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-unread-qubit",
+        unread_sentence in axiom
+        and unread_sentence in note
+        and qubit_sentence in axiom
+        and qubit_sentence in note,
+    )
+    checks.check(
+        "perp-mask-count",
+        len(masks) == 12
+        and masks[0] == (0, 1, 0, 1, 1, 1)
+        and masks[-1] == (1, 1, 1, 0, 1, 0)
+        and all(sum(mask) == 4 for mask in masks)
+        and "12 perpendicular" in note_flat,
+        f"N_perp={len(masks)}",
+    )
+    checks.check(
+        "theorem-1-n-real",
+        n_real == 12
+        and not data["remaining"]
+        and "N_real = 12" in note
+        and "all 12" in note_flat,
+        f"N_real={n_real}",
+    )
+    checks.check(
+        "prefix-2000",
+        n_prefix == PREFIX
+        and n_prefix_real == 12
+        and "N_prefix = 2000" in note
+        and "N_prefix_real = 12" in note,
+        f"N_prefix={n_prefix} N_prefix_real={n_prefix_real}",
+    )
+    for sigma in masks:
+        host = hosts.get(sigma)
+        checks.check(
+            f"exists-mask-{sigma}",
+            host is not None and str(host) in note,
+            str(host),
+        )
+    checks.check("claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "displayed-not-adopted",
+        "Displayed, not adopted" in note
+        and "Do not write a host into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "not-leftover-uneqrad",
+        "not leftover of uneqrad (one mask)" in note_flat
+        and "uneqrad" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        covariance_clause in axiom_flat
+        and "N_real" not in axiom
+        and "N_prefix_real" not in axiom
+        and "perp mask" not in axiom
+        and "3-ball union" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        all(phrase not in note for phrase in FORBIDDEN)
+        and all(
+            phrase not in self_source.split("FORBIDDEN = ", 1)[0]
+            for phrase in FORBIDDEN
+        ),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: N_real, N_prefix, and N_prefix_real are exact integers")
+    print("per_site: unread weight-4 uneqrad 3-ball stars in the declared box")
+    print("per_mode: no spectral calculation")
+    print("per_block: 12 perp masks and 3-ball stars")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

N_real=12. Every perpendicular weight-4 occupancy appears as an unread 6-NN of a 3-ball union with radii in {1,2,3}. Displayed, not adopted. No axiom edit.

## Runner

`scripts/perp_mask_three_ball_realization_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.