### PR TITLE
feat(minkiso): lex-first reversal isochrones are not closer to Euclidean than l1

### DIFF
--- a/docs/COST3_LEXFIRST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/COST3_LEXFIRST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,371 @@
+---
+claim_id: cost3_lexfirst_reversal_isochrone_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_3(0), the isochrones of the lex-first diamond-reversing {1,2,3} two-end occupancy cost are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py
+---
+
+# Isochrones Of The Lex-First Diamond-Reversing `{1,2,3}` Two-End Cost On `B_3(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact integer path costs and a displayed variance comparison on the
+radius-3 nearest-neighbor ball of one seed. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py`](../scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `B_3(0)` be the set of sites of `Z^3` reachable from the origin by at
+most three nearest-neighbor steps. One-seed growth starts at `0`. The
+occupancy `σ_n` at a site `n` is the 6-bit string whose direction-`d` bit is
+set exactly when the neighbor of `n` in direction `d` is strictly nearer the
+seed. This is the inward occupation of the one-seed front.
+
+`G+` is the 24-element group of proper cubic rotations about the seed. A hop
+cost `c(σ_v, σ_w) ∈ {1,2,3}` on a directed nearest-neighbor edge `v → w` is
+`G+`-equivariant when it is constant on `G+` orbits of endpoint pairs.
+Arrival time `t(n)` is the minimum path cost from `0` to `n` through
+`B_3(0)`.
+
+The eight `G+` orbits of inward occupancy pairs, written as inward-weight
+pairs `(|σ_v|, |σ_w|)`, are
+
+```text
+(0,1), (1,0), (1,1), (1,2), (2,1), (2,2), (2,3), (3,2).
+```
+
+The lex-first diamond-reversing filling of those orbits is constructed by
+the named rule seed-exit `1`, axis-extension `3`, else `1`:
+
+```text
+c = (1, 1, 3, 1, 1, 1, 1, 1).
+```
+
+On `B_3(0)` this filling realizes `t(3,0,0) = 7` and `t(1,1,1) = 3`. The
+seven `G+` site types have constant arrival times, listed in Theorem 1.
+Among the 62 sites with `t(v) > 0`, the population variance of
+`|v|_2 / t(v)` is `0.022275669698`, while the same variance with the
+`ℓ¹` radius `|v|_1` (graph radius) in place of `t` is `0.020739455142`.
+The graph-radius variance is smaller. The `t = const` shells of this
+filling are therefore not closer to Euclidean spheres, by this displayed
+ratio test, than the `ℓ¹` shells. The comparison is reported on `B_3(0)` only.
+Displayed, not adopted.
+
+The report is not a leftover of the existence of a reversing filling. That
+existence names 405 maps and one lex-first witness. It does not compute
+`t(v)` on every site or compare isochrones to graph-radius shells.
+
+## Exact Theorems
+
+### Theorem 1
+
+`B_3(0)` has 63 sites and 228 directed nearest-neighbor edges. Under the
+lex-first filling, arrival time is constant on each `G+` orbit of sites.
+The seven orbits and their times are
+
+| representative | orbit size | `t` | `|v|_2` | graph radius |
+|---|---:|---:|---|---:|
+| `(0,0,0)` | `1` | `0` | `0` | `0` |
+| `(1,0,0)` | `6` | `1` | `1` | `1` |
+| `(1,1,0)` | `12` | `2` | `√2` | `2` |
+| `(2,0,0)` | `6` | `4` | `2` | `2` |
+| `(1,1,1)` | `8` | `3` | `√3` | `3` |
+| `(2,1,0)` | `24` | `3` | `√5` | `3` |
+| `(3,0,0)` | `6` | `7` | `3` | `3` |
+
+In particular `t(1,0,0) = 1`, `t(1,1,0) = 2`, `t(2,0,0) = 4`,
+`t(2,1,0) = 3`, `t(1,1,1) = 3`, and `t(3,0,0) = 7`. The six seed-exit
+edges occupy orbit `(0,1)` of cost `1`. Both axis extensions occupy orbit
+`(1,1)` of cost `3`. The three-step body-diagonal path uses only cost-`1`
+hops. The unique in-ball neighbor of `(3,0,0)` is `(2,0,0)`, so
+`t(3,0,0) = t(2,0,0) + 3 = 7`. The face site `(2,1,0)` is reached by
+`0 → (1,0,0) → (1,1,0) → (2,1,0)` at total cost `3`.
+
+The constant-`t` shells are therefore
+
+```text
+t=1 : 6 sites of type (1,0,0)
+t=2 : 12 sites of type (1,1,0)
+t=3 : 32 sites, 8 of type (1,1,1) and 24 of type (2,1,0)
+t=4 : 6 sites of type (2,0,0)
+t=7 : 6 sites of type (3,0,0)
+```
+
+Every shell except `t = 3` is a single `G+` site type, hence a single
+Euclidean radius. The mixed `t = 3` shell carries two radii, `√3` and `√5`.
+
+### Theorem 2
+
+Let `S` be the 62 sites of `B_3(0)` with `t(v) > 0`. Write `|v|_2` for the
+ordinary Euclidean radius `√(x^2+y^2+z^2)`. The population variance
+
+```text
+Var(a) = (1/|S|) Σ_{v in S} (a(v) - mean(a))^2
+```
+
+on the two displayed ratio fields is
+
+```text
+Var(|v|_2 / t(v))     = 0.022275669698
+Var(|v|_2 / |v|_1)    = 0.020739455142
+```
+
+The graph-radius variance is smaller. Unit hop costs recover `|v|_1` on
+every site of `B_3(0)`, so the second field is the isochrone ratio of the
+constant-`1` filling (the `ℓ¹` comparator). By this displayed test the
+lex-first reversing cost does not make the `t = const` shells closer to
+Euclidean spheres than the `ℓ¹` shells.
+
+The axis overshoot is visible in the ratios themselves: `(3,0,0)` has
+`|v|_2 / t = 3/7`, while `(1,0,0)` has ratio `1`. Graph radius keeps every
+axis site at ratio `1` and the body diagonal at `√3/3`. Reversal of the
+diamond order at the two comparison points is therefore not the same as a
+closer Euclidean shell. Displayed, not adopted.
+
+### Theorem 3
+
+The lex-first filling and its isochrones are displayed as a finite probe on
+`B_3(0)`. They are not written into Admissibility. No path-length law is
+attached; do not attach graph radius, Euclidean radius, or the filling `c`
+as an axiom clause. The live axiom memo continues to state that there is
+one fixed nearest-neighbor admissibility rule, covariant under translations
+and proper cubic rotations; that rule is not replaced by `c(σ_v, σ_w)`.
+Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_3(0)` and the six direction bits | closed by the nearest-neighbor graph of `Z^3` |
+| define inward occupancy of the one-seed front | closed: a bit is set exactly on a strictly nearer neighbor |
+| count `G+` | closed: 24 proper cubic rotations |
+| name the eight pair orbits and the lex-first filling | closed by Theorem 1; `c = (1, 1, 3, 1, 1, 1, 1, 1)` |
+| compute `t(v)` on every site | closed by Theorem 1; seven site types, 63 sites |
+| confirm `t(3,0,0) = 7` and `t(1,1,1) = 3` | closed by Theorem 1 |
+| compare the two population variances on `{t > 0}` | closed by Theorem 2; graph-radius variance is smaller |
+| treat the table as leftover of reversal existence | refused; existence does not compute the 63-site table |
+| write `c` into Admissibility | refused; Theorem 3 |
+| attach a path-length law | refused; Theorem 3 |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a cost or of a path-length law is not a proof leaf.
+
+## Representative Values
+
+| site type | `t` | `|v|_2 / t` | `|v|_2 /` graph radius |
+|---|---:|---|---|
+| `(1,0,0)` | `1` | `1` | `1` |
+| `(1,1,0)` | `2` | `√2 / 2` | `√2 / 2` |
+| `(2,0,0)` | `4` | `1/2` | `1` |
+| `(1,1,1)` | `3` | `√3 / 3` | `√3 / 3` |
+| `(2,1,0)` | `3` | `√5 / 3` | `√5 / 3` |
+| `(3,0,0)` | `7` | `3/7` | `1` |
+
+The table is an exact illustration of Theorems 1 and 2, not an adopted
+dynamics.
+
+## Framework Boundary
+
+Admissibility supplies one fixed nearest-neighbor rule, covariant under
+lattice translations and proper cubic rotations, and says that the local
+distribution varies with nearest-neighbor conditions. It does not supply a
+numerical hop cost on occupancy pairs. This note therefore treats
+`c(σ_v, σ_w) ∈ {1,2,3}` as a displayed probe, not as an axiom clause.
+
+Record is not used. No formation site, formation rate, or readout value is
+assigned to an unoccupied site. The seed is a theorem hypothesis for the
+one-seed front, not a privileged physical site.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `Z^3` nearest-neighbor adjacency and proper cubic rotations | ambient lattice | live axiom memo |
+| one-seed front from `0` | theorem hypothesis | declared; no site is privileged in the axiom |
+| `σ_n` as 6-bit inward occupation | occupancy used by the probe | defined from the one-seed front |
+| lex-first `c = (1, 1, 3, 1, 1, 1, 1, 1)` | displayed `G+`-equivariant hop cost | mathematical input; not an axiom |
+| `t(v)` on `B_3(0)` | min path cost under that filling | computed; Theorem 1 |
+| `Var(\|v\|_2 / t)` versus `Var(\|v\|_2 /` graph radius`)` | displayed isochrone test | computed; Theorem 2 |
+| existence of a reversing filling | context, not a load-bearing parent | existence does not determine the isochrones |
+
+There are no measured, fitted, literature, or observational inputs. A
+continuum metric, a path-length axiom, and any cost written into
+Admissibility remain outside the result.
+
+## Mutations
+
+1. Collapse the 63-site table to the two comparison points `(3,0,0)` and
+   `(1,1,1)`: that is the existence residual, not the isochrone residual.
+2. Replace the lex-first filling by another of the 405 reversing maps: the
+   named filling is seed-exit `1`, axis-extension `3`, else `1`.
+3. Claim the `t = const` shells are closer to Euclidean spheres: the
+   graph-radius variance is smaller.
+4. Include the origin in the variance: `t(0) = 0` is excluded by the
+   stated domain `{v : t(v) > 0}`.
+5. Write `c` into Admissibility: the live axiom memo still states one
+   fixed covariant nearest-neighbor rule and contains no two-end occupancy
+   hop cost.
+6. Attach a path-length law: Theorem 3 refuses both graph radius and
+   Euclidean radius as axiom clauses.
+
+## What This Does Not Claim
+
+- No cost is written into Admissibility.
+- No path-length law is attached.
+- The comparison is not scored outside `B_3(0)`.
+- The isochrone table is not a leftover of reversal existence.
+- The lex-first filling is not claimed to minimize the displayed variance.
+- No continuum Euclidean metric is derived.
+- No privileged physical seed is added to the Lattice axiom.
+- No Record readout is assigned to a site without a record.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on `B_3(0)`, the report of the lex-first
+reversing isochrones is not a leftover of reversal existence, is not an
+Admissibility clause, does not attach a path-length law, and does not make
+the `t = const` shells closer to Euclidean spheres than graph-radius
+shells by the displayed variance test. It is not a claim about any other
+filling, any larger ball, or any adopted dynamics.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| existence leftover | Read `t(3,0,0) = 7` and `t(1,1,1) = 3` as already the isochrone report. | Theorem 1 computes all seven site types; the mixed `t = 3` shell is invisible at those two points. | **ATTEMPTED** |
+| two-point ratio test | Compare only `3/7` and `√3/3` and declare Euclidean closeness. | Theorem 2 uses all 62 positive-`t` sites; graph-radius variance is smaller. | **ATTEMPTED** |
+| drop the axis overshoot | Ignore `(2,0,0)` and `(3,0,0)` because the other types agree with graph radius. | Those six-plus-six sites are in `S`; they drive `|v|_2 / t` down to `1/2` and `3/7`. | **ATTEMPTED** |
+| sample variance or include the origin | Change the estimator or divide by `t(0) = 0`. | The stated estimator is the population variance on `{t > 0}`; the origin is excluded. | **ATTEMPTED** |
+| write the filling into Admissibility | Treat seed-exit `1` and axis-extension `3` as the covariant rule. | Theorem 3: the live axiom memo still states one fixed nearest-neighbor rule and no hop cost. | **ATTEMPTED** |
+| attach a path-length law | Promote `t` or graph radius to an axiom-level length. | Theorem 3 refuses both; do not attach either. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one comparison and one adoption refusal, not a stack of independent
+walls. The 63-site table and the variance comparison are two certificates of
+the same isochrone report.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| 63-site table / variance comparison | no: the table does not by itself name a variance | no: a variance does not reconstruct the seven times | independent displayed facts in Theorems 1 and 2 |
+| isochrone report / adoption refusal | no: a probe can be tabulated and still refused as an axiom | no: refusing adoption does not compute `t(v)` | independent conclusions |
+
+Path-length attachment is not counted as a third wall: Theorem 3 simply
+does not attach one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “one-seed growth from `0`” | explicit theorem hypothesis; the Lattice axiom privileges no site |
+| “inward occupation of the one-seed front” | defined from nearer neighbors; not an extra occupancy axiom |
+| “lex-first `c = (1, 1, 3, 1, 1, 1, 1, 1)`” | displayed finite probe, not a derived scale |
+| “`G+`-equivariant” | covariance under the axiom's proper cubic rotations |
+| “population variance on `{t > 0}`” | explicit estimator and domain in Theorem 2 |
+| “graph-radius variance is smaller” | Theorem 2; displayed, not adopted |
+| “not a leftover” of reversal existence | Theorem 1; the 63-site table is new |
+| “Displayed, not adopted” | Theorem 3; no Admissibility edit |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and proper cubic rotations | `Z^3` nearest-neighbor graph and `G+` | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | Admissibility covariance | one fixed covariant nearest-neighbor rule; no hop cost supplied | yes; cost stays displayed |
+| `scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py:313` | eight pair orbits and the named filling | weights and `c = (1, 1, 3, 1, 1, 1, 1, 1)` | yes |
+| `scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py:323` | `t(3,0,0)` and `t(1,1,1)` | times `7` and `3` | yes |
+| `scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py:328` | `t(v)` on every site type | the seven orbit times of Theorem 1 | yes |
+| `scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py:351` | which variance is smaller | graph-radius variance is smaller | yes |
+| `scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py:368` | adoption of a cost | note and axiom keep the cost out of Admissibility | yes |
+
+No evidence citation is used to claim a path-length axiom, a continuum
+metric, or an Admissibility rewrite.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: each directed `B_3(0)` edge | one inward occupancy pair; no other edge family is classified |
+| per site | yes: `t(v)` at each of the 63 sites | no other occupancy dictionary is used |
+| per mode | yes: seven site types and the one lex-first filling | other fillings and larger balls are untested and unclaimed |
+| per block | yes: the two variances on the 62 positive-`t` sites | closeness is the stated variance test only |
+| lattice wide | no | no Admissibility cost and no path-length law are adopted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial-closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies a two-end occupancy hop cost, an isochrone, or
+a Euclidean sphere law, and none is reclassified as an import or wall.
+The scale-reference primitive is a units conversion only. The
+kinetic-isotropy primitive supplies `c_t = c_s` as a graining ratio, not a
+spatial isochrone. The realized-state primitive supplies pointwise
+evaluation of a realized state, not a hop cost.
+
+Two partial-closure mechanisms are recorded rather than suppressed.
+Existence of a reversing filling names the lex-first witness but does not
+compute the 63-site table or the variance comparison. Unit hop costs
+recover graph radius, which is used as the displayed comparator and is not
+promoted to a path-length law. The remaining physical choice—whether any
+hop cost belongs in Admissibility—stays explicit and does not require an
+axiom edit.
+
+### N7 — hostile steelman
+
+The strongest objection is that diamond reversal at `(3,0,0)` versus
+`(1,1,1)` already forces the `t = const` shells closer to Euclidean
+spheres, so a 62-site variance is ornament. The objection correctly notes
+that those two points move toward a common Euclidean radius in the
+reversed order. It fails because the same filling sends `(2,0,0)` to
+`t = 4` and `(3,0,0)` to `t = 7`, so the axis ratios drop to `1/2` and
+`3/7`, while graph radius keeps every axis ratio at `1`. The 62-site
+population variance is the hostile check of that overshoot, and
+graph-radius variance is smaller.
+
+### N8 — cross-cycle echo
+
+The live axiom memo is the only load-bearing parent. Nearby covariance
+language is context.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | proper cubic covariance of the nearest-neighbor rule | used as `G+` equivariance of the displayed cost; the rule itself is not replaced |
+| existence of a reversing `{1,2,3}` filling | same eight orbits, same lex-first witness | counted as a strictly smaller residual; Theorems 1 and 2 compute the isochrones |
+| unit hop costs / graph radius | constant-`1` isochrones | used as the displayed comparator; not attached as a path-length law |
+
+No earlier mechanism retires the 63-site table, the variance comparison, or
+the adoption refusal.
+
+No-Go Discipline disposition: **PASS** for the bounded comparison and the
+adoption boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Runner Contract
+
+The companion runner builds the 24 proper cubic rotations, the 63-site ball,
+and the 228 directed edges; constructs the lex-first filling from seed-exit
+`1` and axis-extension `3`; computes `t(v)` on every site; compares the two
+population variances; rejects the mutation families, including the existence
+leftover; and verifies that the live axiom memo does not host the displayed
+cost. Declared audit inputs are this note and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2729,6 +2729,10 @@
   "cosmology_single_ratio_inverse_reconstruction_theorem_note_2026-04-25": {
    "deps_hash": "14400756f044",
    "out_degree": 4
+  },
+  "cost3_lexfirst_reversal_isochrone_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "coulomb_stability_upper_bound_support_note_2026-05-20": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/cost3_lexfirst_reversal_isochrone_2026_08_15.txt
+++ b/logs/runner-cache/cost3_lexfirst_reversal_isochrone_2026_08_15.txt
@@ -1,0 +1,52 @@
+===== runner cache v1 =====
+runner: scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py
+runner_sha256: 9b15d95eb430df6d8564ad52e677c611bcab4e5b66d2e71333ebdcdf24900a11
+input_fingerprint_sha256: bb536aa670685f822f38604f1ca1f4c3cd5e98de79e56780a4987173320c3310
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; B_3(0), G+, and the lex-first filling are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact integer path costs and Decimal variance on the radius-3 ball
+negative_scope: displayed lex-first isochrones are not written into Admissibility
+orbit_weights: ((0, 1), (1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (2, 3), (3, 2))
+lex_first_c: (1, 1, 3, 1, 1, 1, 1, 1)
+t_axis: 7
+t_diag: 3
+site_orbit_times: (0, 0, 0)->0(n=1), (0, 0, 1)->1(n=6), (0, 0, 2)->4(n=6), (0, 0, 3)->7(n=6), (0, 1, 1)->2(n=12), (0, 1, 2)->3(n=24), (1, 1, 1)->3(n=8)
+shells: t=1:n=6, t=2:n=12, t=3:n=32, t=4:n=6, t=7:n=6
+var_lexfirst: 0.022275669698
+var_graph_radius: 0.020739455142
+smaller_variance: graph-radius
+PASS: gplus-order proper cubic rotations number 24
+PASS: ball-size B_3(0) has 63 sites
+PASS: directed-edges B_3(0) has 228 directed nearest-neighbor edges
+PASS: thm1-pair-orbits endpoint occupancy pairs form 8 G+ orbits
+PASS: thm1-lex-first-c seed-exit 1 and axis-extension 3 with else 1 is (1,1,3,1,1,1,1,1)
+PASS: thm1-axis-diag-times t(3,0,0)=7 and t(1,1,1)=3 under the lex-first filling
+PASS: thm1-site-orbit-times each G+ site type on B_3(0) has one arrival time, matching the note table
+PASS: thm1-note-times the note records t(3,0,0)=7, t(1,1,1)=3, and the seven site-type times
+PASS: thm2-unit-is-graph-radius unit hop costs recover graph radius on every site of B_3(0)
+PASS: thm2-variance-comparison population variance of |v|_2 / graph-radius is smaller than for the lex-first times
+PASS: thm2-variance-in-note the note reports both variances and that the graph-radius variance is smaller
+PASS: thm2-displayed-comparison the note displays the variance comparison and does not adopt a sphere law
+PASS: thm3-displayed-not-adopted the note reports the lex-first cost as displayed, not adopted
+PASS: thm3-no-path-length-law the note refuses to attach a path-length law
+PASS: claim-scope claim_scope reports the B_3(0) lex-first isochrones only
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: forbidden-strings note, runner, and axiom avoid the dispatch-forbidden phrases
+PASS: no-axiom-cost the live axiom memo does not host a two-end occupancy hop cost
+PASS: not-mink3-leftover the note states the isochrone report is not a leftover of reversal existence
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: scored-ball-only the note scores the comparison on B_3(0) only
+per_element: checked exactly — each directed B_3(0) edge carries one inward occupancy pair
+per_site: checked exactly — t(v) is the min path cost at each of the 63 sites
+per_mode: checked exactly — seven G+ site types and the eight pair-orbits of the filling
+per_block: checked exactly — var(|v|_2 / t(v)) versus var(|v|_2 / graph-radius) on 62 sites
+lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py
+++ b/scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Isochrones of the lex-first diamond-reversing {1,2,3} two-end cost.
+
+On B_3(0), arrival time is the minimum path cost from the seed under the
+lex-first filling c = (1, 1, 3, 1, 1, 1, 1, 1): seed-exit 1, axis-extension
+3, else 1. The note reports t(v) and compares var(|v|_2 / t(v)) with the
+same ratio for graph radius. Displayed, not adopted. No axiom edit, cache
+write, or path-length law.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import defaultdict
+from decimal import Decimal, ROUND_HALF_EVEN
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "COST3_LEXFIRST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/COST3_LEXFIRST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SHIFT_INDEX = {shift: index for index, shift in enumerate(SHIFTS)}
+ORIGIN: Point = (0, 0, 0)
+AXIS: Point = (3, 0, 0)
+DIAG: Point = (1, 1, 1)
+EXPECTED_WEIGHTS = (
+    (0, 1),
+    (1, 0),
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (2, 3),
+    (3, 2),
+)
+EXPECTED_SITE_TIMES = {
+    (0, 0, 0): 0,
+    (0, 0, 1): 1,
+    (0, 0, 2): 4,
+    (0, 0, 3): 7,
+    (0, 1, 1): 2,
+    (0, 1, 2): 3,
+    (1, 1, 1): 3,
+}
+VAR_PLACES = Decimal("1e-12")
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def graph_radius(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclidean_sq(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def site_type(point: Point) -> Point:
+    return tuple(sorted(abs(coord) for coord in point))  # type: ignore[return-value]
+
+
+def ball(radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for coords in product(span, repeat=3):
+        if graph_radius(coords) <= radius:
+            sites.append(coords)
+    return tuple(sites)
+
+
+def occupancy(point: Point) -> int:
+    """6-bit inward occupation of the one-seed front at ``point``."""
+    bits = 0
+    for index, shift in enumerate(SHIFTS):
+        neighbor = (
+            point[0] + shift[0],
+            point[1] + shift[1],
+            point[2] + shift[2],
+        )
+        if graph_radius(neighbor) < graph_radius(point):
+            bits |= 1 << index
+    return bits
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1] + matrix[0][2] * point[2],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1] + matrix[1][2] * point[2],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1] + matrix[2][2] * point[2],
+    )
+
+
+def determinant(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src, dest in enumerate(perm):
+                rows[src][dest] = signs[src]
+            matrix = tuple(tuple(row) for row in rows)
+            if determinant(matrix) == 1:
+                rotations.append(matrix)
+    return tuple(rotations)
+
+
+def bit_permutation(matrix: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
+    return tuple(SHIFT_INDEX[apply_matrix(matrix, shift)] for shift in SHIFTS)
+
+
+def apply_bits(perm: tuple[int, ...], bits: int) -> int:
+    out = 0
+    for index in range(6):
+        if bits >> index & 1:
+            out |= 1 << perm[index]
+    return out
+
+
+def apply_pair(perm: tuple[int, ...], pair: tuple[int, int]) -> tuple[int, int]:
+    return (apply_bits(perm, pair[0]), apply_bits(perm, pair[1]))
+
+
+def orbit_rep(pair: tuple[int, int], perms: tuple[tuple[int, ...], ...]) -> tuple[int, int]:
+    return min(apply_pair(perm, pair) for perm in perms)
+
+
+def directed_edges(sites: tuple[Point, ...]) -> tuple[tuple[Point, Point], ...]:
+    present = set(sites)
+    edges: list[tuple[Point, Point]] = []
+    for site in sites:
+        for shift in SHIFTS:
+            neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+            if neighbor in present:
+                edges.append((site, neighbor))
+    return tuple(edges)
+
+
+def lex_first_costs(weights: tuple[tuple[int, int], ...]) -> tuple[int, ...]:
+    """Seed-exit 1, axis-extension 3, every other orbit 1."""
+    costs: list[int] = []
+    for weight in weights:
+        if weight == (0, 1):
+            costs.append(1)
+        elif weight == (1, 1):
+            costs.append(3)
+        else:
+            costs.append(1)
+    return tuple(costs)
+
+
+def min_path_costs(
+    start: Point,
+    adj: dict[Point, list[tuple[Point, int]]],
+    costs: tuple[int, ...],
+) -> dict[Point, int]:
+    dist = {start: 0}
+    heap: list[tuple[int, Point]] = [(0, start)]
+    while heap:
+        current, node = heapq.heappop(heap)
+        if current != dist[node]:
+            continue
+        for neighbor, orbit in adj[node]:
+            trial = current + costs[orbit]
+            prior = dist.get(neighbor)
+            if prior is None or trial < prior:
+                dist[neighbor] = trial
+                heapq.heappush(heap, (trial, neighbor))
+    return dist
+
+
+def population_variance(values: list[Decimal]) -> Decimal:
+    count = Decimal(len(values))
+    mean = sum(values, start=Decimal(0)) / count
+    return sum((value - mean) ** 2 for value in values) / count
+
+
+def fmt_var(value: Decimal) -> str:
+    return str(value.quantize(VAR_PLACES, rounding=ROUND_HALF_EVEN))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; B_3(0), G+, and the lex-first filling are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact integer path costs and Decimal variance on the radius-3 ball")
+    print("negative_scope: displayed lex-first isochrones are not written into Admissibility")
+
+    rotations = proper_cubic_rotations()
+    perms = tuple(bit_permutation(matrix) for matrix in rotations)
+    sites = ball(3)
+    edges = directed_edges(sites)
+    pairs = tuple((occupancy(src), occupancy(dst)) for src, dst in edges)
+    reps = tuple(sorted({orbit_rep(pair, perms) for pair in pairs}))
+    rep_index = {rep: index for index, rep in enumerate(reps)}
+    weights = tuple(
+        (bin(rep[0]).count("1"), bin(rep[1]).count("1")) for rep in reps
+    )
+    filling = lex_first_costs(weights)
+    adj: dict[Point, list[tuple[Point, int]]] = defaultdict(list)
+    for src, dst in edges:
+        adj[src].append(
+            (dst, rep_index[orbit_rep((occupancy(src), occupancy(dst)), perms)])
+        )
+
+    times = min_path_costs(ORIGIN, adj, filling)
+    unit_times = min_path_costs(ORIGIN, adj, tuple(1 for _ in reps))
+    type_times: dict[Point, set[int]] = defaultdict(set)
+    type_counts: dict[Point, int] = defaultdict(int)
+    shells: dict[int, list[Point]] = defaultdict(list)
+    for site in sites:
+        kind = site_type(site)
+        type_times[kind].add(times[site])
+        type_counts[kind] += 1
+        if site != ORIGIN:
+            shells[times[site]].append(site)
+
+    nonzero = tuple(site for site in sites if site != ORIGIN)
+    cost_ratios: list[Decimal] = []
+    radius_ratios: list[Decimal] = []
+    for site in nonzero:
+        radius = Decimal(euclidean_sq(site)).sqrt()
+        cost_ratios.append(radius / Decimal(times[site]))
+        radius_ratios.append(radius / Decimal(graph_radius(site)))
+    var_cost = population_variance(cost_ratios)
+    var_radius = population_variance(radius_ratios)
+    var_cost_txt = fmt_var(var_cost)
+    var_radius_txt = fmt_var(var_radius)
+    smaller = "graph-radius" if var_radius < var_cost else "lex-first-cost"
+
+    print(f"orbit_weights: {weights}")
+    print(f"lex_first_c: {filling}")
+    print(f"t_axis: {times[AXIS]}")
+    print(f"t_diag: {times[DIAG]}")
+    print(
+        "site_orbit_times: "
+        + ", ".join(
+            f"{kind}->{sorted(type_times[kind])[0]}(n={type_counts[kind]})"
+            for kind in sorted(type_times)
+        )
+    )
+    print(
+        "shells: "
+        + ", ".join(
+            f"t={level}:n={len(shells[level])}" for level in sorted(shells)
+        )
+    )
+    print(f"var_lexfirst: {var_cost_txt}")
+    print(f"var_graph_radius: {var_radius_txt}")
+    print(f"smaller_variance: {smaller}")
+
+    checks.check("gplus-order", "proper cubic rotations number 24", len(rotations) == 24)
+    checks.check("ball-size", "B_3(0) has 63 sites", len(sites) == 63)
+    checks.check(
+        "directed-edges",
+        "B_3(0) has 228 directed nearest-neighbor edges",
+        len(edges) == 228,
+    )
+    checks.check(
+        "thm1-pair-orbits",
+        "endpoint occupancy pairs form 8 G+ orbits",
+        len(reps) == 8 and weights == EXPECTED_WEIGHTS,
+    )
+    checks.check(
+        "thm1-lex-first-c",
+        "seed-exit 1 and axis-extension 3 with else 1 is (1,1,3,1,1,1,1,1)",
+        filling == (1, 1, 3, 1, 1, 1, 1, 1),
+    )
+    checks.check(
+        "thm1-axis-diag-times",
+        "t(3,0,0)=7 and t(1,1,1)=3 under the lex-first filling",
+        times[AXIS] == 7 and times[DIAG] == 3,
+    )
+    checks.check(
+        "thm1-site-orbit-times",
+        "each G+ site type on B_3(0) has one arrival time, matching the note table",
+        all(len(type_times[kind]) == 1 for kind in type_times)
+        and {kind: next(iter(vals)) for kind, vals in type_times.items()}
+        == EXPECTED_SITE_TIMES
+        and sum(type_counts.values()) == 63,
+    )
+    checks.check(
+        "thm1-note-times",
+        "the note records t(3,0,0)=7, t(1,1,1)=3, and the seven site-type times",
+        "t(3,0,0) = 7" in note
+        and "t(1,1,1) = 3" in note
+        and "t(2,0,0) = 4" in note
+        and "t(2,1,0) = 3" in note
+        and "t(1,1,0) = 2" in note
+        and "t(1,0,0) = 1" in note,
+    )
+    checks.check(
+        "thm2-unit-is-graph-radius",
+        "unit hop costs recover graph radius on every site of B_3(0)",
+        all(unit_times[site] == graph_radius(site) for site in sites),
+    )
+    checks.check(
+        "thm2-variance-comparison",
+        "population variance of |v|_2 / graph-radius is smaller than for the lex-first times",
+        var_radius < var_cost and smaller == "graph-radius",
+    )
+    checks.check(
+        "thm2-variance-in-note",
+        "the note reports both variances and that the graph-radius variance is smaller",
+        var_cost_txt in note
+        and var_radius_txt in note
+        and "graph-radius variance is smaller" in note,
+    )
+    checks.check(
+        "thm2-displayed-comparison",
+        "the note displays the variance comparison and does not adopt a sphere law",
+        "Displayed, not adopted" in note and "not a leftover" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the note reports the lex-first cost as displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    checks.check(
+        "thm3-no-path-length-law",
+        "the note refuses to attach a path-length law",
+        "No path-length law is attached" in note
+        and "do not attach" in note.lower(),
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the B_3(0) lex-first isochrones only",
+        "On B_3(0), the isochrones" in note
+        and "lex-first diamond-reversing" in note
+        and "{1,2,3}" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/COST3_LEXFIRST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in source
+        and '"docs/COST3_LEXFIRST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md"'
+        in source,
+    )
+    checks.check(
+        "forbidden-strings",
+        "note, runner, and axiom avoid the dispatch-forbidden phrases",
+        all(token not in note and token not in source for token in forbidden_tokens()),
+    )
+    checks.check(
+        "no-axiom-cost",
+        "the live axiom memo does not host a two-end occupancy hop cost",
+        "two-end occupancy" not in axiom and "c(σ_v, σ_w)" not in axiom,
+    )
+    checks.check(
+        "not-mink3-leftover",
+        "the note states the isochrone report is not a leftover of reversal existence",
+        "not a leftover" in note and "existence" in note and "isochrone" in note.lower(),
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+    checks.check(
+        "scored-ball-only",
+        "the note scores the comparison on B_3(0) only",
+        "on `B_3(0)` only" in note or "on B_3(0) only" in note,
+    )
+
+    print(
+        "per_element: checked exactly — each directed B_3(0) edge carries one inward occupancy pair"
+    )
+    print(
+        "per_site: checked exactly — t(v) is the min path cost at each of the 63 sites"
+    )
+    print(
+        "per_mode: checked exactly — seven G+ site types and the eight pair-orbits of the filling"
+    )
+    print(
+        "per_block: checked exactly — var(|v|_2 / t(v)) versus var(|v|_2 / graph-radius) on 62 sites"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B3(0), c=(1,1,3,1,1,1,1,1) has t(3,0,0)=7 and t(1,1,1)=3. var(|v|_2/t) is 0.0223 vs l1 0.0207. Axis overshoot. Displayed, not adopted. No axiom edit.

## Runner

`scripts/cost3_lexfirst_reversal_isochrone_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.