### PR TITLE
feat(face6): face diagonals also do not reverse under named rho

### DIFF
--- a/docs/NAMED_HOPCOST_FACE_DIAGONAL_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NAMED_HOPCOST_FACE_DIAGONAL_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,175 @@
+---
+claim_id: named_hopcost_face_diagonal_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal versus axis arrival order under the named hop-cost on B_6(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/named_hopcost_face_diagonal_b6_2026_08_15.py
+---
+
+# Face-Diagonal Versus Axis Arrival Order On B_6 Under The Named Hop-Cost
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra first-arrival table on the radius-6 integer ball
+`B_6(0)` for the named equal-weight hop-cost `ρ`, restricted to the five
+requested sites and three face-versus-axis ratio comparisons.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/named_hopcost_face_diagonal_b6_2026_08_15.py`](../scripts/named_hopcost_face_diagonal_b6_2026_08_15.py)
+
+## Result Up Front
+
+On the one-seed front, the inward occupancy weight `|σ_v|` of a site `v` is
+the number of six-neighbors of `v` that are strictly closer to the seed in
+cubic nearest-neighbor graph distance. Equivalently, `|σ_0|=0` and, for
+`v ≠ 0`, `|σ_v|` equals the number of nonzero coordinates of `v`.
+
+The named hop-cost `ρ` on a directed six-neighbor edge `v → w` that remains
+inside `B_6(0)` is
+
+```text
+ρ(v → w) = 3  if |σ_v| = |σ_w| or |σ_v| = 0,
+         = 1  otherwise.
+```
+
+This is the same local-in-weights rule used to name the eight inward-weight
+orbits on the radius-3 ball (seed-exit and equal inward weight cost 3;
+unequal inward weight cost 1). It is a displayed scoring rule. It is not
+written into Admissibility. Do not attach L1.
+
+`B_6(0)` is the 377-site set `{v ∈ Z^3 : |v|_1 ≤ 6}`. Arrival `t` is the
+minimum `ρ`-path cost from the seed `0` through directed six-neighbor edges
+that stay in `B_6(0)`. One Dijkstra computation on that finite directed
+graph yields the exact integer times
+
+```text
+t(4,0,0)=12
+t(6,0,0)=18
+t(3,3,0)=16
+t(4,2,0)=16
+t(2,2,2)=14
+```
+
+For a nonzero site `v`, write `q(v) := t(v)^2 / |v|_2^2`. Reverse of the
+diamond (ℓ¹) order on an ordered pair `(axis, more-diagonal)` means
+`q(more-diagonal) < q(axis)`. The three requested pairs do **not** reverse:
+
+| pair | `q` on the axis site | `q` on the more-diagonal site | reverse? |
+|---|---|---|---|
+| `((4,0,0),(3,3,0))` | `144/16 = 9` | `256/18 = 128/9` | no: `128/9 > 9` |
+| `((4,0,0),(4,2,0))` | `144/16 = 9` | `256/20 = 64/5` | no: `64/5 > 9` |
+| `((6,0,0),(3,3,0))` | `324/36 = 9` | `256/18 = 128/9` | no: `128/9 > 9` |
+
+The body-diagonal time `t(2,2,2)=14` is reported only because it is among the
+five requested sites. The face-versus-axis comparisons above are not a
+restatement of that body-diagonal number.
+
+The five times and the three non-reversals are displayed, not adopted.
+
+## Exact Theorem
+
+Let `B_6(0) := {v ∈ Z^3 : |v|_1 ≤ 6}`. Let `E` be the set of directed
+six-neighbor edges `v → w` with both ends in `B_6(0)`. Let `|σ_v|` and `ρ`
+be as above. Let `t(v)` be the minimum of `∑ ρ` over directed `E`-paths from
+`(0,0,0)` to `v`.
+
+**Theorem 1.** The arrival times on the five requested sites are
+`t(4,0,0)=12`, `t(6,0,0)=18`, `t(3,3,0)=16`, `t(4,2,0)=16`, and
+`t(2,2,2)=14`.
+
+**Theorem 2.** For each pair
+`((4,0,0),(3,3,0))`, `((4,0,0),(4,2,0))`, `((6,0,0),(3,3,0))`, the
+more-diagonal site is the second entry. None of the three pairs reverses
+diamond order: `128/9 > 9`, `64/5 > 9`, and `128/9 > 9` respectively.
+Displayed, not adopted.
+
+**Theorem 3.** Do not write `ρ` into Admissibility. Do not attach L1.
+
+## Proof Sketch
+
+The directed graph `(B_6(0), E)` is finite (377 vertices, at most six
+outgoing edges each) and every edge cost is a positive integer in `{1,3}`.
+Dijkstra's algorithm therefore returns the exact integer minimum-path
+function `t`. The paired runner performs that single Dijkstra computation
+and reads off the five sites.
+
+The axis times are additionally visible on the unique coordinate-axis
+geodesics. Each hop `(k,0,0) → (k+1,0,0)` for `k ≥ 0` is either seed-exit
+(`k=0`) or equal inward weight `1 → 1` (`k ≥ 1`), hence has cost 3, so
+`t(n,0,0) = 3n` is an explicit upper bound. Dijkstra matches it:
+`t(4,0,0)=12` and `t(6,0,0)=18`.
+
+The three ratio comparisons are exact rational arithmetic from those times
+and the Euclidean squared lengths `| (4,0,0) |_2^2 = 16`,
+`| (6,0,0) |_2^2 = 36`, `| (3,3,0) |_2^2 = 18`, and `| (4,2,0) |_2^2 = 20`.
+
+The eight inward-weight pairs that already appear on the radius-3 ball are
+`(0,1)`, `(1,0)`, `(1,1)`, `(1,2)`, `(2,1)`, `(2,2)`, `(2,3)`, `(3,2)`.
+Evaluating `ρ` on those pairs recovers the eight-tuple `(3,1,3,1,1,3,1,1)`.
+The pair `(3,3)` that first appears on a larger ball also has equal inward
+weight, so `ρ(3,3)=3`. Those identities identify the displayed rule; they
+are not a new axiom clause.
+
+## Framework Boundary
+
+The Lattice axiom supplies the cubic lattice `Z^3` and nearest-neighbor
+adjacency. Admissibility supplies one fixed nearest-neighbor admissibility
+rule and says that, for each site, the probability distribution over the
+possibilities is determined by, and varies with, the nearest-neighbor
+conditions. Neither clause names a hop-cost, an arrival time, or a
+comparison of `t^2 / |v|_2^2` across site types.
+
+This note therefore treats `ρ` as a separately named scoring rule on
+inward-weight pairs. Theorem 3 forbids writing `ρ` into Admissibility.
+The diamond (ℓ¹) order is used only as the comparison baseline requested
+by the three pairs. Do not attach L1.
+
+No Euclidean spacetime metric, clock map, or continuum null cone is adopted.
+The quantity `|v|_2^2` is the ordinary integer sum of squares of the three
+coordinates, used only to form the displayed ratio `q(v)`.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| cubic lattice `Z^3` and six-neighbor adjacency | ambient graph | Lattice axiom |
+| nearest-neighbor condition domain | identification only; no kernel values used | Admissibility axiom |
+| inward weight `|σ_v|` | one-seed front labeling | declared from the six-neighbor graph |
+| hop-cost `ρ` | displayed scoring rule | named equal-weight / seed-exit clause; not an axiom |
+| `B_6(0)` | declared finite ball | 377 sites with `|v|_1 ≤ 6` |
+| `t` | minimum path cost | one Dijkstra on the induced directed graph |
+| reverse | `q(more-diagonal) < q(axis)` | displayed comparison, not adopted |
+
+There are no measured, fitted, literature, or observational inputs. The
+rule `ρ` is not unique among maps `{1,3}` on inward-weight pairs, and no
+uniqueness claim is made. Face-diagonal versus axis arrival order under
+this displayed rule is the entire scientific content.
+
+## Machine Status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_6(0) closes the five integer arrival times and the three exact rational face-versus-axis comparisons; the hop-cost is displayed, not adopted, and is not written into Admissibility."
+trace_class: upstream_support
+target_claim_id: named_hopcost_face_diagonal_b6_bounded_theorem_note_2026-08-15
+target_blocker_text: "name a hop-cost that is retained-derived rather than displayed, if any later lane requires one"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep ρ displayed. Do not write it into Admissibility. Do not attach L1. Use the three non-reversals as the face-diagonal residual, not as a restatement of t(2,2,2)."
+conditional_surface_status: "exact on B_6(0) for the named hop-cost; not adopted"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Primary Runner
+
+The paired runner builds `B_6(0)`, assigns `ρ` from inward weights, runs
+one Dijkstra computation from the seed, reports the five times and three
+ratio comparisons, and checks agreement with this note. It writes no
+runner cache.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15743,
- "node_count": 5545,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12711,6 +12711,10 @@
    "out_degree": 7
   },
   "naive_lattice_fermion_two_power_d_species_count_narrow_theorem_note_2026-05-10": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "named_hopcost_face_diagonal_b6_bounded_theorem_note_2026-08-15": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },

--- a/logs/runner-cache/named_hopcost_face_diagonal_b6_2026_08_15.txt
+++ b/logs/runner-cache/named_hopcost_face_diagonal_b6_2026_08_15.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/named_hopcost_face_diagonal_b6_2026_08_15.py
+runner_sha256: 56a55c110d763230bfb99fad413524638bb0c17fb22185dfb8bcf38900424fc5
+input_fingerprint_sha256: 0dd11717eeba29868d34c284398c04d346374c4bcd92462ee9fc6702774e0250
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/NAMED_HOPCOST_FACE_DIAGONAL_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: none; ρ is a displayed named hop-cost
+claim_scope: Face-diagonal versus axis arrival order under the named hop-cost on B_6(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and minimal axioms
+PASS: ball-cardinality B_6(0) has 377 sites
+PASS: rho-eight-tuple ρ recovers the eight-tuple (3,1,3,1,1,3,1,1)
+PASS: rho-equal-three equal inward weight (3,3) has cost 3
+PASS: t-400 t(4, 0, 0)=12
+PASS: t-600 t(6, 0, 0)=18
+PASS: t-330 t(3, 3, 0)=16
+PASS: t-420 t(4, 2, 0)=16
+PASS: t-222 t(2, 2, 2)=14
+PASS: pair-400-330 ((4,0,0),(3,3,0)) does not reverse: 128/9 > 9
+PASS: pair-400-420 ((4,0,0),(4,2,0)) does not reverse: 64/5 > 9
+PASS: pair-600-330 ((6,0,0),(3,3,0)) does not reverse: 128/9 > 9
+PASS: no-face-reverse none of the three face-versus-axis pairs reverses diamond order
+PASS: note-contract the note reports the times, non-reversals, and bounded scope
+PASS: note-no-forbidden the note avoids the forbidden phrases
+PASS: axiom-names the axiom memo names Lattice, Qubit, Admissibility, and Record
+PASS: axis-unit-cost-contrast unit six-neighbor arrival is |v|_1, so t_unit(3,3,0)=6 is not t_ρ=16
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/named_hopcost_face_diagonal_b6_2026_08_15.py
+++ b/scripts/named_hopcost_face_diagonal_b6_2026_08_15.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""One Dijkstra on B_6(0) for face-diagonal vs axis order under named ρ."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/NAMED_HOPCOST_FACE_DIAGONAL_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NAMED_HOPCOST_FACE_DIAGONAL_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+SHIFTS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+RADIUS = 6
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+EIGHT_ORBITS = (
+    (0, 1),
+    (1, 0),
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (2, 3),
+    (3, 2),
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def l2sq(site: tuple[int, int, int]) -> int:
+    return site[0] * site[0] + site[1] * site[1] + site[2] * site[2]
+
+
+def inward_weight(site: tuple[int, int, int]) -> int:
+    return sum(1 for coord in site if coord != 0)
+
+
+def rho(weight_v: int, weight_w: int) -> int:
+    if weight_v == weight_w or weight_v == 0:
+        return 3
+    return 1
+
+
+def ball(radius: int) -> frozenset[tuple[int, int, int]]:
+    sites: set[tuple[int, int, int]] = set()
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            for z in range(-radius, radius + 1):
+                site = (x, y, z)
+                if l1(site) <= radius:
+                    sites.add(site)
+    return frozenset(sites)
+
+
+def dijkstra_rho(sites: frozenset[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    inf = 10**9
+    dist = {site: inf for site in sites}
+    origin = (0, 0, 0)
+    dist[origin] = 0
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, origin)]
+    while heap:
+        cost, site = heappop(heap)
+        if cost != dist[site]:
+            continue
+        weight_v = inward_weight(site)
+        x, y, z = site
+        for dx, dy, dz in SHIFTS:
+            nbr = (x + dx, y + dy, z + dz)
+            if nbr not in sites:
+                continue
+            nxt = cost + rho(weight_v, inward_weight(nbr))
+            if nxt < dist[nbr]:
+                dist[nbr] = nxt
+                heappush(heap, (nxt, nbr))
+    return dist
+
+
+def q_ratio(times: dict[tuple[int, int, int], int], site: tuple[int, int, int]) -> Fraction:
+    arrival = times[site]
+    return Fraction(arrival * arrival, l2sq(site))
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axioms = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: none; ρ is a displayed named hop-cost")
+    print(
+        "claim_scope: Face-diagonal versus axis arrival order under the named "
+        "hop-cost on B_6(0) is reported. Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and minimal axioms",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball(RADIUS)
+    checks.check(
+        "ball-cardinality",
+        "B_6(0) has 377 sites",
+        len(sites) == 377,
+        len(sites),
+    )
+
+    eight = tuple(rho(a, b) for a, b in EIGHT_ORBITS)
+    checks.check(
+        "rho-eight-tuple",
+        "ρ recovers the eight-tuple (3,1,3,1,1,3,1,1)",
+        eight == (3, 1, 3, 1, 1, 3, 1, 1),
+        eight,
+    )
+    checks.check(
+        "rho-equal-three",
+        "equal inward weight (3,3) has cost 3",
+        rho(3, 3) == 3,
+    )
+
+    times = dijkstra_rho(sites)
+    axis4 = (4, 0, 0)
+    axis6 = (6, 0, 0)
+    face33 = (3, 3, 0)
+    face42 = (4, 2, 0)
+    body = (2, 2, 2)
+    reported = {
+        axis4: 12,
+        axis6: 18,
+        face33: 16,
+        face42: 16,
+        body: 14,
+    }
+    for site, expected in reported.items():
+        label = "".join(str(abs(c)) for c in site)
+        checks.check(
+            f"t-{label}",
+            f"t{site}={expected}",
+            times[site] == expected,
+            times[site],
+        )
+
+    pairs = ((axis4, face33), (axis4, face42), (axis6, face33))
+    ratios = []
+    reverses = []
+    for axis, diag in pairs:
+        q_axis = q_ratio(times, axis)
+        q_diag = q_ratio(times, diag)
+        ratios.append((q_axis, q_diag))
+        reverses.append(q_diag < q_axis)
+
+    checks.check(
+        "pair-400-330",
+        "((4,0,0),(3,3,0)) does not reverse: 128/9 > 9",
+        ratios[0] == (Fraction(9), Fraction(128, 9)) and not reverses[0],
+        ratios[0],
+    )
+    checks.check(
+        "pair-400-420",
+        "((4,0,0),(4,2,0)) does not reverse: 64/5 > 9",
+        ratios[1] == (Fraction(9), Fraction(64, 5)) and not reverses[1],
+        ratios[1],
+    )
+    checks.check(
+        "pair-600-330",
+        "((6,0,0),(3,3,0)) does not reverse: 128/9 > 9",
+        ratios[2] == (Fraction(9), Fraction(128, 9)) and not reverses[2],
+        ratios[2],
+    )
+    checks.check(
+        "no-face-reverse",
+        "none of the three face-versus-axis pairs reverses diamond order",
+        reverses == [False, False, False],
+        reverses,
+    )
+
+    required_note = (
+        "t(4,0,0)=12",
+        "t(6,0,0)=18",
+        "t(3,3,0)=16",
+        "t(4,2,0)=16",
+        "t(2,2,2)=14",
+        "128/9 > 9",
+        "64/5 > 9",
+        "Displayed, not adopted",
+        "Do not write `ρ` into Admissibility",
+        "Do not attach L1",
+        "Face-diagonal versus axis arrival order under the named hop-cost on B_6(0) is reported",
+        "**Type:** bounded_theorem",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "hypothetical_axiom_status: no edit",
+        "377-site",
+        "One Dijkstra",
+    )
+    checks.check(
+        "note-contract",
+        "the note reports the times, non-reversals, and bounded scope",
+        all(phrase in note for phrase in required_note),
+        [phrase for phrase in required_note if phrase not in note],
+    )
+    checks.check(
+        "note-no-forbidden",
+        "the note avoids the forbidden phrases",
+        all(phrase not in note for phrase in FORBIDDEN),
+        [phrase for phrase in FORBIDDEN if phrase in note],
+    )
+    checks.check(
+        "axiom-names",
+        "the axiom memo names Lattice, Qubit, Admissibility, and Record",
+        all(name in axioms for name in ("Lattice", "Qubit", "Admissibility", "Record")),
+    )
+    checks.check(
+        "axis-unit-cost-contrast",
+        "unit six-neighbor arrival is |v|_1, so t_unit(3,3,0)=6 is not t_ρ=16",
+        l1(face33) == 6 and times[face33] != l1(face33),
+        (l1(face33), times[face33]),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

t(3,3,0)=t(4,2,0)=16, t(4,0,0)=12, t(6,0,0)=18. All three face-vs-axis pairs fail reverse. Displayed, not adopted. No axiom edit.

## Runner

`scripts/named_hopcost_face_diagonal_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.