### PR TITLE
feat(nuiso): nu isochrones mix radii; still rounder than l1

### DIFF
--- a/docs/SUPPORT_DROP_ISOCHRONE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_ISOCHRONE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,395 @@
+---
+claim_id: support_drop_isochrone_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_6(0), the isochrones of the named support-drop hop-cost are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_isochrone_b6_2026_08_15.py
+---
+
+# Isochrones Of The Named Support-Drop Hop-Cost On `B_6(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact integer path costs, the twenty-two `G+` site-type arrival
+times, the `|v|_2/t` table, and whether the `t = const` shells are single
+Euclidean radii, on the radius-6 nearest-neighbor ball of one seed.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_isochrone_b6_2026_08_15.py`](../scripts/support_drop_isochrone_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Let `B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. Write `|σ_v|` for
+the number of nonzero coordinates of `v`. On a directed hop `v → w` still
+inside `B_6(0)`, the named support-drop rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+Those three clauses are the whole rule. Arrival time `t(v)` is the least
+sum of `ν` along a directed path from `0` to `v` in that graph. One
+Dijkstra from the origin computes every arrival.
+
+`G+` is the 24-element group of proper cubic rotations about the seed. The
+376 nonzero sites of `B_6(0)` fall into 22 `G+` site-types, labelled by a
+representative with coordinates `a ≥ b ≥ c ≥ 0`. Arrival time is constant
+on each type. In particular
+
+`t(4,0,0) = 10`, `t(2,2,2) = 8`.
+
+The twenty-two type times and the ratios `|v|_2 / t` are the table of
+Theorem 1. They are not only the two-point arrivals. The `t = const`
+shells are **not** all single Euclidean radii: six of the ten arrival
+values (`t = 3,4,9,10,11,14`) are single-radius, while four mixed shells
+(`t = 5,6,7,8`) each join two or more distinct Euclidean radii.
+
+On the 376 nonzero sites the population variance of `|v|_2 / t` equals the
+noshrt figure `0.00590563902870` and is strictly below the ℓ¹ comparator
+`0.01350203761919`. So `var_ν < var_ℓ¹`. Displayed, not adopted.
+
+The report is not a leftover of the two-point `10` and `8` times. Naming
+`t(4,0,0) = 10` and `t(2,2,2) = 8` does not compute the twenty-two-type
+table or decide whether the `t = const` shells are single Euclidean
+radii. The rule is not written into Admissibility. It is not attached to
+L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Lattice supplies the six-neighbor graph, the ball, and `G+`. Admissibility
+supplies none of the hop costs. The integers `3` and `1`, the support-size
+clauses, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Unit-cost ℓ¹ arrival is the closed form `t_ℓ¹(v) = |v|_1`; it is not
+obtained from a second Dijkstra. The support-drop hop-cost is the same
+named rule scored on `B_6(0)` for diamond reverse and variance. This note
+loads that rule as a displayed input and reports its isochrones.
+
+## Theorem 1 — Arrival Time Of Each `G+` Site-Type
+
+`B_6(0)` has 377 sites and 376 nonzero sites. Under `ν`, arrival time is
+constant on each of the 22 `G+` site-types in `B_6(0) \ {0}`. The types,
+orbit sizes, times, Euclidean radii, and ratios `|v|_2 / t` are
+
+| representative | orbit size | `t` | `|v|_2` | `|v|_2 / t` |
+|---|---:|---:|---|---|
+| `(1,0,0)` | `6` | `3` | `1` | `1/3` |
+| `(1,1,0)` | `12` | `4` | `√2` | `√2 / 4` |
+| `(2,0,0)` | `6` | `6` | `2` | `1/3` |
+| `(1,1,1)` | `8` | `5` | `√3` | `√3 / 5` |
+| `(2,1,0)` | `24` | `5` | `√5` | `√5 / 5` |
+| `(3,0,0)` | `6` | `9` | `3` | `1/3` |
+| `(2,1,1)` | `24` | `6` | `√6` | `√6 / 6` |
+| `(2,2,0)` | `12` | `6` | `2√2` | `√2 / 3` |
+| `(3,1,0)` | `24` | `6` | `√10` | `√10 / 6` |
+| `(4,0,0)` | `6` | `10` | `4` | `2/5` |
+| `(2,2,1)` | `24` | `7` | `3` | `3/7` |
+| `(3,1,1)` | `24` | `7` | `√11` | `√11 / 7` |
+| `(3,2,0)` | `24` | `7` | `√13` | `√13 / 7` |
+| `(4,1,0)` | `24` | `7` | `√17` | `√17 / 7` |
+| `(5,0,0)` | `6` | `11` | `5` | `5/11` |
+| `(2,2,2)` | `8` | `8` | `2√3` | `√3 / 4` |
+| `(3,2,1)` | `48` | `8` | `√14` | `√14 / 8` |
+| `(3,3,0)` | `12` | `8` | `3√2` | `3√2 / 8` |
+| `(4,1,1)` | `24` | `8` | `3√2` | `3√2 / 8` |
+| `(4,2,0)` | `24` | `8` | `2√5` | `√5 / 4` |
+| `(5,1,0)` | `24` | `8` | `√26` | `√26 / 8` |
+| `(6,0,0)` | `6` | `14` | `6` | `3/7` |
+
+In particular `t(4,0,0) = 10` and `t(2,2,2) = 8`. The ten constant-`t`
+shells are
+
+```text
+t = 3 : type (1,0,0); single radius 1
+t = 4 : type (1,1,0); single radius √2
+t = 5 : types (1,1,1), (2,1,0); radii √3 and √5
+t = 6 : types (2,0,0), (2,1,1), (2,2,0), (3,1,0); radii 2, √6, 2√2, √10
+t = 7 : types (2,2,1), (3,1,1), (3,2,0), (4,1,0); radii 3, √11, √13, √17
+t = 8 : types (2,2,2), (3,2,1), (3,3,0), (4,1,1), (4,2,0), (5,1,0);
+        radii 2√3, √14, 3√2, 2√5, √26
+t = 9 : type (3,0,0); single radius 3
+t = 10 : type (4,0,0); single radius 4
+t = 11 : type (5,0,0); single radius 5
+t = 14 : type (6,0,0); single radius 6
+```
+
+There are six single-radius shells and four mixed shells. The mixed
+`t = 8` shell includes both `(2,2,2)` and five other types; `(3,3,0)` and
+`(4,1,1)` share the common radius `3√2` but sit with three further radii
+in the same arrival set. The `t = const` shells are therefore not all
+single Euclidean radii. The twenty-two-type table is not only the
+two-point times.
+
+## Theorem 2 — Population Variance Of `|v|_2/t`
+
+On the 376 nonzero sites of `B_6(0)`, let `r(v) = |v|_2 / t(v)` and write
+population variance `(1/n) ∑ (r − mean)^2`. The runner computes
+
+`var_ν = 0.00590563902870`, `var_ℓ¹ = 0.01350203761919`.
+
+The first figure equals the noshrt population variance and is strictly
+below the ℓ¹ figure. So `var_ν < var_ℓ¹`. Unit hop costs recover `|v|_1`
+on every site of `B_6(0)`, so the second field is the isochrone ratio of
+the constant-`1` filling. The comparison is displayed, not adopted. No
+path-length law is attached.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` and its isochrones are a displayed scoring device on
+`B_6(0)`. They are not written into Admissibility. They are not attached
+to L1. They are not a replacement for unit-cost first arrival, and they
+are not offered as the unique hop-cost whose shells match Euclidean
+spheres. The live axiom memo continues to state that there is one fixed
+nearest-neighbor admissibility rule, covariant under translations and
+proper cubic rotations; that rule is not replaced by `ν(v→w)`. Displayed,
+not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer arrivals on every G+ site-type of B_6(0) for the named support-drop hop-cost, together with a displayed variance comparison. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_6(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_6(0)` and the six nearest-neighbor steps | closed by the nearest-neighbor graph of `Z^3` |
+| name `ν` by the three support-size clauses | closed; seed-exit, both weights `1`, support drop |
+| count `G+` | closed: 24 proper cubic rotations |
+| compute `t(v)` on every `G+` site-type | closed by Theorem 1; 22 nonzero types |
+| confirm `t(4,0,0) = 10` and `t(2,2,2) = 8` | closed by Theorem 1 |
+| report `|v|_2 / t` for each type | closed by Theorem 1 |
+| decide whether `t = const` shells are single Euclidean radii | closed by Theorem 1; six single-radius, four mixed |
+| treat the table as leftover of the two-point `10` and `8` times | refused; the two times do not report the 22-type shells |
+| compare the population variance on the 376 nonzero sites with ℓ¹ | closed by Theorem 2; equals the noshrt figure and strictly below |
+| write `ν` into Admissibility | refused; Theorem 3 |
+| attach L1 | refused; Theorem 3 |
+
+The obligation graph is acyclic. Every leaf of the bounded comparison is
+closed. Adoption of a cost or of a path-length law is not a proof leaf.
+
+## Framework Boundary
+
+Admissibility supplies one fixed nearest-neighbor rule, covariant under
+lattice translations and proper cubic rotations, and says that the local
+distribution varies with nearest-neighbor conditions. It does not supply a
+numerical hop cost on support sizes. This note therefore treats `ν` as a
+displayed probe, not as an axiom clause.
+
+Record is not used. No formation site, formation rate, or readout value is
+assigned to an unoccupied site. The seed is a theorem hypothesis for the
+one-seed front, not a privileged physical site.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `Z^3` nearest-neighbor adjacency and proper cubic rotations | ambient lattice | live axiom memo |
+| one-seed front from `0` | theorem hypothesis | declared; no site is privileged in the axiom |
+| named support-drop hop-cost `ν` | displayed `G+`-equivariant hop cost | mathematical input; not an axiom |
+| `t(v)` on `B_6(0)` | min path cost under that rule | computed; Theorem 1; one Dijkstra |
+| `|v|_2 / t` on the 22 site-types | displayed Euclidean-ratio table | computed; Theorem 1 |
+| whether `t = const` shells are single Euclidean radii | displayed isochrone test | computed; not all single |
+| `Var(\|v\|_2 / t)` versus ℓ¹ | displayed variance test | computed; Theorem 2; noshrt figure |
+| two-point times `t(4,0,0) = 10`, `t(2,2,2) = 8` | context, not a load-bearing parent | identity does not determine the shells |
+
+There are no measured, fitted, literature, or observational inputs. A
+continuum metric, a path-length axiom, L1 attachment, and any cost written
+into Admissibility remain outside the result.
+
+## Mutations
+
+1. Collapse the twenty-two-type table to the two comparison points
+   `(4,0,0)` and `(2,2,2)`: that is the two-point residual, not the
+   isochrone residual.
+2. Claim every `t = const` shell is a single Euclidean radius: four mixed
+   shells (`t = 5,6,7,8`) join several radii.
+3. Include the origin in the variance: `t(0) = 0` is excluded by the
+   stated domain of 376 nonzero sites.
+4. Write `ν` into Admissibility: the live axiom memo still states one
+   fixed covariant nearest-neighbor rule and contains no support-drop hop
+   cost.
+5. Attach L1: Theorem 3 refuses L1 attachment.
+6. Replace `ν` by unit-cost ℓ¹: the axis and body-diagonal times become
+   `4` and `6`, the diamond does not reverse, and the variance is the
+   larger comparator.
+
+## What This Does Not Claim
+
+- No cost is written into Admissibility.
+- No path-length law is attached.
+- The comparison is not scored outside `B_6(0)`.
+- The isochrone table is not a leftover of the two-point `10` and `8`
+  times.
+- The filling is not claimed to be unique among hop-costs that reverse
+  the diamond or beat ℓ¹ variance.
+- No continuum Euclidean metric is derived.
+- No privileged physical seed is added to the Lattice axiom.
+- No Record readout is assigned to a site without a record.
+- The rule is not attached to L1.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on `B_6(0)`, the report of the named
+support-drop isochrones is not a leftover of the two-point `10` and `8`
+times, is not an Admissibility clause, and is not attached to L1. It is
+not a claim about any other hop-cost, any larger ball, or any adopted
+dynamics.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| two-point leftover | Read `t(4,0,0) = 10` and `t(2,2,2) = 8` as already the isochrone report. | Theorem 1 computes all 22 site-types and the 10 arrival shells. | **ATTEMPTED** |
+| two-point ratio test | Compare only `4/10` and `√12 / 8` and declare the Euclidean-ratio table. | Theorem 1 reports `|v|_2 / t` on every type; four shells mix radii. | **ATTEMPTED** |
+| force single-radius shells | Treat each `t = const` set as one Euclidean sphere. | Four mixed shells (`t = 5,6,7,8`) join several radii. | **ATTEMPTED** |
+| sample variance or include the origin | Change the estimator or divide by `t(0) = 0`. | The stated estimator is the population variance on the 376 nonzero sites. | **ATTEMPTED** |
+| write the rule into Admissibility | Treat seed-exit `3`, axis-extension `3`, and support-drop `3` as the covariant rule. | Theorem 3: the live axiom memo still states one fixed nearest-neighbor rule and no hop cost. | **ATTEMPTED** |
+| attach L1 | Promote `t` or ℓ¹ to an L1 clause. | Theorem 3 refuses L1 attachment. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There is one comparison and one adoption refusal, not a stack of independent
+walls. The twenty-two-type table and the variance comparison are two
+certificates of the same isochrone report.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| twenty-two-type table / variance comparison | no: the table does not by itself name a variance | no: a variance does not reconstruct the 22 times | independent displayed facts in Theorems 1 and 2 |
+| isochrone report / adoption refusal | no: a probe can be tabulated and still refused as an axiom | no: refusing adoption does not compute `t(v)` | independent conclusions |
+
+L1 attachment is not counted as a third wall: Theorem 3 simply does not
+attach one.
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “one-seed growth from `0`” | explicit theorem hypothesis; the Lattice axiom privileges no site |
+| “named support-drop hop-cost `ν`” | displayed finite probe, not a derived scale |
+| “`G+`-equivariant” | covariance under the axiom's proper cubic rotations |
+| “population variance on 376 nonzero sites” | explicit estimator and domain in Theorem 2 |
+| “strictly below” the ℓ¹ variance | Theorem 2; displayed, not adopted |
+| “not a leftover” of the two-point times | Theorem 1; the 22-type shells are new |
+| “Displayed, not adopted” | Theorem 3; no Admissibility edit; not attached to L1 |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:37` | ambient lattice and proper cubic rotations | `Z^3` nearest-neighbor graph and `G+` | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | Admissibility covariance | one fixed covariant nearest-neighbor rule; no hop cost supplied | yes; cost stays displayed |
+| `scripts/support_drop_isochrone_b6_2026_08_15.py` | named rule `ν` | seed-exit, both weights `1`, support drop | yes |
+| `scripts/support_drop_isochrone_b6_2026_08_15.py` | `t(4,0,0)` and `t(2,2,2)` | times `10` and `8` | yes |
+| `scripts/support_drop_isochrone_b6_2026_08_15.py` | `t(v)` on every site-type | the 22 orbit times of Theorem 1 | yes |
+| `scripts/support_drop_isochrone_b6_2026_08_15.py` | whether shells are single Euclidean radii | six single-radius, four mixed | yes |
+| `scripts/support_drop_isochrone_b6_2026_08_15.py` | population variance versus ℓ¹ | noshrt digits, strictly below | yes |
+| `scripts/support_drop_isochrone_b6_2026_08_15.py` | adoption of a cost | note and axiom keep the cost out of Admissibility; not attached to L1 | yes |
+
+No evidence citation is used to claim a path-length axiom, a continuum
+metric, L1 attachment, or an Admissibility rewrite.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: each directed `B_6(0)` edge | one support-drop hop; no other edge family is classified |
+| per site | yes: `t(v)` and `|v|_2 / t` at each of the 376 nonzero sites | no other hop-cost dictionary is used |
+| per mode | yes: 22 site-types and the ten arrival shells | other hop-costs and larger balls are untested and unclaimed |
+| per block | yes: the population variance on the 376 nonzero sites | closeness is the stated variance test only |
+| lattice wide | no | no Admissibility cost and no L1 attachment are adopted |
+
+The runner prints the same five resolution statements.
+
+### N6 — partial-closure and primitive scan
+
+The only dependency used is the registered `minimal_axioms` node. No
+approved primitive supplies a support-drop hop cost, an isochrone, or a
+Euclidean sphere law, and none is reclassified as an import or wall.
+
+One partial-closure mechanism is recorded rather than suppressed. The
+two-point times `t(4,0,0) = 10` and `t(2,2,2) = 8` name the diamond
+reverse but do not compute the twenty-two-type table or decide whether
+`t = const` shells are single Euclidean radii. The remaining physical
+choice—whether any hop cost belongs in Admissibility—stays explicit and
+does not require an axiom edit.
+
+### N7 — hostile steelman
+
+The strongest objection is that naming `t(4,0,0) = 10` and `t(2,2,2) = 8`
+already is the isochrone report, so a twenty-two-type table is ornament.
+The objection correctly notes that those two numbers are part of the
+table. It fails because the isochrone residual asks whether every
+`t = const` shell is a Euclidean radius. That is a statement about all
+22 types: the axis types do not share one arrival, `(1,1,1)` and
+`(2,1,0)` share `t = 5` at two radii, and the `t = 8` shell mixes
+`(2,2,2)` with five other types. The two-point identity does not exhibit
+those shells.
+
+### N8 — cross-cycle echo
+
+The live axiom memo is the only load-bearing parent. Nearby hop-cost
+language is context.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md` | proper cubic covariance of the nearest-neighbor rule | used as `G+` equivariance of the displayed cost; the rule itself is not replaced |
+| named support-drop hop-cost on `B_6(0)` | same rule, two-point times and variance | counted as a strictly smaller residual; Theorem 1 reports the 22-type shells |
+
+No earlier mechanism retires the twenty-two-type table, the mixed-shell
+classification, the variance comparison, or the adoption refusal.
+
+No-Go Discipline disposition: **PASS** for the bounded comparison and the
+adoption boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> For each site, the probability distribution over the possibilities is
+> determined by, and varies with, the nearest-neighbor conditions.
+
+## Runner Contract
+
+The companion runner builds the 24 proper cubic rotations and the 377-site
+ball; applies the named support-drop hop-cost; runs one Dijkstra; computes
+`t(v)` on every site-type; reports `|v|_2 / t` and that the `t = const`
+shells are not all single Euclidean radii; compares the two population
+variances; rejects the mutation families, including the two-point leftover;
+and verifies that the live axiom memo does not host the displayed cost.
+Declared audit inputs are this note and the axiom memo.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_isochrone_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_isochrone_b6_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_isochrone_b6_2026_08_15.txt
@@ -1,0 +1,69 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_isochrone_b6_2026_08_15.py
+runner_sha256: 726b43c9c75d2a37b6cf161c3905eefba09c244bd519e33e73467f3da291248f
+input_fingerprint_sha256: f351ea55545868cd2bbd10f90ff895b676da8b0ff5ef0fe7461267313c860727
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_ISOCHRONE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: On B_6(0), the isochrones of the named support-drop hop-cost are reported. Displayed, not adopted.
+external_scientific_inputs: none; B_6(0), G+, and the named support-drop hop-cost are theorem hypotheses
+package_local_integrity_reads: runner source, proposed source note, and live axiom memo
+measure_boundary: exact integer path costs and |v|_2/t on the radius-6 ball
+negative_scope: displayed support-drop isochrones are not written into Admissibility
+n_sites 377
+n_nonzero 376
+n_types 22
+t(4,0,0) 10
+t(2,2,2) 8
+site_type_times: (1, 0, 0)->3(n=6, |v|_2/t=0.333333333333), (1, 1, 0)->4(n=12, |v|_2/t=0.353553390593), (2, 0, 0)->6(n=6, |v|_2/t=0.333333333333), (1, 1, 1)->5(n=8, |v|_2/t=0.346410161514), (2, 1, 0)->5(n=24, |v|_2/t=0.447213595500), (3, 0, 0)->9(n=6, |v|_2/t=0.333333333333), (2, 1, 1)->6(n=24, |v|_2/t=0.408248290464), (2, 2, 0)->6(n=12, |v|_2/t=0.471404520791), (3, 1, 0)->6(n=24, |v|_2/t=0.527046276695), (4, 0, 0)->10(n=6, |v|_2/t=0.400000000000), (2, 2, 1)->7(n=24, |v|_2/t=0.428571428571), (3, 1, 1)->7(n=24, |v|_2/t=0.473803541479), (3, 2, 0)->7(n=24, |v|_2/t=0.515078753638), (4, 1, 0)->7(n=24, |v|_2/t=0.589015089374), (5, 0, 0)->11(n=6, |v|_2/t=0.454545454545), (2, 2, 2)->8(n=8, |v|_2/t=0.433012701892), (3, 2, 1)->8(n=48, |v|_2/t=0.467707173347), (3, 3, 0)->8(n=12, |v|_2/t=0.530330085890), (4, 1, 1)->8(n=24, |v|_2/t=0.530330085890), (4, 2, 0)->8(n=24, |v|_2/t=0.559016994375), (5, 1, 0)->8(n=24, |v|_2/t=0.637377439199), (6, 0, 0)->14(n=6, |v|_2/t=0.428571428571)
+shells: t=3:types=[(1, 0, 0)]:r2=[1]:single=True, t=4:types=[(1, 1, 0)]:r2=[2]:single=True, t=5:types=[(1, 1, 1), (2, 1, 0)]:r2=[3, 5]:single=False, t=6:types=[(2, 0, 0), (2, 1, 1), (2, 2, 0), (3, 1, 0)]:r2=[4, 6, 8, 10]:single=False, t=7:types=[(2, 2, 1), (3, 1, 1), (3, 2, 0), (4, 1, 0)]:r2=[9, 11, 13, 17]:single=False, t=8:types=[(2, 2, 2), (3, 2, 1), (3, 3, 0), (4, 1, 1), (4, 2, 0), (5, 1, 0)]:r2=[12, 14, 18, 20, 26]:single=False, t=9:types=[(3, 0, 0)]:r2=[9]:single=True, t=10:types=[(4, 0, 0)]:r2=[16]:single=True, t=11:types=[(5, 0, 0)]:r2=[25]:single=True, t=14:types=[(6, 0, 0)]:r2=[36]:single=True
+n_t_values 10
+n_single_radius_shells 6
+n_mixed_radius_shells 4
+var_nu 0.00590563902870
+var_l1 0.01350203761919
+dijkstra_calls 1
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed isochrone statement
+PASS: gplus-order proper cubic rotations number 24
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b6 B_6(0) has 377 sites and 376 nonzero sites
+PASS: reachable every site of B_6(0) is reached
+PASS: thm1-type-count B_6(0)\{0} has 22 G+ site-types
+PASS: thm1-orbit-sizes each G+ site-type has the expected orbit size
+PASS: thm1-type-constant arrival time is constant on each G+ site-type
+PASS: thm1-axis-diag-times t(4,0,0)=10 and t(2,2,2)=8
+PASS: thm1-all-type-times each of the 22 G+ site-types has the reported arrival time
+PASS: thm1-note-times the note records t(4,0,0)=10, t(2,2,2)=8, and every type time
+PASS: thm1-note-ratios the note reports |v|_2/t for each of the 22 site-types
+PASS: thm1-gplus-action G+ acts and preserves both type and arrival time
+PASS: thm1-shells-not-all-single t=const shells are not all single Euclidean radii
+PASS: thm1-note-shells the note reports the mixed t=5,6,7,8 shells and the six single-radius shells
+PASS: thm2-var-nu population variance under ν equals the noshrt figure
+PASS: thm2-var-l1 population variance under ℓ¹ matches the noshrt comparator
+PASS: thm2-var-below var(|v|_2/t) is strictly below ℓ¹
+PASS: thm2-vars-in-note the note records both variances and the comparison
+PASS: thm3-displayed-not-adopted the rule is displayed, not adopted
+PASS: thm3-not-attach-l1 the displayed rule is not attached to L1
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: not-two-point-leftover the isochrone report is not leftover of the two-point 10 and 8 times
+PASS: forbidden-absent forbidden phrases are absent from the source note and runner
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: scored-ball-only the note scores the comparison on B_6(0) only
+per_element: checked exactly — each directed B_6(0) edge carries one support-drop hop cost
+per_site: checked exactly — t(v) and |v|_2/t(v) on each of the 376 nonzero sites
+per_mode: checked exactly — 22 G+ site-types and the 10 arrival shells
+per_block: checked exactly — population variance of |v|_2/t on B_6(0)\{0}
+lattice_wide: checked and not executed — no Admissibility cost and no L1 attachment are adopted
+TOTAL: PASS=29 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_isochrone_b6_2026_08_15.py
+++ b/scripts/support_drop_isochrone_b6_2026_08_15.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Isochrones of the named support-drop hop-cost on B_6(0).
+
+One origin Dijkstra under ν as in noshrt. The note reports t on every
+G+ site-type, the |v|_2/t table, and whether the t=const shells are
+single Euclidean radii. Displayed, not adopted. No axiom edit, cache
+write, or L1 attachment.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from itertools import permutations, product
+from pathlib import Path
+
+
+getcontext().prec = 80
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_ISOCHRONE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_ISOCHRONE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "On B_6(0), the isochrones of the named support-drop hop-cost "
+    "are reported. Displayed, not adopted."
+)
+
+Point = tuple[int, int, int]
+NEIGH: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+ORIGIN: Point = (0, 0, 0)
+AXIS: Point = (4, 0, 0)
+DIAG: Point = (2, 2, 2)
+SITE_TYPES: tuple[Point, ...] = (
+    (1, 0, 0),
+    (1, 1, 0),
+    (2, 0, 0),
+    (1, 1, 1),
+    (2, 1, 0),
+    (3, 0, 0),
+    (2, 1, 1),
+    (2, 2, 0),
+    (3, 1, 0),
+    (4, 0, 0),
+    (2, 2, 1),
+    (3, 1, 1),
+    (3, 2, 0),
+    (4, 1, 0),
+    (5, 0, 0),
+    (2, 2, 2),
+    (3, 2, 1),
+    (3, 3, 0),
+    (4, 1, 1),
+    (4, 2, 0),
+    (5, 1, 0),
+    (6, 0, 0),
+)
+EXPECTED_TYPE_TIMES = {
+    (1, 0, 0): 3,
+    (1, 1, 0): 4,
+    (2, 0, 0): 6,
+    (1, 1, 1): 5,
+    (2, 1, 0): 5,
+    (3, 0, 0): 9,
+    (2, 1, 1): 6,
+    (2, 2, 0): 6,
+    (3, 1, 0): 6,
+    (4, 0, 0): 10,
+    (2, 2, 1): 7,
+    (3, 1, 1): 7,
+    (3, 2, 0): 7,
+    (4, 1, 0): 7,
+    (5, 0, 0): 11,
+    (2, 2, 2): 8,
+    (3, 2, 1): 8,
+    (3, 3, 0): 8,
+    (4, 1, 1): 8,
+    (4, 2, 0): 8,
+    (5, 1, 0): 8,
+    (6, 0, 0): 14,
+}
+EXPECTED_ORBIT_SIZES = {
+    (1, 0, 0): 6,
+    (1, 1, 0): 12,
+    (2, 0, 0): 6,
+    (1, 1, 1): 8,
+    (2, 1, 0): 24,
+    (3, 0, 0): 6,
+    (2, 1, 1): 24,
+    (2, 2, 0): 12,
+    (3, 1, 0): 24,
+    (4, 0, 0): 6,
+    (2, 2, 1): 24,
+    (3, 1, 1): 24,
+    (3, 2, 0): 24,
+    (4, 1, 0): 24,
+    (5, 0, 0): 6,
+    (2, 2, 2): 8,
+    (3, 2, 1): 48,
+    (3, 3, 0): 12,
+    (4, 1, 1): 24,
+    (4, 2, 0): 24,
+    (5, 1, 0): 24,
+    (6, 0, 0): 6,
+}
+VAR_NU_REPORTED = "0.00590563902870"
+VAR_L1_REPORTED = "0.01350203761919"
+DIJKSTRA_CALLS = 0
+
+
+def forbidden_tokens() -> tuple[str, ...]:
+    return (
+        "G" + "_N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+
+
+def l1(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclid2(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def support_size(point: Point) -> int:
+    return int(point[0] != 0) + int(point[1] != 0) + int(point[2] != 0)
+
+
+def site_type(point: Point) -> Point:
+    return tuple(sorted((abs(coord) for coord in point), reverse=True))  # type: ignore[return-value]
+
+
+def ball(radius: int) -> tuple[Point, ...]:
+    sites: list[Point] = []
+    span = range(-radius, radius + 1)
+    for coords in product(span, repeat=3):
+        if l1(coords) <= radius:
+            sites.append(coords)
+    return tuple(sites)
+
+
+def nu_cost(src: Point, dst: Point) -> int:
+    sigma_v = support_size(src)
+    sigma_w = support_size(dst)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1] + matrix[0][2] * point[2],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1] + matrix[1][2] * point[2],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1] + matrix[2][2] * point[2],
+    )
+
+
+def determinant(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for src, dest in enumerate(perm):
+                rows[src][dest] = signs[src]
+            matrix = tuple(tuple(row) for row in rows)
+            if determinant(matrix) == 1:
+                rotations.append(matrix)
+    return tuple(rotations)
+
+
+def dijkstra_nu(sites: tuple[Point, ...]) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    present = set(sites)
+    dist: dict[Point, int] = {ORIGIN: 0}
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    seen: set[Point] = set()
+    while heap:
+        current, node = heapq.heappop(heap)
+        if node in seen:
+            continue
+        seen.add(node)
+        for shift in NEIGH:
+            neighbor = (node[0] + shift[0], node[1] + shift[1], node[2] + shift[2])
+            if neighbor not in present:
+                continue
+            trial = current + nu_cost(node, neighbor)
+            prior = dist.get(neighbor)
+            if prior is None or trial < prior:
+                dist[neighbor] = trial
+                heapq.heappush(heap, (trial, neighbor))
+    return dist
+
+
+def ratio_list(dist: dict[Point, int], sites: tuple[Point, ...]) -> list[Decimal]:
+    values: list[Decimal] = []
+    for point in sites:
+        if point == ORIGIN:
+            continue
+        values.append(Decimal(euclid2(point)).sqrt() / Decimal(dist[point]))
+    return values
+
+
+def population_variance(values: list[Decimal]) -> Decimal:
+    count = Decimal(len(values))
+    mean = sum(values) / count
+    return sum((item - mean) ** 2 for item in values) / count
+
+
+def rounded(value: Decimal, places: int) -> str:
+    quantize = Decimal(10) ** -places
+    return format(value.quantize(quantize), "f")
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS" for target in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print("external_scientific_inputs: none; B_6(0), G+, and the named support-drop hop-cost are theorem hypotheses")
+    print("package_local_integrity_reads: runner source, proposed source note, and live axiom memo")
+    print("measure_boundary: exact integer path costs and |v|_2/t on the radius-6 ball")
+    print("negative_scope: displayed support-drop isochrones are not written into Admissibility")
+
+    rotations = proper_cubic_rotations()
+    sites = ball(6)
+    nonzero = tuple(site for site in sites if site != ORIGIN)
+    times = dijkstra_nu(sites)
+
+    type_times: dict[Point, set[int]] = defaultdict(set)
+    type_counts: dict[Point, int] = defaultdict(int)
+    type_radii: dict[Point, set[int]] = defaultdict(set)
+    shells: dict[int, set[Point]] = defaultdict(set)
+    shell_radii: dict[int, set[int]] = defaultdict(set)
+    for site in nonzero:
+        kind = site_type(site)
+        type_times[kind].add(times[site])
+        type_counts[kind] += 1
+        type_radii[kind].add(euclid2(site))
+        shells[times[site]].add(kind)
+        shell_radii[times[site]].add(euclid2(site))
+
+    type_time_map = {kind: next(iter(vals)) for kind, vals in type_times.items()}
+    type_ratios = {
+        kind: Decimal(euclid2(kind)).sqrt() / Decimal(type_time_map[kind])
+        for kind in SITE_TYPES
+    }
+    var_nu = population_variance(ratio_list(times, sites))
+    var_l1 = population_variance(
+        [Decimal(euclid2(site)).sqrt() / Decimal(l1(site)) for site in nonzero]
+    )
+    single_radius_shells = {
+        level: len(radii) == 1 for level, radii in shell_radii.items()
+    }
+    n_single = sum(1 for flag in single_radius_shells.values() if flag)
+    n_mixed = len(single_radius_shells) - n_single
+
+    print(f"n_sites {len(sites)}")
+    print(f"n_nonzero {len(nonzero)}")
+    print(f"n_types {len(SITE_TYPES)}")
+    print(f"t(4,0,0) {times[AXIS]}")
+    print(f"t(2,2,2) {times[DIAG]}")
+    print(
+        "site_type_times: "
+        + ", ".join(
+            f"{kind}->{type_time_map[kind]}(n={type_counts[kind]}, |v|_2/t={rounded(type_ratios[kind], 12)})"
+            for kind in SITE_TYPES
+        )
+    )
+    print(
+        "shells: "
+        + ", ".join(
+            f"t={level}:types={sorted(shells[level])}:r2={sorted(shell_radii[level])}:single={single_radius_shells[level]}"
+            for level in sorted(shells)
+        )
+    )
+    print(f"n_t_values {len(shells)}")
+    print(f"n_single_radius_shells {n_single}")
+    print(f"n_mixed_radius_shells {n_mixed}")
+    print(f"var_nu {rounded(var_nu, 14)}")
+    print(f"var_l1 {rounded(var_l1, 14)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed isochrone statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "gplus-order",
+        "proper cubic rotations number 24",
+        len(rotations) == 24,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b6",
+        "B_6(0) has 377 sites and 376 nonzero sites",
+        len(sites) == 377 and len(nonzero) == 376 and all(l1(site) <= 6 for site in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        len(times) == 377,
+    )
+    checks.check(
+        "thm1-type-count",
+        "B_6(0)\\{0} has 22 G+ site-types",
+        len(type_times) == 22
+        and set(type_times) == set(SITE_TYPES)
+        and sum(type_counts[kind] for kind in SITE_TYPES) == 376,
+    )
+    checks.check(
+        "thm1-orbit-sizes",
+        "each G+ site-type has the expected orbit size",
+        all(type_counts[kind] == EXPECTED_ORBIT_SIZES[kind] for kind in SITE_TYPES),
+    )
+    checks.check(
+        "thm1-type-constant",
+        "arrival time is constant on each G+ site-type",
+        all(len(type_times[kind]) == 1 for kind in SITE_TYPES)
+        and all(len(type_radii[kind]) == 1 for kind in SITE_TYPES),
+    )
+    checks.check(
+        "thm1-axis-diag-times",
+        "t(4,0,0)=10 and t(2,2,2)=8",
+        times[AXIS] == 10 and times[DIAG] == 8,
+    )
+    checks.check(
+        "thm1-all-type-times",
+        "each of the 22 G+ site-types has the reported arrival time",
+        type_time_map == EXPECTED_TYPE_TIMES,
+    )
+    checks.check(
+        "thm1-note-times",
+        "the note records t(4,0,0)=10, t(2,2,2)=8, and every type time",
+        "t(4,0,0) = 10" in note
+        and "t(2,2,2) = 8" in note
+        and all(f"`{kind[0]},{kind[1]},{kind[2]}`" in note.replace(" ", "") or f"({kind[0]},{kind[1]},{kind[2]})" in note.replace(" ", "") for kind in SITE_TYPES)
+        and all(
+            f"`{EXPECTED_TYPE_TIMES[kind]}`" in note
+            or f"| `{EXPECTED_TYPE_TIMES[kind]}` |" in note
+            for kind in SITE_TYPES
+        ),
+    )
+    checks.check(
+        "thm1-note-ratios",
+        "the note reports |v|_2/t for each of the 22 site-types",
+        "1/3" in note
+        and "√2 / 4" in note
+        and "√3 / 5" in note
+        and "√5 / 5" in note
+        and "2/5" in note
+        and "√3 / 4" in note
+        and "3/7" in note,
+    )
+    checks.check(
+        "thm1-gplus-action",
+        "G+ acts and preserves both type and arrival time",
+        all(
+            site_type(apply_matrix(matrix, kind)) == kind
+            and times[apply_matrix(matrix, kind)] == times[kind]
+            for matrix in rotations
+            for kind in SITE_TYPES
+        ),
+    )
+    checks.check(
+        "thm1-shells-not-all-single",
+        "t=const shells are not all single Euclidean radii",
+        n_single == 6
+        and n_mixed == 4
+        and len(shells) == 10
+        and single_radius_shells[3]
+        and single_radius_shells[4]
+        and not single_radius_shells[5]
+        and not single_radius_shells[6]
+        and not single_radius_shells[7]
+        and not single_radius_shells[8]
+        and single_radius_shells[9]
+        and single_radius_shells[10]
+        and single_radius_shells[11]
+        and single_radius_shells[14],
+    )
+    checks.check(
+        "thm1-note-shells",
+        "the note reports the mixed t=5,6,7,8 shells and the six single-radius shells",
+        "not all single Euclidean radii" in note
+        and "t = 5" in note
+        and "t = 8" in note
+        and "six single-radius" in note
+        and "four mixed" in note,
+    )
+    checks.check(
+        "thm2-var-nu",
+        "population variance under ν equals the noshrt figure",
+        rounded(var_nu, 14) == VAR_NU_REPORTED,
+    )
+    checks.check(
+        "thm2-var-l1",
+        "population variance under ℓ¹ matches the noshrt comparator",
+        rounded(var_l1, 14) == VAR_L1_REPORTED,
+    )
+    checks.check(
+        "thm2-var-below",
+        "var(|v|_2/t) is strictly below ℓ¹",
+        var_nu < var_l1,
+    )
+    checks.check(
+        "thm2-vars-in-note",
+        "the note records both variances and the comparison",
+        VAR_NU_REPORTED in note
+        and VAR_L1_REPORTED in note
+        and "strictly below" in note
+        and "var_ν < var_ℓ¹" in note,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "not written into Admissibility" in note,
+    )
+    checks.check(
+        "thm3-not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "not attached to L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "not-two-point-leftover",
+        "the isochrone report is not leftover of the two-point 10 and 8 times",
+        "not a leftover" in note
+        and "two-point" in note
+        and "isochrone" in note.lower(),
+    )
+    forbidden = forbidden_tokens()
+    forbidden_hits = [
+        token
+        for token in forbidden
+        if token in note or token in source
+    ]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note and runner",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom
+        and "support-drop hop-cost" not in axiom,
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") >= 5,
+    )
+    checks.check(
+        "scored-ball-only",
+        "the note scores the comparison on B_6(0) only",
+        "on `B_6(0)` only" in note or "On B_6(0)" in note,
+    )
+
+    print("per_element: checked exactly — each directed B_6(0) edge carries one support-drop hop cost")
+    print("per_site: checked exactly — t(v) and |v|_2/t(v) on each of the 376 nonzero sites")
+    print("per_mode: checked exactly — 22 G+ site-types and the 10 arrival shells")
+    print("per_block: checked exactly — population variance of |v|_2/t on B_6(0)\\{0}")
+    print("lattice_wide: checked and not executed — no Admissibility cost and no L1 attachment are adopted")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B6, 22 G+ types. Six arrival values are single-radius; t=5,6,7,8 mix radii. var 0.00591 vs l1 0.0135. Displayed, not adopted. No axiom edit.

## Runner

`scripts/support_drop_isochrone_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.