### PR TITLE
feat(samhost): same-host fire survives labels but not cost-1 filter

### DIFF
--- a/docs/SAME_HOST_AGEBIT_HOPCOST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SAME_HOST_AGEBIT_HOPCOST_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,341 @@
+---
+claim_id: same_host_agebit_hopcost_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the uneqrad breaker, leftover-frame fire and the named hop cost are scored on the same host. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/same_host_agebit_hopcost_2026_08_15.py
+---
+
+# Same-Host Leftover-Frame Fire And Named Hop Cost (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one host only, the uneqrad lex-first breaker
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))` and the unread
+six-neighbor star at `v = (−3,−3,−1)`. Score leftover-frame-positive fire
+`f` and the named hop cost `ρ` on this host. Uniqueness is not required.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/same_host_agebit_hopcost_2026_08_15.py`](../scripts/same_host_agebit_hopcost_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+## Result Up Front
+
+Investment ourmem scored leftover-frame fire on the uneqrad host and
+hop-cost reverse on a second host. New residual: on the uneqrad
+lex-first breaker, does the named hop-cost `ρ` change `N_new` of
+leftover-frame `f`? A matching member must carry both extras on one
+host. Uniqueness not required. Do not attach L1.
+
+Host `U` is the uneqrad lex-first breaker. Direction order is
+
+`(+x, −x, +y, −y, +z, −z)`.
+
+Occupancy mask
+
+`σ = (1, 0, 1, 0, 1, 1)`.
+
+`f` is the leftover-frame-positive pair section. The named hop cost is
+
+`ρ = 3` iff equal inward weight or seed-exit, else `1`.
+
+Inward occupation at a site `x` uses the same seed-distance already
+used for lock-ticks,
+
+`d(x) = min_i ‖x − s_i‖_1`,
+
+with a direction bit set exactly when the neighbor is strictly nearer
+the nearest seed. Inward weight is the number of such bits. Seed-exit
+means the source has inward weight `0`.
+
+**Theorem 1.** On `U`, `f` still fires `N_new = 1` when hop costs are
+ignored (bitfire).
+
+**Theorem 2.** Assigning `ρ` to directed nearest-neighbor edges of `U`
+does not change the occupancy mask or the age bit, so `f` still fires
+`N_new = 1`. If `ρ` is instead used as a readiness filter (fire only
+along cost-1 edges), the filtered occupancy is `σ_ready = (1, 0, 1, 0, 1, 0)`
+and `N_new = 0`.
+
+**Theorem 3.** Displayed, not adopted. Do not write `f` or `ρ` into
+Admissibility. Do not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Current Premise Boundary
+
+The Lattice, Admissibility, Record, and Qubit sentences used here are quoted
+from [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+it does not supply the formation site, probability,
+or rate.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site never carries more than one record; records are permanent.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility names neither the leftover-frame-positive section nor any
+numerical hop cost as the framework's fixed rule. Record permanence is
+used only to keep the locks on `U`. Formation site and rate remain
+outside the axiom memo. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact same-host score of leftover-frame-positive f and named hop-cost ρ on the uneqrad lex-first breaker: bitfire N_new=1, ρ does not change σ or b, and the cost-1 readiness filter reports N_new=0. Displayed report only."
+trace_class: frontier_discovery
+target_claim_id: same_host_agebit_hopcost
+target_blocker_text: "on the uneqrad lex-first breaker, whether the named hop-cost ρ changes N_new of leftover-frame f"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of same-host f and ρ, including the readiness-filter N_new; do not write f or ρ into Admissibility or attach L1"
+conditional_surface_status: "exact on the uneqrad lex-first breaker; bitfire N_new=1; ρ leaves σ and b unchanged so N_new=1; readiness filter N_new=0; displayed, not adopted"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `s1 = (−2,−2,−2)`, `s2 = (−2,−2,−1)`, and `s3 = (−2,−2,1)`. The
+closed ℓ¹ ball of radius `r` is
+
+`B_r(c) = { x ∈ Z^3 : ‖x − c‖_1 ≤ r }`.
+
+The locked set is the already-given unequal-radius union
+
+`U = B_2((−2,−2,−2)) ∪ B_1((−2,−2,−1)) ∪ B_3((−2,−2,1))`.
+
+The three balls have 25, 7, and 63 sites. Pairwise overlaps are 7, 7,
+and 7, and the triple overlap has 7 sites, so `|U| = 81`. The unread
+site is
+
+`v = (−3,−3,−1)`.
+
+Then `‖v − s1‖_1 = 3 > 2`, `‖v − s2‖_1 = 2 > 1`, and
+`‖v − s3‖_1 = 4 > 3`, so `v ∉ U`.
+
+The six nearest neighbors, in the declared order, are
+
+| slot | neighbor | in `U` | lock tick | inward weight |
+|---|---|---|---|---|
+| `+x` | `(−2,−3,−1)` | yes | `1` | `1` |
+| `−x` | `(−4,−3,−1)` | no | none | `2` |
+| `+y` | `(−3,−2,−1)` | yes | `1` | `1` |
+| `−y` | `(−3,−4,−1)` | no | none | `2` |
+| `+z` | `(−3,−3,0)` | yes | `3` | `4` |
+| `−z` | `(−3,−3,−2)` | yes | `2` | `2` |
+
+Occupancy mask at `v`:
+
+`σ = (1, 0, 1, 0, 1, 1)`.
+
+On the four occupied slots the lock-tick list is
+
+`t = (1, ·, 1, ·, 3, 2)`,
+
+so `t(+x) = t(+y) = 1`, `t(+z) = 3`, and `t(−z) = 2`. Empty slots have
+no tick. The unique full axis is `z`. The age bit is
+`b = [t(−z) < t(+z)]`, hence `b = 1`. Letters are `{0, +, −}` with `0`
+empty. Encode `0 ↦ 0`, `+ ↦ 1`, `− ↦ 2`. The July-3 `k = 3` pair is
+the unique pair of proper-cube orbits of 3-letter 6-tuples that are not
+proper-equivalent to their inversion images. That set has 48 members.
+
+Completions of `(σ,b)` are the pair members that match occupancy `σ`
+and write `c(+z)=+`, `c(−z)=−` when `b = 1`. The leftover-frame sign of
+a completion is the determinant of the ordered triple of directions
+(leftover `+`, leftover `−`, full-axis `+` letter). The section `f`
+takes the unique completion of sign `+1`. A displayed pair step at an
+unread site forms that site if and only if the encoded 6-tuple lies in
+the pair; existing locks are not removed.
+
+Inward occupation at `x` is the 6-bit string whose direction bit is
+set exactly when `d` of the neighbor is strictly less than `d(x)`. The
+unread center has
+
+`d(v) = 2`, inward occupancy `(1, 0, 1, 0, 0, 0)`, inward weight `2`.
+
+On a directed nearest-neighbor edge `x → y`,
+
+`ρ(x → y) = 3` if `|σ_in(x)| = |σ_in(y)|` or `|σ_in(x)| = 0`, else `1`.
+
+The directed nearest-neighbor graph of `U` has 288 edges. Assigning
+`ρ` labels those edges. It does not rewrite which neighbors of `v` lie
+in `U`, and it does not rewrite the lock-ticks `t(w) = d(w)`.
+
+The four occupied-neighbor edges into `v` receive
+
+| edge | inward weights | `ρ` |
+|---|---|---|
+| `+x → v` | `(1, 2)` | `1` |
+| `+y → v` | `(1, 2)` | `1` |
+| `+z → v` | `(4, 2)` | `1` |
+| `−z → v` | `(2, 2)` | `3` |
+
+The `−z` edge is cost `3` because the inward weights are equal. A
+readiness filter that fires only along cost-1 edges keeps the three
+cost-1 occupied slots and drops `−z`, so
+
+`σ_ready = (1, 0, 1, 0, 1, 0)`.
+
+That mask has no unique full axis.
+
+Score this uneqrad host only. One host only.
+
+## Theorem 1 — hop costs ignored, `f` still fires
+
+The unique full axis of `σ` is `z`. The bit `b = 1` writes `+` on `+z`
+and `−` on `−z`. The two completions are
+
+`(+, 0, −, 0, +, −)` and `(−, 0, +, 0, +, −)`.
+
+The first has leftover `+` on `+x`, leftover `−` on `+y`, and full-axis
+`+` on `+z`. That ordered triple of directions has determinant `+1`.
+Therefore
+
+`f(σ,b) = (+, 0, −, 0, +, −)`.
+
+This 6-tuple lies in the 48-member July-3 pair. The center `v` is
+unread. With hop costs ignored, the displayed pair step forms exactly
+`v` (`N_new = 1`) and does not remove any lock of `U`. So `U`
+persists. Same fire report as bitfire, now as the hop-cost-ignored
+coordinate of the same-host pair.
+
+## Theorem 2 — `ρ` as edge labels versus as a readiness filter
+
+Assigning `ρ` to the 288 directed nearest-neighbor edges of `U` is a
+labeling of already-present edges. Occupancy `σ` is the 6-bit
+indicator of `U` at `v`. The age bit is `b = [t(−z) < t(+z)]` from
+the lock-ticks `t(w) = d(w)`. Neither definition reads `ρ`. After the
+labeling,
+
+`σ = (1, 0, 1, 0, 1, 1)`, `b = 1`,
+
+unchanged, so the same section `f(σ,b)` still fires `N_new = 1` and
+`U` persists.
+
+If `ρ` is instead used as a readiness filter, an occupied neighbor
+participates in the pair step only when the directed edge from that
+neighbor to `v` has cost `1`. The filtered occupancy is
+`σ_ready = (1, 0, 1, 0, 1, 0)`. That 6-tuple has no unique full axis,
+so leftover-frame-positive `f` is not defined on the filtered star.
+The pair step does not form `v`. Under the filter,
+
+`N_new = 0`.
+
+Thus `ρ` as a mere labeling of `U` does not change `N_new` of `f`,
+while `ρ` as a cost-1 readiness filter does: `N_new` drops from `1`
+to `0`. A matching member that wants both extras on this host must
+carry both and must say which of those two uses of `ρ` it means.
+Uniqueness of that member is not required.
+
+This residual is not leftover of ourmem (those two extras were scored
+on two hosts) and is not leftover of bitfire (hop costs were ignored).
+
+## Theorem 3 — displayed, not adopted
+
+The same-host pair `(f, ρ)`, the unchanged `(σ, b)`, and the two
+`N_new` reports are displayed member data. They are not the
+framework's fixed Admissibility rule. This note does not write `f` or
+`ρ` into Admissibility. Do not write f or ρ into Admissibility.
+Do not attach L1. Occupancy-only formation is not attached. Qubit
+remains `M_2(C)`. No approved primitive is added. No axiom edit.
+
+## Honest-auditor / Boundary
+
+- **What is proved.** On the uneqrad lex-first breaker, hop-cost-ignored
+  leftover-frame-positive `f(σ,b) = (+, 0, −, 0, +, −)` fires with
+  `N_new = 1` and `U` persists. Assigning `ρ` to directed
+  nearest-neighbor edges of `U` leaves `σ` and `b` unchanged, so that
+  same `f` still fires `N_new = 1`. Used as a cost-1 readiness filter,
+  `ρ` yields `σ_ready = (1, 0, 1, 0, 1, 0)` and `N_new = 0`.
+- **What is displayed only.** The same-host pair `(f, ρ)` and the two
+  uses of `ρ` are one rival table. They are not adopted.
+- **What is not claimed.** No attachment of `f` or `ρ` to
+  Admissibility; no attachment of L1; no uniqueness of the matching
+  member; no leftover of ourmem (two hosts) or of bitfire (hop costs
+  ignored); no axiom edit; no formation rate; no compiler no-go; no
+  second host.
+- **Mutation controls.** A rebuilt `f(σ,b)` other than
+  `(+, 0, −, 0, +, −)` fails. A rebuilt hop-cost-ignored `N_new ≠ 1`
+  fails. A rebuilt `(σ, b)` after assigning `ρ` other than
+  `((1, 0, 1, 0, 1, 1), 1)` fails. A rebuilt readiness-filter
+  `N_new ≠ 0` or `σ_ready` other than `(1, 0, 1, 0, 1, 0)` fails. A
+  note that writes `f` or `ρ` into Admissibility, attaches L1, claims
+  uniqueness, scores a second host, or authors an audit verdict fails.
+
+This note authors no audit verdict.
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name the uneqrad lex-first breaker and rebuild `f` | closed by Theorem 1 |
+| report hop-cost-ignored `N_new` | closed by Theorem 1; `N_new = 1` |
+| name `ρ` on inward weights of this host | closed: cost `3` iff equal inward weight or seed-exit |
+| show `ρ` does not change `σ` or `b` | closed by Theorem 2 |
+| report `N_new` after labeling `U` by `ρ` | closed by Theorem 2; `N_new = 1` |
+| report readiness-filter `N_new` | closed by Theorem 2; `N_new = 0` |
+| treat two-host pairing as the same-host score | refused; not leftover of ourmem |
+| treat hop-cost-ignored fire as the same-host score | refused; not leftover of bitfire |
+| write `f` or `ρ` into Admissibility | refused; Theorem 3 |
+| attach L1 | refused; Theorem 3 |
+| claim uniqueness | refused; uniqueness not required |
+
+The obligation graph is acyclic. Adoption of `f` or of `ρ` is not a
+proof leaf.
+
+## What This Does Not Claim
+
+- Do not write `f` or `ρ` into Admissibility.
+- Do not attach L1.
+- Uniqueness is not required and is not claimed.
+- The comparison is not leftover of ourmem (two hosts).
+- The comparison is not leftover of bitfire (hop costs ignored).
+- One host only; no second host is scored.
+- No path-length law is attached.
+- No Record readout is assigned to a site without a record.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Primary Runner
+
+The primary runner rebuilds `U`, the star at `v`, occupancy `σ`,
+lock ticks `t`, the age bit `b = [t(−z) < t(+z)]`, the 48-member
+July-3 pair, leftover-frame-positive `f(σ,b)`, hop-cost-ignored fire
+(`N_new = 1`, `U` persists), inward weights and `ρ` on directed
+nearest-neighbor edges of `U`, the unchanged `(σ, b)` after that
+labeling, the four incoming costs at `v`, the cost-1 readiness filter
+(`σ_ready`, `N_new = 0`), the current premise boundary, and the
+mutation controls. It scores this uneqrad host only. It writes no
+cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16557,6 +16557,10 @@
   "same_family_3d_closure_note": {
    "deps_hash": "473ab73403e7",
    "out_degree": 3
+  },
+  "same_host_agebit_hopcost_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "scalar_3plus1_temporal_ratio_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/same_host_agebit_hopcost_2026_08_15.txt
+++ b/logs/runner-cache/same_host_agebit_hopcost_2026_08_15.txt
@@ -1,0 +1,76 @@
+===== runner cache v1 =====
+runner: scripts/same_host_agebit_hopcost_2026_08_15.py
+runner_sha256: 86a8ece4340e126ae01c49a447a71e8d970a68a6ce9f22761ea06c93143b4f26
+input_fingerprint_sha256: 95bcc3a3cd39827321be82242dd5d2345643f2a5b653151cd266792a8d0e1513
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SAME_HOST_AGEBIT_HOPCOST_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: current Lattice, Qubit, Admissibility, and Record sentences; leftover-frame-positive section rebuilt from the July-3 pair; named hop-cost rho; uneqrad lex-first breaker
+construction: one host U=B_2((-2,-2,-2))∪B_1((-2,-2,-1))∪B_3((-2,-2,1)), unread v=(-3,-3,-1), f leftover-frame-positive, rho=3 iff equal inward weight or seed-exit else 1
+negative_scope: one host only; displayed, not adopted; L1 not attached; f and rho not written into Admissibility
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static two-string literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-covariance Admissibility still requires one proper-cubic covariant rule
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-qubit Qubit remains M_2(C)
+PASS: source-record lock, permanence, content-only readout, and unreadability at absence are pinned
+U_card=81
+v_in_U=False
+occupancy_mask=(1, 0, 1, 0, 1, 1)
+lock_ticks=(1, None, 1, None, 3, 2)
+unique_full_axis=2
+b=1
+N_pair=48
+f=(+, 0, −, 0, +, −)
+N_new=1
+U_persists=True
+fires=True
+v_inward=(1, 0, 1, 0, 0, 0)
+v_inward_weight=2
+neighbor_inward_weights=(1, 2, 1, 2, 4, 2)
+U_directed_edges=288
+rho_cost_counts={1: 192, 3: 96}
+seed_exit_weights_zero=True
+incoming_rho=(1, 1, 1, 3)
+incoming_slots=((0, 1, 1), (2, 1, 1), (4, 1, 4), (5, 3, 2))
+sigma_after_rho=(1, 0, 1, 0, 1, 1)
+b_after_rho=1
+N_new_after_rho=1
+fires_after_rho=True
+sigma_ready=(1, 0, 1, 0, 1, 0)
+ready_full_axis=None
+N_new_ready=0
+score: uneqrad host only
+PASS: g-plus-order finite G+ is exactly the 24 proper cube rotations
+PASS: one-host-only exactly one host is scored: the uneqrad lex-first breaker
+PASS: u-geometry U is the uneqrad lex-first unequal-radius 3-ball union
+PASS: occupancy-and-ticks σ, t, unique full axis, and b=[t(−z)<t(+z)] match the uneqrad star
+PASS: theorem-1-bitfire on U, f still fires N_new=1 when hop costs are ignored
+PASS: theorem-2-rho-labels assigning rho to directed NN edges of U does not change σ or the age bit
+PASS: theorem-2-still-fires because σ and b are unchanged, f still fires N_new=1 after rho labeling
+PASS: theorem-2-readiness-filter cost-1 readiness filter reports N_new=0 on sigma_ready=(1,0,1,0,1,0)
+PASS: claim-scope the note reports the declared displayed claim_scope
+PASS: displayed-not-adopted f and rho are displayed and not written into Admissibility
+PASS: l1-not-attached the note does not attach L1
+PASS: uniqueness-not-required uniqueness of the matching member is not claimed
+PASS: not-leftover-two-hosts same-host score is not leftover of ourmem two-host pairing or bitfire
+PASS: admissibility-unedited f and rho are not written into Admissibility
+PASS: forbidden-phrases the forbidden rhetoric strings are absent from the note and runner
+PASS: no-axiom-edit the only axiom authority is the current memo; no cache or axiom rewrite
+per_element: f(σ,b), rho labels, and both N_new reports are exact
+per_site: only the unread star center v is scored
+per_mode: no spectral calculation
+per_block: the six-neighbor star at v and directed edges of U
+lattice_wide: checked and not executed
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/same_host_agebit_hopcost_2026_08_15.py
+++ b/scripts/same_host_agebit_hopcost_2026_08_15.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""Same-host leftover-frame fire and named hop cost on the uneqrad breaker.
+
+Host U is the uneqrad lex-first breaker. f is leftover-frame-positive.
+rho is cost 3 iff equal inward weight or seed-exit, else 1. Score both
+extras on this one host: bitfire N_new, rho as an edge labeling, and
+rho as a cost-1 readiness filter. Displayed, not adopted. No cache.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from collections import Counter
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/SAME_HOST_AGEBIT_HOPCOST_"
+    "BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SAME_HOST_AGEBIT_HOPCOST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Coloring = tuple[int, ...]
+Tick = tuple[int | None, ...]
+Matrix = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+DIRS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+AXES: tuple[tuple[int, int], ...] = ((0, 1), (2, 3), (4, 5))
+EMPTY, PLUS, MINUS = 0, 1, 2
+LETTER = {EMPTY: "0", PLUS: "+", MINUS: "−"}
+V: Point = (-3, -3, -1)
+SEEDS: tuple[Point, ...] = ((-2, -2, -2), (-2, -2, -1), (-2, -2, 1))
+RADII: tuple[int, ...] = (2, 1, 3)
+CLAIM_SCOPE = (
+    'claim_scope: "On the uneqrad breaker, leftover-frame fire and the '
+    "named hop cost are scored on the same host. Displayed, not "
+    'adopted."'
+)
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1(left: Point, right: Point) -> int:
+    return abs(left[0] - right[0]) + abs(left[1] - right[1]) + abs(left[2] - right[2])
+
+
+def ball(center: Point, radius: int) -> frozenset[Point]:
+    sites: set[Point] = set()
+    span = range(-radius, radius + 1)
+    for offset in itertools.product(span, repeat=3):
+        site = add(center, offset)
+        if l1(site, center) <= radius:
+            sites.add(site)
+    return frozenset(sites)
+
+
+def locked_union(
+    seeds: tuple[Point, ...] = SEEDS, radii: tuple[int, ...] = RADII
+) -> frozenset[Point]:
+    occupied = frozenset()
+    for seed, radius in zip(seeds, radii):
+        occupied = occupied | ball(seed, radius)
+    return occupied
+
+
+def occupancy_tuple(site: Point, occupied: frozenset[Point]) -> Coloring:
+    return tuple(int(add(site, direction) in occupied) for direction in DIRS)
+
+
+def seed_distance(site: Point) -> int:
+    return min(l1(site, seed) for seed in SEEDS)
+
+
+def lock_tick(site: Point) -> int:
+    return seed_distance(site)
+
+
+def tick_on_occupied(site: Point, occupied: frozenset[Point]) -> Tick:
+    ticks: list[int | None] = []
+    for direction in DIRS:
+        neighbor = add(site, direction)
+        if neighbor in occupied:
+            ticks.append(lock_tick(neighbor))
+        else:
+            ticks.append(None)
+    return tuple(ticks)
+
+
+def inward_occupancy(site: Point) -> Coloring:
+    here = seed_distance(site)
+    return tuple(
+        int(seed_distance(add(site, direction)) < here) for direction in DIRS
+    )
+
+
+def inward_weight(site: Point) -> int:
+    return int(sum(inward_occupancy(site)))
+
+
+def named_rho(source: Point, target: Point) -> int:
+    source_weight = inward_weight(source)
+    target_weight = inward_weight(target)
+    if source_weight == target_weight or source_weight == 0:
+        return 3
+    return 1
+
+
+def directed_edges_of(occupied: frozenset[Point]) -> tuple[tuple[Point, Point], ...]:
+    edges: list[tuple[Point, Point]] = []
+    for site in occupied:
+        for direction in DIRS:
+            neighbor = add(site, direction)
+            if neighbor in occupied:
+                edges.append((site, neighbor))
+    return tuple(edges)
+
+
+def support(coloring: Coloring) -> Coloring:
+    return tuple(int(slot != EMPTY) for slot in coloring)
+
+
+def det3(matrix: Matrix) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def mat_vec(matrix: Matrix, vector: Point) -> Point:
+    return (
+        matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
+        matrix[1][0] * vector[0] + matrix[1][1] * vector[1] + matrix[1][2] * vector[2],
+        matrix[2][0] * vector[0] + matrix[2][1] * vector[1] + matrix[2][2] * vector[2],
+    )
+
+
+def direction_perm(matrix: Matrix) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: Coloring | tuple) -> tuple:
+    out = [None] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def proper_rotations() -> tuple[tuple[Matrix, tuple[int, ...]], ...]:
+    records: list[tuple[Matrix, tuple[int, ...]]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((-1, 1), repeat=3):
+            rows = []
+            for row, col in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[col] = signs[row]
+                rows.append(tuple(entry))
+            matrix = (rows[0], rows[1], rows[2])
+            if det3(matrix) != 1:
+                continue
+            slots = direction_perm(matrix)
+            if slots not in seen:
+                seen.add(slots)
+                records.append((matrix, slots))
+    return tuple(records)
+
+
+def inversion_perm() -> tuple[int, ...]:
+    return direction_perm(((-1, 0, 0), (0, -1, 0), (0, 0, -1)))
+
+
+def july3_k3_pair() -> frozenset[Coloring]:
+    proper = [slots for _matrix, slots in proper_rotations()]
+    inversion = inversion_perm()
+    unseen = set(itertools.product(range(3), repeat=6))
+    pair: set[Coloring] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in proper}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def unique_full_axis(sigma: Coloring) -> int | None:
+    named = tuple(
+        axis_index
+        for axis_index, (plus, minus) in enumerate(AXES)
+        if sigma[plus] == 1 and sigma[minus] == 1
+    )
+    if len(named) == 1:
+        return named[0]
+    return None
+
+
+def age_bit(ticks: Tick, axis_index: int) -> int:
+    plus, minus = AXES[axis_index]
+    minus_tick = ticks[minus]
+    plus_tick = ticks[plus]
+    if minus_tick is not None and plus_tick is not None and minus_tick < plus_tick:
+        return 1
+    return 0
+
+
+def axis_letters(bit: int) -> tuple[int, int]:
+    if bit == 1:
+        return (PLUS, MINUS)
+    return (MINUS, PLUS)
+
+
+def completions(
+    sigma: Coloring,
+    bit: int,
+    pair: frozenset[Coloring],
+) -> tuple[Coloring, ...]:
+    named = unique_full_axis(sigma)
+    if named is None:
+        return ()
+    plus, minus = AXES[named]
+    plus_letter, minus_letter = axis_letters(bit)
+    matches = [
+        item
+        for item in pair
+        if support(item) == sigma
+        and item[plus] == plus_letter
+        and item[minus] == minus_letter
+    ]
+    return tuple(sorted(matches))
+
+
+def leftover_frame_sign(coloring: Coloring) -> int:
+    named = unique_full_axis(support(coloring))
+    if named is None:
+        raise AssertionError("completion has no unique full axis")
+    leftover = [
+        index
+        for index in range(6)
+        if support(coloring)[index] == 1 and index not in AXES[named]
+    ]
+    plus_left = next(index for index in leftover if coloring[index] == PLUS)
+    minus_left = next(index for index in leftover if coloring[index] == MINUS)
+    plus_full = next(index for index in AXES[named] if coloring[index] == PLUS)
+    return det3((DIRS[plus_left], DIRS[minus_left], DIRS[plus_full]))
+
+
+def leftover_frame_positive(
+    sigma: Coloring,
+    bit: int,
+    pair: frozenset[Coloring],
+) -> Coloring | None:
+    found = completions(sigma, bit, pair)
+    positive = [item for item in found if leftover_frame_sign(item) == 1]
+    if len(positive) != 1:
+        return None
+    return positive[0]
+
+
+def format_tuple(coloring: Coloring) -> str:
+    return "(" + ", ".join(LETTER[slot] for slot in coloring) + ")"
+
+
+def execute_at_v(
+    occupied: frozenset[Point],
+    coloring: Coloring | None,
+    pair: frozenset[Coloring],
+) -> tuple[frozenset[Point], int]:
+    if coloring is None or V in occupied or coloring not in pair:
+        return occupied, 0
+    return occupied | {V}, 1
+
+
+def parse_audit_input_paths(source: str) -> object:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                return ast.literal_eval(node.value)
+    raise AssertionError("AUDIT_INPUT_PATHS assignment is missing")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    literal_paths = parse_audit_input_paths(self_source)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: current Lattice, Qubit, Admissibility, "
+        "and Record sentences; leftover-frame-positive section rebuilt from "
+        "the July-3 pair; named hop-cost rho; uneqrad lex-first breaker"
+    )
+    print(
+        "construction: one host U=B_2((-2,-2,-2))∪B_1((-2,-2,-1))∪B_3((-2,-2,1)), "
+        "unread v=(-3,-3,-1), f leftover-frame-positive, "
+        "rho=3 iff equal inward weight or seed-exit else 1"
+    )
+    print(
+        "negative_scope: one host only; displayed, not adopted; "
+        "L1 not attached; f and rho not written into Admissibility"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static two-string literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SAME_HOST_AGEBIT_HOPCOST_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and literal_paths == AUDIT_INPUT_PATHS
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    covariance_clause = (
+        "one fixed nearest-neighbor admissibility rule, covariant under "
+        "lattice translations and proper cubic rotations"
+    )
+    formation_boundary = "it does not supply the formation site, probability,"
+    qubit_sentence = (
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_perm = "A site never carries more than one record; records are permanent."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in axiom_flat and admissibility_sentence in note_flat,
+    )
+    checks.check(
+        "source-covariance",
+        "Admissibility still requires one proper-cubic covariant rule",
+        covariance_clause in axiom_flat and covariance_clause in note_flat,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in axiom and formation_boundary in note,
+    )
+    checks.check(
+        "source-qubit",
+        "Qubit remains M_2(C)",
+        qubit_sentence in axiom
+        and qubit_sentence in note
+        and "Qubit remains `M_2(C)`" in note,
+    )
+    checks.check(
+        "source-record",
+        "lock, permanence, content-only readout, and unreadability at absence are pinned",
+        all(
+            phrase in axiom_flat
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        )
+        and all(
+            phrase in note
+            for phrase in (record_lock, record_perm, record_content, record_absence)
+        ),
+    )
+
+    occupied = locked_union()
+    mask = occupancy_tuple(V, occupied)
+    ticks = tick_on_occupied(V, occupied)
+    rotations = proper_rotations()
+    pair = july3_k3_pair()
+    named = unique_full_axis(mask)
+    bit = age_bit(ticks, named) if named is not None else None
+    found = completions(mask, bit, pair) if bit is not None else ()
+    chosen = leftover_frame_positive(mask, bit, pair) if bit is not None else None
+    after, n_new = execute_at_v(occupied, chosen, pair)
+    u_persists = occupied <= after and V not in occupied
+    fires = chosen is not None and n_new == 1 and u_persists and V in after
+
+    edges = directed_edges_of(occupied)
+    edge_costs = tuple(named_rho(source, target) for source, target in edges)
+    cost_counts = Counter(edge_costs)
+    seed_exit_ok = all(inward_weight(seed) == 0 for seed in SEEDS)
+    incoming = tuple(
+        named_rho(add(V, direction), V)
+        for direction in DIRS
+        if add(V, direction) in occupied
+    )
+    incoming_slots = tuple(
+        (index, named_rho(add(V, direction), V), inward_weight(add(V, direction)))
+        for index, direction in enumerate(DIRS)
+        if add(V, direction) in occupied
+    )
+    mask_after_rho = occupancy_tuple(V, occupied)
+    ticks_after_rho = tick_on_occupied(V, occupied)
+    bit_after_rho = (
+        age_bit(ticks_after_rho, named) if named is not None else None
+    )
+    after_rho, n_new_rho = execute_at_v(occupied, chosen, pair)
+    fires_rho = (
+        chosen is not None
+        and n_new_rho == 1
+        and occupied <= after_rho
+        and V in after_rho
+        and mask_after_rho == mask
+        and bit_after_rho == bit
+    )
+
+    ready_mask = tuple(
+        int(add(V, direction) in occupied and named_rho(add(V, direction), V) == 1)
+        for direction in DIRS
+    )
+    ready_axis = unique_full_axis(ready_mask)
+    ready_chosen = (
+        leftover_frame_positive(ready_mask, bit, pair)
+        if ready_axis is not None and bit is not None
+        else None
+    )
+    _after_ready, n_new_ready = execute_at_v(occupied, ready_chosen, pair)
+
+    neighbor_weights = tuple(inward_weight(add(V, direction)) for direction in DIRS)
+    v_inward = inward_occupancy(V)
+    v_weight = inward_weight(V)
+
+    print(f"U_card={len(occupied)}")
+    print(f"v_in_U={V in occupied}")
+    print(f"occupancy_mask={mask}")
+    print(f"lock_ticks={ticks}")
+    print(f"unique_full_axis={named}")
+    print(f"b={bit}")
+    print(f"N_pair={len(pair)}")
+    print(f"f={format_tuple(chosen) if chosen is not None else None}")
+    print(f"N_new={n_new}")
+    print(f"U_persists={u_persists}")
+    print(f"fires={fires}")
+    print(f"v_inward={v_inward}")
+    print(f"v_inward_weight={v_weight}")
+    print(f"neighbor_inward_weights={neighbor_weights}")
+    print(f"U_directed_edges={len(edges)}")
+    print(f"rho_cost_counts={dict(sorted(cost_counts.items()))}")
+    print(f"seed_exit_weights_zero={seed_exit_ok}")
+    print(f"incoming_rho={incoming}")
+    print(f"incoming_slots={incoming_slots}")
+    print(f"sigma_after_rho={mask_after_rho}")
+    print(f"b_after_rho={bit_after_rho}")
+    print(f"N_new_after_rho={n_new_rho}")
+    print(f"fires_after_rho={fires_rho}")
+    print(f"sigma_ready={ready_mask}")
+    print(f"ready_full_axis={ready_axis}")
+    print(f"N_new_ready={n_new_ready}")
+    print("score: uneqrad host only")
+
+    balls = tuple(ball(seed, radius) for seed, radius in zip(SEEDS, RADII))
+    pairwise = (
+        len(balls[0] & balls[1]),
+        len(balls[0] & balls[2]),
+        len(balls[1] & balls[2]),
+    )
+    triple = len(balls[0] & balls[1] & balls[2])
+
+    checks.check(
+        "g-plus-order",
+        "finite G+ is exactly the 24 proper cube rotations",
+        len(rotations) == 24
+        and len({slots for _matrix, slots in rotations}) == 24,
+    )
+    checks.check(
+        "one-host-only",
+        "exactly one host is scored: the uneqrad lex-first breaker",
+        len(occupied) == 81
+        and V not in occupied
+        and "One host only" in note
+        and "uneqrad lex-first breaker" in note
+        and "second host" in note_flat.lower(),
+    )
+    checks.check(
+        "u-geometry",
+        "U is the uneqrad lex-first unequal-radius 3-ball union",
+        tuple(len(item) for item in balls) == (25, 7, 63)
+        and pairwise == (7, 7, 7)
+        and triple == 7
+        and len(occupied) == 81
+        and "B_2((−2,−2,−2))" in note
+        and "B_1((−2,−2,−1))" in note
+        and "B_3((−2,−2,1))" in note,
+    )
+    checks.check(
+        "occupancy-and-ticks",
+        "σ, t, unique full axis, and b=[t(−z)<t(+z)] match the uneqrad star",
+        mask == (1, 0, 1, 0, 1, 1)
+        and ticks == (1, None, 1, None, 3, 2)
+        and named == 2
+        and bit == 1
+        and ticks[5] is not None
+        and ticks[4] is not None
+        and ticks[5] < ticks[4]
+        and "`σ = (1, 0, 1, 0, 1, 1)`" in note
+        and "`t = (1, ·, 1, ·, 3, 2)`" in note
+        and "`b = 1`" in note,
+    )
+    checks.check(
+        "theorem-1-bitfire",
+        "on U, f still fires N_new=1 when hop costs are ignored",
+        chosen == (PLUS, EMPTY, MINUS, EMPTY, PLUS, MINUS)
+        and leftover_frame_sign(chosen) == 1
+        and chosen in pair
+        and n_new == 1
+        and fires
+        and u_persists
+        and after == occupied | {V}
+        and format_tuple(chosen) in note
+        and "`N_new = 1`" in note
+        and "hop costs are ignored" in note_flat,
+        residual=(format_tuple(chosen) if chosen is not None else None, n_new),
+    )
+    checks.check(
+        "theorem-2-rho-labels",
+        "assigning rho to directed NN edges of U does not change σ or the age bit",
+        seed_exit_ok
+        and v_weight == 2
+        and v_inward == (1, 0, 1, 0, 0, 0)
+        and neighbor_weights == (1, 2, 1, 2, 4, 2)
+        and len(edges) == 288
+        and cost_counts[1] + cost_counts[3] == 288
+        and mask_after_rho == mask == (1, 0, 1, 0, 1, 1)
+        and ticks_after_rho == ticks
+        and bit_after_rho == bit == 1
+        and "does not change the occupancy mask or the age bit" in note_flat,
+        residual=(mask_after_rho, bit_after_rho, len(edges)),
+    )
+    checks.check(
+        "theorem-2-still-fires",
+        "because σ and b are unchanged, f still fires N_new=1 after rho labeling",
+        fires_rho
+        and n_new_rho == 1
+        and after_rho == occupied | {V}
+        and incoming == (1, 1, 1, 3)
+        and incoming_slots[3][1] == 3
+        and incoming_slots[3][2] == 2,
+        residual=(n_new_rho, incoming),
+    )
+    checks.check(
+        "theorem-2-readiness-filter",
+        "cost-1 readiness filter reports N_new=0 on sigma_ready=(1,0,1,0,1,0)",
+        ready_mask == (1, 0, 1, 0, 1, 0)
+        and ready_axis is None
+        and ready_chosen is None
+        and n_new_ready == 0
+        and "`σ_ready = (1, 0, 1, 0, 1, 0)`" in note
+        and "`N_new = 0`" in note
+        and "readiness filter" in note,
+        residual=(ready_mask, n_new_ready),
+    )
+    checks.check(
+        "claim-scope",
+        "the note reports the declared displayed claim_scope",
+        CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "f and rho are displayed and not written into Admissibility",
+        "Displayed, not adopted" in note
+        and "Do not write f or ρ into Admissibility" in note
+        and "hypothetical_axiom_status:" in note
+        and "This note authors no audit verdict" in note,
+    )
+    checks.check(
+        "l1-not-attached",
+        "the note does not attach L1",
+        "Do not attach L1" in note
+        and "we attach L1" not in note_flat
+        and "we add a 4th ball" not in note_flat,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "uniqueness of the matching member is not claimed",
+        "Uniqueness not required" in note
+        and "uniqueness not required" in note_flat.lower()
+        and "unique leftover" not in note_flat.lower(),
+    )
+    checks.check(
+        "not-leftover-two-hosts",
+        "same-host score is not leftover of ourmem two-host pairing or bitfire",
+        "not leftover of ourmem" in note_flat.replace("`", "").lower()
+        and "not leftover of bitfire" in note_flat.replace("`", "").lower()
+        and "two hosts" in note_flat.lower(),
+    )
+    checks.check(
+        "admissibility-unedited",
+        "f and rho are not written into Admissibility",
+        covariance_clause in axiom_flat
+        and "leftover-frame-positive" not in axiom
+        and "named hop" not in axiom
+        and "N_new" not in axiom
+        and "uneqrad" not in axiom,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the forbidden rhetoric strings are absent from the note and runner",
+        all(phrase not in note for phrase in forbidden_tokens())
+        and all(phrase not in self_source for phrase in forbidden_tokens()),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "the only axiom authority is the current memo; no cache or axiom rewrite",
+        "[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)" in note
+        and "cache_write: false" in self_source
+        and AXIOM_REL in AUDIT_INPUT_PATHS
+        and "no axiom" in note_flat.lower(),
+    )
+
+    print("per_element: f(σ,b), rho labels, and both N_new reports are exact")
+    print("per_site: only the unread star center v is scored")
+    print("per_mode: no spectral calculation")
+    print("per_block: the six-neighbor star at v and directed edges of U")
+    print("lattice_wide: checked and not executed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On uneqrad host, leftover-frame f still has N_new=1 when rho is an edge label. As a readiness filter (fire only cost-1) N_new=0. Clock not readiness. Displayed, not adopted. No axiom edit.

## Runner

`scripts/same_host_agebit_hopcost_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.