### PR TITLE
feat(011why): cheap-seed reverser paths: axis 8 via detour, diag 6 all-1s

### DIFF
--- a/docs/CLAUSE_011_REVERSE_PATHS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_REVERSE_PATHS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,392 @@
+---
+claim_id: clause_011_reverse_paths_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Shortest paths under the named (0,1,1) clause-toggle that reverse diamond on B_6(0) are exhibited. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_reverse_paths_2026_08_15.py
+---
+
+# Clause `(0,1,1)` Reverse Paths On The Radius-Six Ball
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** lex-first minimum-cost walks from the origin to `(4,0,0)` and to
+`(2,2,2)` on the closed radius-six nearest-neighbor ball, under the named
+clause-toggle with cheap seed-exit and expensive axis-one and support-drop
+hops. The rule is displayed, not adopted. The walks are not leftover of the
+two arrival numbers.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_reverse_paths_2026_08_15.py`](../scripts/clause_011_reverse_paths_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Work on the cubic lattice `Z^3` with nearest-neighbor adjacency. Write
+`B_6(0)` for the closed ball `{v ∈ Z^3 : |v|_1 ≤ 6}`. Hops that would leave
+the ball are absent. For a site `v`, write `σ_v` for the set of nonzero
+coordinates and write the inward weight `w(v) = |σ_v|`.
+
+A directed nearest-neighbor hop `v → u` is classified by three named clauses:
+
+- seed-exit when `w(v) = 0`,
+- both-weights-one (axis-one) when `w(v) = w(u) = 1`,
+- support-drop when `w(u) < w(v)`.
+
+The displayed clause-toggle `(s,a,d) = (0,1,1)` charges cost `3` if
+both-weights-one holds or support-drop holds, and charges cost `1` otherwise.
+Seed-exit is therefore cheap. This is a finite named hop-cost on `B_6(0)`. It
+is not written into Admissibility, and it is not the uniform graph-length
+rule that charges `1` on every nearest-neighbor hop.
+
+Three exact statements survive review.
+
+1. The lex-first shortest walk `0 → (4,0,0)` is
+   `(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (4,0,0)`
+   with hop-cost list `(1,1,1,1,1,3)` summing to `8`. The lex-first shortest
+   walk `0 → (2,2,2)` is
+   `(0,0,0) → (0,0,1) → (0,1,1) → (0,1,2) → (0,2,2) → (1,2,2) → (2,2,2)`
+   with hop-cost list `(1,1,1,1,1,1)` summing to `6`. Those arrival numbers
+   reverse the two-point comparison `(4,0,0)` versus `(2,2,2)`.
+2. Both displayed walks begin with a cost-`1` seed-exit. The first hop is
+   not an axis-one hop and is not a support-drop.
+3. The clause-toggle is displayed, not adopted. It is not written into
+   Admissibility. The uniform graph-length comparator is not attached as a
+   physical time.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact Dijkstra reconstruction exhibits the lex-first minimum-cost walks to the two reverse-diamond sites under the named (0,1,1) clause-toggle on B_6(0). The rule and the walks are displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: clause_011_reverse_paths
+target_blocker_text: "exhibit lex-first shortest paths that reverse diamond under the cheap-seed (0,1,1) clause-toggle"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the exhibited walks; do not write the clause-toggle into Admissibility and do not attach uniform graph-length as physical time"
+conditional_surface_status: "exact for the named (0,1,1) hop-cost on B_6(0); other clause triples, other radii, and any physical selector remain unclaimed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target And Proof Obligations
+
+**Exact target.** On `B_6(0)` under the named `(0,1,1)` hop-cost, exhibit the
+lex-first shortest walks from the origin to `(4,0,0)` and to `(2,2,2)`, record
+the hop-cost lists, confirm the lists sum to the arrival numbers `8` and `6`,
+and confirm that both walks start with a cost-`1` seed-exit. Do not treat the
+two arrival numbers as a substitute for the walks. Do not write the
+clause-toggle into Admissibility. Do not attach the uniform graph-length
+comparator.
+
+| Obligation | Disposition |
+|---|---|
+| named `(0,1,1)` hop-cost on `B_6(0)` | defined here; executed in Theorem 1 |
+| lex-first shortest walk `0 → (4,0,0)` with costs summing to `8` | proved here in Theorem 1 |
+| lex-first shortest walk `0 → (2,2,2)` with costs summing to `6` | proved here in Theorem 1 |
+| both walks start with a cost-`1` seed-exit | proved here in Theorem 2 |
+| walks are not leftover of the two-point times | proved here in Theorem 1 by exhibiting the hops |
+| clause-toggle not written into Admissibility | Theorem 3 |
+| uniform graph-length not attached | Theorem 3 |
+
+Boundary cases are not hidden. The axis-only walk
+`(0,0,0) → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0)` has hop-cost list
+`(1,3,3,3)` and sums to `10`, so it is not shortest. Charging seed-exit `3`
+as well recovers a different named triple and different arrivals. Other
+radii, other destinations, and any selector that would adopt the
+clause-toggle as the framework's nearest-neighbor rule are outside the
+target.
+
+## Inputs And Support Inventory
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the
+  cubic nearest-neighbor substrate and the one-fixed-rule Admissibility
+  sentence. As the registered `minimal_axioms` premise, it is not a
+  bounded-status source.
+- The three clause names (seed-exit, both-weights-one, support-drop) and the
+  toggle `(s,a,d) = (0,1,1)` are displayed mathematical hypotheses, not
+  framework-derived physical selectors.
+- No approved primitive is used. Scale reference, kinetic isotropy, and
+  realized-state evaluation are not inputs.
+- The uniform graph-length comparator that charges `1` on every
+  nearest-neighbor hop is a disclosed contrast only. It is not attached.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Record is quoted only to keep formation and readout outside the hop-cost:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility does not supply the formation site, probability, or rate. It
+also does not name a hop-cost, a two-point arrival table, or a preferred
+clause-toggle.
+
+## Objects
+
+Let `e_1 = (1,0,0)`, `e_2 = (0,1,0)`, `e_3 = (0,0,1)`. The six nearest-neighbor
+shifts are `±e_1`, `±e_2`, `±e_3`. The closed ball is
+
+```text
+B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }.
+```
+
+It contains exactly `377` sites. The directed graph used here has an edge
+`v → u` precisely when `u − v` is one of the six shifts and both endpoints
+lie in `B_6(0)`.
+
+Inward weight: `w(v) = |σ_v|`, the number of nonzero coordinates of `v`.
+Then `w(0) = 0`, `w(±e_i) = 1`, and `w((2,2,2)) = 3`.
+
+Named hop-cost for the displayed triple `(s,a,d) = (0,1,1)`:
+
+```text
+c(v → u) = 3  if  (w(v) = w(u) = 1)  or  (w(u) < w(v)),
+c(v → u) = 1  otherwise.
+```
+
+Seed-exit hops have `w(v) = 0` and therefore cost `1` under this triple.
+Axis-one hops and support-drop hops cost `3`.
+
+Arrival time `t(v)` is the minimum sum of hop-costs over directed walks from
+`0` to `v` that remain in `B_6(0)`.
+
+A walk from `0` to a target is a **shortest path** when its hop-cost sum
+equals `t(target)`. Among shortest paths, the **lex-first** walk is the one
+obtained by the following local rule, which is the ordinary lexicographic
+minimum on the sequence of sites: starting at `0`, if the walk so far ends
+at `v ≠ target`, the next site is the lexicographically smallest neighbor
+`u` for which some shortest `0 → target` walk continues `v → u`. Site order
+is the ordinary tuple order on `Z^3`.
+
+## Theorem 1 — Lex-first shortest paths
+
+**Statement.** Under the named `(0,1,1)` hop-cost on `B_6(0)`,
+
+- `t(4,0,0) = 8` and `t(2,2,2) = 6`,
+- the lex-first shortest path `0 → (4,0,0)` is the six-hop walk
+  `(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (4,0,0)`
+  with hop-cost list `(1,1,1,1,1,3)`,
+- the lex-first shortest path `0 → (2,2,2)` is the six-hop walk
+  `(0,0,0) → (0,0,1) → (0,1,1) → (0,1,2) → (0,2,2) → (1,2,2) → (2,2,2)`
+  with hop-cost list `(1,1,1,1,1,1)`.
+
+In particular `t(4,0,0) > t(2,2,2)`, so the two-point comparison on these
+sites reverses relative to uniform graph-length (where the same sites have
+arrivals `4` and `6`). The hop-cost lists are part of the claim: the result
+is not leftover of the two arrival numbers.
+
+**Proof.** The directed graph is finite. Dijkstra's algorithm from the origin
+computes every arrival. The same algorithm run backward from each target,
+using the original directed costs on reversed edges, computes remaining
+cost-to-target. A neighbor `u` of `v` lies on some shortest `0 → target`
+walk if and only if
+
+```text
+t(v) + c(v → u) = t(u)    and    t(u) + t_to_target(u) = t(target).
+```
+
+The lex-first reconstruction then always takes the lexicographically
+smallest such `u`. The runner executes both reconstructions.
+
+Direct inspection of the first walk: `w(0) = 0`, so the opening hop is a
+seed-exit of cost `1`. Each of the next four hops stays at inward weight
+`2` and is neither axis-one nor a support-drop, hence costs `1`. The last
+hop `(4,-1,0) → (4,0,0)` drops weight `2 → 1` and therefore costs `3`. The
+list sums to `8`, matching `t(4,0,0)`.
+
+Direct inspection of the second walk: the opening hop is again a seed-exit
+of cost `1`. The remaining five hops have weight pairs
+`(1,2)`, `(2,2)`, `(2,2)`, `(2,3)`, `(3,3)` and are therefore all cost `1`.
+The list sums to `6`, matching `t(2,2,2)`.
+
+The axis-only competitor to `(4,0,0)` is not shortest: after the cheap
+seed-exit, the three remaining hops are axis-one and cost `3` each, for
+total `10`. A first hop into the negative first-coordinate half-space cannot
+reach `(4,0,0)` at cost `8`, because returning across the plane `x = 0` and
+then advancing to `x = 4` plus a final axis-one or support-drop hop already
+overshoots. The reconstruction therefore begins at `(0,-1,0)`, the
+lexicographically smallest first site that still lies on a shortest walk.
+
+On the body-diagonal target, every first hop that decreases a coordinate
+forces a later compensating support-drop or a longer walk, and the
+remaining-cost test excludes those neighbors. The lexicographically
+smallest surviving first site is `(0,0,1)`.
+
+Thus the two walks, the two hop-cost lists, and the two arrival numbers are
+exhibited together.
+
+## Theorem 2 — Cheap seed-exit, displayed not adopted
+
+**Statement.** Both lex-first shortest paths of Theorem 1 start with a
+cost-`1` seed-exit. That opening hop is displayed as a feature of the named
+toggle. It is not adopted as a physical selector.
+
+**Proof.** Both walks begin `0 → u` with `w(0) = 0` and `w(u) = 1`. Seed-exit
+holds. Axis-one fails because the destination weight is `1` but the source
+weight is `0`, not `1`. Support-drop fails because the weight rises. Under
+`(s,a,d) = (0,1,1)` the hop therefore costs `1`. The hop-cost lists of
+Theorem 1 begin with that `1`.
+
+If seed-exit were charged `3` as well, the same opening hops would cost `3`
+and the displayed lists would no longer be the lists of Theorem 1. That is
+a different named triple. This note does not run that triple as a claim.
+
+## Theorem 3 — Not written into Admissibility; uniform graph-length not attached
+
+**Statement.** The named clause-toggle `(0,1,1)` is not written into
+Admissibility. The uniform graph-length comparator is not attached as a
+physical time, a hop-cost, or a two-point law. Uniqueness of the toggle
+among reversing rules is not claimed.
+
+**Proof.** Admissibility, as quoted above, supplies one fixed nearest-neighbor
+rule that determines a local possibility distribution from nearest-neighbor
+conditions. It does not name inward weights, seed-exit, axis-one hops,
+support-drop, or a numerical hop-cost. Inserting `(s,a,d) = (0,1,1)` into
+that sentence would be an axiom edit. This note proposes none.
+
+Uniform graph-length charges `1` on every nearest-neighbor hop and therefore
+gives arrivals `|v|_1`. On the two displayed sites those arrivals are `4`
+and `6`, which do not reverse. Using that comparator as a parent of the
+walks, or rewriting the walks as leftover of those two integers, would
+attach a different rule. The walks of Theorem 1 use the named toggle and
+are longer than graph-length on the axis site precisely because the last
+hop is a charged support-drop.
+
+No later selector is forbidden. The claim is only that the present
+exhibition does not perform the selection.
+
+## Boundary And Non-Claims
+
+- The note does not claim that `(0,1,1)` is the unique reversing
+  clause-toggle, nor that it minimizes any variance.
+- The note does not extend the ball past radius six, and it does not score
+  other destinations except as Dijkstra scaffolding for the two targets.
+- The note does not identify hop-cost with a Record readout, a formation
+  rate, or a nearest-neighbor possibility law.
+- The note does not attach uniform graph-length, and it does not treat the
+  two arrival numbers as a substitute for the exhibited walks.
+- The note does not propose axiom text.
+
+## Imports Table
+
+| Input | Role | Status language |
+|---|---|---|
+| live axiom memo | cubic nearest-neighbor substrate; Admissibility does not name a hop-cost | registered `minimal_axioms` premise |
+| displayed `(0,1,1)` toggle | finite hop-cost hypothesis | displayed, not adopted |
+| uniform graph-length | disclosed contrast only | not attached |
+
+No approved primitive is consumed.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the path-exhibition residual for the cheap-seed reversing toggle: the walks and hop-cost lists are produced, not only the two arrival numbers. |
+| V2 | Current `origin/main` has no landed source note exhibiting these two lex-first walks under the named `(0,1,1)` clause-toggle on `B_6(0)`. |
+| V3 | The graph, costs, and reconstructions are finite and exact. No observational input is used. |
+| V4 | The hop-cost lists distinguish the claim from a restatement of `t(4,0,0)=8` and `t(2,2,2)=6`. The axis-only competitor summing to `10` is an explicit contrast. |
+| V5 | The toggle is displayed, not adopted. It is not a physical time, not an Admissibility edit, and not a uniqueness theorem. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: this exhibition does not write `(0,1,1)`
+into Admissibility and does not attach uniform graph-length. No global
+impossibility for a later hop-cost selector is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| named `(0,1,1)` Dijkstra | charge axis-one and support-drop only | executed; yields the displayed walks |
+| axis-only competitor | stay on the first-coordinate axis | sums to `10`; not shortest |
+| charge seed-exit as well | use the triple `(1,1,1)` | different arrivals; not this claim |
+| uniform graph-length | charge `1` on every hop | arrivals `4` and `6`; no reverse; not attached |
+| write the toggle into Admissibility | treat hop-cost as the axiom's nearest-neighbor rule | axiom edit; not derived |
+| other radii or destinations | leave `B_6(0)` or change the two sites | different object |
+| later selector among reversing triples | uniqueness or variance ranking | live route; not claimed here |
+
+### N2 — wall independence
+
+The missing physical selector, the missing identification of hop-cost with
+Admissibility, and the missing uniqueness statement are distinct residuals.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball radius, the three clause names, the toggle `(0,1,1)`, the
+lex-first reconstruction rule, and the two targets are declared. Uniform
+graph-length is used only as a disclosed contrast.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate and
+does not name a hop-cost. The residual is therefore an exhibition under a
+displayed hypothesis, matching those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | named hops and inward-weight clauses | no continuum interpolation |
+| per site | arrivals at `(4,0,0)` and `(2,2,2)` | no lattice-wide time law |
+| per mode | no mode calculation | no spectral claim |
+| per block | one Dijkstra family and two lex-first reconstructions | no selector among all reversing triples |
+| lattice wide | checked and not executed | no Admissibility edit; no attached uniform graph-length |
+
+### N6 — live partial-closure paths
+
+Live routes include a later derivation that would select a hop-cost from
+Admissibility, a comparison among several reversing triples, a different
+radius, and a Record-typed reading of arrival. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once the two arrivals `8` and `6` are known, the paths are
+leftover and need not be exhibited.
+
+**Answer:** Several walks can share an arrival. The axis-only walk to
+`(4,0,0)` has a different hop-cost list and is not shortest. The lex-first
+rule plus the hop-cost lists are the content that the two integers do not
+record. Theorem 1 therefore exhibits the walks.
+
+### N8 — cross-cycle echo
+
+A full three-clause scan and a seed-exit-expensive support-drop rule are
+different objects. This note does not import their arrivals as premises. It
+recomputes the `(0,1,1)` walks on `B_6(0)` from the named cost.
+
+**Gate disposition:** PASS for the exhibited lex-first walks, the hop-cost
+lists, the cheap seed-exit opening, and the narrow non-adoption statements.
+FAIL / DO NOT SHIP for “Admissibility is `(0,1,1)`,” “uniform graph-length
+is the physical time,” or “no other reversing rule exists.”
+
+## Primary Runner
+
+The primary runner builds `B_6(0)`, evaluates the named hop-cost, computes
+arrivals by Dijkstra, reconstructs both lex-first shortest paths, checks the
+hop-cost lists and the cheap seed-exit openings, pins the current axiom
+wording, and runs mutation controls that replace the named toggle by uniform
+graph-length or by an expensive seed-exit. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2329,6 +2329,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_reverse_paths_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_reverse_paths_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_reverse_paths_2026_08_15.txt
@@ -1,0 +1,49 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_reverse_paths_2026_08_15.py
+runner_sha256: 2be8e76cbbef86b56ca9b54b74ea32eb61de5b86c99b0a0b4a619fa1c8a37c1c
+input_fingerprint_sha256: d631fb9acdd49a4be630da0dde794ff2a9891e8ebec0ba5d76dadedd05773d54
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice and Admissibility wording; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: named (0,1,1) hop-cost on B_6(0) with lex-first Dijkstra reconstruction
+negative_scope: displayed, not adopted; not written into Admissibility; uniform graph-length not attached
+PASS: audit-inputs declared source-bound inputs exist as the required string-literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current one-fixed-rule wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: ball-cardinality B_6(0) has exactly 377 integer sites
+PASS: targets-inside both reverse-diamond sites lie in B_6(0)
+PASS: clause-identity seed-exit is cheap and axis-one and support-drop cost 3
+lex_first_axis_path: (0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (4,0,0)
+lex_first_axis_costs: (1,1,1,1,1,3) sum=8
+lex_first_diag_path: (0,0,0) → (0,0,1) → (0,1,1) → (0,1,2) → (0,2,2) → (1,2,2) → (2,2,2)
+lex_first_diag_costs: (1,1,1,1,1,1) sum=6
+PASS: arrival-axis computed t(4,0,0) equals the reconstructed hop-cost sum
+PASS: arrival-diag computed t(2,2,2) equals the reconstructed hop-cost sum
+PASS: reverse-diamond the two-point comparison reverses on these sites
+PASS: axis-path-endpoints the axis reconstruction starts at the origin and ends at (4,0,0)
+PASS: diag-path-endpoints the body-diagonal reconstruction starts at the origin and ends at (2,2,2)
+PASS: note-axis-walk the note exhibits the computed axis walk and hop-cost list
+PASS: note-diag-walk the note exhibits the computed body-diagonal walk and hop-cost list
+PASS: not-leftover the hop-cost lists are longer than a two-point leftover
+PASS: cheap-seed-exit both lex-first walks open with a cost-1 seed-exit
+PASS: axis-only-not-shortest the axis-only competitor is strictly more expensive than t(4,0,0)
+PASS: graph-length-contrast uniform graph-length does not reverse and is not the named toggle
+PASS: mutation-seed-exit charging seed-exit 3 changes the opening hop and the arrivals
+PASS: mutation-graph-length replacing hop_cost by uniform ones would drop t(4,0,0) to graph-length 4
+PASS: note-contract machine fields, exhibition wording, N1-N8, and forbidden-phrase hygiene hold
+PASS: claim-scope front matter keeps the dispatch claim_scope
+per_element: inward-weight clauses and hop-costs are evaluated on named directed nearest-neighbor edges
+per_site: lex-first reconstructions are executed at (4,0,0) and (2,2,2) inside B_6(0)
+per_mode: checked and not executed — no spectral or harmonic mode claim occurs in this finite graph theorem
+per_block: one Dijkstra family, two lex-first walks, and two mutation controls are executed
+lattice_wide: checked and not executed — no Admissibility edit and no attached uniform graph-length time
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_reverse_paths_2026_08_15.py
+++ b/scripts/clause_011_reverse_paths_2026_08_15.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Exact lex-first shortest paths under the named (0,1,1) clause-toggle.
+
+The runner reconstructs the minimum-cost walks 0 → (4,0,0) and 0 → (2,2,2)
+on the closed radius-six nearest-neighbor ball. Seed-exit is cheap; axis-one
+and support-drop hops cost 3. The rule is displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_REVERSE_PATHS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+AXIS_SITE: Point = (4, 0, 0)
+DIAG_SITE: Point = (2, 2, 2)
+RADIUS = 6
+SHIFTS: tuple[Point, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+CLAUSE_011 = (0, 1, 1)
+EXPENSIVE_SEED = (1, 1, 1)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1_norm(site: Point) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def inward_weight(site: Point) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def ball_sites(radius: int = RADIUS) -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+BALL = ball_sites()
+
+
+def neighbors(site: Point) -> tuple[Point, ...]:
+    """Nearest-neighbor successors that remain inside B_6(0)."""
+    return tuple(dest for shift in SHIFTS if (dest := add(site, shift)) in BALL)
+
+
+def hop_clauses(src: Point, dest: Point) -> tuple[bool, bool, bool]:
+    source_weight = inward_weight(src)
+    dest_weight = inward_weight(dest)
+    seed_exit = source_weight == 0
+    both_weights_one = source_weight == 1 and dest_weight == 1
+    support_drop = dest_weight < source_weight
+    return seed_exit, both_weights_one, support_drop
+
+
+def hop_cost(src: Point, dest: Point, clauses: tuple[int, int, int] = CLAUSE_011) -> int:
+    """Named three-clause hop-cost. Identity-gate function."""
+    seed_exit, both_weights_one, support_drop = hop_clauses(src, dest)
+    seed_bit, axis_bit, drop_bit = clauses
+    if (seed_bit and seed_exit) or (axis_bit and both_weights_one) or (drop_bit and support_drop):
+        return 3
+    return 1
+
+
+def dijkstra_from(source: Point, clauses: tuple[int, int, int] = CLAUSE_011) -> dict[Point, int]:
+    dist = {source: 0}
+    heap: list[tuple[int, Point]] = [(0, source)]
+    while heap:
+        cost, site = heappop(heap)
+        if cost != dist[site]:
+            continue
+        for dest in neighbors(site):
+            candidate = cost + hop_cost(site, dest, clauses)
+            if dest not in dist or candidate < dist[dest]:
+                dist[dest] = candidate
+                heappush(heap, (candidate, dest))
+    return dist
+
+
+def remaining_to(target: Point, clauses: tuple[int, int, int] = CLAUSE_011) -> dict[Point, int]:
+    dist = {target: 0}
+    heap: list[tuple[int, Point]] = [(0, target)]
+    while heap:
+        cost, dest = heappop(heap)
+        if cost != dist[dest]:
+            continue
+        for src in neighbors(dest):
+            candidate = cost + hop_cost(src, dest, clauses)
+            if src not in dist or candidate < dist[src]:
+                dist[src] = candidate
+                heappush(heap, (candidate, src))
+    return dist
+
+
+def lex_first_shortest_path(
+    target: Point,
+    clauses: tuple[int, int, int] = CLAUSE_011,
+) -> tuple[tuple[Point, ...], tuple[int, ...]]:
+    arrivals = dijkstra_from(ORIGIN, clauses)
+    leftover = remaining_to(target, clauses)
+    if target not in arrivals or ORIGIN not in leftover:
+        raise RuntimeError(f"target {target} is unreachable")
+    if arrivals[target] != leftover[ORIGIN]:
+        raise RuntimeError("forward and reverse arrivals disagree")
+    path = [ORIGIN]
+    costs: list[int] = []
+    site = ORIGIN
+    goal = arrivals[target]
+    while site != target:
+        candidates = []
+        for dest in neighbors(site):
+            step = hop_cost(site, dest, clauses)
+            if arrivals[site] + step != arrivals[dest]:
+                continue
+            if arrivals[dest] + leftover[dest] != goal:
+                continue
+            candidates.append(dest)
+        if not candidates:
+            raise RuntimeError(f"lex reconstruction stuck at {site}")
+        dest = min(candidates)
+        costs.append(hop_cost(site, dest, clauses))
+        path.append(dest)
+        site = dest
+    return tuple(path), tuple(costs)
+
+
+def path_cost(path: tuple[Point, ...], clauses: tuple[int, int, int] = CLAUSE_011) -> int:
+    return sum(hop_cost(path[index], path[index + 1], clauses) for index in range(len(path) - 1))
+
+
+def format_path(path: tuple[Point, ...]) -> str:
+    return " → ".join(str(site).replace(" ", "") for site in path)
+
+
+def format_costs(costs: tuple[int, ...]) -> str:
+    return "(" + ",".join(str(cost) for cost in costs) + ")"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = (ROOT / AUDIT_INPUT_PATHS[0]).read_text(encoding="utf-8")
+    axiom = (ROOT / AUDIT_INPUT_PATHS[1]).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("external_scientific_inputs: current Lattice and Admissibility wording; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: named (0,1,1) hop-cost on B_6(0) with lex-first Dijkstra reconstruction")
+    print("negative_scope: displayed, not adopted; not written into Admissibility; uniform graph-length not attached")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_REVERSE_PATHS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_fixed = "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current one-fixed-rule wording is pinned", admissibility_fixed in normalized_axiom and admissibility_sentence in normalized_axiom and admissibility_sentence in note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check("source-formation-boundary", "formation site/probability/rate remains outside Admissibility", formation_boundary in normalized_axiom and formation_boundary in normalized_note)
+
+    checks.check("ball-cardinality", "B_6(0) has exactly 377 integer sites", len(BALL) == 377)
+    checks.check("targets-inside", "both reverse-diamond sites lie in B_6(0)", AXIS_SITE in BALL and DIAG_SITE in BALL)
+    checks.check(
+        "clause-identity",
+        "seed-exit is cheap and axis-one and support-drop cost 3",
+        hop_cost(ORIGIN, (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    arrivals = dijkstra_from(ORIGIN)
+    axis_path, axis_costs = lex_first_shortest_path(AXIS_SITE)
+    diag_path, diag_costs = lex_first_shortest_path(DIAG_SITE)
+    axis_sum = sum(axis_costs)
+    diag_sum = sum(diag_costs)
+
+    print(f"lex_first_axis_path: {format_path(axis_path)}")
+    print(f"lex_first_axis_costs: {format_costs(axis_costs)} sum={axis_sum}")
+    print(f"lex_first_diag_path: {format_path(diag_path)}")
+    print(f"lex_first_diag_costs: {format_costs(diag_costs)} sum={diag_sum}")
+
+    checks.check("arrival-axis", "computed t(4,0,0) equals the reconstructed hop-cost sum", arrivals[AXIS_SITE] == axis_sum == path_cost(axis_path))
+    checks.check("arrival-diag", "computed t(2,2,2) equals the reconstructed hop-cost sum", arrivals[DIAG_SITE] == diag_sum == path_cost(diag_path))
+    checks.check("reverse-diamond", "the two-point comparison reverses on these sites", arrivals[AXIS_SITE] > arrivals[DIAG_SITE])
+    checks.check(
+        "axis-path-endpoints",
+        "the axis reconstruction starts at the origin and ends at (4,0,0)",
+        axis_path[0] == ORIGIN and axis_path[-1] == AXIS_SITE and all(site in BALL for site in axis_path),
+    )
+    checks.check(
+        "diag-path-endpoints",
+        "the body-diagonal reconstruction starts at the origin and ends at (2,2,2)",
+        diag_path[0] == ORIGIN and diag_path[-1] == DIAG_SITE and all(site in BALL for site in diag_path),
+    )
+    checks.check(
+        "note-axis-walk",
+        "the note exhibits the computed axis walk and hop-cost list",
+        format_path(axis_path) in note and format_costs(axis_costs) in note,
+        residual=(format_path(axis_path), format_costs(axis_costs)),
+    )
+    checks.check(
+        "note-diag-walk",
+        "the note exhibits the computed body-diagonal walk and hop-cost list",
+        format_path(diag_path) in note and format_costs(diag_costs) in note,
+        residual=(format_path(diag_path), format_costs(diag_costs)),
+    )
+    checks.check(
+        "not-leftover",
+        "the hop-cost lists are longer than a two-point leftover",
+        len(axis_costs) > 1 and len(diag_costs) > 1 and axis_costs != diag_costs,
+    )
+
+    first_axis = hop_clauses(axis_path[0], axis_path[1])
+    first_diag = hop_clauses(diag_path[0], diag_path[1])
+    checks.check(
+        "cheap-seed-exit",
+        "both lex-first walks open with a cost-1 seed-exit",
+        axis_costs[0] == 1
+        and diag_costs[0] == 1
+        and first_axis == (True, False, False)
+        and first_diag == (True, False, False),
+    )
+
+    axis_only = (ORIGIN, (1, 0, 0), (2, 0, 0), (3, 0, 0), AXIS_SITE)
+    axis_only_costs = tuple(hop_cost(axis_only[index], axis_only[index + 1]) for index in range(len(axis_only) - 1))
+    checks.check(
+        "axis-only-not-shortest",
+        "the axis-only competitor is strictly more expensive than t(4,0,0)",
+        path_cost(axis_only) == sum(axis_only_costs) > arrivals[AXIS_SITE] and axis_only_costs[0] == 1 and set(axis_only_costs[1:]) == {3},
+    )
+
+    graph_length_axis = l1_norm(AXIS_SITE)
+    graph_length_diag = l1_norm(DIAG_SITE)
+    checks.check(
+        "graph-length-contrast",
+        "uniform graph-length does not reverse and is not the named toggle",
+        graph_length_axis == 4
+        and graph_length_diag == 6
+        and graph_length_axis < graph_length_diag
+        and (graph_length_axis, graph_length_diag) != (arrivals[AXIS_SITE], arrivals[DIAG_SITE]),
+    )
+
+    expensive = dijkstra_from(ORIGIN, EXPENSIVE_SEED)
+    expensive_axis_path, expensive_axis_costs = lex_first_shortest_path(AXIS_SITE, EXPENSIVE_SEED)
+    checks.check(
+        "mutation-seed-exit",
+        "charging seed-exit 3 changes the opening hop and the arrivals",
+        expensive[AXIS_SITE] != arrivals[AXIS_SITE]
+        and expensive[DIAG_SITE] != arrivals[DIAG_SITE]
+        and expensive_axis_costs[0] == 3
+        and hop_cost(ORIGIN, (1, 0, 0), EXPENSIVE_SEED) == 3,
+    )
+    checks.check(
+        "mutation-graph-length",
+        "replacing hop_cost by uniform ones would drop t(4,0,0) to graph-length 4",
+        arrivals[AXIS_SITE] != graph_length_axis and hop_cost((4, -1, 0), AXIS_SITE) == 3,
+    )
+
+    allowed_retained = ("audit_required_before_effective_retained: true", "bare_retained_allowed: false")
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        "hypothetical_axiom_status: \"no edit\"",
+        "Displayed, not adopted",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "not leftover of the two-point times",
+        "not written into Admissibility",
+        "uniform graph-length",
+    )
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "we adopt",
+        "new axiom",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, exhibition wording, N1-N8, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and not any(phrase in note for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "Codex" not in note
+        and "toe-lphys" not in note,
+        residual=[phrase for phrase in required if phrase not in note],
+    )
+    checks.check(
+        "claim-scope",
+        "front matter keeps the dispatch claim_scope",
+        'Shortest paths under the named (0,1,1) clause-toggle that reverse diamond on B_6(0) are exhibited. Displayed, not adopted.'
+        in note,
+    )
+
+    print("per_element: inward-weight clauses and hop-costs are evaluated on named directed nearest-neighbor edges")
+    print("per_site: lex-first reconstructions are executed at (4,0,0) and (2,2,2) inside B_6(0)")
+    print("per_mode: checked and not executed — no spectral or harmonic mode claim occurs in this finite graph theorem")
+    print("per_block: one Dijkstra family, two lex-first walks, and two mutation controls are executed")
+    print("lattice_wide: checked and not executed — no Admissibility edit and no attached uniform graph-length time")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Rule (0,1,1): 0 to (4,0,0) costs 1+1+1+1+1+3=8; 0 to (2,2,2) is six 1s. Both start with cheap seed-exit. Displayed, not adopted. No axiom edit.

## Runner

`scripts/clause_011_reverse_paths_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.