### PR TITLE
feat(ratio): nu reverse holds at k=1 and k=2; k=3,4 diag off B8

### DIFF
--- a/docs/SUPPORT_DROP_SCALE_RATIOS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_SCALE_RATIOS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,185 @@
+---
+claim_id: support_drop_scale_ratios_b8_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Axis and body-diagonal arrival ratios under the named support-drop hop-cost on B_8(0) are reported for k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_scale_ratios_b8_2026_08_15.py
+---
+
+# Axis And Body-Diagonal Arrival Ratios Under Support-Drop On B_8(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_8(0)`,
+scored only for axis arrivals `t(k,0,0)` and body-diagonal arrivals
+`t(k,k,k)` at `k=1,2,3,4` on sites that exist, and for the displayed
+scale-ratio reverse test at each available `k`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_scale_ratios_b8_2026_08_15.py`](../scripts/support_drop_scale_ratios_b8_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Axis and body-diagonal arrival ratios under the named support-drop hop-cost on B_8(0) are reported for k=1..4. Displayed, not adopted.
+
+The same named support-drop hop-cost `ν` already scored for the single
+pair `(4,0,0)` versus `(2,2,2)` is scored independently at every integer
+scale `k=1,2,3,4` whose sites lie in `B_8(0)`. The table is not leftover of that one pair:
+both available same-`k` pairs reverse, and the
+body-diagonal sites at `k=3,4` are omitted because they lie outside the
+ball.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_8(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_8(0)` (833 sites; 832 nonzero) gives
+
+`t(1,0,0) = 3`, `t(1,1,1) = 5`,
+`t(2,0,0) = 6`, `t(2,2,2) = 8`,
+`t(3,0,0) = 9`, `t(4,0,0) = 10`.
+
+The sites `(3,3,3)` and `(4,4,4)` have ℓ¹ norms `9` and `12`, so they are
+outside `B_8(0)` and are omitted.
+
+The Euclidean-normalized axis and body-diagonal ratios are
+
+`t(k,0,0)/k` and `t(k,k,k)/(k√3)`
+
+for those sites that exist. Their squares are `t(k,0,0)^2 / k^2` and
+`t(k,k,k)^2 / (3k^2)`. Reverse at scale `k` means the first square is
+strictly larger. That holds at both available scales:
+
+`9 > 25/3` at `k=1`, and `9 > 16/3` at `k=2`.
+
+The ratio gap stays open. It is not the leftover of one pair.
+
+The rule is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_8(0) = { v ∈ Z^3 : |v|_1 ≤ 8 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_8(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+A site `(k,0,0)` lies in the ball for every `k=1,2,3,4`. A site `(k,k,k)`
+lies in the ball if and only if `3k ≤ 8`, so only `k=1` and `k=2`.
+
+## Theorem 1 — Arrival Table At Scales `k=1,2,3,4`
+
+One origin Dijkstra on `B_8(0)` returns the integer arrivals below. A
+blank cell means the site is outside the ball and is omitted.
+
+| `k` | `t(k,0,0)` | `t(k,0,0)/k` | `t(k,k,k)` | `t(k,k,k)/(k√3)` |
+|---|---:|---:|---:|---:|
+| `1` | `3` | `3` | `5` | `5/√3` |
+| `2` | `6` | `3` | `8` | `4/√3` |
+| `3` | `9` | `3` | omitted | omitted |
+| `4` | `10` | `5/2` | omitted | omitted |
+
+Witnessing paths of those `ν`-costs exist. The walk `0 → (1,0,0)` has hop
+cost `3`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1)`
+
+has hop-costs `3,1,1` and sum `5`. The walk
+
+`0 → (1,0,0) → (2,0,0)`
+
+has hop-costs `3,3` and sum `6`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2)`
+
+has hop-costs `3,1,1,1,1,1` and sum `8`. The walk
+
+`0 → (1,0,0) → (2,0,0) → (3,0,0)`
+
+has hop-costs `3,3,3` and sum `9`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (4,0,0)`
+
+has hop-costs `3,1,1,1,1,3` and sum `10`.
+
+## Theorem 2 — Reverse At Each Available Scale
+
+For each available `k`, reverse means
+
+`t(k,0,0)^2 / k^2 > t(k,k,k)^2 / (3k^2)`,
+
+equivalently `3 t(k,0,0)^2 > t(k,k,k)^2`. Displayed, not adopted.
+
+| `k` | `t(k,0,0)^2 / k^2` | `t(k,k,k)^2 / (3k^2)` | reverse |
+|---|---:|---:|---|
+| `1` | `9` | `25/3` | yes (`27 > 25`) |
+| `2` | `9` | `16/3` | yes (`108 > 64`) |
+| `3` | `9` | omitted | omitted |
+| `4` | `25/4` | omitted | omitted |
+
+Both available same-`k` comparisons reverse. The ratio gap stays open
+across the two scales that exist on `B_8(0)`. The `(4,0,0)` versus
+`(2,2,2)` diamond is a mixed-scale pair; it is not a substitute for this
+same-`k` table.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_8(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+a same-`k` ratio gap.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer arrivals and same-k axis versus body-diagonal ratio reverse on the finite ball B_8(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_8(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs that reverse same-`k` ratios.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_8(0)`.
+- Any reuse of a single mixed-scale pair as a substitute for the
+  `k=1..4` table.
+- Any write of `ν` into Admissibility.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_scale_ratios_b8_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_scale_ratios_b8_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_scale_ratios_b8_2026_08_15.txt
@@ -1,0 +1,62 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_scale_ratios_b8_2026_08_15.py
+runner_sha256: d15d52ccf905e63fd08f24152dd6f871ddfe5047e04d227a84ad61b5c224212c
+input_fingerprint_sha256: 7c55c7dcd13886cb990b8821e0df7abb4744bdf3066469e96441f7afd88136f2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_SCALE_RATIOS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Axis and body-diagonal arrival ratios under the named support-drop hop-cost on B_8(0) are reported for k=1..4. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 833
+t(1,0,0) 3
+t(1,1,1) 5
+axis_ratio_sq[1] 9
+diag_ratio_sq[1] 25/3
+reverse[1] True
+t(2,0,0) 6
+t(2,2,2) 8
+axis_ratio_sq[2] 9
+diag_ratio_sq[2] 16/3
+reverse[2] True
+t(3,0,0) 9
+t(3,3,3) None
+axis_ratio_sq[3] 9
+diag_ratio_sq[3] None
+reverse[3] None
+t(4,0,0) 10
+t(4,4,4) None
+axis_ratio_sq[4] 25/4
+diag_ratio_sq[4] None
+reverse[4] None
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b8 B_8(0) has 833 sites and 832 nonzero sites
+PASS: reachable every site of B_8(0) is reached
+PASS: axis-arrivals t(k,0,0) is 3,6,9,10 for k=1,2,3,4
+PASS: diag-arrivals t(k,k,k) is 5,8 for k=1,2 and omitted for k=3,4
+PASS: reverse-k1 t(1,0,0)^2 / 1^2 > t(1,1,1)^2 / 3
+PASS: reverse-k2 t(2,0,0)^2 / 4 > t(2,2,2)^2 / 12
+PASS: gap-open the same-k ratio gap stays open at both available scales
+PASS: note-records-times note records the computed arrivals and omitted sites
+PASS: note-records-reverse note records both same-k reverse inequalities
+PASS: not-leftover-of-one-pair the table is not leftover of the mixed-scale pair
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_scale_ratios_b8_2026_08_15.py
+++ b/scripts/support_drop_scale_ratios_b8_2026_08_15.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Score axis and body-diagonal ν ratios on B_8(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from fractions import Fraction
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_SCALE_RATIOS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_SCALE_RATIOS_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Axis and body-diagonal arrival ratios under the named "
+    "support-drop hop-cost on B_8(0) are reported for k=1..4. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(8)
+    site_set = set(sites)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_nu(sites)
+
+    times: dict[int, dict[str, int | None]] = {}
+    for k in (1, 2, 3, 4):
+        axis = (k, 0, 0)
+        diag = (k, k, k)
+        t_axis = dist[axis] if axis in site_set else None
+        t_diag = dist[diag] if diag in site_set else None
+        times[k] = {"axis": t_axis, "diag": t_diag}
+
+    reverse: dict[int, bool | None] = {}
+    axis_sq: dict[int, Fraction] = {}
+    diag_sq: dict[int, Fraction | None] = {}
+    for k in (1, 2, 3, 4):
+        t_axis = times[k]["axis"]
+        t_diag = times[k]["diag"]
+        assert t_axis is not None
+        axis_sq[k] = Fraction(t_axis * t_axis, k * k)
+        if t_diag is None:
+            diag_sq[k] = None
+            reverse[k] = None
+        else:
+            diag_sq[k] = Fraction(t_diag * t_diag, 3 * k * k)
+            reverse[k] = axis_sq[k] > diag_sq[k]
+
+    print(f"n_sites {len(sites)}")
+    for k in (1, 2, 3, 4):
+        print(f"t({k},0,0) {times[k]['axis']}")
+        print(f"t({k},{k},{k}) {times[k]['diag']}")
+        print(f"axis_ratio_sq[{k}] {axis_sq[k]}")
+        print(f"diag_ratio_sq[{k}] {diag_sq[k]}")
+        print(f"reverse[{k}] {reverse[k]}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b8",
+        "B_8(0) has 833 sites and 832 nonzero sites",
+        len(sites) == 833 and len(nonzero) == 832 and all(l1(v) <= 8 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_8(0) is reached",
+        len(dist) == 833,
+    )
+    checks.check(
+        "axis-arrivals",
+        "t(k,0,0) is 3,6,9,10 for k=1,2,3,4",
+        [times[k]["axis"] for k in (1, 2, 3, 4)] == [3, 6, 9, 10],
+    )
+    checks.check(
+        "diag-arrivals",
+        "t(k,k,k) is 5,8 for k=1,2 and omitted for k=3,4",
+        times[1]["diag"] == 5
+        and times[2]["diag"] == 8
+        and times[3]["diag"] is None
+        and times[4]["diag"] is None
+        and (3, 3, 3) not in site_set
+        and (4, 4, 4) not in site_set,
+    )
+    checks.check(
+        "reverse-k1",
+        "t(1,0,0)^2 / 1^2 > t(1,1,1)^2 / 3",
+        reverse[1] is True and axis_sq[1] == 9 and diag_sq[1] == Fraction(25, 3),
+    )
+    checks.check(
+        "reverse-k2",
+        "t(2,0,0)^2 / 4 > t(2,2,2)^2 / 12",
+        reverse[2] is True and axis_sq[2] == 9 and diag_sq[2] == Fraction(16, 3),
+    )
+    checks.check(
+        "gap-open",
+        "the same-k ratio gap stays open at both available scales",
+        reverse[1] is True and reverse[2] is True,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the computed arrivals and omitted sites",
+        "t(1,0,0) = 3" in note
+        and "t(1,1,1) = 5" in note
+        and "t(2,0,0) = 6" in note
+        and "t(2,2,2) = 8" in note
+        and "t(3,0,0) = 9" in note
+        and "t(4,0,0) = 10" in note
+        and "`(3,3,3)` and `(4,4,4)`" in note,
+    )
+    checks.check(
+        "note-records-reverse",
+        "note records both same-k reverse inequalities",
+        "9 > 25/3" in note and "9 > 16/3" in note and "27 > 25" in note and "108 > 64" in note,
+    )
+    checks.check(
+        "not-leftover-of-one-pair",
+        "the table is not leftover of the mixed-scale pair",
+        "not leftover of that one pair" in note
+        and "not a substitute for this" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and nu_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_8(0) under nu: t(1,0,0)=3, t(1,1,1)=5, t(2,0,0)=6, t(2,2,2)=8, t(3,0,0)=9, t(4,0,0)=10. Both available same-k pairs reverse (k=1 and k=2). (3,3,3) and (4,4,4) lie outside B_8. Displayed, not adopted.

## Runner

`scripts/support_drop_scale_ratios_b8_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.