### PR TITLE
feat(detour): alpha undercut is a parallel-axis detour costing 8

### DIFF
--- a/docs/AXIS_SKELETON_AXIS_DETOUR_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/AXIS_SKELETON_AXIS_DETOUR_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,256 @@
+---
+claim_id: axis_skeleton_axis_detour_path_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "A shortest 0→(4,0,0) path under the named axis-skeleton hop-cost leaves the axis and sums to 8. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/axis_skeleton_axis_detour_path_2026_08_15.py
+---
+
+# A Lex-First Shortest Axis-Leaving Path To (4,0,0) Under The Axis-Skeleton Hop-Cost
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact shortest-path arithmetic on the six-neighbor cubic graph
+about one seed, for the named axis-skeleton hop-cost, exhibiting a
+lex-first shortest path from `0` to `(4,0,0)` that leaves the axis.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/axis_skeleton_axis_detour_path_2026_08_15.py`](../scripts/axis_skeleton_axis_detour_path_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Fix one seed at the origin of `Z^3` and the six nearest-neighbor steps
+`B_6`. For a site `v`, write `σ_v` for the inward-neighbor set toward the
+seed: one inward neighbor for each nonzero coordinate of `v`. The inward
+weight is `w_v = |σ_v|`. The named axis-skeleton hop-cost on a directed
+step `v → w` is
+
+`α(v,w) = 3` if `w_v = 0` or (`w_v = w_w = 1`), else `1`.
+
+The first clause is seed-exit. The second is the remaining axis-skeleton
+hop: both endpoints have inward weight `1`. This rule is a displayed
+finite member clause, not Admissibility content.
+
+A lexicographically first shortest path from `0` to `(4,0,0)` is the
+six-step site list
+
+```text
+(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (4,0,0).
+```
+
+The six hop costs along it are `3,1,1,1,1,1`. Their orbit-cost sum is
+`8`. After the seed, the site `(1,-1,0)` has inward weight `2`, so the
+path leaves the axis. The residual is this path type, not leftover of
+the arrival number `8`.
+
+The on-axis-only path
+
+```text
+(0,0,0) → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0)
+```
+
+has hop costs `3,3,3,3` and sums to `12`. It is displayed, not adopted,
+and it is not shortest.
+
+Do not write `α` into Admissibility. Do not attach L1. Six-neighbor
+graph distance is the hop count, not the named cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "An exhibited lex-first shortest 0→(4,0,0) path under the named axis-skeleton hop-cost leaves the axis and has orbit-cost sum 8. The on-axis-only path costs 12. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: axis_skeleton_axis_detour_path
+target_blocker_text: "exhibit a lex-first shortest 0→(4,0,0) path under α that leaves the axis, with hop costs summing to 8"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "keep the named axis-skeleton hop-cost displayed; do not write it into Admissibility; do not attach L1"
+conditional_surface_status: "exact on the six-neighbor graph about one seed; no admissibility or metric adoption"
+hypothetical_axiom_status: "no edit; α is displayed and is not proposed as axiom content"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence names `Z^3` with
+  nearest-neighbor adjacency. The live Admissibility sentence names one
+  fixed nearest-neighbor admissibility rule. Both are quoted without
+  rewrite. This note does not add a hop-cost to either axiom.
+- **Explicit theorem-domain condition:** one seed at the origin; the six
+  nearest-neighbor steps `B_6`; inward weights `w_v = |σ_v|`; the named
+  rule `α`; the finite ball of six-neighbor graph radius `6` about the
+  seed, which contains `(4,0,0)`.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selecting `α` as a physical cost, writing it
+  into Admissibility, attaching L1, and identifying arrival with a
+  physical time or metric remain outside the target.
+
+## Exact Objects
+
+Sites are integer triples. The unique seed is `s = (0,0,0)`. The six
+nearest-neighbor steps are
+
+`B_6 = {±e_1, ±e_2, ±e_3}`.
+
+The search domain is the finite ball
+
+`Ball_6(s) = { v in Z^3 : six-neighbor graph distance from s to v is at most 6 }`.
+
+It has `377` sites and contains the axis target `(4,0,0)`.
+
+For `v = (v_1,v_2,v_3)` the inward-neighbor set toward the seed is
+
+`σ_v = { v - sgn(v_i) e_i : v_i ≠ 0 }`.
+
+Thus `w_v = |σ_v|` equals the number of nonzero coordinates of `v`, so
+`w_s = 0` and `w_{(4,0,0)} = 1`. A directed nearest-neighbor hop `v → w`
+carries the ordered inward-weight pair `(w_v, w_w)` and the cost
+
+`α(v,w) = 3` if `w_v = 0` or (`w_v = w_w = 1`), else `1`.
+
+Arrival `t(v)` is the least sum of `α` along a `B_6` path in `Ball_6(s)`
+from `s` to `v`. A path is lexicographically first among a set when its
+sequence of sites is the least sequence in the dictionary order of
+integer triples.
+
+A site after the seed is said to leave the axis when its inward weight
+is not `1`. These objects are supplied mathematical data for the
+theorems below.
+
+## Theorem 1 — Lex-First Shortest Path, Hop Costs, And Axis Exit
+
+On `Ball_6(s)`, a lexicographically first shortest `s → (4,0,0)` path is
+
+```text
+P = (
+  (0,0,0),
+  (0,-1,0),
+  (1,-1,0),
+  (2,-1,0),
+  (3,-1,0),
+  (4,-1,0),
+  (4,0,0)
+).
+```
+
+The six directed hops, inward-weight pairs, and costs are
+
+| hop | pair `(w_v,w_w)` | clause | `α` |
+|---|---|---|---:|
+| `(0,0,0) → (0,-1,0)` | `(0,1)` | seed-exit | `3` |
+| `(0,-1,0) → (1,-1,0)` | `(1,2)` | neither | `1` |
+| `(1,-1,0) → (2,-1,0)` | `(2,2)` | neither | `1` |
+| `(2,-1,0) → (3,-1,0)` | `(2,2)` | neither | `1` |
+| `(3,-1,0) → (4,-1,0)` | `(2,2)` | neither | `1` |
+| `(4,-1,0) → (4,0,0)` | `(2,1)` | neither | `1` |
+
+The hop-cost list is `3,1,1,1,1,1`. The orbit-cost sum is
+`3+1+1+1+1+1 = 8`. Hence `t(4,0,0) ≤ 8`. The companion runner's Dijkstra
+search on `Ball_6(s)` returns the same path and the same value
+`t(4,0,0) = 8`, so `P` is shortest.
+
+After the seed, `P` visits `(1,-1,0)`, whose inward weight is `2` and is
+therefore not `1`. The path leaves the axis. The residual is this
+leaving path type, not leftover of the arrival number.
+
+## Theorem 2 — The On-Axis-Only Path Costs 12
+
+The on-axis-only path that stays on the first coordinate axis is
+
+```text
+A = (
+  (0,0,0),
+  (1,0,0),
+  (2,0,0),
+  (3,0,0),
+  (4,0,0)
+).
+```
+
+Its four hops are seed-exit then three both-weights-`1` axis-skeleton
+hops, so the hop-cost list is `3,3,3,3` and the sum is `12`. Displayed,
+not adopted.
+
+Every site of `A` after the seed has inward weight `1`. That path does
+not leave the axis. Because `12 > 8`, `A` is not shortest. The cheap
+detour undercuts the on-axis-only word.
+
+## Theorem 3 — Displayed, Not Adopted
+
+Do not write `α` into Admissibility. The live Admissibility sentences
+remain the quoted nearest-neighbor distribution rule. They do not name
+inward weights, seed-exit, axis-skeleton cost, or a numerical hop-cost.
+
+Do not attach L1. Do not identify the named hop-cost with six-neighbor graph distance. The integer `8` is the orbit-cost sum along the exhibited path type, not an L1 length.
+
+The rule and the path are displayed, not adopted. Uniqueness of `α`
+among cost rules is not claimed.
+
+## Proof-Obligation Boundary
+
+| Obligation | Disposition |
+|---|---|
+| one seed and the six-neighbor stencil | supplied domain |
+| inward weights and the named rule `α` | supplied display |
+| lexicographically first shortest path | computed; listed in Theorem 1 |
+| six hop costs and their sum | computed; orbit-cost table; sum `8` |
+| some post-seed site has weight not `1` | `(1,-1,0)` has weight `2` |
+| on-axis-only path cost | displayed; sum `12`; not adopted |
+| `α` written into Admissibility | refused |
+| L1 attached as the residual | refused |
+
+## What This Does Not Claim
+
+- `α` is not Admissibility content and is not a new axiom.
+- The arrival number is not adopted as a physical time, rate, or metric.
+- No hop-cost uniqueness theorem is claimed.
+- L1 is not attached and is not the named residual.
+- Sites outside `Ball_6(s)` and stencils other than `B_6` are outside
+  the theorem.
+- No formation process, record lock, or readout value is derived.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A readout value is determined by record content alone.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's lattice and
+admissibility vocabulary. Record supplies no hop-cost. This theorem
+separately supplies the named hop-cost as displayed data. No axiom
+sentence is edited.
+
+## Runner Contract
+
+The companion runner constructs `Ball_6(s)`, computes Dijkstra arrival
+from the seed under `α`, extracts the lexicographically first shortest
+path to `(4,0,0)`, and sums the six computed hop costs. It checks that
+some site after the seed has inward weight not `1`. It scores the
+on-axis-only path at `12`. It quotes the live Admissibility sentences,
+checks that the axiom memo is not edited, and checks that the note keeps
+`α` displayed and does not attach L1. Declared review inputs are this
+note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1237,6 +1237,10 @@
   "axiom_stack_minimality_cl4c_no_go_theorem_note_2026-04-29": {
    "deps_hash": "43bbfd6e9fc5",
    "out_degree": 5
+  },
+  "axis_skeleton_axis_detour_path_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "b4_clock_relation_run_cycle879_bounded_theorem_note_2026-07-28": {
    "deps_hash": "2a26c7562e24",

--- a/logs/runner-cache/axis_skeleton_axis_detour_path_2026_08_15.txt
+++ b/logs/runner-cache/axis_skeleton_axis_detour_path_2026_08_15.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/axis_skeleton_axis_detour_path_2026_08_15.py
+runner_sha256: 92bbb7585f51fc45cf465facac98a50e9ddb5d31806fd873b3582960e6329912
+input_fingerprint_sha256: 7d15a26cee22990fb44aea837931e321a53451f6b04009453f9c06c25300f624
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact six-neighbor hop-cost algebra
+package_local_integrity_reads: proposed source note and live axiom memo
+claim_boundary: displayed named hop-cost; no admissibility edit
+lex_first_path: ((0, 0, 0), (0, -1, 0), (1, -1, 0), (2, -1, 0), (3, -1, 0), (4, -1, 0), (4, 0, 0))
+hop_pairs: [(0, 1), (1, 2), (2, 2), (2, 2), (2, 2), (2, 1)]
+hop_clauses: ['seed-exit', 'neither', 'neither', 'neither', 'neither', 'neither']
+hop_costs: (3, 1, 1, 1, 1, 1)
+orbit_cost_sum: 8
+post_seed_weights: [1, 2, 2, 2, 2, 1]
+axis_path: ((0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0), (4, 0, 0))
+axis_hop_costs: (3, 3, 3, 3)
+axis_cost_sum: 12
+shortest_path_count: 8
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: one-seed-b6-domain the search domain is the 377-site radius-6 ball about one seed
+PASS: inward-weights seed weight is 0 and the axis target weight is 1
+PASS: thm1-lex-path the lex-first shortest path is the displayed six-step site list
+PASS: thm1-six-hops that path has six nearest-neighbor hops
+PASS: thm1-hop-costs the six computed hop costs are 3,1,1,1,1,1
+PASS: thm1-orbit-cost-sum the orbit-cost sum equals the Dijkstra arrival and equals 8
+PASS: thm1-leaves-axis some site after the seed has inward weight not 1
+PASS: thm1-seed-exit-only-expensive the path uses one seed-exit and five ordinary hops
+PASS: thm1-lex-is-shortest the displayed path is among the enumerated shortest paths and is lex-first
+PASS: thm2-on-axis-costs-12 the on-axis-only path costs 12 and is not shortest
+PASS: axiom-unedited the live Admissibility sentences are present and the named rule is absent
+PASS: thm3-not-written-into-admissibility the note refuses to write the named rule into Admissibility
+PASS: no-l1-attachment the note refuses to attach L1
+PASS: claim-scope-contract the declared claim_scope matches the exhibited-path statement
+PASS: forbidden-phrases the note omits the dispatch-forbidden phrases
+PASS: note-contains-path-and-costs the note records the lex path, the six costs, the sum, and the on-axis 12
+PASS: source-lattice the cubic nearest-neighbor graph is the current Lattice premise
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/axis_skeleton_axis_detour_path_2026_08_15.py
+++ b/scripts/axis_skeleton_axis_detour_path_2026_08_15.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Exact shortest-path checks for the axis-skeleton detour to (4,0,0).
+
+The runner computes a lexicographically first shortest path from one seed
+to (4,0,0) on the six-neighbor ball of radius 6, sums the hop costs, and
+checks that the path leaves the axis. The on-axis-only path is scored at
+12 and is not adopted. It does not write a cache or edit the axiom memo.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "AXIS_SKELETON_AXIS_DETOUR_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/AXIS_SKELETON_AXIS_DETOUR_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Site = tuple[int, int, int]
+SEED: Site = (0, 0, 0)
+TARGET: Site = (4, 0, 0)
+STEPS: tuple[Site, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+RADIUS = 6
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+LEX_PATH: tuple[Site, ...] = (
+    (0, 0, 0),
+    (0, -1, 0),
+    (1, -1, 0),
+    (2, -1, 0),
+    (3, -1, 0),
+    (4, -1, 0),
+    (4, 0, 0),
+)
+AXIS_PATH: tuple[Site, ...] = (
+    (0, 0, 0),
+    (1, 0, 0),
+    (2, 0, 0),
+    (3, 0, 0),
+    (4, 0, 0),
+)
+
+
+def add(left: Site, right: Site) -> Site:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def graph_radius(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def inward_weight(site: Site) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(source: Site, dest: Site) -> int:
+    weight_source = inward_weight(source)
+    weight_dest = inward_weight(dest)
+    if weight_source == 0 or (weight_source == 1 and weight_dest == 1):
+        return 3
+    return 1
+
+
+def hop_clause(source: Site, dest: Site) -> str:
+    weight_source = inward_weight(source)
+    weight_dest = inward_weight(dest)
+    if weight_source == 0:
+        return "seed-exit"
+    if weight_source == 1 and weight_dest == 1:
+        return "both-weights-1"
+    return "neither"
+
+
+def neighbors(site: Site) -> tuple[Site, ...]:
+    out = []
+    for step in STEPS:
+        dest = add(site, step)
+        if graph_radius(dest) <= RADIUS:
+            out.append(dest)
+    return tuple(sorted(out))
+
+
+def ball_sites() -> tuple[Site, ...]:
+    sites = []
+    for x in range(-RADIUS, RADIUS + 1):
+        for y in range(-RADIUS, RADIUS + 1):
+            for z in range(-RADIUS, RADIUS + 1):
+                site = (x, y, z)
+                if graph_radius(site) <= RADIUS:
+                    sites.append(site)
+    return tuple(sites)
+
+
+def dijkstra() -> tuple[dict[Site, int], dict[Site, tuple[Site, ...]]]:
+    dist: dict[Site, int] = {SEED: 0}
+    path: dict[Site, tuple[Site, ...]] = {SEED: (SEED,)}
+    heap: list[tuple[int, tuple[Site, ...], Site]] = [(0, (SEED,), SEED)]
+    finalized: set[Site] = set()
+    while heap:
+        cost, current_path, site = heappop(heap)
+        if site in finalized:
+            continue
+        finalized.add(site)
+        for dest in neighbors(site):
+            new_cost = cost + hop_cost(site, dest)
+            new_path = current_path + (dest,)
+            better_cost = dest not in dist or new_cost < dist[dest]
+            better_path = dest in dist and new_cost == dist[dest] and new_path < path[dest]
+            if better_cost or better_path:
+                dist[dest] = new_cost
+                path[dest] = new_path
+                heappush(heap, (new_cost, new_path, dest))
+    return dist, path
+
+
+def path_costs(path: tuple[Site, ...]) -> tuple[int, ...]:
+    return tuple(hop_cost(path[index], path[index + 1]) for index in range(len(path) - 1))
+
+
+def shortest_paths(dist: dict[Site, int]) -> list[tuple[Site, ...]]:
+    predecessors: dict[Site, list[Site]] = defaultdict(list)
+    for site, cost in dist.items():
+        for dest in neighbors(site):
+            if dest in dist and dist[dest] == cost + hop_cost(site, dest):
+                predecessors[dest].append(site)
+    found: list[tuple[Site, ...]] = []
+
+    def walk(node: Site, acc: list[Site]) -> None:
+        if node == SEED:
+            found.append(tuple(reversed(acc + [node])))
+            return
+        for pred in predecessors[node]:
+            walk(pred, acc + [node])
+
+    walk(TARGET, [])
+    return found
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    sites = ball_sites()
+    dist, best_path = dijkstra()
+    path = best_path[TARGET]
+    costs = path_costs(path)
+    all_short = shortest_paths(dist)
+    clauses = [hop_clause(path[i], path[i + 1]) for i in range(len(path) - 1)]
+    pairs = [
+        (inward_weight(path[i]), inward_weight(path[i + 1]))
+        for i in range(len(path) - 1)
+    ]
+    post_seed_weights = [inward_weight(site) for site in path[1:]]
+    axis_costs = path_costs(AXIS_PATH)
+
+    print("external_scientific_inputs: none; exact six-neighbor hop-cost algebra")
+    print("package_local_integrity_reads: proposed source note and live axiom memo")
+    print("claim_boundary: displayed named hop-cost; no admissibility edit")
+    print("lex_first_path:", path)
+    print("hop_pairs:", pairs)
+    print("hop_clauses:", clauses)
+    print("hop_costs:", costs)
+    print("orbit_cost_sum:", sum(costs))
+    print("post_seed_weights:", post_seed_weights)
+    print("axis_path:", AXIS_PATH)
+    print("axis_hop_costs:", axis_costs)
+    print("axis_cost_sum:", sum(axis_costs))
+    print("shortest_path_count:", len(all_short))
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/AXIS_SKELETON_AXIS_DETOUR_PATH_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "one-seed-b6-domain",
+        "the search domain is the 377-site radius-6 ball about one seed",
+        SEED in sites
+        and TARGET in sites
+        and len(sites) == 377
+        and len(STEPS) == 6
+        and all(graph_radius(step) == 1 for step in STEPS),
+    )
+    checks.check(
+        "inward-weights",
+        "seed weight is 0 and the axis target weight is 1",
+        inward_weight(SEED) == 0 and inward_weight(TARGET) == 1,
+    )
+    checks.check(
+        "thm1-lex-path",
+        "the lex-first shortest path is the displayed six-step site list",
+        path == LEX_PATH,
+    )
+    hop_steps = tuple(
+        (
+            path[index + 1][0] - path[index][0],
+            path[index + 1][1] - path[index][1],
+            path[index + 1][2] - path[index][2],
+        )
+        for index in range(len(path) - 1)
+    )
+    checks.check(
+        "thm1-six-hops",
+        "that path has six nearest-neighbor hops",
+        len(path) == 7
+        and len(hop_steps) == 6
+        and all(step in STEPS for step in hop_steps),
+    )
+    checks.check(
+        "thm1-hop-costs",
+        "the six computed hop costs are 3,1,1,1,1,1",
+        costs == (3, 1, 1, 1, 1, 1),
+    )
+    checks.check(
+        "thm1-orbit-cost-sum",
+        "the orbit-cost sum equals the Dijkstra arrival and equals 8",
+        sum(costs) == dist[TARGET] == 8,
+    )
+    checks.check(
+        "thm1-leaves-axis",
+        "some site after the seed has inward weight not 1",
+        any(weight != 1 for weight in post_seed_weights)
+        and inward_weight((1, -1, 0)) == 2
+        and (1, -1, 0) in path[1:],
+    )
+    checks.check(
+        "thm1-seed-exit-only-expensive",
+        "the path uses one seed-exit and five ordinary hops",
+        clauses.count("seed-exit") == 1
+        and clauses.count("both-weights-1") == 0
+        and clauses.count("neither") == 5
+        and pairs == [(0, 1), (1, 2), (2, 2), (2, 2), (2, 2), (2, 1)],
+    )
+    checks.check(
+        "thm1-lex-is-shortest",
+        "the displayed path is among the enumerated shortest paths and is lex-first",
+        path in all_short and path == min(all_short) and len(all_short) == 8,
+    )
+    checks.check(
+        "thm2-on-axis-costs-12",
+        "the on-axis-only path costs 12 and is not shortest",
+        axis_costs == (3, 3, 3, 3)
+        and sum(axis_costs) == 12
+        and sum(axis_costs) != dist[TARGET]
+        and AXIS_PATH not in all_short
+        and all(inward_weight(site) == 1 for site in AXIS_PATH[1:]),
+    )
+    checks.check(
+        "axiom-unedited",
+        "the live Admissibility sentences are present and the named rule is absent",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "the probability distribution over the possibilities is" in axiom
+        and "named hop-cost" not in axiom
+        and "seed-exit" not in axiom
+        and "axis-skeleton" not in axiom,
+    )
+    checks.check(
+        "thm3-not-written-into-admissibility",
+        "the note refuses to write the named rule into Admissibility",
+        "Do not write `α` into Admissibility" in note
+        and "Displayed, not adopted" in note
+        and "displayed, not adopted" in note
+        and "hypothetical_axiom_status: \"no edit" in note,
+    )
+    checks.check(
+        "no-l1-attachment",
+        "the note refuses to attach L1",
+        "Do not attach L1" in note
+        and "Do not identify the named hop-cost with six-neighbor graph distance" in note,
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the declared claim_scope matches the exhibited-path statement",
+        'claim_scope: "A shortest 0→(4,0,0) path under the named axis-skeleton hop-cost leaves the axis and sums to 8. Displayed, not adopted."'
+        in note,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note omits the dispatch-forbidden phrases",
+        all(token not in note for token in FORBIDDEN),
+    )
+    checks.check(
+        "note-contains-path-and-costs",
+        "the note records the lex path, the six costs, the sum, and the on-axis 12",
+        "(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (4,0,0)"
+        in note
+        and "3,1,1,1,1,1" in note
+        and "3,3,3,3" in note
+        and "t(4,0,0) = 8" in note
+        and "sums to `12`" in note,
+    )
+    checks.check(
+        "source-lattice",
+        "the cubic nearest-neighbor graph is the current Lattice premise",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in note,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Lex-first 0 to (4,0,0) under alpha: (0,-1) then along to (4,-1) then drop. Costs 3,1,1,1,1,1. On-axis path costs 12. Displayed, not adopted. No axiom edit.

## Runner

`scripts/axis_skeleton_axis_detour_path_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.