### PR TITLE
feat(axis3): axis-skeleton cost does not reverse; t(4,0,0)=t(2,2,2)=8

### DIFF
--- a/docs/AXIS_SKELETON_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/AXIS_SKELETON_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,261 @@
+---
+claim_id: axis_skeleton_hopcost_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_6(0), the named axis-skeleton hop-cost is scored for diamond reverse at (4,0,0) vs (2,2,2) and for var(|v|_2/t) vs ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/axis_skeleton_hopcost_b6_2026_08_15.py
+---
+
+# Named Axis-Skeleton Hop-Cost On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one finite Dijkstra score of a named hop-cost on the closed
+nearest-neighbor graph ball `B_6(0)` in `Z^3`. The score is displayed, not
+adopted. Uniqueness is not claimed. This note does not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/axis_skeleton_hopcost_b6_2026_08_15.py`](../scripts/axis_skeleton_hopcost_b6_2026_08_15.py)
+
+## Result Up Front
+
+On the cubic lattice, write `|σ_v|` for the number of nonzero coordinates of
+`v∈Z^3`. The named hop-cost `α` on a nearest-neighbor step `v→w` is
+
+```text
+α(v→w) = 3  if |σ_v|=0 or (|σ_v|=|σ_w|=1),
+α(v→w) = 1  otherwise.
+```
+
+The first clause is the seed exit from the origin. The second clause is the
+axis 1-skeleton: both endpoints have weight one. Every other nearest-neighbor
+step is cheap. Axis-extension hops therefore stay expensive as hops, while
+face and body steps that leave that 1-skeleton are cheap.
+
+Let `B_6(0):={v∈Z^3 : |v|_1 ≤ 6}` be the closed graph ball of radius 6 for
+the nearest-neighbor path metric. Let `t(v)` be the `α`-length of a shortest
+path from the origin inside this ball, computed by one Dijkstra run. Let
+`ℓ¹` be the comparison hop-cost that assigns every nearest-neighbor step the
+value `1`, so its arrival time is `|v|_1`.
+
+**Theorem 1.** `t(4,0,0)=8` and `t(2,2,2)=8`. The diamond-reverse test
+`12 t(4,0,0)^2 > 16 t(2,2,2)^2` is `768 > 1024`, which is false. The named
+rule does not reverse `(4,0,0)` against `(2,2,2)`.
+
+**Theorem 2.** On the 376 nonzero sites of `B_6(0)`, the population variances
+of `|v|_2/t` are
+
+```text
+var_α = 0.005489876321,
+var_ℓ¹ = 0.013502037619.
+```
+
+The `α` variance is smaller.
+
+**Theorem 3.** The named rule is displayed, not adopted. It is not written
+into Admissibility. Uniqueness is not required and is not claimed.
+
+The rule is not a leftover of the 27 three-slot family (including the
+investment rule with no reverse): that family cannot split the face targets
+`(1,1,0)` and `(2,2,0)`. Here `t(1,1,0)=4` and `t(2,2,0)=6`.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+`α` is not that admissibility rule. The axiom already says there is one fixed
+nearest-neighbor admissibility rule. This note does not edit that sentence and
+does not add a hop-cost to Admissibility.
+
+The current Record boundary is unused by the score:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Record supplies no hop-cost, no arrival time, and no Euclidean comparator.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: displayed
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra score of a named hop-cost on B_6(0) for diamond reverse and for population variance of |v|_2/t against ℓ¹. Displayed, not adopted."
+trace_class: residual_score
+target_claim_id: axis_skeleton_hopcost_b6_bounded_theorem_note_2026-08-15
+target_blocker_text: "score the named axis-skeleton hop-cost on B_6(0) for reverse and for variance against ℓ¹"
+source_of_blocker_text: handoff
+reachability_to_target: scores
+artifact_role: theorem
+next_trace_action: "Keep α displayed only; do not write it into Admissibility and do not attach L1."
+conditional_surface_status: "exact finite score on B_6(0); not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0=(0,0,0)` and `e_1,e_2,e_3` for the standard basis of `Z^3`. The open
+neighbor set is `N(v)={v±e_1,v±e_2,v±e_3}`. A directed hop is a pair
+`(v,w)` with `w∈N(v)` and with both endpoints in `B_6(0)`.
+
+The weight `|σ_v|` is the number of nonzero Cartesian coordinates. Then:
+
+- seed exit: `α(0,e_i)=3` and `α(0,-e_i)=3`;
+- axis 1-skeleton: if `|σ_v|=|σ_w|=1`, then `α(v,w)=3`;
+- otherwise `α(v,w)=1`.
+
+In particular the axis-extension hops `(n e_i)→((n+1)e_i)` for `n≥1` cost `3`,
+while `(e_1)→(e_1+e_2)`, `(e_1+e_2)→(2e_1+e_2)`, and
+`(e_1+e_2)→(e_1+e_2+e_3)` each cost `1`. That is the intended cheapening of
+`(2,2)` and `(3,3)` face targets without cheapening axis-extension hops.
+
+`t` is the arrival time of one Dijkstra tree for `α` rooted at the origin on
+the directed graph just named. The comparison arrival time for `ℓ¹` is
+`|v|_1`; on this ball every `ℓ¹` geodesic stays inside, so no second search
+is required.
+
+## Theorem 1
+
+The Dijkstra values are `t(4,0,0)=8` and `t(2,2,2)=8`.
+
+An explicit body path of `α`-length `8` is
+
+```text
+0 → e_1 → e_1+e_2 → e_1+e_2+e_3 → 2e_1+e_2+e_3 → 2e_1+2e_2+e_3 → 2e_1+2e_2+2e_3
+```
+
+with costs `3,1,1,1,1,1`. Any path to `(2,2,2)` has at least six hops and
+begins with a seed exit of cost `3`, so `8` is also a lower bound.
+
+An explicit path of `α`-length `8` to `(4,0,0)` is
+
+```text
+0 → e_1 → e_1+e_2 → 2e_1+e_2 → 3e_1+e_2 → 4e_1+e_2 → 4e_1
+```
+
+with costs `3,1,1,1,1,1`. The direct axis path costs `12`. The off-axis
+detour is legal in `B_6(0)` because `(4,1,0)` has ℓ¹-norm `5`. Thus the
+shortest-path value `t(4,0,0)` is cheaper than the axis-extension path even
+though every axis-extension *hop* still costs `3`.
+
+The diamond test is then `12·8^2=768` against `16·8^2=1024`. Reverse fails.
+
+## Theorem 2
+
+Let `S=B_6(0)\{0}`, so `|S|=376`. The population variance is
+
+```text
+var(x) = (1/|S|) ∑_{v∈S} (x(v) - mean(x))^2.
+```
+
+The runner evaluates `x_α(v)=|v|_2/t(v)` and `x_ℓ¹(v)=|v|_2/|v|_1` in one
+pass over the Dijkstra tree and reports
+
+```text
+var_α = 0.005489876321,
+var_ℓ¹ = 0.013502037619.
+```
+
+So `var_α < var_ℓ¹`. The score is only this finite comparison on `B_6(0)`.
+
+## Theorem 3
+
+`α` is a named displayed hop-cost. It is not adopted as a physical law and is
+not written into Admissibility. The axiom text still contains exactly one
+fixed nearest-neighbor admissibility rule, and that sentence is unchanged.
+
+Uniqueness is not required. The note does not claim that `α` is the only
+hop-cost with a smaller Euclidean-ratio variance than `ℓ¹`, nor that it is
+the only hop-cost that splits `(1,1,0)` from `(2,2,0)`.
+
+This note does not attach L1.
+
+## Relation To The 27 Three-Slot Family
+
+A prior 27-member three-slot family, including the investment rule with no
+reverse, cannot split `(1,1)` from `(2,2)`. The present named rule is
+therefore not a leftover of that family: it marks as expensive only the seed
+exit and the axis 1-skeleton, so the two-hop face target `(1,1,0)` and the
+four-hop face target `(2,2,0)` receive different arrival times `4` and `6`.
+Direct all-expensive accounting would have given `6` and `12`. The same
+cheapening produces `t(3,3,0)=8` rather than `18`.
+
+The investment comparison that assigned cost `3` to every seed or equal-weight
+hop made a geodesic to `(2,2,2)` use two cheap unequal hops and four expensive
+seed or equal hops, for total `14`. Replacing equal-weight expense by
+axis-skeleton expense is exactly the change from that comparison to `α`.
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice nearest-neighbor graph | quoted; no edit |
+| current Admissibility rule | quoted; `α` not written into it |
+| current Record boundary | quoted as unused |
+| named hop-cost `α` | displayed definition |
+| one Dijkstra on `B_6(0)` | executed |
+| `t(4,0,0)` and `t(2,2,2)` | exact integers `8,8` |
+| diamond reverse `12 t(4,0,0)^2 > 16 t(2,2,2)^2` | false |
+| population variance of `|v|_2/t` versus `ℓ¹` | `α` smaller |
+| split of `(1,1,0)` from `(2,2,0)` | exact `4` versus `6` |
+| uniqueness | not claimed |
+| adoption into Admissibility | refused |
+| L1 attachment | refused |
+
+The obligation graph is acyclic. Every scored leaf is a finite statement on
+`B_6(0)`. Adoption and uniqueness are not proof leaves.
+
+## Boundary And Imports
+
+There are no measured, fitted, literature, or observational inputs. The only
+scientific source is the current axiom memo for the cubic nearest-neighbor
+graph and the explicit non-adoption of `α` as axiom content.
+
+The score does not select a physical clock, a continuum limit, a Record
+readout, a formation rate, or a Newton-lane residual. It does not enlarge
+Admissibility.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It scores one named hop-cost on a declared finite ball for reverse and for variance against `ℓ¹`. |
+| V2 | Current main has no landed score of this axis-skeleton rule on `B_6(0)`. |
+| V3 | Arrival times are exact integers; the variance comparison is a finite population statistic. |
+| V4 | The rule is not a restatement of Admissibility and is not written into it. |
+| V5 | Displayed, not adopted. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: this named rule does not reverse
+`(4,0,0)` against `(2,2,2)` on `B_6(0)`. No global hop-cost impossibility is
+claimed. Uniqueness is not required.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| direct axis path | use only weight-one hops | cost `12` to `(4,0,0)`; not shortest |
+| off-axis detour | leave and rejoin the axis inside `B_6(0)` | shortest `t(4,0,0)=8` |
+| body geodesic | six hops, one seed exit, then cheap | shortest `t(2,2,2)=8` |
+| `ℓ¹` comparison | unit hops | larger population variance |
+| 27 three-slot leftovers | reuse a rule that cannot split `(1,1)` from `(2,2)` | different family; not this rule |
+| write `α` into Admissibility | adopt the hop-cost as the axiom rule | refused |
+| attach L1 | promote the score as a Newton residual | refused |

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1237,6 +1237,10 @@
   "axiom_stack_minimality_cl4c_no_go_theorem_note_2026-04-29": {
    "deps_hash": "43bbfd6e9fc5",
    "out_degree": 5
+  },
+  "axis_skeleton_hopcost_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2a26c7562e24",

