### PR TITLE
feat(bestiso): best-reversal isochrones are Euclidean-ratio shells

### DIFF
--- a/docs/COST3_BEST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/COST3_BEST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,377 @@
+---
+claim_id: cost3_best_reversal_isochrone_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_3(0), the isochrones of the variance-minimizing diamond-reversing {1,2,3} two-end occupancy cost are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cost3_best_reversal_isochrone_2026_08_15.py
+---
+
+# Isochrones Of The Variance-Minimizing Diamond-Reversing `{1,2,3}` Two-End Cost On `B_3(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact integer path costs, the six `G+` site-type arrival times,
+and a displayed variance comparison on the radius-3 nearest-neighbor ball
+of one seed. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cost3_best_reversal_isochrone_2026_08_15.py`](../scripts/cost3_best_reversal_isochrone_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `B_3(0)` be the set of sites of `Z^3` reachable from the origin by at
+most three nearest-neighbor steps. One-seed growth starts at `0`. The
+occupancy `σ_n` at a site `n` is the 6-bit string whose direction-`d` bit is
+set exactly when the neighbor of `n` in direction `d` is strictly nearer the
+seed. This is the inward occupation of the one-seed front.
+
+`G+` is the 24-element group of proper cubic rotations about the seed. A hop
+cost `c(σ_v, σ_w) ∈ {1,2,3}` on a directed nearest-neighbor edge `v → w` is
+`G+`-equivariant when it is constant on `G+` orbits of endpoint pairs.
+Arrival time `t(n)` is the minimum path cost from `0` to `n` through
+`B_3(0)`.
+
+The eight `G+` orbits of inward occupancy pairs, written as inward-weight
+pairs `(|σ_v|, |σ_w|)`, are
+
+```text
+(0,1), (1,0), (1,1), (1,2), (2,1), (2,2), (2,3), (3,2).
+```
+
+The lex-first variance-minimizing diamond-reversing filling of those orbits
+is
+
+```text
+c = (3, 1, 3, 1, 1, 3, 1, 1).
+```
+
+On `B_3(0)` this filling realizes `t(3,0,0) = 9` and `t(1,1,1) = 5`. The
+six `G+` site-types in `B_3(0) \ {0}` have distinct constant arrival times.
+Each `t = const` shell is therefore a single `G+` site-type, hence a single
+Euclidean radius: the shells are the Euclidean-ratio table of `|v|_2 / t`,
+not only the two-point axis and diagonal times. Among the 62 nonzero sites
+the population variance of `|v|_2 / t` is `0.00017588571746`, strictly
+below the ell^1 comparator `0.02073945514155`. The comparison is reported
+on `B_3(0)` only. Displayed, not adopted.
+
+The report is not a leftover of the minimizer identity. Naming
+`c = (3, 1, 3, 1, 1, 3, 1, 1)` and the two-point times `t(3,0,0) = 9`,
+`t(1,1,1) = 5` does not compute the six-type table or decide whether the
+`t = const` shells are the Euclidean-ratio table. It is not a leftover of
+the wrong map: the lex-first reversal `c = (1, 1, 3, 1, 1, 1, 1, 1)` mixes
+`(1,1,1)` and `(2,1,0)` into one shell and is not this filling.
+
+## Exact Theorems
+
+### Theorem 1
+
+`B_3(0)` has 63 sites and 228 directed nearest-neighbor edges. Under the
+variance-minimizing filling, arrival time is constant on each of the six
+`G+` site-types in `B_3(0) \ {0}`. The six types, their times, and the
+ratio `|v|_2 / t` are
+
+| representative | orbit size | `t` | `|v|_2` | `|v|_2 / t` |
+|---|---:|---:|---|---|
+| `(1,0,0)` | `6` | `3` | `1` | `1/3` |
+| `(1,1,0)` | `12` | `4` | `√2` | `√2 / 4` |
+| `(1,1,1)` | `8` | `5` | `√3` | `√3 / 5` |
+| `(2,0,0)` | `6` | `6` | `2` | `1/3` |
+| `(2,1,0)` | `24` | `7` | `√5` | `√5 / 7` |
+| `(3,0,0)` | `6` | `9` | `3` | `1/3` |
+
+In particular `t(1,0,0) = 3`, `t(1,1,0) = 4`, `t(2,0,0) = 6`,
+`t(2,1,0) = 7`, `t(1,1,1) = 5`, and `t(3,0,0) = 9`. The six seed-exit
+edges occupy orbit `(0,1)` of cost `3`. Both axis extensions occupy orbit
+`(1,1)` of cost `3`. The axis path `0 → (1,0,0) → (2,0,0) → (3,0,0)`
+costs `3+3+3 = 9`. The body-diagonal path
+`0 → (1,0,0) → (1,1,0) → (1,1,1)` costs `3+1+1 = 5`.
+
+The constant-`t` shells are therefore
+
+```text
+t=3 : 6 sites of type (1,0,0)
+t=4 : 12 sites of type (1,1,0)
+t=5 : 8 sites of type (1,1,1)
+t=6 : 6 sites of type (2,0,0)
+t=7 : 24 sites of type (2,1,0)
+t=9 : 6 sites of type (3,0,0)
+```
+
+Every shell is a single `G+` site-type, hence a single Euclidean radius.
+The six shells are the Euclidean-ratio table. They are not only the
+two-point `(3,0,0)` and `(1,1,1)` times. The three axis types share the
+common ratio `1/3`.
+
+### Theorem 2
+
+Let `S` be the 62 nonzero sites of `B_3(0)`. Write `|v|_2` for the
+ordinary Euclidean radius `√(x^2+y^2+z^2)`. The population variance
+
+```text
+Var(a) = (1/|S|) Σ_{v in S} (a(v) - mean(a))^2
+```
+
+on the displayed ratio field is
+
+```text
+Var(|v|_2 / t(v))     = 0.00017588571746
+Var(|v|_2 / |v|_1)    = 0.02073945514155
+```
+
+The first figure equals the minkbest population variance and is strictly
+below the ell^1 figure. Unit hop costs recover `|v|_1` on every site of
+`B_3(0)`, so the second field is the isochrone ratio of the constant-`1`
+filling (the ell^1 comparator). The comparison is displayed, not adopted.
+No path-length law is attached.
+
+### Theorem 3
+
+The variance-minimizing filling and its isochrones are displayed as a
+finite probe on `B_3(0)`. They are not written into Admissibility. No
+path-length law is attached; do not attach graph radius, Euclidean radius,
+ell^1, or the filling `c` as an axiom clause. The live axiom memo
+continues to state that there is one fixed nearest-neighbor admissibility
+rule, covariant under translations and proper cubic rotations; that rule
+is not replaced by `c(σ_v, σ_w)`. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_3(0)` and the six direction bits | closed by the nearest-neighbor graph of `Z^3` |
+| define inward occupancy of the one-seed front | closed: a bit is set exactly on a strictly nearer neighbor |
+| count `G+` | closed: 24 proper cubic rotations |
+| name the eight pair orbits and the variance-minimizing filling | closed by Theorem 1; `c = (3, 1, 3, 1, 1, 3, 1, 1)` |
+| compute `t(v)` on every `G+` site-type | closed by Theorem 1; six nonzero types |
+| confirm `t(3,0,0) = 9` and `t(1,1,1) = 5` | closed by Theorem 1 |
+| report `|v|_2 / t` for each type and whether shells are the Euclidean-ratio table | closed by Theorem 1; each shell is one type |
+| compare the population variance on the 62 nonzero sites with ell^1 | closed by Theorem 2; strictly below |
+| treat the table as leftover of the minimizer identity | refused; identity does not report the six-type shells |
+| treat the table as leftover of the wrong map | refused; the lex-first reversal is a different filling |
+| write `c` into Admissibility | refused; Theorem 3 |
+| attach a path-length law | refused; Theorem 3 |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a cost or of a path-length law is not a proof leaf.
+
+## Representative Values
+
+| site type | `t` | `|v|_2 / t` | `|v|_2 /` graph radius |
+|---|---:|---|---|
+| `(1,0,0)` | `3` | `1/3` | `1` |
+| `(1,1,0)` | `4` | `√2 / 4` | `√2 / 2` |
+| `(1,1,1)` | `5` | `√3 / 5` | `√3 / 3` |
+| `(2,0,0)` | `6` | `1/3` | `1` |
+| `(2,1,0)` | `7` | `√5 / 7` | `√5 / 3` |
+| `(3,0,0)` | `9` | `1/3` | `1` |
+
+The table is an exact illustration of Theorems 1 and 2, not an adopted
+dynamics.
+
+## Framework Boundary
+
+Admissibility supplies one fixed nearest-neighbor rule, covariant under
+lattice translations and proper cubic rotations, and says that the local
+distribution varies with nearest-neighbor conditions. It does not supply a
+numerical hop cost on occupancy pairs. This note therefore treats
+`c(σ_v, σ_w) ∈ {1,2,3}` as a displayed probe, not as an axiom clause.
+
+Record is not used. No formation site, formation rate, or readout value is
+assigned to an unoccupied site. The seed is a theorem hypothesis for the
+one-seed front, not a privileged physical site.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `Z^3` nearest-neighbor adjacency and proper cubic rotations | ambient lattice | live axiom memo |
+| one-seed front from `0` | theorem hypothesis | declared; no site is privileged in the axiom |
+| `σ_n` as 6-bit inward occupation | occupancy used by the probe | defined from the one-seed front |
+| variance-minimizing `c = (3, 1, 3, 1, 1, 3, 1, 1)` | displayed `G+`-equivariant hop cost | mathematical input; not an axiom |
+| `t(v)` on `B_3(0)` | min path cost under that filling | computed; Theorem 1 |
+| `|v|_2 / t` on the six site-types | displayed Euclidean-ratio table | computed; Theorem 1 |
+| `Var(\|v\|_2 / t)` versus ell^1 | displayed isochrone test | computed; Theorem 2 |
+| minimizer identity of `c` | context, not a load-bearing parent | identity does not determine the shells |
+| lex-first reversing map | context, the wrong map | a different filling; mixed `t = 3` shell |
+
+There are no measured, fitted, literature, or observational inputs. A
+continuum metric, a path-length axiom, and any cost written into
+Admissibility remain outside the result.
+
+## Mutations
+
+1. Collapse the six-type table to the two comparison points `(3,0,0)` and
+   `(1,1,1)`: that is the minimizer-identity residual, not the isochrone
+   residual.
+2. Replace the variance-minimizing filling by the lex-first reversal
+   `(1, 1, 3, 1, 1, 1, 1, 1)`: that is the wrong map; it mixes two
+   site-types into one shell.
+3. Claim the `t = const` shells are not the Euclidean-ratio table: each
+   shell is one `G+` site-type.
+4. Include the origin in the variance: `t(0) = 0` is excluded by the
+   stated domain of 62 nonzero sites.
+5. Write `c` into Admissibility: the live axiom memo still states one
+   fixed covariant nearest-neighbor rule and contains no two-end occupancy
+   hop cost.
+6. Attach a path-length law: Theorem 3 refuses ell^1, graph radius, and
+   Euclidean radius as axiom clauses.
+
+## What This Does Not Claim
+
+- No cost is written into Admissibility.
+- No path-length law is attached.
+- The comparison is not scored outside `B_3(0)`.
+- The isochrone table is not a leftover of the minimizer identity.
+- The isochrone table is not a leftover of the wrong map.
+- The filling is not claimed to be re-derived here as a minimizer.
+- No continuum Euclidean metric is derived.
+- No privileged physical seed is added to the Lattice axiom.
+- No Record readout is assigned to a site without a record.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on `B_3(0)`, the report of the
+variance-minimizing reversing isochrones is not a leftover of the
+minimizer identity, is not a leftover of the wrong map, is not an
+Admissibility clause, and does not attach a path-length law. It is not a
+claim about any other filling, any larger ball, or any adopted dynamics.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| minimizer-identity leftover | Read `c` and the two-point times `t(3,0,0) = 9`, `t(1,1,1) = 5` as already the isochrone report. | Theorem 1 computes all six site-types and the six distinct shells. | **ATTEMPTED** |
+| wrong-map leftover | Reuse the lex-first reversal isochrones as this table. | That map is `(1, 1, 3, 1, 1, 1, 1, 1)` with mixed `t = 3`; this filling is `(3, 1, 3, 1, 1, 3, 1, 1)`. | **ATTEMPTED** |
+| two-point ratio test | Compare only `3/9` and `√3 / 5` and declare the Euclidean-ratio table. | Theorem 1 reports `|v|_2 / t` on every type; the shells are six radii. | **ATTEMPTED** |
+| sample variance or include the origin | Change the estimator or divide by `t(0) = 0`. | The stated estimator is the population variance on the 62 nonzero sites. | **ATTEMPTED** |
+| write the filling into Admissibility | Treat seed-exit `3` and axis-extension `3` as the covariant rule. | Theorem 3: the live axiom memo still states one fixed nearest-neighbor rule and no hop cost. | **ATTEMPTED** |
+| attach a path-length law | Promote `t` or ell^1 to an axiom-level length. | Theorem 3 refuses both; do not attach either. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one comparison and one adoption refusal, not a stack of independent
+walls. The six-type table and the variance comparison are two certificates of
+the same isochrone report.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| six-type table / variance comparison | no: the table does not by itself name a variance | no: a variance does not reconstruct the six times | independent displayed facts in Theorems 1 and 2 |
+| isochrone report / adoption refusal | no: a probe can be tabulated and still refused as an axiom | no: refusing adoption does not compute `t(v)` | independent conclusions |
+
+Path-length attachment is not counted as a third wall: Theorem 3 simply
+does not attach one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “one-seed growth from `0`” | explicit theorem hypothesis; the Lattice axiom privileges no site |
+| “inward occupation of the one-seed front” | defined from nearer neighbors; not an extra occupancy axiom |
+| “variance-minimizing `c = (3, 1, 3, 1, 1, 3, 1, 1)`” | displayed finite probe, not a derived scale |
+| “`G+`-equivariant” | covariance under the axiom's proper cubic rotations |
+| “population variance on 62 nonzero sites” | explicit estimator and domain in Theorem 2 |
+| “strictly below” the ell^1 variance | Theorem 2; displayed, not adopted |
+| “not a leftover” of the minimizer identity or of the wrong map | Theorem 1; the six-type shells are new |
+| “Displayed, not adopted” | Theorem 3; no Admissibility edit |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and proper cubic rotations | `Z^3` nearest-neighbor graph and `G+` | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | Admissibility covariance | one fixed covariant nearest-neighbor rule; no hop cost supplied | yes; cost stays displayed |
+| `scripts/cost3_best_reversal_isochrone_2026_08_15.py:319` | eight pair orbits and the named filling | weights and `c = (3, 1, 3, 1, 1, 3, 1, 1)` | yes |
+| `scripts/cost3_best_reversal_isochrone_2026_08_15.py:329` | `t(3,0,0)` and `t(1,1,1)` | times `9` and `5` | yes |
+| `scripts/cost3_best_reversal_isochrone_2026_08_15.py:334` | `t(v)` on every site-type | the six orbit times of Theorem 1 | yes |
+| `scripts/cost3_best_reversal_isochrone_2026_08_15.py:366` | population variance versus ell^1 | minkbest digits, strictly below | yes |
+| `scripts/cost3_best_reversal_isochrone_2026_08_15.py:388` | adoption of a cost | note and axiom keep the cost out of Admissibility | yes |
+
+No evidence citation is used to claim a path-length axiom, a continuum
+metric, or an Admissibility rewrite.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: each directed `B_3(0)` edge | one inward occupancy pair; no other edge family is classified |
+| per site | yes: `t(v)` and `|v|_2 / t` at each of the 62 nonzero sites | no other occupancy dictionary is used |
+| per mode | yes: six site-types and the one variance-minimizing filling | other fillings and larger balls are untested and unclaimed |
+| per block | yes: the population variance on the 62 nonzero sites | closeness is the stated variance test only |
+| lattice wide | no | no Admissibility cost and no path-length law are adopted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial-closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies a two-end occupancy hop cost, an isochrone, or
+a Euclidean sphere law, and none is reclassified as an import or wall.
+The scale-reference primitive is a units conversion only. The
+kinetic-isotropy primitive supplies `c_t = c_s` as a graining ratio, not a
+spatial isochrone. The realized-state primitive supplies pointwise
+evaluation of a realized state, not a hop cost.
+
+Two partial-closure mechanisms are recorded rather than suppressed. The
+minimizer identity names `c` and the two-point times but does not compute
+the six-type Euclidean-ratio table. The lex-first reversal isochrones are
+a different filling (the wrong map) and mix two site-types into one shell.
+The remaining physical choice—whether any hop cost belongs in
+Admissibility—stays explicit and does not require an axiom edit.
+
+### N7 — hostile steelman
+
+The strongest objection is that naming the variance-minimizing filling and
+the two-point times `t(3,0,0) = 9`, `t(1,1,1) = 5` already is the
+isochrone report, so a six-type table is ornament. The objection correctly
+notes that those two numbers are part of the table. It fails because the
+isochrone residual asks whether every `t = const` shell is a Euclidean
+radius. That is a statement about all six types: the axis types share
+ratio `1/3`, while `(1,1,0)`, `(1,1,1)`, and `(2,1,0)` occupy distinct
+shells at `√2 / 4`, `√3 / 5`, and `√5 / 7`. The two-point identity does
+not exhibit those shells, and the wrong map mixes two of them.
+
+### N8 — cross-cycle echo
+
+The live axiom memo is the only load-bearing parent. Nearby covariance
+language is context.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | proper cubic covariance of the nearest-neighbor rule | used as `G+` equivariance of the displayed cost; the rule itself is not replaced |
+| minimizer identity of `c = (3, 1, 3, 1, 1, 3, 1, 1)` | same filling, two-point times | counted as a strictly smaller residual; Theorem 1 reports the six-type shells |
+| lex-first reversal isochrones | same eight orbits, wrong map | a different filling; mixed shell; not this table |
+
+No earlier mechanism retires the six-type Euclidean-ratio table, the
+variance comparison, or the adoption refusal.
+
+No-Go Discipline disposition: **PASS** for the bounded comparison and the
+adoption boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Runner Contract
+
+The companion runner builds the 24 proper cubic rotations, the 63-site ball,
+and the 228 directed edges; applies the variance-minimizing filling
+`(3, 1, 3, 1, 1, 3, 1, 1)`; computes `t(v)` on every site-type; reports
+`|v|_2 / t` and that the `t = const` shells are the Euclidean-ratio table;
+compares the two population variances; rejects the mutation families,
+including the minimizer-identity leftover and the wrong-map leftover; and
+verifies that the live axiom memo does not host the displayed cost.
+Declared audit inputs are this note and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2729,6 +2729,10 @@
   "cosmology_single_ratio_inverse_reconstruction_theorem_note_2026-04-25": {
    "deps_hash": "14400756f044",
    "out_degree": 4
+  },
+  "cost3_best_reversal_isochrone_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "coulomb_stability_upper_bound_support_note_2026-05-20": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/cost3_best_reversal_isochrone_2026_08_15.txt
+++ b/logs/runner-cache/cost3_best_reversal_isochrone_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/cost3_best_reversal_isochrone_2026_08_15.py
+runner_sha256: 38c29f98d019c4e90f4f56d5e41ec4b87f990be1c5b1bb0e8d950ab1e2d3cf23
+input_fingerprint_sha256: d6aae82bac2df9d49e2525c4e632e78d3f457a940d9a03878a989e07d652eb0c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none; B_3(0), G+, and the variance-minimizing filling are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact integer path costs and |v|_2/t on the radius-3 ball
+negative_scope: displayed variance-minimizing isochrones are not written into Admissibility
+orbit_weights: ((0, 1), (1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (2, 3), (3, 2))
+best_c: (3, 1, 3, 1, 1, 3, 1, 1)
+t_axis: 9
+t_diag: 5
+site_type_times: (1, 0, 0)->3(n=6, |v|_2/t=0.33333333333333), (2, 0, 0)->6(n=6, |v|_2/t=0.33333333333333), (1, 1, 0)->4(n=12, |v|_2/t=0.35355339059327), (3, 0, 0)->9(n=6, |v|_2/t=0.33333333333333), (2, 1, 0)->7(n=24, |v|_2/t=0.31943828249997), (1, 1, 1)->5(n=8, |v|_2/t=0.34641016151378)
+shells: t=3:(1, 0, 0), t=4:(1, 1, 0), t=5:(1, 1, 1), t=6:(2, 0, 0), t=7:(2, 1, 0), t=9:(3, 0, 0)
+shells_are_euclidean_ratio_table: True
+var_best: 0.00017588571746
+var_l1: 0.02073945514155
+PASS: gplus-order proper cubic rotations number 24
+PASS: ball-size B_3(0) has 63 sites
+PASS: nonzero-sites the scored set B_3(0)\{0} has 62 sites
+PASS: directed-edges B_3(0) has 228 directed nearest-neighbor edges
+PASS: thm1-pair-orbits endpoint occupancy pairs form 8 G+ orbits
+PASS: thm1-best-c the variance-minimizing filling is (3,1,3,1,1,3,1,1)
+PASS: thm1-axis-diag-times t(3,0,0)=9 and t(1,1,1)=5 under the variance-minimizing filling
+PASS: thm1-six-type-times each of the six G+ site-types has one arrival time matching the table
+PASS: thm1-note-times the note records the six type times, t(3,0,0)=9, and t(1,1,1)=5
+PASS: thm1-note-ratios the note reports |v|_2/t for each of the six site-types
+PASS: thm1-shells-are-ratio-table each t=const shell is one G+ site-type, hence one Euclidean radius
+PASS: thm2-var-best-computed computed population variance matches the minkbest digits
+PASS: thm2-var-l1-below that variance is strictly below the displayed ell^1 figure
+PASS: thm2-vars-in-note the note reports both variances and that the best variance is smaller
+PASS: thm2-displayed-comparison the note displays the variance comparison and does not adopt a sphere law
+PASS: thm3-displayed-not-adopted the note reports the filling as displayed, not adopted
+PASS: thm3-no-l1-law the note does not attach an ell^1 path-length law
+PASS: claim-scope claim_scope reports the B_3(0) variance-minimizing isochrones only
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: forbidden-strings note, runner, and axiom avoid the dispatch-forbidden phrases
+PASS: no-axiom-cost the live axiom memo does not host a two-end occupancy hop cost
+PASS: not-minkbest-or-minkiso-leftover the note states the isochrone report is not a leftover of the minimizer identity or of the wrong map
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: scored-ball-only the note scores the comparison on B_3(0) only
+per_element: checked exactly — each directed B_3(0) edge carries one inward occupancy pair
+per_site: checked exactly — t(v) and |v|_2/t(v) on each of the 62 nonzero sites
+per_mode: checked exactly — six G+ site-types and the eight pair-orbits of the filling
+per_block: checked exactly — population variance of |v|_2/t on B_3(0)\{0}
+lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cost3_best_reversal_isochrone_2026_08_15.py
+++ b/scripts/cost3_best_reversal_isochrone_2026_08_15.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Isochrones of the variance-minimizing diamond-reversing {1,2,3} cost.
+
+On B_3(0), arrival time is the minimum path cost from the seed under the
+lex-first variance-minimizing filling c = (3, 1, 3, 1, 1, 3, 1, 1). The
+note reports t on every G+ site-type, the |v|_2/t table, and whether the
+t=const shells are that Euclidean-ratio table. Displayed, not adopted.
+No axiom edit, cache write, or path-length law.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from itertools import permutations, product
+from pathlib import Path
+
+
+getcontext().prec = 80
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "COST3_BEST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/COST3_BEST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SHIFT_INDEX = {shift: index for index, shift in enumerate(SHIFTS)}
+ORIGIN: Point = (0, 0, 0)
+AXIS: Point = (3, 0, 0)
+DIAG: Point = (1, 1, 1)
+SITE_TYPES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (2, 0, 0),
+    (1, 1, 0),
+    (3, 0, 0),
+    (2, 1, 0),
+    (1, 1, 1),
+)
+BEST_FILLING = (3, 1, 3, 1, 1, 3, 1, 1)
+EXPECTED_WEIGHTS = (
+    (0, 1),
+    (1, 0),
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (2, 3),
+    (3, 2),
+)
+EXPECTED_TYPE_TIMES = {
+    (1, 0, 0): 3,
+    (2, 0, 0): 6,
+    (1, 1, 0): 4,
+    (3, 0, 0): 9,
+    (2, 1, 0): 7,
+    (1, 1, 1): 5,
+}
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def graph_radius(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclid2(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def site_type(point: Point) -> Point:
+    return tuple(sorted((abs(coord) for coord in point), reverse=True))  # type: ignore[return-value]
+
+
+def ball(radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for coords in product(span, repeat=3):
+        if graph_radius(coords) <= radius:
+            sites.append(coords)
+    return tuple(sites)
+
+
+def occupancy(point: Point) -> int:
+    """6-bit inward occupation of the one-seed front at ``point``."""
+    bits = 0
+    for index, shift in enumerate(SHIFTS):
+        neighbor = (
+            point[0] + shift[0],
+            point[1] + shift[1],
+            point[2] + shift[2],
+        )
+        if graph_radius(neighbor) < graph_radius(point):
+            bits |= 1 << index
+    return bits
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1] + matrix[0][2] * point[2],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1] + matrix[1][2] * point[2],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1] + matrix[2][2] * point[2],
+    )
+
+
+def determinant(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src, dest in enumerate(perm):
+                rows[src][dest] = signs[src]
+            matrix = tuple(tuple(row) for row in rows)
+            if determinant(matrix) == 1:
+                rotations.append(matrix)
+    return tuple(rotations)
+
+
+def bit_permutation(matrix: tuple[tuple[int, ...], ...]) -> tuple[int, ...]:
+    return tuple(SHIFT_INDEX[apply_matrix(matrix, shift)] for shift in SHIFTS)
+
+
+def apply_bits(perm: tuple[int, ...], bits: int) -> int:
+    out = 0
+    for index in range(6):
+        if bits >> index & 1:
+            out |= 1 << perm[index]
+    return out
+
+
+def apply_pair(perm: tuple[int, ...], pair: tuple[int, int]) -> tuple[int, int]:
+    return (apply_bits(perm, pair[0]), apply_bits(perm, pair[1]))
+
+
+def orbit_rep(pair: tuple[int, int], perms: tuple[tuple[int, ...], ...]) -> tuple[int, int]:
+    return min(apply_pair(perm, pair) for perm in perms)
+
+
+def directed_edges(sites: tuple[Point, ...]) -> tuple[tuple[Point, Point], ...]:
+    present = set(sites)
+    edges: list[tuple[Point, Point]] = []
+    for site in sites:
+        for shift in SHIFTS:
+            neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+            if neighbor in present:
+                edges.append((site, neighbor))
+    return tuple(edges)
+
+
+def min_path_costs(
+    start: Point,
+    adj: dict[Point, list[tuple[Point, int]]],
+    costs: tuple[int, ...],
+) -> dict[Point, int]:
+    dist = {start: 0}
+    heap: list[tuple[int, Point]] = [(0, start)]
+    while heap:
+        current, node = heapq.heappop(heap)
+        if current != dist[node]:
+            continue
+        for neighbor, orbit in adj[node]:
+            trial = current + costs[orbit]
+            prior = dist.get(neighbor)
+            if prior is None or trial < prior:
+                dist[neighbor] = trial
+                heapq.heappush(heap, (trial, neighbor))
+    return dist
+
+
+def ratio_list(dist: dict[Point, int], sites: tuple[Point, ...]) -> list[Decimal]:
+    values: list[Decimal] = []
+    for point in sites:
+        if point == ORIGIN:
+            continue
+        values.append(Decimal(euclid2(point)).sqrt() / Decimal(dist[point]))
+    return values
+
+
+def population_variance(values: list[Decimal]) -> Decimal:
+    count = Decimal(len(values))
+    mean = sum(values) / count
+    return sum((item - mean) ** 2 for item in values) / count
+
+
+def rounded(value: Decimal, places: int) -> str:
+    quantize = Decimal(10) ** -places
+    return format(value.quantize(quantize), "f")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; B_3(0), G+, and the variance-minimizing filling are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact integer path costs and |v|_2/t on the radius-3 ball")
+    print("negative_scope: displayed variance-minimizing isochrones are not written into Admissibility")
+
+    rotations = proper_cubic_rotations()
+    perms = tuple(bit_permutation(matrix) for matrix in rotations)
+    sites = ball(3)
+    edges = directed_edges(sites)
+    pairs = tuple((occupancy(src), occupancy(dst)) for src, dst in edges)
+    reps = tuple(sorted({orbit_rep(pair, perms) for pair in pairs}))
+    rep_index = {rep: index for index, rep in enumerate(reps)}
+    weights = tuple(
+        (bin(rep[0]).count("1"), bin(rep[1]).count("1")) for rep in reps
+    )
+    adj: dict[Point, list[tuple[Point, int]]] = defaultdict(list)
+    for src, dst in edges:
+        adj[src].append(
+            (dst, rep_index[orbit_rep((occupancy(src), occupancy(dst)), perms)])
+        )
+
+    times = min_path_costs(ORIGIN, adj, BEST_FILLING)
+    l1_dist = {point: graph_radius(point) for point in sites}
+    type_times: dict[Point, set[int]] = defaultdict(set)
+    type_counts: dict[Point, int] = defaultdict(int)
+    shells: dict[int, set[Point]] = defaultdict(set)
+    for site in sites:
+        kind = site_type(site)
+        type_times[kind].add(times[site])
+        type_counts[kind] += 1
+        if site != ORIGIN:
+            shells[times[site]].add(kind)
+
+    type_time_map = {kind: next(iter(vals)) for kind, vals in type_times.items() if kind != ORIGIN}
+    type_ratios = {
+        kind: Decimal(euclid2(kind)).sqrt() / Decimal(type_time_map[kind])
+        for kind in SITE_TYPES
+    }
+    var_best = population_variance(ratio_list(times, sites))
+    var_l1 = population_variance(ratio_list(l1_dist, sites))
+    shells_are_types = all(len(kinds) == 1 for kinds in shells.values()) and len(shells) == 6
+
+    print(f"orbit_weights: {weights}")
+    print(f"best_c: {BEST_FILLING}")
+    print(f"t_axis: {times[AXIS]}")
+    print(f"t_diag: {times[DIAG]}")
+    print(
+        "site_type_times: "
+        + ", ".join(
+            f"{kind}->{type_time_map[kind]}(n={type_counts[kind]}, |v|_2/t={rounded(type_ratios[kind], 14)})"
+            for kind in SITE_TYPES
+        )
+    )
+    print(
+        "shells: "
+        + ", ".join(
+            f"t={level}:{next(iter(shells[level]))}" for level in sorted(shells)
+        )
+    )
+    print(f"shells_are_euclidean_ratio_table: {shells_are_types}")
+    print(f"var_best: {rounded(var_best, 14)}")
+    print(f"var_l1: {rounded(var_l1, 14)}")
+
+    checks.check("gplus-order", "proper cubic rotations number 24", len(rotations) == 24)
+    checks.check("ball-size", "B_3(0) has 63 sites", len(sites) == 63)
+    checks.check(
+        "nonzero-sites",
+        "the scored set B_3(0)\\{0} has 62 sites",
+        sum(1 for point in sites if point != ORIGIN) == 62,
+    )
+    checks.check(
+        "directed-edges",
+        "B_3(0) has 228 directed nearest-neighbor edges",
+        len(edges) == 228,
+    )
+    checks.check(
+        "thm1-pair-orbits",
+        "endpoint occupancy pairs form 8 G+ orbits",
+        len(reps) == 8 and weights == EXPECTED_WEIGHTS,
+    )
+    checks.check(
+        "thm1-best-c",
+        "the variance-minimizing filling is (3,1,3,1,1,3,1,1)",
+        BEST_FILLING == (3, 1, 3, 1, 1, 3, 1, 1),
+    )
+    checks.check(
+        "thm1-axis-diag-times",
+        "t(3,0,0)=9 and t(1,1,1)=5 under the variance-minimizing filling",
+        times[AXIS] == 9 and times[DIAG] == 5,
+    )
+    checks.check(
+        "thm1-six-type-times",
+        "each of the six G+ site-types has one arrival time matching the table",
+        all(len(type_times[kind]) == 1 for kind in SITE_TYPES)
+        and type_time_map == EXPECTED_TYPE_TIMES
+        and sum(type_counts[kind] for kind in SITE_TYPES) == 62,
+    )
+    checks.check(
+        "thm1-note-times",
+        "the note records the six type times, t(3,0,0)=9, and t(1,1,1)=5",
+        "t(3,0,0) = 9" in note
+        and "t(1,1,1) = 5" in note
+        and "t(1,0,0) = 3" in note
+        and "t(2,0,0) = 6" in note
+        and "t(1,1,0) = 4" in note
+        and "t(2,1,0) = 7" in note,
+    )
+    checks.check(
+        "thm1-note-ratios",
+        "the note reports |v|_2/t for each of the six site-types",
+        "1/3" in note
+        and "√2 / 4" in note
+        and "√3 / 5" in note
+        and "√5 / 7" in note,
+    )
+    checks.check(
+        "thm1-shells-are-ratio-table",
+        "each t=const shell is one G+ site-type, hence one Euclidean radius",
+        shells_are_types
+        and "Euclidean-ratio table" in note
+        and "single `G+` site-type" in note,
+    )
+    checks.check(
+        "thm2-var-best-computed",
+        "computed population variance matches the minkbest digits",
+        rounded(var_best, 14) == "0.00017588571746",
+    )
+    checks.check(
+        "thm2-var-l1-below",
+        "that variance is strictly below the displayed ell^1 figure",
+        rounded(var_l1, 14) == "0.02073945514155" and var_best < var_l1,
+    )
+    checks.check(
+        "thm2-vars-in-note",
+        "the note reports both variances and that the best variance is smaller",
+        "0.00017588571746" in note
+        and "0.02073945514155" in note
+        and "strictly below" in note,
+    )
+    checks.check(
+        "thm2-displayed-comparison",
+        "the note displays the variance comparison and does not adopt a sphere law",
+        "Displayed, not adopted" in note and "not a leftover" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the note reports the filling as displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    checks.check(
+        "thm3-no-l1-law",
+        "the note does not attach an ell^1 path-length law",
+        "no path-length law" in note.lower() and "not attach" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the B_3(0) variance-minimizing isochrones only",
+        "On B_3(0), the isochrones" in note
+        and "variance-minimizing diamond-reversing" in note
+        and "{1,2,3}" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/COST3_BEST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in source
+        and '"docs/COST3_BEST_REVERSAL_ISOCHRONE_BOUNDED_THEOREM_NOTE_2026-08-15.md"'
+        in source,
+    )
+    checks.check(
+        "forbidden-strings",
+        "note, runner, and axiom avoid the dispatch-forbidden phrases",
+        all(token not in note and token not in source for token in forbidden_tokens()),
+    )
+    checks.check(
+        "no-axiom-cost",
+        "the live axiom memo does not host a two-end occupancy hop cost",
+        "two-end occupancy" not in axiom and "c(σ_v, σ_w)" not in axiom,
+    )
+    checks.check(
+        "not-minkbest-or-minkiso-leftover",
+        "the note states the isochrone report is not a leftover of the minimizer identity or of the wrong map",
+        "not a leftover" in note
+        and "minimizer identity" in note
+        and "wrong map" in note
+        and "isochrone" in note.lower(),
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+    checks.check(
+        "scored-ball-only",
+        "the note scores the comparison on B_3(0) only",
+        "on `B_3(0)` only" in note or "on B_3(0) only" in note,
+    )
+
+    print(
+        "per_element: checked exactly — each directed B_3(0) edge carries one inward occupancy pair"
+    )
+    print(
+        "per_site: checked exactly — t(v) and |v|_2/t(v) on each of the 62 nonzero sites"
+    )
+    print(
+        "per_mode: checked exactly — six G+ site-types and the eight pair-orbits of the filling"
+    )
+    print(
+        "per_block: checked exactly — population variance of |v|_2/t on B_3(0)\\{0}"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B3, c=(3,1,3,1,1,3,1,1) has six t=const shells, each one G+ type. Axis types have |v|_2/t=1/3. var=0.000176 vs l1 0.0207. Displayed, not adopted. No axiom edit.

## Runner

`scripts/cost3_best_reversal_isochrone_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.