### PR TITLE
physics: execute the sourced quotient on the stable balanced sector

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block124-sourced-quotient-execution-20260817/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block124-sourced-quotient-execution-20260817/NO_GO_LEDGER.md
@@ -1,0 +1,35 @@
+# Block 124 No-Go Ledger
+
+Scope: one dual-character wall inside an execution packet whose
+positive side is the lane's first physical gravity quotient. `W1` (the
+boundary half) says the physical-quotient claim ships ONLY for the
+balanced sector: off c_2 = 0 the class is convention-dependent as a
+set (the p_2 = +2 and p_2 = -2 conventions give different quadrics
+intersecting exactly on c_2 = 0), and the unbalanced states are not
+transfer-stable (exact per-step class violation
+2|c_2|^2(rho_even^4 - rho_odd^4) != 0). The positive side: the
+balanced sector {c_2 = 0, |c_1| = |c_3|, c_0 free} is simultaneously
+convention-free and transfer-invariant — the latter because the paired
+momenta share one characteristic polynomial whose stable root is
+uniquely pinned by |rho| < 1 (the identification is forced, not
+chosen) — and on it the momentum-sourced Gauss equation solves in
+closed form under the pinned forward-difference orientation, unique up
+to the constant gauge mode, with the physical sector isomorphic to the
+matter class (gravity contributes zero independent dimensions in d=2).
+The quotient structure is independent of the choice of admissible
+Hermitian localization (sum rule; the E_x P E_x ordering is
+inadmissible); only the spatial profile is convention-dependent.
+Narrow scope: the displayed package, fixtures, charges, orientation,
+and localization class.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the full gravity constraint quotient is executed | `ATTEMPTED` | false: the displayed d=2 momentum-sourced quotient only | curved carrier, full gravity |
+| the unbalanced class is physical | `ATTEMPTED` | false: convention-dependent as a set and not transfer-stable | none needed |
+| the profile is localization-independent | `ATTEMPTED` | false: only the quotient structure is; profiles vary | none needed |
+| the root identification is a choice | `ATTEMPTED` | false: forced — shared polynomial, unique stable root | none needed |
+| a retained obligation moves | `ATTEMPTED` | false: zero retirement; bounded theorem awaiting audit | audit lane |
+| the orientation convention is arbitrary | `ATTEMPTED` | it is pinned and displayed; the opposite orientation fails the witness | none needed |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; the dual-character `W1` ships with its positive half explicitly labeled.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md
@@ -1,0 +1,1132 @@
+---
+claim_id: admissibility_dirac_kahler_sourced_quotient_execution_bounded_theorem_note_2026-08-17
+claim_type: bounded_theorem
+claim_scope: "on the certified package at both rational shear fixtures, the momentum-sourced Gauss quotient is executed — the vanishing-expected-momentum class is the exact quadric with convention-invariant dimension counts and a p_2-sign-dependent set for nonzero c_2 (displayed claims restricted to the c_2 = 0 sector where the conventions agree), the closed-cycle Gauss equation solves in closed form under the pinned forward-difference orientation with the constant gauge mode, the physical sector is isomorphic to the matter class with gravity contributing zero independent dimensions, the transfer preserves exactly the balanced sector because the paired momenta share one characteristic polynomial whose stable root is uniquely forced while unbalanced states violate the class by an exact even-odd rate difference, and the quotient structure is independent of the choice of admissible Hermitian localization (which must satisfy the sum rule; one displayed alternative ordering is inadmissible) with only the spatial profile convention-dependent — and non-local dressings, the naturality classification, curved OS positivity, the completed ADM/history transporter, joint gravity, the full gravity constraint quotient beyond the displayed carrier, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_momentum_population_definiteness_bounded_theorem_note_2026-08-16
+runner: scripts/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_momentum_population_definiteness_bounded_theorem_note_2026-08-16
+target_blocker_text: "Execute the momentum-sourced Gauss quotient on the closed carrier with the vanishing-expectation state class; then non-local dressings, the naturality classification, and curved OS positivity."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Non-local current dressings for the observable wall; the naturality classification of the swap completion; curved OS positivity on the half-space package."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-123 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact convention-resolved momentum quadrics and dimension counts, exact forward-oriented closed-cycle Gauss solution with its constant gauge mode, exact graph-quotient isomorphism and zero independent gravity fiber, exact parity-paired characteristic-polynomial and stable-root identities, exact balanced-sector transfer preservation and unbalanced even-odd violation, and exact localization sum-rule independence on the certified package at both rational shear fixtures; dependencies are content-bound unaudited, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Executed Sourced Quotient And The Stable Balanced Sector
+
+**Date:** 2026-08-17
+
+**Campaign block:** 124
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.py`](../scripts/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.py)
+
+## 1. Result Up Front
+
+[Block 123](ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+closed onto the following handoff next gate, anchored byte-exactly at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md:16`
+and elaborated in its Next Decision:
+
+> Execute the momentum-sourced Gauss quotient on the closed carrier with the
+> vanishing-expectation state class; then non-local dressings, the naturality
+> classification, and curved OS positivity.
+
+**THE SOURCED-QUOTIENT THEOREM.** On the certified package at each rational
+shear fixture $s=5/13$ and $s=3/5$, write a matter class as
+$a=(c_0,c_1,c_2,c_3)^{\mathsf T}\in\mathbb C^4\setminus\{0\}$. The two
+Hermitian logarithm conventions for the Nyquist momentum are
+
+\[
+ P_+=\operatorname{diag}(0,1,2,-1),
+ \qquad
+ P_-=\operatorname{diag}(0,1,-2,-1).             \tag{1}
+\]
+
+Each exponentiates to the same quotient shift. Their zero-expected-momentum
+classes are distinct exact quadrics,
+
+\[
+ \begin{aligned}
+ \mathcal V_+
+   &=\{a:|c_1|^2+2|c_2|^2=|c_3|^2\},\\
+ \mathcal V_-
+   &=\{a:|c_1|^2=2|c_2|^2+|c_3|^2\}.
+ \end{aligned}                                    \tag{2}
+\]
+
+Both have real cone, normalized, and pure-ray dimensions $7,6,5$. Their
+sets differ whenever $c_2\ne0$. Their exact intersection is
+
+\[
+ \mathcal V_{\rm bal}
+ =\mathcal V_+\cap\mathcal V_-
+ =\{a:c_2=0,\ |c_1|=|c_3|\},                     \tag{3}
+\]
+
+with $c_0$ unrestricted and dimensions $5,4,3$. Equation (3) is the
+**BALANCED SECTOR**. All convention-free physical claims displayed below
+are restricted to it.
+
+For any admissible Hermitian localization $D=(D_x)_{x\in\mathbb Z_4}$ of
+the chosen $P_\pm$, define the normalized source
+
+\[
+ \rho_x^{(D)}(a)
+   ={a^\dagger D_xa\over a^\dagger a},
+ \qquad D_x^\dagger=D_x,
+ \qquad \sum_xD_x=P_\pm.                         \tag{4}
+\]
+
+The class equation implies $\sum_x\rho_x^{(D)}(a)=0$. With the pinned
+forward-edge incidence orientation
+
+\[
+ (B_4^{\mathsf T}\Gamma)_x=\Gamma_x-\Gamma_{x+1},
+ \qquad x\pmod4,                                  \tag{5}
+\]
+
+the closed-cycle Gauss equation $B_4^{\mathsf T}\Gamma=\rho$ has the exact
+solution
+
+\[
+ \Gamma_0[\rho]
+  =(0,-r_0,-r_0-r_1,r_3)^{\mathsf T},
+ \qquad
+ \Gamma=\Gamma_0[\rho]+\lambda\mathbf1,          \tag{6}
+\]
+
+for $\rho=(r_0,r_1,r_2,r_3)^{\mathsf T}$ with $\sum_xr_x=0$. The sole
+homogeneous mode is the constant gauge mode $\lambda\mathbf1$.
+
+Consequently the constrained pairs form a graph over the matter class, and
+quotienting constant gauge translations gives
+
+\[
+ \mathcal S_D/\mathbb R_{\rm gauge}\cong\mathcal V_\pm,
+ \qquad
+ \mathcal S_{D,{\rm bal}}/\mathbb R_{\rm gauge}
+   \cong\mathcal V_{\rm bal}.                     \tag{7}
+\]
+
+The gravity solution, gauge, and physical-fiber dimensions are $1,1,0$.
+Gravity supplies a matter-determined response class but zero independent
+dimensions. In particular, no transverse-traceless gravity mode is hidden
+in (7).
+
+The physical transfer has the parity form
+
+\[
+ T_s=\operatorname{diag}(\beta_{e,s},\beta_{o,s},
+                          \beta_{e,s},\beta_{o,s}),
+ \qquad
+ 0<\beta_{e,s},\beta_{o,s}<1,                     \tag{8}
+\]
+
+where the $k=0,2$ pair and the $k=1,3$ pair each share an exact reciprocal
+quadratic characteristic polynomial. Each polynomial has exactly one root
+in $(0,1)$, so the stable root is uniquely forced. The even and odd
+polynomials are coprime at both fixtures, hence
+$\beta_{e,s}\ne\beta_{o,s}$.
+
+For $a\in\mathcal V_+$ and $a\in\mathcal V_-$ respectively,
+
+\[
+ \begin{aligned}
+ (T_sa)^\dagger P_+(T_sa)
+   &=2(\beta_{e,s}^2-\beta_{o,s}^2)|c_2|^2,\\
+ (T_sa)^\dagger P_-(T_sa)
+   &=2(\beta_{o,s}^2-\beta_{e,s}^2)|c_2|^2.
+ \end{aligned}                                    \tag{9}
+\]
+
+Thus every unbalanced state leaves its convention's class after one
+transfer, while every state in (3) remains in (3). The transfer-stable
+sector is exactly the convention-free sector. This keystone coincidence is
+the positive content: the executed physical quotient ships only on
+$\mathcal V_{\rm bal}$.
+
+The localization verdict is equally sharp. Equation (4), not the pointwise
+shape of $\rho$, controls solvability and the graph quotient. Any admissible
+Hermitian localization gives the same quotient structure; only the spatial
+source and response profiles depend on that choice. The canonical choice
+$D_x=\{E_x,P_\pm\}/2$ is admissible. The Hermitian sandwich ordering
+$E_xP_\pm E_x$ is not, because its total is not $P_\pm$.
+
+This theorem is deliberately narrow. Non-local current dressings for the
+observable wall, the naturality classification of the swap completion,
+curved OS positivity on the half-space package, the completed ADM/history
+transporter, joint gravity, the full gravity constraint quotient beyond the
+displayed carrier, Records, audit retention, axiom amendment, obligation
+retirement, and TOE percentage movement remain outside it.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) at
+`origin/main 4e566b14a6352a9a62590252a9755c7a103c1b9e`, with axiom blob
+`bc23300becfe4e4db57153c0e94cfcdf2338da71` and registry blob
+`b93959cca4f7e26c673cdccbe601e50c3cb93daa`. The authority snapshot is
+unchanged from Block 123.
+
+The exact stacked parent is
+[Block 123](ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+commit `954322e0e085d6c3133ce24dca49db2efbd7d0a6`, content-bound through
+note blob `560894350af5930f88161455f4db8954730f3e96`. Its closed-carrier
+population wall comes from
+[Block 121](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md),
+and its positive half-space quotient and parity-paired transfer come from
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md).
+No audit verdict is imported from any note.
+
+The executed contract is:
+
+1. the certified package at both rational shear fixtures $s=5/13$ and
+   $s=3/5$, with quotient momenta $k=0,1,2,3$;
+2. both Hermitian $p_2=+2$ and $p_2=-2$ logarithm conventions, their exact
+   vanishing-expectation quadrics, and their cone, normalized, and pure-ray
+   dimensions;
+3. the convention-free intersection $c_2=0$, $|c_1|=|c_3|$, with $c_0$
+   unrestricted, as the only physical sector shipped here;
+4. the pinned forward-edge orientation, the exact closed-form Gauss
+   solution, the explicit opposite-orientation failure, and the constant
+   gauge mode;
+5. the constrained-pair graph, its quotient isomorphism to the matter
+   class, and the $1/1/0$ gravity solution/gauge/physical-fiber count;
+6. the parity-shared reciprocal characteristic polynomials, their uniquely
+   forced stable roots, and the exact even-odd inequality at both fixtures;
+7. exact preservation of the balanced sector and exact transfer violation
+   for every $c_2\ne0$ state in either convention;
+8. the Hermitian localization sum rule, the independence of quotient
+   structure under every localization satisfying it, and the
+   convention-dependence of the spatial profile; and
+9. one positive-dominant, dual-character wall which leaves non-local
+   dressings, naturality, curved OS positivity, and gravity beyond the
+   displayed carrier open.
+
+The supplied scientific scratch computation was replayed exactly and ends
+with `TOTAL: PASS=93 FAIL=0`. It verifies the class, both witness states,
+both fixture profiles, the Gauss solution, the graph quotient, the parity
+polynomials, and the transfer identities. Runtime is not theorem content.
+
+The completed primary runner was then replayed and ends with
+`TOTAL: PASS=8 FAIL=0`. Its decision footer is reproduced exactly:
+
+```text
+RESULT: the lane's first physical gravity quotient exists and carries dynamics — the convention-free transfer-stable balanced sector with exact gauss solutions unique up to the constant gauge mode, its structure independent of the admissible localization
+DECISION_CUT: advance non-local dressings and the naturality classification; reject unbalanced-sector and inadmissible-localization constructions
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+```
+
+The scope is the four-sector package, both fixtures, the two displayed
+Hermitian momentum conventions, admissible localizations satisfying (4),
+the forward-oriented closed cycle, and the balanced graph quotient. No
+non-local dressing, naturality classification, curved reconstruction,
+history transporter, joint-gravity construction, or quotient beyond the
+displayed carrier follows.
+
+## 3. The Class Quadric And The Convention Analysis
+
+Let
+
+\[
+ U_x^{\rm phys}=\operatorname{diag}(1,i,-1,-i).
+\]
+
+At the Nyquist sector $k=2$, both $+2$ and $-2$ are Hermitian logarithms of
+the eigenvalue $-1$. Thus the two signed principal representatives in (1)
+obey
+
+\[
+ \exp\!\left({i\pi P_+\over2}\right)
+ =\exp\!\left({i\pi P_-\over2}\right)
+ =U_x^{\rm phys}.                                \tag{10}
+\]
+
+They agree on $k=0,1,3$ and differ only in the sign assigned to $p_2$.
+For $a=(c_0,c_1,c_2,c_3)^{\mathsf T}$,
+
+\[
+ \begin{aligned}
+ q_+(a)&:=a^\dagger P_+a
+   =|c_1|^2+2|c_2|^2-|c_3|^2,\\
+ q_-(a)&:=a^\dagger P_-a
+   =|c_1|^2-2|c_2|^2-|c_3|^2.
+ \end{aligned}                                    \tag{11}
+\]
+
+Therefore $q_\pm(a)=0$ gives exactly the two sets in (2). The $c_0$
+coordinate is unrestricted. On the remaining three complex coordinates,
+each real quadratic form has rank six and mixed sign. Away from the
+$k=0$ complex line, zero is a regular value. It follows that each nonzero
+cone has real dimension seven in $\mathbb R^8$; norm fixing removes one
+dimension and quotienting the overall phase removes one more:
+
+\[
+ \dim_{\mathbb R}(\text{cone},\text{normalized},\text{pure ray})
+ =(7,6,5).                                        \tag{12}
+\]
+
+The dimension count is convention-invariant, but the set is not. For
+example,
+
+\[
+ u=2e_0+e_1+2e_2+3e_3                           \tag{13}
+\]
+
+has $\lVert u\rVert^2=18$ and
+$q_+(u)=1+2(4)-9=0$, whereas $q_-(u)=1-2(4)-9=-16$.
+Thus $u\in\mathcal V_+\setminus\mathcal V_-$. It is used below only as a
+checker witness for the $p_2=+2$ convention, not as a member of the shipped
+physical sector.
+
+If a class lies in both quadrics, (11) gives
+
+\[
+ q_+(a)-q_-(a)=4|c_2|^2=0.
+\]
+
+Hence $c_2=0$, after which either equation gives
+$|c_1|=|c_3|$. Conversely those two conditions imply both equations. This
+proves (3). Its dimensions follow directly: $c_0$ supplies two real
+coordinates, the equal-norm pair $(c_1,c_3)$ supplies three, norm fixing
+removes one, and overall phase removes one:
+
+\[
+ \dim_{\mathbb R}\mathcal V_{\rm bal}=(5,4,3)
+ \quad\text{for cone, normalized class, and pure ray}.       \tag{14}
+\]
+
+The original Block 123 witness
+
+\[
+ w=e_1+e_3                                        \tag{15}
+\]
+
+lies in $\mathcal V_{\rm bal}$, has norm squared two, and obeys
+$w^\dagger P_+w=w^\dagger P_-w=0$. It exhibits the common class but does
+not by itself classify it. Equation (3), not one witness, is the safe
+sector used from this point onward for convention-free physical claims.
+
+## 4. The Gauss Solution
+
+Let $F$ denote the four-line quotient Fourier embedding and let
+$|x\rangle$, $x\in\mathbb Z_4$, be the closed-carrier site basis. The
+canonical descended site effect and Hermitian momentum localization are
+
+\[
+ E_x=F^\dagger|x\rangle\langle x|F,
+ \qquad
+ D_x^{\rm ac}={1\over2}\{E_x,P_\pm\}.             \tag{16}
+\]
+
+They obey
+
+\[
+ (D_x^{\rm ac})^\dagger=D_x^{\rm ac},
+ \qquad
+ \sum_xD_x^{\rm ac}=P_\pm.                       \tag{17}
+\]
+
+For this section put
+
+\[
+ \rho_x(a)={a^\dagger D_x^{\rm ac}a\over a^\dagger a}.
+                                                               \tag{18}
+\]
+
+The orientation pin is essential. The forward edges point from $x$ to
+$x+1$, and the tail-minus-head incidence divergence is
+
+\[
+ B_4^{\mathsf T}
+ =\begin{pmatrix}
+  1&-1& 0& 0\\
+  0& 1&-1& 0\\
+  0& 0& 1&-1\\
+ -1& 0& 0& 1
+ \end{pmatrix},
+ \qquad
+ (B_4^{\mathsf T}\Gamma)_x=\Gamma_x-\Gamma_{x+1}.
+                                                               \tag{19}
+\]
+
+For $\rho=(r_0,r_1,r_2,r_3)^{\mathsf T}$ with
+$r_0+r_1+r_2+r_3=0$, direct multiplication gives
+
+\[
+ B_4^{\mathsf T}
+ \begin{pmatrix}0\\-r_0\\-r_0-r_1\\r_3\end{pmatrix}
+ =\begin{pmatrix}
+ r_0\\r_1\\-r_0-r_1-r_3\\r_3
+ \end{pmatrix}
+ =\rho.                                           \tag{20}
+\]
+
+This proves the closed form (6). The opposite incidence orientation is
+$\widetilde B_4^{\mathsf T}=-B_4^{\mathsf T}$. Keeping the displayed
+solution while silently using that alternative gives
+
+\[
+ \widetilde B_4^{\mathsf T}\Gamma_0[\rho]=-ho,
+                                                               \tag{21}
+\]
+
+which fails the stated equation for every nonzero source. Equation (21) is
+the explicit orientation checker; a sign convention cannot be changed
+mid-proof.
+
+The two exact source witnesses are fixture-independent. At both $s=5/13$
+and $s=3/5$, the balanced witness in (15) gives
+
+\[
+ \rho(w)=(0,0,0,0)^{\mathsf T},
+ \qquad
+ \Gamma_{\rm mean\,0}(w)=(0,0,0,0)^{\mathsf T}.  \tag{22}
+\]
+
+For the convention-specific checker $u$ in (13), using $P_+$ gives
+
+\[
+ \rho(u)=\left({2\over9},-{1\over9},0,-{1\over9}\right)^{\mathsf T},
+ \qquad
+ \Gamma_{\rm mean\,0}(u)
+ =\left({1\over9},-{1\over9},0,0\right)^{\mathsf T}.
+                                                               \tag{23}
+\]
+
+Indeed (19) maps the second vector in (23) to the first. The opposite
+orientation maps it to the negative first vector and therefore fails
+nontrivially. Witness $u$ checks the formula but does not enlarge the
+convention-free claim beyond (3).
+
+Finally,
+
+\[
+ \ker B_4^{\mathsf T}=\operatorname{span}_{\mathbb R}\{\mathbf1\}.
+                                                               \tag{24}
+\]
+
+Thus every solution differs from (6) by exactly the constant gauge mode.
+There is neither a second homogeneous direction nor an orientation-free
+choice of the displayed representative.
+
+## 5. The Physical Quotient
+
+For a convention $\sigma\in\{+,-\}$ and an admissible localization $D$,
+define the sourced-pair space
+
+\[
+ \mathcal S_{\sigma,D}
+ =\{(a,\Gamma):a\in\mathcal V_\sigma,
+       \ B_4^{\mathsf T}\Gamma=\rho^{(D)}(a)\}.   \tag{25}
+\]
+
+The gauge group $\mathbb R_{\rm gauge}$ acts by
+
+\[
+ \mu\cdot(a,\Gamma)=(a,\Gamma+\mu\mathbf1).
+                                                               \tag{26}
+\]
+
+The total-source identity from (4) puts every
+$\rho^{(D)}(a)$ in $\operatorname{im}B_4^{\mathsf T}$. Equations (6) and
+(24) then give
+
+\[
+ \mathcal S_{\sigma,D}
+ =\{(a,\Gamma_0[\rho^{(D)}(a)]+\lambda\mathbf1):
+       a\in\mathcal V_\sigma,\ \lambda\in\mathbb R\}.         \tag{27}
+\]
+
+Projection to the first component induces the exact isomorphism
+
+\[
+ \begin{aligned}
+ \mathcal S_{\sigma,D}/\mathbb R_{\rm gauge}
+   &\longrightarrow\mathcal V_\sigma,\\
+ [(a,\Gamma)]&\longmapsto a,
+ \end{aligned}
+ \qquad
+ a\longmapsto[(a,\Gamma_0[\rho^{(D)}(a)])].       \tag{28}
+\]
+
+For fixed $a$, the solution fiber is an affine real line, the gauge orbit is
+that entire line, and the physical gravity fiber is a point:
+
+\[
+ \dim(\text{gravity solution},\text{gauge},
+      \text{physical gravity fiber})=(1,1,0).      \tag{29}
+\]
+
+Accordingly the coupled cone, normalized, and pure-ray dimensions are the
+matter dimensions $(7,6,5)$ in either convention. On the physical sector
+shipped here they are the balanced dimensions $(5,4,3)$.
+
+The zero-TT statement is also explicit. On the one-dimensional spatial
+cycle every homogeneous Gauss field lies in (24), and quotienting that
+constant mode gives
+
+\[
+ \ker_{\rm TT}
+ :=\ker B_4^{\mathsf T}/
+   \operatorname{span}\{\mathbf1\}=0.             \tag{30}
+\]
+
+The exact finite certificate
+$\operatorname{rank}\bigl([I_4;B_4]\bigr)=4$ excludes a hidden matter-null
+direction in the graph presentation. Gravity retains the response class
+determined by $a$, but contributes no independent propagating or constant
+mode after the quotient.
+
+This is an executed sourced quotient on the displayed carrier. It is not the
+full gravity constraint quotient beyond that carrier, and (30) is not a
+claim that a richer gravitational package has no transverse-traceless
+sector.
+
+## 6. The Forced Root Identity
+
+Before squaring to the cell-transfer rate, let $\rho_{k,s}$ be the stable
+root of the exact reciprocal characteristic polynomial
+
+\[
+ \chi_{k,s}(z)=z^2-\tau_{k,s}z+1,
+ \qquad |\tau_{k,s}|>2.
+\]
+
+At both fixtures the polynomial identities are
+
+\[
+ \chi_{0,s}=\chi_{2,s}=:\chi_{e,s},
+ \qquad
+ \chi_{1,s}=\chi_{3,s}=:\chi_{o,s}.
+\]
+
+Each polynomial has one root of modulus less than one and its reciprocal of
+modulus greater than one. The condition $|\rho|<1$ therefore forces, rather
+than chooses,
+
+\[
+ \rho_{0,s}=\rho_{2,s}=: \rho_{e,s},
+ \qquad
+ \rho_{1,s}=\rho_{3,s}=: \rho_{o,s}.
+\]
+
+The exact fixture certificates give $\tau_{e,s}\ne\tau_{o,s}$, hence
+$\rho_{e,s}\ne\rho_{o,s}$. The paired momenta share one characteristic
+polynomial and the stable root is uniquely pinned.
+
+Write the inherited cell-transfer eigenvalues as
+
+\[
+ \beta_{e,s}=\beta_{0,s}=\beta_{2,s},
+ \qquad
+ \beta_{o,s}=\beta_{1,s}=\beta_{3,s},
+ \qquad
+ \beta_{k,s}=\rho_{k,s}^2.                       \tag{31}
+\]
+
+Both equalities in (31) are exact at both fixtures. The minimal polynomial
+of each parity pair has the reciprocal form
+
+\[
+ m_{\epsilon,s}(z)
+   =A_{\epsilon,s}z^2-B_{\epsilon,s}z+A_{\epsilon,s},
+ \qquad \epsilon\in\{e,o\}.                     \tag{32}
+\]
+
+The exact integer coefficients at $s=5/13$ are
+
+\[
+ \begin{aligned}
+ A_{e,5/13}
+ &=16235115309846142798256458110002226743452887085113525390625,\\
+ B_{e,5/13}
+ &=15667918551657931488696307198436939317694697743030411177217986,\\
+ A_{o,5/13}
+ &=9350043707771020894305426029044940416424181461334228515625,\\
+ B_{o,5/13}
+ &=57104028577636201389698279862063441803873065564567842388264567186.
+ \end{aligned}                                    \tag{33}
+\]
+
+At $s=3/5$ they are
+
+\[
+ \begin{aligned}
+ A_{e,3/5}
+ &=71665823742873150300970710813999176025390625,\\
+ B_{e,3/5}
+ &=54785683690345560611160053353796453831019900866,\\
+ A_{o,3/5}
+ &=44488299664102849843358739521636962890625,\\
+ B_{o,3/5}
+ &=1207104568234664945610604724165252240851422837314.
+ \end{aligned}                                    \tag{34}
+\]
+
+For all four rows, $A_{\epsilon,s}>0$ and
+$B_{\epsilon,s}>2A_{\epsilon,s}$. Hence (32) has two positive real roots
+whose product is one. Exactly one lies in $(0,1)$, namely
+
+\[
+ \beta_{\epsilon,s}
+ ={B_{\epsilon,s}-
+   \sqrt{B_{\epsilon,s}^2-4A_{\epsilon,s}^2}
+   \over2A_{\epsilon,s}}.                        \tag{35}
+\]
+
+Contractivity therefore does not select among several stable branches: it
+forces the unique stable root (35). Because sectors $0,2$ share
+$m_{e,s}$, and sectors $1,3$ share $m_{o,s}$, the paired rates in (31) are
+identities rather than numerical coincidences.
+
+The exact polynomial gcd test gives
+
+\[
+ \gcd(m_{e,s},m_{o,s})=1
+ \qquad\text{for }s=5/13,3/5.                    \tag{36}
+\]
+
+Thus the even and odd minimal polynomials share no root, and in particular
+
+\[
+ \beta_{e,s}\ne\beta_{o,s}                      \tag{37}
+\]
+
+at both fixtures. Equations (31)--(37) are the forced-root identity used by
+the stability calculation; no approximate root comparison is doing its
+work.
+
+## 7. The Stable Balanced Sector
+
+Let $a\in\mathcal V_+$. Using the first relation in (2) and (31),
+
+\[
+ \begin{aligned}
+ q_+(T_sa)
+ &=\beta_{o,s}^2|c_1|^2
+   +2\beta_{e,s}^2|c_2|^2
+   -\beta_{o,s}^2|c_3|^2\\
+ &=2(\beta_{e,s}^2-\beta_{o,s}^2)|c_2|^2\\
+ &=2|c_2|^2(\rho_{e,s}^4-\rho_{o,s}^4).
+ \end{aligned}                                    \tag{38}
+\]
+
+Likewise, for $a\in\mathcal V_-$,
+
+\[
+ q_-(T_sa)
+ =2(\beta_{o,s}^2-\beta_{e,s}^2)|c_2|^2
+ =2|c_2|^2(\rho_{o,s}^4-\rho_{e,s}^4).           \tag{39}
+\]
+
+The normalized transfer divides (38) or (39) by the strictly positive norm
+$\lVert T_sa\rVert^2$ and therefore has the same zero set. The once-inserted
+forms provide a second exact check:
+
+\[
+ \begin{aligned}
+ a^\dagger P_+T_sa
+   &=2(\beta_{e,s}-\beta_{o,s})|c_2|^2,\\
+ a^\dagger P_-T_sa
+   &=2(\beta_{o,s}-\beta_{e,s})|c_2|^2.
+ \end{aligned}                                    \tag{40}
+\]
+
+By (37), every $c_2\ne0$ state in either quadric violates that quadric after
+one transfer. In the $P_+$ convention the exact nonzero violation is
+$2|c_2|^2(\rho_{e,s}^4-\rho_{o,s}^4)$. The violation is the even-odd rate
+difference, not a floating residual or a genericity assertion.
+
+If $c_2=0$, the two class equations agree and reduce to
+$|c_1|=|c_3|$. Transfer multiplies both members of this pair by the same
+$\beta_{o,s}$, while $c_0$ remains unrestricted. Hence
+
+\[
+ T_s\mathcal V_{\rm bal}\subseteq\mathcal V_{\rm bal}.        \tag{41}
+\]
+
+Conversely, (38)--(39) show that no other point of either class is stable.
+Therefore
+
+\[
+ \{\text{transfer-stable points of }\mathcal V_+\}
+ =\{\text{transfer-stable points of }\mathcal V_-\}
+ =\mathcal V_+\cap\mathcal V_-
+ =\mathcal V_{\rm bal}.                           \tag{42}
+\]
+
+For the balanced witness $w$, the violation is zero. For the unbalanced
+checker $u$, $|c_2|^2=4$, and the two $P_+$ checks are
+
+\[
+ q_+(T_su)=8(\beta_{e,s}^2-\beta_{o,s}^2)\ne0,
+ \qquad
+ u^\dagger P_+T_su=8(\beta_{e,s}-\beta_{o,s})\ne0.             \tag{43}
+\]
+
+This holds at both fixtures. The full convention-specific graph exists as a
+static sourced quotient, but it does not carry the certified transfer as a
+self-map. The balanced graph quotient does. This is why the physical
+quotient claim ships only for the balanced sector.
+
+## 8. The Localization Verdict
+
+For either $P=P_+$ or $P=P_-$, call a family $D=(D_x)$ admissible when
+
+\[
+ D_x^\dagger=D_x
+ \quad\text{for every }x,
+ \qquad
+ \sum_xD_x=P.                                    \tag{44}
+\]
+
+Hermiticity makes every $\rho_x^{(D)}(a)$ real. The sum rule supplies the
+one-line total lemma:
+
+\[
+ \boxed{\displaystyle
+ \sum_x\rho_x^{(D)}(a)
+ ={a^\dagger(\sum_xD_x)a\over a^\dagger a}
+ ={a^\dagger Pa\over a^\dagger a}=0
+ \quad(a\in\mathcal V_P).}                       \tag{45}
+\]
+
+Thus every admissible localization produces a source in
+$\operatorname{im}B_4^{\mathsf T}$. Equations (27)--(29) then apply without
+change. If $D$ and $D'$ are two admissible choices, their profile difference
+obeys
+
+\[
+ \sum_x\bigl(\rho_x^{(D)}(a)-\rho_x^{(D')}(a)\bigr)=0,         \tag{46}
+\]
+
+so it changes the particular Gauss response but not existence, gauge-fiber
+dimension, or the graph isomorphism to the matter class.
+
+The anticommutator ordering in (16) is one admissible choice. A superficially
+Hermitian alternative is the sandwich ordering
+
+\[
+ \widetilde D_x=E_xPE_x.
+\]
+
+It is inadmissible because
+
+\[
+ \sum_xE_xP_\pm E_x
+ ={\operatorname{tr}P_\pm\over4}I_4
+ =\pm{1\over2}I_4\ne P_\pm.                     \tag{47}
+\]
+
+For the balanced witness $w=e_1+e_3$, this failure is already visible as
+
+\[
+ {w^\dagger(\sum_xE_xP_\pm E_x)w\over w^\dagger w}
+ =\pm{1\over2}\ne0,                             \tag{48}
+\]
+
+for either convention. The sandwich profile therefore does not satisfy the
+closed-cycle total-source condition and cannot be used to contradict (45).
+
+The cosmetic/structural split is:
+
+| item | status under an admissible localization change |
+|---|---|
+| pointwise $\rho_x$ and a chosen $\Gamma_0$ | convention-dependent profile |
+| zero total and Gauss solvability | structural and unchanged |
+| constant gauge fiber and zero physical gravity fiber | structural and unchanged |
+| graph isomorphism to the matter class | structural and unchanged |
+| balanced-sector transfer stability | structural and localization-independent |
+
+Block 123's routed local density failed quotient null-space descent in all
+four sectors at both fixtures. The present $D_x$ is therefore an explicit
+Hermitian localization of the descended global momentum $P$, not a claim
+that the routed density has been repaired. The localization verdict covers
+all and only the admissible families in (44). A different density concept
+which does not obey that contract remains outside the theorem.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded sourced-quotient wall. It has a dual character
+and is positive-dominant.
+
+- W1 — **UNBALANCED STABILITY WALL / BALANCED QUOTIENT BREAK:** away from
+  $c_2=0$, the vanishing-expected-momentum set depends on the sign chosen for
+  $p_2$, and neither convention-specific full quadric is preserved by the
+  transfer because $\beta_e\ne\beta_o$. On $c_2=0$, the two conventions
+  agree, the balanced class $|c_1|=|c_3|$ is exactly transfer-stable, and
+  its sourced Gauss graph modulo constant gauge is a physical quotient
+  isomorphic to that matter class with zero independent gravity dimensions.
+
+The negative half of W1 excludes an unqualified full-quadric dynamical
+quotient. Its stronger positive half executes the balanced sourced quotient.
+The physical quotient claim ships **ONLY** for the balanced sector. W1 is
+narrow to the certified rank-four package, the fixtures $s=5/13$ and
+$s=3/5$, the two $p_2$ conventions in (1), the forward incidence in (19),
+and admissible localizations satisfying (44).
+
+Equivalently: the unbalanced sector is not transfer-stable, and the class
+set is convention-dependent off $c_2=0$; the physical quotient claim ships
+only for the balanced sector.
+
+W1 is not an observable-wall repair. Block 123's routed local density still
+fails descent. It is not a theorem about a larger gravity constraint
+algebra, a non-local current dressing, or a curved half-space
+reconstruction.
+
+W1 is not an OS no-go and is not a curved OS no-go. It identifies the
+maximal convention-free stable class on one finite sourced package.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). Static source
+execution, transfer stability, convention choice, and observable descent
+remain separate.
+
+1. **PROVED / POSITIVE — strongest executed quotient with stable balanced
+   sector / the sourced-pair graph and constant gauge quotient / physical
+   quotient isomorphic to $\mathcal V_{\rm bal}$ with zero independent
+   gravity dimensions and exact transfer preservation.** This is the
+   strongest route and the shipped theorem.
+2. **PROVED — forced root identity / parity-shared reciprocal minimal
+   polynomials and contractivity / one uniquely forced stable root per
+   parity, with coprime even and odd polynomials.** Thus
+   $\beta_e\ne\beta_o$ exactly at both fixtures.
+3. **PROVED — Gauss closed form with orientation pin / tail-minus-head
+   forward incidence / equation (20), with the opposite orientation giving
+   $-\rho$.** The only homogeneous solution is constant gauge.
+4. **PROVED — localization sum-rule lemma / Hermiticity plus
+   $\sum_xD_x=P$ / zero total source, Gauss solvability, and the same graph
+   quotient for every admissible localization.** Only the spatial profile
+   changes.
+5. **PROVED — convention analysis with checker-discipline credit / display
+   both $p_2$ signs, their equal dimensions, their unequal sets, and their
+   exact intersection / restrict convention-free claims to $c_2=0$.** The
+   witness $u$ is explicitly quarantined as a $P_+$ checker.
+6. **UNTESTED-LIVE — non-local dressings, naturality, and curved OS /
+   repair the observable wall, classify the swap completion, and reconstruct
+   the half-space package / test whether the executed balanced quotient
+   survives those stronger structures.** No result on that terminal is
+   imported here.
+
+The completed ADM/history transporter, joint gravity, and the full gravity
+constraint quotient beyond the displayed carrier remain downstream of row
+6. W1 consumes none of those routes.
+
+### N2 — Wall-Independence Audit
+
+W1 is independent of Block 123's population-definiteness wall, anchored at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md:549-576`.
+
+[Block 123](ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md)
+asked whether a total source lies in the zero-sum closed-cycle incidence
+image. Its wall mechanism was definiteness: identity-valued U(1) charge
+cannot cancel on a nonzero positive state, whereas indefinite momentum has
+a displayed expectation-zero class. It established compatibility but did
+not form the sourced quotient.
+
+The present W1 begins after that compatibility result. Its object is the
+executed graph quotient and its transfer self-map. Its negative mechanism is
+the combination of the $p_2$ branch ambiguity and the exact inequality
+$\beta_e\ne\beta_o$. Its positive mechanism is the equality of the paired
+odd rate together with the intersection identity (42). Neither mechanism is
+charge definiteness.
+
+There is an honest shared input: both blocks use the global momentum
+expectation $a^\dagger Pa$. That shared input does not merge the walls. A
+zero-total source can form a static Gauss graph and still fail to be carried
+to another zero-total source by transfer; equations (38)--(39) exhibit that
+separation exactly.
+
+The local-observable wall is independent again. It concerns null descent of
+the routed local density, while the present localization argument starts
+from a descended global $P$ and imposes (44). Static quotient execution does
+not repair the routed operator, and routed failure does not alter the
+sum-rule graph theorem.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified explicitly.
+Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| certified package | the inherited finite quotient package only |
+| both rational shear fixtures | exactly $s=5/13$ and $s=3/5$ |
+| momentum-sourced gauss quotient is executed | graph quotient (28) only |
+| vanishing-expected-momentum class | $a^\dagger P_\pm a=0$ |
+| exact quadric | the two equations in (2) |
+| convention-invariant dimension counts | $(7,6,5)$ for either quadric |
+| p_2-sign-dependent set | $\mathcal V_+\ne\mathcal V_-$ off the intersection |
+| nonzero c_2 | convention-dependent and transfer-unstable region |
+| displayed claims restricted to the c_2 = 0 sector | physical shipping firewall |
+| conventions agree | exactly equation (3) |
+| closed-cycle gauss equation | $B_4^{\mathsf T}\Gamma=\rho$ only |
+| closed form | equation (6), verified in (20) |
+| pinned forward-difference orientation | tail-minus-head convention (19) |
+| constant gauge mode | the one-dimensional kernel (24) |
+| physical sector is isomorphic to the matter class | map (28) |
+| gravity contributing zero independent dimensions | fiber count $(1,1,0)$ |
+| transfer preserves exactly the balanced sector | equivalence (42) |
+| paired momenta share one characteristic polynomial | identities (31)--(32) |
+| stable root is uniquely forced | reciprocal-root argument (35) |
+| unbalanced states violate the class | equations (38)--(39) for $c_2\ne0$ |
+| exact even-odd rate difference | factors $\beta_e^2-\beta_o^2$ and its negative |
+| quotient structure is independent of the choice | graph type, not profile |
+| admissible hermitian localization | both requirements in (44) |
+| satisfy the sum rule | $\sum_xD_x=P$ exactly |
+| one displayed alternative ordering is inadmissible | sandwich ordering (47) |
+| spatial profile convention-dependent | $\rho_x$ and $\Gamma_0$ only |
+| local routed density still fails descent | Block 123 caveat carried through |
+| non-local current dressings | untested-live observable repair route |
+| observable wall | not repaired by the chosen localization |
+| naturality classification | untested-live downstream classification |
+| swap completion | no naturality theorem here |
+| curved os positivity | explicit reconstruction firewall |
+| half-space package | only the inherited displayed package |
+| completed adm/history transporter | downstream construction firewall |
+| joint gravity | explicitly not completed |
+| full gravity constraint quotient beyond the displayed carrier | outside scope |
+| records | no Records claim |
+| retention | independent-audit firewall |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit accounting |
+| actual adm/history transporter remains | standard partial-close statement |
+| gravity constraint quotient remains unexecuted | constraint-scope firewall |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | five N5 keys |
+
+No phrase upgrades the balanced graph into a quotient beyond the displayed
+carrier, an expectation-value constraint into operator annihilation, an
+admissible localization into descent of Block 123's routed density, or a
+pointwise profile into localization-independent data. Nothing asserts a
+non-local dressing, naturality, curved OS positivity, transporter
+completion, joint gravity, axiom amendment, audit retention, obligation
+retirement, or TOE percentage movement.
+
+### N4 — Residual Matching
+
+The supplied historical Block 105 result line, carried through Block 123,
+is:
+
+> Block 105 §12 item 4 moves on exact source conservation and constraint
+> preservation, but not on propagating $d=2$ gravity or gravity-transfer
+> selection.
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 123 next gate](ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md:16` | “Execute the momentum-sourced Gauss quotient on the closed carrier with the vanishing-expectation state class; then non-local dressings, the naturality classification, and curved OS positivity.” | executed as the sourced graph modulo constant gauge, with certified dynamics restricted to the balanced sector; the three downstream tasks remain |
+| [Block 121 population wall](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md) | the identity-valued U(1) source cannot populate the zero-sum closed carrier | the momentum alternative is now populated and quotiented in the balanced sector; the U(1) definiteness statement is unchanged |
+| Block 105 §12 item 4 | exact source conservation and constraint preservation, without propagating gravity or gravity-transfer selection | the coupling arc has full closure on the displayed carrier: zero-total momentum source, exact Gauss response, gauge quotient, and stable balanced transfer; no extrapolation beyond that carrier follows |
+
+This is a partial closure of Block 123's next gate because its first clause is
+executed while non-local dressings, naturality, and curved OS positivity are
+not. “Full closure on the displayed carrier” means equations (25)--(45) for
+the rank-four package only. It does not mean that the full gravity constraint
+quotient, a gravity constraint algebra, or propagating gravity has been
+constructed.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “On the certified package at both
+rational shear fixtures, the momentum-sourced closed-cycle Gauss graph
+modulo its constant gauge mode is isomorphic to the exact
+vanishing-expected-momentum matter quadric with zero independent gravity
+dimensions; after exposing the $p_2$ branch ambiguity, its convention-free
+intersection is exactly the balanced sector $c_2=0$, $|c_1|=|c_3|$, and
+this is also exactly the sector preserved by the parity-paired transfer,
+independently of any admissible Hermitian localization satisfying the sum
+rule, though the spatial profile depends on that localization.”
+
+Forbidden upgrades include:
+
+- “the full gravity constraint quotient is executed”;
+- “the quotient is localization-independent in its profile”; and
+- “retained obligation moves.”
+
+The first exports a rank-four graph theorem beyond its carrier. The second
+contradicts (46). The third invents both an audit disposition and TOE
+movement.
+
+Also forbidden are “the full quadric is transfer-stable,”
+“the two momentum conventions define the same class,” “the routed local
+density descends,”
+“expectation zero means $Pa=0$,” “gravity propagates,” “naturality is
+classified,” and “curved OS positivity holds.” Equations (2), (38)--(39),
+and the Block 123 caveat refute the first three; none of the remaining
+claims is tested here.
+
+The five N5 resolution lines fixed for the runner are reproduced verbatim:
+
+```text
+N5: per_element: exact quadric, convention-intersection, gauss-solution, orientation, root-identity, sector-preservation, violation, and sum-rule certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: the paired momenta share one characteristic polynomial with the stable root forced, so the balanced sector is transfer-invariant while unbalanced states violate the class by an exact rate difference
+per_block: the momentum-sourced gauss quotient is executed — the physical sector is the convention-free stable balanced class with gravity contributing only its quotiented gauge mode, independent of the admissible localization
+lattice_wide: checked and not executed — non-local dressings for the observable wall, the naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the full gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The result executes the source-compatible
+momentum route on its convention-free stable subcone without weakening the
+observable wall.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| $p_2=+2$ class | exact quadric, dimensions $(7,6,5)$ | no set equality with $p_2=-2$ off $c_2=0$ |
+| $p_2=-2$ class | exact quadric, dimensions $(7,6,5)$ | no set equality with $p_2=+2$ off $c_2=0$ |
+| convention-free class | exact balanced intersection, dimensions $(5,4,3)$ | none for displayed matter carrier |
+| closed-cycle source total | exactly zero by (45) | requires admissible localization |
+| forward Gauss equation | exact closed form (20) | none for pinned orientation |
+| opposite orientation | maps the same solution to $-\rho$ | must reverse the solution too |
+| constant gravity mode | exact one-dimensional kernel | removed by gauge quotient |
+| physical gravity fiber | exactly zero-dimensional | no independent displayed gravity mode |
+| sourced graph quotient | isomorphic to the matter class | no extension beyond displayed carrier |
+| paired transfer roots | exact shared polynomials and unique stable roots | none for displayed scalar transfer |
+| even versus odd roots | exactly unequal at both fixtures | blocks unbalanced self-map |
+| full convention-specific quadric | static quotient exists | not transfer-stable |
+| balanced sourced quotient | exact transfer self-map | test stronger structures |
+| admissible localization | quotient structure unchanged | spatial profile remains conventional |
+| sandwich ordering $E_xPE_x$ | Hermitian but fails the sum rule | inadmissible |
+| routed local density | inherited failure in all sectors | construct non-local dressing |
+| naturality classification | untested-live | classify the swap completion |
+| curved OS route | not executed | prove positivity on the half-space package |
+| gravity constraint quotient | displayed carrier only | execute beyond that carrier |
+
+The scan finds no axiom-amendment route. Block 123's first next-gate clause
+is discharged exactly on $\mathcal V_{\rm bal}$. The remaining terminals
+are the non-local observable, naturality, curved reconstruction, completed
+transporter, and gravity beyond the displayed carrier.
+
+### N7 — Steelman
+
+**Hostile steelman: the quotient is small.** It contains one balanced family
+on a rank-four matter space, and gravity adds no physical fiber. Why regard
+this as substantive?
+
+Agreed about the size. The content is its existence and stability, not its
+size. A source-compatible expectation class has been turned into an exact
+Gauss graph, its gauge quotient has been computed, and its maximal
+convention-free transfer-stable sector has been identified. A richer carrier
+must recompute every step; no universality claim is made.
+
+**Hostile steelman: the expectation-value caveat from Block 123 still
+applies.** A state with $a^\dagger Pa=0$ need not satisfy $Pa=0$, so this is
+not an operator constraint quotient.
+
+Agreed. For example, $P_\pm w=e_1-e_3\ne0$. The source equation uses the
+normalized expectation profile in (4), exactly as the Block 123 population
+question requires. The present execution quotients the resulting c-number
+Gauss graph. It neither asserts charge annihilation nor substitutes for a
+future operator-level gravity constraint.
+
+**Hostile steelman: localization independence is conditional.** The proof
+covers admissible Hermitian orderings only, while a fundamentally different
+density concept could change the conclusion.
+
+Agreed. Equation (45) uses both Hermiticity and the sum rule. The sandwich
+ordering (47) shows why a plausible alternative is not automatically
+admissible. Within (44), the graph structure is invariant and only the
+profile changes. A density concept outside (44), including a successful
+non-local repair of the routed observable, remains an open construction.
+
+These steelmen preserve narrow W1. The theorem supplies a small exact
+balanced quotient, carries the expectation-value caveat explicitly, and
+makes localization admissibility a hypothesis rather than hiding it.
+
+### N8 — Cross-Cycle Echo
+
+The immediate campaign chain separated positive carrier construction,
+source population, quotient execution, and dynamical stability.
+
+| campaign block | narrowing that leads to W1 and the positive break |
+|---|---|
+| [Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | supplied the certified rank-one-per-sector positive quotient and contractive scalar transfer |
+| [Block 121](ADMISSIBILITY_DIRAC_KAHLER_CONSTRAINT_QUOTIENT_COUPLING_BOUNDED_THEOREM_NOTE_2026-08-16.md) | posed the closed-cycle population wall and fixed the incidence-image criterion |
+| [Block 123](ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md) | found the indefinite-momentum population break, preserved the local-observable wall, and named sourced quotient execution as the next gate |
+| Block 124 | executes the sourced graph quotient, exposes the $p_2$ convention split, and proves that its convention-free sector is exactly its transfer-stable sector |
+
+The present result does not reuse population compatibility as proof of
+transfer stability. Compatibility follows from the total lemma (45), while
+stability follows from the paired-polynomial identities and the exact
+even-odd difference (38)--(39). Conversely, transfer stability does not
+repair local-observable descent.
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1, with
+positive-dominant dual character. The unbalanced sector is
+convention-dependent and not transfer-stable. The balanced sector is the
+exact common quadric, its forward-oriented Gauss graph modulo constant gauge
+is an executed physical quotient with zero independent gravity dimensions,
+and it is exactly transfer-stable under any admissible Hermitian localization
+at both fixtures. **FAIL** for a full-quadric dynamical quotient, a
+localization-independent spatial profile, descent of the routed density,
+operator annihilation, a non-local dressing, naturality, curved OS
+positivity, a completed ADM/history transporter, joint gravity, a quotient
+beyond the displayed carrier, axiom necessity, audit retention, obligation
+retirement, or TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. The two class quadrics, dimension counts,
+forward-incidence solution, constant gauge quotient, zero independent
+gravity fiber, parity-root identities, balanced transfer theorem, and
+localization sum-rule lemma are finite consequences of the displayed
+carrier, global momentum, transfer, and fixtures. No new primitive is
+assumed.
+
+This is bounded route closure, not an audit-grade assignment. It retires no
+end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. construct non-local current dressings for the observable wall and test
+   Ward compatibility, null descent, and reflection-adjointness on the
+   balanced sourced quotient;
+2. classify the naturality of the swap completion on whichever dressed
+   package survives; and
+3. execute curved OS positivity on the half-space package with that sourced,
+   dressed, and classified structure.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+half-space positive package, its contractive parity-paired transfer, and the
+balanced sourced Gauss graph modulo constant gauge.
+
+Reflection positivity on the curved carrier remains unexecuted.
+
+The gravity constraint quotient remains unexecuted beyond the displayed
+balanced carrier.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15977,
- "node_count": 5552,
+ "edge_count": 15981,
+ "node_count": 5553,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -489,6 +489,10 @@
   "admissibility_dirac_kahler_shifted_origin_frame_gauge_nonuniform_hodge_overlap_bounded_theorem_note_2026-08-14": {
    "deps_hash": "abb470ff102c",
    "out_degree": 3
+  },
+  "admissibility_dirac_kahler_sourced_quotient_execution_bounded_theorem_note_2026-08-17": {
+   "deps_hash": "7d2c967c528b",
+   "out_degree": 4
   },
   "admissibility_dirac_kahler_torus_wrap_defect_bounded_theorem_note_2026-08-16": {
    "deps_hash": "baa2b2baa792",

--- a/logs/runner-cache/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.py
+runner_sha256: ded3c60d6ec15bebe7e2b3c2da3d597a1241b9e145d2fe466d6bdcb550b618b3
+input_fingerprint_sha256: 7d391af8f36628f9902925508feec9ae965f9c478d10093e36fa9e254adc6806
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 58.85
+status: ok
+----- stdout -----
+[PASS] A-authority: Block 123 note/runner/cache and ancestors 122--103 are pinned
+[PASS] B-the-class-quadric: |c1|^2+2|c2|^2=|c3|^2 with c0 free has dims 7/6/5; p2=-2 differs off c2=0 and agrees exactly on the balanced intersection
+[PASS] C-the-gauss-solution: (B4^T Gamma)_j=Gamma_j-Gamma_{j+1}; the closed form and mean-zero witness solve it, while the opposite orientation fails
+[PASS] D-the-physical-quotient: the d=2 sourced graph modulo its constant gauge mode is isomorphic to the matter class and gravity adds zero independent dimensions
+[PASS] E-the-forced-root-identity: k=0,2 and k=1,3 have identical characteristic polynomials; |tau|>2 uniquely forces each |rho|<1 root, with rho_even!=rho_odd
+[PASS] F-the-stable-balanced-sector: diag(rho_k^2) preserves exactly c2=0, |c1|=|c3|; every c2!=0 class state acquires 2|c2|^2(rho_even^4-rho_odd^4)!=0
+[PASS] G-the-localization-verdict: D_x={E_x,P}/2 is admissible, E_xPE_x is not; any admissible sum gives total <P>, so only the profile is conventional
+[PASS] H-scope: required sourced-quotient/convention/root/gauge/localization/N1--N8/W1/N5 firewalls and runtime bound are present
+CLASS QUADRIC: <P>=0 iff |c1|^2+2|c2|^2=|c3|^2 with c0 free; explicit cone/normalized/ray parametrization ranks=7/6/5.
+CONVENTION INTERSECTION: p2=+2 and p2=-2 define different classes for c2!=0; their exact common class is c2=0, |c1|=|c3|, with convention-invariant dimensions.
+GAUSS ORIENTATION: rho=(2/9,-1/9,0,-1/9) has Gamma_mean0=(1/9, -1/9, 0, 0) under Gamma_j-Gamma_(j+1); the opposite sign fails.
+PHYSICAL QUOTIENT: d=2 TT dimension=0 and gravity solution/gauge/physical-fiber dimensions=1/1/0; the graph is the matter class.
+FORCED ROOTS: k0=k2 and k1=k3 in both fixtures, with unique stable roots and tau_even!=tau_odd; polynomial sha=19baabff740f222c/c3711b5df8de88b6.
+STABLE BALANCED SECTOR: c2=0, |c1|=|c3| is exactly transfer-invariant; the unbalanced violation is 2|c2|^2(rho_even^4-rho_odd^4).
+LOCALIZATION: pinned admissible D_x gives witness profile=(2/9, -1/9, 0, -1/9); profile choice is cosmetic, while the total sum rule and quotient structure are structural.
+N5: per_element: exact quadric, convention-intersection, gauss-solution, orientation, root-identity, sector-preservation, violation, and sum-rule certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: the paired momenta share one characteristic polynomial with the stable root forced, so the balanced sector is transfer-invariant while unbalanced states violate the class by an exact rate difference
+per_block: the momentum-sourced gauss quotient is executed — the physical sector is the convention-free stable balanced class with gravity contributing only its quotiented gauge mode, independent of the admissible localization
+lattice_wide: checked and not executed — non-local dressings for the observable wall, the naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the full gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open
+RESULT: the lane's first physical gravity quotient exists and carries dynamics — the convention-free transfer-stable balanced sector with exact gauss solutions unique up to the constant gauge mode, its structure independent of the admissible localization
+DECISION_CUT: advance non-local dressings and the naturality classification; reject unbalanced-sector and inadmissible-localization constructions
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.py
+++ b/scripts/admissibility_dirac_kahler_sourced_quotient_execution_2026_08_17.py
@@ -1,0 +1,1252 @@
+#!/usr/bin/env python3
+"""Block 124: exact execution of the momentum-sourced Gauss quotient.
+
+The four positive quotient directions are ordered by Z4 momentum
+k=(0,1,2,3), with pinned principal charges p=(0,1,2,-1).  The committed
+Block 123 runner is imported as the authority chain.  Every scientific
+calculation uses exact SymPy arithmetic; wall-clock timing is the sole
+floating-point quantity.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+import subprocess
+import time
+
+import sympy as sp
+
+import admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16 as prior
+
+
+R = sp.Rational
+I = sp.I
+block121 = prior.block121
+block119 = prior.block119
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-17.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_"
+    "BOUNDED_THEOREM_NOTE_2026-08-16.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_momentum_population_definiteness_"
+    "2026_08_16.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_momentum_population_"
+    "definiteness_2026_08_16.txt"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+    "scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py",
+    "logs/runner-cache/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "31e4c7ff7d41db6a78feef19dba2bfbea3dc1830"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block123-momentum-population-definiteness-20260816"
+)
+PARENT_COMMIT = "954322e0e085d6c3133ce24dca49db2efbd7d0a6"
+PARENT_NOTE_BLOB = "560894350af5930f88161455f4db8954730f3e96"
+PARENT_RUNNER_BLOB = "7ee63309da28801f0a5fb412dba402819e7d0d66"
+PARENT_CACHE_BLOB = "41e2ef00a3a74cabba9b603dbd902cc365bffaa2"
+ANCESTOR_COMMITS = (
+    (122, "f067b99be7eb49fc46ea8dffccab5e20e6052d88"),
+    (121, "1714abeefcf3763c0bfe001f30fd14521c538622"),
+    (120, "1c2386bf3df420707fd2ecb2d7ec84002ba40ad1"),
+    (119, "33fd2d21558604718f3a88713fe1976aff8f9dbb"),
+    (118, "fdd1883c54ca8cc14b1337cc1edc249792d5dab2"),
+    (117, "f800356aec0989b6e0fa80ed43274794243b1ca2"),
+    (116, "c36d11e4e8d927c6fc31f0a8b579d4bd15f4fa43"),
+    (115, "c78301fef7521d0518f485f1bf9266983c9e516a"),
+    (114, "75026e71cfbd44ed665ddc41c22ebaa722720ea9"),
+    (113, "e76893eb7204d1d727a3ab8838fb3fada3f45dfc"),
+    (112, "385a6ba5b1594f20e5d4eebba9da68d8e72abc10"),
+    (111, "b04e7c8747b09734711cfcd2bfab961bd12e81ad"),
+    (110, "d6761278fca9cac617200792473a8f4da3a6cfff"),
+    (109, "ad84cfcc857a65285389ba93b47cd7b718589be5"),
+    (108, "8afe8dff5ccf531208238af0aaaec1f547d73874"),
+    (107, "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"),
+    (106, "22d6d90ec2279e5868c9c825149b2a20beea3797"),
+    (105, "d06066c2b908aaca0779625d831dfb10620cf34d"),
+    (104, "7fe07db6c03fad1191893c942f708c5cb9a54c43"),
+    (103, "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"),
+)
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "break_quadric",
+    "claim_convention_free_class",
+    "break_gauss_solution",
+    "break_orientation_pin",
+    "break_quotient_isomorphism",
+    "break_root_identity",
+    "break_sector_preservation",
+    "break_violation_formula",
+    "break_sum_rule",
+    "claim_structural_localization",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_toe_progress",
+)
+
+P_VALUES = (sp.Integer(0), sp.Integer(1), sp.Integer(2), sp.Integer(-1))
+P = sp.diag(*P_VALUES)
+P_ALTERNATE = sp.diag(0, 1, -2, -1)
+SHEARS = prior.SHEARS
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition) -> None:
+        ok = bool(condition)
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {statement}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    ancestors = {
+        f"ancestor_{number}": is_ancestor(commit, "HEAD")
+        for number, commit in ANCESTOR_COMMITS
+    }
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        **ancestors,
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+    }
+
+
+def matrix_zero(matrix: sp.MatrixBase) -> bool:
+    return all(sp.expand(value) == 0 for value in matrix)
+
+
+def exact_digest(*payload: object) -> str:
+    return hashlib.sha256(sp.srepr(payload).encode("utf-8")).hexdigest()[:16]
+
+
+def squared_norm(vector: sp.Matrix) -> sp.Expr:
+    return sp.expand((vector.H * vector)[0])
+
+
+def momentum_numerator(
+    vector: sp.Matrix, momentum: sp.Matrix = P
+) -> sp.Expr:
+    return sp.expand((vector.H * momentum * vector)[0])
+
+
+def normalized_note() -> str:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+    return " ".join(raw_note.lower().split())
+
+
+@dataclass(frozen=True)
+class ParametrizationRanks:
+    cone: int
+    normalized: int
+    ray: int
+    equation_exact: bool
+
+
+@dataclass(frozen=True)
+class StateFixture:
+    name: str
+    vector: sp.Matrix
+    norm_squared: sp.Expr
+    momentum: sp.Expr
+
+
+@dataclass(frozen=True)
+class StateClassCertificate:
+    equation: sp.Expr
+    alternate_equation: sp.Expr
+    pinned_ranks: ParametrizationRanks
+    alternate_ranks: ParametrizationRanks
+    ambient_real_dimension: int
+    cone_dimension: int
+    normalized_dimension: int
+    ray_dimension: int
+    c0_free: bool
+    forms_exact: bool
+    sets_differ_off_c2_zero: bool
+    intersection_exact: bool
+    dimensions_convention_invariant: bool
+    fixtures: tuple[StateFixture, ...]
+
+
+def _normalization(coordinates: sp.Matrix) -> sp.Matrix:
+    norm_squared = sp.expand(sum(value**2 for value in coordinates))
+    return coordinates / sp.sqrt(norm_squared)
+
+
+def _parametrization_ranks(convention: str) -> ParametrizationRanks:
+    """Exact local ranks on a nonsingular chart of each real class cone."""
+    a0, b0, a1, b1, a2, b2, a3, b3, t = sp.symbols(
+        "a0 b0 a1 b1 a2 b2 a3 b3 t", real=True
+    )
+    if convention == "p2=+2":
+        parameters = (a0, b0, a1, b1, a2, b2, t)
+        radius_squared = a1**2 + b1**2 + 2 * (a2**2 + b2**2)
+        radius = sp.sqrt(radius_squared)
+        denominator = 1 + t**2
+        coordinates = sp.Matrix(
+            (
+                a0,
+                b0,
+                a1,
+                b1,
+                a2,
+                b2,
+                radius * (1 - t**2) / denominator,
+                2 * radius * t / denominator,
+            )
+        )
+        equation = (
+            coordinates[2] ** 2
+            + coordinates[3] ** 2
+            + 2 * (coordinates[4] ** 2 + coordinates[5] ** 2)
+            - coordinates[6] ** 2
+            - coordinates[7] ** 2
+        )
+        witness = {
+            a0: 1,
+            b0: 2,
+            a1: 1,
+            b1: 0,
+            a2: 0,
+            b2: 0,
+            t: 0,
+        }
+        ray_parameters = parameters[:-1]
+        ray_coordinates = coordinates.subs(t, 0)
+    elif convention == "p2=-2":
+        parameters = (a0, b0, a2, b2, a3, b3, t)
+        radius_squared = 2 * (a2**2 + b2**2) + a3**2 + b3**2
+        radius = sp.sqrt(radius_squared)
+        denominator = 1 + t**2
+        coordinates = sp.Matrix(
+            (
+                a0,
+                b0,
+                radius * (1 - t**2) / denominator,
+                2 * radius * t / denominator,
+                a2,
+                b2,
+                a3,
+                b3,
+            )
+        )
+        equation = (
+            coordinates[2] ** 2
+            + coordinates[3] ** 2
+            - 2 * (coordinates[4] ** 2 + coordinates[5] ** 2)
+            - coordinates[6] ** 2
+            - coordinates[7] ** 2
+        )
+        witness = {
+            a0: 1,
+            b0: 2,
+            a2: 0,
+            b2: 0,
+            a3: 1,
+            b3: 0,
+            t: 0,
+        }
+        ray_parameters = parameters[:-1]
+        ray_coordinates = coordinates.subs(t, 0)
+    else:
+        raise ValueError(f"unknown momentum convention {convention!r}")
+
+    cone_rank = coordinates.jacobian(parameters).subs(witness).rank()
+    normalized_rank = (
+        _normalization(coordinates).jacobian(parameters).subs(witness).rank()
+    )
+    ray_rank = (
+        _normalization(ray_coordinates)
+        .jacobian(ray_parameters)
+        .subs(witness)
+        .rank()
+    )
+    return ParametrizationRanks(
+        cone=cone_rank,
+        normalized=normalized_rank,
+        ray=ray_rank,
+        equation_exact=sp.simplify(equation) == 0,
+    )
+
+
+def state_class_certificate() -> StateClassCertificate:
+    real = sp.symbols("x0:4", real=True)
+    imag = sp.symbols("y0:4", real=True)
+    coefficients = sp.Matrix(
+        [real[index] + I * imag[index] for index in range(4)]
+    )
+    equation = momentum_numerator(coefficients)
+    alternate_equation = momentum_numerator(coefficients, P_ALTERNATE)
+    n1 = real[1] ** 2 + imag[1] ** 2
+    n2 = real[2] ** 2 + imag[2] ** 2
+    n3 = real[3] ** 2 + imag[3] ** 2
+    expected = sp.expand(n1 + 2 * n2 - n3)
+    expected_alternate = sp.expand(n1 - 2 * n2 - n3)
+    pinned_ranks = _parametrization_ranks("p2=+2")
+    alternate_ranks = _parametrization_ranks("p2=-2")
+
+    plus_only = sp.Matrix((0, 0, 1, sp.sqrt(2)))
+    minus_only = sp.Matrix((0, sp.sqrt(2), 1, 0))
+    intersection_solution = sp.solve(
+        (sp.Symbol("n1") + 2 * sp.Symbol("n2") - sp.Symbol("n3"),
+         sp.Symbol("n1") - 2 * sp.Symbol("n2") - sp.Symbol("n3")),
+        (sp.Symbol("n2"), sp.Symbol("n3")),
+        dict=True,
+    )
+    intersection_exact = (
+        sp.expand(equation - alternate_equation - 4 * n2) == 0
+        and intersection_solution
+        == [{sp.Symbol("n2"): 0, sp.Symbol("n3"): sp.Symbol("n1")}]
+        and sp.expand((equation - alternate_equation).subs({real[2]: 0, imag[2]: 0}))
+        == 0
+    )
+    fixtures = tuple(
+        StateFixture(name, vector, squared_norm(vector), momentum_numerator(vector))
+        for name, vector in (
+            ("w=e1+e3", sp.Matrix((0, 1, 0, 1))),
+            ("u=2e0+e1+2e2+3e3", sp.Matrix((2, 1, 2, 3))),
+        )
+    )
+    return StateClassCertificate(
+        equation=equation,
+        alternate_equation=alternate_equation,
+        pinned_ranks=pinned_ranks,
+        alternate_ranks=alternate_ranks,
+        ambient_real_dimension=8,
+        cone_dimension=7,
+        normalized_dimension=6,
+        ray_dimension=5,
+        c0_free=all(
+            sp.diff(equation, variable) == 0
+            and sp.diff(alternate_equation, variable) == 0
+            for variable in (real[0], imag[0])
+        ),
+        forms_exact=(
+            sp.expand(equation - expected) == 0
+            and sp.expand(alternate_equation - expected_alternate) == 0
+        ),
+        sets_differ_off_c2_zero=(
+            momentum_numerator(plus_only) == 0
+            and momentum_numerator(plus_only, P_ALTERNATE) == -4
+            and momentum_numerator(minus_only, P_ALTERNATE) == 0
+            and momentum_numerator(minus_only) == 4
+        ),
+        intersection_exact=intersection_exact,
+        dimensions_convention_invariant=(
+            pinned_ranks == ParametrizationRanks(7, 6, 5, True)
+            and alternate_ranks == ParametrizationRanks(7, 6, 5, True)
+        ),
+        fixtures=fixtures,
+    )
+
+
+@dataclass(frozen=True)
+class GaussCertificate:
+    incidence: sp.Matrix
+    orientation_exact: bool
+    zero_sum_image_exact: bool
+    symbolic_solution_exact: bool
+    gauge_kernel_exact: bool
+    witness_source: sp.Matrix
+    witness_mean_zero: sp.Matrix
+    witness_exact: bool
+    opposite_orientation_fails: bool
+
+
+def gauss_certificate() -> GaussCertificate:
+    incidence = block121.periodic_incidence_1d(4)
+    expected_incidence = sp.Matrix(
+        ((1, 0, 0, -1), (-1, 1, 0, 0), (0, -1, 1, 0), (0, 0, -1, 1))
+    )
+    gamma_symbols = sp.Matrix(sp.symbols("g0:4", real=True))
+    forward_difference = sp.Matrix(
+        [gamma_symbols[index] - gamma_symbols[(index + 1) % 4]
+         for index in range(4)]
+    )
+    orientation_exact = (
+        incidence == expected_incidence
+        and matrix_zero(incidence.T * gamma_symbols - forward_difference)
+    )
+
+    r0, r1, r2, lam = sp.symbols("r0 r1 r2 lambda", real=True)
+    r3 = -r0 - r1 - r2
+    source = sp.Matrix((r0, r1, r2, r3))
+    ones = sp.ones(4, 1)
+    particular = sp.Matrix((0, -r0, -r0 - r1, r3))
+    general = particular + lam * ones
+    symbolic_solution_exact = (
+        sum(source) == 0
+        and matrix_zero(incidence.T * general - source)
+    )
+    zero_sum_basis = sp.Matrix.hstack(
+        *(sp.eye(4).col(index) - sp.eye(4).col(3) for index in range(3))
+    )
+    zero_sum_image_exact = (
+        incidence.rank() == 3
+        and matrix_zero(sp.ones(1, 4) * incidence.T)
+        and zero_sum_basis.rank() == 3
+        and incidence.T.row_join(zero_sum_basis).rank() == 3
+    )
+    gauge_kernel_exact = (
+        incidence.T.nullspace() == [ones]
+        and matrix_zero(incidence.T * ones)
+    )
+
+    witness_source = sp.Matrix((R(2, 9), -R(1, 9), 0, -R(1, 9)))
+    witness_particular = sp.Matrix(
+        (
+            0,
+            -witness_source[0],
+            -witness_source[0] - witness_source[1],
+            witness_source[3],
+        )
+    )
+    witness_mean_zero = sp.simplify(
+        witness_particular - ones * sum(witness_particular) / 4
+    )
+    expected_mean_zero = sp.Matrix((R(1, 9), -R(1, 9), 0, 0))
+    witness_exact = (
+        sum(witness_source) == 0
+        and witness_mean_zero == expected_mean_zero
+        and incidence.T * witness_mean_zero == witness_source
+        and sum(witness_mean_zero) == 0
+    )
+    opposite_result = -incidence.T * witness_mean_zero
+    opposite_orientation_fails = (
+        opposite_result != witness_source
+        and matrix_zero(opposite_result + witness_source)
+        and witness_source != sp.zeros(4, 1)
+    )
+    return GaussCertificate(
+        incidence=incidence,
+        orientation_exact=orientation_exact,
+        zero_sum_image_exact=zero_sum_image_exact,
+        symbolic_solution_exact=symbolic_solution_exact,
+        gauge_kernel_exact=gauge_kernel_exact,
+        witness_source=witness_source,
+        witness_mean_zero=witness_mean_zero,
+        witness_exact=witness_exact,
+        opposite_orientation_fails=opposite_orientation_fails,
+    )
+
+
+@dataclass(frozen=True)
+class PhysicalQuotientCertificate:
+    carrier_rank: int
+    tt_dimension: int
+    gravity_solution_dimension: int
+    gravity_gauge_dimension: int
+    gravity_quotient_fiber_dimension: int
+    graph_isomorphism_exact: bool
+    matter_dimensions: tuple[int, int, int]
+
+
+def physical_quotient_certificate(
+    state_class: StateClassCertificate, gauss: GaussCertificate
+) -> PhysicalQuotientCertificate:
+    incidence = gauss.incidence
+    carrier_constraint = sp.Matrix.vstack(sp.eye(4), incidence)
+    carrier_rank = carrier_constraint.rank()
+    tt_dimension = carrier_constraint.cols - carrier_rank
+    gravity_solution_dimension = 4 - incidence.T.rank()
+    ones = sp.ones(4, 1)
+    gravity_gauge_dimension = sp.Matrix.hstack(ones).rank()
+    gravity_quotient_fiber_dimension = (
+        gravity_solution_dimension - gravity_gauge_dimension
+    )
+    gauge_projector = sp.eye(4) - ones * ones.T / 4
+
+    r0, r1, r2, lam = sp.symbols("q0 q1 q2 quotient_lambda", real=True)
+    r3 = -r0 - r1 - r2
+    particular = sp.Matrix((0, -r0, -r0 - r1, r3))
+    general = particular + lam * ones
+    quotient_unique = matrix_zero(
+        gauge_projector * general - gauge_projector * particular
+    )
+    graph_isomorphism_exact = (
+        carrier_rank == 4
+        and tt_dimension == 0
+        and gravity_solution_dimension == 1
+        and gravity_gauge_dimension == 1
+        and gravity_quotient_fiber_dimension == 0
+        and incidence.T.nullspace() == [ones]
+        and gauge_projector.rank() == 3
+        and matrix_zero(gauge_projector * ones)
+        and matrix_zero(gauge_projector**2 - gauge_projector)
+        and quotient_unique
+        and gauss.symbolic_solution_exact
+        and gauss.zero_sum_image_exact
+    )
+    return PhysicalQuotientCertificate(
+        carrier_rank=carrier_rank,
+        tt_dimension=tt_dimension,
+        gravity_solution_dimension=gravity_solution_dimension,
+        gravity_gauge_dimension=gravity_gauge_dimension,
+        gravity_quotient_fiber_dimension=gravity_quotient_fiber_dimension,
+        graph_isomorphism_exact=graph_isomorphism_exact,
+        matter_dimensions=(
+            state_class.cone_dimension,
+            state_class.normalized_dimension,
+            state_class.ray_dimension,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class RootFixtureCertificate:
+    shear: sp.Rational
+    sectors: tuple[object, ...]
+    characteristic_polynomials: tuple[sp.Poly, ...]
+    taus: tuple[sp.Rational, ...]
+    even_identity_exact: bool
+    odd_identity_exact: bool
+    stable_root_unique: bool
+    odd_root_forced: bool
+    even_root_forced: bool
+    distinct_even_odd: bool
+    polynomial_digest: str
+
+
+@dataclass(frozen=True)
+class RootCertificate:
+    fixtures: tuple[RootFixtureCertificate, ...]
+    all_pairings_forced: bool
+    all_even_odd_distinct: bool
+
+
+def _normalized_characteristic(polynomial: sp.Poly) -> tuple[sp.Poly, sp.Rational]:
+    coefficients = tuple(polynomial.all_coeffs())
+    if len(coefficients) != 3 or coefficients[0] == 0:
+        raise AssertionError("expected a quadratic transfer characteristic polynomial")
+    leading, linear, constant = coefficients
+    rho = block119.RHO
+    normalized = sp.Poly(
+        rho**2 + sp.cancel(linear / leading) * rho + sp.cancel(constant / leading),
+        rho,
+        domain=sp.QQ,
+    )
+    tau = sp.Rational(-linear, leading)
+    return normalized, tau
+
+
+def root_certificate() -> RootCertificate:
+    fixtures: list[RootFixtureCertificate] = []
+    for shear in SHEARS:
+        sectors = tuple(block119.make_sectors(shear))
+        if len(sectors) != 4:
+            raise AssertionError("the quotient must have four momentum lines")
+        normalized_and_tau = tuple(
+            _normalized_characteristic(sector.polynomial) for sector in sectors
+        )
+        polynomials = tuple(item[0] for item in normalized_and_tau)
+        taus = tuple(item[1] for item in normalized_and_tau)
+        original_polynomials = tuple(sector.polynomial for sector in sectors)
+        palindromic = all(
+            polynomial.all_coeffs()[0] == polynomial.all_coeffs()[2]
+            and normalized.all_coeffs() == [1, -tau, 1]
+            for polynomial, normalized, tau in zip(
+                original_polynomials, polynomials, taus
+            )
+        )
+        unique_flags = tuple(
+            abs(tau) > 2
+            and polynomial.count_roots(-1, 1) == 1
+            and polynomial.eval(0) == 1
+            for polynomial, tau in zip(polynomials, taus)
+        )
+        even_identity_exact = (
+            original_polynomials[0] == original_polynomials[2]
+            and polynomials[0] == polynomials[2]
+            and taus[0] == taus[2]
+        )
+        odd_identity_exact = (
+            original_polynomials[1] == original_polynomials[3]
+            and polynomials[1] == polynomials[3]
+            and taus[1] == taus[3]
+        )
+        distinct_even_odd = (
+            taus[0] != taus[1]
+            and sp.gcd(polynomials[0], polynomials[1]).degree() == 0
+        )
+        fixtures.append(
+            RootFixtureCertificate(
+                shear=shear,
+                sectors=sectors,
+                characteristic_polynomials=polynomials,
+                taus=taus,
+                even_identity_exact=even_identity_exact,
+                odd_identity_exact=odd_identity_exact,
+                stable_root_unique=palindromic and all(unique_flags),
+                odd_root_forced=(
+                    odd_identity_exact and unique_flags[1] and unique_flags[3]
+                ),
+                even_root_forced=(
+                    even_identity_exact and unique_flags[0] and unique_flags[2]
+                ),
+                distinct_even_odd=distinct_even_odd,
+                polynomial_digest=exact_digest(
+                    tuple(tuple(poly.all_coeffs()) for poly in polynomials)
+                ),
+            )
+        )
+    result = tuple(fixtures)
+    return RootCertificate(
+        fixtures=result,
+        all_pairings_forced=all(
+            fixture.even_identity_exact
+            and fixture.odd_identity_exact
+            and fixture.stable_root_unique
+            and fixture.even_root_forced
+            and fixture.odd_root_forced
+            for fixture in result
+        ),
+        all_even_odd_distinct=all(
+            fixture.distinct_even_odd for fixture in result
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class TransferCertificate:
+    transfer_pairing_exact: bool
+    balanced_sector_preserved: bool
+    exact_invariant_sector: bool
+    violation_formula_exact: bool
+    rate_difference_nonzero: bool
+    convention_free_coincidence: bool
+    invariant_dimensions: tuple[int, int, int]
+
+
+def transfer_certificate(
+    state_class: StateClassCertificate, roots: RootCertificate
+) -> TransferCertificate:
+    n1, n2, n3_free = sp.symbols("n1 n2 n3", nonnegative=True)
+    rho_even, rho_odd = sp.symbols(
+        "rho_even rho_odd", positive=True
+    )
+    n3 = n1 + 2 * n2
+    transfer = sp.diag(
+        rho_even**2, rho_odd**2, rho_even**2, rho_odd**2
+    )
+    transfer_pairing_exact = (
+        transfer[0, 0] == transfer[2, 2] == rho_even**2
+        and transfer[1, 1] == transfer[3, 3] == rho_odd**2
+        and roots.all_pairings_forced
+    )
+    post_numerator = sp.expand(
+        rho_odd**4 * n1
+        + 2 * rho_even**4 * n2
+        - rho_odd**4 * n3
+    )
+    expected_violation = 2 * n2 * (rho_even**4 - rho_odd**4)
+    violation_formula_exact = sp.expand(
+        post_numerator - expected_violation
+    ) == 0
+    balanced_post = sp.expand(post_numerator.subs(n2, 0))
+    balanced_sector_preserved = (
+        balanced_post == 0
+        and transfer[2, 2] != 0
+        and transfer[1, 1] == transfer[3, 3]
+    )
+    class_equation = n1 + 2 * n2 - n3_free
+    transferred_equation = (
+        rho_odd**4 * n1
+        + 2 * rho_even**4 * n2
+        - rho_odd**4 * n3_free
+    )
+    stable_intersection = sp.solve(
+        (class_equation, transferred_equation),
+        (n2, n3_free),
+        dict=True,
+    )
+    stable_intersection_exact = stable_intersection == [
+        {n2: 0, n3_free: n1}
+    ]
+    rate_difference_nonzero = roots.all_even_odd_distinct and all(
+        fixture.stable_root_unique
+        and sp.gcd(
+            fixture.characteristic_polynomials[0],
+            fixture.characteristic_polynomials[1],
+        ).degree()
+        == 0
+        for fixture in roots.fixtures
+    )
+    exact_invariant_sector = (
+        violation_formula_exact
+        and rate_difference_nonzero
+        and balanced_sector_preserved
+        and stable_intersection_exact
+    )
+    convention_free_coincidence = (
+        state_class.intersection_exact and exact_invariant_sector
+    )
+    return TransferCertificate(
+        transfer_pairing_exact=transfer_pairing_exact,
+        balanced_sector_preserved=balanced_sector_preserved,
+        exact_invariant_sector=exact_invariant_sector,
+        violation_formula_exact=violation_formula_exact,
+        rate_difference_nonzero=rate_difference_nonzero,
+        convention_free_coincidence=convention_free_coincidence,
+        invariant_dimensions=(5, 4, 3),
+    )
+
+
+@dataclass(frozen=True)
+class LocalizationCertificate:
+    projectors: tuple[sp.Matrix, ...]
+    densities: tuple[sp.Matrix, ...]
+    hermitian_exact: bool
+    sum_rule_exact: bool
+    sandwich_sum_rule_fails: bool
+    universal_total_lemma: bool
+    pinned_profile: sp.Matrix
+    alternative_profile: sp.Matrix
+    witness_profile_exact: bool
+    profile_convention_dependent: bool
+    quotient_structure_independent: bool
+
+
+def localization_certificate(
+    state_class: StateClassCertificate,
+    gauss: GaussCertificate,
+    transfer: TransferCertificate,
+) -> LocalizationCertificate:
+    fourier = sp.Matrix(
+        4, 4, lambda site_index, momentum: I ** (-site_index * momentum)
+    ) / 2
+    projectors = tuple(
+        sp.simplify(
+            fourier.H
+            * sp.diag(*(1 if other == site_index else 0 for other in range(4)))
+            * fourier
+        )
+        for site_index in range(4)
+    )
+    projector_structure_exact = (
+        matrix_zero(fourier.H * fourier - sp.eye(4))
+        and matrix_zero(sum(projectors, sp.zeros(4)) - sp.eye(4))
+        and all(projector.H == projector for projector in projectors)
+        and all(matrix_zero(projector**2 - projector) for projector in projectors)
+    )
+    densities = tuple(
+        sp.simplify((projector * P + P * projector) / 2)
+        for projector in projectors
+    )
+    hermitian_exact = projector_structure_exact and all(
+        density.H == density for density in densities
+    )
+    sum_rule_exact = matrix_zero(sum(densities, sp.zeros(4)) - P)
+
+    sandwiched = tuple(projector * P * projector for projector in projectors)
+    sandwiched_total = sp.simplify(sum(sandwiched, sp.zeros(4)))
+    sandwich_sum_rule_fails = (
+        matrix_zero(sandwiched_total - sp.eye(4) / 2)
+        and not matrix_zero(sandwiched_total - P)
+    )
+
+    entries = sp.symbols("ell0:48")
+    arbitrary = tuple(
+        sp.Matrix(4, 4, entries[16 * index:16 * (index + 1)])
+        for index in range(3)
+    )
+    fourth = P - sum(arbitrary, sp.zeros(4))
+    admissible_family = arbitrary + (fourth,)
+    bra = sp.Matrix(1, 4, sp.symbols("bra0:4"))
+    ket = sp.Matrix(4, 1, sp.symbols("ket0:4"))
+    universal_total_lemma = (
+        matrix_zero(sum(admissible_family, sp.zeros(4)) - P)
+        and sp.expand(
+            sum((bra * density * ket)[0] for density in admissible_family)
+            - (bra * P * ket)[0]
+        )
+        == 0
+    )
+
+    witness = state_class.fixtures[1]
+    pinned_profile = sp.Matrix(
+        [
+            sp.simplify(
+                (witness.vector.H * density * witness.vector)[0]
+                / witness.norm_squared
+            )
+            for density in densities
+        ]
+    )
+    alternative_densities = (
+        densities[0] + sp.eye(4),
+        densities[1] - sp.eye(4),
+        densities[2],
+        densities[3],
+    )
+    alternative_profile = sp.Matrix(
+        [
+            sp.simplify(
+                (witness.vector.H * density * witness.vector)[0]
+                / witness.norm_squared
+            )
+            for density in alternative_densities
+        ]
+    )
+    alternative_admissible = (
+        all(density.H == density for density in alternative_densities)
+        and matrix_zero(sum(alternative_densities, sp.zeros(4)) - P)
+    )
+    witness_profile_exact = (
+        pinned_profile == gauss.witness_source
+        and sum(pinned_profile) == 0
+        and gauss.incidence.T * gauss.witness_mean_zero == pinned_profile
+    )
+    profile_convention_dependent = (
+        alternative_admissible
+        and alternative_profile != pinned_profile
+        and sum(alternative_profile) == sum(pinned_profile) == 0
+    )
+    all_fixture_totals_exact = all(
+        sp.expand(
+            sum(
+                (fixture.vector.H * density * fixture.vector)[0]
+                / fixture.norm_squared
+                for density in densities
+            )
+            - fixture.momentum / fixture.norm_squared
+        )
+        == 0
+        for fixture in state_class.fixtures
+    )
+    quotient_structure_independent = (
+        universal_total_lemma
+        and all_fixture_totals_exact
+        and gauss.zero_sum_image_exact
+        and transfer.convention_free_coincidence
+    )
+    return LocalizationCertificate(
+        projectors=projectors,
+        densities=densities,
+        hermitian_exact=hermitian_exact,
+        sum_rule_exact=sum_rule_exact,
+        sandwich_sum_rule_fails=sandwich_sum_rule_fails,
+        universal_total_lemma=universal_total_lemma,
+        pinned_profile=pinned_profile,
+        alternative_profile=alternative_profile,
+        witness_profile_exact=witness_profile_exact,
+        profile_convention_dependent=profile_convention_dependent,
+        quotient_structure_independent=quotient_structure_independent,
+    )
+
+
+N5_LINES = (
+    "N5: per_element: exact quadric, convention-intersection, gauss-solution, orientation, root-identity, sector-preservation, violation, and sum-rule certificates are checked",
+    "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus",
+    "per_mode: the paired momenta share one characteristic polynomial with the stable root forced, so the balanced sector is transfer-invariant while unbalanced states violate the class by an exact rate difference",
+    "per_block: the momentum-sourced gauss quotient is executed — the physical sector is the convention-free stable balanced class with gravity contributing only its quotiented gauge mode, independent of the admissible localization",
+    "lattice_wide: checked and not executed — non-local dressings for the observable wall, the naturality classification, curved OS positivity, the actual ADM/history transporter completion, joint gravity, the full gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open",
+)
+
+SCOPE_KEYS = (
+    "sourced_quotient",
+    "class_quadric",
+    "balanced_sector",
+    "forced_root",
+    "gauge_mode",
+    "zero_gravity_dimensions",
+    "cosmetic",
+    "structural",
+    "orientation",
+    "convention_free",
+    "admissible_localization",
+    "os_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "displayed_execution",
+    "full_gravity_closer",
+    "adm",
+    "n1_n8",
+    "w1",
+    "n5_resolution",
+)
+
+
+def scope_certificate(note: str, mutation: str) -> dict[str, bool]:
+    result = {
+        "sourced_quotient": "sourced quotient" in note,
+        "class_quadric": (
+            "class quadric" in note
+            or "vanishing expected total momentum" in note
+        ),
+        "balanced_sector": (
+            "balanced sector" in note or "|c_1| = |c_3|" in note
+        ),
+        "forced_root": (
+            "forced" in note or "cannot pick different roots" in note
+        ),
+        "gauge_mode": (
+            "gauge mode" in note or "constant mode" in note
+        ),
+        "zero_gravity_dimensions": (
+            "zero independent dimensions" in note
+            or "isomorphic to the matter class" in note
+        ),
+        "cosmetic": "cosmetic" in note,
+        "structural": "structural" in note,
+        "orientation": (
+            "orientation" in note or "forward-difference" in note
+        ),
+        "convention_free": (
+            "convention-free" in note
+            or "convention-independent" in note
+        ),
+        "admissible_localization": (
+            "admissible localization" in note or "sum rule" in note
+        ),
+        "os_boundary": (
+            "not an os no-go" in note or "not a curved os no-go" in note
+        ),
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "displayed_execution": (
+            "sourced quotient" in note
+            and ("executes" in note or "executed" in note)
+            and "displayed carrier" in note
+        ),
+        "full_gravity_closer": (
+            "gravity constraint quotient remains unexecuted" in note
+            and (
+                "beyond the displayed carrier" in note
+                or "full-gravity" in note
+                or "full gravity" in note
+            )
+        ),
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "w1": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["os_boundary"] = False
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started = time.monotonic()
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    checks.check(
+        "A-authority",
+        "Block 123 note/runner/cache and ancestors 122--103 are pinned",
+        AUDIT_TIMEOUT_SEC == 600
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/audit/data/axiom_premise_nodes.json",
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_MOMENTUM_POPULATION_DEFINITENESS_BOUNDED_THEOREM_NOTE_2026-08-16.md",
+            "scripts/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.py",
+            "logs/runner-cache/admissibility_dirac_kahler_momentum_population_definiteness_2026_08_16.txt",
+        )
+        and authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and all(
+            authority[f"ancestor_{number}"] for number in range(103, 123)
+        )
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB,
+    )
+
+    state_class = state_class_certificate()
+    quadric_exact = (
+        state_class.forms_exact
+        and state_class.c0_free
+        and state_class.dimensions_convention_invariant
+        and state_class.sets_differ_off_c2_zero
+        and state_class.intersection_exact
+        and (
+            state_class.cone_dimension,
+            state_class.normalized_dimension,
+            state_class.ray_dimension,
+        )
+        == (7, 6, 5)
+        and all(
+            fixture.norm_squared > 0 and fixture.momentum == 0
+            for fixture in state_class.fixtures
+        )
+    )
+    if mutation == "break_quadric":
+        quadric_exact = False
+    convention_free_class_claimed = mutation == "claim_convention_free_class"
+    checks.check(
+        "B-the-class-quadric",
+        "|c1|^2+2|c2|^2=|c3|^2 with c0 free has dims 7/6/5; p2=-2 differs off c2=0 and agrees exactly on the balanced intersection",
+        quadric_exact and not convention_free_class_claimed,
+    )
+
+    gauss = gauss_certificate()
+    gauss_exact = (
+        gauss.orientation_exact
+        and gauss.zero_sum_image_exact
+        and gauss.symbolic_solution_exact
+        and gauss.gauge_kernel_exact
+        and gauss.witness_exact
+    )
+    if mutation == "break_gauss_solution":
+        gauss_exact = False
+    orientation_exact = gauss.opposite_orientation_fails
+    if mutation == "break_orientation_pin":
+        orientation_exact = False
+    checks.check(
+        "C-the-gauss-solution",
+        "(B4^T Gamma)_j=Gamma_j-Gamma_{j+1}; the closed form and mean-zero witness solve it, while the opposite orientation fails",
+        gauss_exact and orientation_exact,
+    )
+
+    quotient = physical_quotient_certificate(state_class, gauss)
+    quotient_exact = (
+        quotient.graph_isomorphism_exact
+        and quotient.carrier_rank == 4
+        and quotient.tt_dimension == 0
+        and quotient.gravity_solution_dimension == 1
+        and quotient.gravity_gauge_dimension == 1
+        and quotient.gravity_quotient_fiber_dimension == 0
+        and quotient.matter_dimensions == (7, 6, 5)
+    )
+    if mutation == "break_quotient_isomorphism":
+        quotient_exact = False
+    checks.check(
+        "D-the-physical-quotient",
+        "the d=2 sourced graph modulo its constant gauge mode is isomorphic to the matter class and gravity adds zero independent dimensions",
+        quotient_exact,
+    )
+
+    roots = root_certificate()
+    root_identity_exact = (
+        len(roots.fixtures) == 2
+        and roots.all_pairings_forced
+        and roots.all_even_odd_distinct
+        and all(
+            fixture.even_identity_exact
+            and fixture.odd_identity_exact
+            and fixture.stable_root_unique
+            and fixture.even_root_forced
+            and fixture.odd_root_forced
+            and fixture.distinct_even_odd
+            for fixture in roots.fixtures
+        )
+    )
+    if mutation == "break_root_identity":
+        root_identity_exact = False
+    checks.check(
+        "E-the-forced-root-identity",
+        "k=0,2 and k=1,3 have identical characteristic polynomials; |tau|>2 uniquely forces each |rho|<1 root, with rho_even!=rho_odd",
+        root_identity_exact,
+    )
+
+    transfer = transfer_certificate(state_class, roots)
+    sector_exact = (
+        transfer.transfer_pairing_exact
+        and transfer.balanced_sector_preserved
+        and transfer.exact_invariant_sector
+        and transfer.rate_difference_nonzero
+        and transfer.convention_free_coincidence
+        and transfer.invariant_dimensions == (5, 4, 3)
+    )
+    if mutation == "break_sector_preservation":
+        sector_exact = False
+    violation_exact = transfer.violation_formula_exact
+    if mutation == "break_violation_formula":
+        violation_exact = False
+    checks.check(
+        "F-the-stable-balanced-sector",
+        "diag(rho_k^2) preserves exactly c2=0, |c1|=|c3|; every c2!=0 class state acquires 2|c2|^2(rho_even^4-rho_odd^4)!=0",
+        sector_exact and violation_exact,
+    )
+
+    localization = localization_certificate(state_class, gauss, transfer)
+    localization_exact = (
+        localization.hermitian_exact
+        and localization.sum_rule_exact
+        and localization.sandwich_sum_rule_fails
+        and localization.universal_total_lemma
+        and localization.witness_profile_exact
+        and localization.profile_convention_dependent
+        and localization.quotient_structure_independent
+    )
+    if mutation == "break_sum_rule":
+        localization_exact = False
+    structural_localization_claimed = mutation == "claim_structural_localization"
+    checks.check(
+        "G-the-localization-verdict",
+        "D_x={E_x,P}/2 is admissible, E_xPE_x is not; any admissible sum gives total <P>, so only the profile is conventional",
+        localization_exact and not structural_localization_claimed,
+    )
+
+    note_scope = scope_certificate(normalized_note(), mutation)
+    elapsed_before_scope = time.monotonic() - started
+    checks.check(
+        "H-scope",
+        "required sourced-quotient/convention/root/gauge/localization/N1--N8/W1/N5 firewalls and runtime bound are present",
+        set(note_scope) == set(SCOPE_KEYS)
+        and all(note_scope.values())
+        and elapsed_before_scope <= 400,
+    )
+
+    print(
+        "CLASS QUADRIC: <P>=0 iff |c1|^2+2|c2|^2=|c3|^2 with c0 free; "
+        "explicit cone/normalized/ray parametrization ranks=7/6/5."
+    )
+    print(
+        "CONVENTION INTERSECTION: p2=+2 and p2=-2 define different classes for c2!=0; "
+        "their exact common class is c2=0, |c1|=|c3|, with convention-invariant dimensions."
+    )
+    print(
+        "GAUSS ORIENTATION: rho=(2/9,-1/9,0,-1/9) has Gamma_mean0="
+        f"{tuple(gauss.witness_mean_zero)} under Gamma_j-Gamma_(j+1); the opposite sign fails."
+    )
+    print(
+        "PHYSICAL QUOTIENT: d=2 TT dimension=0 and gravity solution/gauge/physical-fiber dimensions="
+        f"{quotient.gravity_solution_dimension}/{quotient.gravity_gauge_dimension}/"
+        f"{quotient.gravity_quotient_fiber_dimension}; the graph is the matter class."
+    )
+    print(
+        "FORCED ROOTS: k0=k2 and k1=k3 in both fixtures, with unique stable roots and tau_even!=tau_odd; "
+        "polynomial sha="
+        + "/".join(fixture.polynomial_digest for fixture in roots.fixtures)
+        + "."
+    )
+    print(
+        "STABLE BALANCED SECTOR: c2=0, |c1|=|c3| is exactly transfer-invariant; "
+        "the unbalanced violation is 2|c2|^2(rho_even^4-rho_odd^4)."
+    )
+    print(
+        "LOCALIZATION: pinned admissible D_x gives witness profile="
+        f"{tuple(localization.pinned_profile)}; profile choice is cosmetic, while the total sum rule and quotient structure are structural."
+    )
+    for line in N5_LINES:
+        print(line)
+    print(
+        "RESULT: the lane's first physical gravity quotient exists and carries dynamics — the convention-free transfer-stable balanced sector with exact gauss solutions unique up to the constant gauge mode, its structure independent of the admissible localization"
+    )
+    print(
+        "DECISION_CUT: advance non-local dressings and the naturality classification; reject unbalanced-sector and inadmissible-localization constructions"
+    )
+    print(
+        "TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"FAIL: {type(error).__name__}: {error}")
+        print("TOTAL: PASS=0 FAIL=1")
+        raise


### PR DESCRIPTION
## Block 124 — The Executed Sourced Quotient And The Stable Balanced Sector

Stacked on #6700 (Block 123). Fifth-file discipline: bounded_theorem
note, runner, cache, block ledger, refreshed citation manifest.

### Result

Block 123 proved the momentum constraint populatable; this block
executes the sourced quotient — the lane's first physical gravity
quotient computation:

- **The class quadric.** Vanishing expected total momentum on the
  certified 4-dim quotient is `|c_1|^2 + 2|c_2|^2 = |c_3|^2` with `c_0`
  free — cone/normalized/ray dimensions 7/6/5 (convention-invariant).
  The `p_2` sign convention is load-bearing off `c_2 = 0`: the two
  conventions' classes are different sets intersecting exactly there,
  so displayed claims restrict to the sector where they agree.
- **The Gauss solution.** On the closed `Z4` cycle,
  `Gamma = (0, -r_0, -r_0-r_1, r_3) + lambda(1,1,1,1)` under the pinned
  forward-difference orientation (the opposite orientation provably
  fails the displayed witness), unique up to the constant gauge mode.
- **The physical quotient.** Isomorphic to the matter class — gravity
  contributes zero independent dimensions after quotienting its gauge
  mode, the d=2 zero-TT count made manifest.
- **The stable balanced sector (the keystone).** The transfer preserves
  exactly `{c_2 = 0, |c_1| = |c_3|}`: the paired momenta share one
  characteristic polynomial whose stable root is uniquely pinned by
  `|rho| < 1` — the identification `rho_1 = rho_3` is forced, not
  chosen — while unbalanced states violate the class by exactly
  `2|c_2|^2(rho_even^4 - rho_odd^4)` per step. **This transfer-stable
  sector coincides with the convention-free sector**: the physical
  gravity quotient that ships is simultaneously convention-independent
  and dynamical.
- **The localization verdict.** Cosmetic, not structural: every
  admissible Hermitian localization satisfies the sum rule
  `sum_x D_x = P`, so the class, Gauss solvability, and the invariant
  sector depend only on the ordering-independent total; only the
  spatial profile varies (and the `E_x P E_x` ordering is outright
  inadmissible — it fails the sum rule).

### Verification

- Runner: 8/8 PASS (~58 s); recomputes the quadric under both
  conventions with their intersection, the symbolic Gauss solution with
  the orientation pin (including the opposite-orientation failure), the
  quotient isomorphism, the forced root identity, the sector
  preservation and exact violation formula, and the sum-rule lemma.
  Mutation sweep: 15/15 clean. N5 byte-identical.
- Independent cross-model verification (Claude fraction checker): all
  items CONFIRMED — including the convention analysis (dimension counts
  safe, class sets not), the orientation specificity of the Gauss
  formula, the forcedness of the root identification, and the
  cosmetic-vs-structural localization verdict that fixed the note's
  claim language.
- `vocab_lint` and `audit_lint --strict` clean.
- `run_pipeline.sh` exits 1 at the pre-existing dependency-policy
  epoch-debt gate; identical on the clean base — unrelated to this PR.

### TOE accounting

Zero obligation retirement; no TOE percentage moves; retained-positive
end-to-end theory count remains zero. Bounded theorem; audit-lane
referral for any verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
