### PR TITLE
feat(mix8): six of twelve B8 arrival shells mix radii; t=8 is mixed

### DIFF
--- a/docs/SUPPORT_DROP_MIXED_SHELLS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_MIXED_SHELLS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,196 @@
+---
+claim_id: support_drop_mixed_shells_b8_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Mixed t=const shells under the named support-drop hop-cost on B_8(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_mixed_shells_b8_2026_08_15.py
+---
+
+# Mixed t=const Shells Of The Named Support-Drop Hop-Cost On B_8(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival field for a named six-neighbor hop-cost on the
+closed ℓ¹ ball of radius 8 in `Z^3`. The mixed `t`-constant shells are named
+by arrival value, site count, and number of distinct Euclidean radii. The
+cost and the census are displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_mixed_shells_b8_2026_08_15.py`](../scripts/support_drop_mixed_shells_b8_2026_08_15.py)
+
+## Result Up Front
+
+On `B_8(0)={v in Z^3 : |v|_1 <= 8}` (833 sites), let `σ_v` be the set of
+nonzero coordinates of `v`, and write `|σ_v|` for its cardinality. On the
+six-neighbor graph restricted to this ball, the named support-drop hop-cost is
+
+```text
+ν(v → w) = 3  if |σ_v|=0 or (|σ_v|=|σ_w|=1) or |σ_w| < |σ_v|,
+         = 1  otherwise.
+```
+
+Let `t` be first-arrival time from the origin under one Dijkstra with this
+cost. The 832 nonzero sites carry exactly twelve distinct arrival values
+
+```text
+{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16}.
+```
+
+Six of those twelve values are single Euclidean radii. The other six mix
+more than one `|v|_2^2`. Those mixed arrivals, named rather than left as a
+six-of-twelve bit, are:
+
+| `t` | sites | distinct `|v|_2^2` | the set of `|v|_2^2` |
+|---|---:|---:|---|
+| `t=5` | 32 | 2 | `{3, 5}` |
+| `t=6` | 66 | 4 | `{4, 6, 8, 10}` |
+| `t=7` | 96 | 4 | `{9, 11, 13, 17}` |
+| `t=8` | 140 | 5 | `{12, 14, 18, 20, 26}` |
+| `t=9` | 198 | 8 | `{9, 17, 19, 21, 25, 27, 29, 37}` |
+| `t=10` | 258 | 10 | `{16, 22, 24, 26, 30, 32, 34, 38, 40, 50}` |
+
+The reverse-critical shell `t=8` is present and is among the mixed shells:
+it holds 140 sites and five distinct radii, and it contains the body-diagonal
+type `(2,2,2)` with `|v|_2^2=12`. Displayed, not adopted.
+
+Do not write `ν` into Admissibility. Do not attach L1. The named cost is
+not attached as a hop-cost law.
+
+## Named Objects
+
+`B_8(0)` is the closed ℓ¹ ball of radius 8. Lattice supplies nearest-neighbor
+adjacency and the proper cubic rotations about each site. The hop-cost `ν` is
+not Admissibility content: Admissibility supplies one fixed nearest-neighbor
+probability rule and does not name a path metric, a seed-exit penalty, an
+axis-skeleton penalty, or a support-drop penalty.
+
+The three clauses of `ν` are:
+
+1. seed-exit: `|σ_v|=0`, the unique hop leaving the origin;
+2. both-weights-1: `|σ_v|=|σ_w|=1`, a hop along the coordinate-axis 1-skeleton;
+3. support drop: `|σ_w| < |σ_v|`, a hop that strictly decreases the number of
+   occupied axes.
+
+Each expensive clause costs 3; every other six-neighbor hop that stays in the
+ball costs 1. Uniqueness of this cost among all integer hop-costs is not
+claimed.
+
+A `t`-constant shell is the set of nonzero sites with a fixed arrival. It is
+mixed when that set contains more than one value of `|v|_2^2`. Euclidean
+radius enters only as that diagnostic. No inverse-power radial law is used.
+
+The phrase reverse-critical `t=8` names the unique shell that contains the
+body-diagonal type `(2,2,2)` under this displayed cost. This note does not
+re-score the diamond comparison and does not adopt that shell as a physical
+clock.
+
+## Theorem 1 — Named Mixed Arrival Values
+
+One Dijkstra on the 833-site graph produces a unique finite arrival `t(v)` at
+every site. Restricting to `B_8(0)\{0}` yields twelve arrival values. The
+six mixed values, with site counts and distinct-radius counts computed on
+this ball, are exactly the table above.
+
+The same census written as named rows:
+
+- `t=5`: 32 sites, 2 distinct `|v|_2^2`, set `{3, 5}`.
+- `t=6`: 66 sites, 4 distinct `|v|_2^2`, set `{4, 6, 8, 10}`.
+- `t=7`: 96 sites, 4 distinct `|v|_2^2`, set `{9, 11, 13, 17}`.
+- `t=8`: 140 sites, 5 distinct `|v|_2^2`, set `{12, 14, 18, 20, 26}`.
+- `t=9`: 198 sites, 8 distinct `|v|_2^2`, set `{9, 17, 19, 21, 25, 27, 29, 37}`.
+- `t=10`: 258 sites, 10 distinct `|v|_2^2`, set `{16, 22, 24, 26, 30, 32, 34, 38, 40, 50}`.
+
+Site counts sum to 790. The remaining 42 nonzero sites occupy the six
+single-radius arrivals `t in {3, 4, 11, 12, 13, 16}` and are not the target
+of this note.
+
+The first mixed shell is already `t=5`, which joins the body-diagonal type
+`(1,1,1)` (`|v|_2^2=3`) to the type `(2,1,0)` (`|v|_2^2=5`). The largest
+mixed shell is `t=10`, which joins ten radii including the axis type
+`(4,0,0)` (`|v|_2^2=16`). These identities are computed on `B_8(0)` itself.
+They are not leftovers of a mixed-shell bit that only said six of twelve mix.
+
+## Theorem 2 — Reverse-Critical `t=8` Is Mixed
+
+The shell `t=8` is present on this ball. It is not single-radius: it
+contains five distinct `|v|_2^2` values `{12, 14, 18, 20, 26}` on 140 sites.
+The body-diagonal type `(2,2,2)` arrives at `t=8` with `|v|_2^2=12`, so this
+is the reverse-critical shell of the named cost.
+
+That shell is among the six mixed arrivals of Theorem 1. The statement is
+displayed, not adopted: naming the shell and recording that it mixes five
+radii does not select a physical time metric, a diamond law, or a Record
+readout.
+
+## Theorem 3 — Boundary
+
+Do not write `ν` into Admissibility. The current axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) names one
+fixed nearest-neighbor admissibility rule by which, for each site, the
+probability distribution over local possibilities is determined by, and varies
+with, the nearest-neighbor conditions. That clause does not supply hop-costs,
+arrival times, mixed shells, or a preferred path metric. This note does not
+amend the axiom memo.
+
+Do not attach L1. The mixed-shell census is a property of the named cost
+alone. An ℓ¹ arrival is not used, not scored, and not attached.
+
+The named cost is a displayed scoring rule on `B_8(0)`. It is not adopted as
+a dynamics, a time metric, a clock, or a Record readout.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_8(0) names the six mixed t-constant shells by arrival, site count, and distinct |v|_2^2. The named cost remains displayed, not adopted."
+trace_class: bounded_positive
+artifact_role: theorem
+conditional_surface_status: "exact on the named hop-cost restricted to B_8(0); no axiom or time-metric closure"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Proof-Obligation Graph
+
+| Obligation | Disposition |
+|---|---|
+| name `B_8(0)` and the six-neighbor graph | closed: ℓ¹ ball of radius 8, 833 sites |
+| name `ν` by the three support-weight clauses | closed: seed-exit, both-weights-1, support drop |
+| compute one Dijkstra arrival field | closed by the primary runner |
+| list every mixed `t` on `B_8(0)\{0}` | closed: `{5, 6, 7, 8, 9, 10}` |
+| report distinct `|v|_2^2` count and site count for each mixed `t` | closed: table above |
+| decide whether reverse-critical `t=8` is mixed | closed: mixed, five radii, 140 sites |
+| write `ν` into Admissibility | refused |
+| attach L1 | refused |
+| adopt `ν` as a physical time metric | outside the claim |
+
+The obligation graph is acyclic. Every leaf of the bounded report is closed
+on `B_8(0)`. Axiom edits, adoption, and any statement outside this ball are
+not proof leaves.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| Lattice nearest-neighbor adjacency | graph of the ball | current minimal axiom memo |
+| Admissibility | negative boundary only | current minimal axiom memo; not a hop-cost |
+| `ν` | named displayed hop-cost | declared in this note |
+| `B_8(0)` | declared finite domain | 833 integer sites |
+| ℓ¹ arrival | not used | not attached |
+
+There are no measured, fitted, literature, or observational inputs. The
+result does not select a physical clock, a Lorentzian reconstruction, or a
+Record-to-time bridge.
+
+## Review Record
+
+The residual asked for the mixed arrival values of the named support-drop
+hop-cost on `B_8(0)`, together with the number of distinct `|v|_2^2` in each
+shell, not for a leftover mixed-shell bit and not for an adopted law. The
+durable content is the six-row census and the display that `t=8` is mixed.
+No axiom sentence is added.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_mixed_shells_b8_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_mixed_shells_b8_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_mixed_shells_b8_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_mixed_shells_b8_2026_08_15.py
+runner_sha256: 8c908c6ad6997410cfd7997c213127a3aa3b7ff92228a16dab27d9f033b0c94d
+input_fingerprint_sha256: 2017b1ad56448ce37150d6d255ccc66f5e832b23a61d372fffcee277268eedd4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_MIXED_SHELLS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count: 1
+external_scientific_inputs: none; the named support-drop hop-cost is a declared displayed rule on B_8(0)
+claim_scope: Mixed t=const shells under the named support-drop hop-cost on B_8(0) are named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and current axiom memo
+PASS: ball-cardinality B_8(0) is the closed ℓ¹ ball of radius 8 and has 833 sites
+PASS: one-dijkstra-complete the single Dijkstra reaches every site of B_8(0)
+PASS: origin-time-zero t(0,0,0) = 0 and the origin is excluded from the mixed-shell census
+arrival_values=[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16]
+n_arrival_values=12
+single_radius_t=[3, 4, 11, 12, 13, 16]
+mixed_t=[5, 6, 7, 8, 9, 10]
+mixed t=5 sites=32 n_|v|_2^2=2 radii=[3, 5]
+mixed t=6 sites=66 n_|v|_2^2=4 radii=[4, 6, 8, 10]
+mixed t=7 sites=96 n_|v|_2^2=4 radii=[9, 11, 13, 17]
+mixed t=8 sites=140 n_|v|_2^2=5 radii=[12, 14, 18, 20, 26]
+mixed t=9 sites=198 n_|v|_2^2=8 radii=[9, 17, 19, 21, 25, 27, 29, 37]
+mixed t=10 sites=258 n_|v|_2^2=10 radii=[16, 22, 24, 26, 30, 32, 34, 38, 40, 50]
+reverse_critical_t=8 sites=140 n_|v|_2^2=5 mixed=True
+PASS: twelve-arrival-values B_8(0)\{0} carries exactly twelve distinct arrival values
+PASS: six-of-twelve-mixed exactly six of those twelve arrival values mix Euclidean radii
+PASS: named-mixed-shells each mixed t is named with its site count and distinct |v|_2^2 count
+PASS: mixed-t5 t=5 has 32 sites and 2 distinct |v|_2^2 [3, 5]
+PASS: mixed-t6 t=6 has 66 sites and 4 distinct |v|_2^2 [4, 6, 8, 10]
+PASS: mixed-t7 t=7 has 96 sites and 4 distinct |v|_2^2 [9, 11, 13, 17]
+PASS: mixed-t8 t=8 has 140 sites and 5 distinct |v|_2^2 [12, 14, 18, 20, 26]
+PASS: mixed-t9 t=9 has 198 sites and 8 distinct |v|_2^2 [9, 17, 19, 21, 25, 27, 29, 37]
+PASS: mixed-t10 t=10 has 258 sites and 10 distinct |v|_2^2 [16, 22, 24, 26, 30, 32, 34, 38, 40, 50]
+PASS: t8-present-and-mixed the reverse-critical t=8 shell is present and mixes five Euclidean radii
+PASS: t8-contains-body-diagonal t(2,2,2)=8, so the reverse-critical body-diagonal type sits in the mixed t=8 shell
+PASS: not-leftover-mixed-bit the census is the six named mixed arrivals with radii counts, not a leftover six-mix bit
+PASS: named-cost-clauses ν is 3 on seed-exit, both-weights-1, and support-drop, else 1
+PASS: forbidden-tokens the note avoids the forbidden tokens
+PASS: displayed-not-adopted the mixed shells are displayed, not adopted
+PASS: nu-not-admissibility the note refuses to write ν into Admissibility, and the axiom memo is untouched by this claim
+PASS: l1-not-attached L1 is not attached as a hop-cost, comparator, or leftover
+PASS: claim-scope-text the note states the declared mixed-shell claim_scope
+PASS: note-names-mixed-arrivals the note names each mixed t with its distinct-radius count and site count
+PASS: note-records-t8-mixed the note displays the reverse-critical t=8 shell as mixed, not adopted
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_mixed_shells_b8_2026_08_15.py
+++ b/scripts/support_drop_mixed_shells_b8_2026_08_15.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Mixed t=const shells of the named support-drop hop-cost on B_8(0).
+
+One Dijkstra on the six-neighbor graph of the closed ℓ¹ ball of radius 8.
+Names each mixed arrival and the number of distinct |v|_2^2 in that shell.
+The named cost is displayed, not adopted. No cache is written and
+Admissibility is not edited. L1 is not attached.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_MIXED_SHELLS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_MIXED_SHELLS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+RADIUS = 8
+NEIGHBORS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def radius2(site: tuple[int, int, int]) -> int:
+    return site[0] * site[0] + site[1] * site[1] + site[2] * site[2]
+
+
+def support_weight(site: tuple[int, int, int]) -> int:
+    return sum(coord != 0 for coord in site)
+
+
+def support_drop_cost(
+    source: tuple[int, int, int],
+    target: tuple[int, int, int],
+) -> int:
+    source_weight = support_weight(source)
+    target_weight = support_weight(target)
+    if source_weight == 0 or (source_weight == 1 and target_weight == 1) or target_weight < source_weight:
+        return 3
+    return 1
+
+
+def ball_sites(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            for z in range(-radius, radius + 1):
+                if abs(x) + abs(y) + abs(z) <= radius:
+                    sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_times(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    allowed = set(sites)
+    infinity = 10**9
+    arrival = {site: infinity for site in sites}
+    origin = (0, 0, 0)
+    arrival[origin] = 0
+    queue: list[tuple[int, tuple[int, int, int]]] = [(0, origin)]
+    while queue:
+        time, site = heappop(queue)
+        if time != arrival[site]:
+            continue
+        for step in NEIGHBORS:
+            neighbor = (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+            if neighbor not in allowed:
+                continue
+            candidate = time + support_drop_cost(site, neighbor)
+            if candidate < arrival[neighbor]:
+                arrival[neighbor] = candidate
+                heappush(queue, (candidate, neighbor))
+    return arrival
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count: 1")
+    print(
+        "external_scientific_inputs: none; the named support-drop hop-cost is a "
+        "declared displayed rule on B_8(0)"
+    )
+    print(
+        "claim_scope: Mixed t=const shells under the named support-drop "
+        "hop-cost on B_8(0) are named. Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball_sites(RADIUS)
+    checks.check(
+        "ball-cardinality",
+        "B_8(0) is the closed ℓ¹ ball of radius 8 and has 833 sites",
+        len(sites) == 833,
+        residual=len(sites),
+    )
+
+    arrival = dijkstra_times(sites)
+    checks.check(
+        "one-dijkstra-complete",
+        "the single Dijkstra reaches every site of B_8(0)",
+        all(arrival[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "origin-time-zero",
+        "t(0,0,0) = 0 and the origin is excluded from the mixed-shell census",
+        arrival[(0, 0, 0)] == 0,
+    )
+
+    shells: dict[int, set[int]] = defaultdict(set)
+    shell_count: dict[int, int] = defaultdict(int)
+    for site in sites:
+        if site == (0, 0, 0):
+            continue
+        shells[arrival[site]].add(radius2(site))
+        shell_count[arrival[site]] += 1
+
+    all_times = sorted(shells)
+    mixed_times = [time for time in all_times if len(shells[time]) > 1]
+    single_times = [time for time in all_times if len(shells[time]) == 1]
+    mixed_rows = [
+        (time, shell_count[time], len(shells[time]), tuple(sorted(shells[time])))
+        for time in mixed_times
+    ]
+
+    print(f"arrival_values={all_times}")
+    print(f"n_arrival_values={len(all_times)}")
+    print(f"single_radius_t={single_times}")
+    print(f"mixed_t={mixed_times}")
+    for time, n_sites, n_radii, radii in mixed_rows:
+        print(f"mixed t={time} sites={n_sites} n_|v|_2^2={n_radii} radii={list(radii)}")
+    if 8 in shells:
+        print(
+            f"reverse_critical_t=8 sites={shell_count[8]} "
+            f"n_|v|_2^2={len(shells[8])} mixed={len(shells[8]) > 1}"
+        )
+
+    checks.check(
+        "twelve-arrival-values",
+        "B_8(0)\\{0} carries exactly twelve distinct arrival values",
+        all_times == [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16],
+        residual=all_times,
+    )
+    checks.check(
+        "six-of-twelve-mixed",
+        "exactly six of those twelve arrival values mix Euclidean radii",
+        mixed_times == [5, 6, 7, 8, 9, 10] and len(single_times) == 6,
+        residual=mixed_times,
+    )
+
+    expected_mixed = {
+        5: (32, 2, (3, 5)),
+        6: (66, 4, (4, 6, 8, 10)),
+        7: (96, 4, (9, 11, 13, 17)),
+        8: (140, 5, (12, 14, 18, 20, 26)),
+        9: (198, 8, (9, 17, 19, 21, 25, 27, 29, 37)),
+        10: (258, 10, (16, 22, 24, 26, 30, 32, 34, 38, 40, 50)),
+    }
+    computed_map = {time: (n_sites, n_radii, radii) for time, n_sites, n_radii, radii in mixed_rows}
+    checks.check(
+        "named-mixed-shells",
+        "each mixed t is named with its site count and distinct |v|_2^2 count",
+        computed_map == expected_mixed,
+        residual=computed_map,
+    )
+    for time, (n_sites, n_radii, radii) in expected_mixed.items():
+        checks.check(
+            f"mixed-t{time}",
+            f"t={time} has {n_sites} sites and {n_radii} distinct |v|_2^2 {list(radii)}",
+            computed_map.get(time) == (n_sites, n_radii, radii),
+            residual=computed_map.get(time),
+        )
+
+    checks.check(
+        "t8-present-and-mixed",
+        "the reverse-critical t=8 shell is present and mixes five Euclidean radii",
+        8 in mixed_times and computed_map[8] == (140, 5, (12, 14, 18, 20, 26)),
+        residual=computed_map.get(8),
+    )
+    checks.check(
+        "t8-contains-body-diagonal",
+        "t(2,2,2)=8, so the reverse-critical body-diagonal type sits in the mixed t=8 shell",
+        arrival[(2, 2, 2)] == 8 and radius2((2, 2, 2)) == 12,
+        residual=arrival[(2, 2, 2)],
+    )
+    checks.check(
+        "not-leftover-mixed-bit",
+        "the census is the six named mixed arrivals with radii counts, not a leftover six-mix bit",
+        sum(row[1] for row in mixed_rows) == 32 + 66 + 96 + 140 + 198 + 258
+        and {row[0] for row in mixed_rows} == set(expected_mixed)
+        and all(row[2] > 1 for row in mixed_rows),
+    )
+
+    seed_exit = support_drop_cost((0, 0, 0), (1, 0, 0)) == 3
+    axis_skeleton = support_drop_cost((1, 0, 0), (2, 0, 0)) == 3
+    drop_clause = support_drop_cost((1, 1, 0), (1, 0, 0)) == 3
+    cheap_raise = support_drop_cost((1, 1, 0), (1, 1, 1)) == 1
+    checks.check(
+        "named-cost-clauses",
+        "ν is 3 on seed-exit, both-weights-1, and support-drop, else 1",
+        seed_exit and axis_skeleton and drop_clause and cheap_raise,
+    )
+
+    forbidden = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+    checks.check(
+        "forbidden-tokens",
+        "the note avoids the forbidden tokens",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the mixed shells are displayed, not adopted",
+        "Displayed, not adopted" in note and "not adopted" in note,
+    )
+    checks.check(
+        "nu-not-admissibility",
+        "the note refuses to write ν into Admissibility, and the axiom memo is untouched by this claim",
+        "Do not write" in note
+        and "Admissibility" in note
+        and "named support-drop hop-cost" in note
+        and "ν" not in axiom
+        and "support-drop" not in axiom,
+    )
+    checks.check(
+        "l1-not-attached",
+        "L1 is not attached as a hop-cost, comparator, or leftover",
+        "Do not attach L1" in note
+        and "not attached" in note
+        and "var(|v|_2/t)" not in note
+        and "var_ℓ" not in note,
+    )
+    checks.check(
+        "claim-scope-text",
+        "the note states the declared mixed-shell claim_scope",
+        "Mixed t=const shells under the named support-drop hop-cost on B_8(0) are named."
+        in note,
+    )
+    checks.check(
+        "note-names-mixed-arrivals",
+        "the note names each mixed t with its distinct-radius count and site count",
+        all(
+            f"t={time}" in note and str(n_sites) in note and str(n_radii) in note
+            for time, (n_sites, n_radii, _radii) in expected_mixed.items()
+        )
+        and "{3, 5}" in note
+        and "{4, 6, 8, 10}" in note
+        and "{9, 11, 13, 17}" in note
+        and "{12, 14, 18, 20, 26}" in note
+        and "{9, 17, 19, 21, 25, 27, 29, 37}" in note
+        and "{16, 22, 24, 26, 30, 32, 34, 38, 40, 50}" in note,
+    )
+    checks.check(
+        "note-records-t8-mixed",
+        "the note displays the reverse-critical t=8 shell as mixed, not adopted",
+        "t=8" in note
+        and "140" in note
+        and "five" in note
+        and "Displayed, not adopted" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_8(0) under nu, twelve arrival values; six mix Euclidean radii. The reverse-critical t=8 shell (140 sites, five radii) is mixed and contains (2,2,2). Displayed, not adopted. Do not write nu into Admissibility.

## Runner

`scripts/support_drop_mixed_shells_b8_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.