### PR TITLE
feat(numeet): two-seed nu meetings stay closer to Euclidean than l1

### DIFF
--- a/docs/TWO_SEED_SUPPORT_DROP_MEET_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_SEED_SUPPORT_DROP_MEET_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,156 @@
+---
+claim_id: two_seed_support_drop_meet_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Two-seed meetings under the named support-drop hop-cost are scored vs ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_seed_support_drop_meet_2026_08_15.py
+---
+
+# Two-Seed Meetings Under The Named Support-Drop Hop-Cost
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** two seeds `s0=(0,0,0)` and `s1=(2,0,0)` on the union
+`B_4(0) ∪ B_4((2,0,0))`, with fronts grown by the named support-drop
+hop-cost `ν` using inward weights relative to the seed being grown.
+First-meeting sites and the equal-arrival midplane are scored against
+unit-cost ℓ¹. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_seed_support_drop_meet_2026_08_15.py`](../scripts/two_seed_support_drop_meet_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The one-seed support-drop rule `ν` reversed the diamond and beat ℓ¹
+variance on a single ball. The residual here is two-seed: grow a front
+from each seed by the same named rule, with support measured from the
+seed being grown, and ask whether first-meeting sites sit closer to a
+common ratio `|x-s|_2/t` than under ℓ¹.
+
+Write `|σ_s(v)|` for the number of nonzero coordinates of `v-s`. On a
+directed nearest-neighbor hop `v → w` still inside the union, the
+displayed rule relative to the seed `s` being grown is
+
+`ν_s(v→w) = 3` if `|σ_s(v)|=0` or `(|σ_s(v)|=|σ_s(w)|=1)` or
+`|σ_s(w)| < |σ_s(v)|`, else `1`.
+
+The first clause is seed-exit. The second is both inward weights `1`.
+The third is support drop. Those three clauses are the whole rule.
+
+Let `t0` and `t1` be the least path costs from `s0` and `s1` under `ν`
+relative to that seed. One pair of Dijkstras on the 195-site union
+gives a first-meeting set
+
+`M = { v : t0(v)=t1(v)` and no neighbor is strictly earlier for both `}`.
+
+The lex-first meeting site is `(1,0,0)` at time `t=3`, and `|M|=1`.
+
+The equal-arrival midplane is `{ v : t0(v)=t1(v) }`. Population
+variances of `|v-s0|_2/t0` on each law's own midplane are
+
+`var_ν = 0.00405294265643`, `var_ℓ¹ = 0.00995038158264`.
+
+The `ν` variance is strictly smaller. The midplane under `ν` has 33
+sites; the midplane under ℓ¹ has 25 sites. The comparison is two-seed:
+it uses both arrivals, so it is not a leftover of one-seed variance on
+a single ball.
+
+The rule is displayed, not adopted. It is not written into Admissibility.
+It is not attached to L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Lattice supplies the six-neighbor graph and the two balls. Admissibility
+supplies none of the hop costs. The integers `3` and `1`, the seed-relative
+support-size clauses, and the two arrival functions are separately
+displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule And Domain
+
+Let `B_4(s) = { v ∈ Z^3 : |v-s|_1 ≤ 4 }`. The host is the union
+`B_4(0) ∪ B_4((2,0,0))`, which has 195 sites. Directed edges are the
+six nearest-neighbor steps whose both ends lie in the union.
+
+For the seed `s0`, inward weight is `|σ_{s0}(v)|`. For the seed `s1`,
+inward weight is `|σ_{s1}(v)|`. Each Dijkstra uses only the copy of
+`ν` relative to the seed it grows. Unit-cost ℓ¹ arrival is the closed
+form `t_ℓ¹_s(v) = |v-s|_1`; it is not obtained from a third Dijkstra.
+
+A neighbor `w` of `v` is strictly earlier for both if `t0(w)<t0(v)` and
+`t1(w)<t1(v)`. First-meeting sites are the equal-arrival sites with no
+such neighbor.
+
+The eight sites
+
+`(0,±2,0)`, `(0,0,±2)`, `(2,±2,0)`, `(2,0,±2)`
+
+lie on the `ν` midplane and not on the ℓ¹ midplane `x=1`. Equal arrival
+under `ν` is therefore not the one-seed leftover of the geometric
+midplane of ℓ¹, and it is not the one-seed leftover of a single-ball
+`|v|_2/t` census.
+
+## Theorem 1 — Lex-First Meeting Site
+
+One pair of Dijkstras returns integer arrivals with first-meeting set
+`M = { (1,0,0) }`. The lex-first meeting site and its time are
+
+`(1,0,0)` at `t0=t1=3`.
+
+So `|M|=1`. Under unit-cost ℓ¹ the same meeting definition also yields
+the singleton `{(1,0,0)}`, at time `1`.
+
+## Theorem 2 — Midplane Variance Of `|v-s0|_2/t0`
+
+On the equal-arrival midplane of each law, let `r(v) = |v-s0|_2 / t0(v)`
+and write population variance `(1/n) ∑ (r − mean)^2`. The runner computes
+
+`var_ν = 0.00405294265643` on 33 sites,
+`var_ℓ¹ = 0.00995038158264` on 25 sites.
+
+So `var_ν < var_ℓ¹`. First-meeting and later equal-arrival sites under
+`ν` lie closer to a common ratio than the ℓ¹ midplane does. Uniqueness is not claimed.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on the two-seed union. It is
+not written into Admissibility. It is not attached to L1. It is not a
+replacement for unit-cost first arrival, and it is not offered as the
+unique hop-cost with a tighter two-seed midplane ratio.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer two-seed arrivals and a midplane population-variance comparison on B_4(0)∪B_4((2,0,0)) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on the two-seed union for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs that tighten two-seed midplane
+  variance below ℓ¹.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off the union `B_4(0) ∪ B_4((2,0,0))`.
+- That the midplane comparison is a leftover of one-seed variance.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18617,6 +18617,10 @@
   "two_seam_forest_gauge_polyakov_holonomy_preservation_bounded_theorem_note_2026-07-12": {
    "deps_hash": "5fc9a31251f2",
    "out_degree": 3
+  },
+  "two_seed_support_drop_meet_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_sign_comparison_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/two_seed_support_drop_meet_2026_08_15.txt
+++ b/logs/runner-cache/two_seed_support_drop_meet_2026_08_15.txt
@@ -1,0 +1,49 @@
+===== runner cache v1 =====
+runner: scripts/two_seed_support_drop_meet_2026_08_15.py
+runner_sha256: 07654b4cc162c529031526257f399374d641e0d8816f7631dec2f045ab32e156
+input_fingerprint_sha256: f3966927b6b19aee8b8c554ee32f1bda91fde5e9ac6562bf662f3fb6d7877809
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/TWO_SEED_SUPPORT_DROP_MEET_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Two-seed meetings under the named support-drop hop-cost are scored vs ℓ¹. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 195
+lex_first (1, 0, 0)
+meet_t 3
+|M| 1
+n_mid_nu 33
+n_mid_l1 25
+var_nu 0.00405294265643
+var_l1 0.00995038158264
+dijkstra_calls 2
+PASS: one-pair-dijkstra exactly one pair of Dijkstras ran
+PASS: union-b4 the union B_4(0)∪B_4((2,0,0)) has 195 sites
+PASS: reachable every site of the union is reached from both seeds
+PASS: lex-first-meeting lex-first meeting site is (1,0,0) at t=3
+PASS: meeting-cardinality |M| = 1
+PASS: note-records-meeting note records the lex-first meeting site, time, and |M|
+PASS: var-nu midplane population variance under ν matches the reported value
+PASS: var-l1 midplane population variance under ℓ¹ matches the reported value
+PASS: var-nu-smaller var(|v-s0|_2/t0) is strictly smaller under ν than under ℓ¹
+PASS: note-records-variances note records both midplane variances and the comparison
+PASS: not-leftover-one-seed ν midplane includes eight sites off the ℓ¹ plane x=1
+PASS: seed-relative-clauses seed-exit and support drop cost 3 relative to each seed
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_seed_support_drop_meet_2026_08_15.py
+++ b/scripts/two_seed_support_drop_meet_2026_08_15.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Score two-seed meetings under the named support-drop hop-cost.
+
+One pair of Dijkstras on B_4(0)∪B_4((2,0,0)). No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+import math
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/TWO_SEED_SUPPORT_DROP_MEET_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_SEED_SUPPORT_DROP_MEET_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Two-seed meetings under the named support-drop hop-cost are "
+    "scored vs ℓ¹. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+S0 = (0, 0, 0)
+S1 = (2, 0, 0)
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+VAR_NU_REPORTED = 0.00405294265643
+VAR_L1_REPORTED = 0.00995038158264
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int], seed: tuple[int, int, int] = S0) -> int:
+    return abs(v[0] - seed[0]) + abs(v[1] - seed[1]) + abs(v[2] - seed[2])
+
+
+def support_size(v: tuple[int, int, int], seed: tuple[int, int, int]) -> int:
+    return int(v[0] != seed[0]) + int(v[1] != seed[1]) + int(v[2] != seed[2])
+
+
+def l2(v: tuple[int, int, int], seed: tuple[int, int, int] = S0) -> float:
+    dx = v[0] - seed[0]
+    dy = v[1] - seed[1]
+    dz = v[2] - seed[2]
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+def ball(center: tuple[int, int, int], radius: int) -> list[tuple[int, int, int]]:
+    cx, cy, cz = center
+    sites: list[tuple[int, int, int]] = []
+    for x in range(cx - radius, cx + radius + 1):
+        for y in range(cy - radius, cy + radius + 1):
+            rem = radius - abs(x - cx) - abs(y - cy)
+            for z in range(cz - rem, cz + rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(
+    v: tuple[int, int, int],
+    w: tuple[int, int, int],
+    seed: tuple[int, int, int],
+) -> int:
+    sigma_v = support_size(v, seed)
+    sigma_w = support_size(w, seed)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_nu(
+    sites: set[tuple[int, int, int]],
+    seed: tuple[int, int, int],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    dist: dict[tuple[int, int, int], int] = {seed: 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, seed)]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in sites:
+                continue
+            nd = d + nu_cost(v, w, seed)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def first_meetings(
+    sites: list[tuple[int, int, int]],
+    site_set: set[tuple[int, int, int]],
+    t0: dict[tuple[int, int, int], int],
+    t1: dict[tuple[int, int, int], int],
+) -> list[tuple[int, int, int]]:
+    meetings: list[tuple[int, int, int]] = []
+    for v in sites:
+        if t0[v] != t1[v]:
+            continue
+        vx, vy, vz = v
+        earlier_both = False
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            if t0[w] < t0[v] and t1[w] < t1[v]:
+                earlier_both = True
+                break
+        if not earlier_both:
+            meetings.append(v)
+    return meetings
+
+
+def population_variance(values: list[float]) -> float:
+    n = len(values)
+    mean = math.fsum(values) / n
+    return math.fsum((x - mean) ** 2 for x in values) / n
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "not written into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "not attached to L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = sorted(set(ball(S0, 4)) | set(ball(S1, 4)))
+    site_set = set(sites)
+    t0 = dijkstra_nu(site_set, S0)
+    t1 = dijkstra_nu(site_set, S1)
+    mid_nu = [v for v in sites if t0[v] == t1[v]]
+    meetings = first_meetings(sites, site_set, t0, t1)
+    lex_first = min(meetings)
+    meet_t = t0[lex_first]
+    var_nu = population_variance([l2(v, S0) / t0[v] for v in mid_nu])
+
+    mid_l1 = [v for v in sites if l1(v, S0) == l1(v, S1)]
+    var_l1 = population_variance([l2(v, S0) / l1(v, S0) for v in mid_l1])
+    extra_mid = [
+        (0, -2, 0),
+        (0, 0, -2),
+        (0, 0, 2),
+        (0, 2, 0),
+        (2, -2, 0),
+        (2, 0, -2),
+        (2, 0, 2),
+        (2, 2, 0),
+    ]
+
+    print(f"n_sites {len(sites)}")
+    print(f"lex_first {lex_first}")
+    print(f"meet_t {meet_t}")
+    print(f"|M| {len(meetings)}")
+    print(f"n_mid_nu {len(mid_nu)}")
+    print(f"n_mid_l1 {len(mid_l1)}")
+    print(f"var_nu {var_nu:.14f}")
+    print(f"var_l1 {var_l1:.14f}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-pair-dijkstra",
+        "exactly one pair of Dijkstras ran",
+        DIJKSTRA_CALLS == 2,
+    )
+    checks.check(
+        "union-b4",
+        "the union B_4(0)∪B_4((2,0,0)) has 195 sites",
+        len(sites) == 195
+        and all(l1(v, S0) <= 4 or l1(v, S1) <= 4 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of the union is reached from both seeds",
+        len(t0) == 195 and len(t1) == 195,
+    )
+    checks.check(
+        "lex-first-meeting",
+        "lex-first meeting site is (1,0,0) at t=3",
+        lex_first == (1, 0, 0) and meet_t == 3 and t1[lex_first] == 3,
+    )
+    checks.check(
+        "meeting-cardinality",
+        "|M| = 1",
+        meetings == [(1, 0, 0)],
+    )
+    checks.check(
+        "note-records-meeting",
+        "note records the lex-first meeting site, time, and |M|",
+        "(1,0,0)" in note and "t=3" in note and "|M|=1" in note,
+    )
+    checks.check(
+        "var-nu",
+        "midplane population variance under ν matches the reported value",
+        abs(var_nu - VAR_NU_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-l1",
+        "midplane population variance under ℓ¹ matches the reported value",
+        abs(var_l1 - VAR_L1_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-nu-smaller",
+        "var(|v-s0|_2/t0) is strictly smaller under ν than under ℓ¹",
+        var_nu < var_l1,
+    )
+    checks.check(
+        "note-records-variances",
+        "note records both midplane variances and the comparison",
+        "0.00405294265643" in note
+        and "0.00995038158264" in note
+        and "var_ν < var_ℓ¹" in note,
+    )
+    checks.check(
+        "not-leftover-one-seed",
+        "ν midplane includes eight sites off the ℓ¹ plane x=1",
+        len(mid_nu) == 33
+        and len(mid_l1) == 25
+        and all(v in mid_nu and v not in mid_l1 for v in extra_mid)
+        and "not a leftover of one-seed variance" in note,
+    )
+    checks.check(
+        "seed-relative-clauses",
+        "seed-exit and support drop cost 3 relative to each seed",
+        nu_cost(S0, (1, 0, 0), S0) == 3
+        and nu_cost(S1, (1, 0, 0), S1) == 3
+        and nu_cost((1, 1, 0), (1, 0, 0), S0) == 3
+        and nu_cost((3, 1, 0), (3, 0, 0), S1) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0), S0) == 1
+        and nu_cost((1, 0, 0), (2, 0, 0), S0) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom
+        and "ν_s(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Seeds 0 and (2,0,0): unique first meet (1,0,0) at t=3. Midplane var_nu=0.00405 vs l1 0.00995. Displayed, not adopted. No axiom edit.

## Runner

`scripts/two_seed_support_drop_meet_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.