### PR TITLE
feat(axpath): axis-skeleton diagonal is seed-exit then five cheap hops

### DIFF
--- a/docs/AXIS_SKELETON_BODY_DIAGONAL_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/AXIS_SKELETON_BODY_DIAGONAL_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,246 @@
+---
+claim_id: axis_skeleton_body_diagonal_path_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "A shortest 0→(2,2,2) path under the named axis-skeleton hop-cost is exhibited. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/axis_skeleton_body_diagonal_path_2026_08_15.py
+---
+
+# A Lex-First Shortest Body-Diagonal Path Under The Axis-Skeleton Hop-Cost
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact shortest-path arithmetic on the six-neighbor cubic graph
+about one seed, for the named axis-skeleton hop-cost. The rule, the path,
+and the hop-cost multiset are displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/axis_skeleton_body_diagonal_path_2026_08_15.py`](../scripts/axis_skeleton_body_diagonal_path_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Fix one seed at the origin of `Z^3` and the six nearest-neighbor steps
+`B_6`. For a site `v`, write `σ_v` for the inward-neighbor set toward the
+seed: one inward neighbor for each nonzero coordinate of `v`. The inward
+weight is `w_v = |σ_v|`. The named axis-skeleton hop-cost on a directed
+step `v → w` is
+
+`α(v,w) = 3` if `w_v = 0` or (`w_v = w_w = 1`), else `1`.
+
+The first clause is seed-exit. The second is the remaining axis-skeleton
+hop: both endpoints have inward weight `1`. This rule is a displayed
+finite member clause, not Admissibility content. It is a different rule
+from the equal-inward-weight hop-cost: equal-weight stays at weights `2`
+and `3` are cheap here.
+
+A lexicographically first shortest path from `0` to the body-diagonal site
+`(2,2,2)` is the six-step site list
+
+```text
+(0,0,0) → (0,0,1) → (0,1,1) → (0,1,2) → (0,2,2) → (1,2,2) → (2,2,2).
+```
+
+The six hop costs along it are `3,1,1,1,1,1`. Their orbit-cost sum is
+`8`. Every shortest path uses the same hop-cost multiset `{1,1,1,1,1,3}`.
+The path type is the residual under this rule: the unique expensive hop
+is the seed-exit, and every shortest path leaves the axis after that
+exit.
+
+Do not attach L1. Six-neighbor graph distance is the hop count, not the
+named cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "An exhibited shortest 0→(2,2,2) path under the named axis-skeleton hop-cost has orbit-cost sum 8, and every shortest path shares hop-cost multiset {1,1,1,1,1,3}. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: axis_skeleton_body_diagonal_path
+target_blocker_text: "exhibit the lex-first shortest 0→(2,2,2) path, the hop-cost list, and the common hop-cost multiset under the named axis-skeleton hop-cost"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "keep the named axis-skeleton hop-cost displayed; do not write it into Admissibility; do not attach L1"
+conditional_surface_status: "exact on the six-neighbor graph about one seed; no admissibility or metric adoption"
+hypothetical_axiom_status: "no edit; α is displayed and is not proposed as axiom content"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence names `Z^3` with
+  nearest-neighbor adjacency. The live Admissibility sentence names one
+  fixed nearest-neighbor admissibility rule. Both are quoted without
+  rewrite. This note does not add a hop-cost to either axiom.
+- **Explicit theorem-domain condition:** one seed at the origin; the six
+  nearest-neighbor steps `B_6`; inward weights `w_v = |σ_v|`; the named
+  rule `α`; the finite ball of six-neighbor graph radius `6` about the
+  seed, which contains `(2,2,2)`.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selecting `α` as a physical cost, writing it
+  into Admissibility, attaching L1, and identifying arrival with a
+  physical time or metric remain outside the target.
+
+## Exact Objects
+
+Sites are integer triples. The unique seed is `s = (0,0,0)`. The six
+nearest-neighbor steps are
+
+`B_6 = {±e_1, ±e_2, ±e_3}`.
+
+The search domain is the finite ball
+
+`Ball_6(s) = { v in Z^3 : six-neighbor graph distance from s to v is at most 6 }`.
+
+It has `377` sites and contains the body-diagonal target `(2,2,2)`.
+
+For `v = (v_1,v_2,v_3)` the inward-neighbor set toward the seed is
+
+`σ_v = { v - sgn(v_i) e_i : v_i ≠ 0 }`.
+
+Thus `w_v = |σ_v|` equals the number of nonzero coordinates of `v`, so
+`w_s = 0` and `w_{(2,2,2)} = 3`. A directed nearest-neighbor hop `v → w`
+carries the ordered inward-weight pair `(w_v, w_w)` and the cost
+
+`α(v,w) = 3` if `w_v = 0` or (`w_v = w_w = 1`), else `1`.
+
+Arrival `t(v)` is the least sum of `α` along a `B_6` path in `Ball_6(s)`
+from `s` to `v`. A path is lexicographically first among a set when its
+sequence of sites is the least sequence in the dictionary order of
+integer triples.
+
+These objects are supplied mathematical data for the theorems below.
+
+## Theorem 1 — Lex-First Shortest Path, Hop Costs, And Sum
+
+On `Ball_6(s)`, a lexicographically first shortest `s → (2,2,2)` path is
+
+```text
+P = (
+  (0,0,0),
+  (0,0,1),
+  (0,1,1),
+  (0,1,2),
+  (0,2,2),
+  (1,2,2),
+  (2,2,2)
+).
+```
+
+The six directed hops, inward-weight pairs, and costs are
+
+| hop | pair `(w_v,w_w)` | clause | `α` |
+|---|---|---|---:|
+| `(0,0,0) → (0,0,1)` | `(0,1)` | seed-exit | `3` |
+| `(0,0,1) → (0,1,1)` | `(1,2)` | neither | `1` |
+| `(0,1,1) → (0,1,2)` | `(2,2)` | neither | `1` |
+| `(0,1,2) → (0,2,2)` | `(2,2)` | neither | `1` |
+| `(0,2,2) → (1,2,2)` | `(2,3)` | neither | `1` |
+| `(1,2,2) → (2,2,2)` | `(3,3)` | neither | `1` |
+
+The hop-cost list is `3,1,1,1,1,1`. The orbit-cost sum is
+`3+1+1+1+1+1 = 8`. Hence `t(2,2,2) ≤ 8`. The companion runner's Dijkstra
+search on `Ball_6(s)` returns the same path and the same value
+`t(2,2,2) = 8`, so `P` is shortest.
+
+The second hop leaves the axis. The axis-extension hop
+`(0,0,1) → (0,0,2)` would be a both-weights-`1` step of cost `3` and is
+not used on `P`.
+
+## Theorem 2 — Every Shortest Path Has The Same Hop-Cost Multiset
+
+Every shortest `s → (2,2,2)` path in `Ball_6(s)` has exactly six hops and
+hop-cost multiset `{1,1,1,1,1,3}`. Displayed, not adopted.
+
+The six-neighbor graph distance from `s` to `(2,2,2)` is `6`, so every
+path has at least six hops. The seed-exit hop is present on every path
+out of `s` and has cost `3`. Any extra both-weights-`1` hop also has
+cost `3`. A six-hop path that stays on the first axis for a second step
+therefore sums to `10`. A path with seven or more hops sums to at least
+`3+6 = 9`. The only way to reach orbit-cost `8` is a six-hop path whose
+unique cost-`3` hop is the seed-exit.
+
+The `90` words with two steps `+e_1`, two steps `+e_2`, and two steps
+`+e_3` are exactly the monotone six-hop paths. Among them, the first two
+hops use the same axis on exactly `18` words, and those `18` each carry
+one both-weights-`1` hop. The remaining `72` words leave the axis
+immediately after seed-exit. Along any such word the costs are one
+seed-exit `3` and five ordinary `1`s, so the hop-cost multiset is
+`{1,1,1,1,1,3}` and the orbit-cost sum is `8`.
+
+The runner enumerates all shortest paths by predecessor search on the
+Dijkstra tree of `Ball_6(s)` and finds exactly these `72` words, each
+with hop-cost multiset `{1,1,1,1,1,3}`. No cheaper detour exists in the
+ball.
+
+This common multiset is displayed. It is not adopted as a physical
+arrival law, and it is not a leftover of the equal-inward-weight path
+type.
+
+## Theorem 3 — Displayed, Not Adopted
+
+Do not write `α` into Admissibility. The live Admissibility sentences
+remain the quoted nearest-neighbor distribution rule. They do not name
+inward weights, seed-exit, axis-skeleton cost, or a numerical hop-cost.
+
+Do not attach L1. Do not identify the named hop-cost with six-neighbor graph distance. The integer `8` is the orbit-cost sum along the exhibited path type, not an L1 length.
+
+The rule and the path are displayed, not adopted. Uniqueness of `α`
+among cost rules is not claimed.
+
+## Proof-Obligation Boundary
+
+| Obligation | Disposition |
+|---|---|
+| one seed and the six-neighbor stencil | supplied domain |
+| inward weights and the named rule `α` | supplied display |
+| lexicographically first shortest path | computed; listed in Theorem 1 |
+| six hop costs and their sum | computed; orbit-cost table; sum `8` |
+| common hop-cost multiset on every shortest path | proved for monotone words; enumerated on `Ball_6(s)` |
+| `α` written into Admissibility | refused |
+| L1 attached as the residual | refused |
+
+## What This Does Not Claim
+
+- `α` is not Admissibility content and is not a new axiom.
+- The arrival number is not adopted as a physical time, rate, or metric.
+- No hop-cost uniqueness theorem is claimed.
+- L1 is not attached and is not the named residual.
+- Sites outside `Ball_6(s)` and stencils other than `B_6` are outside
+  the theorem.
+- No formation process, record lock, or readout value is derived.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+Their dependency role is limited to the repository's lattice and
+admissibility vocabulary. This theorem separately supplies the named
+hop-cost as displayed data. No axiom sentence is edited.
+
+## Runner Contract
+
+The companion runner constructs `Ball_6(s)`, computes Dijkstra arrival
+from the seed under `α`, extracts the lexicographically first shortest
+path to `(2,2,2)`, and sums the six computed hop costs. It enumerates
+every shortest path and checks the common hop-cost multiset. It quotes
+the live Admissibility sentences, checks that the axiom memo is not
+edited, and checks that the note keeps `α` displayed and does not attach
+L1. Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1237,6 +1237,10 @@
   "axiom_stack_minimality_cl4c_no_go_theorem_note_2026-04-29": {
    "deps_hash": "43bbfd6e9fc5",
    "out_degree": 5
+  },
+  "axis_skeleton_body_diagonal_path_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2a26c7562e24",

--- a/logs/runner-cache/axis_skeleton_body_diagonal_path_2026_08_15.txt
+++ b/logs/runner-cache/axis_skeleton_body_diagonal_path_2026_08_15.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/axis_skeleton_body_diagonal_path_2026_08_15.py
+runner_sha256: 2362409b15fb063ec9805cd7db47c041b8218909914aa929b29d545abfd8a6e6
+input_fingerprint_sha256: 56de7047919e1637fbf74881d6bce1ccf7fb9eeab94468c1ae9753d99cfccbbf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact six-neighbor hop-cost algebra
+package_local_integrity_reads: proposed source note and live axiom memo
+claim_boundary: displayed named hop-cost; no admissibility edit
+lex_first_path: ((0, 0, 0), (0, 0, 1), (0, 1, 1), (0, 1, 2), (0, 2, 2), (1, 2, 2), (2, 2, 2))
+hop_pairs: [(0, 1), (1, 2), (2, 2), (2, 2), (2, 3), (3, 3)]
+hop_clauses: ['seed-exit', 'neither', 'neither', 'neither', 'neither', 'neither']
+hop_costs: (3, 1, 1, 1, 1, 1)
+orbit_cost_sum: 8
+shortest_path_count: 72
+common_multiset: (1, 1, 1, 1, 1, 3)
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: one-seed-b6-domain the search domain is the 377-site radius-6 ball about one seed
+PASS: inward-weights seed weight is 0 and the body-diagonal weight is 3
+PASS: thm1-lex-path the lex-first shortest path is the displayed six-step site list
+PASS: thm1-six-hops that path has six nearest-neighbor hops
+PASS: thm1-hop-costs the six computed hop costs are 3,1,1,1,1,1
+PASS: thm1-orbit-cost-sum the orbit-cost sum equals the Dijkstra arrival and equals 8
+PASS: thm1-seed-exit-only-expensive the path uses one seed-exit and five ordinary hops
+PASS: thm2-common-multiset every shortest path has hop-cost multiset {1,1,1,1,1,3}
+PASS: thm2-lex-is-shortest the displayed path is among the enumerated shortest paths and is lex-first
+PASS: mutation-unit-costs-fail replacing every hop by cost 1 does not recover the orbit-cost sum 8
+PASS: mutation-axis-stay-fails the axis-extension word costs 10 and is not shortest
+PASS: axiom-unedited the live Admissibility sentences are present and the named rule is absent
+PASS: thm3-not-written-into-admissibility the note refuses to write the named rule into Admissibility
+PASS: no-l1-attachment the note refuses to attach L1
+PASS: claim-scope-contract the declared claim_scope matches the exhibited-path statement
+PASS: forbidden-phrases the note omits the dispatch-forbidden phrases
+PASS: note-contains-path-and-costs the note records the lex path, the six costs, the sum, and the common multiset
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/axis_skeleton_body_diagonal_path_2026_08_15.py
+++ b/scripts/axis_skeleton_body_diagonal_path_2026_08_15.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Exact shortest-path checks for the named axis-skeleton hop-cost.
+
+The runner computes a lexicographically first shortest path from one seed
+to (2,2,2) on the six-neighbor ball of radius 6 and sums the hop costs.
+It does not write a cache or edit the axiom memo.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "AXIS_SKELETON_BODY_DIAGONAL_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/AXIS_SKELETON_BODY_DIAGONAL_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Site = tuple[int, int, int]
+SEED: Site = (0, 0, 0)
+TARGET: Site = (2, 2, 2)
+STEPS: tuple[Site, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+RADIUS = 6
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def add(left: Site, right: Site) -> Site:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def graph_radius(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def inward_weight(site: Site) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(source: Site, dest: Site) -> int:
+    weight_source = inward_weight(source)
+    weight_dest = inward_weight(dest)
+    if weight_source == 0 or (weight_source == 1 and weight_dest == 1):
+        return 3
+    return 1
+
+
+def hop_clause(source: Site, dest: Site) -> str:
+    weight_source = inward_weight(source)
+    weight_dest = inward_weight(dest)
+    if weight_source == 0:
+        return "seed-exit"
+    if weight_source == 1 and weight_dest == 1:
+        return "both-weights-1"
+    return "neither"
+
+
+def neighbors(site: Site) -> tuple[Site, ...]:
+    out = []
+    for step in STEPS:
+        dest = add(site, step)
+        if graph_radius(dest) <= RADIUS:
+            out.append(dest)
+    return tuple(sorted(out))
+
+
+def ball_sites() -> tuple[Site, ...]:
+    sites = []
+    for x in range(-RADIUS, RADIUS + 1):
+        for y in range(-RADIUS, RADIUS + 1):
+            for z in range(-RADIUS, RADIUS + 1):
+                site = (x, y, z)
+                if graph_radius(site) <= RADIUS:
+                    sites.append(site)
+    return tuple(sites)
+
+
+def dijkstra() -> tuple[dict[Site, int], dict[Site, tuple[Site, ...]]]:
+    dist: dict[Site, int] = {SEED: 0}
+    path: dict[Site, tuple[Site, ...]] = {SEED: (SEED,)}
+    heap: list[tuple[int, tuple[Site, ...], Site]] = [(0, (SEED,), SEED)]
+    finalized: set[Site] = set()
+    while heap:
+        cost, current_path, site = heappop(heap)
+        if site in finalized:
+            continue
+        finalized.add(site)
+        for dest in neighbors(site):
+            new_cost = cost + hop_cost(site, dest)
+            new_path = current_path + (dest,)
+            better_cost = dest not in dist or new_cost < dist[dest]
+            better_path = dest in dist and new_cost == dist[dest] and new_path < path[dest]
+            if better_cost or better_path:
+                dist[dest] = new_cost
+                path[dest] = new_path
+                heappush(heap, (new_cost, new_path, dest))
+    return dist, path
+
+
+def path_costs(path: tuple[Site, ...]) -> tuple[int, ...]:
+    return tuple(hop_cost(path[index], path[index + 1]) for index in range(len(path) - 1))
+
+
+def shortest_paths(dist: dict[Site, int]) -> list[tuple[Site, ...]]:
+    predecessors: dict[Site, list[Site]] = defaultdict(list)
+    for site, cost in dist.items():
+        for dest in neighbors(site):
+            if dest in dist and dist[dest] == cost + hop_cost(site, dest):
+                predecessors[dest].append(site)
+    found: list[tuple[Site, ...]] = []
+
+    def walk(node: Site, acc: list[Site]) -> None:
+        if node == SEED:
+            found.append(tuple(reversed(acc + [node])))
+            return
+        for pred in predecessors[node]:
+            walk(pred, acc + [node])
+
+    walk(TARGET, [])
+    return found
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    sites = ball_sites()
+    dist, best_path = dijkstra()
+    path = best_path[TARGET]
+    costs = path_costs(path)
+    all_short = shortest_paths(dist)
+    multisets = {tuple(sorted(path_costs(item))) for item in all_short}
+    clauses = [hop_clause(path[i], path[i + 1]) for i in range(len(path) - 1)]
+    pairs = [
+        (inward_weight(path[i]), inward_weight(path[i + 1]))
+        for i in range(len(path) - 1)
+    ]
+
+    print("external_scientific_inputs: none; exact six-neighbor hop-cost algebra")
+    print("package_local_integrity_reads: proposed source note and live axiom memo")
+    print("claim_boundary: displayed named hop-cost; no admissibility edit")
+    print("lex_first_path:", path)
+    print("hop_pairs:", pairs)
+    print("hop_clauses:", clauses)
+    print("hop_costs:", costs)
+    print("orbit_cost_sum:", sum(costs))
+    print("shortest_path_count:", len(all_short))
+    print("common_multiset:", next(iter(multisets)) if len(multisets) == 1 else multisets)
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/AXIS_SKELETON_BODY_DIAGONAL_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "one-seed-b6-domain",
+        "the search domain is the 377-site radius-6 ball about one seed",
+        SEED in sites
+        and TARGET in sites
+        and len(sites) == 377
+        and len(STEPS) == 6
+        and all(graph_radius(step) == 1 for step in STEPS),
+    )
+    checks.check(
+        "inward-weights",
+        "seed weight is 0 and the body-diagonal weight is 3",
+        inward_weight(SEED) == 0 and inward_weight(TARGET) == 3,
+    )
+    checks.check(
+        "thm1-lex-path",
+        "the lex-first shortest path is the displayed six-step site list",
+        path
+        == (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 1),
+            (0, 1, 2),
+            (0, 2, 2),
+            (1, 2, 2),
+            (2, 2, 2),
+        ),
+    )
+    hop_steps = tuple(
+        (
+            path[index + 1][0] - path[index][0],
+            path[index + 1][1] - path[index][1],
+            path[index + 1][2] - path[index][2],
+        )
+        for index in range(len(path) - 1)
+    )
+    checks.check(
+        "thm1-six-hops",
+        "that path has six nearest-neighbor hops",
+        len(path) == 7
+        and len(hop_steps) == 6
+        and all(step in STEPS for step in hop_steps),
+    )
+    checks.check(
+        "thm1-hop-costs",
+        "the six computed hop costs are 3,1,1,1,1,1",
+        costs == (3, 1, 1, 1, 1, 1),
+    )
+    checks.check(
+        "thm1-orbit-cost-sum",
+        "the orbit-cost sum equals the Dijkstra arrival and equals 8",
+        sum(costs) == dist[TARGET] == 8,
+    )
+    checks.check(
+        "thm1-seed-exit-only-expensive",
+        "the path uses one seed-exit and five ordinary hops",
+        clauses.count("seed-exit") == 1
+        and clauses.count("both-weights-1") == 0
+        and clauses.count("neither") == 5
+        and pairs == [(0, 1), (1, 2), (2, 2), (2, 2), (2, 3), (3, 3)],
+    )
+    checks.check(
+        "thm2-common-multiset",
+        "every shortest path has hop-cost multiset {1,1,1,1,1,3}",
+        len(all_short) == 72
+        and multisets == {(1, 1, 1, 1, 1, 3)}
+        and all(len(item) == 7 for item in all_short),
+    )
+    checks.check(
+        "thm2-lex-is-shortest",
+        "the displayed path is among the enumerated shortest paths and is lex-first",
+        path in all_short and path == min(all_short),
+    )
+    axis_stay_path = (
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 0, 2),
+        (0, 1, 2),
+        (0, 2, 2),
+        (1, 2, 2),
+        (2, 2, 2),
+    )
+    axis_stay_costs = path_costs(axis_stay_path)
+    mutation_unit = tuple(1 for _ in costs)
+    checks.check(
+        "mutation-unit-costs-fail",
+        "replacing every hop by cost 1 does not recover the orbit-cost sum 8",
+        sum(mutation_unit) != 8 and sum(mutation_unit) == 6,
+    )
+    checks.check(
+        "mutation-axis-stay-fails",
+        "the axis-extension word costs 10 and is not shortest",
+        axis_stay_costs == (3, 3, 1, 1, 1, 1)
+        and sum(axis_stay_costs) == 10
+        and sum(axis_stay_costs) != dist[TARGET]
+        and axis_stay_path not in all_short,
+    )
+    checks.check(
+        "axiom-unedited",
+        "the live Admissibility sentences are present and the named rule is absent",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "the probability distribution over the possibilities is" in axiom
+        and "named hop-cost" not in axiom
+        and "seed-exit" not in axiom
+        and "axis-skeleton" not in axiom,
+    )
+    checks.check(
+        "thm3-not-written-into-admissibility",
+        "the note refuses to write the named rule into Admissibility",
+        "Do not write `α` into Admissibility" in note
+        and "Displayed, not adopted" in note
+        and "displayed, not adopted" in note
+        and "hypothetical_axiom_status: \"no edit" in note,
+    )
+    checks.check(
+        "no-l1-attachment",
+        "the note refuses to attach L1",
+        "Do not attach L1" in note
+        and "Do not identify the named hop-cost with six-neighbor graph distance" in note,
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the declared claim_scope matches the exhibited-path statement",
+        'claim_scope: "A shortest 0→(2,2,2) path under the named axis-skeleton hop-cost is exhibited. Displayed, not adopted."'
+        in note,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note omits the dispatch-forbidden phrases",
+        all(token not in note for token in FORBIDDEN),
+    )
+    checks.check(
+        "note-contains-path-and-costs",
+        "the note records the lex path, the six costs, the sum, and the common multiset",
+        "(0,0,0) → (0,0,1) → (0,1,1) → (0,1,2) → (0,2,2) → (1,2,2) → (2,2,2)"
+        in note
+        and "3,1,1,1,1,1" in note
+        and "{1,1,1,1,1,3}" in note
+        and "orbit-cost sum is `8`" in note,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Lex-first 0 to (2,2,2) under alpha: costs 3,1,1,1,1,1 sum 8. Multiset {1^5,3}. Leaves axis after seed-exit. Displayed, not adopted. No axiom edit.

## Runner

`scripts/axis_skeleton_body_diagonal_path_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.