--- a/logs/runner-cache/axis_skeleton_hopcost_b6_2026_08_15.txt
+++ b/logs/runner-cache/axis_skeleton_hopcost_b6_2026_08_15.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/axis_skeleton_hopcost_b6_2026_08_15.py
+runner_sha256: 93cfe5c27f1a8beb3494f22b56adc7c01133e109cc313192dac55ca14b11a29d
+input_fingerprint_sha256: 6d8ecc91cf28caf3bd636ae25d349cea96cbc9cc2b5b79d889d9c716d15df247
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice nearest-neighbor graph and Admissibility non-adoption boundary are source-bound; no observation or fit
+integrity_reads: this runner, its note, and the current axiom memo; no cache or governance surface is written
+construction: one Dijkstra for the named axis-skeleton hop-cost on B_6(0)
+negative_scope: displayed score only; alpha is not adopted, not written into Admissibility, and does not attach L1
+PASS: audit-input-paths declared inputs are exactly the note and the current axiom memo
+PASS: source-lattice the cubic nearest-neighbor graph is the current Lattice premise
+PASS: source-admissibility-unedited the axiom still names one fixed nearest-neighbor admissibility rule
+PASS: axiom-has-no-alpha the axiom memo does not contain the named hop-cost
+PASS: source-record-unused lock, content-only readout, and unreadability at absence are quoted as unused
+PASS: claim-scope the note carries the declared displayed claim_scope
+PASS: displayed-not-adopted the note states displayed, not adopted, and uniqueness is not claimed
+PASS: no-l1-attachment the note refuses L1 attachment
+PASS: forbidden-phrases the note omits the forbidden tokens
+PASS: alpha-seed-exit seed exit costs 3
+PASS: alpha-axis-skeleton both-weight-one hops cost 3
+PASS: alpha-off-skeleton leaving the axis 1-skeleton costs 1
+PASS: one-dijkstra exactly one Dijkstra run covers B_6(0)
+PASS: theorem-1-times t(4,0,0)=8 and t(2,2,2)=8
+PASS: theorem-1-reverse 12 t(4,0,0)^2 > 16 t(2,2,2)^2 is false
+PASS: face-split (1,1,0) and (2,2,0) split, and (2,2),(3,3) are cheaper than 3 |v|_1
+PASS: theorem-2-variance var_α is smaller than var_ℓ¹ on B_6(0)\{0}
+PASS: note-reports-score the note reports the computed times, reverse integers, and variances
+PASS: ball-membership (4,0,0) and (2,2,2) lie in the declared graph ball and not beyond it
+t(4,0,0)=8
+t(2,2,2)=8
+reverse_left=768 reverse_right=1024 reverse=False
+var_alpha=0.005489876321 var_l1=0.013502037619
+sites=377 nonzero=376 dijkstra_runs=1
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/axis_skeleton_hopcost_b6_2026_08_15.py
+++ b/scripts/axis_skeleton_hopcost_b6_2026_08_15.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Score the named axis-skeleton hop-cost on B_6(0).
+
+One Dijkstra computes α-arrival times on the closed nearest-neighbor graph
+ball of radius 6. The runner reports diamond reverse at (4,0,0) versus
+(2,2,2) and the population variance of |v|_2/t against ℓ¹. α is displayed,
+not adopted. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = (
+    ROOT
+    / "docs"
+    / "AXIS_SKELETON_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/AXIS_SKELETON_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+RADIUS = 6
+VAR_ALPHA_TEXT = "0.005489876321"
+VAR_L1_TEXT = "0.013502037619"
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def weight(point: Point) -> int:
+    return sum(coord != 0 for coord in point)
+
+
+def l1_norm(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def l2_norm(point: Point) -> float:
+    return math.sqrt(point[0] * point[0] + point[1] * point[1] + point[2] * point[2])
+
+
+def alpha(source: Point, target: Point) -> int:
+    source_weight = weight(source)
+    target_weight = weight(target)
+    if source_weight == 0 or (source_weight == 1 and target_weight == 1):
+        return 3
+    return 1
+
+
+def graph_ball(radius: int) -> frozenset[Point]:
+    span = range(-radius, radius + 1)
+    return frozenset(point for point in product(span, repeat=3) if l1_norm(point) <= radius)
+
+
+def dijkstra_alpha(ball: frozenset[Point]) -> dict[Point, int]:
+    dist = {ORIGIN: 0}
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while heap:
+        cost, site = heapq.heappop(heap)
+        if cost != dist[site]:
+            continue
+        for shift in SHIFTS:
+            neighbor = add(site, shift)
+            if neighbor not in ball:
+                continue
+            new_cost = cost + alpha(site, neighbor)
+            if new_cost < dist.get(neighbor, 10**9):
+                dist[neighbor] = new_cost
+                heapq.heappush(heap, (new_cost, neighbor))
+    return dist
+
+
+def population_variance(values: list[float]) -> float:
+    count = len(values)
+    mean = sum(values) / count
+    return sum((value - mean) ** 2 for value in values) / count
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(
+        "external_scientific_inputs: current Lattice nearest-neighbor graph "
+        "and Admissibility non-adoption boundary are source-bound; no observation or fit"
+    )
+    print(
+        "integrity_reads: this runner, its note, and the current axiom memo; "
+        "no cache or governance surface is written"
+    )
+    print(
+        "construction: one Dijkstra for the named axis-skeleton hop-cost on B_6(0)"
+    )
+    print(
+        "negative_scope: displayed score only; alpha is not adopted, not written "
+        "into Admissibility, and does not attach L1"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the note and the current axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/AXIS_SKELETON_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_one = (
+        "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    checks.check(
+        "source-lattice",
+        "the cubic nearest-neighbor graph is the current Lattice premise",
+        lattice_sentence in axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility-unedited",
+        "the axiom still names one fixed nearest-neighbor admissibility rule",
+        admissibility_one in axiom and admissibility_one in note,
+    )
+    checks.check(
+        "axiom-has-no-alpha",
+        "the axiom memo does not contain the named hop-cost",
+        "axis-skeleton" not in axiom and "α(v→w)" not in axiom and "alpha hop" not in axiom,
+    )
+    checks.check(
+        "source-record-unused",
+        "lock, content-only readout, and unreadability at absence are quoted as unused",
+        all(
+            phrase in normalized_axiom and phrase in normalized_note
+            for phrase in (record_lock, record_content, record_absence)
+        )
+        and "Record supplies no hop-cost" in note,
+    )
+
+    claim_scope = (
+        "On B_6(0), the named axis-skeleton hop-cost is scored for diamond "
+        "reverse at (4,0,0) vs (2,2,2) and for var(|v|_2/t) vs ℓ¹. "
+        "Displayed, not adopted."
+    )
+    checks.check(
+        "claim-scope",
+        "the note carries the declared displayed claim_scope",
+        claim_scope in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note states displayed, not adopted, and uniqueness is not claimed",
+        "Displayed, not adopted" in note
+        and "displayed, not adopted" in note
+        and "Uniqueness is not required" in note
+        and "not written into Admissibility" in note,
+    )
+    checks.check(
+        "no-l1-attachment",
+        "the note refuses L1 attachment",
+        "This note does not attach L1." in note
+        and "L1 attachment | refused" in normalize(note).replace(" | ", " | "),
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-phrases",
+        "the note omits the forbidden tokens",
+        all(token not in note for token in forbidden),
+        [token for token in forbidden if token in note],
+    )
+
+    checks.check(
+        "alpha-seed-exit",
+        "seed exit costs 3",
+        alpha(ORIGIN, (1, 0, 0)) == 3 and alpha(ORIGIN, (0, -1, 0)) == 3,
+    )
+    checks.check(
+        "alpha-axis-skeleton",
+        "both-weight-one hops cost 3",
+        alpha((1, 0, 0), (2, 0, 0)) == 3
+        and alpha((2, 0, 0), (3, 0, 0)) == 3
+        and alpha((0, 4, 0), (0, 3, 0)) == 3,
+    )
+    checks.check(
+        "alpha-off-skeleton",
+        "leaving the axis 1-skeleton costs 1",
+        alpha((1, 0, 0), (1, 1, 0)) == 1
+        and alpha((1, 1, 0), (2, 1, 0)) == 1
+        and alpha((1, 1, 0), (1, 1, 1)) == 1
+        and alpha((4, 1, 0), (4, 0, 0)) == 1,
+    )
+
+    ball = graph_ball(RADIUS)
+    dijkstra_runs = 0
+    dijkstra_runs += 1
+    dist = dijkstra_alpha(ball)
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra run covers B_6(0)",
+        dijkstra_runs == 1
+        and len(ball) == 377
+        and set(dist) == set(ball)
+        and dist[ORIGIN] == 0,
+        (dijkstra_runs, len(ball), len(dist)),
+    )
+
+    t400 = dist[(4, 0, 0)]
+    t222 = dist[(2, 2, 2)]
+    t110 = dist[(1, 1, 0)]
+    t220 = dist[(2, 2, 0)]
+    t330 = dist[(3, 3, 0)]
+    reverse_left = 12 * t400 * t400
+    reverse_right = 16 * t222 * t222
+    reverse = reverse_left > reverse_right
+    checks.check(
+        "theorem-1-times",
+        "t(4,0,0)=8 and t(2,2,2)=8",
+        t400 == 8 and t222 == 8,
+        (t400, t222),
+    )
+    checks.check(
+        "theorem-1-reverse",
+        "12 t(4,0,0)^2 > 16 t(2,2,2)^2 is false",
+        reverse_left == 768 and reverse_right == 1024 and reverse is False,
+        (reverse_left, reverse_right, reverse),
+    )
+    checks.check(
+        "face-split",
+        "(1,1,0) and (2,2,0) split, and (2,2),(3,3) are cheaper than 3 |v|_1",
+        t110 == 4
+        and t220 == 6
+        and t330 == 8
+        and t220 < 3 * l1_norm((2, 2, 0))
+        and t330 < 3 * l1_norm((3, 3, 0)),
+        (t110, t220, t330),
+    )
+
+    nonzero = sorted(point for point in ball if point != ORIGIN)
+    ratios_alpha = [l2_norm(point) / dist[point] for point in nonzero]
+    ratios_l1 = [l2_norm(point) / l1_norm(point) for point in nonzero]
+    var_alpha = population_variance(ratios_alpha)
+    var_l1 = population_variance(ratios_l1)
+    checks.check(
+        "theorem-2-variance",
+        "var_α is smaller than var_ℓ¹ on B_6(0)\\{0}",
+        len(nonzero) == 376
+        and f"{var_alpha:.12f}" == VAR_ALPHA_TEXT
+        and f"{var_l1:.12f}" == VAR_L1_TEXT
+        and var_alpha < var_l1,
+        (len(nonzero), f"{var_alpha:.12f}", f"{var_l1:.12f}"),
+    )
+
+    checks.check(
+        "note-reports-score",
+        "the note reports the computed times, reverse integers, and variances",
+        "t(4,0,0)=8" in note
+        and "t(2,2,2)=8" in note
+        and "768 > 1024" in note
+        and VAR_ALPHA_TEXT in note
+        and VAR_L1_TEXT in note
+        and "t(1,1,0)=4" in note
+        and "t(2,2,0)=6" in note,
+    )
+    checks.check(
+        "ball-membership",
+        "(4,0,0) and (2,2,2) lie in the declared graph ball and not beyond it",
+        (4, 0, 0) in ball
+        and (2, 2, 2) in ball
+        and l1_norm((2, 2, 2)) == RADIUS
+        and (7, 0, 0) not in ball,
+    )
+
+    print(f"t(4,0,0)={t400}")
+    print(f"t(2,2,2)={t222}")
+    print(f"reverse_left={reverse_left} reverse_right={reverse_right} reverse={reverse}")
+    print(f"var_alpha={var_alpha:.12f} var_l1={var_l1:.12f}")
+    print(f"sites={len(ball)} nonzero={len(nonzero)} dijkstra_runs={dijkstra_runs}")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Named alpha (3 iff seed-exit or both weights 1) has t_axis=t_diag=8 on B6. Reverse fails 768>1024. var 0.00549 vs l1 0.0135. Cheap detours undercut the axis. Displayed, not adopted. No axiom edit.

## Runner

`scripts/axis_skeleton_hopcost_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.