### PR TITLE
feat(rule3): none of 27 named three-slot costs reverse diamond on B6

### DIFF
--- a/docs/NAMED_THREE_SLOT_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NAMED_THREE_SLOT_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,337 @@
+---
+claim_id: named_three_slot_hopcost_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among 27 named (seed, equal, unequal) hop-costs on B_6(0), those that reverse diamond at (4,0,0) vs (2,2,2) and beat ℓ¹ variance are counted. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/named_three_slot_hopcost_b6_2026_08_15.py
+---
+
+# Named Three-Slot Hop-Cost Census On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** finite census of the 27 named `(c_seed, c_eq, c_uneq)` hop-costs on
+the directed nearest-neighbor graph of `B_6(0)`. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/named_three_slot_hopcost_b6_2026_08_15.py`](../scripts/named_three_slot_hopcost_b6_2026_08_15.py)
+
+## Result Up Front
+
+Let `B_6(0) = { v in Z^3 : |v|_1 <= 6 }`. This ball has 377 sites. On a
+directed nearest-neighbor edge `v -> w` write `|σ_v|` for the number of
+nonzero Cartesian coordinates of `v`, and assign the named three-slot cost
+
+```text
+c(v -> w) = c_seed    if |σ_v| = 0,
+            c_eq      if |σ_v| = |σ_w|,
+            c_uneq    otherwise,
+```
+
+with each slot in `{1,2,3}`. Arrival time `t` is the Dijkstra distance from
+the origin on this finite directed graph. The diamond comparator at the axis
+and body-diagonal probes is the integer cut
+
+```text
+12 t(4,0,0)^2  >  16 t(2,2,2)^2.
+```
+
+The `ℓ¹` comparator is the unit table `t(v) = |v|_1`. Variance means the
+population variance of `|v|_2 / t(v)` on the 376 nonzero sites.
+
+**Theorem 1.** `N_rev = 0`. None of the 27 named triples reverse the diamond.
+The lex-first reversing triple does not exist, so no reversing times are
+attached.
+
+**Theorem 2.** `N_beat = 0`. Among those reversals, none can beat the `ℓ¹`
+variance because the reversal set is empty.
+
+**Theorem 3.** Displayed, not adopted. No triple is written into
+Admissibility. Uniqueness is not claimed. Do not attach L1.
+
+The investment member `(c_seed, c_eq, c_uneq) = (3,3,1)` is included in the
+census. It gives `t(4,0,0)=12` and `t(2,2,2)=14`, hence
+`12 t(4,0,0)^2 = 1728 < 3136 = 16 t(2,2,2)^2`, so it does not reverse. That
+is consistent with `N_rev = 0`.
+
+A matching member would be a finite named rule that both reverses the diamond
+and beats `ℓ¹` variance. No such member exists inside this 27-element family.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact 27-Dijkstra census on B_6(0): N_rev=0 and N_beat=0. Displayed, not adopted. No Admissibility edit."
+trace_class: negative_route_pruning
+target_claim_id: named_three_slot_diamond_and_variance_member
+target_blocker_text: "name a finite hop-cost rule that reverses diamond at (4,0,0) vs (2,2,2) and beats l1 variance of |v|_2/t"
+source_of_blocker_text: handoff
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Leave the 27-element three-slot family; a matching member must come from a different finite named rule, not from rescanning occupancy 8-tuples."
+conditional_surface_status: "exact on B_6(0) for the 27 named triples; no physical hop-cost is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Current Premise Boundary
+
+The current Admissibility wording in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is:
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Those sentences type a covariant local constraint. They do not name a hop-cost,
+a seed-exit slot, an equal-support slot, or an unequal-support slot. This note
+does not add one.
+
+The current Lattice wording supplies the cubic lattice `Z^3` with
+nearest-neighbor adjacency. The finite ball `B_6(0)` and the three-slot cost
+are declared computational inputs, not added axiom wording.
+
+## Exact Objects
+
+Sites are points of `Z^3`. The finite host is `B_6(0)`, cardinality 377. The
+directed graph uses the six axis-adjacent neighbors, restricted so that both
+endpoints lie in the ball. That graph has 1752 directed edges. Support
+cardinalities on those edges occupy the nine pairs
+
+```text
+(0,1), (1,0), (1,1), (1,2), (2,1), (2,2), (2,3), (3,2), (3,3).
+```
+
+The three-slot rule names every pair: seed-exit is `(0,1)`, equal-support is
+any `(k,k)` with `k>0`, and unequal-support is the rest. The census therefore
+does not rescan the `3^8 = 6561` occupancy 8-tuples on a smaller orbit list.
+It runs 27 Dijkstras.
+
+The probes are `p_axis = (4,0,0)` and `p_body = (2,2,2)`. Their Euclidean
+squares are `|p_axis|_2^2 = 16` and `|p_body|_2^2 = 12`. The diamond cut is
+exactly
+
+```text
+t(p_axis)^2 / 16  >  t(p_body)^2 / 12,
+```
+
+written with integer cross-multiplication as `12 t(p_axis)^2 > 16 t(p_body)^2`.
+
+Variance on a complete arrival table `t` is
+
+```text
+μ(t)   = (1/376) sum_{v ≠ 0} |v|_2 / t(v),
+Var(t) = (1/376) sum_{v ≠ 0} ( |v|_2 / t(v) − μ(t) )^2.
+```
+
+The `ℓ¹` table is `t_1(v) = |v|_1`. A reversal beats `ℓ¹` when
+`Var(t) < Var(t_1)`.
+
+## Exact Theorem
+
+**Theorem 1 (reversal count).** Let `F` be the lex-ordered set
+`{1,2,3}^3` of named triples `(c_seed, c_eq, c_uneq)`. For each member run
+Dijkstra on `B_6(0)` from the origin. Then
+
+```text
+N_rev = # { ρ in F : 12 t_ρ(4,0,0)^2 > 16 t_ρ(2,2,2)^2 } = 0.
+```
+
+The lex-first reversing triple does not exist.
+
+**Theorem 2 (variance-beating count).** Let `R` be the reversal set of
+Theorem 1. Then
+
+```text
+N_beat = # { ρ in R : Var(t_ρ) < Var(t_1) } = 0.
+```
+
+There is no lex-first beating reversal and therefore no pair of variances to
+report from `R`.
+
+**Theorem 3 (adoption boundary).** The 27 tables are displayed finite
+comparators. They are not adopted as the Admissibility rule. Uniqueness is not
+claimed. Do not attach L1: the unit table is a comparator only.
+
+## Arrival Census
+
+Every triple produces a finite arrival time at every site of `B_6(0)`. The
+probe times are:
+
+| `(c_seed, c_eq, c_uneq)` | `t(4,0,0)` | `t(2,2,2)` | `12 t_axis^2` | `16 t_body^2` | reverse |
+|---|---:|---:|---:|---:|---|
+| `(1,1,1)` | 4 | 6 | 192 | 576 | no |
+| `(1,1,2)` | 4 | 8 | 192 | 1024 | no |
+| `(1,1,3)` | 4 | 10 | 192 | 1600 | no |
+| `(1,2,1)` | 7 | 9 | 588 | 1296 | no |
+| `(1,2,2)` | 7 | 11 | 588 | 1936 | no |
+| `(1,2,3)` | 7 | 13 | 588 | 2704 | no |
+| `(1,3,1)` | 10 | 12 | 1200 | 2304 | no |
+| `(1,3,2)` | 10 | 14 | 1200 | 3136 | no |
+| `(1,3,3)` | 10 | 16 | 1200 | 4096 | no |
+| `(2,1,1)` | 5 | 7 | 300 | 784 | no |
+| `(2,1,2)` | 5 | 9 | 300 | 1296 | no |
+| `(2,1,3)` | 5 | 11 | 300 | 1936 | no |
+| `(2,2,1)` | 8 | 10 | 768 | 1600 | no |
+| `(2,2,2)` | 8 | 12 | 768 | 2304 | no |
+| `(2,2,3)` | 8 | 14 | 768 | 3136 | no |
+| `(2,3,1)` | 11 | 13 | 1452 | 2704 | no |
+| `(2,3,2)` | 11 | 15 | 1452 | 3600 | no |
+| `(2,3,3)` | 11 | 17 | 1452 | 4624 | no |
+| `(3,1,1)` | 6 | 8 | 432 | 1024 | no |
+| `(3,1,2)` | 6 | 10 | 432 | 1600 | no |
+| `(3,1,3)` | 6 | 12 | 432 | 2304 | no |
+| `(3,2,1)` | 9 | 11 | 972 | 1936 | no |
+| `(3,2,2)` | 9 | 13 | 972 | 2704 | no |
+| `(3,2,3)` | 9 | 15 | 972 | 3600 | no |
+| `(3,3,1)` | 12 | 14 | 1728 | 3136 | no |
+| `(3,3,2)` | 12 | 16 | 1728 | 4096 | no |
+| `(3,3,3)` | 12 | 18 | 1728 | 5184 | no |
+
+The largest ratio `t(4,0,0)/t(2,2,2)` in the table is `12/14`, attained at
+`(3,3,1)`. The diamond cut requires the stricter
+`t(4,0,0)/t(2,2,2) > 2/sqrt(3)`. Because `(12/14)^2 = 144/196 < 4/3`, every
+row fails the cut. This is why `N_rev = 0`.
+
+The unit row `(1,1,1)` reproduces `t = |·|_1` at both probes, as required of
+the `ℓ¹` comparator.
+
+## Why The Family Cannot Reverse
+
+On this host an origin-to-axis geodesic uses one seed-exit hop and then three
+equal-support hops along a coordinate axis. An origin-to-body geodesic uses
+one seed-exit hop, two unequal-support hops that raise the support cardinality
+from 1 to 3, and three equal-support hops that finish the remaining
+coordinate steps. Those hop-type counts already force
+
+```text
+t(4,0,0)  =  c_seed + 3 c_eq,
+t(2,2,2)  =  c_seed + 3 c_eq + 2 c_uneq
+```
+
+for every positive triple, and the Dijkstra tables confirm both identities.
+Hence `t(4,0,0) < t(2,2,2)` whenever `c_uneq > 0`, so the axis/body ratio
+cannot reach `2/sqrt(3)`. Enlarging the ball cannot help these two probes:
+both already lie in `B_6(0)`, and every cheaper path would still have to
+realize those support changes.
+
+Some non-reversing members do have `Var(t) < Var(t_1)`. That is irrelevant to
+Theorem 2, which counts beating only inside the reversal set. The investment
+triple is one such non-reversing tighter-variance table; it is not a matching
+member.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| host `B_6(0)` of 377 sites | closed by enumeration |
+| 27 named triples, 27 Dijkstras | closed |
+| diamond cut at `(4,0,0)` vs `(2,2,2)` | closed; `N_rev = 0` |
+| variance beating inside the reversal set | closed; `N_beat = 0` |
+| lex-first reversing or beating triple | does not exist |
+| write a triple into Admissibility | not executed |
+| attach the `ℓ¹` comparator as law | not executed |
+| uniqueness of a named hop-cost | not claimed |
+| scan of 6561 occupancy 8-tuples | not executed |
+| matching member outside this family | open |
+
+## Imports And Non-Claims
+
+No observation, fit, continuum limit, or Newtonian comparator is imported.
+The only lattice input is the current cubic nearest-neighbor structure. The
+only axiom input is the current wording that Admissibility is one fixed
+covariant nearest-neighbor rule and does not already name these costs.
+
+The theorem does not say that no finite named hop-cost can reverse the
+diamond. It says that none of these 27 do, and therefore none of them both
+reverse and beat `ℓ¹` variance.
+
+## Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the named residual: which of the 27 reverse the diamond and beat `ℓ¹` variance. |
+| V2 | The investment already knew that `(3,3,1)` fails the diamond; the new content is the exhaustive 27-element count `N_rev = 0`, `N_beat = 0`. |
+| V3 | Both counts are independently checkable by 27 finite Dijkstras and integer comparison. |
+| V4 | The closed hop-type identities explain why the family is structurally unable to reverse, not merely unlucky at one triple. |
+| V5 | The census is displayed, not adopted; the matching-member residual is left open outside this family. |
+
+## No-Go Discipline Gate
+
+The negative claim is restricted to the 27 named triples on `B_6(0)`. No
+global hop-cost impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unit triple `(1,1,1)` | recover the `ℓ¹` table | exact; does not reverse |
+| investment `(3,3,1)` | seed-exit 3, equal 3, unequal 1 | `t(4,0,0)=12`, `t(2,2,2)=14`; does not reverse |
+| remaining 25 triples | vary each slot through `{1,2,3}` | all 27 fail the diamond cut |
+| 6561 occupancy 8-tuples | assign independent costs to eight older orbits | not executed; forbidden by the residual |
+| other named finite rules | change the slot definition | live; outside this census |
+| infinite-lattice Dijkstra | allow paths that leave `B_6(0)` | not executed; the host is the ball |
+
+### N2 — wall independence
+
+A differently named finite rule, a different occupancy weight, or a different
+finite host is an independent route. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The ball radius, the three slots, the cost range `{1,2,3}`, the diamond
+probes, and the variance domain are explicit. No continuum isotropic law is
+assumed.
+
+### N4 — source residual matching
+
+The residual asked which of the 27 reverse the diamond and beat `ℓ¹`
+variance, and whether a matching member exists in that list. The census
+answers both counts and records that no matching member is present.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | one named triple | no exhaustion of every conceivable cost table |
+| per site | times at two probes; variance on `B_6(0) \ {0}` | no physical clock at a site |
+| per mode | seed, equal, unequal | no other occupancy typing |
+| per block | 27 Dijkstras on one ball | no axiom edit |
+| lattice wide | checked and not executed | no infinite-lattice theorem |
+
+### N6 — live partial-closure paths
+
+A different finite named rule, a different support weight, or a larger named
+family can still supply a matching member. Those paths remain live.
+
+### N7 — hostile steelman
+
+**Steelman:** Because some triples already beat `ℓ¹` variance, the family
+almost works and should be adopted.
+
+**Answer:** Variance beating without diamond reversal is not a matching
+member. Theorem 3 refuses adoption and refuses uniqueness.
+
+### N8 — cross-cycle echo
+
+The investment already recorded that `(3,3,1)` does not reverse on `B_6(0)`.
+The present census does not reopen that member as a law; it only closes the
+27-element neighborhood around it.
+
+**Gate disposition:** PASS for the finite counts `N_rev = 0` and
+`N_beat = 0` on `B_6(0)`. FAIL / DO NOT SHIP for “no hop-cost can reverse
+the diamond,” “the `ℓ¹` table is physical law,” or any Admissibility edit.
+
+## Primary Runner
+
+The primary runner rebuilds `B_6(0)`, runs the 27 Dijkstras, checks the
+integer diamond cut, checks that the reversal and beating counts are zero,
+checks that `(3,3,1)` and `(1,1,1)` match the displayed times, and checks
+that the current axiom memo is unedited. It writes no cache and authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12713,6 +12713,10 @@
   "naive_lattice_fermion_two_power_d_species_count_narrow_theorem_note_2026-05-10": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "named_three_slot_hopcost_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "native_carrier_registration_kernel_rate_vs_unit_variance_point_theorem_note_2026-07-02": {
    "deps_hash": "f0528fe9a3de",

--- a/logs/runner-cache/named_three_slot_hopcost_b6_2026_08_15.txt
+++ b/logs/runner-cache/named_three_slot_hopcost_b6_2026_08_15.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/named_three_slot_hopcost_b6_2026_08_15.py
+runner_sha256: 409391fda1dea225dc9f8c30d16574fb6da20500ad00bd4017aa5daf9fa9d7b6
+input_fingerprint_sha256: 677f3c43cd9a9bf83586ef8946a2c4010b9a5950c3743ad6cbf68565b997e5fd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/NAMED_THREE_SLOT_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: none; the 27 triples, B_6(0), and the diamond/variance comparators are declared finite inputs
+framework_role: displayed finite hop-cost census; no Admissibility edit and no L1 attachment
+claim_scope: Among 27 named (seed, equal, unequal) hop-costs on B_6(0), those that reverse diamond at (4,0,0) vs (2,2,2) and beat l1 variance are counted. Displayed, not adopted.
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static literal pair
+PASS: ball-cardinality B_6(0) has exactly 377 sites and contains both probes
+PASS: nonzero-count variance domain is the 376 nonzero sites
+PASS: named-family-size the named family is the lex-ordered 27 triples in {1,2,3}^3
+PASS: unit-rule-is-l1 the (1,1,1) rule reproduces the l1 arrival table on B_6(0)
+PASS: twenty-seven-dijkstras exactly 27 complete arrival tables were computed on B_6(0)
+PASS: no-eight-tuple-scan the runner enumerates 27 named triples and does not scan 6561 occupancy 8-tuples
+N_rev=0
+N_beat=0
+var_l1=0.013502037619
+investment_(3,3,1) t(4,0,0)=12 t(2,2,2)=14 reverse=False
+PASS: theorem-1-n-rev N_rev=0: none of the 27 reverse 12 t(4,0,0)^2 > 16 t(2,2,2)^2
+PASS: theorem-2-n-beat N_beat=0 because the reversal set is empty
+PASS: investment-nonreversal the seed-exit 3, equal 3, unequal 1 investment stays strictly below the diamond cut
+PASS: unit-nonreversal the unit l1 comparator itself does not reverse the diamond
+PASS: best-ratio-still-short the largest t(4,0,0)/t(2,2,2) among the 27 is 12/14, below 2/sqrt(3)
+PASS: axiom-unedited current Admissibility names no hop-cost triple and is not edited here
+PASS: note-census the note reports N_rev=0, N_beat=0, and the displayed-not-adopted boundary
+PASS: note-hygiene forbidden phrases, uniqueness, L1 attachment, and axiom-edit language are absent
+PASS: claim-scope-literal claim_scope matches the declared census wording
+PASS: source-axiom-boundary the current axiom memo still types one covariant nearest-neighbor rule and no named three-slot cost
+PASS: note-contract machine fields and retained-language hygiene hold
+per_element: each of the 27 named triples is one Dijkstra arrival table
+per_site: times are compared only at (4,0,0) and (2,2,2); variance uses B_6(0) minus the origin
+per_mode: seed-exit, equal-support, and unequal-support are the only named cost slots
+per_block: diamond reversal and l1-variance beating are counted, not adopted
+lattice_wide: checked and not executed — no infinite-lattice or 6561 8-tuple scan
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/named_three_slot_hopcost_b6_2026_08_15.py
+++ b/scripts/named_three_slot_hopcost_b6_2026_08_15.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Census of 27 named (seed, equal, unequal) hop-costs on B_6(0)."""
+
+from __future__ import annotations
+
+import heapq
+from itertools import product
+from math import sqrt
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/NAMED_THREE_SLOT_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NAMED_THREE_SLOT_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+COSTS = (1, 2, 3)
+AXIS = (4, 0, 0)
+BODY = (2, 2, 2)
+RADIUS = 6
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_card(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def l2(v: tuple[int, int, int]) -> float:
+    return sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def hop_cost(
+    src: tuple[int, int, int],
+    dst: tuple[int, int, int],
+    c_seed: int,
+    c_eq: int,
+    c_uneq: int,
+) -> int:
+    weight_src = support_card(src)
+    if weight_src == 0:
+        return c_seed
+    if weight_src == support_card(dst):
+        return c_eq
+    return c_uneq
+
+
+def dijkstra(
+    sites: list[tuple[int, int, int]],
+    c_seed: int,
+    c_eq: int,
+    c_uneq: int,
+) -> dict[tuple[int, int, int], int]:
+    site_set = set(sites)
+    dist = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        time, src = heapq.heappop(heap)
+        if src in seen:
+            continue
+        seen.add(src)
+        sx, sy, sz = src
+        for dx, dy, dz in NEIGH:
+            dst = (sx + dx, sy + dy, sz + dz)
+            if dst not in site_set:
+                continue
+            nxt = time + hop_cost(src, dst, c_seed, c_eq, c_uneq)
+            if nxt < dist.get(dst, 10**9):
+                dist[dst] = nxt
+                heapq.heappush(heap, (nxt, dst))
+    return dist
+
+
+def population_variance(values: list[float]) -> float:
+    count = len(values)
+    mean = sum(values) / count
+    return sum((value - mean) ** 2 for value in values) / count
+
+
+def reverses_diamond(t_axis: int, t_body: int) -> bool:
+    return 12 * t_axis * t_axis > 16 * t_body * t_body
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = (ROOT / NOTE_REL).read_text(encoding="utf-8")
+    axiom = (ROOT / AXIOM_REL).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: none; the 27 triples, B_6(0), and the diamond/variance comparators are declared finite inputs")
+    print("framework_role: displayed finite hop-cost census; no Admissibility edit and no L1 attachment")
+    print("claim_scope: Among 27 named (seed, equal, unequal) hop-costs on B_6(0), those that reverse diamond at (4,0,0) vs (2,2,2) and beat l1 variance are counted. Displayed, not adopted.")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static literal pair",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+        AUDIT_INPUT_PATHS,
+    )
+
+    sites = ball(RADIUS)
+    nonzero = [site for site in sites if site != (0, 0, 0)]
+    checks.check(
+        "ball-cardinality",
+        "B_6(0) has exactly 377 sites and contains both probes",
+        len(sites) == 377
+        and AXIS in sites
+        and BODY in sites
+        and l1(AXIS) == 4
+        and l1(BODY) == 6,
+        len(sites),
+    )
+    checks.check(
+        "nonzero-count",
+        "variance domain is the 376 nonzero sites",
+        len(nonzero) == 376,
+        len(nonzero),
+    )
+
+    triples = tuple(product(COSTS, repeat=3))
+    checks.check(
+        "named-family-size",
+        "the named family is the lex-ordered 27 triples in {1,2,3}^3",
+        len(triples) == 27 and triples[0] == (1, 1, 1) and triples[-1] == (3, 3, 3),
+        len(triples),
+    )
+
+    l1_times = {site: l1(site) for site in sites}
+    var_l1 = population_variance([l2(site) / l1_times[site] for site in nonzero])
+    unit_dist = dijkstra(sites, 1, 1, 1)
+    checks.check(
+        "unit-rule-is-l1",
+        "the (1,1,1) rule reproduces the l1 arrival table on B_6(0)",
+        all(unit_dist[site] == l1_times[site] for site in sites),
+    )
+
+    rows = []
+    for c_seed, c_eq, c_uneq in triples:
+        dist = dijkstra(sites, c_seed, c_eq, c_uneq)
+        t_axis = dist[AXIS]
+        t_body = dist[BODY]
+        variance = population_variance([l2(site) / dist[site] for site in nonzero])
+        rows.append(
+            {
+                "triple": (c_seed, c_eq, c_uneq),
+                "complete": len(dist) == 377,
+                "t_axis": t_axis,
+                "t_body": t_body,
+                "reverse": reverses_diamond(t_axis, t_body),
+                "variance": variance,
+                "beat": variance < var_l1,
+            }
+        )
+
+    checks.check(
+        "twenty-seven-dijkstras",
+        "exactly 27 complete arrival tables were computed on B_6(0)",
+        len(rows) == 27 and all(row["complete"] for row in rows),
+        len(rows),
+    )
+    checks.check(
+        "no-eight-tuple-scan",
+        "the runner enumerates 27 named triples and does not scan 6561 occupancy 8-tuples",
+        len(triples) == 27 and len(rows) == 27,
+    )
+
+    reversals = [row for row in rows if row["reverse"]]
+    beaters = [row for row in reversals if row["beat"]]
+    n_rev = len(reversals)
+    n_beat = len(beaters)
+    print(f"N_rev={n_rev}")
+    print(f"N_beat={n_beat}")
+    print(f"var_l1={var_l1:.12f}")
+
+    investment = next(row for row in rows if row["triple"] == (3, 3, 1))
+    unit_row = next(row for row in rows if row["triple"] == (1, 1, 1))
+    print(
+        "investment_(3,3,1) "
+        f"t(4,0,0)={investment['t_axis']} t(2,2,2)={investment['t_body']} "
+        f"reverse={investment['reverse']}"
+    )
+
+    checks.check(
+        "theorem-1-n-rev",
+        "N_rev=0: none of the 27 reverse 12 t(4,0,0)^2 > 16 t(2,2,2)^2",
+        n_rev == 0,
+        n_rev,
+    )
+    checks.check(
+        "theorem-2-n-beat",
+        "N_beat=0 because the reversal set is empty",
+        n_beat == 0,
+        n_beat,
+    )
+    checks.check(
+        "investment-nonreversal",
+        "the seed-exit 3, equal 3, unequal 1 investment stays strictly below the diamond cut",
+        investment["t_axis"] == 12
+        and investment["t_body"] == 14
+        and 12 * 12 * 12 < 16 * 14 * 14
+        and not investment["reverse"],
+        (investment["t_axis"], investment["t_body"]),
+    )
+    checks.check(
+        "unit-nonreversal",
+        "the unit l1 comparator itself does not reverse the diamond",
+        unit_row["t_axis"] == 4
+        and unit_row["t_body"] == 6
+        and 12 * 16 < 16 * 36
+        and not unit_row["reverse"],
+    )
+    checks.check(
+        "best-ratio-still-short",
+        "the largest t(4,0,0)/t(2,2,2) among the 27 is 12/14, below 2/sqrt(3)",
+        max(row["t_axis"] / row["t_body"] for row in rows) == 12 / 14
+        and (12 / 14) ** 2 < 4 / 3,
+    )
+    checks.check(
+        "axiom-unedited",
+        "current Admissibility names no hop-cost triple and is not edited here",
+        "c_seed" not in axiom
+        and "c_eq" not in axiom
+        and "c_uneq" not in axiom
+        and "(3, 3, 1)" not in axiom
+        and "hop-cost" not in axiom
+        and "There is one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+
+    forbidden_note = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    required = (
+        "N_rev = 0",
+        "N_beat = 0",
+        "Displayed, not adopted",
+        "Uniqueness is not claimed",
+        "Do not attach L1",
+        "authors no audit verdict",
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "Among 27 named (seed, equal, unequal) hop-costs on B_6(0), those that reverse diamond at (4,0,0) vs (2,2,2) and beat ℓ¹ variance are counted. Displayed, not adopted.",
+    )
+    checks.check(
+        "note-census",
+        "the note reports N_rev=0, N_beat=0, and the displayed-not-adopted boundary",
+        all(item in note for item in required)
+        and "lex-first reversing triple does not exist" in normalized_note
+        and "t(4,0,0)=12" in note
+        and "t(2,2,2)=14" in note,
+    )
+    checks.check(
+        "note-hygiene",
+        "forbidden phrases, uniqueness, L1 attachment, and axiom-edit language are absent",
+        all(phrase not in note for phrase in forbidden_note)
+        and all(phrase not in axiom for phrase in forbidden_note)
+        and "new axiom" not in note.lower()
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and all(f"### N{index}" in note for index in range(1, 9)),
+        [phrase for phrase in forbidden_note if phrase in note],
+    )
+    checks.check(
+        "claim-scope-literal",
+        "claim_scope matches the declared census wording",
+        "Among 27 named (seed, equal, unequal) hop-costs on B_6(0)" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "source-axiom-boundary",
+        "the current axiom memo still types one covariant nearest-neighbor rule and no named three-slot cost",
+        "one fixed nearest-neighbor admissibility rule" in normalized_axiom
+        and "covariant under lattice translations and proper cubic rotations" in normalized_axiom
+        and "named three-slot" not in normalized_axiom,
+    )
+
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "machine fields and retained-language hygiene hold",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "FAIL / DO NOT SHIP" in note
+        and "27 Dijkstras" in note,
+    )
+
+    print("per_element: each of the 27 named triples is one Dijkstra arrival table")
+    print("per_site: times are compared only at (4,0,0) and (2,2,2); variance uses B_6(0) minus the origin")
+    print("per_mode: seed-exit, equal-support, and unequal-support are the only named cost slots")
+    print("per_block: diamond reversal and l1-variance beating are counted, not adopted")
+    print("lattice_wide: checked and not executed — no infinite-lattice or 6561 8-tuple scan")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

N_rev=0 and N_beat=0 among (c_seed,c_eq,c_uneq) in {1,2,3}^3. Matching member is not in this 27. Displayed, not adopted. No axiom edit.

## Runner

`scripts/named_three_slot_hopcost_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.