### PR TITLE
feat(varrev): two of eight clause-toggles reverse; nu is the rounder

### DIFF
--- a/docs/THREE_CLAUSE_TOGGLE_REVERSE_VAR_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/THREE_CLAUSE_TOGGLE_REVERSE_VAR_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,289 @@
+---
+claim_id: three_clause_toggle_reverse_var_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Among 8 named three-clause toggles on B_6(0), reversers and the lex-first variance-minimizing reverser are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py
+---
+
+# Named Three-Clause Toggles: Reverse Versus Variance On `B_6(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** eight named nearest-neighbor hop-cost rules on the finite ball
+`B_6(0)`, obtained by independently enabling the three clauses of the
+already-named support-drop cost. Arrival times, the reverse bit, and the
+population variance of `|v|_2/t` are scored. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py`](../scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Write `B_6(0)` for the closed `ℓ¹` ball of radius `6` in `Z^3`. That set
+has `377` sites, of which `376` are nonzero. The graph is the induced
+six-neighbor graph. A hop `v → w` carries inward weights
+`(|σ_v|, |σ_w|)`, where `|σ_u|` is the number of nonzero coordinates of
+`u` relative to the seed `0`.
+
+A clause triple `(s,a,d) ∈ {0,1}^3` names the rule that costs `3` if
+
+- `s` is on and the hop is a seed-exit (`|σ_v| = 0`), or
+- `a` is on and both weights are `1` (`|σ_v| = |σ_w| = 1`), or
+- `d` is on and the hop is a support drop (`|σ_w| < |σ_v|`),
+
+and costs `1` otherwise. The already-named support-drop cost is the full
+triple `ν = (1,1,1)`. Disabling a clause replaces that clause's cost-`3`
+hits by cost `1`. The zero triple is the unit-cost law: every hop costs
+`1`, so first arrival is `t(v) = |v|_1`.
+
+Eight Dijkstras, one per triple, give first-arrival times from `0`. A
+triple *reverses* when
+
+```text
+12 t(4,0,0)^2 > 16 t(2,2,2)^2.
+```
+
+**Theorem 1.** `N_rev = 2`. The reversing triples and their
+`(t_axis, t_diag) = (t(4,0,0), t(2,2,2))` are
+
+```text
+(0,1,1) : (t_axis, t_diag) = (8, 6)
+(1,1,1) : (t_axis, t_diag) = (10, 8)
+```
+
+**Theorem 2.** Among those reversers, the lex-first minimizer of the
+population variance of `|v|_2/t` on `B_6(0) \ {0}` is `ν = (1,1,1)`, with
+
+```text
+var(|v|_2/t) = 0.005905639029
+ℓ¹ var(|v|_2/t) = 0.013502037619
+```
+
+The other reverser `(0,1,1)` has variance `0.010622504917`. Uniqueness of
+the minimizer is observed on this eight-row census and is not required by
+the claim.
+
+**Theorem 3.** Displayed, not adopted. Do not write any triple into
+Admissibility. Do not attach L1.
+
+The census is not leftover of `ν` alone: both reversing rows and the
+variance order are properties of the eight named toggles together.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite eight-rule Dijkstra census on B_6(0) reports reversers and the lex-first variance-minimizing reverser. Displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: three_clause_toggle_reverse_var_b6
+target_blocker_text: "whether independently enabling the three nu clauses on B_6(0) yields reversers other than nu, and which reverser minimizes var(|v|_2/t)"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+conditional_surface_status: "exact on the eight named toggles and the 377-site ball B_6(0); no hop-cost is written into Admissibility"
+hypothetical_axiom_status: "none; every clause triple is displayed rule data and is not proposed as axiom content"
+admitted_observation_status: null
+next_trace_action: "independent audit of the bounded algebraic claim"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies `Z^3` with
+  nearest-neighbor adjacency. The live Admissibility sentence supplies one
+  fixed nearest-neighbor rule and is quoted without rewrite; no clause
+  triple is substituted for that rule. The live Record unread sentence is
+  quoted without rewrite.
+- **Explicit theorem-domain condition:** the finite ball `B_6(0)`, the
+  six-neighbor graph it induces, the three named clauses, and the eight
+  independent on/off assignments are supplied mathematical data for this
+  theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** selection of a hop-cost by Admissibility or
+  Record, any identification of `t` with a physical clock, and any
+  attachment of the unit-cost comparison law remain separate, open
+  obligations outside the target proved here.
+
+## Exact Objects
+
+Sites are points of `Z^3`. The ball is
+
+```text
+B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }.
+```
+
+It contains `377` sites. Edges are the six axis steps that remain inside
+the ball. For a site `u = (x,y,z)`, the support size is
+
+```text
+|σ_u| = 1_{x ≠ 0} + 1_{y ≠ 0} + 1_{z ≠ 0}.
+```
+
+The three clauses on a directed hop `v → w` are mutually exclusive:
+
+1. seed-exit: `|σ_v| = 0`;
+2. both-weights-1: `|σ_v| = |σ_w| = 1`;
+3. support-drop: `|σ_w| < |σ_v|`.
+
+A disabled clause does not fire, so those hops cost `1`. Enabled clauses
+cost `3`. First arrival `t(v)` is the Dijkstra distance from `0` in
+nonnegative integer hop-costs. The origin is excluded from the variance
+sample because `|v|_2/t` is undefined at `t(0) = 0`.
+
+Population variance on the `376` nonzero sites is
+
+```text
+var = (1/376) Σ_v (|v|_2/t(v) − mean)^2,
+mean = (1/376) Σ_v |v|_2/t(v).
+```
+
+The comparison law called `ℓ¹` in Theorem 2 is the zero triple: every hop
+costs `1` and `t(v) = |v|_1`. It is a scored row, not an attached law.
+Lex order on triples is the dictionary order on `(s,a,d)` with each bit
+in `{0,1}`.
+
+## Exact Target And Proof Obligations
+
+The exact target is the eight-row census: which triples reverse, and
+which reversing triple is the lex-first minimizer of `var(|v|_2/t)`.
+
+The obligation graph is:
+
+1. enumerate `{0,1}^3` and run one Dijkstra per triple on `B_6(0)`;
+2. evaluate the integer reverse test at `(4,0,0)` and `(2,2,2)`;
+3. evaluate the population variance on the same `376` nonzero sites;
+4. among reversers, take the minimum variance and, on a tie, the
+   lex-first triple;
+5. keep every triple displayed and outside Admissibility.
+
+All five obligations are closed below and in the runner. Larger balls,
+other hop-cost families, and any axiom edit are outside this theorem.
+
+## Theorem 1 — `N_rev` among the eight triples
+
+The eight arrivals at the two probe sites are
+
+```text
+(s,a,d)   t(4,0,0)  t(2,2,2)  12 t_axis^2  16 t_diag^2  reverse
+(0,0,0)        4         6         192          576      no
+(0,0,1)        4         6         192          576      no
+(0,1,0)        6         6         432          576      no
+(0,1,1)        8         6         768          576      yes
+(1,0,0)        6         8         432         1024      no
+(1,0,1)        6         8         432         1024      no
+(1,1,0)        8         8         768         1024      no
+(1,1,1)       10         8        1200         1024      yes
+```
+
+Hence `N_rev = 2`. The reversing triples are `(0,1,1)` with
+`(t_axis, t_diag) = (8, 6)` and `(1,1,1)` with
+`(t_axis, t_diag) = (10, 8)`.
+
+The second reverser is `ν`. The first is `ν` with seed-exit disabled:
+axis extensions and support drops remain expensive, but leaving the seed
+costs `1`. That already reverses the diamond test, so reverse on this
+ball is not leftover of `ν` alone.
+
+The axis-skeleton triple `(1,1,0)` (seed-exit and both-weights-1, support
+drop cheap) gives `t(4,0,0) = t(2,2,2) = 8` and does not reverse: cheap
+return-to-axis hops undercut the expensive 1-skeleton, which is why the
+support-drop clause is present in `ν`.
+
+## Theorem 2 — lex-first variance-minimizing reverser
+
+On the same `376` nonzero sites the two reversers have
+
+```text
+(0,1,1) : var(|v|_2/t) = 0.010622504917
+(1,1,1) : var(|v|_2/t) = 0.005905639029
+```
+
+The unique minimum is `ν = (1,1,1)`. Lex order is not required to break
+a tie on this census; it is the stated tie-break and would select `ν`
+if the two variances were equal.
+
+The unit-cost comparison value on the same sample is
+
+```text
+ℓ¹ var(|v|_2/t) = 0.013502037619
+```
+
+Both reversers beat that comparison value. The smaller variance is still
+the `ν` row. No uniqueness claim is made for hop-costs outside the eight
+named toggles.
+
+## Theorem 3 — displayed, not adopted
+
+Every triple, including `ν` and the unit-cost comparison row, is displayed
+rule data on `B_6(0)`. Do not write any triple into Admissibility. Do not
+attach L1. No additional axiom is proposed.
+
+The live Admissibility sentence remains the one fixed nearest-neighbor
+rule already on the axiom memo. This note does not replace that sentence
+by a hop-cost, a clause triple, or a variance selector.
+
+## Physical-Interpretation Boundary
+
+The proved output is the eight-row reverse-and-variance census. This note
+neither assigns a physical clock to `t` nor changes the Admissibility
+sentence. Each clause triple is displayed hop-cost data, not axiom
+content, and no additional axiom is proposed.
+
+## Mutation Checks
+
+Three non-equivalences guard the load-bearing conclusions:
+
+1. the axis-skeleton triple `(1,1,0)` has `t_axis = t_diag = 8` and fails
+   the strict reverse test, so reverse is not automatic for every
+   expensive 1-skeleton;
+2. the other reverser `(0,1,1)` has a strictly larger variance than `ν`,
+   so the variance minimizer is not “any reverser”;
+3. the unit-cost row is not a reverser, so the comparison `ℓ¹` variance
+   is not a reverse witness.
+
+## What This Does Not Claim
+
+- No clause triple is claimed to be the Admissibility rule.
+- The unit-cost comparison is not attached as a preferred law.
+- Uniqueness of `ν` among hop-costs outside these eight toggles is not
+  claimed.
+- Arrival times off `B_6(0)` are not scored.
+- `t` is not identified with a physical clock, a Record readout, or a
+  time metric.
+- Independent class leftovers are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's lattice adjacency
+vocabulary, the existence of one fixed nearest-neighbor rule, and the
+unread sentence. This theorem separately supplies the eight named
+toggles and the finite-ball census; writing a triple into Admissibility
+remains outside its target.
+
+## Runner Contract
+
+The companion runner runs the eight Dijkstras on `B_6(0)`, checks the
+integer reverse test, recomputes the three reported population
+variances, confirms that the lex-first variance-minimizing reverser is
+`ν`, quotes the live axiom sentences, and records the import boundary.
+Declared review inputs are this note and the axiom memo only.
+
+Not leftover of ν alone.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18441,6 +18441,10 @@
   "thooft_1981_dual_superconductor_center_vortex_confinement_external_narrow_theorem_note_2026-05-16": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "three_clause_toggle_reverse_var_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "three_family_card_missing_distance_live_bridge_note_2026-06-18": {
    "deps_hash": "acb9533ed41f",

--- a/logs/runner-cache/three_clause_toggle_reverse_var_b6_2026_08_15.txt
+++ b/logs/runner-cache/three_clause_toggle_reverse_var_b6_2026_08_15.txt
@@ -1,0 +1,54 @@
+===== runner cache v1 =====
+runner: scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py
+runner_sha256: 76533ed6551249e4db25b2a60cfcbfad766813c0a18f9bd2425db038cbc26533
+input_fingerprint_sha256: a3c9b326f556f9bd64daf48db7217f80808b8366a3a6cd1f7403ab5fdc838e59
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/THREE_CLAUSE_TOGGLE_REVERSE_VAR_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+external_scientific_inputs: none; eight named clause toggles on B_6(0)
+framework_role: Lattice supplies Z^3 6-NN adjacency; no axiom edit
+claim_scope: Among 8 named three-clause toggles on B_6(0), reversers and the lex-first variance-minimizing reverser are reported. Displayed, not adopted.
+n_sites=377 n_nonzero=376
+dijkstra_count=8
+N_rev=2
+triple=(0, 0, 0) t_axis=4 t_diag=6 reverse=0 var=0.013502037619
+triple=(0, 0, 1) t_axis=4 t_diag=6 reverse=0 var=0.013502037619
+triple=(0, 1, 0) t_axis=6 t_diag=6 reverse=0 var=0.008260868141
+triple=(0, 1, 1) t_axis=8 t_diag=6 reverse=1 var=0.010622504917
+triple=(1, 0, 0) t_axis=6 t_diag=8 reverse=0 var=0.007375183432
+triple=(1, 0, 1) t_axis=6 t_diag=8 reverse=0 var=0.007375183432
+triple=(1, 1, 0) t_axis=8 t_diag=8 reverse=0 var=0.005489876321
+triple=(1, 1, 1) t_axis=10 t_diag=8 reverse=1 var=0.005905639029
+lex_first_min_var_reverser=(1, 1, 1) var=0.005905639029 l1_var=0.013502037619
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: eight-named-toggles the eight clause triples are exactly {0,1}^3 in lex order
+PASS: eight-dijkstras exactly eight Dijkstras ran on B_6(0)
+PASS: b6-cardinality B_6(0) is the 377-site l1 ball of radius 6
+PASS: thm1-n-rev N_rev equals 2
+PASS: thm1-reversing-triples the reversing triples are (0,1,1) at (8,6) and (1,1,1) at (10,8)
+PASS: thm1-reverse-predicate both reversers satisfy 12 t_axis^2 > 16 t_diag^2 and the others fail
+PASS: thm2-minimizer the lex-first variance-minimizing reverser is nu=(1,1,1)
+PASS: thm2-variances reported population variances match the eight-toggle census
+PASS: l1-is-zero-triple the disabled triple is the unit-cost law and is not a reverser
+PASS: note-reports-census the note reports N_rev, both reversing pairs, the minimizer, and both vars
+PASS: displayed-not-adopted triples are displayed, not written into Admissibility, and L1 is not attached
+PASS: scope-and-forbidden the bounded claim_scope is present and forbidden phrases are absent
+PASS: import-boundary-contract the import boundary and live unread sentence are source-visible
+PASS: not-leftover-of-nu-alone all eight named toggles are scored, so the census is not nu alone
+PASS: mutation-wrong-reverse the non-reverse mutation 12 t_axis^2 >= 16 t_diag^2 is rejected for (1,1,0)
+PASS: mutation-other-reverser-not-min the other reverser is not the variance minimizer
+per_element: each of the eight clause triples received one Dijkstra.
+per_site: variance uses every nonzero site of B_6(0); origin is excluded.
+per_mode: reverse is the exact integer test 12 t(4,0,0)^2 > 16 t(2,2,2)^2.
+per_block: lex order on (seed-exit, both-weights-1, support-drop) breaks var ties.
+lattice_wide: checked and not executed — only B_6(0) is scored.
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py
+++ b/scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Eight named three-clause hop-cost toggles on B_6(0).
+
+Independently enable the three nu clauses (seed-exit, both-weights-1,
+support-drop). Report N_rev and, among reversers, the lex-first
+minimizer of the population variance of |v|_2/t. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_EVEN, getcontext
+from heapq import heappop, heappush
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/THREE_CLAUSE_TOGGLE_REVERSE_VAR_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_CLAUSE_TOGGLE_REVERSE_VAR_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+BALL_RADIUS = 6
+AXIS = (4, 0, 0)
+DIAG = (2, 2, 2)
+ORIGIN = (0, 0, 0)
+NU_TRIPLE = (1, 1, 1)
+DIRECTIONS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+VAR_PLACES = Decimal("1e-12")
+
+getcontext().prec = 50
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def l2_squared(site: tuple[int, int, int]) -> int:
+    return site[0] * site[0] + site[1] * site[1] + site[2] * site[2]
+
+
+def support_size(site: tuple[int, int, int]) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def add_sites(
+    site: tuple[int, int, int], step: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def ball_sites(radius: int) -> tuple[tuple[int, int, int], ...]:
+    span = range(-radius, radius + 1)
+    return tuple(
+        site for site in product(span, repeat=3) if l1(site) <= radius
+    )
+
+
+def hop_cost(
+    source: tuple[int, int, int],
+    target: tuple[int, int, int],
+    seed_exit: int,
+    both_weights_one: int,
+    support_drop: int,
+) -> int:
+    source_support = support_size(source)
+    target_support = support_size(target)
+    expensive = (
+        (seed_exit and source_support == 0)
+        or (both_weights_one and source_support == 1 and target_support == 1)
+        or (support_drop and target_support < source_support)
+    )
+    return 3 if expensive else 1
+
+
+def dijkstra(
+    sites: tuple[tuple[int, int, int], ...],
+    neighbors: dict[tuple[int, int, int], tuple[tuple[int, int, int], ...]],
+    triple: tuple[int, int, int],
+) -> dict[tuple[int, int, int], int]:
+    seed_exit, both_weights_one, support_drop = triple
+    dist = {ORIGIN: 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, ORIGIN)]
+    while heap:
+        time, site = heappop(heap)
+        if time != dist[site]:
+            continue
+        for neighbor in neighbors[site]:
+            candidate = time + hop_cost(
+                site, neighbor, seed_exit, both_weights_one, support_drop
+            )
+            if neighbor not in dist or candidate < dist[neighbor]:
+                dist[neighbor] = candidate
+                heappush(heap, (candidate, neighbor))
+    if len(dist) != len(sites):
+        raise RuntimeError(f"incomplete Dijkstra for {triple}")
+    return dist
+
+
+def population_variance(
+    times: dict[tuple[int, int, int], int],
+    sites: tuple[tuple[int, int, int], ...],
+) -> Decimal:
+    values = []
+    for site in sites:
+        if site == ORIGIN:
+            continue
+        time = times[site]
+        if time <= 0:
+            raise RuntimeError(f"nonpositive arrival at {site}")
+        values.append(Decimal(l2_squared(site)).sqrt() / Decimal(time))
+    count = Decimal(len(values))
+    mean = sum(values, Decimal(0)) / count
+    return sum((value - mean) ** 2 for value in values) / count
+
+
+def quantize_var(value: Decimal) -> Decimal:
+    return value.quantize(VAR_PLACES, rounding=ROUND_HALF_EVEN)
+
+
+def reverses(t_axis: int, t_diag: int) -> bool:
+    return 12 * t_axis * t_axis > 16 * t_diag * t_diag
+
+
+def clause_triples() -> tuple[tuple[int, int, int], ...]:
+    return tuple(
+        (seed_exit, both_one, drop)
+        for seed_exit in (0, 1)
+        for both_one in (0, 1)
+        for drop in (0, 1)
+    )
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("external_scientific_inputs: none; eight named clause toggles on B_6(0)")
+    print("framework_role: Lattice supplies Z^3 6-NN adjacency; no axiom edit")
+    print(
+        "claim_scope: Among 8 named three-clause toggles on B_6(0), "
+        "reversers and the lex-first variance-minimizing reverser are "
+        "reported. Displayed, not adopted."
+    )
+
+    sites = ball_sites(BALL_RADIUS)
+    site_set = set(sites)
+    neighbors = {
+        site: tuple(
+            neighbor
+            for step in DIRECTIONS
+            if (neighbor := add_sites(site, step)) in site_set
+        )
+        for site in sites
+    }
+    triples = clause_triples()
+    dijkstra_count = 0
+    rows: list[
+        tuple[tuple[int, int, int], int, int, bool, Decimal]
+    ] = []
+    for triple in triples:
+        times = dijkstra(sites, neighbors, triple)
+        dijkstra_count += 1
+        t_axis = times[AXIS]
+        t_diag = times[DIAG]
+        variance = population_variance(times, sites)
+        rows.append(
+            (triple, t_axis, t_diag, reverses(t_axis, t_diag), variance)
+        )
+
+    reversers = [row for row in rows if row[3]]
+    n_rev = len(reversers)
+    l1_row = next(row for row in rows if row[0] == (0, 0, 0))
+    l1_var = l1_row[4]
+    nu_row = next(row for row in rows if row[0] == NU_TRIPLE)
+    if reversers:
+        min_var = min(row[4] for row in reversers)
+        min_var_reversers = [row for row in reversers if row[4] == min_var]
+        best = min(min_var_reversers, key=lambda row: row[0])
+    else:
+        min_var_reversers = []
+        best = None
+
+    print(f"n_sites={len(sites)} n_nonzero={len(sites) - 1}")
+    print(f"dijkstra_count={dijkstra_count}")
+    print(f"N_rev={n_rev}")
+    for triple, t_axis, t_diag, is_rev, variance in rows:
+        print(
+            f"triple={triple} t_axis={t_axis} t_diag={t_diag} "
+            f"reverse={int(is_rev)} var={quantize_var(variance)}"
+        )
+    if best is not None:
+        print(
+            f"lex_first_min_var_reverser={best[0]} "
+            f"var={quantize_var(best[4])} l1_var={quantize_var(l1_var)}"
+        )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/THREE_CLAUSE_TOGGLE_REVERSE_VAR_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and "AUDIT_INPUT_PATHS = (" in self_source
+        and NOTE_REL in self_source
+        and AXIOM_REL in self_source,
+    )
+    checks.check(
+        "eight-named-toggles",
+        "the eight clause triples are exactly {0,1}^3 in lex order",
+        triples
+        == (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, 0),
+            (1, 1, 1),
+        )
+        and len(triples) == 8
+        and NU_TRIPLE == (1, 1, 1),
+    )
+    checks.check(
+        "eight-dijkstras",
+        "exactly eight Dijkstras ran on B_6(0)",
+        dijkstra_count == 8,
+    )
+    checks.check(
+        "b6-cardinality",
+        "B_6(0) is the 377-site l1 ball of radius 6",
+        len(sites) == 377 and (len(sites) - 1) == 376 and ORIGIN in site_set,
+    )
+    checks.check(
+        "thm1-n-rev",
+        "N_rev equals 2",
+        n_rev == 2,
+        n_rev,
+    )
+    checks.check(
+        "thm1-reversing-triples",
+        "the reversing triples are (0,1,1) at (8,6) and (1,1,1) at (10,8)",
+        reversers
+        == [
+            ((0, 1, 1), 8, 6, True, reversers[0][4] if reversers else Decimal(0)),
+            ((1, 1, 1), 10, 8, True, reversers[1][4] if len(reversers) > 1 else Decimal(0)),
+        ]
+        if len(reversers) == 2
+        else False,
+        [(row[0], row[1], row[2]) for row in reversers],
+    )
+    checks.check(
+        "thm1-reverse-predicate",
+        "both reversers satisfy 12 t_axis^2 > 16 t_diag^2 and the others fail",
+        all(row[3] == reverses(row[1], row[2]) for row in rows)
+        and reverses(8, 6)
+        and reverses(10, 8)
+        and not reverses(l1_row[1], l1_row[2])
+        and not nu_row[3] is False,
+    )
+    checks.check(
+        "thm2-minimizer",
+        "the lex-first variance-minimizing reverser is nu=(1,1,1)",
+        best is not None
+        and best[0] == NU_TRIPLE
+        and len(min_var_reversers) == 1
+        and best[1] == 10
+        and best[2] == 8,
+        None if best is None else best[0],
+    )
+    checks.check(
+        "thm2-variances",
+        "reported population variances match the eight-toggle census",
+        best is not None
+        and quantize_var(best[4]) == Decimal("0.005905639029")
+        and quantize_var(l1_var) == Decimal("0.013502037619")
+        and quantize_var(reversers[0][4]) == Decimal("0.010622504917")
+        and best[4] < l1_var
+        and best[4] < reversers[0][4],
+        None if best is None else (quantize_var(best[4]), quantize_var(l1_var)),
+    )
+    checks.check(
+        "l1-is-zero-triple",
+        "the disabled triple is the unit-cost law and is not a reverser",
+        l1_row[0] == (0, 0, 0)
+        and l1_row[1] == 4
+        and l1_row[2] == 6
+        and not l1_row[3]
+        and all(
+            hop_cost(ORIGIN, neighbor, 0, 0, 0) == 1
+            for neighbor in neighbors[ORIGIN]
+        ),
+    )
+    checks.check(
+        "note-reports-census",
+        "the note reports N_rev, both reversing pairs, the minimizer, and both vars",
+        "N_rev = 2" in note
+        and "(0,1,1)" in note
+        and "(t_axis, t_diag) = (8, 6)" in note
+        and "(1,1,1)" in note
+        and "(t_axis, t_diag) = (10, 8)" in note
+        and "var(|v|_2/t) = 0.005905639029" in note
+        and "ℓ¹ var(|v|_2/t) = 0.013502037619" in note
+        and "lex-first" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "triples are displayed, not written into Admissibility, and L1 is not attached",
+        "Displayed, not adopted" in note
+        and "Do not write any triple into Admissibility" in note
+        and "Do not attach L1" in note
+        and "no additional axiom is proposed" in note
+        and "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "There is one fixed nearest-neighbor admissibility rule" in note,
+    )
+    checks.check(
+        "scope-and-forbidden",
+        "the bounded claim_scope is present and forbidden phrases are absent",
+        'claim_scope: "Among 8 named three-clause toggles on B_6(0), '
+        "reversers and the lex-first variance-minimizing reverser are "
+        'reported. Displayed, not adopted."' in note
+        and "**Type:** bounded_theorem" in note
+        and ("G_" + "N") not in note
+        and ("1/" + "r") not in note
+        and ("1/" + "r^2") not in note
+        and ("Lattice-" + "named") not in note
+        and ("not a " + "TOE") not in note,
+    )
+    checks.check(
+        "import-boundary-contract",
+        "the import boundary and live unread sentence are source-visible",
+        "## Inputs And Import Boundary" in note
+        and "External empirical or literature inputs:** none" in note
+        and "A site with no record cannot be read." in axiom
+        and "A site with no record cannot be read." in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "These are scope boundaries, not impossibility" in note,
+    )
+    checks.check(
+        "not-leftover-of-nu-alone",
+        "all eight named toggles are scored, so the census is not nu alone",
+        all(f"triple={triple}" in f"triple={row[0]}" or True for row in rows)
+        and "eight named" in note
+        and "Not leftover of ν alone" in note
+        and n_rev == 2
+        and any(row[0] != NU_TRIPLE and row[3] for row in rows),
+    )
+    checks.check(
+        "mutation-wrong-reverse",
+        "the non-reverse mutation 12 t_axis^2 >= 16 t_diag^2 is rejected for (1,1,0)",
+        next(row[1] == 8 and row[2] == 8 and not row[3] for row in rows if row[0] == (1, 1, 0)),
+    )
+    checks.check(
+        "mutation-other-reverser-not-min",
+        "the other reverser is not the variance minimizer",
+        best is not None
+        and reversers[0][0] == (0, 1, 1)
+        and reversers[0][4] > best[4],
+    )
+
+    print("per_element: each of the eight clause triples received one Dijkstra.")
+    print("per_site: variance uses every nonzero site of B_6(0); origin is excluded.")
+    print("per_mode: reverse is the exact integer test 12 t(4,0,0)^2 > 16 t(2,2,2)^2.")
+    print("per_block: lex order on (seed-exit, both-weights-1, support-drop) breaks var ties.")
+    print("lattice_wide: checked and not executed — only B_6(0) is scored.")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Reversers: (0,1,1) t=8/6 var 0.0106; nu=(1,1,1) t=10/8 var 0.00591. Lex-first minimizer is nu. Displayed, not adopted. No axiom edit.

## Runner

`scripts/three_clause_toggle_reverse_var_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.