### PR TITLE
feat(nuface12): B12 face reverse yes/no/yes/yes; (8,0,0) vs (4,4,0) fails

### DIFF
--- a/docs/SUPPORT_DROP_FACE_DIAGONAL_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_FACE_DIAGONAL_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,253 @@
+---
+claim_id: support_drop_face_diagonal_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal versus axis arrival order under the named support-drop hop-cost on B_12(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_face_diagonal_b12_2026_08_15.py
+---
+
+# Face-Diagonal Versus Axis Order Under The Support-Drop Hop-Cost On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one directed Dijkstra on the nearest-neighbor graph of the
+ball $B_{12}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 12\}$ for the named support-drop
+hop-cost $\nu$. Face-diagonal versus axis arrival order is reported.
+Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_face_diagonal_b12_2026_08_15.py`](../scripts/support_drop_face_diagonal_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost $\nu$ already scored on $B_8(0)$ is
+scored independently on $B_{12}(0)$. The ball is not leftover of the $B_8(0)$
+face times: $t(8,0,0)$ on this ball is not the radius-$8$ value, and the
+sites $(12,0,0)$ and $(6,6,0)$ are not in $B_8(0)$.
+
+Let $\sigma_v=\{i\in\{1,2,3\}:v_i\neq 0\}$ and write $|\sigma_v|$ for its
+cardinality. On every nearest-neighbor hop $v\to w$ that remains inside
+$B_{12}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 12\}$, the named support-drop hop-cost is
+
+$$
+\nu(v\to w)=
+\begin{cases}
+3 & \text{if }|\sigma_v|=0\text{ or }(|\sigma_v|=|\sigma_w|=1)\text{ or }|\sigma_w|<|\sigma_v|,\\
+1 & \text{otherwise.}
+\end{cases}
+$$
+
+A single Dijkstra computation from the origin on this directed weighted graph
+returns the arrival times
+
+$$
+t(4,0,0)=10,\qquad t(8,0,0)=14,\qquad t(12,0,0)=20,
+$$
+$$
+t(2,2,0)=6,\qquad t(4,4,0)=10,\qquad t(6,6,0)=14,
+$$
+$$
+t(2,2,2)=8,\qquad t(4,4,4)=14.
+$$
+
+For each pair below, the second site is the more-diagonal site (strictly more
+nonzero coordinates). Reverse means $t^2/|v|_2^2$ is strictly smaller on that
+more-diagonal site:
+
+| pair | axis $t^2/|v|_2^2$ | more-diagonal $t^2/|v|_2^2$ | reverse |
+|---|---|---|---|
+| $((4,0,0),(2,2,0))$ | $100/16=25/4$ | $36/8=9/2$ | yes |
+| $((8,0,0),(4,4,0))$ | $196/64=49/16$ | $100/32=25/8$ | no |
+| $((12,0,0),(6,6,0))$ | $400/144=25/9$ | $196/72=49/18$ | yes |
+| $((4,0,0),(2,2,2))$ | $100/16=25/4$ | $64/12=16/3$ | yes |
+
+Exact integer comparisons:
+
+- $16\,t(2,2,0)^2=576<800=8\,t(4,0,0)^2$
+- $64\,t(4,4,0)^2=6400>6272=32\,t(8,0,0)^2$
+- $144\,t(6,6,0)^2=28224<28800=72\,t(12,0,0)^2$
+- $16\,t(2,2,2)^2=1024<1200=12\,t(4,0,0)^2$
+
+These four reverse bits are not leftover of the $B_8(0)$ face times. The
+values $t(8,0,0)=14$, $t(12,0,0)=20$, and $t(6,6,0)=14$ are independent Dijkstra
+outputs on $B_{12}(0)$. The pair $((8,0,0),(4,4,0))$ is reverse on $B_8(0)$ and
+is not reverse on this ball. The score is displayed, not adopted. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom. It does not choose a Hamiltonian or
+transfer operator, supply transition-probability or weight values, select a
+scalar or nonzero kinetic branch, assert a Dirac-square carrier, define a time
+metric, or provide a record-production process or physical persistence
+dynamics.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The named hop-cost $\nu$ is a displayed scoring rule on the nearest-neighbor
+graph of $B_{12}(0)$. It is not written into Admissibility. It is not attached to L1.
+It supplies no time metric, no Record formation rule, and no physical hop law.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Arrival times and four face-versus-axis reverse bits on B_12(0) are finite exact Dijkstra values for a named hop-cost; the hop-cost is displayed, not adopted."
+trace_class: upstream_support
+target_claim_id: support_drop_face_diagonal_b12_bounded_theorem_note_2026-08-15
+target_blocker_text: "the named hop-cost is displayed, not adopted, and is not Admissibility content"
+source_of_blocker_text: this note
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the face-versus-axis reverse bits as a displayed B_12(0) score; do not write nu into Admissibility."
+conditional_surface_status: "exact for the named support-drop hop-cost on B_12(0); not adopted as a law"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write $0=(0,0,0)$ and $B_{12}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 12\}$. This set has
+$2625$ sites, of which $2624$ are nonzero. The directed graph is the
+nearest-neighbor graph of $\mathbb{Z}^3$ induced on $B_{12}(0)$: from $v$ there
+is an edge to $w=v\pm e_i$ exactly when $w\in B_{12}(0)$.
+
+The support $\sigma_v$ and the hop-cost $\nu$ are as in Result Up Front. In
+words: seed exit from the origin costs $3$; every hop that stays on a
+coordinate axis costs $3$; every hop that strictly drops the number of
+nonzero coordinates costs $3$; every other in-ball nearest-neighbor hop
+costs $1$.
+
+Arrival time $t(v)$ is the least $\nu$-length of a directed path from $0$ to
+$v$ in this graph. One Dijkstra computation from the origin produces every
+$t(v)$ used below.
+
+The Euclidean squared length is $|v|_2^2=v_1^2+v_2^2+v_3^2$. The displayed
+comparison density is $t(v)^2/|v|_2^2$ at $v\neq 0$. For an ordered pair
+$(a,b)$ in which $b$ has strictly more nonzero coordinates than $a$, the pair
+is reverse when
+
+$$
+t(b)^2\,|a|_2^2 < t(a)^2\,|b|_2^2.
+$$
+
+On the smaller ball $B_8(0)$ the same local rule gives $t(8,0,0)=16$, because
+$(8,1,0)$ lies outside that ball and the only in-ball last step onto
+$(8,0,0)$ is the axis hop from $(7,0,0)$. On $B_{12}(0)$ the site $(8,1,0)$ is
+interior, the support-drop last step is available, and $t(8,0,0)=14$. The
+sites $(12,0,0)$ and $(6,6,0)$ are not in $B_8(0)$ at all. The $B_{12}(0)$ table
+is therefore not leftover of the $B_8(0)$ face times.
+
+## Theorem 1 — Named Arrival Times
+
+On $B_{12}(0)$ under $\nu$,
+
+$$
+t(4,0,0)=10,\qquad t(8,0,0)=14,\qquad t(12,0,0)=20,
+$$
+$$
+t(2,2,0)=6,\qquad t(4,4,0)=10,\qquad t(6,6,0)=14,
+$$
+$$
+t(2,2,2)=8,\qquad t(4,4,4)=14.
+$$
+
+These eight values are Dijkstra outputs, not fitted scalars.
+
+Witnessing paths of those $\nu$-costs exist. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(4,0,0)$
+
+has hop-costs $3,1,1,1,1,3$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(8,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,3$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(11,1,0)\to(11,0,0)\to(12,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,3,3$ and sum $20$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(2,2,0)$
+
+has hop-costs $3,1,1,1$ and sum $6$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(2,4,0)\to(3,4,0)\to(4,4,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(1,6,0)\to(2,6,0)\to(3,6,0)\to(4,6,0)\to(5,6,0)\to(6,6,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)\to(2,1,1)\to(2,2,1)\to(2,2,2)$
+
+has hop-costs $3,1,1,1,1,1$ and sum $8$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)\to(1,1,2)\to(1,1,3)\to(1,1,4)\to(1,2,4)\to(1,3,4)\to(1,4,4)\to(2,4,4)\to(3,4,4)\to(4,4,4)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1$ and sum $14$.
+
+## Theorem 2 — Face-Diagonal Versus Axis Reverse Bits
+
+The four scored pairs are $((4,0,0),(2,2,0))$, $((8,0,0),(4,4,0))$,
+$((12,0,0),(6,6,0))$, and $((4,0,0),(2,2,2))$. In each pair the second site is
+more diagonal.
+
+Whether each pair is reverse:
+
+- $t(2,2,0)^2/|(2,2,0)|_2^2=9/2 < 25/4=t(4,0,0)^2/|(4,0,0)|_2^2$ (yes)
+- $t(4,4,0)^2/|(4,4,0)|_2^2=25/8 \not< 49/16=t(8,0,0)^2/|(8,0,0)|_2^2$ (no)
+- $t(6,6,0)^2/|(6,6,0)|_2^2=49/18 < 25/9=t(12,0,0)^2/|(12,0,0)|_2^2$ (yes)
+- $t(2,2,2)^2/|(2,2,2)|_2^2=16/3 < 25/4=t(4,0,0)^2/|(4,0,0)|_2^2$ (yes)
+
+The $B_8(0)$ face times do not determine $t(8,0,0)$, $t(12,0,0)$, or
+$t(6,6,0)$ on this ball. The four reverse bits are therefore not leftover
+of the $B_8(0)$ face times.
+
+These reverse bits are displayed, not adopted.
+
+## Theorem 3 — Not Admissibility, Not Attached To L1
+
+Do not write $\nu$ into Admissibility. Admissibility names one fixed
+nearest-neighbor rule for the local possibility distribution. It does not
+supply hop weights, a time metric, or an arrival-time comparison.
+
+Do not attach L1. The named hop-cost is not attached to L1 and is not
+offered as a replacement for unit-cost first arrival. No uniqueness claim is
+made among hop-costs.
+
+## What This Note Does Not Claim
+
+- $\nu$ is not an axiom, not an approved primitive, and not a derived law.
+- The reverse bits are not promoted to a continuum speed, a physical clock,
+  or a Record readout.
+- Face-diagonal reverse is not claimed outside $B_{12}(0)$ and is not claimed
+  for any hop-cost other than the named $\nu$.
+- L1 is not adopted and is not attached to Admissibility.
+- The $B_8(0)$ face-arrival table is not reused as a substitute for the
+  radius-$12$ Dijkstra.
+
+## claim_scope
+
+Face-diagonal versus axis arrival order under the named support-drop hop-cost on B_12(0) is reported. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_face_diagonal_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_face_diagonal_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_face_diagonal_b12_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_face_diagonal_b12_2026_08_15.py
+runner_sha256: 0371afc08eaffc151ffe09110ebb54cbaf2dbb6aff383b26efb30c26fd6194aa
+input_fingerprint_sha256: 46221ced26fe76b5958ffa6821a113f8ae1461b3e9eed811b0a30d07c48b4686
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_FACE_DIAGONAL_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count_budget: 1
+claim_scope: Face-diagonal versus axis arrival order under the named support-drop hop-cost on B_12(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and the axiom memo
+PASS: audit-input-literals AUDIT_INPUT_PATHS is a static two-string literal in this runner
+PASS: ball-cardinality B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: one-dijkstra exactly one Dijkstra computation is used
+PASS: finite-times every target is reached by a finite path
+arrival_times:
+  t(4, 0, 0)=10  t^2/|v|_2^2=100/16
+  t(8, 0, 0)=14  t^2/|v|_2^2=196/64
+  t(12, 0, 0)=20  t^2/|v|_2^2=400/144
+  t(2, 2, 0)=6  t^2/|v|_2^2=36/8
+  t(4, 4, 0)=10  t^2/|v|_2^2=100/32
+  t(6, 6, 0)=14  t^2/|v|_2^2=196/72
+  t(2, 2, 2)=8  t^2/|v|_2^2=64/12
+  t(4, 4, 4)=14  t^2/|v|_2^2=196/48
+PASS: time-400 computed t(4,0,0)=10 is written in the note
+PASS: time-800 computed t(8,0,0)=14 is written in the note
+PASS: time-1200 computed t(12,0,0)=20 is written in the note
+PASS: time-220 computed t(2,2,0)=6 is written in the note
+PASS: time-440 computed t(4,4,0)=10 is written in the note
+PASS: time-660 computed t(6,6,0)=14 is written in the note
+PASS: time-222 computed t(2,2,2)=8 is written in the note
+PASS: time-444 computed t(4,4,4)=14 is written in the note
+reverse_bits:
+  (4, 0, 0) vs (2, 2, 0): reverse=True (36*16=576 vs 100*8=800)
+  (8, 0, 0) vs (4, 4, 0): reverse=False (100*64=6400 vs 196*32=6272)
+  (12, 0, 0) vs (6, 6, 0): reverse=True (196*144=28224 vs 400*72=28800)
+  (4, 0, 0) vs (2, 2, 2): reverse=True (64*16=1024 vs 100*12=1200)
+PASS: reverse-400-220 ((4,0,0),(2,2,0)) is reverse and the note records 16 t(2,2,0)^2=576<800=8 t(4,0,0)^2
+PASS: reverse-800-440 ((8,0,0),(4,4,0)) is not reverse and the note records 64 t(4,4,0)^2=6400>6272=32 t(8,0,0)^2
+PASS: reverse-1200-660 ((12,0,0),(6,6,0)) is reverse and the note records 144 t(6,6,0)^2=28224<28800=72 t(12,0,0)^2
+PASS: reverse-400-222 ((4,0,0),(2,2,2)) is reverse and the note records 16 t(2,2,2)^2=1024<1200=12 t(4,0,0)^2
+PASS: not-b8-face-leftover note states the B_12 face reverse bits are not leftover of the B_8 face times
+PASS: source-lattice Lattice nearest-neighbor wording is pinned in the axiom memo and the note
+PASS: source-admissibility Admissibility distribution wording and non-dynamics clause are pinned
+PASS: nu-not-admissibility the note refuses to write nu into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: displayed-not-adopted claim_scope and displayed-not-adopted wording are present
+PASS: forbidden-phrases forbidden phrases are absent from the note and from runner prose
+PASS: pair-reverse-bits the four declared pairs have the displayed reverse bits
+PASS: axiom-untouched the axiom memo is an input only
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_face_diagonal_b12_2026_08_15.py
+++ b/scripts/support_drop_face_diagonal_b12_2026_08_15.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Face-diagonal versus axis order under the named support-drop hop-cost on B_12(0)."""
+
+from __future__ import annotations
+
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_FACE_DIAGONAL_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+RADIUS = 12
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+TARGETS = (
+    (4, 0, 0),
+    (8, 0, 0),
+    (12, 0, 0),
+    (2, 2, 0),
+    (4, 4, 0),
+    (6, 6, 0),
+    (2, 2, 2),
+    (4, 4, 4),
+)
+PAIRS = (
+    ((4, 0, 0), (2, 2, 0)),
+    ((8, 0, 0), (4, 4, 0)),
+    ((12, 0, 0), (6, 6, 0)),
+    ((4, 0, 0), (2, 2, 2)),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    "Face-diagonal versus axis arrival order under the named "
+    "support-drop hop-cost on B_12(0) is reported. Displayed, not adopted."
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def l2sq(v: tuple[int, int, int]) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return sum(1 for x in v if x != 0)
+
+
+def nu(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sv = support_size(v)
+    sw = support_size(w)
+    if sv == 0 or (sv == 1 and sw == 1) or sw < sv:
+        return 3
+    return 1
+
+
+def ball_sites(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_from_origin(
+    sites: set[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    origin = (0, 0, 0)
+    inf = 10**9
+    dist = {site: inf for site in sites}
+    dist[origin] = 0
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, origin)]
+    while heap:
+        cost, v = heapq.heappop(heap)
+        if cost != dist[v]:
+            continue
+        for step in NEIGHBOR_STEPS:
+            w = (v[0] + step[0], v[1] + step[1], v[2] + step[2])
+            if w not in sites:
+                continue
+            nxt = cost + nu(v, w)
+            if nxt < dist[w]:
+                dist[w] = nxt
+                heapq.heappush(heap, (nxt, w))
+    return dist
+
+
+def more_diagonal(
+    a: tuple[int, int, int], b: tuple[int, int, int]
+) -> tuple[int, int, int]:
+    if support_size(b) > support_size(a):
+        return b
+    if support_size(a) > support_size(b):
+        return a
+    raise ValueError("pair is not an axis/face comparison")
+
+
+def flatten(text: str) -> str:
+    return " ".join(text.split())
+
+
+def is_reverse(
+    times: dict[tuple[int, int, int], int],
+    axis: tuple[int, int, int],
+    diag: tuple[int, int, int],
+) -> bool:
+    ta = times[axis]
+    tb = times[diag]
+    return tb * tb * l2sq(axis) < ta * ta * l2sq(diag)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count_budget: 1")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SUPPORT_DROP_FACE_DIAGONAL_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "audit-input-literals",
+        "AUDIT_INPUT_PATHS is a static two-string literal in this runner",
+        'AUDIT_INPUT_PATHS = (\n    "docs/SUPPORT_DROP_FACE_DIAGONAL_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in source,
+    )
+
+    sites_list = ball_sites(RADIUS)
+    sites = set(sites_list)
+    checks.check(
+        "ball-cardinality",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites_list) == 2625 and (0, 0, 0) in sites and len(sites) == 2625,
+    )
+
+    dijkstra_runs = 0
+    times = dijkstra_from_origin(sites)
+    dijkstra_runs += 1
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra computation is used",
+        dijkstra_runs == 1,
+    )
+    checks.check(
+        "finite-times",
+        "every target is reached by a finite path",
+        all(times[v] < 10**9 for v in TARGETS),
+    )
+
+    reported = {v: times[v] for v in TARGETS}
+    print("arrival_times:")
+    for v in TARGETS:
+        print(f"  t{v}={reported[v]}  t^2/|v|_2^2={reported[v] ** 2}/{l2sq(v)}")
+
+    token = {
+        (4, 0, 0): "t(4,0,0)=10",
+        (8, 0, 0): "t(8,0,0)=14",
+        (12, 0, 0): "t(12,0,0)=20",
+        (2, 2, 0): "t(2,2,0)=6",
+        (4, 4, 0): "t(4,4,0)=10",
+        (6, 6, 0): "t(6,6,0)=14",
+        (2, 2, 2): "t(2,2,2)=8",
+        (4, 4, 4): "t(4,4,4)=14",
+    }
+    for v in TARGETS:
+        checks.check(
+            f"time-{v[0]}{v[1]}{v[2]}",
+            f"computed {token[v]} is written in the note",
+            token[v] in note and reported[v] == int(token[v].split("=")[1]),
+            residual=reported[v],
+        )
+
+    print("reverse_bits:")
+    pair_bits: list[bool] = []
+    for axis, diag in PAIRS:
+        if more_diagonal(axis, diag) != diag:
+            pair_bits.append(False)
+            continue
+        bit = is_reverse(times, axis, diag)
+        pair_bits.append(bit)
+        ta, tb = times[axis], times[diag]
+        print(
+            f"  {axis} vs {diag}: reverse={bit} "
+            f"({tb * tb}*{l2sq(axis)}={tb * tb * l2sq(axis)} vs "
+            f"{ta * ta}*{l2sq(diag)}={ta * ta * l2sq(diag)})"
+        )
+    checks.check(
+        "reverse-400-220",
+        "((4,0,0),(2,2,0)) is reverse and the note records 16 t(2,2,0)^2=576<800=8 t(4,0,0)^2",
+        is_reverse(times, (4, 0, 0), (2, 2, 0))
+        and "16\\,t(2,2,0)^2=576<800=8\\,t(4,0,0)^2" in note,
+    )
+    checks.check(
+        "reverse-800-440",
+        "((8,0,0),(4,4,0)) is not reverse and the note records 64 t(4,4,0)^2=6400>6272=32 t(8,0,0)^2",
+        (not is_reverse(times, (8, 0, 0), (4, 4, 0)))
+        and "64\\,t(4,4,0)^2=6400>6272=32\\,t(8,0,0)^2" in note,
+    )
+    checks.check(
+        "reverse-1200-660",
+        "((12,0,0),(6,6,0)) is reverse and the note records 144 t(6,6,0)^2=28224<28800=72 t(12,0,0)^2",
+        is_reverse(times, (12, 0, 0), (6, 6, 0))
+        and "144\\,t(6,6,0)^2=28224<28800=72\\,t(12,0,0)^2" in note,
+    )
+    checks.check(
+        "reverse-400-222",
+        "((4,0,0),(2,2,2)) is reverse and the note records 16 t(2,2,2)^2=1024<1200=12 t(4,0,0)^2",
+        is_reverse(times, (4, 0, 0), (2, 2, 2))
+        and "16\\,t(2,2,2)^2=1024<1200=12\\,t(4,0,0)^2" in note,
+    )
+    checks.check(
+        "not-b8-face-leftover",
+        "note states the B_12 face reverse bits are not leftover of the B_8 face times",
+        "not leftover of the $B_8(0)$ face times" in note
+        and "independent Dijkstra" in note
+        and reported[(8, 0, 0)] == 14
+        and reported[(8, 0, 0)] != 16
+        and reported[(12, 0, 0)] == 20
+        and reported[(6, 6, 0)] == 14
+        and l1((12, 0, 0)) == 12
+        and l1((6, 6, 0)) == 12,
+    )
+
+    flat_note = flatten(note)
+    flat_axiom = flatten(axiom)
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    admissibility_quote = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    not_dynamics = "Admissibility is not a dynamics axiom."
+    checks.check(
+        "source-lattice",
+        "Lattice nearest-neighbor wording is pinned in the axiom memo and the note",
+        lattice_quote in flat_axiom and lattice_quote in flat_note,
+    )
+    checks.check(
+        "source-admissibility",
+        "Admissibility distribution wording and non-dynamics clause are pinned",
+        admissibility_quote in flat_axiom
+        and admissibility_quote in flat_note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+    checks.check(
+        "nu-not-admissibility",
+        "the note refuses to write nu into Admissibility",
+        "It is not written into Admissibility." in note
+        and "Do not write $\\nu$ into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "not attached to L1" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "claim_scope and displayed-not-adopted wording are present",
+        CLAIM_SCOPE in note and "displayed, not adopted" in note,
+    )
+    forbidden_hits = [
+        phrase
+        for phrase in FORBIDDEN
+        if phrase in note or phrase in source.split("FORBIDDEN =", 1)[0]
+    ]
+    checks.check(
+        "forbidden-phrases",
+        "forbidden phrases are absent from the note and from runner prose",
+        not forbidden_hits,
+        residual=forbidden_hits,
+    )
+    expected_bits = (
+        True,
+        False,
+        True,
+        True,
+    )
+    checks.check(
+        "pair-reverse-bits",
+        "the four declared pairs have the displayed reverse bits",
+        tuple(pair_bits) == expected_bits,
+        residual=pair_bits,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu: t(4,0,0)=10, t(8,0,0)=14, t(12,0,0)=20, t(2,2,0)=6, t(4,4,0)=10, t(6,6,0)=14, t(2,2,2)=8, t(4,4,4)=14. Face reverse holds for (4,0,0) vs (2,2,0) and (12,0,0) vs (6,6,0); fails for (8,0,0) vs (4,4,0). Body (4,0,0) vs (2,2,2) still reverses. Displayed, not adopted.

## Runner

`scripts/support_drop_face_diagonal_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.