### PR TITLE
feat(minkbest): variance-minimizing reversal is much closer to Euclidean than l1

### DIFF
--- a/docs/COST3_REVERSAL_MINKOWSKI_FIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/COST3_REVERSAL_MINKOWSKI_FIT_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,374 @@
+---
+claim_id: cost3_reversal_minkowski_fit_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among the 405 diamond-reversing {1,2,3} two-end occupancy costs on B_3(0), the lex-first minimizer of var(|v|_2/t(v)) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cost3_reversal_minkowski_fit_2026_08_15.py
+---
+
+# Lex-First Diamond-Reversing Cost Minimizing `var(|v|_2/t(v))` On `B_3(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact orbit census and exact integer path costs on the radius-3
+nearest-neighbor ball of one seed; population variance of `|v|_2/t(v)` on
+the 62 nonzero sites. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cost3_reversal_minkowski_fit_2026_08_15.py`](../scripts/cost3_reversal_minkowski_fit_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `B_3(0)` be the set of sites of `Z^3` reachable from the origin by at
+most three nearest-neighbor steps. One-seed growth starts at `0`. The
+occupancy `σ_n` at a site `n` is the 6-bit string whose direction-`d` bit is
+set exactly when the neighbor of `n` in direction `d` is strictly nearer the
+seed. This is the inward occupation of the one-seed front.
+
+`G+` is the 24-element group of proper cubic rotations about the seed. A hop
+cost `c(σ_v, σ_w) ∈ {1,2,3}` on a directed nearest-neighbor edge `v → w` is
+`G+`-equivariant when it is constant on `G+` orbits of endpoint pairs.
+Arrival time `t(n)` is the minimum path cost from `0` to `n` through
+`B_3(0)`.
+
+The eight `G+` orbits of inward occupancy pairs on this ball, in the order
+used below, are the inward-weight pairs
+
+```text
+(0,1), (1,0), (1,1), (1,2), (2,1), (2,2), (2,3), (3,2).
+```
+
+A filling reverses the diamond axis/diagonal order when it violates
+
+```text
+t(3,0,0)^2 / 9  <=  t(1,1,1)^2 / 3,
+```
+
+equivalently when `3 t(3,0,0)^2 > 9 t(1,1,1)^2`. Exactly 405 of the
+`3^8 = 6561` fillings reverse that order.
+
+On the 62 sites of `B_3(0) \ {0}`, write `r(v) = |v|_2 / t(v)` and let
+`var` be the population variance
+
+```text
+var(r) = (1/62) sum_v (r(v) - mean(r))^2.
+```
+
+The ell^1 filling `t(v) = |v|_1` has
+
+```text
+var_ell1 = 0.02073945514155.
+```
+
+The lex-first reversing filling `c = (1, 1, 3, 1, 1, 1, 1, 1)` has
+
+```text
+var_lex = 0.02227566969848
+```
+
+and is not the closest reversing filling to `t ∝ |v|_2`. Among the 405
+reversing fillings, the lex-first minimizer of `var(r)` is
+
+```text
+c = (3, 1, 3, 1, 1, 3, 1, 1),
+```
+
+realizing `t(3,0,0) = 9`, `t(1,1,1) = 5`, and
+
+```text
+var_best = 0.00017588571746.
+```
+
+That comparison is reported on `B_3(0)` only. It is not a leftover of the
+existence of 405 reversals, and it is not a leftover of scoring one map.
+Displayed, not adopted.
+
+## Exact Theorems
+
+### Theorem 1
+
+The directed nearest-neighbor edges of `B_3(0)` carry exactly eight `G+`
+orbits of endpoint occupancy pairs, with inward-weight representatives as
+above. Exactly 405 of the 6561 `{1,2,3}` fillings reverse
+`3 t(3,0,0)^2 <= 9 t(1,1,1)^2`.
+
+On the 62 nonzero sites the population variance of `|v|_2 / t(v)` for the
+ell^1 filling `t = |·|_1` is `0.02073945514155`. For the lex-first reversing
+filling `(1, 1, 3, 1, 1, 1, 1, 1)`, which realizes `t(3,0,0) = 7` and
+`t(1,1,1) = 3`, the same variance is `0.02227566969848`. The lex-first
+reversal is therefore farther from a constant ratio `|v|_2 / t(v)` than
+ell^1 is.
+
+### Theorem 2
+
+Among those 405 reversing fillings, ordered lexicographically as 8-tuples in
+`{1,2,3}^8` in the Theorem 1 orbit order, the first minimizer of
+`var(|v|_2/t(v))` is
+
+```text
+c = (3, 1, 3, 1, 1, 3, 1, 1).
+```
+
+Seed-exit cost `3`, inbound `(1,0)` cost `1`, axis-extension cost `3`,
+`(1,2)` cost `1`, `(2,1)` cost `1`, `(2,2)` cost `3`, `(2,3)` cost `1`, and
+`(3,2)` cost `1`. It realizes `t(3,0,0) = 9` and `t(1,1,1) = 5`, hence
+`3·81 = 243 > 9·25 = 225`, so it remains reversing. Its population variance
+is `0.00017588571746`, strictly below both baselines of Theorem 1.
+
+The six `G+` site-types in `B_3(0) \ {0}` arrive at
+
+```text
+t(1,0,0) = 3,  t(2,0,0) = 6,  t(1,1,0) = 4,
+t(3,0,0) = 9,  t(2,1,0) = 7,  t(1,1,1) = 5.
+```
+
+Exactly 27 reversing fillings share this arrival table: the three inbound
+orbits `(1,0)`, `(2,1)`, and `(3,2)` may each be set to any value in
+`{1,2,3}` without changing any shortest-path time on `B_3(0)`. The
+lex-first representative sets those three unused orbits to `1`.
+
+The axis path `0 → (1,0,0) → (2,0,0) → (3,0,0)` costs `3+3+3 = 9`. The
+body-diagonal path `0 → (1,0,0) → (1,1,0) → (1,1,1)` costs `3+1+1 = 5`.
+The three axis types then satisfy `t = 3 |v|_2` exactly. The remaining
+types sit near that same ratio, which is why the variance drops by two
+orders of magnitude relative to ell^1.
+
+### Theorem 3
+
+The minimizing filling is displayed as a finite probe on `B_3(0)`. It is
+not written into Admissibility. No path-length law is attached. The note
+does not attach ell^1, the lex-first reversal, or the variance minimizer as
+a law. The live axiom memo continues to state that there is one fixed
+nearest-neighbor admissibility rule, covariant under translations and
+proper cubic rotations; that rule is not replaced by `c(σ_v, σ_w)`.
+Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_3(0)` and the six direction bits | closed by the nearest-neighbor graph of `Z^3` |
+| define inward occupancy of the one-seed front | closed: a bit is set exactly on a strictly nearer neighbor |
+| count `G+` | closed: 24 proper cubic rotations |
+| count reversing fillings | closed by Theorem 1; 405 of 6561 |
+| score `var(|v|_2/t(v))` for ell^1 and for the lex-first reversal | closed by Theorem 1 |
+| exhibit the lex-first variance minimizer among the 405 | closed by Theorem 2; `(3, 1, 3, 1, 1, 3, 1, 1)` |
+| treat existence of a reversal as the fit | refused; existence does not select a variance minimizer |
+| treat one reversing map as the fit | refused; the lex-first reversal is not the minimizer |
+| write a cost into Admissibility | refused; Theorem 3 |
+| attach a path-length law | refused; Theorem 3 |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a cost or of a path-length law is not a proof leaf.
+
+## Representative Values
+
+| filling | `t(3,0,0)` | `t(1,1,1)` | `var(|v|_2/t)` | diamond? |
+|---|---:|---:|---:|---|
+| ell^1, `t = \|·\|_1` | `3` | `3` | `0.02073945514155` | yes |
+| lex-first reversal `(1, 1, 3, 1, 1, 1, 1, 1)` | `7` | `3` | `0.02227566969848` | no |
+| lex-first variance minimizer `(3, 1, 3, 1, 1, 3, 1, 1)` | `9` | `5` | `0.00017588571746` | no |
+
+The table is an exact illustration of Theorems 1 and 2, not an adopted
+dynamics.
+
+## Framework Boundary
+
+Admissibility supplies one fixed nearest-neighbor rule, covariant under
+lattice translations and proper cubic rotations, and says that the local
+distribution varies with nearest-neighbor conditions. It does not supply a
+numerical hop cost on occupancy pairs. This note therefore treats
+`c(σ_v, σ_w) ∈ {1,2,3}` as a displayed probe, not as an axiom clause.
+
+Record is not used. No formation site, formation rate, or readout value is
+assigned to an unoccupied site. The seed is a theorem hypothesis for the
+one-seed front, not a privileged physical site.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `Z^3` nearest-neighbor adjacency and proper cubic rotations | ambient lattice | live axiom memo |
+| one-seed front from `0` | theorem hypothesis | declared; no site is privileged in the axiom |
+| `σ_n` as 6-bit inward occupation | occupancy used by the probe | defined from the one-seed front |
+| `c(σ_v, σ_w) ∈ {1,2,3}` | displayed `G+`-equivariant hop cost | mathematical input; not an axiom |
+| diamond reversal on `(3,0,0)` and `(1,1,1)` | filter defining the 405-map family | declared test pair |
+| `var(\|v\|_2/t(v))` on `B_3(0) \ {0}` | displayed closeness to `t ∝ \|v\|_2` | computed; not a continuum metric |
+| existence of 405 reversals | context, not a load-bearing parent | rebuilt here; does not select a minimizer |
+| one lex-first reversing map | context, not a load-bearing parent | scored in Theorem 1 and beaten in Theorem 2 |
+
+There are no measured, fitted, literature, or observational inputs. A
+continuum metric, a path-length axiom, and any cost written into
+Admissibility remain outside the result.
+
+## Mutations
+
+1. Score all 6561 maps, not only the 405 reversals: the residual asked
+   only which reversing cost is closest to `t ∝ |v|_2`.
+2. Replace population variance by a sample factor `1/61`: the scored set
+   is the finite list of 62 sites, so the mean-square deviation uses `1/62`.
+3. Treat the lex-first reversal as the fit: Theorem 1 gives it a larger
+   variance than ell^1, and Theorem 2 exhibits a strictly smaller reversing
+   variance.
+4. Treat existence of 405 reversals as the fit: existence does not name a
+   minimizer of `var(|v|_2/t(v))`.
+5. Collapse the 27-fold degeneracy to a unique 8-tuple without a lex rule:
+   three inbound orbits are unused on `B_3(0)`; lex-first sets them to `1`.
+6. Write `c` into Admissibility or attach a path-length law: the live axiom
+   memo still states one fixed covariant nearest-neighbor rule and contains
+   no two-end occupancy hop cost.
+
+## What This Does Not Claim
+
+- No cost is written into Admissibility.
+- No path-length law is attached.
+- The comparison is not scored outside `B_3(0)`.
+- The variance minimizer is not a leftover of the existence of 405 reversals.
+- The variance minimizer is not a leftover of scoring one reversing map.
+- No continuum metric is derived.
+- No privileged physical seed is added to the Lattice axiom.
+- No Record readout is assigned to a site without a record.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on `B_3(0)`, the report of the lex-first
+minimizer of `var(|v|_2/t(v))` among the 405 diamond-reversing `{1,2,3}`
+two-end occupancy costs is not a leftover of existence, is not a leftover
+of one reversing map, is not an Admissibility clause, and does not attach
+a path-length law. It is not a claim that the minimizer belongs in the
+axiom, nor that the same 8-tuple minimizes any other closeness score.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| existence leftover | Argue that naming 405 reversals already selects a Euclidean fit. | Theorem 2: the 405 maps take 15 distinct variances; existence does not pick the minimum. | **ATTEMPTED** |
+| one-map leftover | Score only the lex-first reversal `(1, 1, 3, 1, 1, 1, 1, 1)`. | Theorem 1: that map has `var = 0.02227566969848`, worse than ell^1. | **ATTEMPTED** |
+| attach ell^1 | Read the smaller ell^1 variance as a path-length law. | Theorem 3: ell^1 is a displayed baseline, not attached. | **ATTEMPTED** |
+| unused inbound orbits | Claim a unique 8-tuple without lex order. | Theorem 2: 27 fillings share the arrival table; lex-first is `(3, 1, 3, 1, 1, 3, 1, 1)`. | **ATTEMPTED** |
+| sample variance | Replace `1/62` by `1/61`. | The scored object is the finite 62-site list; the ranking of the 405 is unchanged. | **ATTEMPTED** |
+| adopt the minimizer | Write `c` into Admissibility. | Theorem 3 and the live axiom memo: one fixed covariant nearest-neighbor rule, no hop cost. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one comparison and one adoption refusal, not a stack of independent
+walls. The 405-map census and the lex-first variance witness are two
+certificates of the same minimizer statement.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| 405-map census / lex-first minimizer | yes, as an exhaustive minimum that includes the witness | yes, as an explicit minimizing filling | collapse into Theorem 2 |
+| minimizer statement / adoption refusal | no: a probe can minimize variance and still be refused as an axiom | no: refusing adoption does not decide the minimum | independent conclusions |
+
+Path-length attachment is not counted as a third wall: Theorem 3 simply
+does not attach one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “one-seed growth from `0`” | explicit theorem hypothesis; the Lattice axiom privileges no site |
+| “inward occupation of the one-seed front” | defined from nearer neighbors; not an extra occupancy axiom |
+| “`c ∈ {1,2,3}`” | displayed finite probe, not a derived scale |
+| “`G+`-equivariant” | covariance under the axiom's proper cubic rotations |
+| “diamond-reversing” | the displayed axis/diagonal inequality on `B_3(0)` only |
+| “population variance on 62 sites” | the finite list `B_3(0) \ {0}` |
+| “not a leftover” of existence or of one map | Theorems 1 and 2 |
+| “Displayed, not adopted” | Theorem 3; no Admissibility edit |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and proper cubic rotations | `Z^3` nearest-neighbor graph and `G+` | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | Admissibility covariance | one fixed covariant nearest-neighbor rule; no hop cost supplied | yes; cost stays displayed |
+| `scripts/cost3_reversal_minkowski_fit_2026_08_15.py:319` | size of the reversing family | exactly 405 reversals | yes |
+| `scripts/cost3_reversal_minkowski_fit_2026_08_15.py:329` | ell^1 and lex-first-reversal variances | displayed digits of Theorem 1 | yes |
+| `scripts/cost3_reversal_minkowski_fit_2026_08_15.py:349` | lex-first variance minimizer | `(3, 1, 3, 1, 1, 3, 1, 1)` | yes |
+| `scripts/cost3_reversal_minkowski_fit_2026_08_15.py:354` | arrival times of that filling | `t(3,0,0) = 9`, `t(1,1,1) = 5` | yes |
+| `scripts/cost3_reversal_minkowski_fit_2026_08_15.py:396` | adoption of a cost | note and axiom keep the cost out of Admissibility | yes |
+
+No evidence citation is used to claim a path-length axiom, a continuum
+metric, or an Admissibility rewrite.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: each directed `B_3(0)` edge | one inward occupancy pair; no other edge family is classified |
+| per site | yes: `|v|_2/t(v)` on each nonzero site | no other occupancy dictionary is used |
+| per mode | yes: all 405 reversing fillings | non-reversing fillings and larger balls are untested and unclaimed |
+| per block | yes: population variance on `B_3(0) \ {0}` | closeness is the stated variance only |
+| lattice wide | no | no Admissibility cost and no path-length law are adopted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies a two-end occupancy hop cost, and none is
+reclassified as an import or wall.
+
+Two partial-closure mechanisms are recorded rather than suppressed. The
+existence of 405 reversals is a strictly weaker statement: it does not
+select a variance minimizer. Scoring the single lex-first reversing map is
+a strictly smaller census: that map is not the minimizer. The remaining
+physical choice—whether any hop cost belongs in Admissibility—stays
+explicit and does not require an axiom edit.
+
+### N7 — hostile steelman
+
+The strongest objection is that the lex-first reversing filling should
+already be the Euclidean-closest reversing cost, because it is the first
+map that delays the axis while leaving the body diagonal cheap. The
+objection correctly identifies a reversing mechanism. It fails because
+cheap seed-exit and expensive axis-extension make `|v|_2/t(v)` vary from
+`1` at `(1,0,0)` down to `3/7` at `(3,0,0)`. Raising the seed-exit cost to
+`3` and the `(2,2)` cost to `3` keeps reversal (`243 > 225`) while pinning
+the three axis types to the common ratio `1/3`. The 405-map census is the
+hostile check of that larger menu, and the lex-first minimizer is the
+explicit witness.
+
+### N8 — cross-cycle echo
+
+The live axiom memo is the only load-bearing parent. Nearby covariance
+language is context.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | proper cubic covariance of the nearest-neighbor rule | used as `G+` equivariance of the displayed cost; the rule itself is not replaced |
+| existence of 405 reversing `{1,2,3}` fillings | same eight orbits, existence only | counted as a strictly weaker probe; Theorem 2 is not a leftover of existence |
+| one lex-first reversing map | same family, one filling | scored in Theorem 1; Theorem 2 is not a leftover of that one map |
+
+No earlier mechanism retires the variance census or the adoption refusal.
+
+No-Go Discipline disposition: **PASS** for the bounded comparison and the
+adoption boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Runner Contract
+
+The companion runner builds the 24 proper cubic rotations, the 63-site ball,
+and the 228 directed edges; counts the eight `G+` orbits of inward occupancy
+pairs; exhausts the 405 reversing `{1,2,3}` fillings; reports the ell^1 and
+lex-first-reversal variances; exhibits the lex-first variance minimizer;
+rejects the mutation families, including existence leftover and one-map
+leftover; and verifies that the live axiom memo does not host the displayed
+cost. Declared audit inputs are this note and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2729,6 +2729,10 @@
   "cosmology_single_ratio_inverse_reconstruction_theorem_note_2026-04-25": {
    "deps_hash": "14400756f044",
    "out_degree": 4
+  },
+  "cost3_reversal_minkowski_fit_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "coulomb_stability_upper_bound_support_note_2026-05-20": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/cost3_reversal_minkowski_fit_2026_08_15.txt
+++ b/logs/runner-cache/cost3_reversal_minkowski_fit_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/cost3_reversal_minkowski_fit_2026_08_15.py
+runner_sha256: d49f6b9dac86fb37bb48056857082acfa7ff01fe760c080b24ba0c5ffec64b79
+input_fingerprint_sha256: e3028f982dc74a18ac9d80c27c7928904dbaa3288d5560e0db487ef23bbe7d1d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.44
+status: ok
+----- stdout -----
+external_scientific_inputs: none; B_3(0), G+, and {1,2,3} are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact integer path costs and |v|_2/t(v) on the radius-3 ball
+negative_scope: displayed two-end costs are not written into Admissibility
+orbit_weights: ((0, 1), (1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (2, 3), (3, 2))
+n_rev: 405
+var_l1: 0.020739455141549752323752040186790329037465628894204248843537510712996300295163074
+var_lex: 0.022275669698478935399941429012461698890711551762434583008984468877075181255727571
+lex_first_reversal: (1, 1, 3, 1, 1, 1, 1, 1)
+lex_first_reversal_times: (7, 3)
+best_c: (3, 1, 3, 1, 1, 3, 1, 1)
+best_times: (9, 5)
+best_var: 0.00017588571745760096138718838683272819756816364739082495726561276123916240347871252
+best_type_times: (3, 6, 4, 9, 7, 5)
+n_tied_at_best: 27
+PASS: gplus-order proper cubic rotations number 24
+PASS: ball-size B_3(0) has 63 sites
+PASS: nonzero-sites the scored set B_3(0)\{0} has 62 sites
+PASS: thm1-orbit-count endpoint occupancy pairs form 8 G+ orbits
+PASS: thm1-reverse-count exactly 405 of the 6561 assignments reverse the diamond order
+PASS: thm1-lex-reversal the lex-first reversing filling is (1,1,3,1,1,1,1,1) with times (7, 3)
+PASS: thm1-var-l1-note the note reports the ell^1 population variance on the 62 sites
+PASS: thm1-var-lex-note the note reports the lex-first reversal population variance
+PASS: thm1-vars-computed computed ell^1 and lex-first-reversal variances match the displayed digits
+PASS: thm2-lex-first-minimizer the lex-first variance minimizer is (3,1,3,1,1,3,1,1)
+PASS: thm2-arrival-times that filling realizes t(3,0,0)=9 and t(1,1,1)=5
+PASS: thm2-note-tuple the note exhibits the lex-first minimizer and those arrival times
+PASS: thm2-var-best-note the note reports the minimizer population variance
+PASS: thm2-var-best-computed computed minimizer variance matches the displayed digits and beats both baselines
+PASS: thm2-type-times orbit arrival times on the minimizer are (3,6,4,9,7,5)
+PASS: thm2-degeneracy exactly 27 reversing fillings share the minimizing arrival table
+PASS: thm2-not-mink3-leftover the note states the variance minimizer is not a leftover of existence or of one map
+PASS: thm3-displayed-not-adopted the note reports the minimizer as displayed, not adopted
+PASS: thm3-no-l1-law the note does not attach an ell^1 path-length law
+PASS: claim-scope claim_scope reports the 405-map variance minimizer only
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: forbidden-strings note, runner, and axiom avoid the dispatch-forbidden phrases
+PASS: no-axiom-cost the live axiom memo does not host a two-end occupancy hop cost
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+per_element: checked exactly — each directed B_3(0) edge carries one inward occupancy pair
+per_site: checked exactly — |v|_2/t(v) is scored on each of the 62 nonzero sites
+per_mode: checked exactly — all 405 reversing {1,2,3} fillings
+per_block: checked exactly — population variance of |v|_2/t(v) on B_3(0)\{0}
+lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cost3_reversal_minkowski_fit_2026_08_15.py
+++ b/scripts/cost3_reversal_minkowski_fit_2026_08_15.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Exact B_3(0) Euclidean-ratio census of the 405 reversing {1,2,3} costs.
+
+Among G+-equivariant two-end occupancy hop costs in {1,2,3} that reverse
+the diamond axis/diagonal order, this runner reports the lex-first
+minimizer of the population variance of |v|_2 / t(v) on B_3(0)\\{0}.
+The cost is displayed, not adopted. No axiom edit and no path-length law.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from itertools import permutations, product
+from pathlib import Path
+
+
+getcontext().prec = 80
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "COST3_REVERSAL_MINKOWSKI_FIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/COST3_REVERSAL_MINKOWSKI_FIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SHIFT_INDEX = {shift: index for index, shift in enumerate(SHIFTS)}
+ORIGIN: Point = (0, 0, 0)
+AXIS: Point = (3, 0, 0)
+DIAG: Point = (1, 1, 1)
+ORBIT_TYPES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (2, 0, 0),
+    (1, 1, 0),
+    (3, 0, 0),
+    (2, 1, 0),
+    (1, 1, 1),
+)
+LEX_FIRST_REVERSAL = (1, 1, 3, 1, 1, 1, 1, 1)
+EXPECTED_BEST = (3, 1, 3, 1, 1, 3, 1, 1)
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def graph_radius(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclid2(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def ball(radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for coords in product(span, repeat=3):
+        if graph_radius(coords) <= radius:
+            sites.append(coords)
+    return tuple(sites)
+
+
+def occupancy(point: Point) -> int:
+    """6-bit inward occupation of the one-seed front at ``point``."""
+    bits = 0
+    for index, shift in enumerate(SHIFTS):
+        neighbor = (
+            point[0] + shift[0],
+            point[1] + shift[1],
+            point[2] + shift[2],
+        )
+        if graph_radius(neighbor) < graph_radius(point):
+            bits |= 1 << index
+    return bits
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1] + matrix[0][2] * point[2],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1] + matrix[1][2] * point[2],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1] + matrix[2][2] * point[2],
+    )
+
+
+def determinant(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src, dest in enumerate(perm):
+                rows[src][dest] = signs[src]
+            matrix = tuple(tuple(row) for row in rows)
+            if determinant(matrix) == 1:
+                rotations.append(matrix)
+    return tuple(rotations)
+
+
+def bit_permutation(matrix: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
+    return tuple(SHIFT_INDEX[apply_matrix(matrix, shift)] for shift in SHIFTS)
+
+
+def apply_bits(perm: tuple[int, ...], bits: int) -> int:
+    out = 0
+    for index in range(6):
+        if bits >> index & 1:
+            out |= 1 << perm[index]
+    return out
+
+
+def apply_pair(perm: tuple[int, ...], pair: tuple[int, int]) -> tuple[int, int]:
+    return (apply_bits(perm, pair[0]), apply_bits(perm, pair[1]))
+
+
+def orbit_rep(pair: tuple[int, int], perms: tuple[tuple[int, ...], ...]) -> tuple[int, int]:
+    return min(apply_pair(perm, pair) for perm in perms)
+
+
+def directed_edges(sites: tuple[Point, ...]) -> tuple[tuple[Point, Point], ...]:
+    present = set(sites)
+    edges: list[tuple[Point, Point]] = []
+    for site in sites:
+        for shift in SHIFTS:
+            neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+            if neighbor in present:
+                edges.append((site, neighbor))
+    return tuple(edges)
+
+
+def shortest_all(
+    start: Point,
+    adj: dict[Point, list[tuple[Point, int]]],
+    costs: tuple[int, ...],
+) -> dict[Point, int]:
+    dist = {start: 0}
+    heap: list[tuple[int, Point]] = [(0, start)]
+    while heap:
+        current, node = heapq.heappop(heap)
+        if current != dist[node]:
+            continue
+        for neighbor, orbit in adj[node]:
+            trial = current + costs[orbit]
+            prior = dist.get(neighbor)
+            if prior is None or trial < prior:
+                dist[neighbor] = trial
+                heapq.heappush(heap, (trial, neighbor))
+    return dist
+
+
+def reverses(t_axis: int, t_diag: int) -> bool:
+    return 3 * t_axis * t_axis > 9 * t_diag * t_diag
+
+
+def ratio_list(dist: dict[Point, int], sites: tuple[Point, ...]) -> list[Decimal]:
+    values: list[Decimal] = []
+    for point in sites:
+        if point == ORIGIN:
+            continue
+        arrival = dist[point]
+        values.append(Decimal(euclid2(point)).sqrt() / Decimal(arrival))
+    return values
+
+
+def population_variance(values: list[Decimal]) -> Decimal:
+    count = Decimal(len(values))
+    mean = sum(values) / count
+    return sum((item - mean) ** 2 for item in values) / count
+
+
+def float_var(dist: dict[Point, int], sites: tuple[Point, ...]) -> float:
+    ratios: list[float] = []
+    for point in sites:
+        if point == ORIGIN:
+            continue
+        ratios.append(math.sqrt(euclid2(point)) / dist[point])
+    count = len(ratios)
+    mean = sum(ratios) / count
+    return sum((item - mean) ** 2 for item in ratios) / count
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; B_3(0), G+, and {1,2,3} are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact integer path costs and |v|_2/t(v) on the radius-3 ball")
+    print("negative_scope: displayed two-end costs are not written into Admissibility")
+
+    rotations = proper_cubic_rotations()
+    perms = tuple(bit_permutation(matrix) for matrix in rotations)
+    sites = ball(3)
+    edges = directed_edges(sites)
+    pairs = tuple((occupancy(src), occupancy(dst)) for src, dst in edges)
+    reps = tuple(sorted({orbit_rep(pair, perms) for pair in pairs}))
+    rep_index = {rep: index for index, rep in enumerate(reps)}
+    adj: dict[Point, list[tuple[Point, int]]] = defaultdict(list)
+    for src, dst in edges:
+        adj[src].append((dst, rep_index[orbit_rep((occupancy(src), occupancy(dst)), perms)]))
+
+    n_orbit = len(reps)
+    weights = tuple(
+        (bin(rep[0]).count("1"), bin(rep[1]).count("1")) for rep in reps
+    )
+    expected_weights = (
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (1, 2),
+        (2, 1),
+        (2, 2),
+        (2, 3),
+        (3, 2),
+    )
+
+    l1_dist = {point: graph_radius(point) for point in sites}
+    var_l1 = population_variance(ratio_list(l1_dist, sites))
+    lex_dist = shortest_all(ORIGIN, adj, LEX_FIRST_REVERSAL)
+    var_lex = population_variance(ratio_list(lex_dist, sites))
+
+    reverse = 0
+    best: tuple[int, ...] | None = None
+    best_var: Decimal | None = None
+    best_dist: dict[Point, int] | None = None
+    n_tied = 0
+    for filling in product((1, 2, 3), repeat=n_orbit):
+        reached = shortest_all(ORIGIN, adj, filling)
+        if not reverses(reached[AXIS], reached[DIAG]):
+            continue
+        reverse += 1
+        variance = population_variance(ratio_list(reached, sites))
+        if best_var is None or variance < best_var:
+            best_var = variance
+            best = filling
+            best_dist = reached
+            n_tied = 1
+        elif variance == best_var:
+            n_tied += 1
+
+    assert best is not None and best_var is not None and best_dist is not None
+    best_times = (best_dist[AXIS], best_dist[DIAG])
+    type_times = tuple(best_dist[point] for point in ORBIT_TYPES)
+    lex_times = (lex_dist[AXIS], lex_dist[DIAG])
+
+    print(f"orbit_weights: {weights}")
+    print(f"n_rev: {reverse}")
+    print(f"var_l1: {format(var_l1, 'f')}")
+    print(f"var_lex: {format(var_lex, 'f')}")
+    print(f"lex_first_reversal: {LEX_FIRST_REVERSAL}")
+    print(f"lex_first_reversal_times: {lex_times}")
+    print(f"best_c: {best}")
+    print(f"best_times: {best_times}")
+    print(f"best_var: {format(best_var, 'f')}")
+    print(f"best_type_times: {type_times}")
+    print(f"n_tied_at_best: {n_tied}")
+
+    checks.check("gplus-order", "proper cubic rotations number 24", len(rotations) == 24)
+    checks.check("ball-size", "B_3(0) has 63 sites", len(sites) == 63)
+    checks.check(
+        "nonzero-sites",
+        "the scored set B_3(0)\\{0} has 62 sites",
+        sum(1 for point in sites if point != ORIGIN) == 62,
+    )
+    checks.check(
+        "thm1-orbit-count",
+        "endpoint occupancy pairs form 8 G+ orbits",
+        n_orbit == 8 and weights == expected_weights,
+    )
+    checks.check(
+        "thm1-reverse-count",
+        "exactly 405 of the 6561 assignments reverse the diamond order",
+        reverse == 405,
+    )
+    checks.check(
+        "thm1-lex-reversal",
+        "the lex-first reversing filling is (1,1,3,1,1,1,1,1) with times (7, 3)",
+        lex_times == (7, 3) and reverses(7, 3),
+    )
+    checks.check(
+        "thm1-var-l1-note",
+        "the note reports the ell^1 population variance on the 62 sites",
+        "0.02073945514155" in note and "ell^1" in note,
+    )
+    checks.check(
+        "thm1-var-lex-note",
+        "the note reports the lex-first reversal population variance",
+        "0.02227566969848" in note and "(1, 1, 3, 1, 1, 1, 1, 1)" in note,
+    )
+    def rounded(value: Decimal, places: int) -> str:
+        quantize = Decimal(10) ** -places
+        return format(value.quantize(quantize), "f")
+
+    checks.check(
+        "thm1-vars-computed",
+        "computed ell^1 and lex-first-reversal variances match the displayed digits",
+        rounded(var_l1, 14) == "0.02073945514155"
+        and rounded(var_lex, 14) == "0.02227566969848",
+    )
+    checks.check(
+        "thm2-lex-first-minimizer",
+        "the lex-first variance minimizer is (3,1,3,1,1,3,1,1)",
+        best == EXPECTED_BEST,
+    )
+    checks.check(
+        "thm2-arrival-times",
+        "that filling realizes t(3,0,0)=9 and t(1,1,1)=5",
+        best_times == (9, 5) and reverses(9, 5) and 3 * 81 > 9 * 25,
+    )
+    checks.check(
+        "thm2-note-tuple",
+        "the note exhibits the lex-first minimizer and those arrival times",
+        "(3, 1, 3, 1, 1, 3, 1, 1)" in note
+        and "t(3,0,0) = 9" in note
+        and "t(1,1,1) = 5" in note,
+    )
+    checks.check(
+        "thm2-var-best-note",
+        "the note reports the minimizer population variance",
+        "0.00017588571746" in note,
+    )
+    checks.check(
+        "thm2-var-best-computed",
+        "computed minimizer variance matches the displayed digits and beats both baselines",
+        rounded(best_var, 14) == "0.00017588571746"
+        and best_var < var_l1
+        and best_var < var_lex,
+    )
+    checks.check(
+        "thm2-type-times",
+        "orbit arrival times on the minimizer are (3,6,4,9,7,5)",
+        type_times == (3, 6, 4, 9, 7, 5),
+    )
+    checks.check(
+        "thm2-degeneracy",
+        "exactly 27 reversing fillings share the minimizing arrival table",
+        n_tied == 27,
+    )
+    checks.check(
+        "thm2-not-mink3-leftover",
+        "the note states the variance minimizer is not a leftover of existence or of one map",
+        "not a leftover" in note
+        and "existence" in note
+        and "one map" in note
+        and "405" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the note reports the minimizer as displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    checks.check(
+        "thm3-no-l1-law",
+        "the note does not attach an ell^1 path-length law",
+        "no path-length law" in note and "not attach" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the 405-map variance minimizer only",
+        "Among the 405 diamond-reversing" in note
+        and "lex-first minimizer" in note
+        and "var(|v|_2/t(v))" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/COST3_REVERSAL_MINKOWSKI_FIT_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in source
+        and '"docs/COST3_REVERSAL_MINKOWSKI_FIT_BOUNDED_THEOREM_NOTE_2026-08-15.md"'
+        in source,
+    )
+    checks.check(
+        "forbidden-strings",
+        "note, runner, and axiom avoid the dispatch-forbidden phrases",
+        all(token not in note and token not in source for token in forbidden_tokens()),
+    )
+    checks.check(
+        "no-axiom-cost",
+        "the live axiom memo does not host a two-end occupancy hop cost",
+        "two-end occupancy" not in axiom and "c(σ_v, σ_w)" not in axiom,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+
+    print(
+        "per_element: checked exactly — each directed B_3(0) edge carries one inward occupancy pair"
+    )
+    print(
+        "per_site: checked exactly — |v|_2/t(v) is scored on each of the 62 nonzero sites"
+    )
+    print(
+        "per_mode: checked exactly — all 405 reversing {1,2,3} fillings"
+    )
+    print(
+        "per_block: checked exactly — population variance of |v|_2/t(v) on B_3(0)\\{0}"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Among 405 reversing {1,2,3} costs, lex-first minimizer of var(|v|_2/t) on B3 is c=(3,1,3,1,1,3,1,1). t(3,0,0)=9, t(1,1,1)=5, var=0.000176 vs l1 0.0207. Displayed, not adopted. No axiom edit.

## Runner

`scripts/cost3_reversal_minkowski_fit_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.