### PR TITLE
feat(ratio12): same-k reverse holds for k=1..4 on B12

### DIFF
--- a/docs/SUPPORT_DROP_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,152 @@
+---
+claim_id: support_drop_scale_ratios_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Axis and body-diagonal arrival ratios under the named support-drop hop-cost on B_12(0) are reported for k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_scale_ratios_b12_2026_08_15.py
+---
+
+# Named Support-Drop Scale Ratios On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only for same-`k` axis versus body-diagonal arrival ratios at
+`k=1,2,3,4`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_scale_ratios_b12_2026_08_15.py`](../scripts/support_drop_scale_ratios_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_12(0)` (2625 sites) gives the same-`k`
+arrivals
+
+| `k` | `t(k,0,0)` | `t(k,k,k)` | `t(k,0,0)^2 / k^2` | `t(k,k,k)^2 / (3k^2)` | reverse |
+|---|---:|---:|---:|---:|---|
+| `1` | `3` | `5` | `9` | `25/3` | yes |
+| `2` | `6` | `8` | `9` | `16/3` | yes |
+| `3` | `9` | `11` | `9` | `121/27` | yes |
+| `4` | `10` | `14` | `25/4` | `49/12` | yes |
+
+For every `k=1,2,3,4`,
+
+`t(k,0,0)^2 / k^2 > t(k,k,k)^2 / (3k^2)`.
+
+Every available same-`k` scale on this ball still reverses. The `k=3` and
+`k=4` rows are not a leftover of a `B_8` table: `(3,3,3)` and `(4,4,4)` lie
+outside `B_8(0)`.
+
+The rule is displayed, not adopted. It is not written into Admissibility.
+It is not attached to L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+The axis-skeleton comparator `α` uses only the first two clauses of `ν`.
+On the support-drop hop `(1,1,0) → (1,0,0)` one has `|σ| : 2 → 1`, so
+`α = 1` while `ν = 3`. Therefore `α` cannot price support drop, and the
+`ν` scores below are not a leftover of `α`.
+
+## Theorem 1 — Same-`k` Arrival Table On `B_12(0)`
+
+One origin Dijkstra on `B_12(0)` returns the integer arrivals
+
+| site | `t_ν` |
+|---|---:|
+| `(1,0,0)` | `3` |
+| `(1,1,1)` | `5` |
+| `(2,0,0)` | `6` |
+| `(2,2,2)` | `8` |
+| `(3,0,0)` | `9` |
+| `(3,3,3)` | `11` |
+| `(4,0,0)` | `10` |
+| `(4,4,4)` | `14` |
+
+Every listed site lies in `B_12(0)`. The sites `(3,3,3)` and `(4,4,4)` have
+ℓ¹ norms `9` and `12`, so they are absent from `B_8(0)`. The table is
+computed on `B_12(0)`, not copied from a smaller-ball table.
+
+## Theorem 2 — Reverse At Each Same-`k` Scale
+
+For each `k=1,2,3,4` the Euclidean-normalized comparison is
+
+`t(k,0,0)^2 / k^2  ?  t(k,k,k)^2 / (3k^2)`,
+
+equivalently `3 t(k,0,0)^2 ? t(k,k,k)^2`. Substituting the computed times
+gives
+
+| `k` | `3 t(k,0,0)^2` | `t(k,k,k)^2` | reverse |
+|---|---:|---:|---|
+| `1` | `27` | `25` | `27 > 25` |
+| `2` | `108` | `64` | `108 > 64` |
+| `3` | `243` | `121` | `243 > 121` |
+| `4` | `300` | `196` | `300 > 196` |
+
+Arrival per Euclidean length is larger at `(k,0,0)` than at `(k,k,k)` for
+every listed `k`. The comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_12(0)`. It is not written
+into Admissibility. It is not attached to L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparisons on the finite ball B_12(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule ν at k=1..4; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs that reverse any same-`k` pair.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any score for a pair that is not a same-`k` axis / body-diagonal pair.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_scale_ratios_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_scale_ratios_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_scale_ratios_b12_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_scale_ratios_b12_2026_08_15.py
+runner_sha256: 7627818774cc768f2b90c02875ea40dc86d965475bea463664c9c0d91cf9fa7a
+input_fingerprint_sha256: 09f2464c337f824843d6a3a4e89173afb8a287874722f992792bf13824a294d1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Axis and body-diagonal arrival ratios under the named support-drop hop-cost on B_12(0) are reported for k=1..4. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+dijkstra_calls 1
+k 1 t(1,0,0) 3 t(1,1,1) 5 3t_axis^2 27 t_body^2 25 reverse True
+PASS: t-k1 t(1,0,0)=3 and t(1,1,1)=5
+PASS: reverse-k1 t(1,0,0)^2/1^2 > t(1,1,1)^2/(3*1^2)
+k 2 t(2,0,0) 6 t(2,2,2) 8 3t_axis^2 108 t_body^2 64 reverse True
+PASS: t-k2 t(2,0,0)=6 and t(2,2,2)=8
+PASS: reverse-k2 t(2,0,0)^2/2^2 > t(2,2,2)^2/(3*2^2)
+k 3 t(3,0,0) 9 t(3,3,3) 11 3t_axis^2 243 t_body^2 121 reverse True
+PASS: t-k3 t(3,0,0)=9 and t(3,3,3)=11
+PASS: reverse-k3 t(3,0,0)^2/3^2 > t(3,3,3)^2/(3*3^2)
+k 4 t(4,0,0) 10 t(4,4,4) 14 3t_axis^2 300 t_body^2 196 reverse True
+PASS: t-k4 t(4,0,0)=10 and t(4,4,4)=14
+PASS: reverse-k4 t(4,0,0)^2/4^2 > t(4,4,4)^2/(3*4^2)
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and is the ℓ¹ ball of radius 12
+PASS: reachable every site of B_12(0) is reached
+PASS: all-scales-reverse every k=1..4 same-k pair reverses
+PASS: note-records-times note records the eight computed arrivals
+PASS: note-records-reverse-products note records the four integer reverse products
+PASS: not-leftover-of-b8 (3,3,3) and (4,4,4) lie outside B_8(0) and the note says so
+PASS: not-leftover-of-alpha α cannot price the support-drop hop (1,1,0)→(1,0,0)
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_scale_ratios_b12_2026_08_15.py
+++ b/scripts/support_drop_scale_ratios_b12_2026_08_15.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Score same-k axis/body-diagonal ratios under ν on B_12(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Axis and body-diagonal arrival ratios under the named "
+    "support-drop hop-cost on B_12(0) are reported for k=1..4. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+# (k, t(k,0,0), t(k,k,k))
+REPORTED = ((1, 3, 5), (2, 6, 8), (3, 9, 11), (4, 10, 14))
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def alpha_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1):
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "not written into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "not attached to L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    dist = dijkstra_nu(sites)
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    times: dict[int, tuple[int, int]] = {}
+    all_reverse = True
+    for k, t_axis_rep, t_body_rep in REPORTED:
+        t_axis = dist[(k, 0, 0)]
+        t_body = dist[(k, k, k)]
+        times[k] = (t_axis, t_body)
+        reverse = 3 * t_axis * t_axis > t_body * t_body
+        all_reverse = all_reverse and reverse
+        print(
+            f"k {k} t({k},0,0) {t_axis} t({k},{k},{k}) {t_body} "
+            f"3t_axis^2 {3 * t_axis * t_axis} t_body^2 {t_body * t_body} "
+            f"reverse {reverse}"
+        )
+        checks.check(
+            f"t-k{k}",
+            f"t({k},0,0)={t_axis_rep} and t({k},{k},{k})={t_body_rep}",
+            t_axis == t_axis_rep and t_body == t_body_rep,
+        )
+        checks.check(
+            f"reverse-k{k}",
+            f"t({k},0,0)^2/{k}^2 > t({k},{k},{k})^2/(3*{k}^2)",
+            reverse,
+        )
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and is the ℓ¹ ball of radius 12",
+        len(sites) == 2625 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "all-scales-reverse",
+        "every k=1..4 same-k pair reverses",
+        all_reverse,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the eight computed arrivals",
+        all(
+            f"`{t_axis}`" in note and f"`{t_body}`" in note
+            for _k, t_axis, t_body in REPORTED
+        )
+        and "`(4,0,0)`" in note
+        and "`(4,4,4)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the four integer reverse products",
+        "27 > 25" in note
+        and "108 > 64" in note
+        and "243 > 121" in note
+        and "300 > 196" in note,
+    )
+    checks.check(
+        "not-leftover-of-b8",
+        "(3,3,3) and (4,4,4) lie outside B_8(0) and the note says so",
+        l1((3, 3, 3)) == 9
+        and l1((4, 4, 4)) == 12
+        and "outside `B_8(0)`" in note
+        and "not a leftover of a `B_8` table" in note,
+    )
+    checks.check(
+        "not-leftover-of-alpha",
+        "α cannot price the support-drop hop (1,1,0)→(1,0,0)",
+        nu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and alpha_cost((1, 1, 0), (1, 0, 0)) == 1
+        and "cannot price support drop" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu, t(k,0,0) vs t(k,k,k) reverses at every k=1,2,3,4. The k=3,4 pairs exist on this ball and are not leftover of B8. Displayed, not adopted.

## Runner

`scripts/support_drop_scale_ratios_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.