### PR TITLE
feat(mix12): ten mixed shells on B12; both reverse-critical diagonals mixed

### DIFF
--- a/docs/SUPPORT_DROP_MIXED_SHELLS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_MIXED_SHELLS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,157 @@
+---
+claim_id: support_drop_mixed_shells_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Mixed t=const shells under the named support-drop hop-cost on B_12(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_mixed_shells_b12_2026_08_15.py
+---
+
+# Mixed t=const Shells Of The Named Support-Drop Hop-Cost On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only for which arrival values mix more than one Euclidean squared
+radius and for whether the reverse-critical body diagonal sits among them.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_mixed_shells_b12_2026_08_15.py`](../scripts/support_drop_mixed_shells_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost `ν` already scored on `B_8(0)` is
+scored independently on `B_12(0)`. Mixed `t=const` shells are not leftover
+of the radius-`8` mixed list: that list is six arrival values
+`5,6,7,8,9,10`, while `B_12(0)` adds four further mixed arrivals
+`11,12,13,14`. The site `(4,4,4)` is not in `B_8(0)` at all.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_12(0)` (2625 sites; 2624 nonzero) names
+exactly ten mixed arrival values on `B_12(0) \ {0}`:
+
+| `t` | distinct `|v|_2^2` | site count |
+|---:|---:|---:|
+| `5` | `2` | `32` |
+| `6` | `4` | `66` |
+| `7` | `4` | `96` |
+| `8` | `5` | `140` |
+| `9` | `8` | `198` |
+| `10` | `10` | `258` |
+| `11` | `10` | `326` |
+| `12` | `13` | `402` |
+| `13` | `15` | `486` |
+| `14` | `15` | `578` |
+
+The reverse-critical body diagonal `(2,2,2)` arrives at `t=8`, which is
+mixed. The doubled body diagonal `(4,4,4)` arrives at `t=14`, which is
+mixed. Both sit in mixed shells.
+
+The census is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+A `t=const` shell is mixed when the sites of that arrival carry more than
+one value of `|v|_2^2`. The six mixed arrivals on `B_8(0)` remain mixed
+here with the same site counts. The four new mixed arrivals exist only
+because sites with `|v|_1 > 8` are present; on `B_8(0)` the values
+`t=11,12,13` are single-radius six-site shells and `t=14` does not occur.
+
+## Theorem 1 — Mixed Arrival Values
+
+One origin Dijkstra on `B_12(0)` returns sixteen positive arrival values.
+The ten listed in the opening table are exactly those whose shells contain
+more than one `|v|_2^2`. The remaining six arrivals `3,4,15,16,17,20` are
+single-radius.
+
+The first six mixed rows copy the `B_8(0)` mixed list. The last four rows
+are new. In particular `t=11` now mixes ten squared radii across 326
+sites, and `t=14` mixes fifteen squared radii across 578 sites. The
+`B_12(0)` mixed list is therefore not leftover of the `B_8(0)` mixed list.
+
+## Theorem 2 — Body Diagonals Sit In Mixed Shells
+
+The same Dijkstra gives `t(2,2,2) = 8` and `t(4,4,4) = 14`. Both values
+appear in the mixed list of Theorem 1.
+
+The `t=8` shell has five squared radii `{12,14,18,20,26}` and 140 sites.
+The reverse-critical body diagonal `(2,2,2)` contributes the radius `12`
+orbit of size `8`; it shares the shell with `(3,2,1)`, `(3,3,0)`,
+`(4,1,1)`, `(4,2,0)`, and `(5,1,0)` (and their cubic images). So the
+reverse-critical body diagonal sits in a mixed shell.
+
+The `t=14` shell has fifteen squared radii and 578 sites. The doubled body
+diagonal `(4,4,4)` contributes the radius `48` orbit of size `8`; it shares
+the shell with, among others, `(8,0,0)` at radius `64`. So `(4,4,4)` also
+sits in a mixed shell.
+
+Both facts are displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_12(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. The mixed-shell census is not offered
+as a unique hop-cost property and is not a replacement for unit-cost first
+arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact mixed t=const census on the finite ball B_12(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs with mixed `t=const` shells.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any reuse of the `B_8(0)` mixed list as a substitute for the radius-`12`
+  Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_mixed_shells_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_mixed_shells_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_mixed_shells_b12_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_mixed_shells_b12_2026_08_15.py
+runner_sha256: cc030da56f34eff54cde9432f79c8d19a11c53df1ea850ec5ae707742d172fb2
+input_fingerprint_sha256: 8dd177273a5654e2e48f0d6dc3dc61548b5cf7f281420e3c94ae5ec1adcd86ed
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_MIXED_SHELLS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Mixed t=const shells under the named support-drop hop-cost on B_12(0) are named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the mixed-shell naming statement
+PASS: displayed-not-adopted the census is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+n_mixed 10
+mixed t=5 n_radii=2 n_sites=32 radii=[3, 5]
+mixed t=6 n_radii=4 n_sites=66 radii=[4, 6, 8, 10]
+mixed t=7 n_radii=4 n_sites=96 radii=[9, 11, 13, 17]
+mixed t=8 n_radii=5 n_sites=140 radii=[12, 14, 18, 20, 26]
+mixed t=9 n_radii=8 n_sites=198 radii=[9, 17, 19, 21, 25, 27, 29, 37]
+mixed t=10 n_radii=10 n_sites=258 radii=[16, 22, 24, 26, 30, 32, 34, 38, 40, 50]
+mixed t=11 n_radii=10 n_sites=326 radii=[25, 27, 29, 33, 35, 41, 45, 51, 53, 65]
+mixed t=12 n_radii=13 n_sites=402 radii=[34, 36, 38, 42, 44, 46, 50, 52, 54, 58, 66, 68, 82]
+mixed t=13 n_radii=15 n_sites=486 radii=[41, 43, 45, 49, 51, 53, 57, 59, 61, 65, 69, 73, 83, 85, 101]
+mixed t=14 n_radii=15 n_sites=578 radii=[48, 50, 54, 56, 62, 64, 66, 72, 74, 80, 86, 90, 102, 104, 122]
+t(2,2,2) 8
+t(4,4,4) 14
+t8_mixed True
+t14_mixed True
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: reachable every site of B_12(0) is reached
+PASS: mixed-list ten mixed arrivals with the named radius and site counts
+PASS: t-222-mixed t(2,2,2)=8 sits in a mixed shell
+PASS: t-444-mixed t(4,4,4)=14 sits in a mixed shell
+PASS: reverse-critical-among-mixed the reverse-critical t=8 shell mixes five squared radii
+PASS: not-leftover-of-b8 B_12 mixed list adds t=11,12,13,14 beyond the B_8 six
+PASS: note-records-mixed-list note records every mixed t with radius count and site count
+PASS: note-records-body-diagonals note records both body-diagonal arrivals as mixed
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_mixed_shells_b12_2026_08_15.py
+++ b/scripts/support_drop_mixed_shells_b12_2026_08_15.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Name mixed t=const shells of the support-drop hop-cost on B_12(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from collections import defaultdict
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_MIXED_SHELLS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_MIXED_SHELLS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Mixed t=const shells under the named support-drop hop-cost "
+    "on B_12(0) are named. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+MIXED_SHELLS = (
+    (5, 2, 32),
+    (6, 4, 66),
+    (7, 4, 96),
+    (8, 5, 140),
+    (9, 8, 198),
+    (10, 10, 258),
+    (11, 10, 326),
+    (12, 13, 402),
+    (13, 15, 486),
+    (14, 15, 578),
+)
+T8_RADII = (12, 14, 18, 20, 26)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def r2(v: tuple[int, int, int]) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def mixed_shells(
+    dist: dict[tuple[int, int, int], int],
+) -> list[tuple[int, int, int, tuple[int, ...]]]:
+    by_t: dict[int, list[tuple[int, int, int]]] = defaultdict(list)
+    for v, t in dist.items():
+        if v != (0, 0, 0):
+            by_t[t].append(v)
+    rows: list[tuple[int, int, int, tuple[int, ...]]] = []
+    for t in sorted(by_t):
+        radii = tuple(sorted({r2(v) for v in by_t[t]}))
+        if len(radii) > 1:
+            rows.append((t, len(radii), len(by_t[t]), radii))
+    return rows
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the mixed-shell naming statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the census is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_nu(sites)
+    rows = mixed_shells(dist)
+    mixed_triples = tuple((t, n_radii, n_sites) for t, n_radii, n_sites, _ in rows)
+    t222 = dist[(2, 2, 2)]
+    t444 = dist[(4, 4, 4)]
+    radii8 = next(radii for t, _, _, radii in rows if t == 8)
+    mixed_t = {t for t, _, _, _ in rows}
+
+    print(f"n_sites {len(sites)}")
+    print(f"n_mixed {len(rows)}")
+    for t, n_radii, n_sites, radii in rows:
+        print(f"mixed t={t} n_radii={n_radii} n_sites={n_sites} radii={list(radii)}")
+    print(f"t(2,2,2) {t222}")
+    print(f"t(4,4,4) {t444}")
+    print(f"t8_mixed {t222 in mixed_t}")
+    print(f"t14_mixed {t444 in mixed_t}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == 2625 and len(nonzero) == 2624 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "mixed-list",
+        "ten mixed arrivals with the named radius and site counts",
+        mixed_triples == MIXED_SHELLS,
+    )
+    checks.check(
+        "t-222-mixed",
+        "t(2,2,2)=8 sits in a mixed shell",
+        t222 == 8 and 8 in mixed_t and r2((2, 2, 2)) == 12,
+    )
+    checks.check(
+        "t-444-mixed",
+        "t(4,4,4)=14 sits in a mixed shell",
+        t444 == 14 and 14 in mixed_t and r2((4, 4, 4)) == 48,
+    )
+    checks.check(
+        "reverse-critical-among-mixed",
+        "the reverse-critical t=8 shell mixes five squared radii",
+        radii8 == T8_RADII,
+    )
+    checks.check(
+        "not-leftover-of-b8",
+        "B_12 mixed list adds t=11,12,13,14 beyond the B_8 six",
+        mixed_t == {5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
+        and "not leftover of the `B_8(0)` mixed list" in note
+        and "(4,4,4)` is not in `B_8(0)`" in note,
+    )
+    checks.check(
+        "note-records-mixed-list",
+        "note records every mixed t with radius count and site count",
+        all(
+            f"| `{t}` | `{n_radii}` | `{n_sites}` |" in note
+            for t, n_radii, n_sites in MIXED_SHELLS
+        ),
+    )
+    checks.check(
+        "note-records-body-diagonals",
+        "note records both body-diagonal arrivals as mixed",
+        "t(2,2,2) = 8" in note
+        and "t(4,4,4) = 14" in note
+        and "sits in a mixed shell" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and nu_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu, ten mixed arrival values t=5..14. (2,2,2) sits in mixed t=8; (4,4,4) sits in mixed t=14. Displayed, not adopted.

## Runner

`scripts/support_drop_mixed_shells_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.