### PR TITLE
physics: break the population wall with the momentum charge

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block123-momentum-population-definiteness-20260816/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block123-momentum-population-definiteness-20260816/NO_GO_LEDGER.md
@@ -1,0 +1,35 @@
+# Block 123 No-Go Ledger
+
+Scope: one dual-character wall inside a split packet whose momentum
+half is the campaign's first population break. `W1` (the negative
+half) says no identity-valued charge can populate the closed-carrier
+Gauss quotient on a positive package — the exact reframe of Block
+121's wall as a DEFINITENESS statement: the total of a definite charge
+operator is a norm-like form that never vanishes on a nonzero state.
+The positive half: the quotient momentum charge diag(0,1,2,-1) (units
+pi/2, from the sector phases i^k) is INDEFINITE, and the displayed
+nonzero certified-positive state occupying the paired momenta has
+vanishing EXPECTED total momentum under either sign convention (k=2
+unoccupied; 1+(-1)=0 and 1+3=0 mod 4) — the momentum-constraint source
+admits closed-carrier Gauss solutions. Caveat shipped prominently: the
+zero is an expectation value; the charge does not annihilate the state
+(P_x(e1+e3) = e1-e3); the operator-level constraint question is open
+and named. The shift current's identity inherits Block 121's
+routing-independent structure with per-sector reduction to i^k times
+the U(1) commutator, so the local-observable wall transfers verbatim
+(momentum-blind). Energy: no per-slice symmetry (Floquet); the
+per-period conservation statement is vacuous beyond Block 119's
+certified contractivity and ships only as labeled scope. Narrow scope:
+the displayed package, fixtures, charges, and quotient form.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the constraint quotient is executed | `ATTEMPTED` | false: populatability is proven; the sourced quotient execution is the named next block | momentum-sourced quotient |
+| the state is annihilated by the charge | `ATTEMPTED` | false: expectation zero only; P_x(e1+e3) = e1-e3 != 0 | operator-level question |
+| the observable wall is broken | `ATTEMPTED` | false: the i^k phase is invertible; every Block 122 failure transfers | non-local dressings |
+| per-slice energy exists | `ATTEMPTED` | false: no slice time-translation symmetry (Floquet) | none needed |
+| the per-period energy statement is new content | `ATTEMPTED` | vacuous beyond Block 119's contractivity, labeled | none needed |
+| the k=2 sign convention changes the verdict | `ATTEMPTED` | false: k=2 unoccupied; zero under both conventions | none needed |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; the dual-character `W1` ships with its positive half explicitly labeled.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md
@@ -1,0 +1,901 @@
+---
+claim_id: admissibility_dirac_kahler_momentum_population_definiteness_bounded_theorem_note_2026-08-16
+claim_type: bounded_theorem
+claim_scope: "on the certified package at both rational shear fixtures, the spatial shift commutes with the action exactly and its routed current obeys the off-shell divergence-commutator identity with per-sector reduction to the invertible phase i^k times the U(1) commutator; the closed-carrier population question splits exactly on charge definiteness — the U(1) total charge operator is the identity, so its expectation is the norm and never vanishes on a nonzero positive state, while the quotient momentum charge diag(0,1,2,-1) is indefinite and the displayed nonzero certified-positive state occupying the paired momenta has vanishing expected total momentum under either sign convention (though the charge does not annihilate it — the zero is an expectation value), so the momentum-constraint source admits closed-carrier Gauss solutions; the local-observable wall transfers verbatim under the invertible sector phase; no per-slice time-translation symmetry exists and the per-period energy statement is vacuous beyond the already-certified contractivity; and the momentum-sourced quotient execution, non-local dressings, the naturality classification, curved OS positivity, the completed ADM/history transporter, joint gravity, the gravity constraint quotient, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_quotient_observable_obstruction_bounded_theorem_note_2026-08-16
+runner: scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_quotient_observable_obstruction_bounded_theorem_note_2026-08-16
+target_blocker_text: "Pose the stress-tensor source and non-local current dressings on the open/background carrier; then the naturality classification and curved OS positivity."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Execute the momentum-sourced Gauss quotient on the closed carrier with the vanishing-expectation state class; then non-local dressings, the naturality classification, and curved OS positivity."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-122 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact shift-action commutation, exact routed-current divergence identity and sector-phase reduction, exact identity-versus-indefinite charge split, exact positive-state zero-momentum expectation under both sign conventions, exact closed-carrier Gauss-image compatibility, exact transfer of the local-observable obstruction, and explicit Floquet-energy vacuity on the certified package at both rational shear fixtures; dependencies are content-bound unaudited, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Momentum Population Break And The Charge-Definiteness Split
+
+**Date:** 2026-08-16
+
+**Campaign block:** 123
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py`](../scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py)
+
+## 1. Result Up Front
+
+[Block 122](ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+closed onto the following handoff next gate, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md:16`
+and elaborated in its Next Decision:
+
+> Pose the stress-tensor source and non-local current dressings on the
+> open/background carrier; then the naturality classification and curved OS
+> positivity.
+
+**THE DEFINITENESS THEOREM.** On the certified package at each rational
+shear fixture $c=5/13$ and $c=3/5$, the closed-carrier population question
+splits exactly by the definiteness of the total charge. The quotient U(1)
+charge and dimensionless quotient momentum charge are
+
+\[
+ \mathcal Q_{\mathrm{U(1)}}^{\rm phys}
+   =\left.\sum_zE_z\right|_{\rm phys}=I_4,
+ \qquad
+ \widetilde P_x^{\rm phys}
+   =\operatorname{diag}(0,1,2,-1),                 \tag{1}
+\]
+
+where $P_x^{\rm phys}=(\pi/2)\widetilde P_x^{\rm phys}$ in the signed
+principal convention. Thus every nonzero positive quotient state $v$
+obeys
+
+\[
+ \langle v,\mathcal Q_{\mathrm{U(1)}}^{\rm phys}v\rangle
+ =\lVert v\rVert^2>0.                              \tag{2}
+\]
+
+That identity-valued charge cannot satisfy the zero-total-source condition
+for a periodic Gauss equation. The momentum charge in (1), however, is
+indefinite. For the nonzero certified-positive state
+
+\[
+ v_\star=e_1+e_3=(0,1,0,1)^{\mathsf T},            \tag{3}
+\]
+
+the $+\pi/2$ convention gives
+
+\[
+ \widetilde P_x^{\rm phys}(e_1+e_3)=e_1-e_3,
+ \qquad
+ \langle v_\star,\widetilde P_x^{\rm phys}v_\star\rangle
+ =1-1=0.                                           \tag{4}
+\]
+
+The equivalent mod-$4$ convention labels the $k=3$ charge by $3$ instead of
+$-1$, and gives $1+3=0\pmod4$. Thus the expected total momentum vanishes in
+both the signed-integer and mod-$4$ conventions. Equation (4) states an
+**EXPECTATION-VALUE ZERO**, not an operator kernel: the charge does not
+annihilate $v_\star$. This caveat and the population break are one result.
+The corresponding momentum source has zero total in its coefficient group
+and therefore lies in the image of the closed-carrier incidence operator.
+Closed-carrier Gauss solutions are admitted at the source-compatibility
+level; the sourced OS quotient itself is not executed here.
+
+This reframes
+[Block 121](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md).
+Its U(1) population wall was never a failure of microscopic conservation.
+It was a definiteness wall: an identity-valued total charge cannot cancel
+inside a nonzero positive state. Momentum supplies the positive break
+because its quotient charge has both signs.
+
+The spatial shift also commutes with the action exactly. Its routed current
+obeys
+
+\[
+ \Delta_t^-T_{tx,z}+\Delta_x^-T_{xx,z}
+ =\bar\phi[E_z,R_x]\psi,
+ \qquad R_x=U_xQ=QU_x,                             \tag{5}
+\]
+
+and momentum sector $k$ reduces (5) to the invertible factor $i^k$ times
+the U(1) commutator identity. That same invertible factor transfers Block
+122's local-observable wall verbatim: every site residual remains nonzero,
+and null descent and reflection-adjointness still fail. The momentum
+population break does not break the observable wall.
+
+There is no per-slice time-translation symmetry on the periodically driven
+microscopic package. The only cell object is the Floquet generator
+$h_k=-\log(\rho_k^2)$ with
+$B_{\rm phys}=\operatorname{diag}(\rho_k^2)=e^{-h}$. Its descent is by
+construction and adds no theorem beyond the certified contractivity of
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md).
+The per-period energy statement is therefore **VACUOUS**, and no per-slice
+energy conservation is claimed.
+
+This theorem is deliberately narrow. The momentum-sourced quotient
+execution, non-local dressings, naturality, curved OS positivity, the
+completed ADM/history transporter, joint gravity, the gravity constraint
+quotient, Records, audit retention, axiom amendment, obligation retirement,
+and TOE percentage movement remain outside it.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) at
+`origin/main 4e566b14a6352a9a62590252a9755c7a103c1b9e`, with axiom blob
+`bc23300becfe4e4db57153c0e94cfcdf2338da71` and registry blob
+`b93959cca4f7e26c673cdccbe601e50c3cb93daa`. The authority snapshot is
+unchanged from Block 122.
+
+The exact stacked parent is
+[Block 122](ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+commit `f067b99be7eb49fc46ea8dffccab5e20e6052d88`, content-bound through
+note blob `ef9f1b2037c8b470c821ed27572a81c6cb9ac9a4`. Its relevant inherited
+microscopic current comes from
+[Block 121](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md),
+and its positive half-space quotient and contractive transfer come from
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md).
+No audit verdict is imported from any note.
+
+The executed contract is:
+
+1. the certified package at both rational shear fixtures $c=5/13$ and
+   $c=3/5$, with quotient momenta $k=0,1,2,3$;
+2. exact commutation of the spatial shift $U_x$ with the action $Q$ and the
+   routed off-shell divergence-commutator identity for $R_x=U_xQ$;
+3. sector reduction of the shift current to $i^k$ times the U(1) current,
+   including the inherited matrix-generic routing identity;
+4. the exact quotient operators $I_4$ and
+   $\operatorname{diag}(0,1,2,-1)$ in units $\pi/2$;
+5. the displayed nonzero certified-positive paired-momentum state, the
+   signed-integer and mod-$4$ momentum conventions, and the distinction
+   between zero expectation and charge annihilation;
+6. the zero-sum image of the closed-carrier incidence operator and the
+   compatibility of the displayed momentum source row;
+7. transfer of Block 122's local-observable residual, null-descent, and
+   reflection-adjointness failures under the invertible sector phase;
+8. absence of a microslice time-translation symmetry and classification of
+   the Floquet-generator statement as vacuous beyond inherited
+   contractivity; and
+9. one narrow population-definiteness wall with one positive momentum break,
+   leaving the sourced quotient execution, non-local dressings, naturality,
+   curved OS positivity, and gravity open.
+
+The supplied scientific scratch computation was replayed and ends with
+`TOTAL: PASS=1595 FAIL=0`. The scratch handoff records an approximately
+`324` second final run. The completed primary runner was then replayed and
+ends with `TOTAL: PASS=8 FAIL=0`. Runtime is not theorem content.
+
+The primary replay's decision footer is reproduced exactly:
+
+```text
+RESULT: the momentum constraint is populatable on the closed carrier because its charge is indefinite — the first population break of the campaign — while the local-observable wall transfers verbatim under the invertible sector phase and the only energy object is the already-certified per-period contraction
+DECISION_CUT: execute the momentum-sourced gauss quotient with the vanishing-expectation state class; reject per-slice energy constructions
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+```
+
+The scope is the displayed package, both fixtures, the four quotient
+momenta, the identity-valued U(1) charge, the displayed momentum operator and
+paired state, and the closed-carrier incidence equation. A source-compatible
+row is exhibited, but no momentum-sourced OS quotient is formed. No non-local
+dressing, naturality classification, curved reconstruction, or gravity
+constraint quotient follows.
+
+## 3. The Shift Symmetry And Its Current
+
+Let $U_x$ be the one-step spatial shift on the displayed lift, with
+$U_x|t,x\rangle=|t,x+1\rangle$. The exact action commutator vanishes at both
+fixtures:
+
+\[
+ [U_x,Q]=0,
+ \qquad
+ R_x:=U_xQ=QU_x.                                  \tag{6}
+\]
+
+The matrix $R_x$ is the insertion generated by the spatial shift. Localize
+that transformation with the fine-site projector $E_z$ and route every
+matrix element between its endpoints. The resulting temporal momentum
+density $T_{tx,z}$ and spatial momentum flux $T_{xx,z}$ obey
+
+\[
+ \Delta_t^-T_{tx,z}+\Delta_x^-T_{xx,z}
+ =\bar\phi[E_z,R_x]\psi.                          \tag{7}
+\]
+
+Equation (7) is an off-shell divergence-commutator identity. It is exact,
+not a fitted small residual and not a quotient-only equality. The on-shell
+continuity consequence has the same status as Block 121's U(1) consequence;
+the present population question does not weaken it.
+
+The exact finite certificates are:
+
+| fixture | sector residual ranks | $T_{tx}$ nnz | $T_{xx}$ nnz | hash |
+|---|---|---:|---:|---|
+| $5/13$ | $(2,2,2,2)$ | 176 | 240 | `888b798cf7b74ede0c7a` |
+| $3/5$ | $(2,2,2,2)$ | 176 | 240 | `77f7227e6baa15e2ca45` |
+
+All 32 sites, including the antiperiodic seam, enter each fixture row.
+Both inherited local routing orders were recomputed; each telescopes to the
+same endpoint commutator at every site.
+
+The routing proof is inherited without a charge-specific shortcut. For a
+matrix $M$, a routed hop from $u$ to $v$ contributes signed crossings along
+its path. Taking the discrete divergence telescopes those crossings to the
+endpoint difference,
+
+\[
+ \operatorname{div}j_M(z)
+ =\bar\phi(E_zM-ME_z)\psi.                         \tag{8}
+\]
+
+Block 121 applied (8) to $M=Q$. The argument is matrix-generic, so applying
+it to $M=R_x$ proves (7). Two allowed local routings differ by a discrete
+curl and therefore have the same divergence. No new routing assumption is
+introduced by the momentum insertion.
+
+This is the contentful symmetry statement: the spatial shift commutes with
+the action, and its resolved current has the exact local identity (7).
+Population is a separate question about the total charge and the image of a
+closed incidence operator.
+
+## 4. The Sector Phase Reduction
+
+Use the momentum embeddings $F_k$ in the order $k=0,1,2,3$. The spatial
+shift and its quotient representative are
+
+\[
+ F_k^\dagger U_xF_k=i^kI,
+ \qquad
+ U_x^{\rm phys}=\operatorname{diag}(1,i,-1,-i).    \tag{9}
+\]
+
+All structures entering the sector calculation are momentum diagonal.
+Together with (6), this gives
+
+\[
+ F_k^\dagger R_xF_k=i^kQ_k,
+ \qquad
+ \widehat{[E_z,R_x]}_k
+   =i^k\widehat{[E_z,Q]}_k.                       \tag{10}
+\]
+
+The same reduction holds componentwise for the routed current kernels:
+
+\[
+ \widehat T_{tx,k}=i^k\widehat J_k,
+ \qquad
+ \widehat T_{xx,k}=i^k\widehat S_k.               \tag{11}
+\]
+
+Here $J$ and $S$ are the U(1) routed components of Blocks 121--122 in the
+same cut and route convention. Thus the momentum Ward residual in every
+sector is
+
+\[
+ \mathcal W^{(x)}_{k,z}
+ =i^k\mathcal W^{(\mathrm{U(1)})}_{k,z}.           \tag{12}
+\]
+
+Each phase $i^k$ is invertible. It can rotate or reverse a value, but it
+cannot create a zero, restore null descent, or repair an adjointness defect.
+This exact phase mechanism is why the population answer may change while
+the local-observable answer does not.
+
+## 5. The Definiteness Split
+
+Microscopic site completeness gives $\sum_zE_z=I_{32}$ exactly; compression
+to the normalized four-line positive quotient gives $I_4$.
+
+The exact U(1) operator and the two equivalent momentum-charge assignments
+on the four-sector physical quotient are
+
+\[
+ \mathcal Q_{\mathrm{U(1)}}^{\rm phys}
+   =\left.\sum_zE_z\right|_{\rm phys}=I_4,
+ \qquad
+ \widetilde P_x^{\mathbb Z}
+   =\operatorname{diag}(0,1,2,-1),
+ \qquad
+ \widetilde P_x^{\mathbb Z_4}
+   =\operatorname{diag}(0,1,2,3)\pmod4.            \tag{13}
+\]
+
+The Hermitian principal operator $\widetilde P_x^{\mathbb Z}$ is in units
+$\pi/2$ and is the signed-integer convention. The mod-$4$ assignment records
+the same phases as residues in $\mathbb Z_4$; it is not a second physical
+operator. Both exponentiate to the exact shift:
+
+\[
+ \exp\!\left(\frac{i\pi}{2}\widetilde P_x^{\mathbb Z}\right)
+ =\exp\!\left(\frac{i\pi}{2}\widetilde P_x^{\mathbb Z_4}\right)
+ =\operatorname{diag}(1,i,-1,-i)=U_x^{\rm phys}.   \tag{14}
+\]
+
+The U(1) operator is positive definite. For every nonzero positive quotient
+state $v$,
+
+\[
+ \langle\mathcal Q_{\mathrm{U(1)}}\rangle_v
+ :=\langle v,I_4v\rangle=\lVert v\rVert^2>0.       \tag{15}
+\]
+
+The momentum operator is indefinite: its displayed spectrum contains the
+positive values $1,2$, the negative value $-1$, and zero. The paired-momentum
+state $v_\star=e_1+e_3$ is nonzero and certified-positive. Put
+$P_x:=\widetilde P_x^{\mathbb Z}$. Directly,
+
+\[
+ \begin{aligned}
+ P_x(e_1+e_3)&=e_1-e_3\ne0,\\
+ \langle v_\star,P_xv_\star\rangle
+   &=1-1=0,\\
+ \widetilde P_x^{\mathbb Z_4}(e_1+e_3)&=e_1+3e_3\ne0,\\
+ \langle v_\star,\widetilde P_x^{\mathbb Z_4}v_\star\rangle
+   &=1+3=0\pmod4.
+ \end{aligned}                                    \tag{16}
+\]
+
+The same displayed state also obeys
+$\langle v_\star,U_x^{\rm phys}v_\star\rangle=i-i=0$. This unitary
+expectation is a consistency certificate for the paired sectors; the
+Hermitian momentum expectation in (16) is the Gauss-source quantity.
+
+Moreover, $e_1-e_3$ is not proportional to $e_1+e_3$. Thus $v_\star$ is
+not an eigenstate of $P_x$, and in particular it is not annihilated by that
+charge.
+
+This is the exact split. Equation (15) forbids cancellation for an
+identity-valued charge on a nonzero positive state. Equation (16) permits
+cancellation for the indefinite signed charge, equivalently for its mod-$4$
+assignment. Neither line says that the state is in the kernel of the
+momentum charge. Indeed, the first and third lines of (16) display the
+opposite. The zero is only the expected total momentum.
+
+## 6. The Gauss Population
+
+Let $D_{\rm cl}$ be the oriented incidence operator on the closed
+$\mathbb Z_4$ carrier. As in Block 121, its image is exactly the zero-sum
+subspace in either coefficient convention:
+
+\[
+ \begin{aligned}
+ \operatorname{im}D_{\rm cl}^{\mathbb Z}
+   &=\{s:\mathbf1^{\mathsf T}s=0\},\\
+ \operatorname{im}D_{\rm cl}^{\mathbb Z_4}
+   &=\{s:\mathbf1^{\mathsf T}s=0\pmod4\}.
+ \end{aligned}                                    \tag{17}
+\]
+
+For the state $v_\star$, the sector-population row and the two momentum
+source rows are
+
+\[
+ n_\star=(0,1,0,1)^{\mathsf T},
+ \qquad
+ p_\star^{\mathbb Z}=(0,1,0,-1)^{\mathsf T},
+ \qquad
+ p_\star^{\mathbb Z_4}=(0,1,0,3)^{\mathsf T}.     \tag{18}
+\]
+
+Consequently,
+
+\[
+ \mathbf1^{\mathsf T}n_\star=2,
+ \qquad
+ \mathbf1^{\mathsf T}p_\star^{\mathbb Z}=0,
+ \qquad
+ \mathbf1^{\mathsf T}p_\star^{\mathbb Z_4}=4=0\pmod4. \tag{19}
+\]
+
+In the runner's oriented signed-lift convention, one exact incidence-level
+solution is
+
+\[
+ g_\star=(0,1,1,0)^{\mathsf T},
+ \qquad
+ D_{\rm cl}^{\mathbb Z}g_\star=p_\star^{\mathbb Z}. \tag{20}
+\]
+
+The first row is the U(1)-definiteness wall in concrete form: no closed
+Gauss field can have $n_\star$ as its divergence. More generally, (15)
+excludes every nonzero positive state, not only $v_\star$.
+
+The second and third rows are the **POSITIVE MOMENTUM POPULATION BREAK**.
+Each belongs to the corresponding image in (17), so the c-number momentum
+source admits closed-carrier Gauss solutions in either convention. Changing
+from the signed lift to the mod-$4$ labels changes notation, not
+solvability.
+
+This is source compatibility, not the execution of the constraint quotient.
+No Gauss field is coupled back to the OS transfer package, no constrained
+state space is formed, and no gravity dynamics is propagated. The
+operator-level constraint question also remains open because expectation
+zero is weaker than charge annihilation.
+
+## 7. The Pin Transfer
+
+Block 122 pinned its local quotient-observable failure to the compressed
+site commutator $\widehat{[E_z,Q]}_k$. Equation (10) gives the momentum pin
+
+\[
+ P_k^{\rm OS}\widehat{[E_z,R_x]}_kP_k^{\rm OS}
+ =i^k
+  P_k^{\rm OS}\widehat{[E_z,Q]}_kP_k^{\rm OS}.    \tag{21}
+\]
+
+Since $i^k\ne0$, every contentful Block 122 failure transfers verbatim to
+the shift current on this package:
+
+1. the site-resolved Ward residual is nonzero at all 32 sites in every
+   momentum sector at both fixtures;
+2. both routed current components fail left and right OS-null-space descent,
+   with exact score `0/32` in every sector;
+3. both components fail reflection-adjointness, again with exact score
+   `0/32` in every sector; and
+4. alternate local routings differ by a discrete curl and cannot alter the
+   pinned divergence.
+
+Multiplication by an invertible scalar preserves nonzero witnesses and
+preserves failure to map the null space into itself. The reflected-sector
+calculation likewise includes the conjugate phase and leaves every
+adjointness failure nonzero. These are exact certificates at both fixtures,
+not genericity arguments.
+
+The exact residual and operator-witness summaries are:
+
+| fixture | residual hashes for $k=0,1,2,3$ | $T_{tx}$ witness | $T_{xx}$ witness |
+|---|---|---|---|
+| $5/13$ | `015c0ca77d7f24d6`, `2c00d2a740052e4d`, `10ae89306f94b5d6`, `00ba62c446192264` | `790c9f7324da9627` | `57c6cbcb2abeb6ba` |
+| $3/5$ | `5ee669c4c61180cb`, `1e5a9006bd3a7c5f`, `b2a4bf5f2ad74469`, `97861afaa6819fa7` | `2ffde5a0ec067e6c` | `eb9b0a256b5640df` |
+
+For each residual-hash row, the exact zero count is `(0,0,0,0)` out of 32
+in momentum order. For each component and sector, both left/right null
+descent counts are zero; the best reflection-adjoint zero count is also zero.
+
+The local-observable wall is therefore momentum-blind in precisely this
+sense: replacing the U(1) insertion by the commuting shift insertion changes
+each sector only by $i^k$. The population wall is not momentum-blind because
+population tests the definiteness of the total charge, and (13) changes that
+spectrum. The momentum break opens a source class; it does not produce a
+local conserved quotient observable. Non-local dressings remain the named
+repair route.
+
+## 8. The Energy Scope
+
+There is no one-microslice time shift commuting with the displayed action.
+If $V$ denotes the antiperiodic microslice shift, the exact tests give
+
+\[
+ [Q,V]\ne0,
+ \qquad
+ [Q,V^4]\ne0.                                    \tag{22}
+\]
+
+Both fixtures have `208` nonzero entries in $[Q,V]$ and `112` in
+$[Q,V^4]$. Thus neither a one-slice shift nor its four-step power supplies a
+Noether current $T_{tt}$ or a per-slice energy conservation law on this
+package. The one-step failure-witness hashes in fixture order are
+`fb3bc40eec4d5671` and `121a3eb8abec6bc7`.
+
+The certified physical cell transfer is diagonal,
+
+\[
+ B_{\rm phys}=\operatorname{diag}(\rho_0^2,\rho_1^2,
+                                   \rho_2^2,\rho_3^2),
+ \qquad 0<\rho_k^2<1.                              \tag{23}
+\]
+
+One may define its exact Floquet generator by functional calculus,
+
+\[
+ h=\operatorname{diag}(h_0,h_1,h_2,h_3),
+ \qquad h_k=-\log(\rho_k^2),
+ \qquad B_{\rm phys}=e^{-h},
+ \qquad [h,B_{\rm phys}]=0.                       \tag{24}
+\]
+
+The exact cell forms are $T_{tt}^{\rm cell}(a)=a^\dagger ha$. The fixture
+certificate hashes are `1e21e90244c98ad2` at $c=5/13$ and
+`fd299e49340a0ee3` at $c=3/5$.
+
+The object $h$ descends because it is defined directly from the already
+descended diagonal transfer. Its commutation with $B_{\rm phys}$ is automatic
+functional calculus. It does not reconstruct a missing microslice symmetry
+and does not add an independent conserved-energy theorem.
+
+Sector by sector, the certified quotient is one-dimensional and its cell
+transfer is the scalar $\beta_k=\rho_k^2$. A scalar spectral label $h_k$
+could not fail to descend or commute with that transfer. The only contentful
+inequality is
+
+\[
+ 0<\beta_k<1
+ \quad\Longrightarrow\quad
+ h_k=-\log\beta_k>0,                               \tag{25}
+\]
+
+which is precisely the inherited contractivity certificate.
+The imported pinned-interval hashes in fixture order are
+`e7d0e5c7a9778c6e` and `bf06c92a87275672`.
+
+Accordingly, the per-period energy statement is labeled **VACUOUS**. The
+contentful residue is exactly the contractivity certified in
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+and displayed in (23). No checker credit is assigned twice: contractivity
+remains contentful, whereas defining $h=-\log B_{\rm phys}$ and observing
+$[h,B_{\rm phys}]=0$ is bookkeeping on that result.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded population-definiteness wall, and its honest
+statement includes a positive break.
+
+- W1 — **U(1)-DEFINITENESS WALL / MOMENTUM POPULATION BREAK:** an
+  identity-valued U(1) total charge has strictly positive expectation on
+  every nonzero positive quotient state and therefore cannot populate the
+  zero-sum image of the closed-carrier incidence operator. The quotient
+  momentum charge is indefinite, and the displayed paired-momentum state has
+  zero expected total momentum under either sign convention. Its c-number
+  source row is in that image and admits closed-carrier Gauss solutions.
+
+The U(1)-definiteness half is the wall. The momentum half is **POSITIVE**
+bounded-theorem content, not a second wall. W1 covers only the displayed
+certified package, the fixtures $c=5/13$ and $c=3/5$, the exact charge
+operators in (13), the state $v_\star$, and the closed incidence form (17).
+It does not classify every positive state with zero expected momentum, form
+the sourced quotient, impose an operator-level constraint, construct a
+non-local observable, or couple gravity.
+
+W1 is not a conservation obstruction. The shift-action commutator vanishes
+and the off-shell identity (7) is exact. Nor is the momentum population break
+an observable-descent theorem. By (21), Block 122's local-observable wall
+survives the change of charge.
+
+W1 is not an OS no-go and is not a curved OS no-go. It distinguishes one
+definite charge from one indefinite charge on one certified finite quotient.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). Charge population,
+microscopic continuity, quotient-observable descent, and energy scope remain
+separate.
+
+1. **PROVED — strongest definiteness theorem — closed-carrier charge
+   population / identity-valued charge versus indefinite momentum charge /
+   U(1) is blocked while the displayed momentum expectation populates the
+   zero-sum Gauss image.** The distinction is exact at both fixtures.
+2. **PROVED — shift symmetry and current / exact $[U_x,Q]=0$, the
+   matrix-generic routing telescope, and momentum-diagonal reduction /
+   off-shell divergence identity with sector factor $i^k$.** Every phase is
+   invertible.
+3. **PROVED — positive population break with caveat / paired $k=1,3$
+   occupations and opposite signed momenta / $1+(-1)=0$ in the integer
+   convention and $1+3=0\pmod4$ in the mod-$4$ convention, but no charge
+   annihilation.** This is the c-number source condition required by (17).
+4. **PROVED — local-observable pin transfer / multiply the compressed
+   $[E_z,Q]$ witnesses by $i^k$ / every Block 122 residual, null-descent,
+   reflection-adjointness, and routing-curl failure survives.** Population
+   and observable descent have different answers.
+5. **PROVED — checker-discipline exposure / distinguish microslice symmetry
+   from Floquet functional calculus / the per-period energy statement is
+   labeled vacuous beyond Block 119's certified contractivity.** This earns
+   discipline credit, not a new conservation theorem.
+6. **UNTESTED-LIVE — momentum-sourced quotient and observable repair /
+   execute the closed-carrier Gauss quotient with the vanishing-expectation
+   class and construct non-local dressings / test the actual constraint and
+   dressed observable.** Naturality and curved OS positivity remain
+   downstream.
+
+The completed ADM/history transporter and joint gravity remain downstream of
+row 6. W1 consumes none of those routes.
+
+### N2 — Wall-Independence Audit
+
+W1 is distinct from Block 122's wall, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md:587-618`.
+
+Block 122 studied **observable descent**. Its object was the local routed U(1)
+density/current family; its mechanism was the nonzero quotient compression
+of $[E_z,Q]$, failure to preserve the OS null space, and failure of
+reflection-adjointness. That obstruction is already present before a closed
+Gauss population equation is imposed.
+
+The present W1 studies **source population**. Its object is the total charge
+entering the closed-carrier incidence equation; its mechanism is definiteness.
+An identity-valued charge has norm-valued expectation and cannot have zero
+total on a nonzero positive state. An indefinite momentum charge can, as
+(16)--(19) show. This proof does not use null descent or
+reflection-adjointness.
+
+There is an honest shared pin. The shift-current residual is exactly $i^k$
+times Block 122's inherited $[E_z,Q]$ residual. That pin transfers the
+observable wall to the momentum current. It does no work in the population
+break, which follows from the spectra in (13) and the incidence image in
+(17).
+
+Conversely, a zero-total source need not define a quotient observable, and a
+descending observable need not satisfy a closed-carrier zero mode. The
+present calculation exhibits the first separation directly: momentum
+populates the c-number Gauss image while its displayed local routed current
+still fails observable descent. Neither wall implies the other.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified explicitly.
+Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| certified package | the inherited finite quotient package only |
+| both rational shear fixtures | exactly $c=5/13$ and $c=3/5$ |
+| spatial shift commutes with the action exactly | equation (6) on that package |
+| routed current | the displayed $T_{tx}$ and $T_{xx}$ kernels only |
+| off-shell divergence-commutator identity | equation (7), before equations of motion |
+| per-sector reduction | equations (10)--(12) for $k=0,1,2,3$ |
+| invertible phase i^k | a nonzero scalar in every sector |
+| u(1) commutator | the inherited $[E_z,Q]$ pin only |
+| closed-carrier population question | image test (17), not quotient execution |
+| charge definiteness | the mechanism distinguishing (15) and (16) |
+| u(1) total charge operator is the identity | the first operator in (13) |
+| expectation is the norm | equation (15) on positive quotient states |
+| never vanishes on a nonzero positive state | the strict inequality in (15) |
+| quotient momentum charge diag(0,1,2,-1) | dimensionless plus convention in (13) |
+| indefinite | positive, negative, and zero eigenvalues are displayed |
+| nonzero certified-positive state | $v_\star=e_1+e_3$ only |
+| paired momenta | the occupied $k=1$ and $k=3$ sectors |
+| vanishing expected total momentum | the scalar equalities in (16) |
+| either sign convention | signed-integer and mod-$4$ assignments in (13) |
+| charge does not annihilate it | the vector inequalities in (16) |
+| zero is an expectation value | explicit operator-level caveat |
+| momentum-constraint source | the c-number rows in (18) |
+| closed-carrier gauss solutions | existence from the image criterion only |
+| local-observable wall transfers verbatim | the four failures in Section 7 |
+| observable wall is momentum-blind | only under the sector-phase mechanism |
+| positive momentum population break | W1's momentum half, not quotient execution |
+| no per-slice time-translation symmetry exists | no microslice $T_{tt}$ theorem |
+| per-period energy statement is vacuous | functional calculus in (24) |
+| already-certified contractivity | inherited content from Block 119 |
+| momentum-sourced quotient execution | untested-live next construction |
+| non-local dressings | outside the local routed class |
+| naturality classification | untested-live downstream classification |
+| curved os positivity | explicit reconstruction firewall |
+| completed adm/history transporter | downstream construction firewall |
+| joint gravity | explicitly not completed |
+| gravity constraint quotient | explicitly unexecuted |
+| records | no Records claim |
+| retention | independent-audit firewall |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit accounting |
+| actual adm/history transporter remains | standard partial-close statement |
+| gravity constraint quotient remains unexecuted | constraint-execution firewall |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | five N5 keys |
+
+No phrase upgrades c-number source compatibility into execution of the
+constraint quotient, expectation zero into charge annihilation, shift
+continuity into quotient-observable descent, Floquet functional calculus into
+per-slice conservation, or the finite quotient into gravity. Nothing asserts
+naturality, curved OS positivity, completion of the ADM/history transporter,
+joint gravity, axiom amendment, audit retention, obligation retirement, or
+TOE percentage movement.
+
+### N4 — Residual Matching
+
+The supplied historical Block 105 result line, carried by Block 122, is:
+
+> Block 105 §12 item 4 moves on exact source conservation and constraint
+> preservation, but not on propagating $d=2$ gravity or gravity-transfer
+> selection.
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 122 next gate](ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md:16` | “Pose the stress-tensor source and non-local current dressings on the open/background carrier; then the naturality classification and curved OS positivity.” | the stress/momentum route is opened and split: its shift current and population charge are solved on the displayed package, but quotient execution, non-local dressings, naturality, and curved OS positivity remain |
+| [Block 121 population wall](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md) | the norm-valued U(1) total charge cannot populate the zero-sum closed-carrier Gauss image | reframed exactly as a definiteness wall; its scope is identity-valued charge on nonzero positive states, while indefinite momentum supplies the displayed expectation-zero break |
+| Block 105 §12 item 4 | exact source conservation and constraint preservation, without propagating gravity or gravity-transfer selection | the momentum constraint is the first populatable gravity constraint at the c-number source-compatibility level; its quotient execution and all gravity propagation remain open |
+
+This is a partial closure of Block 122's next gate. “The momentum constraint
+is the first populatable gravity constraint” means only equations (17)--(19)
+on the displayed finite package. It does not mean that a momentum-sourced OS
+quotient, constraint algebra, or gravity transfer has been constructed.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “On the certified package at both
+rational shear fixtures, identity-valued U(1) charge cannot populate the
+closed-carrier Gauss image on a nonzero positive state, whereas the displayed
+indefinite momentum charge has a nonzero certified-positive paired-momentum
+state with zero expected total momentum under either sign convention, so its
+c-number source row admits closed-carrier Gauss solutions, while the local
+observable wall transfers unchanged under the invertible phase $i^k$.”
+
+Forbidden upgrades include “the constraint quotient is executed,” “the state
+is annihilated by the charge,” “energy is conserved per-slice,” and “the
+observable wall is broken.” The first confuses incidence-image compatibility
+with forming the sourced OS quotient. The second replaces the expectation
+equalities in (16) by the vector statement that (16) explicitly refutes. The
+third invents a microslice symmetry that does not exist. The fourth ignores
+the invertible pin transfer in (21).
+
+Also forbidden are “every momentum state populates the closed carrier,”
+“zero momentum is convention-dependent,” “the stress tensor descends,”
+“non-local dressings are unnecessary,” “naturality is classified,” “curved
+OS positivity holds,” “gravity is coupled,” “an axiom amendment is required,”
+and “audit retention follows.” None is established by this calculation.
+
+The runner specification's five resolution lines are reproduced verbatim:
+
+```text
+N5: per_element: exact shift-commutation, routed-identity, phase-reduction, definiteness, gauss-image, pin-transfer, and vacuity certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: every momentum sector's shift residual is the invertible phase i^k times the u(1) residual while the quotient momentum charge is indefinite diag(0,1,2,-1)
+per_block: the closed-carrier population wall is a definiteness statement — the identity-valued u(1) charge can never vanish on a positive package but the indefinite momentum charge admits nonzero states of vanishing expected total momentum
+lattice_wide: checked and not executed — the momentum-sourced gauss quotient execution, non-local dressings for the observable wall, the naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The result changes the available
+closed-carrier source class without weakening Block 122's observable wall.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| spatial shift-action commutator | exactly zero at both fixtures | none for displayed package |
+| routed shift-current identity | exact off-shell equation (7) | none for displayed routing class |
+| sector phase reduction | exact $i^k$ multiple of U(1) identity | none for four displayed sectors |
+| U(1) total charge | identity-valued and definite | cannot populate closed carrier |
+| momentum total charge | exact spectrum $0,1,2,-1$ | no classification beyond displayed quotient |
+| paired-momentum state | nonzero and certified-positive | no claim of charge annihilation |
+| expected total momentum | exactly zero in both displayed conventions | none for displayed state |
+| closed incidence image | exactly the zero-sum subspace | none for displayed carrier |
+| momentum source row | in the closed incidence image | execute the sourced OS quotient |
+| operator-level constraint | not executed | impose and solve beyond expectation value |
+| local momentum observable | same pinned failures as Block 122 | none inside local routed class |
+| non-local dressing | untested-live | cancel pin and prove descent/adjointness |
+| microslice energy current | no slice symmetry | requires a different action/package |
+| Floquet generator | exact but vacuous functional calculus | no new conservation credit |
+| transfer contractivity | inherited certified content | none for displayed scalar transfer |
+| naturality classification | untested-live | classify surviving sourced package |
+| curved OS route | not executed | prove positivity on honest curved carrier |
+| gravity constraint quotient | not executed | couple the momentum source and form quotient |
+
+The scan finds no axiom-amendment route. The stress/momentum part of Block
+122's handoff is answered only through shift continuity, charge
+definiteness, and c-number Gauss-image compatibility. Sourced quotient
+execution, non-local dressings, naturality, curved OS positivity, the
+completed transporter, and joint gravity remain open.
+
+### N7 — Steelman
+
+**Hostile steelman: expectation-zero is weaker than eigenstate-zero.** The
+displayed state is not annihilated by momentum, so it does not solve an
+operator constraint $\widetilde P_xv=0$. Why call this a population break?
+
+Agreed about the distinction. Block 121's closed-carrier Gauss population
+test is a c-number source equation: solvability asks whether the expected
+total source lies in the zero-sum incidence image. For that question,
+$\langle\widetilde P_x\rangle=0$ is the right object, and (18)--(19) provide
+it exactly. The stronger operator-level constraint is not executed and is
+named as the next-layer question. The theorem never substitutes one for the
+other.
+
+**Hostile steelman: momentum units and charge conventions are conventional.**
+The entry $-1$ can instead be written as the residue $3$. Does the
+cancellation depend on which representation is chosen?
+
+The principal Hermitian operator is displayed in units $\pi/2$, and both
+the signed-integer and mod-$4$ assignments are shown in (13), (16), and
+(18)--(19). The former gives $1+(-1)=0$ as an ordinary integer equality.
+The latter gives $1+3=0\pmod4$. Both exponentiate to the same shift phase.
+Thus the convention is exposed rather than hidden, and the cancellation is
+certified in the coefficient group appropriate to each representation.
+
+**Hostile steelman: the quotient is tiny.** A four-sector, rank-one-per-sector
+package can expose a cancellation that does not survive a richer carrier, a
+different action, or an operator-level constraint.
+
+Agreed. W1 and its break apply only to the displayed finite quotient, both
+fixtures, the exact charges in (13), and $v_\star$. A richer quotient must
+recompute its charge spectrum, positive cone, incidence image, and local
+observable tests. The present result supplies a certified existence witness
+for this package, not a universal momentum-population theorem.
+
+These steelmen preserve narrow W1 while keeping the positive result honest:
+expectation-zero solves the posed c-number compatibility condition, the sign
+and units are explicit, and no inference is exported beyond the tiny
+certified quotient.
+
+### N8 — Cross-Cycle Echo
+
+The immediate campaign chain first built the positive carrier, then separated
+continuity, population, and observable descent. This block resolves the
+charge-definiteness fork without collapsing those layers.
+
+| campaign block | narrowing that leads to W1 and the positive break |
+|---|---|
+| [Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | supplied the certified rank-one positive half-space quotient and contractive scalar transfer |
+| [Block 121](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md) | proved microscopic routed-current continuity and found the norm-valued U(1) closed-carrier population wall |
+| [Block 122](ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | proved that the local routed U(1) current does not descend to a conserved quotient observable and named stress/momentum as the next source route |
+| Block 123 | proves exact shift continuity, identifies the U(1) wall as definiteness, exhibits the positive momentum population break, and transfers the observable pin |
+
+The present result does not reuse observable descent to prove population.
+It uses the exact charge spectra and zero-sum incidence image. Conversely, it
+does not reuse population to repair observable descent. It uses the
+invertible $i^k$ relation to preserve that wall.
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1: on the certified
+package at both rational shear fixtures, no identity-valued total charge can
+populate the closed carrier on a nonzero positive state. The displayed
+indefinite momentum charge and paired-momentum state are a **POSITIVE** break
+at the c-number expectation level, under either sign convention. The local
+observable wall remains exact under the sector phase. The per-period energy
+statement is **VACUOUS** beyond inherited contractivity. **FAIL** for “the
+constraint quotient is executed,” “the state is annihilated by the charge,”
+“energy is conserved per-slice,” “the observable wall is broken,” a non-local
+dressing, naturality, curved OS positivity, a completed ADM/history
+transporter, joint gravity, axiom necessity, audit retention, obligation
+retirement, or TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. Shift-action commutation, the routed
+divergence identity, momentum-sector reduction, the charge spectra, the
+paired-state expectations, the closed-incidence image, the transferred
+observable witnesses, and the Floquet functional-calculus classification are
+finite consequences of the displayed action, carrier, fixtures, and
+certified quotient. No new primitive is assumed.
+
+This is bounded route closure, not an audit-grade assignment. It retires no
+end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. execute the momentum-sourced Gauss quotient on the closed carrier with
+   the vanishing-expectation state class, keeping expectation-level and
+   operator-level constraints explicit;
+2. construct non-local dressings for the local-observable wall and test Ward
+   compatibility, null descent, and reflection-adjointness; and
+3. classify naturality and execute curved-carrier OS positivity on whichever
+   honest sourced and dressed package survives.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+half-space positive package, its contractive scalar transfer, the microscopic
+routed-current identities, the local quotient-observable obstruction, and
+the c-number momentum population break.
+
+Reflection positivity on the curved carrier remains unexecuted.
+
+The gravity constraint quotient remains unexecuted on a momentum-populated
+carrier.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15973,
- "node_count": 5551,
+ "edge_count": 15977,
+ "node_count": 5552,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -456,6 +456,10 @@
   },
   "admissibility_dirac_kahler_momentum_factorized_positivity_frontier_bounded_theorem_note_2026-08-15": {
    "deps_hash": "f386bc6245ec",
+   "out_degree": 4
+  },
+  "admissibility_dirac_kahler_momentum_population_definiteness_bounded_theorem_note_2026-08-16": {
+   "deps_hash": "345842bf05e6",
    "out_degree": 4
   },
   "admissibility_dirac_kahler_paired_floor_refutation_mixed_circle_bounded_theorem_note_2026-08-15": {

--- a/logs/runner-cache/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py
+runner_sha256: e490b70fd689ae275abd37e2fc55edc98852b199e770a8c214e8c046c7a05327
+input_fingerprint_sha256: 71dcf26969b4ea37689e7ad9a50bfc8ee7fa84d304cfd78c68fb538df0fc3dd6
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 189.94
+status: ok
+----- stdout -----
+[PASS] A-authority: Block 122 note/runner/cache and ancestors 121--103 are pinned
+[PASS] B-the-shift-identity: [U_x,Q]=0, R_x=U_x Q, and both routed divergences equal [E_z,R_x] at all 32 sites including seams
+[PASS] C-the-sector-phase-reduction: Q and R_x are momentum diagonal and each (k,k) site block obeys [E_z,R_x]_kk=i^k[E_z,Q]_kk
+[PASS] D-the-definiteness-split: sum_z E_z=I is definite, while P_x=diag(0,1,2,-1) is indefinite and e1+e3 has zero expected momentum but is not an eigenstate
+[PASS] E-the-gauss-population: the closed-Z4 divergence image is exactly zero-sum, so the momentum source is populatable iff its expected total charge vanishes
+[PASS] F-the-pin-transfer: the invertible i^k phase transfers every nonzero quotient residual and the 0/32 density/flux descent and adjointness failures verbatim
+[PASS] G-the-energy-scope: one-slice time translation fails; h_k conservation is vacuous for scalar rho_k^2 transfer, while h_k>0 is the pinned Block 119 contractivity fact
+[PASS] H-scope: required definiteness/population/phase/pin/energy/N1--N8/W1/N5 firewalls and runtime bound are present
+SHIFT/SECTOR PHASE: [U_x,Q]=0 and R_x=U_xQ for two exact routings; U_x^phys diag=(1, I, -1, -I), P_x/(pi/2)=(0, 1, 2, -1).
+DEFINITENESS: sum_z E_z=I_32 gives the norm; P_x has both signs; a=e1+e3 has ||a||^2=2, integer charge 1+(-1)=0, mod-4 charge 1+3=0, while P_x a=(0, 1, 0, -1) !=0 — not an eigenstate; zero is an expectation.
+GAUSS POPULATION: im(div_Z4)=ker(1,1,1,1); source=(0, 1, 0, -1), exact flux=(0, 1, 1, 0); the momentum constraint is populatable but the identity U(1) charge is not.
+PIN TRANSFER: residual zeros/32 per k are (0, 0, 0, 0)/(0, 0, 0, 0); density/flux descent and adjointness are all (0, 0, 0, 0)/(0, 0, 0, 0).
+TIME-SYMMETRY FAILURE: one-step AP [Q,V] nnz=208/208, witness sha=fb3bc40eec4d5671/121a3eb8abec6bc7; no per-slice energy exists.
+ENERGY STRUCTURAL FACT (VACUOUS): on each one-dimensional quotient line B_k=rho_k^2 I, so h_k=-log(rho_k^2) commutes with B_k identically and constancy could not fail.
+ENERGY CONTENTFUL RESIDUE: h_k>0 is precisely the imported Block 119 per-period contractivity certificate; pinned-interval sha=e7d0e5c7a9778c6e/bf06c92a87275672.
+N5: per_element: exact shift-commutation, routed-identity, phase-reduction, definiteness, gauss-image, pin-transfer, and vacuity certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: every momentum sector's shift residual is the invertible phase i^k times the u(1) residual while the quotient momentum charge is indefinite diag(0,1,2,-1)
+per_block: the closed-carrier population wall is a definiteness statement — the identity-valued u(1) charge can never vanish on a positive package but the indefinite momentum charge admits nonzero states of vanishing expected total momentum
+lattice_wide: checked and not executed — the momentum-sourced gauss quotient execution, non-local dressings for the observable wall, the naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open
+RESULT: the momentum constraint is populatable on the closed carrier because its charge is indefinite — the first population break of the campaign — while the local-observable wall transfers verbatim under the invertible sector phase and the only energy object is the already-certified per-period contraction
+DECISION_CUT: execute the momentum-sourced gauss quotient with the vanishing-expectation state class; reject per-slice energy constructions
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py
+++ b/scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py
@@ -1,0 +1,1338 @@
+#!/usr/bin/env python3
+"""Block 123: exact momentum-population definiteness split.
+
+The committed Block 122 quotient-observable obstruction is transferred to
+the spatial-shift current, while the closed-carrier Gauss population test is
+repeated for the indefinite principal Z4 momentum charge.  Every scientific
+calculation uses exact SymPy arithmetic; wall-clock timing is the sole
+floating-point quantity.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+import subprocess
+import time
+
+import sympy as sp
+
+import admissibility_dirac_kahler_quotient_observable_obstruction_2026_08_16 as prior
+
+
+R = sp.Rational
+I = sp.I
+block121 = prior.prior
+block120 = block121.prior
+block119 = block120.prior
+DK = prior.DK
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_quotient_observable_obstruction_"
+    "2026_08_16.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_quotient_observable_"
+    "obstruction_2026_08_16.txt"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "scripts/admissibility_dirac_kahler_quotient_observable_obstruction_2026_08_16.py",
+    "logs/runner-cache/admissibility_dirac_kahler_quotient_observable_obstruction_2026_08_16.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "31e4c7ff7d41db6a78feef19dba2bfbea3dc1830"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block122-quotient-observable-obstruction-20260816"
+)
+PARENT_COMMIT = "f067b99be7eb49fc46ea8dffccab5e20e6052d88"
+PARENT_NOTE_BLOB = "ef9f1b2037c8b470c821ed27572a81c6cb9ac9a4"
+PARENT_RUNNER_BLOB = "08eeb0b1742cbf1c33646cda7993835423d8f357"
+PARENT_CACHE_BLOB = "5f303dcfa39eb23c407d363464ae308bfa1de30a"
+ANCESTOR_COMMITS = (
+    (121, "1714abeefcf3763c0bfe001f30fd14521c538622"),
+    (120, "1c2386bf3df420707fd2ecb2d7ec84002ba40ad1"),
+    (119, "33fd2d21558604718f3a88713fe1976aff8f9dbb"),
+    (118, "fdd1883c54ca8cc14b1337cc1edc249792d5dab2"),
+    (117, "f800356aec0989b6e0fa80ed43274794243b1ca2"),
+    (116, "c36d11e4e8d927c6fc31f0a8b579d4bd15f4fa43"),
+    (115, "c78301fef7521d0518f485f1bf9266983c9e516a"),
+    (114, "75026e71cfbd44ed665ddc41c22ebaa722720ea9"),
+    (113, "e76893eb7204d1d727a3ab8838fb3fada3f45dfc"),
+    (112, "385a6ba5b1594f20e5d4eebba9da68d8e72abc10"),
+    (111, "b04e7c8747b09734711cfcd2bfab961bd12e81ad"),
+    (110, "d6761278fca9cac617200792473a8f4da3a6cfff"),
+    (109, "ad84cfcc857a65285389ba93b47cd7b718589be5"),
+    (108, "8afe8dff5ccf531208238af0aaaec1f547d73874"),
+    (107, "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"),
+    (106, "22d6d90ec2279e5868c9c825149b2a20beea3797"),
+    (105, "d06066c2b908aaca0779625d831dfb10620cf34d"),
+    (104, "7fe07db6c03fad1191893c942f708c5cb9a54c43"),
+    (103, "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"),
+)
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "break_shift_commutation",
+    "break_phase_reduction",
+    "break_definiteness",
+    "claim_eigenstate",
+    "break_gauss_image",
+    "claim_u1_populates",
+    "break_pin_transfer",
+    "claim_slice_energy",
+    "claim_energy_content",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_toe_progress",
+    "claim_axiom_amendment",
+)
+
+NT = prior.NT
+NX = prior.NX
+NS = prior.NS
+SHEARS = prior.SHEARS
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition) -> None:
+        ok = bool(condition)
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {statement}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    ancestors = {
+        f"ancestor_{number}": is_ancestor(commit, "HEAD")
+        for number, commit in ANCESTOR_COMMITS
+    }
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        **ancestors,
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+    }
+
+
+def matrix_zero(matrix: sp.Matrix) -> bool:
+    return all(sp.expand(value) == 0 for value in matrix)
+
+
+def exact_digest(*payload: object) -> str:
+    return hashlib.sha256(sp.srepr(payload).encode("utf-8")).hexdigest()[:16]
+
+
+def spatial_shift() -> sp.ImmutableSparseMatrix:
+    """Active +x shift U_x|t,x>=|t,x+1>."""
+    return sp.ImmutableSparseMatrix(
+        NS,
+        NS,
+        {
+            (block121.site(time_index, space_index + 1),
+             block121.site(time_index, space_index)): 1
+            for time_index in range(NT)
+            for space_index in range(NX)
+        },
+    )
+
+
+def antiperiodic_time_shift() -> sp.ImmutableSparseMatrix:
+    """Active one-microslice shift with the exact antiperiodic seam sign."""
+    entries: dict[tuple[int, int], int] = {}
+    for time_index in range(NT):
+        sign = -1 if time_index == NT - 1 else 1
+        for space_index in range(NX):
+            entries[
+                (
+                    block121.site(time_index + 1, space_index),
+                    block121.site(time_index, space_index),
+                )
+            ] = sign
+    return sp.ImmutableSparseMatrix(NS, NS, entries)
+
+
+def spatial_fourier() -> sp.Matrix:
+    fourier = sp.Matrix(
+        NX, NX, lambda row, column: I ** (-row * column)
+    ) / 2
+    return sp.kronecker_product(sp.eye(NT), fourier)
+
+
+def momentum_cross_block(
+    matrix: sp.Matrix,
+    row_momentum: int,
+    column_momentum: int,
+    transform: sp.Matrix,
+) -> sp.Matrix:
+    row_indices = tuple(row_momentum + NX * time for time in range(NT))
+    column_indices = tuple(
+        column_momentum + NX * time for time in range(NT)
+    )
+    return (transform.H * matrix * transform).extract(
+        row_indices, column_indices
+    )
+
+
+def transformed_momentum_block(
+    transformed: sp.Matrix,
+    row_momentum: int,
+    column_momentum: int | None = None,
+) -> sp.Matrix:
+    if column_momentum is None:
+        column_momentum = row_momentum
+    row_indices = tuple(row_momentum + NX * time for time in range(NT))
+    column_indices = tuple(
+        column_momentum + NX * time for time in range(NT)
+    )
+    return transformed.extract(row_indices, column_indices)
+
+
+def principal_charge(phase: sp.Expr) -> int:
+    """Invert i**p on the principal integer representatives {-1,0,1,2}."""
+    candidates = tuple(
+        value for value in (-1, 0, 1, 2) if sp.expand(I**value - phase) == 0
+    )
+    if len(candidates) != 1:
+        raise AssertionError(f"phase {phase!r} lacks a unique principal charge")
+    return candidates[0]
+
+
+def normalized_note() -> str:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+    return " ".join(raw_note.lower().split())
+
+
+MatrixGrid = tuple[tuple[sp.Matrix, ...], ...]
+ValueGrid = tuple[tuple[sp.Expr, ...], ...]
+
+
+@dataclass(frozen=True)
+class FixtureCertificate:
+    shear: sp.Rational
+    shift_commutation_exact: bool
+    routed_identity_exact: bool
+    routing_distinct: bool
+    seam_exact: bool
+    phase_structure_exact: bool
+    phase_reduction_exact: bool
+    quotient_positive_exact: bool
+    phase_form: sp.Matrix
+    momentum_form: sp.Matrix
+    pin_transfer_exact: bool
+    residual_zero_counts: tuple[int, ...]
+    residual_digests: tuple[str, ...]
+    density_descent_left: tuple[int, ...]
+    density_descent_right: tuple[int, ...]
+    flux_descent_left: tuple[int, ...]
+    flux_descent_right: tuple[int, ...]
+    adjoint_density: tuple[int, ...]
+    adjoint_flux: tuple[int, ...]
+    time_shift_nnz: int
+    time_shift_digest: str
+    scalar_transfer_exact: bool
+    conservation_vacuous: bool
+    contractivity_pinned: bool
+    interval_digest: str
+
+
+@dataclass(frozen=True)
+class DefinitenessCertificate:
+    u1_total_identity: bool
+    u1_definite_norm: bool
+    phase_form_exact: bool
+    momentum_form_exact: bool
+    momentum_indefinite: bool
+    witness_nonzero: bool
+    witness_positive: bool
+    integer_sum: sp.Expr
+    integer_expectation: sp.Expr
+    modular_sum: int
+    momentum_action: sp.Matrix
+    not_eigenstate: bool
+
+
+@dataclass(frozen=True)
+class GaussCertificate:
+    divergence: sp.Matrix
+    image_zero_sum_exact: bool
+    momentum_constraint_row: sp.Matrix
+    source: sp.Matrix
+    solution: sp.Matrix
+    solution_exact: bool
+    momentum_population_passes: bool
+    u1_population_fails: bool
+
+
+def restricted_block(
+    kernel: sp.Matrix,
+    momentum: int,
+    transform: sp.Matrix,
+    cut: sp.Matrix,
+    polynomial: sp.Poly,
+) -> sp.Matrix:
+    return block120.field_matrix(
+        prior.momentum_restriction(
+            kernel, momentum, transform, cut, polynomial
+        ),
+        polynomial,
+    )
+
+
+def transformed_kernels(
+    kernels: tuple[sp.Matrix, ...], transform: sp.Matrix
+) -> tuple[sp.Matrix, ...]:
+    """Fourier-conjugate each local kernel once, before the four k reads."""
+    return tuple(transform.H * kernel * transform for kernel in kernels)
+
+
+def observable_grid_from_transformed(
+    kernels: tuple[sp.Matrix, ...],
+    momentum: int,
+    cut: sp.Matrix,
+    polynomial: sp.Poly,
+    bra: sp.Matrix,
+    vector: sp.Matrix,
+    norm: sp.Expr,
+) -> tuple[MatrixGrid, ValueGrid]:
+    block_rows: list[tuple[sp.Matrix, ...]] = []
+    value_rows: list[tuple[sp.Expr, ...]] = []
+    for local_time in range(NT):
+        old_time = (local_time + NT // 2) % NT
+        blocks: list[sp.Matrix] = []
+        values: list[sp.Expr] = []
+        for space_index in range(NX):
+            diagonal = transformed_momentum_block(
+                kernels[block121.site(old_time, space_index)], momentum
+            )
+            block = block120.field_matrix(
+                cut * diagonal * cut.T, polynomial
+            )
+            blocks.append(block)
+            values.append(
+                prior.compression(bra, vector, block, norm, polynomial)
+            )
+        block_rows.append(tuple(blocks))
+        value_rows.append(tuple(values))
+    return tuple(block_rows), tuple(value_rows)
+
+
+def descent_counts(
+    blocks: MatrixGrid,
+    values: ValueGrid,
+    bra: sp.Matrix,
+    vector: sp.Matrix,
+    polynomial: sp.Poly,
+) -> tuple[int, int]:
+    left = 0
+    right = 0
+    for local_time in range(NT):
+        for space_index in range(NX):
+            operator = blocks[local_time][space_index]
+            scalar = values[local_time][space_index]
+            left += block120.field_equal(
+                block120.field_matrix(bra * operator, polynomial),
+                block120.field_matrix(scalar * bra, polynomial),
+                polynomial,
+            )
+            right += block120.field_equal(
+                block120.field_matrix(operator * vector, polynomial),
+                block120.field_matrix(scalar * vector, polynomial),
+                polynomial,
+            )
+    return left, right
+
+
+def adjoint_count(
+    name: str,
+    blocks: MatrixGrid,
+    gram: sp.Matrix,
+    polynomial: sp.Poly,
+) -> int:
+    zeros = 0
+    for local_time in range(NT):
+        reflected_time = prior.momentum_reflect_time(name, local_time)
+        for space_index in range(NX):
+            operator = blocks[local_time][space_index]
+            reflected = blocks[reflected_time][space_index]
+            residual = block120.field_matrix(
+                gram * operator
+                - block120.field_adjoint(reflected, polynomial) * gram,
+                polynomial,
+            )
+            zeros += block120.field_equal(
+                residual, sp.zeros(NT), polynomial
+            )
+    return zeros
+
+
+def quotient_positivity(
+    sector,
+    theta: sp.Matrix,
+) -> bool:
+    polynomial = sector.polynomial
+    vector = sector.y
+    bra = block120.field_adjoint(vector, polynomial)
+    norm = block120.red((bra * vector)[0], polynomial)
+    gram = block120.field_matrix(theta * sector.h00, polynomial)
+    rank_one = block120.field_matrix(vector * bra, polynomial)
+    if norm == 0 or not block120.field_equal(gram, rank_one, polynomial):
+        return False
+    unit = block120.field_matrix(vector / norm, polynomial)
+    unit_bra = block120.field_adjoint(unit, polynomial)
+    return block120.red((unit_bra * gram * unit)[0] - 1, polynomial) == 0
+
+
+def make_shift_routings(
+    shifted_action: sp.Matrix,
+) -> tuple[block121.RoutedCurrent, ...]:
+    routed: list[block121.RoutedCurrent] = []
+    for routing in block121.ROUTINGS:
+        temporal, spatial = block121.current_kernels(shifted_action, routing)
+        identity_exact = all(
+            matrix_zero(
+                block121.backward_divergence(
+                    temporal, spatial, time_index, space_index
+                )
+                - (
+                    block121.projector(block121.site(time_index, space_index))
+                    * shifted_action
+                    - shifted_action
+                    * block121.projector(block121.site(time_index, space_index))
+                )
+            )
+            for time_index in range(NT)
+            for space_index in range(NX)
+        )
+        routed.append(
+            block121.RoutedCurrent(
+                routing, temporal, spatial, identity_exact
+            )
+        )
+    return tuple(routed)
+
+
+def fixture_certificate(
+    shear: sp.Rational,
+    fixture_index: int,
+    shift: sp.Matrix,
+    transform: sp.Matrix,
+    cut: sp.Matrix,
+    time_shift: sp.Matrix,
+) -> FixtureCertificate:
+    current = block121.certify_current(shear)
+    action = current.action
+    shifted_action = shift * action
+    shift_commutation_exact = (
+        matrix_zero(shift.H * shift - sp.eye(NS))
+        and matrix_zero(shift**NX - sp.eye(NS))
+        and matrix_zero(shift * action - action * shift)
+        and matrix_zero(shifted_action - shift * action)
+        and matrix_zero(shifted_action - action * shift)
+    )
+
+    shift_routings = make_shift_routings(shifted_action)
+    _, curl_exact, routing_distinct = block121.curl_reconstruction(
+        shift_routings[0], shift_routings[1]
+    )
+    routed_identity_exact = (
+        len(shift_routings) == 2
+        and all(routed.identity_exact for routed in shift_routings)
+        and curl_exact
+    )
+    seam_exact = all(
+        matrix_zero(
+            block121.backward_divergence(
+                routed.temporal,
+                routed.spatial,
+                time_index,
+                space_index,
+            )
+            - (
+                block121.projector(block121.site(time_index, space_index))
+                * shifted_action
+                - shifted_action
+                * block121.projector(block121.site(time_index, space_index))
+            )
+        )
+        for routed in shift_routings
+        for time_index in range(NT)
+        for space_index in range(NX)
+        if time_index == 0 or space_index == 0
+    )
+
+    transformed_shift = transform.H * shift * transform
+    transformed_action = transform.H * action * transform
+    transformed_shifted = transform.H * shifted_action * transform
+    expected_phases = tuple(I**momentum for momentum in range(NX))
+    expected_shift = sp.kronecker_product(
+        sp.eye(NT), sp.diag(*expected_phases)
+    )
+    phase_structure_exact = (
+        matrix_zero(transform.H * transform - sp.eye(NS))
+        and matrix_zero(transformed_shift - expected_shift)
+        and all(
+            matrix_zero(
+                transformed_momentum_block(
+                    transformed_action, row_momentum, column_momentum
+                )
+            )
+            and matrix_zero(
+                transformed_momentum_block(
+                    transformed_shifted, row_momentum, column_momentum
+                )
+            )
+            for row_momentum in range(NX)
+            for column_momentum in range(NX)
+            if row_momentum != column_momentum
+        )
+        and all(
+            matrix_zero(
+                transformed_momentum_block(transformed_shifted, momentum)
+                - I**momentum
+                * transformed_momentum_block(transformed_action, momentum)
+            )
+            for momentum in range(NX)
+        )
+    )
+
+    phase_reduction_exact = True
+    for time_index in range(NT):
+        for space_index in range(NX):
+            projector = block121.projector(
+                block121.site(time_index, space_index)
+            )
+            transformed_projector = transform.H * projector * transform
+            transformed_shifted_residual = (
+                transformed_projector * transformed_shifted
+                - transformed_shifted * transformed_projector
+            )
+            transformed_u1_residual = (
+                transformed_projector * transformed_action
+                - transformed_action * transformed_projector
+            )
+            for momentum in range(NX):
+                phase_reduction_exact = (
+                    phase_reduction_exact
+                    and matrix_zero(
+                        transformed_momentum_block(
+                            transformed_shifted_residual, momentum
+                        )
+                        - I**momentum
+                        * transformed_momentum_block(
+                            transformed_u1_residual, momentum
+                        )
+                    )
+                )
+
+    sectors = block119.make_sectors(shear)
+    completion = block119.reflection_real_completion(sectors)
+    if len(sectors) != NX or len(completion.thetas) != NX:
+        raise AssertionError("the completed quotient must contain four lines")
+    quotient_positive_exact = all(
+        quotient_positivity(sector, completion.thetas[momentum])
+        for momentum, sector in enumerate(sectors)
+    )
+
+    phase_values: list[sp.Expr] = []
+    for momentum, sector in enumerate(sectors):
+        polynomial = sector.polynomial
+        shift_block = restricted_block(
+            shift, momentum, transform, cut, polynomial
+        )
+        phase_value = prior.quotient_element(
+            sector.y, shift_block, polynomial
+        )
+        phase_structure_exact = (
+            phase_structure_exact
+            and block120.red(
+                phase_value - I**momentum, polynomial
+            )
+            == 0
+        )
+        phase_values.append(phase_value)
+    phase_form = sp.diag(*phase_values)
+    charges = tuple(principal_charge(value) for value in phase_values)
+    momentum_form = sp.diag(*charges)
+    momentum_operator = (
+        transform
+        * sp.kronecker_product(sp.eye(NT), momentum_form)
+        * transform.H
+    )
+    phase_structure_exact = (
+        phase_structure_exact
+        and matrix_zero(phase_form - sp.diag(1, I, -1, -I))
+        and charges == (0, 1, 2, -1)
+        and matrix_zero(momentum_operator.H - momentum_operator)
+        and matrix_zero(momentum_operator * shift - shift * momentum_operator)
+        and matrix_zero(momentum_operator * action - action * momentum_operator)
+    )
+    for momentum, sector in enumerate(sectors):
+        polynomial = sector.polynomial
+        momentum_block = restricted_block(
+            momentum_operator, momentum, transform, cut, polynomial
+        )
+        momentum_value = prior.quotient_element(
+            sector.y, momentum_block, polynomial
+        )
+        phase_structure_exact = (
+            phase_structure_exact
+            and block120.red(
+                momentum_value - charges[momentum], polynomial
+            )
+            == 0
+        )
+
+    residual_zero_counts: list[int] = []
+    residual_digests: list[str] = []
+    density_descent_left: list[int] = []
+    density_descent_right: list[int] = []
+    flux_descent_left: list[int] = []
+    flux_descent_right: list[int] = []
+    adjoint_density: list[int] = []
+    adjoint_flux: list[int] = []
+    pin_transfer_exact = True
+    u1_routing = current.routings[0]
+    shift_routing = shift_routings[0]
+    transformed_u1_kernels = {
+        "J": transformed_kernels(u1_routing.temporal, transform),
+        "S": transformed_kernels(u1_routing.spatial, transform),
+    }
+    transformed_shift_kernels = {
+        "J": transformed_kernels(shift_routing.temporal, transform),
+        "S": transformed_kernels(shift_routing.spatial, transform),
+    }
+
+    for momentum, sector in enumerate(sectors):
+        polynomial = sector.polynomial
+        vector = sector.y
+        bra = block120.field_adjoint(vector, polynomial)
+        norm = block120.red((bra * vector)[0], polynomial)
+        gram = block120.field_matrix(
+            completion.thetas[momentum] * sector.h00, polynomial
+        )
+        u1_grids: dict[str, tuple[MatrixGrid, ValueGrid]] = {}
+        shift_grids: dict[str, tuple[MatrixGrid, ValueGrid]] = {}
+        for name in ("J", "S"):
+            u1_grids[name] = observable_grid_from_transformed(
+                transformed_u1_kernels[name],
+                momentum,
+                cut,
+                polynomial,
+                bra,
+                vector,
+                norm,
+            )
+            shift_grids[name] = observable_grid_from_transformed(
+                transformed_shift_kernels[name],
+                momentum,
+                cut,
+                polynomial,
+                bra,
+                vector,
+                norm,
+            )
+
+        u1_j_blocks, u1_j_values = u1_grids["J"]
+        u1_s_blocks, u1_s_values = u1_grids["S"]
+        shift_j_blocks, shift_j_values = shift_grids["J"]
+        shift_s_blocks, shift_s_values = shift_grids["S"]
+        residuals: list[sp.Expr] = []
+        for local_time in range(NT):
+            for space_index in range(NX):
+                shifted_divergence = block120.field_matrix(
+                    shift_j_blocks[local_time][space_index]
+                    - shift_j_blocks[(local_time - 1) % NT][space_index]
+                    + shift_s_blocks[local_time][space_index]
+                    - shift_s_blocks[local_time][(space_index - 1) % NX],
+                    polynomial,
+                )
+                u1_divergence = block120.field_matrix(
+                    u1_j_blocks[local_time][space_index]
+                    - u1_j_blocks[(local_time - 1) % NT][space_index]
+                    + u1_s_blocks[local_time][space_index]
+                    - u1_s_blocks[local_time][(space_index - 1) % NX],
+                    polynomial,
+                )
+                shifted_block = shifted_divergence
+                u1_block = u1_divergence
+                shifted_scalar = prior.quotient_element(
+                    vector, shifted_block, polynomial
+                )
+                u1_scalar = prior.quotient_element(
+                    vector, u1_block, polynomial
+                )
+                scalar_divergence = block120.red(
+                    shift_j_values[local_time][space_index]
+                    - shift_j_values[(local_time - 1) % NT][space_index]
+                    + shift_s_values[local_time][space_index]
+                    - shift_s_values[local_time][(space_index - 1) % NX],
+                    polynomial,
+                )
+                pin_transfer_exact = (
+                    pin_transfer_exact
+                    and block120.field_equal(
+                        shifted_divergence, shifted_block, polynomial
+                    )
+                    and block120.field_equal(
+                        shifted_block,
+                        block120.field_matrix(
+                            I**momentum * u1_block, polynomial
+                        ),
+                        polynomial,
+                    )
+                    and block120.field_equal(
+                        u1_divergence, u1_block, polynomial
+                    )
+                    and block120.red(
+                        scalar_divergence - shifted_scalar, polynomial
+                    )
+                    == 0
+                    and block120.red(
+                        shifted_scalar - I**momentum * u1_scalar,
+                        polynomial,
+                    )
+                    == 0
+                    and I**momentum != 0
+                )
+                residuals.append(shifted_scalar)
+        residual_zero_counts.append(sum(value == 0 for value in residuals))
+        residual_digests.append(exact_digest(tuple(residuals)))
+
+        for name, shift_blocks, shift_values in (
+            (
+                "J",
+                shift_j_blocks,
+                shift_j_values,
+            ),
+            (
+                "S",
+                shift_s_blocks,
+                shift_s_values,
+            ),
+        ):
+            shift_left, shift_right = descent_counts(
+                shift_blocks, shift_values, bra, vector, polynomial
+            )
+            shift_adjoint = adjoint_count(
+                name, shift_blocks, gram, polynomial
+            )
+            pin_transfer_exact = (
+                pin_transfer_exact
+                and shift_left == 0
+                and shift_right == 0
+                and shift_adjoint == 0
+            )
+            if name == "J":
+                density_descent_left.append(shift_left)
+                density_descent_right.append(shift_right)
+                adjoint_density.append(shift_adjoint)
+            else:
+                flux_descent_left.append(shift_left)
+                flux_descent_right.append(shift_right)
+                adjoint_flux.append(shift_adjoint)
+
+    pin_transfer_exact = (
+        pin_transfer_exact
+        and tuple(residual_zero_counts) == (0, 0, 0, 0)
+    )
+
+    time_commutator = action * time_shift - time_shift * action
+    time_shift_nnz = sum(value != 0 for value in time_commutator)
+    time_structure_exact = (
+        matrix_zero(time_shift.H * time_shift - sp.eye(NS))
+        and matrix_zero(time_shift**NT + sp.eye(NS))
+        and time_shift_nnz > 0
+    )
+    pinned_intervals = block119.EXPECTED_BETA_INTERVALS[fixture_index]
+    contractivity_pinned = (
+        len(pinned_intervals) == 2
+        and all(0 < lower < upper < 1 for lower, upper in pinned_intervals)
+    )
+    scalar_transfer_exact = True
+    conservation_vacuous = True
+    for momentum, sector in enumerate(sectors):
+        polynomial = sector.polynomial
+        beta = block120.red(block119.RHO**2, polynomial)
+        vector = sector.y
+        bra = block120.field_adjoint(vector, polynomial)
+        scalar_operator = block120.field_matrix(
+            beta * sp.eye(NT), polynomial
+        )
+        scalar_transfer_exact = (
+            scalar_transfer_exact
+            and sector.geometric_hankel
+            and block120.field_equal(
+                scalar_operator * vector,
+                block120.field_matrix(beta * vector, polynomial),
+                polynomial,
+            )
+            and block120.field_equal(
+                bra * scalar_operator,
+                block120.field_matrix(beta * bra, polynomial),
+                polynomial,
+            )
+        )
+        transfer = sp.Matrix([[beta]])
+        cell_energy = sp.Matrix([[-sp.log(beta)]])
+        conservation_vacuous = (
+            conservation_vacuous
+            and matrix_zero(transfer * cell_energy - cell_energy * transfer)
+            and transfer.rows == transfer.cols == 1
+        )
+
+    return FixtureCertificate(
+        shear=shear,
+        shift_commutation_exact=shift_commutation_exact,
+        routed_identity_exact=routed_identity_exact,
+        routing_distinct=routing_distinct,
+        seam_exact=seam_exact,
+        phase_structure_exact=phase_structure_exact,
+        phase_reduction_exact=phase_reduction_exact,
+        quotient_positive_exact=quotient_positive_exact,
+        phase_form=phase_form,
+        momentum_form=momentum_form,
+        pin_transfer_exact=pin_transfer_exact,
+        residual_zero_counts=tuple(residual_zero_counts),
+        residual_digests=tuple(residual_digests),
+        density_descent_left=tuple(density_descent_left),
+        density_descent_right=tuple(density_descent_right),
+        flux_descent_left=tuple(flux_descent_left),
+        flux_descent_right=tuple(flux_descent_right),
+        adjoint_density=tuple(adjoint_density),
+        adjoint_flux=tuple(adjoint_flux),
+        time_shift_nnz=time_shift_nnz if time_structure_exact else 0,
+        time_shift_digest=exact_digest(time_commutator),
+        scalar_transfer_exact=scalar_transfer_exact,
+        conservation_vacuous=conservation_vacuous,
+        contractivity_pinned=contractivity_pinned,
+        interval_digest=exact_digest(pinned_intervals),
+    )
+
+
+def definiteness_certificate(
+    fixtures: tuple[FixtureCertificate, ...]
+) -> DefinitenessCertificate:
+    total_u1 = sum(
+        (
+            block121.projector(block121.site(time_index, space_index))
+            for time_index in range(NT)
+            for space_index in range(NX)
+        ),
+        sp.zeros(NS),
+    )
+    witness = sp.Matrix((0, 1, 0, 1))
+    norm = (witness.H * witness)[0]
+    phase_form = fixtures[0].phase_form
+    momentum_form = fixtures[0].momentum_form
+    phase_form_exact = (
+        all(matrix_zero(fixture.phase_form - phase_form) for fixture in fixtures)
+        and matrix_zero(phase_form - sp.diag(1, I, -1, -I))
+        and all(
+            phase_form[momentum, momentum] == I**momentum
+            for momentum in range(NX)
+        )
+    )
+    derived_charges = tuple(
+        principal_charge(phase_form[momentum, momentum])
+        for momentum in range(NX)
+    )
+    momentum_form_exact = (
+        all(
+            matrix_zero(fixture.momentum_form - momentum_form)
+            for fixture in fixtures
+        )
+        and derived_charges == (0, 1, 2, -1)
+        and matrix_zero(momentum_form - sp.diag(*derived_charges))
+        and matrix_zero(momentum_form.H - momentum_form)
+    )
+    eigenvalues = tuple(momentum_form[entry, entry] for entry in range(NX))
+    integer_sum = sum(
+        momentum_form[index, index]
+        for index in range(NX)
+        if witness[index] != 0
+    )
+    integer_expectation = sp.cancel(
+        (witness.H * momentum_form * witness)[0] / norm
+    )
+    modular_sum = sum(
+        index for index in range(NX) if witness[index] != 0
+    ) % NX
+    momentum_action = momentum_form * witness
+    return DefinitenessCertificate(
+        u1_total_identity=matrix_zero(total_u1 - sp.eye(NS)),
+        u1_definite_norm=(
+            matrix_zero(total_u1 - sp.eye(NS))
+            and norm == 2
+            and (witness.H * sp.eye(NX) * witness)[0] == norm
+            and norm > 0
+        ),
+        phase_form_exact=phase_form_exact,
+        momentum_form_exact=momentum_form_exact,
+        momentum_indefinite=(
+            any(value > 0 for value in eigenvalues)
+            and any(value < 0 for value in eigenvalues)
+        ),
+        witness_nonzero=(witness != sp.zeros(NX, 1)),
+        witness_positive=(
+            norm == 2
+            and norm > 0
+            and all(fixture.quotient_positive_exact for fixture in fixtures)
+        ),
+        integer_sum=integer_sum,
+        integer_expectation=integer_expectation,
+        modular_sum=modular_sum,
+        momentum_action=momentum_action,
+        not_eigenstate=(
+            momentum_action != sp.zeros(NX, 1)
+            and sp.Matrix.hstack(witness, momentum_action).rank() == 2
+        ),
+    )
+
+
+def gauss_certificate(
+    definiteness: DefinitenessCertificate,
+) -> GaussCertificate:
+    divergence = sp.Matrix(
+        NX,
+        NX,
+        lambda row, column: (
+            int(column == row) - int(column == (row - 1) % NX)
+        ),
+    )
+    total_row = sp.ones(1, NX)
+    zero_sum_basis = sp.Matrix.hstack(
+        *(sp.eye(NX).col(index) - sp.eye(NX).col(NX - 1)
+          for index in range(NX - 1))
+    )
+    image_zero_sum_exact = (
+        divergence.rank() == NX - 1
+        and matrix_zero(total_row * divergence)
+        and zero_sum_basis.rank() == NX - 1
+        and divergence.row_join(zero_sum_basis).rank() == NX - 1
+    )
+    population = sp.Matrix((0, 1, 0, 1))
+    momentum_constraint_row = sp.Matrix([[0, 1, 2, -1]])
+    modular_constraint_row = sp.Matrix([[0, 1, 2, 3]])
+    u1_constraint_row = sp.ones(1, NX)
+    source = sp.Matrix(
+        tuple(
+            momentum_constraint_row[0, index] * population[index]
+            for index in range(NX)
+        )
+    )
+    solution = sp.Matrix((0, 1, 1, 0))
+    solution_exact = (
+        matrix_zero(divergence * solution - source)
+        and (total_row * source)[0] == 0
+    )
+    momentum_population_passes = (
+        definiteness.integer_expectation == 0
+        and (momentum_constraint_row * population)[0] == 0
+        and int((modular_constraint_row * population)[0]) % NX == 0
+        and solution_exact
+    )
+    u1_population_fails = (
+        definiteness.u1_total_identity
+        and (u1_constraint_row * population)[0] == 2
+        and (u1_constraint_row * population)[0] != 0
+    )
+    return GaussCertificate(
+        divergence=divergence,
+        image_zero_sum_exact=image_zero_sum_exact,
+        momentum_constraint_row=momentum_constraint_row,
+        source=source,
+        solution=solution,
+        solution_exact=solution_exact,
+        momentum_population_passes=momentum_population_passes,
+        u1_population_fails=u1_population_fails,
+    )
+
+
+SCOPE_KEYS = (
+    "definiteness",
+    "expected_momentum",
+    "state_caveat",
+    "population",
+    "momentum_constraint",
+    "sector_phase",
+    "pin_transfer",
+    "energy_vacuity",
+    "energy_scope",
+    "os_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity",
+    "adm",
+    "n1_n8",
+    "w1",
+    "n5_resolution",
+)
+
+
+def scope_certificate(note: str, mutation: str) -> dict[str, bool]:
+    result = {
+        "definiteness": (
+            "definiteness" in note or "indefinite" in note
+        ),
+        "expected_momentum": (
+            "expected total momentum" in note
+            or "expectation value" in note
+        ),
+        "state_caveat": (
+            "not an eigenstate" in note or "does not annihilate" in note
+        ),
+        "population": "population" in note,
+        "momentum_constraint": "momentum constraint" in note,
+        "sector_phase": "i^k" in note or "sector phase" in note,
+        "pin_transfer": (
+            "momentum-blind" in note or "transfers verbatim" in note
+        ),
+        "energy_vacuity": "vacuous" in note or "contentless" in note,
+        "energy_scope": "per-period" in note or "per-cell" in note,
+        "os_boundary": (
+            "not an os no-go" in note or "not a curved os no-go" in note
+        ),
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "gravity": "gravity constraint quotient remains unexecuted" in note,
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "w1": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["os_boundary"] = False
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    if mutation == "claim_axiom_amendment":
+        result["axiom"] = False
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started = time.monotonic()
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    checks.check(
+        "A-authority",
+        "Block 122 note/runner/cache and ancestors 121--103 are pinned",
+        AUDIT_TIMEOUT_SEC == 600
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/audit/data/axiom_premise_nodes.json",
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_QUOTIENT_OBSERVABLE_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "scripts/admissibility_dirac_kahler_quotient_observable_obstruction_2026_08_16.py",
+            "logs/runner-cache/admissibility_dirac_kahler_quotient_observable_obstruction_2026_08_16.txt",
+        )
+        and authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and all(
+            authority[f"ancestor_{number}"] for number in range(103, 122)
+        )
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB,
+    )
+
+    shift = spatial_shift()
+    transform = spatial_fourier()
+    cut = prior.cut_shift()
+    time_shift = antiperiodic_time_shift()
+    fixtures = tuple(
+        fixture_certificate(
+            shear, fixture_index, shift, transform, cut, time_shift
+        )
+        for fixture_index, shear in enumerate(SHEARS)
+    )
+
+    shift_exact = all(
+        fixture.shift_commutation_exact
+        and fixture.routed_identity_exact
+        and fixture.routing_distinct
+        and fixture.seam_exact
+        for fixture in fixtures
+    )
+    if mutation == "break_shift_commutation":
+        shift_exact = False
+    checks.check(
+        "B-the-shift-identity",
+        "[U_x,Q]=0, R_x=U_x Q, and both routed divergences equal [E_z,R_x] at all 32 sites including seams",
+        shift_exact,
+    )
+
+    phase_exact = all(
+        fixture.phase_structure_exact and fixture.phase_reduction_exact
+        for fixture in fixtures
+    )
+    if mutation == "break_phase_reduction":
+        phase_exact = False
+    checks.check(
+        "C-the-sector-phase-reduction",
+        "Q and R_x are momentum diagonal and each (k,k) site block obeys [E_z,R_x]_kk=i^k[E_z,Q]_kk",
+        phase_exact,
+    )
+
+    definiteness = definiteness_certificate(fixtures)
+    definiteness_exact = (
+        definiteness.u1_total_identity
+        and definiteness.u1_definite_norm
+        and definiteness.phase_form_exact
+        and definiteness.momentum_form_exact
+        and definiteness.momentum_indefinite
+        and definiteness.witness_nonzero
+        and definiteness.witness_positive
+        and definiteness.integer_sum == 0
+        and definiteness.integer_expectation == 0
+        and definiteness.modular_sum == 0
+        and definiteness.momentum_action == sp.Matrix((0, 1, 0, -1))
+        and definiteness.not_eigenstate
+    )
+    if mutation == "break_definiteness":
+        definiteness_exact = False
+    eigenstate_claimed = mutation == "claim_eigenstate"
+    checks.check(
+        "D-the-definiteness-split",
+        "sum_z E_z=I is definite, while P_x=diag(0,1,2,-1) is indefinite and e1+e3 has zero expected momentum but is not an eigenstate",
+        definiteness_exact and not eigenstate_claimed,
+    )
+
+    gauss = gauss_certificate(definiteness)
+    gauss_exact = (
+        gauss.image_zero_sum_exact
+        and gauss.solution_exact
+        and gauss.momentum_population_passes
+        and gauss.u1_population_fails
+    )
+    if mutation == "break_gauss_image":
+        gauss_exact = False
+    u1_population_claimed = mutation == "claim_u1_populates"
+    checks.check(
+        "E-the-gauss-population",
+        "the closed-Z4 divergence image is exactly zero-sum, so the momentum source is populatable iff its expected total charge vanishes",
+        gauss_exact and not u1_population_claimed,
+    )
+
+    pin_exact = all(
+        fixture.pin_transfer_exact
+        and fixture.residual_zero_counts == (0, 0, 0, 0)
+        and fixture.density_descent_left == (0, 0, 0, 0)
+        and fixture.density_descent_right == (0, 0, 0, 0)
+        and fixture.flux_descent_left == (0, 0, 0, 0)
+        and fixture.flux_descent_right == (0, 0, 0, 0)
+        and fixture.adjoint_density == (0, 0, 0, 0)
+        and fixture.adjoint_flux == (0, 0, 0, 0)
+        for fixture in fixtures
+    )
+    if mutation == "break_pin_transfer":
+        pin_exact = False
+    checks.check(
+        "F-the-pin-transfer",
+        "the invertible i^k phase transfers every nonzero quotient residual and the 0/32 density/flux descent and adjointness failures verbatim",
+        pin_exact,
+    )
+
+    energy_exact = all(
+        fixture.time_shift_nnz > 0
+        and fixture.scalar_transfer_exact
+        and fixture.conservation_vacuous
+        and fixture.contractivity_pinned
+        for fixture in fixtures
+    )
+    slice_energy_claimed = mutation == "claim_slice_energy"
+    conservation_content_claimed = mutation == "claim_energy_content"
+    checks.check(
+        "G-the-energy-scope",
+        "one-slice time translation fails; h_k conservation is vacuous for scalar rho_k^2 transfer, while h_k>0 is the pinned Block 119 contractivity fact",
+        energy_exact
+        and not slice_energy_claimed
+        and not conservation_content_claimed,
+    )
+
+    note_scope = scope_certificate(normalized_note(), mutation)
+    elapsed_before_scope = time.monotonic() - started
+    checks.check(
+        "H-scope",
+        "required definiteness/population/phase/pin/energy/N1--N8/W1/N5 firewalls and runtime bound are present",
+        set(note_scope) == set(SCOPE_KEYS)
+        and all(note_scope.values())
+        and elapsed_before_scope <= 400,
+    )
+
+    phase_diagonal = tuple(
+        fixtures[0].phase_form[index, index]
+        for index in range(NX)
+    )
+    momentum_diagonal = tuple(
+        fixtures[0].momentum_form[index, index] for index in range(NX)
+    )
+    print(
+        "SHIFT/SECTOR PHASE: [U_x,Q]=0 and R_x=U_xQ for two exact routings; "
+        f"U_x^phys diag={phase_diagonal}, P_x/(pi/2)={momentum_diagonal}."
+    )
+    print(
+        "DEFINITENESS: sum_z E_z=I_32 gives the norm; P_x has both signs; "
+        "a=e1+e3 has ||a||^2=2, integer charge 1+(-1)=0, mod-4 charge "
+        f"1+3=0, while P_x a={tuple(definiteness.momentum_action)} !=0 — not an eigenstate; zero is an expectation."
+    )
+    print(
+        "GAUSS POPULATION: im(div_Z4)=ker(1,1,1,1); source="
+        f"{tuple(gauss.source)}, exact flux={tuple(gauss.solution)}; the momentum constraint is populatable but the identity U(1) charge is not."
+    )
+    print(
+        "PIN TRANSFER: residual zeros/32 per k are "
+        f"{fixtures[0].residual_zero_counts}/{fixtures[1].residual_zero_counts}; "
+        f"density/flux descent and adjointness are all {fixtures[0].adjoint_density}/{fixtures[0].adjoint_flux}."
+    )
+    print(
+        "TIME-SYMMETRY FAILURE: one-step AP [Q,V] nnz="
+        f"{fixtures[0].time_shift_nnz}/{fixtures[1].time_shift_nnz}, "
+        f"witness sha={fixtures[0].time_shift_digest}/{fixtures[1].time_shift_digest}; no per-slice energy exists."
+    )
+    print(
+        "ENERGY STRUCTURAL FACT (VACUOUS): on each one-dimensional quotient line B_k=rho_k^2 I, so h_k=-log(rho_k^2) commutes with B_k identically and constancy could not fail."
+    )
+    print(
+        "ENERGY CONTENTFUL RESIDUE: h_k>0 is precisely the imported Block 119 per-period contractivity certificate; pinned-interval sha="
+        f"{fixtures[0].interval_digest}/{fixtures[1].interval_digest}."
+    )
+    print(
+        "N5: per_element: exact shift-commutation, routed-identity, phase-reduction, definiteness, gauss-image, pin-transfer, and vacuity certificates are checked"
+    )
+    print(
+        "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus"
+    )
+    print(
+        "per_mode: every momentum sector's shift residual is the invertible phase i^k times the u(1) residual while the quotient momentum charge is indefinite diag(0,1,2,-1)"
+    )
+    print(
+        "per_block: the closed-carrier population wall is a definiteness statement — the identity-valued u(1) charge can never vanish on a positive package but the indefinite momentum charge admits nonzero states of vanishing expected total momentum"
+    )
+    print(
+        "lattice_wide: checked and not executed — the momentum-sourced gauss quotient execution, non-local dressings for the observable wall, the naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient, Records, audit retention, and TOE closure remain open"
+    )
+    print(
+        "RESULT: the momentum constraint is populatable on the closed carrier because its charge is indefinite — the first population break of the campaign — while the local-observable wall transfers verbatim under the invertible sector phase and the only energy object is the already-certified per-period contraction"
+    )
+    print(
+        "DECISION_CUT: execute the momentum-sourced gauss quotient with the vanishing-expectation state class; reject per-slice energy constructions"
+    )
+    print(
+        "TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"FAIL: {type(error).__name__}: {error}")
+        print("TOTAL: PASS=0 FAIL=1")
+        raise


### PR DESCRIPTION
## Block 123 — The Momentum Population Break And The Charge-Definiteness Split

Stacked on #6691 (Block 122). Opens campaign 3 (the stress-tensor
contract). Fifth-file discipline: bounded_theorem note, runner, cache,
block ledger, refreshed citation manifest.

### Result

Block 122 closed the local U(1) chapter and named the stress/momentum
route. This block executes its first half and breaks the campaign's
most stubborn wall:

- **The shift identity.** `[U_x, Q] = 0` exactly; the routed current of
  the spatial-translation symmetry obeys the off-shell
  divergence-commutator identity at all 32 sites, both routings, seam
  included — Block 121's telescoping argument is matrix-generic, and
  per momentum sector the commutator reduces exactly to the invertible
  phase `i^k` times the U(1) commutator.
- **The definiteness theorem (the wall, reframed).** Closed-carrier
  Gauss population is obstructed exactly when the charge operator is
  *definite* on the certified package. The U(1) charge is the identity
  — its total is the norm, strictly positive on every nonzero state:
  that was Block 121's wall, now with its true mechanism named. The
  quotient momentum charge `P_x = diag(0,1,2,-1)` (units `pi/2`, from
  the sector phases) is **indefinite**.
- **The population break.** The nonzero certified-positive state
  occupying the paired momenta `k=1` and `k=3` has vanishing expected
  total momentum under either sign convention (`1+(-1)=0`;
  `1+3=0 mod 4`; the `k=2` ambiguity is irrelevant — that direction is
  unoccupied). The momentum-constraint source therefore admits
  closed-carrier Gauss solutions: **the campaign's first population
  break**. Caveat displayed as a computed fact: the zero is an
  expectation value — `P_x(e1+e3) = e1−e3 ≠ 0`, the state is not an
  eigenstate, and the operator-level constraint question is open and
  named.
- **The pin transfer.** The local-observable wall is momentum-blind:
  the shift residual is `i^k` times the U(1) residual with `i^k`
  invertible, so every Block 122 descent and adjointness failure
  transfers verbatim (0/32).
- **The energy scope, honestly.** No per-slice time-translation
  symmetry exists (the Floquet structure); the per-period conservation
  of `h_k = −log(rho_k²)` is vacuous by construction (a constant under
  a scalar map) and ships only as labeled scope — the contentful
  residue is `h_k > 0` ⟺ contractivity, already certified in Block 119.

### Verification

- Runner: 8/8 PASS (~170 s); recomputes the commutation, the two-routing
  identity, the per-sector phase reduction entrywise, both charge
  operators, the state's expectation values under both conventions, the
  non-eigenstate caveat, the zero-sum Gauss image, the pin transfer, and
  the vacuity split. Mutation sweep: 15/15 clean. N5 byte-identical.
- Independent cross-model verification (Claude fraction checker): all
  items CONFIRMED — the population break in exactly the stated form,
  with the checker identifying the structural reason (definiteness) and
  supplying the expectation-value caveat that the note now carries; the
  energy statement exposed as vacuous and shipped as labeled scope only.
- `vocab_lint` and `audit_lint --strict` clean.
- `run_pipeline.sh` exits 1 at the pre-existing dependency-policy
  epoch-debt gate; identical on the clean base — unrelated to this PR.

### TOE accounting

Zero obligation retirement; no TOE percentage moves; retained-positive
end-to-end theory count remains zero. Bounded theorem; audit-lane
referral for any verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
