### PR TITLE
feat(011var8): on B8, var nu < (0,1,1) < l1

### DIFF
--- a/docs/CLAUSE_011_VAR_VS_NU_L1_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_VAR_VS_NU_L1_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,239 @@
+---
+claim_id: clause_011_var_vs_nu_l1_b8_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Arrival-speed variance under (0,1,1), support-drop, and ℓ¹ on B_8(0) is compared. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py
+---
+
+# Clause (0,1,1) Versus ν Versus ℓ¹ Arrival-Speed Variance On B_8(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** three named directed nearest-neighbor hop-costs on the finite
+ℓ¹-ball `B_8(0)`, their Dijkstra arrival times from the origin, and the
+population variance of `|v|_2/t` on the 832 nonzero sites. No hop-cost is
+written into Admissibility. L1 is not attached.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py`](../scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py)
+
+## Result Up Front
+
+On `B_6(0)`, ν is the rounder reverser and the cheaper clause triple
+`(0,1,1)` has worse arrival-speed variance. The same three scores are now
+evaluated on `B_8(0)`. Uniqueness is not required. The executed order is
+
+`var_ν < var_(0,1,1) < var_ℓ¹`.
+
+The cheaper rival stays worse-round. The unique, hence lex-first, minimizer
+among the three displayed scores is ν. The scores are displayed, not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom does not supply hop-cost values. It does not
+supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+None of Record is used to select a hop-cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Three finite Dijkstra scores and their population arrival-speed variances on B_8(0) are exact; no hop-cost is adopted and L1 is not attached."
+trace_class: upstream_support
+target_claim_id: clause_011_var_vs_nu_l1_b8
+target_blocker_text: "compare arrival-speed variance of (0,1,1), ν, and ℓ¹ on B_8(0)"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the three scores displayed. Do not write (0,1,1) or ν into Admissibility. Do not attach L1."
+conditional_surface_status: "exact for the three named hop-costs on the induced B_8(0) graph; no physical law is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0=(0,0,0)` and `B_8(0)={v∈Z^3 : |v|_1 ≤ 8}`. This set has 833 sites.
+The executed graph is the induced nearest-neighbor graph on that set: a
+directed hop `v→w` exists when `w-v` is a signed axis unit and `w∈B_8(0)`.
+
+The coordinate support is `σ_v={i : v_i ≠ 0}`. Its cardinality is the
+weight. On a hop `v→w`:
+
+- seed-exit means `|σ_v|=0`,
+- both-weights-1 means `|σ_v|=|σ_w|=1`,
+- support-drop means `|σ_w| < |σ_v|`.
+
+The three named costs are:
+
+- `(0,1,1)`: cost `3` if both-weights-1 or support-drop, else `1`. Seed-exit
+  is cheap.
+- `ν=(1,1,1)`: cost `3` if seed-exit or both-weights-1 or support-drop, else
+  `1`.
+- `ℓ¹`: every executed hop costs `1`.
+
+Arrival time `t(v)` is the Dijkstra cost from `0` under the named rule.
+The compared statistic on `B_8(0)\{0}` is the population variance
+
+`var(|v|_2/t) = (1/N) Σ_v (|v|_2/t(v) - μ)^2`,
+
+with `N=832` and `μ=(1/N) Σ_v |v|_2/t(v)`. Equivalently,
+`var = Q - μ^2` where the second moment `Q=(1/N) Σ_v |v|_2^2 / t(v)^2` is
+rational. Three Dijkstras are run, one per cost.
+
+This note does not attach L1. The `ℓ¹` score is only the unit-cost comparison
+on the same directed graph.
+
+## Theorem 1 — Three Variances
+
+Every nonzero site is reached under each of the three costs. Under `ℓ¹`,
+`t(v)=|v|_1`. The exact second moments on the 832 nonzero sites are
+
+`Q_(0,1,1) = 1642863107/3329726400`,
+
+`Q_ν = 1255910253469/4501790092800`,
+
+`Q_ℓ¹ = 55/104`.
+
+The population variances, truncated to 18 decimal digits, are
+
+`var_(0,1,1) = 0.008636807122136649`,
+
+`var_ν = 0.006349675165465741`,
+
+`var_ℓ¹ = 0.011339404956514005`.
+
+Thus all three variances are reported. The cheaper rival `(0,1,1)` remains
+strictly worse-round than ν, and both named clause scores remain strictly
+below the unit-cost score.
+
+## Theorem 2 — Lex-First Minimizer
+
+Order the three names as the strings `(0,1,1)`, `l1`, and `nu`. The
+variance-minimizing score is unique and equals ν. Therefore the lex-first
+minimizer among the three is ν.
+
+The minimizer is displayed, not adopted.
+
+## Theorem 3 — No Admissibility Write, L1 Not Attached
+
+Do not write `(0,1,1)` or ν into Admissibility. The current admissibility
+rule remains the quoted nearest-neighbor distribution constraint. The two
+clause triples and the unit-cost comparison are scoring rules on `B_8(0)`,
+not a replacement of that axiom.
+
+Do not attach L1. No formation law, occupancy member, or locked-set filling
+rule is identified with any of the three hop-costs.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether the cheaper B_6 rival stays worse-round on B_8(0). |
+| V2 | Current main has no landed (0,1,1)/ν/ℓ¹ variance comparison on B_8(0). |
+| V3 | The three Dijkstras and the 832-site population variances are finite and exact. |
+| V4 | The comparison is not an axiom rewrite: Admissibility is left unchanged. |
+| V5 | Displayed scores are not a physical hop-cost or formation law. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: these three scores are compared on `B_8(0)`
+and are not adopted. No uniqueness of a physical law is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| `(0,1,1)` | cheap seed-exit, expensive axis-1 and support-drop | executed; worse-round than ν |
+| ν | all three clauses expensive | executed; unique variance minimizer |
+| `ℓ¹` | unit hop-cost | executed; largest variance |
+| other clause triples | enable seed-exit only, or drop support-drop | different named family; not this residual |
+| unrestricted `Z^3` paths | leave `B_8(0)` and return | outside the declared ball |
+| adopt a score | write `(0,1,1)` or ν into Admissibility | forbidden; not executed |
+| attach L1 | identify a score with a formation member | forbidden; not executed |
+
+### N2 — wall independence
+
+Ball restriction, hop-cost clauses, the speed statistic, and axiom
+non-adoption are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball, the induced graph, the three cost clauses, population variance,
+and lex-first among the three names are declared. No continuum limit, no
+physical clock, and no formation rate are assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate and the
+distribution sentence. It does not name hop-cost triples. The residual is
+a finite comparison on that substrate, not an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each nonzero site of `B_8(0)` | no other ball |
+| per site | one arrival time per named cost | no physical tick identification |
+| per mode | no spectral calculation | no mode exhaustion |
+| per block | three Dijkstras and one variance triple | no law selection |
+| lattice wide | checked and not executed | no `Z^3` or infinite-volume score |
+
+### N6 — live partial-closure paths
+
+Live routes are a derived hop-cost, a reason to adopt one of the three
+scores, a comparison on a larger ball, and a separately derived formation
+law. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `(0,1,1)` is cheaper at the seed, it should be at
+least as round as ν on every ball that contains `B_6(0)`.
+
+**Answer:** Cheap seed-exit changes the whole arrival field. On `B_8(0)`
+the executed variances remain strictly ordered `var_ν < var_(0,1,1)`.
+Cheaper is not rounder.
+
+### N8 — cross-cycle echo
+
+The B_6 investment that ν is rounder than `(0,1,1)` is not reused as a
+lemma. The three scores are recomputed on `B_8(0)`. L1 remains unattached.
+
+**Gate disposition:** PASS for the three reported variances, the displayed
+lex-first minimizer ν, and the refusal to adopt a hop-cost or attach L1.
+FAIL / DO NOT SHIP for writing `(0,1,1)` or ν into Admissibility, attaching
+L1, or claiming a unique physical law.
+
+## Primary Runner
+
+The primary runner rebuilds `B_8(0)`, runs the three Dijkstras, recomputes
+the second moments and population variances, checks the reported order and
+lex-first minimizer, and pins the current axiom wording together with the
+non-adoption sentences. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2329,6 +2329,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_var_vs_nu_l1_b8_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_var_vs_nu_l1_b8_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_var_vs_nu_l1_b8_2026_08_15.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py
+runner_sha256: a80699ecadcbb22d66e1507ed27f2e6f72e8c4c90e8e96743f9ab8ac516ac0a8
+input_fingerprint_sha256: 0ffc78cb3bf6286e76c0dc91a593c7fd2d204e33f4775a4ee9a01dda9d1b72eb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+claim_scope: Arrival-speed variance under (0,1,1), support-drop, and ℓ¹ on B_8(0) is compared. Displayed, not adopted.
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: three directed Dijkstras on the induced B_8(0) graph
+negative_scope: displayed scores are not adopted and L1 is not attached
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: audit-tuple-literal AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: ball-cardinality B_8(0) has 833 sites and 832 nonzero sites
+PASS: three-dijkstras each named cost reaches every ball site
+PASS: l1-taxicab unit hop-cost arrivals equal the taxicab norm
+Q_(0,1,1) = 1642863107/3329726400
+Q_nu = 1255910253469/4501790092800
+Q_l1 = 55/104
+var_(0,1,1) = 0.008636807122136649
+var_nu = 0.006349675165465741
+var_l1 = 0.011339404956514005
+PASS: second-moments the three exact second moments match the note
+PASS: reported-variances the note reports the three truncated population variances
+PASS: variance-order ν is strictly rounder than (0,1,1), which is strictly rounder than ℓ¹
+lex_first_minimizer = nu
+PASS: lex-first-minimizer the unique and lex-first minimizer is ν
+PASS: cheaper-worse-round the cheaper rival stays worse-round
+PASS: forbidden-phrases note and runner omit the forbidden phrases
+PASS: claim-scope front matter uses the declared claim_scope
+PASS: theorems-displayed three theorems are present and the scores are displayed, not adopted
+PASS: no-admissibility-write the note refuses to write (0,1,1) or ν into Admissibility
+PASS: no-l1-attach the note does not attach L1
+PASS: mutation-unit-as-nu replacing ν by unit cost destroys the reported minimizer
+per_element: checked exactly — each of the 832 nonzero B_8(0) sites receives three arrival times
+per_site: checked exactly — population variance uses |v|_2/t at every nonzero site
+per_mode: checked exactly — three named hop-costs only; no other clause triple is scored
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py
+++ b/scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Exact B_8(0) arrival-speed variance comparison of (0,1,1), ν, and ℓ¹."""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from fractions import Fraction
+from heapq import heappop, heappush
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / "CLAUSE_011_VAR_VS_NU_L1_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_VAR_VS_NU_L1_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+RADIUS = 8
+ORIGIN = (0, 0, 0)
+SHIFTS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+NONZERO_COUNT = 832
+SITE_COUNT = 833
+
+Q_011 = Fraction(1642863107, 3329726400)
+Q_NU = Fraction(1255910253469, 4501790092800)
+Q_L1 = Fraction(55, 104)
+VAR_DIGITS = {
+    "(0,1,1)": "0.008636807122136649",
+    "nu": "0.006349675165465741",
+    "l1": "0.011339404956514005",
+}
+
+
+Point = tuple[int, int, int]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def l1_norm(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def radius_squared(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def weight(point: Point) -> int:
+    return sum(coordinate != 0 for coordinate in point)
+
+
+def ball_sites(radius: int) -> tuple[Point, ...]:
+    extent = range(-radius, radius + 1)
+    return tuple(point for point in product(extent, repeat=3) if l1_norm(point) <= radius)
+
+
+def split_square(value: int) -> tuple[int, int]:
+    square = 1
+    square_free = 1
+    remaining = value
+    prime = 2
+    while prime * prime <= remaining:
+        exponent = 0
+        while remaining % prime == 0:
+            remaining //= prime
+            exponent += 1
+        if exponent:
+            square *= prime ** (exponent // 2)
+            if exponent % 2:
+                square_free *= prime
+        prime += 1 if prime == 2 else 2
+    if remaining > 1:
+        square_free *= remaining
+    return square, square_free
+
+
+def hop_cost(source: Point, target: Point, seed: bool, axis_one: bool, drop: bool) -> int:
+    source_weight = weight(source)
+    target_weight = weight(target)
+    expensive = False
+    if seed and source_weight == 0:
+        expensive = True
+    if axis_one and source_weight == 1 and target_weight == 1:
+        expensive = True
+    if drop and target_weight < source_weight:
+        expensive = True
+    return 3 if expensive else 1
+
+
+def neighbors(site: Point, sites: set[Point]) -> tuple[Point, ...]:
+    out: list[Point] = []
+    for shift in SHIFTS:
+        candidate = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        if candidate in sites:
+            out.append(candidate)
+    return tuple(out)
+
+
+def dijkstra(sites: tuple[Point, ...], cost_fn) -> dict[Point, int]:
+    site_set = set(sites)
+    dist = {ORIGIN: 0}
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while heap:
+        current, site = heappop(heap)
+        if current != dist[site]:
+            continue
+        for nxt in neighbors(site, site_set):
+            trial = current + cost_fn(site, nxt)
+            prior = dist.get(nxt)
+            if prior is None or trial < prior:
+                dist[nxt] = trial
+                heappush(heap, (trial, nxt))
+    return dist
+
+
+def second_moment_and_var_coeff(dist: dict[Point, int], sites: tuple[Point, ...]) -> tuple[Fraction, dict[int, Fraction]]:
+    nonzero = tuple(site for site in sites if site != ORIGIN)
+    count = len(nonzero)
+    moment = Fraction(0)
+    linear: dict[int, Fraction] = defaultdict(Fraction)
+    for site in nonzero:
+        arrival = dist[site]
+        squared = radius_squared(site)
+        moment += Fraction(squared, arrival * arrival)
+        square, square_free = split_square(squared)
+        linear[square_free] += Fraction(square, arrival)
+    moment /= count
+    square_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    keys = tuple(linear)
+    for left in keys:
+        for right in keys:
+            square, square_free = split_square(left * right)
+            square_coeff[square_free] += linear[left] * linear[right] * square
+    var_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    var_coeff[1] += moment
+    denom = count * count
+    for square_free, coeff in square_coeff.items():
+        var_coeff[square_free] -= coeff / denom
+    return moment, {key: value for key, value in var_coeff.items() if value != 0}
+
+
+def eval_coeff(coeff: dict[int, Fraction], precision: int = 50) -> Decimal:
+    getcontext().prec = precision
+    total = Decimal(0)
+    for square_free, value in coeff.items():
+        total += (Decimal(value.numerator) / Decimal(value.denominator)) * Decimal(square_free).sqrt()
+    return total
+
+
+def truncated_decimal(value: Decimal, places: int = 18) -> str:
+    quantized = value.quantize(Decimal(10) ** -places)
+    text = format(quantized, "f")
+    whole, frac = text.split(".")
+    return whole + "." + frac[:places]
+
+
+def parse_audit_tuple(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names and isinstance(node.value, ast.Tuple):
+                values: list[str] = []
+                for element in node.value.elts:
+                    if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                        return None
+                    values.append(element.value)
+                return tuple(values)
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("claim_scope: Arrival-speed variance under (0,1,1), support-drop, and ℓ¹ on B_8(0) is compared. Displayed, not adopted.")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: three directed Dijkstras on the induced B_8(0) graph")
+    print("negative_scope: displayed scores are not adopted and L1 is not attached")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_VAR_VS_NU_L1_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-tuple-literal",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        parse_audit_tuple(self_source) == AUDIT_INPUT_PATHS,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom and admissibility_sentence in normalized_note)
+    checks.check("source-formation-boundary", "formation site/probability/rate remains outside Admissibility", formation_boundary in normalized_axiom and formation_boundary in normalized_note)
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+
+    sites = ball_sites(RADIUS)
+    site_set = set(sites)
+    checks.check("ball-cardinality", "B_8(0) has 833 sites and 832 nonzero sites", len(sites) == SITE_COUNT and ORIGIN in site_set and len(sites) - 1 == NONZERO_COUNT)
+
+    cost_011 = lambda src, dst: hop_cost(src, dst, seed=False, axis_one=True, drop=True)
+    cost_nu = lambda src, dst: hop_cost(src, dst, seed=True, axis_one=True, drop=True)
+    cost_l1 = lambda src, dst: 1
+
+    dist_011 = dijkstra(sites, cost_011)
+    dist_nu = dijkstra(sites, cost_nu)
+    dist_l1 = dijkstra(sites, cost_l1)
+    checks.check(
+        "three-dijkstras",
+        "each named cost reaches every ball site",
+        len(dist_011) == SITE_COUNT and len(dist_nu) == SITE_COUNT and len(dist_l1) == SITE_COUNT,
+        residual=(len(dist_011), len(dist_nu), len(dist_l1)),
+    )
+    checks.check(
+        "l1-taxicab",
+        "unit hop-cost arrivals equal the taxicab norm",
+        all(dist_l1[site] == l1_norm(site) for site in sites),
+    )
+
+    moment_011, var_011_coeff = second_moment_and_var_coeff(dist_011, sites)
+    moment_nu, var_nu_coeff = second_moment_and_var_coeff(dist_nu, sites)
+    moment_l1, var_l1_coeff = second_moment_and_var_coeff(dist_l1, sites)
+    var_011 = eval_coeff(var_011_coeff)
+    var_nu = eval_coeff(var_nu_coeff)
+    var_l1 = eval_coeff(var_l1_coeff)
+
+    print(f"Q_(0,1,1) = {moment_011}")
+    print(f"Q_nu = {moment_nu}")
+    print(f"Q_l1 = {moment_l1}")
+    print(f"var_(0,1,1) = {truncated_decimal(var_011)}")
+    print(f"var_nu = {truncated_decimal(var_nu)}")
+    print(f"var_l1 = {truncated_decimal(var_l1)}")
+
+    checks.check("second-moments", "the three exact second moments match the note", moment_011 == Q_011 and moment_nu == Q_NU and moment_l1 == Q_L1)
+    checks.check(
+        "reported-variances",
+        "the note reports the three truncated population variances",
+        VAR_DIGITS["(0,1,1)"] in note and VAR_DIGITS["nu"] in note and VAR_DIGITS["l1"] in note
+        and truncated_decimal(var_011) == VAR_DIGITS["(0,1,1)"]
+        and truncated_decimal(var_nu) == VAR_DIGITS["nu"]
+        and truncated_decimal(var_l1) == VAR_DIGITS["l1"],
+    )
+    checks.check(
+        "variance-order",
+        "ν is strictly rounder than (0,1,1), which is strictly rounder than ℓ¹",
+        var_nu < var_011 < var_l1,
+        residual=(str(var_nu), str(var_011), str(var_l1)),
+    )
+
+    named = {
+        "(0,1,1)": var_011,
+        "l1": var_l1,
+        "nu": var_nu,
+    }
+    lex_first = min(named, key=lambda name: (named[name], name))
+    print(f"lex_first_minimizer = {lex_first}")
+    checks.check("lex-first-minimizer", "the unique and lex-first minimizer is ν", lex_first == "nu")
+    checks.check("cheaper-worse-round", "the cheaper rival stays worse-round", var_011 > var_nu)
+
+    forbidden = ("G_" "N", "1/" "r", "1/" "r^2", "Lattice-" "named", "not a " "TOE")
+    checks.check(
+        "forbidden-phrases",
+        "note and runner omit the forbidden phrases",
+        all(phrase not in note for phrase in forbidden),
+    )
+    checks.check(
+        "claim-scope",
+        "front matter uses the declared claim_scope",
+        'claim_scope: "Arrival-speed variance under (0,1,1), support-drop, and ℓ¹ on B_8(0) is compared. Displayed, not adopted."'
+        in note,
+    )
+    checks.check(
+        "theorems-displayed",
+        "three theorems are present and the scores are displayed, not adopted",
+        "## Theorem 1 — Three Variances" in note
+        and "## Theorem 2 — Lex-First Minimizer" in note
+        and "## Theorem 3 — No Admissibility Write, L1 Not Attached" in note
+        and "Displayed, not adopted." in note
+        and "displayed, not adopted" in normalized_note,
+    )
+    checks.check(
+        "no-admissibility-write",
+        "the note refuses to write (0,1,1) or ν into Admissibility",
+        "Do not write `(0,1,1)` or ν into Admissibility." in note
+        and "hop-cost values" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom
+        and "(0,1,1)" not in axiom
+        and "support-drop hop-cost" not in axiom,
+    )
+    checks.check(
+        "no-l1-attach",
+        "the note does not attach L1",
+        "This note does not attach L1." in note
+        and "Do not attach L1." in note
+        and "hypothetical_axiom_status: \"no edit\"" in note,
+    )
+
+    mutated = dijkstra(sites, cost_l1)
+    mutated_moment, mutated_coeff = second_moment_and_var_coeff(mutated, sites)
+    mutated_var = eval_coeff(mutated_coeff)
+    checks.check(
+        "mutation-unit-as-nu",
+        "replacing ν by unit cost destroys the reported minimizer",
+        mutated_moment == moment_l1 and mutated_var == var_l1 and mutated_var > var_011,
+    )
+
+    print("per_element: checked exactly — each of the 832 nonzero B_8(0) sites receives three arrival times")
+    print("per_site: checked exactly — population variance uses |v|_2/t at every nonzero site")
+    print("per_mode: checked exactly — three named hop-costs only; no other clause triple is scored")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_8(0): var_nu=0.00635 < var_(0,1,1)=0.00864 < var_l1=0.01134. The cheaper rival stays worse-round. nu is the lex-first minimizer among the three. Displayed, not adopted.

## Runner

`scripts/clause_011_var_vs_nu_l1_b8_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.