### PR TITLE
feat(nu12): B12 still reverses (4,0,0) vs (2,2,2); doubled pair does not

### DIFF
--- a/docs/SUPPORT_DROP_HOPCOST_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_HOPCOST_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,195 @@
+---
+claim_id: support_drop_hopcost_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On B_12(0), the named support-drop hop-cost is scored for diamond reverse and for var(|v|_2/t) vs ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_hopcost_b12_2026_08_15.py
+---
+
+# Named Support-Drop Hop-Cost On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only for diamond reverse at `(4,0,0)` versus `(2,2,2)` and at
+`(8,0,0)` versus `(4,4,4)`, and for population variance of `|v|_2/t`
+against unit-cost ℓ¹ arrival.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_hopcost_b12_2026_08_15.py`](../scripts/support_drop_hopcost_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost `ν` already scored on `B_8(0)` is
+scored independently on `B_12(0)`. The ball is not a leftover of the
+radius-`8` arrival table: `t(8,0,0)` on this ball is not the radius-`8`
+value, and `t(12,0,0)` is a new site.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not
+claimed.
+
+One Dijkstra from the origin on `B_12(0)` (2625 sites; 2624 nonzero) gives
+
+`t(4,0,0) = 10`, `t(8,0,0) = 14`, `t(12,0,0) = 20`, `t(2,2,2) = 8`,
+`t(4,4,4) = 14`.
+
+Then `12 t(4,0,0)^2 = 1200` and `16 t(2,2,2)^2 = 1024`, so
+
+`12 t(4,0,0)^2 > 16 t(2,2,2)^2`.
+
+The original diamond comparison still reverses. The doubled-scale pair is
+`12 t(8,0,0)^2 = 2352` and `16 t(4,4,4)^2 = 3136`, so
+
+`12 t(8,0,0)^2 > 16 t(4,4,4)^2`
+
+fails. Population variances of `|v|_2/t` on `B_12(0) \ {0}` are
+
+`var_ν = 0.00666073807018`, `var_ℓ¹ = 0.00944742571906`.
+
+So `var_ν < var_ℓ¹`. The `ν` variance is strictly smaller.
+
+The rule is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph. Unit-cost ℓ¹ arrival is the closed form `t_ℓ¹(v) = |v|_1`; it
+is not obtained from a second Dijkstra.
+
+On the smaller ball `B_8(0)` the same local rule gives `t(8,0,0) = 16`,
+because `(8,1,0)` lies outside that ball and the only in-ball last step onto
+`(8,0,0)` is the axis hop from `(7,0,0)`. On `B_12(0)` the site `(8,1,0)`
+is interior, the support-drop last step is available, and
+`t(8,0,0) = 14`. The site `(12,0,0)` is not in `B_8(0)` at all. The
+`B_12(0)` table is therefore not leftover of the `B_8(0)` times.
+
+## Theorem 1 — Arrivals And Diamond Reverse
+
+One origin Dijkstra on `B_12(0)` returns the integer arrivals
+
+| site | `t_ν` | `t_ℓ¹` |
+|---|---:|---:|
+| `(4,0,0)` | `10` | `4` |
+| `(8,0,0)` | `14` | `8` |
+| `(12,0,0)` | `20` | `12` |
+| `(2,2,2)` | `8` | `6` |
+| `(4,4,4)` | `14` | `12` |
+
+Witnessing paths of those `ν`-costs exist. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (4,0,0)`
+
+has hop-costs `3,1,1,1,1,3` and sum `10`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2)`
+
+has hop-costs `3,1,1,1,1,1` and sum `8`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (8,0,0)`
+
+has hop-costs `3,1,1,1,1,1,1,1,1,3` and sum `14`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2) → (3,2,2) → (3,3,2) → (3,3,3) → (4,3,3) → (4,4,3) → (4,4,4)`
+
+has hop-costs `3,1,1,1,1,1,1,1,1,1,1,1` and sum `14`. The only in-ball
+neighbor of `(12,0,0)` is `(11,0,0)`, so the last hop is the
+both-weights-`1` axis step of cost `3`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (9,1,0) → (10,1,0) → (11,1,0) → (11,0,0) → (12,0,0)`
+
+has hop-costs `3,1,1,1,1,1,1,1,1,1,1,1,3,3` and sum `20`.
+
+The Euclidean-normalized comparison is `t^2 / |v|_2^2`, equivalently
+
+`12 t(4,0,0)^2 ? 16 t(2,2,2)^2`.
+
+Substituting the computed times gives `1200 > 1024`. The inequality
+reverses: arrival per Euclidean length is larger at `(4,0,0)` than at
+`(2,2,2)`. Under unit-cost ℓ¹ the same comparison is `192 > 576`, which
+fails.
+
+The doubled-scale pair is
+
+`12 t(8,0,0)^2 ? 16 t(4,4,4)^2`.
+
+Substituting gives `2352 > 3136`, which fails. On `B_12(0)` the named rule
+still reverses the original diamond and does not reverse the doubled
+diamond.
+
+## Theorem 2 — Population Variance Of `|v|_2/t`
+
+On the 2624 nonzero sites of `B_12(0)`, let `r(v) = |v|_2 / t(v)` and write
+population variance `(1/n) ∑ (r − mean)^2`. The runner computes
+
+`var_ν = 0.00666073807018`, `var_ℓ¹ = 0.00944742571906`.
+
+So `var_ν < var_ℓ¹`. The named rule is more nearly Euclidean-isotropic
+than unit-cost ℓ¹ on this ball, in the population-variance sense stated
+here. No uniqueness among hop-costs is claimed.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_12(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+diamond reverse or with variance below ℓ¹.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer arrivals and a population-variance comparison on the finite ball B_12(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs that reverse the diamond or beat ℓ¹
+  variance.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any reuse of the `B_8(0)` arrival table as a substitute for the
+  radius-`12` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_hopcost_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_hopcost_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_hopcost_b12_2026_08_15.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_hopcost_b12_2026_08_15.py
+runner_sha256: 2e442c9d0a727b28356e1028242cfc3ee9a096f1b534f36fe5465151c7f332db
+input_fingerprint_sha256: 6ac986dcb09e46c130462c25f495b58101f0020f24e59461da11a69aed046ee5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_HOPCOST_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: On B_12(0), the named support-drop hop-cost is scored for diamond reverse and for var(|v|_2/t) vs ℓ¹. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+t(4,0,0) 10
+t(8,0,0) 14
+t(12,0,0) 20
+t(2,2,2) 8
+t(4,4,4) 14
+12 t(4,0,0)^2 1200
+16 t(2,2,2)^2 1024
+12 t(8,0,0)^2 2352
+16 t(4,4,4)^2 3136
+diamond_reverse True
+double_diamond_reverse False
+var_nu 0.00666073807018
+var_l1 0.00944742571906
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: reachable every site of B_12(0) is reached
+PASS: t-400 t(4,0,0) = 10
+PASS: t-800 t(8,0,0) = 14
+PASS: t-1200 t(12,0,0) = 20
+PASS: t-222 t(2,2,2) = 8
+PASS: t-444 t(4,4,4) = 14
+PASS: diamond-reverse 12 t(4,0,0)^2 > 16 t(2,2,2)^2
+PASS: double-diamond-not-reverse 12 t(8,0,0)^2 > 16 t(4,4,4)^2 fails
+PASS: note-records-times note records the computed arrivals and both product pairs
+PASS: var-nu population variance under ν matches the reported value
+PASS: var-l1 population variance under ℓ¹ matches the reported value
+PASS: var-nu-smaller var(|v|_2/t) is strictly smaller under ν than under ℓ¹
+PASS: note-records-variances note records both variances and the comparison
+PASS: not-leftover-of-b8 t(8,0,0) on B_12(0) is 14, not the B_8 leftover 16
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axis-boundary-last-step (12,0,0) has only the axis in-ball neighbor (11,0,0)
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_hopcost_b12_2026_08_15.py
+++ b/scripts/support_drop_hopcost_b12_2026_08_15.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Score the named support-drop hop-cost on B_12(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+import math
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_HOPCOST_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_HOPCOST_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "On B_12(0), the named support-drop hop-cost is scored for "
+    "diamond reverse and for var(|v|_2/t) vs ℓ¹. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+VAR_NU_REPORTED = 0.00666073807018
+VAR_L1_REPORTED = 0.00944742571906
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def l2(v: tuple[int, int, int]) -> float:
+    return math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def population_variance(values: list[float]) -> float:
+    n = len(values)
+    mean = math.fsum(values) / n
+    return math.fsum((x - mean) ** 2 for x in values) / n
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_nu(sites)
+    t400 = dist[(4, 0, 0)]
+    t800 = dist[(8, 0, 0)]
+    t1200 = dist[(12, 0, 0)]
+    t222 = dist[(2, 2, 2)]
+    t444 = dist[(4, 4, 4)]
+    reverse = 12 * t400 * t400 > 16 * t222 * t222
+    reverse_double = 12 * t800 * t800 > 16 * t444 * t444
+    var_nu = population_variance([l2(v) / dist[v] for v in nonzero])
+    var_l1 = population_variance([l2(v) / l1(v) for v in nonzero])
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(4,0,0) {t400}")
+    print(f"t(8,0,0) {t800}")
+    print(f"t(12,0,0) {t1200}")
+    print(f"t(2,2,2) {t222}")
+    print(f"t(4,4,4) {t444}")
+    print(f"12 t(4,0,0)^2 {12 * t400 * t400}")
+    print(f"16 t(2,2,2)^2 {16 * t222 * t222}")
+    print(f"12 t(8,0,0)^2 {12 * t800 * t800}")
+    print(f"16 t(4,4,4)^2 {16 * t444 * t444}")
+    print(f"diamond_reverse {reverse}")
+    print(f"double_diamond_reverse {reverse_double}")
+    print(f"var_nu {var_nu:.14f}")
+    print(f"var_l1 {var_l1:.14f}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == 2625 and len(nonzero) == 2624 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "t-400",
+        "t(4,0,0) = 10",
+        t400 == 10,
+    )
+    checks.check(
+        "t-800",
+        "t(8,0,0) = 14",
+        t800 == 14,
+    )
+    checks.check(
+        "t-1200",
+        "t(12,0,0) = 20",
+        t1200 == 20,
+    )
+    checks.check(
+        "t-222",
+        "t(2,2,2) = 8",
+        t222 == 8,
+    )
+    checks.check(
+        "t-444",
+        "t(4,4,4) = 14",
+        t444 == 14,
+    )
+    checks.check(
+        "diamond-reverse",
+        "12 t(4,0,0)^2 > 16 t(2,2,2)^2",
+        reverse,
+    )
+    checks.check(
+        "double-diamond-not-reverse",
+        "12 t(8,0,0)^2 > 16 t(4,4,4)^2 fails",
+        (not reverse_double) and 12 * t800 * t800 == 2352 and 16 * t444 * t444 == 3136,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the computed arrivals and both product pairs",
+        "t(4,0,0) = 10" in note
+        and "t(8,0,0) = 14" in note
+        and "t(12,0,0) = 20" in note
+        and "t(2,2,2) = 8" in note
+        and "t(4,4,4) = 14" in note
+        and "1200" in note
+        and "1024" in note
+        and "2352" in note
+        and "3136" in note,
+    )
+    checks.check(
+        "var-nu",
+        "population variance under ν matches the reported value",
+        abs(var_nu - VAR_NU_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-l1",
+        "population variance under ℓ¹ matches the reported value",
+        abs(var_l1 - VAR_L1_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-nu-smaller",
+        "var(|v|_2/t) is strictly smaller under ν than under ℓ¹",
+        var_nu < var_l1,
+    )
+    checks.check(
+        "note-records-variances",
+        "note records both variances and the comparison",
+        "0.00666073807018" in note
+        and "0.00944742571906" in note
+        and "var_ν < var_ℓ¹" in note,
+    )
+    checks.check(
+        "not-leftover-of-b8",
+        "t(8,0,0) on B_12(0) is 14, not the B_8 leftover 16",
+        t800 == 14
+        and t800 != 16
+        and "not leftover of the `B_8(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and nu_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axis-boundary-last-step",
+        "(12,0,0) has only the axis in-ball neighbor (11,0,0)",
+        {(12 + dx, 0 + dy, 0 + dz) for dx, dy, dz in NEIGH if l1((12 + dx, dy, dz)) <= 12}
+        == {(11, 0, 0)}
+        and t1200 == dist[(11, 0, 0)] + 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu: t(4,0,0)=10, t(8,0,0)=14, t(12,0,0)=20, t(2,2,2)=8, t(4,4,4)=14. 12 t(4,0,0)^2=1200>1024=16 t(2,2,2)^2 still reverses. 12 t(8,0,0)^2=2352 is not > 3136=16 t(4,4,4)^2. var_nu=0.00666 < var_l1=0.00945. Displayed, not adopted.

## Runner

`scripts/support_drop_hopcost_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.