### PR TITLE
feat(axis4): axis-skeleton fails small-ball reverse on B4

### DIFF
--- a/docs/AXIS_SKELETON_HOPCOST_B4_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/AXIS_SKELETON_HOPCOST_B4_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,397 @@
+---
+claim_id: axis_skeleton_hopcost_b4_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_4(0), the named axis-skeleton hop-cost is scored for the small-ball reverse and for variance vs ρ and ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/axis_skeleton_hopcost_b4_2026_08_15.py
+---
+
+# Named Axis-Skeleton Hop-Cost Scored On `B_4(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact integer path costs of one displayed named rule on the
+radius-4 nearest-neighbor ball of one seed; small-ball order at `(3,0,0)`
+versus `(1,1,1)` and population variance of `|v|_2/t(v)` versus `ρ` and
+ell^1 on the 128 nonzero sites. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/axis_skeleton_hopcost_b4_2026_08_15.py`](../scripts/axis_skeleton_hopcost_b4_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Let `B_4(0)` be the set of sites of `Z^3` reachable from the origin by at
+most four nearest-neighbor steps. This is the 129-site ball. One-seed growth
+starts at `0`. The occupancy `σ_n` at a site `n` is the 6-bit string whose
+direction-`d` bit is set exactly when the neighbor of `n` in direction `d` is
+strictly nearer the seed. This is the inward occupation of the one-seed
+front.
+
+`G+` is the 24-element group of proper cubic rotations about the seed.
+Arrival time `t(n)` is the minimum path cost from `0` to `n` through
+`B_4(0)`.
+
+The named axis-skeleton rule `α` assigns a hop cost on every inward
+occupancy pair that appears in `B_4`:
+
+```text
+α(σ_v, σ_w) = 3  if |σ_v| = 0 or (|σ_v| = |σ_w| = 1),
+α(σ_v, σ_w) = 1  otherwise.
+```
+
+Seed-exit or both inward weights equal to `1` costs `3`; every other inward
+pair costs `1`. This is the same named rule scored on `B_6(0)`. The nine
+inward-weight pairs realized on `B_4(0)` are
+
+```text
+(0,1), (1,0), (1,1), (1,2), (2,1), (2,2), (2,3), (3,2), (3,3).
+```
+
+On the same sites the note also scores the named equal-weight rule `ρ`,
+
+```text
+ρ(σ_v, σ_w) = 3  if |σ_v| = |σ_w| or |σ_v| = 0,
+ρ(σ_v, σ_w) = 1  otherwise,
+```
+
+and the ell^1 filling `t(v) = |v|_1`. The comparison is not a leftover of
+B_6 times: the balls are a different ball, and the B_6 detour site
+`(4,1,0)` is not a site of `B_4(0)`.
+
+Two Dijkstras capped at the 129-site ball give
+
+```text
+t_α(3,0,0) = 7,  t_α(1,1,1) = 5,  t_α(4,0,0) = 10.
+```
+
+The B_3 small-ball reverse test is `3 t(3,0,0)^2 > 9 t(1,1,1)^2`. Under
+`α` this fails: `3·49 = 147` is not greater than `9·25 = 225`. The B_3
+pair does not reverse.
+
+On the 128 sites of `B_4(0) \ {0}`, write `s(v) = |v|_2 / t(v)` and let
+`var` be the population variance
+
+```text
+var(s) = (1/128) sum_v (s(v) - mean(s))^2.
+```
+
+The three fillings have
+
+```text
+var_alpha = 0.00397088249988,
+var_rho   = 0.00035024862901,
+var_ell1  = 0.01771035124177.
+```
+
+The order is `var_rho < var_alpha < var_ell1`. So `var_α` is strictly
+below ell^1 and strictly above `ρ`. Displayed, not adopted. The note does
+not attach ell^1, does not attach `ρ`, and does not attach `α`, as a
+path-length law.
+
+## Exact Theorems
+
+### Theorem 1
+
+The directed nearest-neighbor edges of `B_4(0)` carry nine inward-weight
+pairs of occupancies. The named axis-skeleton rule assigns every pair:
+seed-exit `(0,1)` costs `3`, the axis pair `(1,1)` costs `3`, and every
+other pair — including the equal-weight pairs `(2,2)` and `(3,3)` —
+costs `1`. By contrast `ρ` costs `3` on those equal-weight pairs.
+
+Two Dijkstras on the 129-site ball yield
+
+```text
+t(3,0,0) = 7,  t(1,1,1) = 5,  t(4,0,0) = 10
+```
+
+under `α`, and
+
+```text
+t_ρ(3,0,0) = 9,  t_ρ(1,1,1) = 5,  t_ρ(4,0,0) = 12
+```
+
+under `ρ`. The B_3 pair is `((3,0,0),(1,1,1))`. The reverse test
+`3 t(3,0,0)^2 > 9 t(1,1,1)^2` does not reverse under `α`.
+
+The axis-only path `0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0)` still
+costs `3+3+3+3 = 12`. It is not shortest. The cheaper `α` path
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (3,0,0)` costs
+`3+1+1+1+1 = 7`, and one further axis hop `(3,0,0) → (4,0,0)` of cost
+`3` gives `t(4,0,0) = 10`. The body-diagonal path
+`0 → (1,0,0) → (1,1,0) → (1,1,1)` costs `3+1+1 = 5`.
+
+The site `(4,1,0)` has ell^1 radius `5` and is not a site of `B_4(0)`.
+A leftover of B_6 times would use that site as a cheap return to
+`(4,0,0)`. The B_4 arrival `t(4,0,0) = 10` is therefore not a leftover
+of B_6 times.
+
+### Theorem 2
+
+On the 128 nonzero sites of `B_4(0)`, the population variance of
+`|v|_2/t(v)` is `0.00397088249988` for `α`, `0.00035024862901` for `ρ`,
+and `0.01771035124177` for the ell^1 filling `t = |·|_1`. The order is
+`var_rho < var_alpha < var_ell1`. The named axis-skeleton rule is
+therefore strictly below ell^1 and strictly above `ρ` on this ball.
+
+The `G+` site-types in `B_4(0)` arrive under `α` at
+
+```text
+t(1,0,0) = 3,  t(1,1,0) = 4,  t(1,1,1) = 5,
+t(2,0,0) = 6,  t(2,1,0) = 5,  t(2,1,1) = 6,
+t(2,2,0) = 6,  t(3,0,0) = 7,  t(3,1,0) = 6,
+t(4,0,0) = 10.
+```
+
+Axis types are no longer pinned to `t = 3 |v|_2`: the off-axis return
+cheapens `(3,0,0)` to `7` and `(4,0,0)` to `10`. That is why `var_α`
+sits between `ρ` and ell^1. The comparison is scored on `B_4(0)` only.
+It is not a leftover of B_6 times: the balls are a different ball, the
+128-site list is not the 376-site list, and `(4,1,0)` is absent.
+
+### Theorem 3
+
+The named rule `α` is displayed as a finite probe on `B_4(0)`. It is
+not written into Admissibility. No path-length law is attached. The note
+does not attach ell^1, `ρ`, or the displayed rule as a law. The live axiom
+memo continues to state that there is one fixed nearest-neighbor
+admissibility rule, covariant under translations and proper cubic
+rotations; that rule is not replaced by `c(σ_v, σ_w)`. Displayed, not
+adopted.
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_4(0)` as the 129-site ball | closed by the nearest-neighbor graph of `Z^3` |
+| define inward occupancy of the one-seed front | closed: a bit is set exactly on a strictly nearer neighbor |
+| count `G+` | closed: 24 proper cubic rotations |
+| name `α` on every inward occupancy pair in `B_4` | closed: cost `3` iff seed-exit or both weights `1`, else `1` |
+| score `ρ` and ell^1 on the same sites | closed by Theorems 1 and 2 |
+| report `t_α(3,0,0)`, `t_α(1,1,1)`, and `t_α(4,0,0)` | closed by Theorem 1 |
+| report whether the B_3 pair still reverses | closed by Theorem 1; it does not reverse |
+| score `var(\|v\|_2/t(v))` for `α`, `ρ`, and ell^1 | closed by Theorem 2; `var_rho < var_alpha < var_ell1` |
+| treat B_6 times as the B_4 score | refused; different ball, `(4,1,0)` absent |
+| write a cost into Admissibility | refused; Theorem 3 |
+| attach a path-length law | refused; Theorem 3 |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a cost or of a path-length law is not a proof leaf.
+
+## Representative Values
+
+| filling | `t(3,0,0)` | `t(1,1,1)` | `t(4,0,0)` | `var(\|v\|_2/t)` | B_3 reverse? |
+|---|---:|---:|---:|---:|---|
+| ell^1, `t = \|·\|_1` | `3` | `3` | `4` | `0.01771035124177` | no |
+| named `ρ` | `9` | `5` | `12` | `0.00035024862901` | yes |
+| named `α` | `7` | `5` | `10` | `0.00397088249988` | no |
+
+The table is an exact illustration of Theorems 1 and 2, not an adopted
+dynamics.
+
+## Framework Boundary
+
+Admissibility supplies one fixed nearest-neighbor rule, covariant under
+lattice translations and proper cubic rotations, and says that the local
+distribution varies with nearest-neighbor conditions. It does not supply a
+numerical hop cost on occupancy pairs. This note therefore treats
+`c(σ_v, σ_w)` as a displayed probe, not as an axiom clause.
+
+Record is not used. No formation site, formation rate, or readout value is
+assigned to an unoccupied site. The seed is a theorem hypothesis for the
+one-seed front, not a privileged physical site.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `Z^3` nearest-neighbor adjacency and proper cubic rotations | ambient lattice | live axiom memo |
+| one-seed front from `0` | theorem hypothesis | declared; no site is privileged in the axiom |
+| `σ_n` as 6-bit inward occupation | occupancy used by the probe | defined from the one-seed front |
+| named rule `α` | displayed hop cost on inward weights | mathematical input; not an axiom |
+| named rule `ρ` | displayed equal-weight comparison on the same sites | mathematical input; not an axiom |
+| small-ball pair `((3,0,0),(1,1,1))` | the B_3 reverse test on `B_4(0)` | declared |
+| `var(\|v\|_2/t(v))` on `B_4(0) \ {0}` | displayed closeness of the three fillings | computed; not a continuum metric |
+| B_6 score of the same `α` | context, not a load-bearing parent | different ball; `(4,1,0)` is absent |
+
+There are no measured, fitted, literature, or observational inputs. A
+continuum metric, a path-length axiom, and any cost written into
+Admissibility remain outside the result.
+
+## Mutations
+
+1. Treat B_6 times as already the B_4 score: the balls are a different
+   ball; `(4,1,0)` is not a site of `B_4(0)`; Theorem 1 recomputes
+   `t(4,0,0) = 10`.
+2. Treat the axis-only path as shortest: that path still costs `12`, but
+   the off-axis return through `(3,1,0)` is cheaper under `α` and is why
+   the B_3 pair does not reverse.
+3. Replace population variance by a sample factor `1/127`: the scored set
+   is the finite list of 128 sites, so the mean-square deviation uses
+   `1/128`.
+4. Enlarge the graph past `B_4(0)`: the residual scores the 129-site
+   ball only.
+5. Write `α` into Admissibility or attach a path-length law: the live
+   axiom memo still states one fixed covariant nearest-neighbor rule and
+   contains no two-end occupancy hop cost.
+6. Attach ell^1 or `ρ` because one variance is smaller: Theorem 3 does
+   not attach either.
+
+## What This Does Not Claim
+
+- No cost is written into Admissibility.
+- No path-length law is attached.
+- The comparison is not scored outside `B_4(0)`.
+- The B_4 score is not a leftover of B_6 times (different ball).
+- The note does not attach ell^1 as a law.
+- The note does not attach `ρ` as a law.
+- No continuum metric is derived.
+- No privileged physical seed is added to the Lattice axiom.
+- No Record readout is assigned to a site without a record.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on `B_4(0)`, scoring the named
+axis-skeleton hop-cost for the small-ball reverse and for
+`var(|v|_2/t)` versus `ρ` and ell^1 is not a leftover of B_6 times, is
+not an Admissibility clause, and does not attach a path-length law. It
+is not a claim that the named rule belongs in the axiom, nor that it
+minimizes any score on `B_4(0)`.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| leftover of B_6 times | Argue that the B_6 arrival table of `α` is already the B_4 table. | Theorem 1: different ball; `(4,1,0)` is absent; `t(4,0,0) = 10` is a new number. | **ATTEMPTED** |
+| keep the axis-only path | Treat `t(3,0,0)` as the four-hop axis cost `9`. | Theorem 1: the off-axis return through `(3,1,0)` gives `7`; the pair does not reverse. | **ATTEMPTED** |
+| attach ell^1 | Read the smaller-than-ell^1 variance as a path-length law. | Theorem 3: ell^1 is a displayed baseline, not attached. | **ATTEMPTED** |
+| attach `ρ` | Read `var_ρ < var_α` as selecting `ρ`. | Theorem 3: `ρ` is a displayed comparison, not attached. | **ATTEMPTED** |
+| invent a tenth cost | Fold a pair that does not appear on `B_4(0)` into `α`. | Theorem 1: the nine realized weight pairs are all named by `α`. | **ATTEMPTED** |
+| adopt the named rule | Write `α` into Admissibility. | Theorem 3 and the live axiom memo: one fixed covariant nearest-neighbor rule, no hop cost. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one comparison and one adoption refusal, not a stack of independent
+walls. The small-ball witness and the three-way variance comparison are two
+certificates of the same B_4 scoring statement.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| small-ball order / variance comparison | no: failure to reverse does not fix the 128-site variances | no: the order `var_rho < var_alpha < var_ell1` does not decide the B_3 pair | independent conclusions on one named rule |
+| scoring statement / adoption refusal | no: a probe can fail to reverse, sit between `ρ` and ell^1, and still be refused as an axiom | no: refusing adoption does not decide the numbers | independent conclusions |
+
+Path-length attachment is not counted as a third wall: Theorem 3 simply
+does not attach one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “one-seed growth from `0`” | explicit theorem hypothesis; the Lattice axiom privileges no site |
+| “inward occupation of the one-seed front” | defined from nearer neighbors; not an extra occupancy axiom |
+| “named axis-skeleton hop-cost” | displayed finite probe, not a derived scale |
+| “two Dijkstras capped at the 129-site ball” | the definition of `t_α` and `t_ρ` through `B_4(0)` |
+| “`(4,1,0)` is not a site” | exact ell^1 radius `5` versus ball radius `4` |
+| “same B_3 pair `((3,0,0),(1,1,1))`” | the small-ball reverse test |
+| “population variance on 128 sites” | the finite list `B_4(0) \ {0}` |
+| “not a leftover” of B_6 times | Theorems 1 and 2; different ball |
+| “Displayed, not adopted” | Theorem 3; no Admissibility edit |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and proper cubic rotations | `Z^3` nearest-neighbor graph and `G+` | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | Admissibility covariance | one fixed covariant nearest-neighbor rule; no hop cost supplied | yes; cost stays displayed |
+| `scripts/axis_skeleton_hopcost_b4_2026_08_15.py:303` | size of the scored ball | `B_4(0)` has 129 sites | yes |
+| `scripts/axis_skeleton_hopcost_b4_2026_08_15.py:327` | arrival times of the B_3 pair and `(4,0,0)` | `t(3,0,0) = 7`, `t(1,1,1) = 5`, `t(4,0,0) = 10` | yes |
+| `scripts/axis_skeleton_hopcost_b4_2026_08_15.py:332` | small-ball reverse test | `3 t(3,0,0)^2 > 9 t(1,1,1)^2` fails | yes |
+| `scripts/axis_skeleton_hopcost_b4_2026_08_15.py:357` | three-way variance order | `var_rho < var_alpha < var_ell1` | yes |
+| `scripts/axis_skeleton_hopcost_b4_2026_08_15.py:370` | leftover of B_6 times | note states different ball and absent `(4,1,0)` | yes |
+| `scripts/axis_skeleton_hopcost_b4_2026_08_15.py:379` | adoption of a cost | note and axiom keep the cost out of Admissibility | yes |
+
+No evidence citation is used to claim a path-length axiom, a continuum
+metric, or an Admissibility rewrite.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: each directed `B_4(0)` edge | nine named inward-weight pairs |
+| per site | yes: `|v|_2/t(v)` on each nonzero site | no other occupancy dictionary is used |
+| per mode | yes: `α`, `ρ`, and ell^1 on the same ball | no other named rule is scored |
+| per block | yes: small-ball order and variance on `B_4(0) \ {0}` | closeness is the stated variance only |
+| lattice wide | no | no Admissibility cost and no path-length law are adopted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies a two-end occupancy hop cost, and none is
+reclassified as an import or wall.
+
+Two partial-closure mechanisms are recorded rather than suppressed. The
+B_6 score of the same `α` is a strictly larger-ball statement: it uses
+sites such as `(4,1,0)` that `B_4(0)` does not contain. Naming `α` on
+the finite weight pairs is a strictly weaker statement: it does not
+decide small-ball order or the 128-site variances. The remaining
+physical choice—whether any hop cost belongs in Admissibility—stays
+explicit and does not require an axiom edit.
+
+### N7 — hostile steelman
+
+The strongest objection is that transporting `α` from `B_6(0)` to
+`B_4(0)` is automatic leftover: the same seed-exit cost, the same axis
+pair cost, and the same cheap off-axis hops should make the smaller-ball
+score a corollary of the B_6 table, including a continuing small-ball
+reverse. The objection correctly identifies that the cost rule is the
+same named rule. It fails because `B_4(0)` is a different finite list,
+does not contain `(4,1,0)`, and the cheapest `α` return to `(4,0,0)`
+through that site is unavailable. The B_4 arrival `t(4,0,0) = 10` and
+the failure of `3·49 > 225` are new certificates, not leftovers.
+
+### N8 — cross-cycle echo
+
+The live axiom memo is the only load-bearing parent. Nearby covariance
+language is context.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | proper cubic covariance of the nearest-neighbor rule | used as `G+` equivariance of the displayed cost; the rule itself is not replaced |
+| B_6 score of the same `α` | same named costs, larger ball, site `(4,1,0)` present | scored as a strictly larger-ball parent; Theorems 1 and 2 are not leftovers |
+| named equal-weight rule `ρ` | cost `3` on every equal-weight pair | scored as a displayed comparison on the same 128 sites; not attached |
+
+No earlier mechanism retires the B_4 score or the adoption refusal.
+
+No-Go Discipline disposition: **PASS** for the bounded comparison and the
+adoption boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Runner Contract
+
+The companion runner builds the 24 proper cubic rotations and the 129-site
+ball; assigns the named axis-skeleton hop-cost on every inward occupancy
+pair in `B_4`; scores `ρ` and ell^1 on the same sites; runs two Dijkstras
+capped at `B_4(0)`; reports `t(3,0,0) = 7`, `t(1,1,1) = 5`, and
+`t(4,0,0) = 10`; reports that the B_3 pair does not reverse; compares
+`var(|v|_2/t)` for `α`, `ρ`, and ell^1 on the 128 nonzero sites; rejects
+the mutation families, including leftover of B_6 times; and verifies that
+the live axiom memo does not host the displayed cost. Declared audit
+inputs are this note and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1237,6 +1237,10 @@
   "axiom_stack_minimality_cl4c_no_go_theorem_note_2026-04-29": {
    "deps_hash": "43bbfd6e9fc5",
    "out_degree": 5
+  },
+  "axis_skeleton_hopcost_b4_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2a26c7562e24",

--- a/logs/runner-cache/axis_skeleton_hopcost_b4_2026_08_15.txt
+++ b/logs/runner-cache/axis_skeleton_hopcost_b4_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/axis_skeleton_hopcost_b4_2026_08_15.py
+runner_sha256: f1e99c38a9555b1fa15b64fd6acb0322624b92995ea2d622b833281b49d47003
+input_fingerprint_sha256: 3511b273473fe92006fdf83cade8d214c256eda59d0793b5e18dfe89f4b861e7
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; B_4(0), G+, and the named axis-skeleton hop-cost are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact integer path costs and |v|_2/t(v) on the radius-4 ball
+negative_scope: displayed two-end costs are not written into Admissibility
+orbit_weights_b4: ((0, 1), (1, 0), (1, 1), (1, 2), (2, 1), (2, 2), (2, 3), (3, 2), (3, 3))
+n_b4_sites: 129
+n_b4_edges: 528
+t_alpha(3,0,0): 7
+t_alpha(1,1,1): 5
+t_alpha(4,0,0): 10
+t_rho(3,0,0): 9
+t_rho(1,1,1): 5
+t_rho(4,0,0): 12
+type_times_alpha: (3, 4, 5, 6, 5, 6, 6, 7, 6, 10)
+type_times_rho: (3, 4, 5, 6, 7, 8, 10, 9, 10, 12)
+b3_pair_reverses: False
+var_alpha: 0.003970882499881050381933428475607742373745345217328109139426882687694257036578135
+var_rho: 0.00035024862900926336984188979868593113574796042066947669842645487810610887706087318
+var_l1: 0.017710351241771545001390082642902462991396702168940717157746837023228578641267290
+(4,1,0)_in_b4: False
+PASS: gplus-order proper cubic rotations number 24
+PASS: ball-size B_4(0) has 129 sites
+PASS: nonzero-sites the scored set B_4(0)\{0} has 128 sites
+PASS: dijkstra-cap both named Dijkstras are capped at the 129-site ball
+PASS: thm1-weight-pairs B_4 inward occupancy pairs realize the nine weight pairs including (3,3)
+PASS: thm1-alpha-vs-rho-pairs alpha cheapens equal-weight pairs of weight greater than 1 that rho costs 3
+PASS: thm1-times alpha realizes t(3,0,0)=7, t(1,1,1)=5, t(4,0,0)=10
+PASS: thm1-b3-pair the B_3 pair does not reverse under alpha: 3*49=147 is not greater than 9*25=225
+PASS: thm1-note-times the note exhibits t_alpha of (3,0,0), (1,1,1), (4,0,0) and reports no reverse
+PASS: thm2-type-times G+ type arrival times under alpha are (3,4,5,6,5,6,6,7,6,10)
+PASS: thm2-vars-computed computed alpha, rho, and ell^1 variances match the displayed digits
+PASS: thm2-order var_rho < var_alpha < var_l1 on the same 128 sites
+PASS: thm2-note-vars the note reports all three population variances and the order
+PASS: thm2-not-leftover-b6 the note states the B_4 score is not a leftover of B_6 times
+PASS: thm3-displayed-not-adopted the note reports the named rule as displayed, not adopted
+PASS: thm3-no-l1-law the note does not attach an ell^1 path-length law
+PASS: claim-scope claim_scope reports the B_4 axis-skeleton score only
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: forbidden-strings note, runner, and axiom avoid the dispatch-forbidden phrases
+PASS: no-axiom-cost the live axiom memo does not host a two-end occupancy hop cost
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+per_element: checked exactly — each directed B_4(0) edge carries alpha and, separately, rho
+per_site: checked exactly — |v|_2/t(v) is scored on each of the 128 nonzero sites
+per_mode: checked exactly — the named axis-skeleton rule, rho, and ell^1 on the same ball
+per_block: checked exactly — B_3 pair order and population variance on B_4(0)\{0}
+lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/axis_skeleton_hopcost_b4_2026_08_15.py
+++ b/scripts/axis_skeleton_hopcost_b4_2026_08_15.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Score the named axis-skeleton hop-cost on B_4(0) only.
+
+The named rule alpha assigns cost 3 iff the source is the seed or both
+inward weights equal 1, else cost 1. This is the same alpha scored on
+B_6(0). On the same B_4(0) sites the runner also scores rho (cost 3 iff
+equal inward weight or seed-exit) and ell^1. The residual is whether the
+B_3 pair (3,0,0) vs (1,1,1) still reverses, and the order of
+var(|v|_2 / t) for alpha, rho, and ell^1. Displayed, not adopted. No
+axiom edit and no path-length law. B_4(0) only; not leftover of B_6 times.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from itertools import permutations, product
+from pathlib import Path
+
+
+getcontext().prec = 80
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "AXIS_SKELETON_HOPCOST_B4_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/AXIS_SKELETON_HOPCOST_B4_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+ORIGIN: Point = (0, 0, 0)
+AXIS3: Point = (3, 0, 0)
+DIAG3: Point = (1, 1, 1)
+AXIS4: Point = (4, 0, 0)
+OFF_AXIS_B6: Point = (4, 1, 0)
+EXPECTED_WEIGHTS = (
+    (0, 1),
+    (1, 0),
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (2, 3),
+    (3, 2),
+    (3, 3),
+)
+ORBIT_TYPES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (1, 1, 0),
+    (1, 1, 1),
+    (2, 0, 0),
+    (2, 1, 0),
+    (2, 1, 1),
+    (2, 2, 0),
+    (3, 0, 0),
+    (3, 1, 0),
+    (4, 0, 0),
+)
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def graph_radius(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclid2(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def ball(radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for coords in product(span, repeat=3):
+        if graph_radius(coords) <= radius:
+            sites.append(coords)
+    return tuple(sites)
+
+
+def occupancy(point: Point) -> int:
+    """6-bit inward occupation of the one-seed front at ``point``."""
+    bits = 0
+    for index, shift in enumerate(SHIFTS):
+        neighbor = (
+            point[0] + shift[0],
+            point[1] + shift[1],
+            point[2] + shift[2],
+        )
+        if graph_radius(neighbor) < graph_radius(point):
+            bits |= 1 << index
+    return bits
+
+
+def inward_weight(point: Point) -> int:
+    return bin(occupancy(point)).count("1")
+
+
+def axis_skeleton_cost(src: Point, dst: Point) -> int:
+    """Cost 3 iff seed-exit or both inward weights equal 1, else 1."""
+    weight_src = inward_weight(src)
+    weight_dst = inward_weight(dst)
+    if weight_src == 0 or (weight_src == 1 and weight_dst == 1):
+        return 3
+    return 1
+
+
+def equal_weight_cost(src: Point, dst: Point) -> int:
+    """Cost 3 iff equal inward weight or seed-exit, else 1."""
+    weight_src = inward_weight(src)
+    weight_dst = inward_weight(dst)
+    if weight_src == weight_dst or weight_src == 0:
+        return 3
+    return 1
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1] + matrix[0][2] * point[2],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1] + matrix[1][2] * point[2],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1] + matrix[2][2] * point[2],
+    )
+
+
+def determinant(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src, dest in enumerate(perm):
+                rows[src][dest] = signs[src]
+            matrix = tuple(tuple(row) for row in rows)
+            if determinant(matrix) == 1:
+                rotations.append(matrix)
+    return tuple(rotations)
+
+
+def directed_edges(sites: tuple[Point, ...]) -> tuple[tuple[Point, Point], ...]:
+    present = set(sites)
+    edges: list[tuple[Point, Point]] = []
+    for site in sites:
+        for shift in SHIFTS:
+            neighbor = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+            if neighbor in present:
+                edges.append((site, neighbor))
+    return tuple(edges)
+
+
+def shortest_named(
+    start: Point,
+    adj: dict[Point, list[tuple[Point, int]]],
+) -> dict[Point, int]:
+    dist = {start: 0}
+    heap: list[tuple[int, Point]] = [(0, start)]
+    while heap:
+        current, node = heapq.heappop(heap)
+        if current != dist[node]:
+            continue
+        for neighbor, cost in adj[node]:
+            trial = current + cost
+            prior = dist.get(neighbor)
+            if prior is None or trial < prior:
+                dist[neighbor] = trial
+                heapq.heappush(heap, (trial, neighbor))
+    return dist
+
+
+def reverses_b3(t_axis: int, t_diag: int) -> bool:
+    return 3 * t_axis * t_axis > 9 * t_diag * t_diag
+
+
+def ratio_list(dist: dict[Point, int], sites: tuple[Point, ...]) -> list[Decimal]:
+    values: list[Decimal] = []
+    for point in sites:
+        if point == ORIGIN:
+            continue
+        arrival = dist[point]
+        values.append(Decimal(euclid2(point)).sqrt() / Decimal(arrival))
+    return values
+
+
+def population_variance(values: list[Decimal]) -> Decimal:
+    count = Decimal(len(values))
+    mean = sum(values) / count
+    return sum((item - mean) ** 2 for item in values) / count
+
+
+def rounded(value: Decimal, places: int) -> str:
+    quantize = Decimal(10) ** -places
+    return format(value.quantize(quantize), "f")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; B_4(0), G+, and the named axis-skeleton hop-cost are theorem hypotheses"
+    )
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact integer path costs and |v|_2/t(v) on the radius-4 ball")
+    print("negative_scope: displayed two-end costs are not written into Admissibility")
+
+    rotations = proper_cubic_rotations()
+    sites = ball(4)
+    edges = directed_edges(sites)
+    adj_alpha: dict[Point, list[tuple[Point, int]]] = defaultdict(list)
+    adj_rho: dict[Point, list[tuple[Point, int]]] = defaultdict(list)
+    weight_pairs: set[tuple[int, int]] = set()
+    alpha_on_equal: set[int] = set()
+    rho_on_equal: set[int] = set()
+    for src, dst in edges:
+        pair = (inward_weight(src), inward_weight(dst))
+        weight_pairs.add(pair)
+        cost_alpha = axis_skeleton_cost(src, dst)
+        cost_rho = equal_weight_cost(src, dst)
+        adj_alpha[src].append((dst, cost_alpha))
+        adj_rho[src].append((dst, cost_rho))
+        if pair[0] == pair[1] and pair[0] > 1:
+            alpha_on_equal.add(cost_alpha)
+            rho_on_equal.add(cost_rho)
+    weights = tuple(sorted(weight_pairs))
+
+    reached_alpha = shortest_named(ORIGIN, adj_alpha)
+    reached_rho = shortest_named(ORIGIN, adj_rho)
+    l1_dist = {point: graph_radius(point) for point in sites}
+    var_alpha = population_variance(ratio_list(reached_alpha, sites))
+    var_rho = population_variance(ratio_list(reached_rho, sites))
+    var_l1 = population_variance(ratio_list(l1_dist, sites))
+    type_times_alpha = tuple(reached_alpha[point] for point in ORBIT_TYPES)
+    type_times_rho = tuple(reached_rho[point] for point in ORBIT_TYPES)
+    t_axis3 = reached_alpha[AXIS3]
+    t_diag3 = reached_alpha[DIAG3]
+    t_axis4 = reached_alpha[AXIS4]
+    still_reverses = reverses_b3(t_axis3, t_diag3)
+
+    print(f"orbit_weights_b4: {weights}")
+    print(f"n_b4_sites: {len(sites)}")
+    print(f"n_b4_edges: {len(edges)}")
+    print(f"t_alpha(3,0,0): {t_axis3}")
+    print(f"t_alpha(1,1,1): {t_diag3}")
+    print(f"t_alpha(4,0,0): {t_axis4}")
+    print(f"t_rho(3,0,0): {reached_rho[AXIS3]}")
+    print(f"t_rho(1,1,1): {reached_rho[DIAG3]}")
+    print(f"t_rho(4,0,0): {reached_rho[AXIS4]}")
+    print(f"type_times_alpha: {type_times_alpha}")
+    print(f"type_times_rho: {type_times_rho}")
+    print(f"b3_pair_reverses: {still_reverses}")
+    print(f"var_alpha: {format(var_alpha, 'f')}")
+    print(f"var_rho: {format(var_rho, 'f')}")
+    print(f"var_l1: {format(var_l1, 'f')}")
+    print(f"(4,1,0)_in_b4: {OFF_AXIS_B6 in set(sites)}")
+
+    checks.check("gplus-order", "proper cubic rotations number 24", len(rotations) == 24)
+    checks.check("ball-size", "B_4(0) has 129 sites", len(sites) == 129)
+    checks.check(
+        "nonzero-sites",
+        "the scored set B_4(0)\\{0} has 128 sites",
+        sum(1 for point in sites if point != ORIGIN) == 128,
+    )
+    checks.check(
+        "dijkstra-cap",
+        "both named Dijkstras are capped at the 129-site ball",
+        len(sites) == 129
+        and len(reached_alpha) == 129
+        and len(reached_rho) == 129
+        and graph_radius(OFF_AXIS_B6) == 5,
+    )
+    checks.check(
+        "thm1-weight-pairs",
+        "B_4 inward occupancy pairs realize the nine weight pairs including (3,3)",
+        weights == EXPECTED_WEIGHTS,
+    )
+    checks.check(
+        "thm1-alpha-vs-rho-pairs",
+        "alpha cheapens equal-weight pairs of weight greater than 1 that rho costs 3",
+        alpha_on_equal == {1} and rho_on_equal == {3},
+    )
+    checks.check(
+        "thm1-times",
+        "alpha realizes t(3,0,0)=7, t(1,1,1)=5, t(4,0,0)=10",
+        t_axis3 == 7 and t_diag3 == 5 and t_axis4 == 10,
+    )
+    checks.check(
+        "thm1-b3-pair",
+        "the B_3 pair does not reverse under alpha: 3*49=147 is not greater than 9*25=225",
+        not still_reverses and 3 * 49 == 147 and 9 * 25 == 225 and 147 < 225,
+    )
+    checks.check(
+        "thm1-note-times",
+        "the note exhibits t_alpha of (3,0,0), (1,1,1), (4,0,0) and reports no reverse",
+        "t(3,0,0) = 7" in note
+        and "t(1,1,1) = 5" in note
+        and "t(4,0,0) = 10" in note
+        and "does not reverse" in note,
+    )
+    checks.check(
+        "thm2-type-times",
+        "G+ type arrival times under alpha are (3,4,5,6,5,6,6,7,6,10)",
+        type_times_alpha == (3, 4, 5, 6, 5, 6, 6, 7, 6, 10),
+    )
+    checks.check(
+        "thm2-vars-computed",
+        "computed alpha, rho, and ell^1 variances match the displayed digits",
+        rounded(var_alpha, 14) == "0.00397088249988"
+        and rounded(var_rho, 14) == "0.00035024862901"
+        and rounded(var_l1, 14) == "0.01771035124177",
+    )
+    checks.check(
+        "thm2-order",
+        "var_rho < var_alpha < var_l1 on the same 128 sites",
+        var_rho < var_alpha < var_l1,
+    )
+    checks.check(
+        "thm2-note-vars",
+        "the note reports all three population variances and the order",
+        "0.00397088249988" in note
+        and "0.00035024862901" in note
+        and "0.01771035124177" in note
+        and "var_rho < var_alpha < var_ell1" in note,
+    )
+    checks.check(
+        "thm2-not-leftover-b6",
+        "the note states the B_4 score is not a leftover of B_6 times",
+        "not a leftover" in note
+        and "B_6" in note
+        and "different ball" in note
+        and "(4,1,0)" in note
+        and "t(4,0,0) = 10" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the note reports the named rule as displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    checks.check(
+        "thm3-no-l1-law",
+        "the note does not attach an ell^1 path-length law",
+        "no path-length law" in note and "not attach" in note,
+    )
+    checks.check(
+        "claim-scope",
+        "claim_scope reports the B_4 axis-skeleton score only",
+        "On B_4(0), the named axis-skeleton hop-cost is scored"
+        in note
+        and "small-ball reverse" in note
+        and "variance vs" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/AXIS_SKELETON_HOPCOST_B4_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in source
+        and '"docs/AXIS_SKELETON_HOPCOST_B4_BOUNDED_THEOREM_NOTE_2026-08-15.md"'
+        in source,
+    )
+    checks.check(
+        "forbidden-strings",
+        "note, runner, and axiom avoid the dispatch-forbidden phrases",
+        all(token not in note and token not in source for token in forbidden_tokens()),
+    )
+    checks.check(
+        "no-axiom-cost",
+        "the live axiom memo does not host a two-end occupancy hop cost",
+        "two-end occupancy" not in axiom and "c(σ_v, σ_w)" not in axiom,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6,
+    )
+
+    print(
+        "per_element: checked exactly — each directed B_4(0) edge carries alpha and, separately, rho"
+    )
+    print(
+        "per_site: checked exactly — |v|_2/t(v) is scored on each of the 128 nonzero sites"
+    )
+    print(
+        "per_mode: checked exactly — the named axis-skeleton rule, rho, and ell^1 on the same ball"
+    )
+    print(
+        "per_block: checked exactly — B_3 pair order and population variance on B_4(0)\\{0}"
+    )
+    print(
+        "lattice_wide: checked and not executed — no Admissibility cost and no path-length law are adopted"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B4, t_alpha(3,0,0)=7, t(1,1,1)=5, t(4,0,0)=10. B3 reverse fails. Displayed, not adopted. No axiom edit.

## Runner

`scripts/axis_skeleton_hopcost_b4_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.