### PR TITLE
feat(best6): named hop-cost does not reverse diamond on B6

### DIFF
--- a/docs/NAMED_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NAMED_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,392 @@
+---
+claim_id: named_hopcost_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_6(0), the named equal-weight hop-cost is scored for diamond order at (4,0,0) vs (2,2,2) and for var(|v|_2/t) vs ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/named_hopcost_b6_2026_08_15.py
+---
+
+# Named Equal-Weight Hop-Cost Scored On `B_6(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact integer path costs of one displayed named rule on the
+radius-6 nearest-neighbor ball of one seed; diamond order at `(4,0,0)`
+versus `(2,2,2)` and population variance of `|v|_2/t(v)` on the 376
+nonzero sites. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/named_hopcost_b6_2026_08_15.py`](../scripts/named_hopcost_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `B_6(0)` be the set of sites of `Z^3` reachable from the origin by at
+most six nearest-neighbor steps. This is the 377-site ball. One-seed growth
+starts at `0`. The occupancy `σ_n` at a site `n` is the 6-bit string whose
+direction-`d` bit is set exactly when the neighbor of `n` in direction `d` is
+strictly nearer the seed. This is the inward occupation of the one-seed
+front.
+
+`G+` is the 24-element group of proper cubic rotations about the seed.
+Arrival time `t(n)` is the minimum path cost from `0` to `n` through
+`B_6(0)`.
+
+The named rule `ρ` assigns a hop cost on every inward occupancy pair that
+appears in `B_6`:
+
+```text
+c(σ_v, σ_w) = 3  if |σ_v| = |σ_w| or |σ_v| = 0,
+c(σ_v, σ_w) = 1  otherwise.
+```
+
+Equal inward weight or seed-exit costs `3`; every other inward pair costs
+`1`. The nine inward-weight pairs realized on `B_6(0)` are
+
+```text
+(0,1), (1,0), (1,1), (1,2), (2,1), (2,2), (2,3), (3,2), (3,3).
+```
+
+This note scores that named rule on `B_6(0)`. It does not rescan the
+`3^8 = 6561` fillings. The comparison is not a leftover of the `B_4`
+score: the ball is a different ball, and `(2,2,2)` first appears here.
+
+One Dijkstra capped at the 377-site ball gives
+
+```text
+t(4,0,0) = 12,  t(6,0,0) = 18,  t(2,2,2) = 14.
+```
+
+Diamond reverse at this scale is tested two ways. The explicit scale
+inequality `3 t(4,0,0)^2 > 16 t(2,2,2)^2` fails: `432 > 3136` is false.
+The same axis/body-diagonal order used on `B_3`, now using `(4,0,0)` and
+`(2,2,2)`, is `|v|_2^2`-normalized comparison
+`12 t(4,0,0)^2 > 16 t(2,2,2)^2`, equivalently
+`t(4,0,0)^2 / 16 > t(2,2,2)^2 / 12`. That also fails: `1728 > 3136` is
+false. So diamond does not reverse at this scale.
+
+On the 376 sites of `B_6(0) \ {0}`, write `r(v) = |v|_2 / t(v)` and let
+`var` be the population variance
+
+```text
+var(r) = (1/376) sum_v (r(v) - mean(r))^2.
+```
+
+The named rule has
+
+```text
+var_ρ = 0.00067960829822.
+```
+
+The ell^1 filling `t(v) = |v|_1` on the same sites has
+
+```text
+var_ell1 = 0.01350203761919.
+```
+
+So `var_ρ` is strictly below the ell^1 variance. Displayed, not adopted.
+The note does not attach ell^1, and it does not attach `ρ`, as a
+path-length law.
+
+## Exact Theorems
+
+### Theorem 1
+
+The directed nearest-neighbor edges of `B_6(0)` carry nine inward-weight
+pairs of occupancies, the eight pairs already seen on `B_3(0)` together
+with the equal-weight pair `(3,3)`. The named rule assigns every pair:
+seed-exit `(0,1)` costs `3`, equal-weight pairs cost `3`, and unequal
+pairs cost `1`. In particular `ρ(3,3) = 3`.
+
+One Dijkstra on the 377-site ball yields
+
+```text
+t(4,0,0) = 12,  t(6,0,0) = 18,  t(2,2,2) = 14.
+```
+
+The body-diagonal site `(2,2,2)` is a site of `B_6(0)`
+(`|(2,2,2)|_1 = 6`). Diamond reverse at this scale is the pair
+`((4,0,0),(2,2,2))`. The explicit test `3 t(4,0,0)^2 > 16 t(2,2,2)^2`
+does not hold. The same axis/body-diagonal order used on `B_3`, now using
+`(4,0,0)` and `(2,2,2)`, is the comparison of `t^2 / |v|_2^2`; it also
+does not reverse. Diamond does not reverse at this scale.
+
+The axis path `0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0) → (5,0,0) → (6,0,0)`
+costs `3+3+3+3+3+3 = 18`. The body-diagonal path
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2)` costs
+`3+1+1+3+3+3 = 14`.
+
+### Theorem 2
+
+On the 376 nonzero sites of `B_6(0)`, the population variance of
+`|v|_2/t(v)` for the named rule is `0.00067960829822`. For the
+ell^1 filling `t = |·|_1` on the same sites the same variance is
+`0.01350203761919`. The named rule is therefore strictly below
+ell^1 on this ball.
+
+The `G+` site-types in `B_6(0)` arrive at
+
+```text
+t(1,0,0) = 3,   t(1,1,0) = 4,   t(1,1,1) = 5,
+t(2,0,0) = 6,   t(2,1,0) = 7,   t(2,1,1) = 8,
+t(2,2,0) = 10,  t(2,2,1) = 11,  t(2,2,2) = 14,
+t(3,0,0) = 9,   t(3,1,0) = 10,  t(3,1,1) = 11,
+t(3,2,0) = 13,  t(3,2,1) = 14,  t(3,3,0) = 16,
+t(4,0,0) = 12,  t(4,1,0) = 13,  t(4,1,1) = 14,
+t(4,2,0) = 16,  t(5,0,0) = 15,  t(5,1,0) = 16,
+t(6,0,0) = 18.
+```
+
+The six axis types satisfy `t = 3 |v|_2` exactly. That is why the variance
+remains more than an order of magnitude below ell^1, even though the
+body-diagonal type `(2,2,2)` sits off that ratio. The comparison is scored
+on `B_6(0)` only. It is not a leftover of the `B_4` score: the balls are a
+different ball, and the 376-site list is not the 128-site list. The site
+`(2,2,2)` is new.
+
+### Theorem 3
+
+The named rule is displayed as a finite probe on `B_6(0)`. It is
+not written into Admissibility. No path-length law is attached. The note
+does not attach ell^1 or the displayed rule as a law. The live axiom memo
+continues to state that there is one fixed nearest-neighbor admissibility
+rule, covariant under translations and proper cubic rotations; that rule is
+not replaced by `c(σ_v, σ_w)`. Displayed, not adopted.
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_6(0)` as the 377-site ball | closed by the nearest-neighbor graph of `Z^3` |
+| define inward occupancy of the one-seed front | closed: a bit is set exactly on a strictly nearer neighbor |
+| count `G+` | closed: 24 proper cubic rotations |
+| name `ρ` on every inward occupancy pair in `B_6` | closed: cost `3` iff equal weight or seed-exit, else `1` |
+| report `t(4,0,0)`, `t(6,0,0)`, and `t(2,2,2)` | closed by Theorem 1 |
+| report diamond order at `(4,0,0)` vs `(2,2,2)` | closed by Theorem 1; it does not reverse |
+| score `var(\|v\|_2/t(v))` versus ell^1 on `B_6(0) \ {0}` | closed by Theorem 2; named rule strictly below ell^1 |
+| treat the B_4 score as the B_6 score | refused; different ball, new diagonal |
+| rescan all 6561 fillings | refused; one named rule, one Dijkstra |
+| write a cost into Admissibility | refused; Theorem 3 |
+| attach a path-length law | refused; Theorem 3 |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a cost or of a path-length law is not a proof leaf.
+
+## Representative Values
+
+| filling | `t(4,0,0)` | `t(6,0,0)` | `t(2,2,2)` | `var(\|v\|_2/t)` | diamond reverse? |
+|---|---:|---:|---:|---:|---|
+| ell^1, `t = \|·\|_1` | `4` | `6` | `6` | `0.01350203761919` | no |
+| named `ρ` | `12` | `18` | `14` | `0.00067960829822` | no |
+
+The table is an exact illustration of Theorems 1 and 2, not an adopted
+dynamics.
+
+## Framework Boundary
+
+Admissibility supplies one fixed nearest-neighbor rule, covariant under
+lattice translations and proper cubic rotations, and says that the local
+distribution varies with nearest-neighbor conditions. It does not supply a
+numerical hop cost on occupancy pairs. This note therefore treats
+`c(σ_v, σ_w)` as a displayed probe, not as an axiom clause.
+
+Record is not used. No formation site, formation rate, or readout value is
+assigned to an unoccupied site. The seed is a theorem hypothesis for the
+one-seed front, not a privileged physical site.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `Z^3` nearest-neighbor adjacency and proper cubic rotations | ambient lattice | live axiom memo |
+| one-seed front from `0` | theorem hypothesis | declared; no site is privileged in the axiom |
+| `σ_n` as 6-bit inward occupation | occupancy used by the probe | defined from the one-seed front |
+| named rule `ρ` | displayed hop cost on inward weights | mathematical input; not an axiom |
+| diamond order on `((4,0,0),(2,2,2))` | the scale test pair on `B_6(0)` | declared; first ball that contains `(2,2,2)` |
+| `var(\|v\|_2/t(v))` on `B_6(0) \ {0}` | displayed closeness to `t ∝ \|v\|_2` | computed; not a continuum metric |
+| B_4 score of the B_3 8-tuple | context, not a load-bearing parent | different ball; `(2,2,2)` was absent |
+
+There are no measured, fitted, literature, or observational inputs. A
+continuum metric, a path-length axiom, and any cost written into
+Admissibility remain outside the result.
+
+## Mutations
+
+1. Rescan all 6561 maps on `B_6(0)`: the residual asked only whether this
+   named rule reverses the diamond at `(4,0,0)` versus `(2,2,2)` and
+   whether its variance stays below ell^1. The runner does not rescan.
+2. Treat the B_4 score as already the B_6 score: the balls are a
+   different ball; `(2,2,2)` is new; Theorem 2 recomputes the 376-site
+   variance.
+3. Replace the scale pair by the B_3 pair `((3,0,0),(1,1,1))`: the residual
+   asks for diamond order at this scale, now using `(4,0,0)` and
+   `(2,2,2)`.
+4. Replace population variance by a sample factor `1/375`: the scored set
+   is the finite list of 376 sites, so the mean-square deviation uses
+   `1/376`.
+5. Run more than one Dijkstra or enlarge the graph past `B_6(0)`: the
+   residual scores the 377-site ball with one Dijkstra.
+6. Write `ρ` into Admissibility or attach a path-length law: the live axiom
+   memo still states one fixed covariant nearest-neighbor rule and contains
+   no two-end occupancy hop cost.
+
+## What This Does Not Claim
+
+- No cost is written into Admissibility.
+- No path-length law is attached.
+- The comparison is not scored outside `B_6(0)`.
+- The B_6 score is not a leftover of the B_4 score (different ball).
+- The note does not attach ell^1 as a law.
+- No continuum metric is derived.
+- No privileged physical seed is added to the Lattice axiom.
+- No Record readout is assigned to a site without a record.
+- The 6561-map family is not re-exhausted on this ball.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on `B_6(0)`, scoring the named
+equal-weight hop-cost for diamond order at `(4,0,0)` versus `(2,2,2)` and
+for `var(|v|_2/t)` versus ell^1 is not a leftover of the B_4 score, is not
+an Admissibility clause, and does not attach a path-length law. It is not
+a claim that the named rule belongs in the axiom, nor that it minimizes
+any score on `B_6(0)`.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| leftover of the B_4 score | Argue that the 128-site 8-tuple score is already the 376-site named-rule score. | Theorem 2: different ball; `(2,2,2)` is new; `var_ρ = 0.00067960829822` is a new number. | **ATTEMPTED** |
+| keep the B_3 pair | Treat diamond reverse as `t(3,0,0)` versus `t(1,1,1)` on this ball. | Theorem 1: the scale pair is `((4,0,0),(2,2,2))`; it does not reverse. | **ATTEMPTED** |
+| attach ell^1 | Read the smaller named-rule variance as a path-length law. | Theorem 3: ell^1 is a displayed baseline, not attached. | **ATTEMPTED** |
+| invent a tenth cost | Fold a pair that does not appear on `B_6(0)` into `ρ`. | Theorem 1: the nine realized weight pairs are all named by `ρ`. | **ATTEMPTED** |
+| rescan 6561 fillings | Re-minimize variance on `B_6(0)`. | The residual scores one named rule; the runner does not rescan. | **ATTEMPTED** |
+| adopt the named rule | Write `ρ` into Admissibility. | Theorem 3 and the live axiom memo: one fixed covariant nearest-neighbor rule, no hop cost. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one comparison and one adoption refusal, not a stack of independent
+walls. The diamond-order witness and the variance comparison are two
+certificates of the same B_6 scoring statement.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| diamond order / variance comparison | no: failure to reverse does not fix the 376-site variance | no: a smaller variance does not decide the scale pair | independent conclusions on one named rule |
+| scoring statement / adoption refusal | no: a probe can fail to reverse and still beat ell^1 and still be refused as an axiom | no: refusing adoption does not decide the numbers | independent conclusions |
+
+Path-length attachment is not counted as a third wall: Theorem 3 simply
+does not attach one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “one-seed growth from `0`” | explicit theorem hypothesis; the Lattice axiom privileges no site |
+| “inward occupation of the one-seed front” | defined from nearer neighbors; not an extra occupancy axiom |
+| “named equal-weight hop-cost” | displayed finite probe, not a derived scale |
+| “one Dijkstra capped at the 377-site ball” | the definition of `t` through `B_6(0)` |
+| “`(2,2,2)` is a site” | exact `ℓ^1` radius `6` versus ball radius `6` |
+| “same axis/body-diagonal order as B_3, now using `(4,0,0)` and `(2,2,2)`” | the scale test pair |
+| “population variance on 376 sites” | the finite list `B_6(0) \ {0}` |
+| “not a leftover” of the B_4 score | Theorems 1 and 2; different ball |
+| “Displayed, not adopted” | Theorem 3; no Admissibility edit |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and proper cubic rotations | `Z^3` nearest-neighbor graph and `G+` | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | Admissibility covariance | one fixed covariant nearest-neighbor rule; no hop cost supplied | yes; cost stays displayed |
+| `scripts/named_hopcost_b6_2026_08_15.py:300` | size of the scored ball | `B_6(0)` has 377 sites | yes |
+| `scripts/named_hopcost_b6_2026_08_15.py:316` | arrival times of the scale sites | `t(4,0,0) = 12`, `t(6,0,0) = 18`, `t(2,2,2) = 14` | yes |
+| `scripts/named_hopcost_b6_2026_08_15.py:321` | explicit scale reverse test | `3 t(4,0,0)^2 > 16 t(2,2,2)^2` fails | yes |
+| `scripts/named_hopcost_b6_2026_08_15.py:326` | B_3 order on the scale pair | `(4,0,0)` vs `(2,2,2)` also fails to reverse | yes |
+| `scripts/named_hopcost_b6_2026_08_15.py:354` | variance versus ell^1 | named rule strictly below ell^1 | yes |
+| `scripts/named_hopcost_b6_2026_08_15.py:366` | leftover of the B_4 score | note states different ball | yes |
+| `scripts/named_hopcost_b6_2026_08_15.py:374` | adoption of a cost | note and axiom keep the cost out of Admissibility | yes |
+
+No evidence citation is used to claim a path-length axiom, a continuum
+metric, or an Admissibility rewrite.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: each directed `B_6(0)` edge | nine named inward-weight pairs |
+| per site | yes: `|v|_2/t(v)` on each nonzero site | no other occupancy dictionary is used |
+| per mode | yes: the single named rule | the 6561-map family is not re-exhausted |
+| per block | yes: diamond order and variance on `B_6(0) \ {0}` | closeness is the stated variance only |
+| lattice wide | no | no Admissibility cost and no path-length law are adopted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies a two-end occupancy hop cost, and none is
+reclassified as an import or wall.
+
+Two partial-closure mechanisms are recorded rather than suppressed. The
+B_4 score of the B_3 8-tuple is a strictly smaller-ball statement: it
+does not score `B_6(0)` and cannot host `(2,2,2)`. Naming `ρ` on the
+finite weight pairs is a strictly weaker statement: it does not decide
+diamond order or the 376-site variance. The remaining physical
+choice—whether any hop cost belongs in Admissibility—stays explicit and
+does not require an axiom edit.
+
+### N7 — hostile steelman
+
+The strongest objection is that transporting the named rule from the B_3
+8-tuple to `B_6(0)` is automatic leftover: the same seed-exit cost, the
+same equal-weight cost, and the same axis path should make the larger-ball
+score a corollary, including a continuing diamond reverse. The objection
+correctly identifies that the axis types remain pinned to `t = 3 |v|_2`.
+It fails because `B_6(0)` is a different finite list, first contains the
+body-diagonal site `(2,2,2)`, and that site arrives at `t = 14`, which
+is slower than the axis ratio. The 376-site variance and the failure of
+both reverse tests are new certificates, not leftovers.
+
+### N8 — cross-cycle echo
+
+The live axiom memo is the only load-bearing parent. Nearby covariance
+language is context.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | proper cubic covariance of the nearest-neighbor rule | used as `G+` equivariance of the displayed cost; the rule itself is not replaced |
+| B_4 score of the B_3 8-tuple | same named costs, smaller ball, no `(2,2,2)` | scored as a strictly smaller-ball parent; Theorems 1 and 2 are not leftovers |
+| existence of 405 reversing `{1,2,3}` fillings | eight B_3 orbits, existence only | not re-exhausted; this note scores one named rule |
+
+No earlier mechanism retires the B_6 score or the adoption refusal.
+
+No-Go Discipline disposition: **PASS** for the bounded comparison and the
+adoption boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Runner Contract
+
+The companion runner builds the 24 proper cubic rotations and the 377-site
+ball; assigns the named equal-weight hop-cost on every inward occupancy
+pair in `B_6`; runs one Dijkstra capped at `B_6(0)`; reports
+`t(4,0,0) = 12`, `t(6,0,0) = 18`, and `t(2,2,2) = 14`; reports that
+diamond does not reverse at this scale under either the explicit test or
+the B_3 axis/body-diagonal order; compares `var(|v|_2/t)` to ell^1 on the
+376 nonzero sites; rejects the mutation families, including leftover of
+the B_4 score and a 6561 rescan; and verifies that the live axiom memo
+does not host the displayed cost. Declared audit inputs are this note and
+the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12713,6 +12713,10 @@
   "naive_lattice_fermion_two_power_d_species_count_narrow_theorem_note_2026-05-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "named_hopcost_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "native_carrier_registration_kernel_rate_vs_unit_variance_point_theorem_note_2026-07-02": {
    "deps_hash": "f0528fe9a3de",

--- a/logs/runner-cache/named_hopcost_b6_2026_08_15.txt
+++ b/logs/runner-cache/named_hopcost_b6_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/named_hopcost_b6_2026_08_15.py
+runner_sha256: 604f830b4a55eae1c51492576dca581217fa03184902cc955a28aeb384eb842a
+input_fingerprint_sha256: 2f1aa10e9bb32ead3830f950eae506f88759e0e839fec2a8e85ee29cb34a9de4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none; B_6(0), G+, and the named hop-cost are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact integer path costs and |v|_2/t(v) on the radius-6 ball
+negative_scope: displayed two-end costs are not written into Admissibility
+orbit_weights_b6: ((0, 1), (1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (2, 3), (3, 2), (3, 3))
+n_b6_sites: 377
+n_b6_edges: 1752
+t(4,0,0): 12
+t(6,0,0): 18
+t(2,2,2): 14
+t(3,0,0): 9
+t(1,1,1): 5
+type_times: (3, 4, 5, 6, 7, 8, 10, 11, 14, 9, 10, 11, 13, 14, 16, 12, 13, 14, 16, 15, 16, 18)
+diamond_spec_reverse: False
+diamond_b3_order_reverse: False
+var_rho: 0.00067960829822208246407407595810321516843827431543681422753506520559981143994638769
+var_l1: 0.013502037619189685715111160448540921258737937159205231622759066199133158218733037
+PASS: gplus-order proper cubic rotations number 24
+PASS: ball-size B_6(0) has 377 sites
+PASS: nonzero-sites the scored set B_6(0)\{0} has 376 sites
+PASS: one-dijkstra one Dijkstra is capped at the 377-site ball
+PASS: thm1-weight-pairs B_6 inward occupancy pairs realize the nine weight pairs including (3,3)
+PASS: thm1-times the named rule realizes t(4,0,0)=12, t(6,0,0)=18, t(2,2,2)=14
+PASS: thm1-diamond-spec the scale test 3 t(4,0,0)^2 > 16 t(2,2,2)^2 fails: 432 vs 3136
+PASS: thm1-diamond-b3-order the B_3 axis/body-diagonal order on (4,0,0) vs (2,2,2) also fails to reverse
+PASS: thm1-note-times the note exhibits t(4,0,0), t(6,0,0), t(2,2,2) and reports no reverse
+PASS: thm2-type-times selected G+ type arrival times include axis 3k and body-diagonal 14
+PASS: thm2-vars-computed computed named-rule and ell^1 variances match the displayed digits
+PASS: thm2-rho-below-l1 var(|v|_2/t) on the named rule is strictly below ell^1 on the same 376 sites
+PASS: thm2-note-vars the note reports both population variances and which is smaller
+PASS: thm2-not-leftover-b4 the note states the B_6 score is not a leftover of the B_4 score
+PASS: thm3-displayed-not-adopted the note reports the named rule as displayed, not adopted
+PASS: thm3-no-l1-law the note does not attach an ell^1 path-length law
+PASS: no-rescan the runner does not rescan the 6561 fillings
+PASS: claim-scope claim_scope reports the B_6 named-rule score only
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: forbidden-strings note, runner, and axiom avoid the dispatch-forbidden phrases
+PASS: no-axiom-cost the live axiom memo does not host a two-end occupancy hop cost
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+per_element: checked exactly — each directed B_6(0) edge carries the named equal-weight hop-cost
+per_site: checked exactly — |v|_2/t(v) is scored on each of the 376 nonzero sites
+per_mode: checked exactly — the single named rule, with one Dijkstra and no 6561 rescan
+per_block: checked exactly — diamond order and population variance on B_6(0)\{0}
+lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/named_hopcost_b6_2026_08_15.py
+++ b/scripts/named_hopcost_b6_2026_08_15.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Score the named equal-weight hop-cost on B_6(0) only.
+
+The named rule rho assigns cost 3 iff the inward weights are equal or the
+source is the seed, else cost 1, on every inward occupancy pair that
+appears in B_6. This runner does not rescan the 6561 fillings. It runs one
+Dijkstra on the 377-site ball B_6(0) and reports diamond order at (4,0,0)
+versus (2,2,2) and the population variance of |v|_2 / t(v) versus ell^1.
+The cost is displayed, not adopted. No axiom edit and no path-length law.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from itertools import permutations, product
+from pathlib import Path
+
+
+getcontext().prec = 80
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "NAMED_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/NAMED_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+SHIFT_INDEX = {shift: index for index, shift in enumerate(SHIFTS)}
+ORIGIN: Point = (0, 0, 0)
+AXIS4: Point = (4, 0, 0)
+AXIS6: Point = (6, 0, 0)
+DIAG6: Point = (2, 2, 2)
+AXIS3: Point = (3, 0, 0)
+DIAG3: Point = (1, 1, 1)
+EXPECTED_WEIGHTS = (
+    (0, 1),
+    (1, 0),
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (2, 3),
+    (3, 2),
+    (3, 3),
+)
+ORBIT_TYPES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (1, 1, 0),
+    (1, 1, 1),
+    (2, 0, 0),
+    (2, 1, 0),
+    (2, 1, 1),
+    (2, 2, 0),
+    (2, 2, 1),
+    (2, 2, 2),
+    (3, 0, 0),
+    (3, 1, 0),
+    (3, 1, 1),
+    (3, 2, 0),
+    (3, 2, 1),
+    (3, 3, 0),
+    (4, 0, 0),
+    (4, 1, 0),
+    (4, 1, 1),
+    (4, 2, 0),
+    (5, 0, 0),
+    (5, 1, 0),
+    (6, 0, 0),
+)
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def graph_radius(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclid2(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def ball(radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for coords in product(span, repeat=3):
+        if graph_radius(coords) <= radius:
+            sites.append(coords)
+    return tuple(sites)
+
+
+def occupancy(point: Point) -> int:
+    """6-bit inward occupation of the one-seed front at ``point``."""
+    bits = 0
+    for index, shift in enumerate(SHIFTS):
+        neighbor = (
+            point[0] + shift[0],
+            point[1] + shift[1],
+            point[2] + shift[2],
+        )
+        if graph_radius(neighbor) < graph_radius(point):
+            bits |= 1 << index
+    return bits
+
+
+def inward_weight(point: Point) -> int:
+    return bin(occupancy(point)).count("1")
+
+
+def named_cost(src: Point, dst: Point) -> int:
+    """Cost 3 iff equal inward weight or seed-exit, else 1."""
+    weight_src = inward_weight(src)
+    weight_dst = inward_weight(dst)
+    if weight_src == weight_dst or weight_src == 0:
+        return 3
+    return 1
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1] + matrix[0][2] * point[2],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1] + matrix[1][2] * point[2],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1] + matrix[2][2] * point[2],
+    )
+
+
+def determinant(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src, dest in enumerate(perm):
+                rows[src][dest] = signs[src]
+            matrix = tuple(tuple(row) for row in rows)
+            if determinant(matrix) == 1:
+                rotations.append(matrix)
+    return tuple(rotations)
+
+
+def directed_edges(sites: tuple[Point, ...]) -> tuple[tuple[Point, Point], ...]:
+    present = set(sites)
+    edges: list[tuple[Point, Point]] = []
+    for site in sites:
+        for shift in SHIFTS:
+            neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+            if neighbor in present:
+                edges.append((site, neighbor))
+    return tuple(edges)
+
+
+def shortest_named(
+    start: Point,
+    adj: dict[Point, list[tuple[Point, int]]],
+) -> dict[Point, int]:
+    dist = {start: 0}
+    heap: list[tuple[int, Point]] = [(0, start)]
+    while heap:
+        current, node = heapq.heappop(heap)
+        if current != dist[node]:
+            continue
+        for neighbor, cost in adj[node]:
+            trial = current + cost
+            prior = dist.get(neighbor)
+            if prior is None or trial < prior:
+                dist[neighbor] = trial
+                heapq.heappush(heap, (trial, neighbor))
+    return dist
+
+
+def spec_reverse(t_axis: int, t_diag: int) -> bool:
+    return 3 * t_axis * t_axis > 16 * t_diag * t_diag
+
+
+def b3_order_reverse(t_axis: int, t_diag: int) -> bool:
+    return 12 * t_axis * t_axis > 16 * t_diag * t_diag
+
+
+def reverses_b3(t_axis: int, t_diag: int) -> bool:
+    return 3 * t_axis * t_axis > 9 * t_diag * t_diag
+
+
+def ratio_list(dist: dict[Point, int], sites: tuple[Point, ...]) -> list[Decimal]:
+    values: list[Decimal] = []
+    for point in sites:
+        if point == ORIGIN:
+            continue
+        arrival = dist[point]
+        values.append(Decimal(euclid2(point)).sqrt() / Decimal(arrival))
+    return values
+
+
+def population_variance(values: list[Decimal]) -> Decimal:
+    count = Decimal(len(values))
+    mean = sum(values) / count
+    return sum((item - mean) ** 2 for item in values) / count
+
+
+def rounded(value: Decimal, places: int) -> str:
+    quantize = Decimal(10) ** -places
+    return format(value.quantize(quantize), "f")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; B_6(0), G+, and the named hop-cost are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact integer path costs and |v|_2/t(v) on the radius-6 ball")
+    print("negative_scope: displayed two-end costs are not written into Admissibility")
+
+    rotations = proper_cubic_rotations()
+    sites = ball(6)
+    edges = directed_edges(sites)
+    adj: dict[Point, list[tuple[Point, int]]] = defaultdict(list)
+    weight_pairs: set[tuple[int, int]] = set()
+    for src, dst in edges:
+        adj[src].append((dst, named_cost(src, dst)))
+        weight_pairs.add((inward_weight(src), inward_weight(dst)))
+    weights = tuple(sorted(weight_pairs))
+
+    reached = shortest_named(ORIGIN, adj)
+    l1_dist = {point: graph_radius(point) for point in sites}
+    var_rho = population_variance(ratio_list(reached, sites))
+    var_l1 = population_variance(ratio_list(l1_dist, sites))
+    type_times = tuple(reached[point] for point in ORBIT_TYPES)
+    t_axis4 = reached[AXIS4]
+    t_axis6 = reached[AXIS6]
+    t_diag6 = reached[DIAG6]
+    t_axis3 = reached[AXIS3]
+    t_diag3 = reached[DIAG3]
+    diamond_spec = spec_reverse(t_axis4, t_diag6)
+    diamond_b3 = b3_order_reverse(t_axis4, t_diag6)
+
+    print(f"orbit_weights_b6: {weights}")
+    print(f"n_b6_sites: {len(sites)}")
+    print(f"n_b6_edges: {len(edges)}")
+    print(f"t(4,0,0): {t_axis4}")
+    print(f"t(6,0,0): {t_axis6}")
+    print(f"t(2,2,2): {t_diag6}")
+    print(f"t(3,0,0): {t_axis3}")
+    print(f"t(1,1,1): {t_diag3}")
+    print(f"type_times: {type_times}")
+    print(f"diamond_spec_reverse: {diamond_spec}")
+    print(f"diamond_b3_order_reverse: {diamond_b3}")
+    print(f"var_rho: {format(var_rho, 'f')}")
+    print(f"var_l1: {format(var_l1, 'f')}")
+
+    checks.check("gplus-order", "proper cubic rotations number 24", len(rotations) == 24)
+    checks.check("ball-size", "B_6(0) has 377 sites", len(sites) == 377)
+    checks.check(
+        "nonzero-sites",
+        "the scored set B_6(0)\\{0} has 376 sites",
+        sum(1 for point in sites if point != ORIGIN) == 376,
+    )
+    checks.check(
+        "one-dijkstra",
+        "one Dijkstra is capped at the 377-site ball",
+        len(sites) == 377 and len(reached) == 377 and DIAG6 in reached,
+    )
+    checks.check(
+        "thm1-weight-pairs",
+        "B_6 inward occupancy pairs realize the nine weight pairs including (3,3)",
+        weights == EXPECTED_WEIGHTS,
+    )
+    checks.check(
+        "thm1-times",
+        "the named rule realizes t(4,0,0)=12, t(6,0,0)=18, t(2,2,2)=14",
+        t_axis4 == 12 and t_axis6 == 18 and t_diag6 == 14,
+    )
+    checks.check(
+        "thm1-diamond-spec",
+        "the scale test 3 t(4,0,0)^2 > 16 t(2,2,2)^2 fails: 432 vs 3136",
+        not diamond_spec and 3 * 144 == 432 and 16 * 196 == 3136,
+    )
+    checks.check(
+        "thm1-diamond-b3-order",
+        "the B_3 axis/body-diagonal order on (4,0,0) vs (2,2,2) also fails to reverse",
+        not diamond_b3 and 12 * 144 < 16 * 196,
+    )
+    checks.check(
+        "thm1-note-times",
+        "the note exhibits t(4,0,0), t(6,0,0), t(2,2,2) and reports no reverse",
+        "t(4,0,0) = 12" in note
+        and "t(6,0,0) = 18" in note
+        and "t(2,2,2) = 14" in note
+        and "does not reverse" in note,
+    )
+    checks.check(
+        "thm2-type-times",
+        "selected G+ type arrival times include axis 3k and body-diagonal 14",
+        type_times[ORBIT_TYPES.index(AXIS4)] == 12
+        and type_times[ORBIT_TYPES.index(AXIS6)] == 18
+        and type_times[ORBIT_TYPES.index(DIAG6)] == 14
+        and type_times[ORBIT_TYPES.index((1, 0, 0))] == 3
+        and type_times[ORBIT_TYPES.index((2, 2, 0))] == 10,
+    )
+    checks.check(
+        "thm2-vars-computed",
+        "computed named-rule and ell^1 variances match the displayed digits",
+        rounded(var_rho, 14) == "0.00067960829822"
+        and rounded(var_l1, 14) == "0.01350203761919",
+    )
+    checks.check(
+        "thm2-rho-below-l1",
+        "var(|v|_2/t) on the named rule is strictly below ell^1 on the same 376 sites",
+        var_rho < var_l1,
+    )
+    checks.check(
+        "thm2-note-vars",
+        "the note reports both population variances and which is smaller",
+        "0.00067960829822" in note
+        and "0.01350203761919" in note
+        and "strictly below" in note,
+    )
+    checks.check(
+        "thm2-not-leftover-b4",
+        "the note states the B_6 score is not a leftover of the B_4 score",
+        "not a leftover" in note
+        and "B_4" in note
+        and "different ball" in note
+        and "(2,2,2)" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the note reports the named rule as displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    checks.check(
+        "thm3-no-l1-law",
+        "the note does not attach an ell^1 path-length law",
+        "no path-length law" in note and "not attach" in note,
+    )
+    checks.check(
+        "no-rescan",
+        "the runner does not rescan the 6561 fillings",
+        "product((1, 2, 3), " + "repeat" not in source
+        and "6561" in note
+        and "does not rescan" in note
+        and source.count("shortest_" + "named(") == 2,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the B_6 named-rule score only",
+        "On B_6(0), the named equal-weight hop-cost is scored"
+        in note
+        and "var(|v|_2/t)" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/NAMED_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in source
+        and '"docs/NAMED_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"'
+        in source,
+    )
+    checks.check(
+        "forbidden-strings",
+        "note, runner, and axiom avoid the dispatch-forbidden phrases",
+        all(token not in note and token not in source for token in forbidden_tokens()),
+    )
+    checks.check(
+        "no-axiom-cost",
+        "the live axiom memo does not host a two-end occupancy hop cost",
+        "two-end occupancy" not in axiom and "c(σ_v, σ_w)" not in axiom,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+
+    print(
+        "per_element: checked exactly — each directed B_6(0) edge carries the named equal-weight hop-cost"
+    )
+    print(
+        "per_site: checked exactly — |v|_2/t(v) is scored on each of the 376 nonzero sites"
+    )
+    print(
+        "per_mode: checked exactly — the single named rule, with one Dijkstra and no 6561 rescan"
+    )
+    print(
+        "per_block: checked exactly — diamond order and population variance on B_6(0)\\{0}"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B6, rho has t(4,0,0)=12, t(6,0,0)=18, t(2,2,2)=14. Diamond does not reverse. var=0.00068 vs l1 0.0135. Displayed, not adopted. No axiom edit.

## Runner

`scripts/named_hopcost_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.