### PR TITLE
feat(noshrt): support-drop hop-cost reverses diamond on B6

### DIFF
--- a/docs/NO_SHORTCUT_SUPPORT_DROP_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NO_SHORTCUT_SUPPORT_DROP_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,147 @@
+---
+claim_id: no_shortcut_support_drop_hopcost_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_6(0), the named support-drop hop-cost is scored for diamond reverse at (4,0,0) vs (2,2,2) and for var(|v|_2/t) vs ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py
+---
+
+# Named Support-Drop Hop-Cost On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_6(0)`,
+scored only for diamond reverse at `(4,0,0)` versus `(2,2,2)` and for
+population variance of `|v|_2/t` against unit-cost ℓ¹ arrival.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py`](../scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The axis-skeleton rule that prices only seed-exit and axis 1-skeleton hops
+is undercut by a cheap off-axis detour: return-to-axis hops stay cheap, so
+`t(4,0,0)` falls to the same value as `t(2,2,2)`. The residual is a named
+rule that also prices support drop.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_6(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not
+claimed.
+
+One Dijkstra from the origin on `B_6(0)` (377 sites; 376 nonzero) gives
+
+`t(4,0,0) = 10`, `t(2,2,2) = 8`.
+
+Then `12 t(4,0,0)^2 = 1200` and `16 t(2,2,2)^2 = 1024`, so
+
+`12 t(4,0,0)^2 > 16 t(2,2,2)^2`.
+
+The diamond comparison reverses. Population variances of `|v|_2/t` on
+`B_6(0) \ {0}` are
+
+`var_ν = 0.00590563902870`, `var_ℓ¹ = 0.01350203761919`.
+
+The `ν` variance is strictly smaller.
+
+The rule is displayed, not adopted. It is not written into Admissibility.
+It is not attached to L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_6(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph. Unit-cost ℓ¹ arrival is the closed form `t_ℓ¹(v) = |v|_1`; it
+is not obtained from a second Dijkstra.
+
+The axis-skeleton comparator `α` uses only the first two clauses of `ν`.
+On the support-drop hop `(1,1,0) → (1,0,0)` one has `|σ| : 2 → 1`, so
+`α = 1` while `ν = 3`. Therefore `α` cannot price support drop, and the
+`ν` scores below are not a leftover of `α`.
+
+## Theorem 1 — Diamond Reverse At `(4,0,0)` Versus `(2,2,2)`
+
+One origin Dijkstra on `B_6(0)` returns the integer arrivals
+
+| site | `t_ν` | `t_ℓ¹` |
+|---|---:|---:|
+| `(4,0,0)` | `10` | `4` |
+| `(2,2,2)` | `8` | `6` |
+
+The Euclidean-normalized comparison is `t^2 / |v|_2^2`, equivalently
+
+`12 t(4,0,0)^2 ? 16 t(2,2,2)^2`.
+
+Substituting the computed times gives `1200 > 1024`. The inequality
+reverses: arrival per Euclidean length is larger at `(4,0,0)` than at
+`(2,2,2)`. Under unit-cost ℓ¹ the same comparison is `192 > 576`, which
+fails.
+
+## Theorem 2 — Population Variance Of `|v|_2/t`
+
+On the 376 nonzero sites of `B_6(0)`, let `r(v) = |v|_2 / t(v)` and write
+population variance `(1/n) ∑ (r − mean)^2`. The runner computes
+
+`var_ν = 0.00590563902870`, `var_ℓ¹ = 0.01350203761919`.
+
+So `var_ν < var_ℓ¹`. The named rule is more nearly Euclidean-isotropic
+than unit-cost ℓ¹ on this ball, in the population-variance sense stated
+here. No uniqueness among hop-costs is claimed.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_6(0)`. It is not written
+into Admissibility. It is not attached to L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+diamond reverse or with variance below ℓ¹.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer arrivals and a population-variance comparison on the finite ball B_6(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_6(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs that reverse the diamond or beat ℓ¹
+  variance.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_6(0)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13213,6 +13213,10 @@
   "no_recovery_intermediate_budget_efficiency_bounded_theorem_note_2026-06-12": {
    "deps_hash": "6de2016ba8a1",
    "out_degree": 2
+  },
+  "no_shortcut_support_drop_hopcost_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "noether_source_current_classification_bounded_note_2026-07-08": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/no_shortcut_support_drop_hopcost_b6_2026_08_15.txt
+++ b/logs/runner-cache/no_shortcut_support_drop_hopcost_b6_2026_08_15.txt
@@ -1,0 +1,50 @@
+===== runner cache v1 =====
+runner: scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py
+runner_sha256: 912c0101d42468d06364e9c042b3c372aff1033f6f9c22209e62f85d8af7b195
+input_fingerprint_sha256: dfd050bbaa0d33e26c0227c5fcd7960c826a7ef9328b84a8817eccb31be22325
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/NO_SHORTCUT_SUPPORT_DROP_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: On B_6(0), the named support-drop hop-cost is scored for diamond reverse at (4,0,0) vs (2,2,2) and for var(|v|_2/t) vs ℓ¹. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 377
+t(4,0,0) 10
+t(2,2,2) 8
+12 t(4,0,0)^2 1200
+16 t(2,2,2)^2 1024
+diamond_reverse True
+var_nu 0.00590563902870
+var_l1 0.01350203761919
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b6 B_6(0) has 377 sites and 376 nonzero sites
+PASS: reachable every site of B_6(0) is reached
+PASS: t-400 t(4,0,0) = 10
+PASS: t-222 t(2,2,2) = 8
+PASS: diamond-reverse 12 t(4,0,0)^2 > 16 t(2,2,2)^2
+PASS: note-records-times note records the computed arrivals and the reverse products
+PASS: var-nu population variance under ν matches the reported value
+PASS: var-l1 population variance under ℓ¹ matches the reported value
+PASS: var-nu-smaller var(|v|_2/t) is strictly smaller under ν than under ℓ¹
+PASS: note-records-variances note records both variances and the comparison
+PASS: not-leftover-of-alpha α cannot price the support-drop hop (1,1,0)→(1,0,0)
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py
+++ b/scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Score the named support-drop hop-cost on B_6(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+import math
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/NO_SHORTCUT_SUPPORT_DROP_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NO_SHORTCUT_SUPPORT_DROP_HOPCOST_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "On B_6(0), the named support-drop hop-cost is scored for "
+    "diamond reverse at (4,0,0) vs (2,2,2) and for var(|v|_2/t) vs ℓ¹. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+VAR_NU_REPORTED = 0.00590563902870
+VAR_L1_REPORTED = 0.01350203761919
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def l2(v: tuple[int, int, int]) -> float:
+    return math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def alpha_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1):
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def population_variance(values: list[float]) -> float:
+    n = len(values)
+    mean = math.fsum(values) / n
+    return math.fsum((x - mean) ** 2 for x in values) / n
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "not written into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "not attached to L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(6)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_nu(sites)
+    t400 = dist[(4, 0, 0)]
+    t222 = dist[(2, 2, 2)]
+    reverse = 12 * t400 * t400 > 16 * t222 * t222
+    var_nu = population_variance([l2(v) / dist[v] for v in nonzero])
+    var_l1 = population_variance([l2(v) / l1(v) for v in nonzero])
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(4,0,0) {t400}")
+    print(f"t(2,2,2) {t222}")
+    print(f"12 t(4,0,0)^2 {12 * t400 * t400}")
+    print(f"16 t(2,2,2)^2 {16 * t222 * t222}")
+    print(f"diamond_reverse {reverse}")
+    print(f"var_nu {var_nu:.14f}")
+    print(f"var_l1 {var_l1:.14f}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b6",
+        "B_6(0) has 377 sites and 376 nonzero sites",
+        len(sites) == 377 and len(nonzero) == 376 and all(l1(v) <= 6 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        len(dist) == 377,
+    )
+    checks.check(
+        "t-400",
+        "t(4,0,0) = 10",
+        t400 == 10,
+    )
+    checks.check(
+        "t-222",
+        "t(2,2,2) = 8",
+        t222 == 8,
+    )
+    checks.check(
+        "diamond-reverse",
+        "12 t(4,0,0)^2 > 16 t(2,2,2)^2",
+        reverse,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the computed arrivals and the reverse products",
+        "t(4,0,0) = 10" in note
+        and "t(2,2,2) = 8" in note
+        and "1200" in note
+        and "1024" in note,
+    )
+    checks.check(
+        "var-nu",
+        "population variance under ν matches the reported value",
+        abs(var_nu - VAR_NU_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-l1",
+        "population variance under ℓ¹ matches the reported value",
+        abs(var_l1 - VAR_L1_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-nu-smaller",
+        "var(|v|_2/t) is strictly smaller under ν than under ℓ¹",
+        var_nu < var_l1,
+    )
+    checks.check(
+        "note-records-variances",
+        "note records both variances and the comparison",
+        "0.00590563902870" in note
+        and "0.01350203761919" in note
+        and "var_ν < var_ℓ¹" in note,
+    )
+    checks.check(
+        "not-leftover-of-alpha",
+        "α cannot price the support-drop hop (1,1,0)→(1,0,0)",
+        nu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and alpha_cost((1, 1, 0), (1, 0, 0)) == 1
+        and "cannot price support drop" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Named nu (3 iff seed-exit or both weights 1 or support drop) has t(4,0,0)=10, t(2,2,2)=8. Reverse 1200>1024. var 0.00591 vs l1 0.0135. Displayed, not adopted. No axiom edit.

## Runner

`scripts/no_shortcut_support_drop_hopcost_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.