### PR TITLE
feat(t8mix): t=8 shell mixes seven G+ types and five radii

### DIFF
--- a/docs/SUPPORT_DROP_T8_MIXED_SHELL_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_T8_MIXED_SHELL_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,265 @@
+---
+claim_id: support_drop_t8_mixed_shell_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The G+ site-types that share arrival t=8 under the named support-drop hop-cost on B_6(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_t8_mixed_shell_2026_08_15.py
+---
+
+# G+ Types Sharing Arrival t=8 Under The Named Support-Drop Hop-Cost
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the lex-sorted G+ representatives that share first-arrival `t=8`
+on the closed taxicab ball `B_6(0)` under the named support-drop hop-cost
+`ν`. Displayed, not adopted. B_6(0) only.
+**Audit-status authority:** independent audit lane only. This note writes no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_t8_mixed_shell_2026_08_15.py`](../scripts/support_drop_t8_mixed_shell_2026_08_15.py)
+
+## Result up front
+
+A prior isochrone census on the same ball showed that the constant-`t` shells
+at `t=5,6,7,8` each mix more than one Euclidean radius. That mixed-shell bit
+is the investment, not the residual. The residual here is to *name* the
+proper-cubic site-types that occupy the reverse-critical shell containing
+`(2,2,2)`.
+
+On `B_6(0)={v∈Z^3:|v|_1≤6}`, six-neighbor hops are assigned the named cost
+
+```text
+ν(v→w) = 3  if |σ_v|=0 or (|σ_v|=|σ_w|=1) or |σ_w|<|σ_v|,
+         1  otherwise,
+```
+
+where `σ_v={i:v_i≠0}` and `|σ_v|` is the number of nonzero coordinates.
+One Dijkstra from the origin gives first-arrival `t`. In particular
+`t(2,2,2)=8` and `t(4,0,0)=10`, so `t=8` is the reverse-critical shell.
+
+The proper cubic group `G+` is the 24 signed-permutation rotations of
+determinant `+1`. A G+ site-type is one `G+` orbit. The representative of an
+orbit is its lexicographically maximal triple. The lex-sorted list of G+
+representatives with `t=8`, each with `|v|_2^2` and orbit size, is
+
+| representative | `|v|_2^2` | orbit size |
+|---|---:|---:|
+| `(2,2,2)` | 12 | 8 |
+| `(3,1,2)` | 14 | 24 |
+| `(3,2,1)` | 14 | 24 |
+| `(3,3,0)` | 18 | 12 |
+| `(4,1,1)` | 18 | 24 |
+| `(4,2,0)` | 20 | 24 |
+| `(5,1,0)` | 26 | 24 |
+
+Those seven orbits partition the 140 sites with `t=8`. The list uses five
+distinct Euclidean squared radii `{12,14,18,20,26}`. Displayed, not adopted.
+Do not write ν into Admissibility. Do not attach L1.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The t=8 G+ representatives, Euclidean squared radii, and orbit sizes are a finite first-arrival census on B_6(0). The hop-cost is a named displayed rule, not an axiom clause."
+trace_class: upstream_support
+target_claim_id: cube_covariant_hop_cost_physical_selection
+target_blocker_text: "select a physical hop-cost from Admissibility rather than display a named finite rule"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "keep ν outside Admissibility; do not promote the mixed t=8 shell to a physical isochrone law"
+conditional_surface_status: "exact for one Dijkstra of the named support-drop hop-cost on B_6(0); no law selection, no L1 attachment, no axiom edit"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premises and declared objects
+
+The only scientific dependency is the current four-axiom authority
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md).
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+When present, a record locks exactly one admissible local possibility.
+
+Record is not used. The hop-cost `ν` is not that Admissibility rule. It is a
+separately named integer weight on already-present six-neighbor edges. The
+axioms do not select `ν`, do not select first-arrival `t`, and do not select
+an Euclidean radius as a physical clock.
+
+Declared mathematical scaffolding, not measured physics:
+
+- the closed taxicab ball `B_6(0)` of 377 integer sites;
+- the induced six-neighbor graph of that ball;
+- the 24-element proper cubic group `G+`;
+- the named three-clause cost `ν` written above;
+- one Dijkstra first-arrival `t` from the origin.
+
+No observational comparator, continuum limit, or Record readout is imported.
+
+## Theorem 1 — Lex-sorted t=8 G+ representatives
+
+Run one Dijkstra for `ν` on the induced six-neighbor graph of `B_6(0)`.
+Every site is reachable. The body-diagonal type has `t(2,2,2)=8`. Every
+other site of that `G+` orbit has the same arrival, so the whole
+eight-point type sits on the reverse-critical shell.
+
+Grouping the 140 sites with `t=8` by `G+` orbits yields exactly the seven
+representatives in the table above, already written in lexicographic order.
+Each listed orbit lies entirely inside `B_6(0)`, and `t` is constant on
+each orbit. The two chiral types `(3,1,2)` and `(3,2,1)` are distinct
+`G+` orbits of size 24; a determinant-`+1` signed permutation cannot send
+one to the other.
+
+The table reports `|v|_2^2` rather than a floating Euclidean length. The
+five exact squared lengths are `12,14,18,20,26`.
+
+## Theorem 2 — More than one Euclidean radius, displayed not adopted
+
+The seven-type list is not a single Euclidean sphere. The squared radii
+`{12,14,18,20,26}` are five distinct values, so the `t=8` shell mixes
+Euclidean radii. In particular `(2,2,2)` has squared radius `12` while
+`(5,1,0)` has squared radius `26`. The pair `(3,3,0)` and `(4,1,1)`
+share squared radius `18` but remain distinct `G+` types, with orbit
+sizes `12` and `24`.
+
+This is the named content of the residual: the mixed-shell bit is refined
+to an explicit type list. The list is displayed, not adopted. It is not a
+physical isochrone law, not a selection of `ν` as the Admissibility
+rule, and not a continuum radius coordinate.
+
+## Theorem 3 — ν stays outside Admissibility; L1 is not attached
+
+Do not write ν into Admissibility. The Admissibility axiom determines a
+local probability distribution from nearest-neighbor *conditions on the
+possibility domain*. It does not assign integer hop costs, first-arrival
+times, or Euclidean radii.
+
+Do not attach L1. Arrival `t` is not taxicab length: the seed exit
+`0→(1,0,0)` already costs `3`, and `t(2,2,2)=8` is not `|v|_1=6`. The
+present census does not identify `ν` with unit-cost nearest-neighbor
+length, does not replace Lattice adjacency by a different stencil, and
+does not promote `t` to a physical clock.
+
+Displayed, not adopted.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice, Admissibility, and Record wording | quoted; no edit |
+| named support-drop hop-cost `ν` | reconstructed as the three-clause rule; displayed only |
+| one Dijkstra on `B_6(0)` | executed |
+| `t(2,2,2)=8` reverse-critical shell | executed |
+| lex-sorted G+ representatives at `t=8` | executed; seven types |
+| `|v|_2^2` and orbit size for each type | executed |
+| more than one Euclidean radius | executed; five squared radii |
+| write `ν` into Admissibility | refused |
+| attach L1 | refused |
+| law outside `B_6(0)` | not claimed |
+
+## Boundary and imports
+
+The theorem uses only the current Lattice graph, the named displayed
+hop-cost, and the 24 proper cubic rotations. It does not import a
+physical Admissibility kernel, a Record content map, a continuum radius,
+or any hop-cost other than `ν`. Uniqueness of `ν` is not claimed.
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It names the G+ types on the reverse-critical `t=8` shell, which the mixed-shell census left unnamed. |
+| V2 | Current main has the four axioms and no landed type list for this hop-cost on `B_6(0)`. |
+| V3 | The census is finite and exact: one Dijkstra on 377 sites. |
+| V4 | Naming the seven types is not a restatement of Admissibility and not a restatement of the mixed-shell bit. |
+| V5 | The hop-cost remains displayed. It is not a physical compiler and is not written into any axiom. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: the named `t=8` shell is not a single
+Euclidean sphere, and the displayed hop-cost is not an axiom clause.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unit-cost six-neighbor length | attach L1 as the arrival | **RULED OUT BY EXECUTION**: `t≠|v|_1` already at `(1,0,0)` and `(2,2,2)` |
+| write `ν` into Admissibility | treat hop-cost as the local possibility law | **ATTEMPTED** and refused; different object |
+| unsigned coordinate type | merge `(3,1,2)` with `(3,2,1)` | **ATTEMPTED**; those are two G+ orbits |
+| single Euclidean sphere at `t=8` | claim one radius | **RULED OUT BY EXECUTION**; five squared radii |
+| leave the ball | Dijkstra on a larger patch | different domain; B_6(0) only |
+| adopt `ν` as physical law | uniqueness or axiom edit | **ATTEMPTED** and refused |
+
+### N2 — wall independence
+
+The missing physical hop-cost selector, the missing Admissibility-to-cost
+bridge, and the missing clock identification are distinct open premises.
+This note claims no complete wall and no compiler impossibility.
+
+### N3 — hidden-condition scan
+
+The ball, the six-neighbor stencil, the three-clause cost, the 24-element
+group, the lex-max representative convention, and the single Dijkstra are
+declared. No continuum radius, no L1 identification, and no axiom edit
+are assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic graph and proper cubic
+rotations used here. It does not supply `ν`. The residual is therefore a
+displayed census on that graph, not an axiom consequence.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each t=8 G+ representative | no classification of other shells |
+| per site | first-arrival on `B_6(0)` | no law outside the ball |
+| per mode | not used | no spectral claim |
+| per block | seven-orbit partition of the 140-site shell | no physical isochrone law |
+| lattice wide | checked and not executed | no `Z^3`-wide adoption of `ν` |
+
+### N6 — live partial-closure paths
+
+Live routes are an independently derived physical hop-cost, a derived
+bridge from Admissibility conditions to integer edge weights, and a
+derived clock identification. None of those is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once the mixed-shell bit is known, naming the `t=8` types
+is leftover bookkeeping.
+
+**Answer:** The mixed-shell bit says only that several radii occur. It
+does not name the G+ types, does not split the chiral pair, and does not
+report orbit sizes. Those are the residual.
+
+### N8 — cross-cycle echo
+
+The investment that `t=5,6,7,8` mix Euclidean radii is used only as
+motivation. This note does not re-score those other shells and does not
+adopt their mixing as a physical law.
+
+**Gate disposition:** PASS for the finite `t=8` type list and the two
+refusals above. FAIL / DO NOT SHIP for “`ν` is the Admissibility rule,”
+“attach L1,” or “the `t=8` shell is a single Euclidean sphere.”
+
+## Primary runner
+
+The primary runner rebuilds `B_6(0)`, applies one Dijkstra for `ν`,
+groups the `t=8` sites by `G+` orbits, and checks the lex-sorted table,
+the mixed-radius statement, the axiom-boundary refusals, and the
+dispatch-forbidden phrases. It writes no cache and authors no audit
+verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_t8_mixed_shell_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_t8_mixed_shell_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_t8_mixed_shell_2026_08_15.txt
@@ -1,0 +1,64 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_t8_mixed_shell_2026_08_15.py
+runner_sha256: 6bb1bddd311279936255f7b892148112d4b0ed0dad59b063aeb3d95583644b18
+input_fingerprint_sha256: f56eea009b341a40e77cd528c0e24d744c321e0ea560032492e92e366efd0adc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+construction: one Dijkstra for named support-drop hop-cost nu on B_6(0)
+negative_scope: nu is displayed, not written into Admissibility; L1 is not attached
+PASS: audit-inputs — AUDIT_INPUT_PATHS is the required string-literal pair and both files exist
+PASS: ball-census — B_6(0) has 377 integer sites and 376 nonzero sites
+PASS: rotation-group — the proper cubic group used for types has 24 elements
+PASS: one-dijkstra-total — every site of B_6(0) receives a finite arrival time
+PASS: reverse-critical-shell — t(2,2,2)=8 and t(4,0,0)=10, so t=8 is the reverse-critical shell
+PASS: l1-not-identified — arrival t is not the taxicab length: t(1,0,0)=3 and t(2,2,2)=8 != 6
+PASS: named-nu-clauses — nu is 3 on seed-exit, both-weight-1, and support drop, else 1
+PASS: orbit-inside-ball — the G+ orbit of (5, 1, 0) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (5, 1, 0)
+PASS: orbit-inside-ball — the G+ orbit of (4, 2, 0) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (4, 2, 0)
+PASS: orbit-inside-ball — the G+ orbit of (4, 1, 1) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (4, 1, 1)
+PASS: orbit-inside-ball — the G+ orbit of (3, 3, 0) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (3, 3, 0)
+PASS: orbit-inside-ball — the G+ orbit of (3, 1, 2) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (3, 1, 2)
+PASS: orbit-inside-ball — the G+ orbit of (3, 2, 1) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (3, 2, 1)
+PASS: orbit-inside-ball — the G+ orbit of (2, 2, 2) lies in B_6(0)
+PASS: orbit-constant-t — arrival is constant on the G+ orbit of (2, 2, 2)
+t8_gplus_types:
+  (2, 2, 2)  |v|_2^2=12  orbit=8
+  (3, 1, 2)  |v|_2^2=14  orbit=24
+  (3, 2, 1)  |v|_2^2=14  orbit=24
+  (3, 3, 0)  |v|_2^2=18  orbit=12
+  (4, 1, 1)  |v|_2^2=18  orbit=24
+  (4, 2, 0)  |v|_2^2=20  orbit=24
+  (5, 1, 0)  |v|_2^2=26  orbit=24
+t8_radius_squares: [12, 14, 18, 20, 26]
+PASS: thm1-lex-list — the lex-sorted G+ representatives at t=8 are the seven computed types
+PASS: thm1-contains-222 — the reverse-critical body-diagonal type (2,2,2) is on the t=8 list
+PASS: thm1-note-table — the note displays each representative with |v|_2^2 and orbit size
+PASS: thm2-mixed-radii — the t=8 list uses more than one Euclidean radius
+PASS: thm2-shared-radius-not-same-type — (3,3,0) and (4,1,1) share |v|_2^2=18 but are distinct G+ types
+PASS: thm2-chiral-pair — (3,1,2) and (3,2,1) are distinct 24-point G+ orbits of the same radius
+PASS: coverage — the seven orbits partition every t=8 site and omit every other site
+PASS: source-lattice — current Lattice wording is pinned in the axiom memo and the note
+PASS: source-admissibility — current Admissibility wording is pinned and nu is not written into it
+PASS: thm3-no-l1 — the note refuses to attach L1 and treats the list as displayed, not adopted
+PASS: claim-scope — front matter carries the declared claim_scope
+PASS: forbidden-phrases — the note avoids the dispatch-forbidden phrases
+PASS: record-unused — Record is quoted only as an unused boundary
+PASS: b6-only — every executed hop and every named type stays inside B_6(0)
+per_element: checked exactly — each t=8 G+ representative, |v|_2^2, and orbit size
+per_site: checked exactly — first-arrival on the 377-site ball
+per_mode: not used
+per_block: checked exactly — the seven-orbit partition of the t=8 shell
+lattice_wide: checked and not executed — no law outside B_6(0) is claimed
+TOTAL: PASS=35 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_t8_mixed_shell_2026_08_15.py
+++ b/scripts/support_drop_t8_mixed_shell_2026_08_15.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Name the G+ types that share arrival t=8 under the support-drop hop-cost.
+
+One Dijkstra on the induced six-neighbor graph of the closed taxicab ball
+B_6(0). The named hop-cost nu is displayed, not adopted. No axiom edit,
+L1 attachment, cache write, or citation manifest.
+"""
+
+from __future__ import annotations
+
+from heapq import heappop, heappush
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_T8_MIXED_SHELL_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_T8_MIXED_SHELL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+
+BALL_RADIUS = 6
+TARGET_T = 8
+ORIGIN: Point = (0, 0, 0)
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN_PHRASES = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+def rotate_vector(rotation: Rotation, vector: Point) -> Point:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def taxicab(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def euclidean_sq(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def support_weight(point: Point) -> int:
+    return sum(coord != 0 for coord in point)
+
+
+def in_ball(point: Point) -> bool:
+    return taxicab(point) <= BALL_RADIUS
+
+
+def ball_sites() -> tuple[Point, ...]:
+    sites: list[Point] = []
+    for x in range(-BALL_RADIUS, BALL_RADIUS + 1):
+        for y in range(-BALL_RADIUS, BALL_RADIUS + 1):
+            remain = BALL_RADIUS - abs(x) - abs(y)
+            for z in range(-remain, remain + 1):
+                sites.append((x, y, z))
+    return tuple(sites)
+
+
+def hop_cost(source: Point, target: Point) -> int:
+    """Named support-drop hop-cost nu, as in the noshrt rule."""
+    source_weight = support_weight(source)
+    target_weight = support_weight(target)
+    if source_weight == 0 or (source_weight == 1 and target_weight == 1) or target_weight < source_weight:
+        return 3
+    return 1
+
+
+def neighbors_in_ball(site: Point) -> tuple[Point, ...]:
+    out: list[Point] = []
+    for shift in SHIFTS:
+        candidate = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        if in_ball(candidate):
+            out.append(candidate)
+    return tuple(out)
+
+
+def one_dijkstra(sites: tuple[Point, ...]) -> dict[Point, int]:
+    """Single-source first-arrival times from the origin. Called once."""
+    infinity = 10**9
+    dist = {site: infinity for site in sites}
+    dist[ORIGIN] = 0
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while heap:
+        time, site = heappop(heap)
+        if time != dist[site]:
+            continue
+        for nxt in neighbors_in_ball(site):
+            arrival = time + hop_cost(site, nxt)
+            if arrival < dist[nxt]:
+                dist[nxt] = arrival
+                heappush(heap, (arrival, nxt))
+    return dist
+
+
+def gplus_orbit(point: Point) -> frozenset[Point]:
+    return frozenset(rotate_vector(rotation, point) for rotation in ROTATIONS)
+
+
+def representative(orbit: frozenset[Point]) -> Point:
+    """Lexicographically maximal first-octant member of a G+ orbit."""
+    octant = tuple(point for point in orbit if point[0] >= 0 and point[1] >= 0 and point[2] >= 0)
+    if not octant:
+        raise ValueError("G+ orbit has no first-octant representative")
+    return max(octant)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} — {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return 0 if self.failed == 0 else 1
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+
+    print("construction: one Dijkstra for named support-drop hop-cost nu on B_6(0)")
+    print("negative_scope: nu is displayed, not written into Admissibility; L1 is not attached")
+
+    checks.check(
+        "audit-inputs",
+        "AUDIT_INPUT_PATHS is the required string-literal pair and both files exist",
+        AUDIT_INPUT_PATHS == (
+            "docs/SUPPORT_DROP_T8_MIXED_SHELL_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+
+    sites = ball_sites()
+    site_set = frozenset(sites)
+    checks.check(
+        "ball-census",
+        "B_6(0) has 377 integer sites and 376 nonzero sites",
+        len(sites) == 377 and ORIGIN in site_set and len(sites) - 1 == 376,
+        residual=len(sites),
+    )
+    checks.check(
+        "rotation-group",
+        "the proper cubic group used for types has 24 elements",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+
+    arrivals = one_dijkstra(sites)
+    checks.check(
+        "one-dijkstra-total",
+        "every site of B_6(0) receives a finite arrival time",
+        all(arrivals[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "reverse-critical-shell",
+        "t(2,2,2)=8 and t(4,0,0)=10, so t=8 is the reverse-critical shell",
+        arrivals[(2, 2, 2)] == TARGET_T and arrivals[(4, 0, 0)] == 10,
+        residual=(arrivals[(2, 2, 2)], arrivals[(4, 0, 0)]),
+    )
+    checks.check(
+        "l1-not-identified",
+        "arrival t is not the taxicab length: t(1,0,0)=3 and t(2,2,2)=8 != 6",
+        arrivals[(1, 0, 0)] == 3 and arrivals[(2, 2, 2)] != taxicab((2, 2, 2)),
+    )
+
+    seed_exit = hop_cost(ORIGIN, (1, 0, 0))
+    axis_step = hop_cost((1, 0, 0), (2, 0, 0))
+    support_drop = hop_cost((1, 1, 0), (1, 0, 0))
+    support_gain = hop_cost((1, 0, 0), (1, 1, 0))
+    equal_off_axis = hop_cost((1, 1, 0), (2, 1, 0))
+    checks.check(
+        "named-nu-clauses",
+        "nu is 3 on seed-exit, both-weight-1, and support drop, else 1",
+        seed_exit == 3
+        and axis_step == 3
+        and support_drop == 3
+        and support_gain == 1
+        and equal_off_axis == 1,
+    )
+
+    t8_sites = tuple(site for site in sites if site != ORIGIN and arrivals[site] == TARGET_T)
+    consumed: set[Point] = set()
+    rows: list[tuple[Point, int, int]] = []
+    for site in t8_sites:
+        if site in consumed:
+            continue
+        orbit = gplus_orbit(site)
+        orbit_in_ball = frozenset(point for point in orbit if point in site_set)
+        checks.check(
+            "orbit-inside-ball",
+            f"the G+ orbit of {representative(orbit)} lies in B_6(0)",
+            orbit == orbit_in_ball,
+            residual=(len(orbit), len(orbit_in_ball)),
+        )
+        times = {arrivals[point] for point in orbit_in_ball}
+        checks.check(
+            "orbit-constant-t",
+            f"arrival is constant on the G+ orbit of {representative(orbit)}",
+            times == {TARGET_T},
+            residual=times,
+        )
+        consumed.update(orbit_in_ball)
+        rep = representative(orbit_in_ball)
+        rows.append((rep, euclidean_sq(rep), len(orbit_in_ball)))
+    rows.sort()
+
+    radii = sorted({radius_sq for _, radius_sq, _ in rows})
+    print("t8_gplus_types:")
+    for rep, radius_sq, orbit_size in rows:
+        print(f"  {rep}  |v|_2^2={radius_sq}  orbit={orbit_size}")
+    print(f"t8_radius_squares: {radii}")
+
+    expected_rows = (
+        ((2, 2, 2), 12, 8),
+        ((3, 1, 2), 14, 24),
+        ((3, 2, 1), 14, 24),
+        ((3, 3, 0), 18, 12),
+        ((4, 1, 1), 18, 24),
+        ((4, 2, 0), 20, 24),
+        ((5, 1, 0), 26, 24),
+    )
+    checks.check(
+        "thm1-lex-list",
+        "the lex-sorted G+ representatives at t=8 are the seven computed types",
+        tuple(rows) == expected_rows,
+        residual=rows,
+    )
+    checks.check(
+        "thm1-contains-222",
+        "the reverse-critical body-diagonal type (2,2,2) is on the t=8 list",
+        rows[0] == ((2, 2, 2), 12, 8),
+    )
+    checks.check(
+        "thm1-note-table",
+        "the note displays each representative with |v|_2^2 and orbit size",
+        all(
+            f"| `{rep[0]},{rep[1]},{rep[2]}` | {radius_sq} | {orbit_size} |"
+            in note
+            or f"| `({rep[0]},{rep[1]},{rep[2]})` | {radius_sq} | {orbit_size} |"
+            in note
+            for rep, radius_sq, orbit_size in rows
+        ),
+    )
+    checks.check(
+        "thm2-mixed-radii",
+        "the t=8 list uses more than one Euclidean radius",
+        len(radii) > 1 and radii == [12, 14, 18, 20, 26],
+        residual=radii,
+    )
+    checks.check(
+        "thm2-shared-radius-not-same-type",
+        "(3,3,0) and (4,1,1) share |v|_2^2=18 but are distinct G+ types",
+        ((3, 3, 0), 18, 12) in rows and ((4, 1, 1), 18, 24) in rows,
+    )
+    checks.check(
+        "thm2-chiral-pair",
+        "(3,1,2) and (3,2,1) are distinct 24-point G+ orbits of the same radius",
+        gplus_orbit((3, 1, 2)).isdisjoint(gplus_orbit((3, 2, 1)))
+        and len(gplus_orbit((3, 1, 2))) == 24
+        and len(gplus_orbit((3, 2, 1))) == 24
+        and euclidean_sq((3, 1, 2)) == euclidean_sq((3, 2, 1)) == 14,
+    )
+    checks.check(
+        "coverage",
+        "the seven orbits partition every t=8 site and omit every other site",
+        len(t8_sites) == sum(orbit_size for _, _, orbit_size in rows) == 140
+        and consumed == set(t8_sites),
+        residual=len(t8_sites),
+    )
+
+    lattice_lead = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    lattice_tail = "adjacency, standard translations, and proper cubic rotations about each site."
+    admissibility_lead = "For each site, the probability distribution over the possibilities is"
+    admissibility_tail = "determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    checks.check(
+        "source-lattice",
+        "current Lattice wording is pinned in the axiom memo and the note",
+        lattice_lead in axiom and lattice_tail in axiom and lattice_lead in note and lattice_tail in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current Admissibility wording is pinned and nu is not written into it",
+        admissibility_lead in axiom
+        and admissibility_tail in axiom
+        and admissibility_lead in note
+        and admissibility_tail in note
+        and "Do not write ν into Admissibility." in note
+        and "hypothetical_axiom_status: no edit" in note,
+    )
+    checks.check(
+        "thm3-no-l1",
+        "the note refuses to attach L1 and treats the list as displayed, not adopted",
+        "Do not attach L1." in note
+        and "Displayed, not adopted." in note
+        and "displayed, not adopted" in note.lower(),
+    )
+    checks.check(
+        "claim-scope",
+        "front matter carries the declared claim_scope",
+        "The G+ site-types that share arrival t=8 under the named support-drop hop-cost on B_6(0) are named. Displayed, not adopted."
+        in note,
+    )
+    checks.check(
+        "forbidden-phrases",
+        "the note avoids the dispatch-forbidden phrases",
+        all(phrase not in note for phrase in FORBIDDEN_PHRASES),
+    )
+    checks.check(
+        "record-unused",
+        "Record is quoted only as an unused boundary",
+        record_lock in axiom and record_lock in note and "Record is not used" in note,
+    )
+    checks.check(
+        "b6-only",
+        "every executed hop and every named type stays inside B_6(0)",
+        all(in_ball(site) for site in sites)
+        and all(in_ball(rep) for rep, _, _ in rows)
+        and BALL_RADIUS == 6
+        and "B_6(0) only" in note,
+    )
+
+    print("per_element: checked exactly — each t=8 G+ representative, |v|_2^2, and orbit size")
+    print("per_site: checked exactly — first-arrival on the 377-site ball")
+    print("per_mode: not used")
+    print("per_block: checked exactly — the seven-orbit partition of the t=8 shell")
+    print("lattice_wide: checked and not executed — no law outside B_6(0) is claimed")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Under nu, t=8 has (2,2,2),(3,1,2),(3,2,1),(3,3,0),(4,1,1),(4,2,0),(5,1,0). Radii 12,14,18,20,26. 140 sites. Displayed, not adopted. No axiom edit.

## Runner

`scripts/support_drop_t8_mixed_shell_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.