### PR TITLE
feat(011b12): (0,1,1) reverses small pair on B12; doubled pair fails

### DIFF
--- a/docs/CLAUSE_011_REVERSE_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_REVERSE_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,156 @@
+---
+claim_id: clause_011_reverse_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Body-diagonal reverse under the named (0,1,1) hop-cost on B_12(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_reverse_b12_2026_08_15.py
+---
+
+# Named (0,1,1) Hop-Cost Body-Diagonal Reverse On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact arrival times under one named hop-cost on the finite
+12-hop neighborhood of the origin in the cubic nearest-neighbor graph.
+The rule is displayed, not adopted.
+**Primary runner:**
+[`scripts/clause_011_reverse_b12_2026_08_15.py`](../scripts/clause_011_reverse_b12_2026_08_15.py)
+
+## Result Up Front
+
+Let `B_12(0)` be the set of sites of `Z^3` whose nearest-neighbor graph
+distance from the origin is at most 12. That set has 2625 sites and is
+used only as a finite domain bound. It is not a hop-cost.
+
+Hops are the six nearest-neighbor steps that remain inside `B_12(0)`.
+Write `σ_v` for the support of a site (the set of nonzero coordinates).
+The named clause-toggle `(0,1,1)` assigns
+
+```text
+cost(v→w) = 3  if |σ_v|=|σ_w|=1 or |σ_w|<|σ_v|,
+          = 1  otherwise.
+```
+
+Seed-exit therefore costs 1. Axis 1-skeleton hops and support-drop hops
+cost 3. Every other admitted hop costs 1. The rule is not written into
+Admissibility: do not write (0,1,1) into Admissibility. Do not attach L1.
+
+One Dijkstra from the origin yields
+
+```text
+t(4,0,0)=8
+t(8,0,0)=12
+t(12,0,0)=18
+t(2,2,2)=6
+t(4,4,4)=12
+```
+
+The displayed reverse tests are
+
+```text
+12 t(4,0,0)^2 = 768 > 576 = 16 t(2,2,2)^2     yes
+12 t(8,0,0)^2 = 1728 > 2304 = 16 t(4,4,4)^2   no
+```
+
+The small body-diagonal pair still reverses. The doubled pair does not.
+A rival member of this family is only live if reverse survives scale, so
+the named rule is not live on that score. Uniqueness is not required.
+Displayed, not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under
+lattice translations and proper cubic rotations.
+
+The axiom set supplies the cubic nearest-neighbor graph. It does not
+supply a hop-cost, a body-diagonal reverse test, or a preferred
+clause-toggle. This note therefore treats `(0,1,1)` as a separately
+named finite scoring rule. The note does not write `(0,1,1)` into
+Admissibility and does not enlarge the axiom set.
+
+Record is not used. No readout, formation site, or scalar collection
+functional enters the arrival times.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Five arrival times and two displayed reverse inequalities are exact outputs of one Dijkstra on the named finite graph; the hop-cost is a disclosed scoring rule, not an axiom, and the doubled pair fails reverse."
+trace_class: compute
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) under the named (0,1,1) hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+`B_12(0)` is the closed 12-hop neighborhood of the origin. Every hop
+used below is a nearest-neighbor step whose endpoints both lie in that
+set. One Dijkstra computes the named arrival time `t(v)` from the
+origin to each site.
+
+The two reverse inequalities compare axis and body-diagonal sites that
+share the same Euclidean squared length pair `(16,12)` after scaling:
+`(4,0,0)` with `(2,2,2)`, and `(8,0,0)` with `(4,4,4)`. The comparison
+is displayed only. It is not a derived continuum law and is not attached
+as an L1 hop-cost.
+
+## Theorem 1
+
+On `B_12(0)` under the named `(0,1,1)` hop-cost,
+
+`t(4,0,0)=8`, `t(8,0,0)=12`, `t(12,0,0)=18`, `t(2,2,2)=6`, and
+`t(4,4,4)=12`.
+
+Each value is the Dijkstra arrival time. The axis values are strictly
+larger than the corresponding nearest-neighbor hop counts, because the
+last step onto a 1-support site costs 3. The body-diagonal values equal
+the hop counts, because a monotone support-nondecreasing path from the
+origin uses only cost-1 hops.
+
+## Theorem 2
+
+The displayed inequalities are
+
+`12 t(4,0,0)^2 = 768 > 576 = 16 t(2,2,2)^2`,
+
+and
+
+`12 t(8,0,0)^2 = 1728 > 2304` is false, since `16 t(4,4,4)^2 = 2304`.
+
+Body-diagonal reverse therefore holds for the small pair and fails for
+the doubled pair on this same finite domain. Displayed, not adopted.
+
+## Theorem 3
+
+The note does not write `(0,1,1)` into Admissibility. Do not attach L1.
+Uniqueness is not required. The current axiom memo is not edited.
+
+## What This Does Not Claim
+
+- It does not adopt the `(0,1,1)` hop-cost as framework content.
+- It does not claim that reverse survives scale.
+- It does not claim that the named rule is the only reverser.
+- It does not identify `t` with nearest-neighbor hop count.
+- It does not supply a physical clock, a continuum metric, or a Record
+  readout of the arrival times.
+
+## Reproducibility
+
+```text
+python3 scripts/clause_011_reverse_b12_2026_08_15.py
+```
+
+The runner prints the five times, both displayed comparisons, and
+`TOTAL: PASS=<n> FAIL=<n>`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2329,6 +2329,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_reverse_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_reverse_b12_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_reverse_b12_2026_08_15.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_reverse_b12_2026_08_15.py
+runner_sha256: e51145a09afb5435c63d74f5e5c680126914060145f590d2fd40fa3969a5e18e
+input_fingerprint_sha256: 655c6590ceb668a0ee6624679202c09bccb8b3242a64586ec7e6a1e084342183
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; hop-costs are the named (0,1,1) rule on the finite 12-hop neighborhood B_12(0)
+package_local_integrity_reads: the note and current minimal axiom are read; no cache or governance surface is written
+negative_scope: the named rule is displayed, not adopted; it is not written into Admissibility and is not attached as an L1 hop-cost
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static literal pair and both files exist
+PASS: ball-b12-only B_12(0) is the 12-hop neighborhood of the origin and contains every named target
+PASS: clause-011-local seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1
+t(4,0,0)=8
+t(8,0,0)=12
+t(12,0,0)=18
+t(2,2,2)=6
+t(4,4,4)=12
+12 t(4,0,0)^2=768 16 t(2,2,2)^2=576 reverse=True
+12 t(8,0,0)^2=1728 16 t(4,4,4)^2=2304 reverse=False
+dijkstra_count=1
+PASS: theorem-1-times the five named arrival times are the Dijkstra values 8,12,18,6,12
+PASS: theorem-2-small-pair 12 t(4,0,0)^2 > 16 t(2,2,2)^2 holds (768 > 576)
+PASS: theorem-2-doubled-pair 12 t(8,0,0)^2 > 16 t(4,4,4)^2 fails (1728 > 2304 is false)
+PASS: scale-survival body-diagonal reverse does not survive the doubled pair on B_12(0)
+PASS: one-dijkstra a single origin Dijkstra assigned a finite time to every ball site
+PASS: note-reports-times the note reports the five computed times and both displayed comparisons
+PASS: displayed-not-adopted the note displays the (0,1,1) scores and does not adopt them
+PASS: admissibility-unedited the current axiom memo still names Admissibility and does not contain the hop-cost rule
+PASS: claim-scope the note states the required claim_scope
+PASS: forbidden-tokens the note avoids the forbidden tokens
+PASS: uniqueness-not-required the note does not claim uniqueness of the named rule
+TOTAL: PASS=14 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_reverse_b12_2026_08_15.py
+++ b/scripts/clause_011_reverse_b12_2026_08_15.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Named (0,1,1) hop-cost arrival times on B_12(0).
+
+One Dijkstra from the origin. Displayed, not adopted. No axiom edit,
+no cache write, no L1 hop-cost attachment.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_NAME = "CLAUSE_011_REVERSE_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+NOTE_PATH = ROOT / "docs" / NOTE_NAME
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_REVERSE_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BALL_RADIUS = 12
+AXIS = ((4, 0, 0), (8, 0, 0), (12, 0, 0))
+DIAG = ((2, 2, 2), (4, 4, 4))
+TARGETS = AXIS + DIAG
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+
+def nn_radius(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def in_ball(site: tuple[int, int, int]) -> bool:
+    return nn_radius(site) <= BALL_RADIUS
+
+
+def support_size(site: tuple[int, int, int]) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(src: tuple[int, int, int], dst: tuple[int, int, int]) -> int:
+    """Rule (0,1,1): cost 3 iff both weights 1 or support drop, else 1."""
+    src_support = support_size(src)
+    dst_support = support_size(dst)
+    both_weights_one = src_support == 1 and dst_support == 1
+    support_drop = dst_support < src_support
+    if both_weights_one or support_drop:
+        return 3
+    return 1
+
+
+def ball_sites() -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-BALL_RADIUS, BALL_RADIUS + 1):
+        for y in range(-BALL_RADIUS, BALL_RADIUS + 1):
+            remain = BALL_RADIUS - abs(x) - abs(y)
+            if remain < 0:
+                continue
+            for z in range(-remain, remain + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def neighbors(site: tuple[int, int, int]) -> list[tuple[int, int, int]]:
+    x, y, z = site
+    out: list[tuple[int, int, int]] = []
+    for dx, dy, dz in NEIGHBOR_STEPS:
+        nxt = (x + dx, y + dy, z + dz)
+        if in_ball(nxt):
+            out.append(nxt)
+    return out
+
+
+def dijkstra_from_origin(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    origin = (0, 0, 0)
+    dist = {origin: 0}
+    heap = [(0, origin)]
+    while heap:
+        cost_here, site = heapq.heappop(heap)
+        if cost_here != dist[site]:
+            continue
+        for nxt in neighbors(site):
+            cand = cost_here + hop_cost(site, nxt)
+            if cand < dist.get(nxt, 10**9):
+                dist[nxt] = cand
+                heapq.heappush(heap, (cand, nxt))
+    if len(dist) != len(sites):
+        raise RuntimeError("Dijkstra did not reach every site of B_12(0)")
+    return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def audit_paths_are_static_literals() -> bool:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names:
+                value = node.value
+                if not isinstance(value, ast.Tuple):
+                    return False
+                return all(
+                    isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    for elt in value.elts
+                )
+    return False
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; hop-costs are the named (0,1,1) "
+        "rule on the finite 12-hop neighborhood B_12(0)"
+    )
+    print(
+        "package_local_integrity_reads: the note and current minimal axiom "
+        "are read; no cache or governance surface is written"
+    )
+    print(
+        "negative_scope: the named rule is displayed, not adopted; it is "
+        "not written into Admissibility and is not attached as an L1 hop-cost"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static literal pair and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_REVERSE_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and audit_paths_are_static_literals()
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball_sites()
+    checks.check(
+        "ball-b12-only",
+        "B_12(0) is the 12-hop neighborhood of the origin and contains every named target",
+        len(sites) == 2625
+        and all(in_ball(site) for site in TARGETS)
+        and (12, 0, 0) in sites
+        and (4, 4, 4) in sites
+        and (13, 0, 0) not in set(sites),
+    )
+
+    checks.check(
+        "clause-011-local",
+        "seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1",
+        hop_cost((0, 0, 0), (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (2, 1, 0)) == 1
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    distances = dijkstra_from_origin(sites)
+    t400 = distances[(4, 0, 0)]
+    t800 = distances[(8, 0, 0)]
+    t1200 = distances[(12, 0, 0)]
+    t222 = distances[(2, 2, 2)]
+    t444 = distances[(4, 4, 4)]
+    left_small = 12 * t400 * t400
+    right_small = 16 * t222 * t222
+    left_double = 12 * t800 * t800
+    right_double = 16 * t444 * t444
+    reverse_small = left_small > right_small
+    reverse_double = left_double > right_double
+
+    print(f"t(4,0,0)={t400}")
+    print(f"t(8,0,0)={t800}")
+    print(f"t(12,0,0)={t1200}")
+    print(f"t(2,2,2)={t222}")
+    print(f"t(4,4,4)={t444}")
+    print(f"12 t(4,0,0)^2={left_small} 16 t(2,2,2)^2={right_small} reverse={reverse_small}")
+    print(f"12 t(8,0,0)^2={left_double} 16 t(4,4,4)^2={right_double} reverse={reverse_double}")
+    print("dijkstra_count=1")
+
+    checks.check(
+        "theorem-1-times",
+        "the five named arrival times are the Dijkstra values 8,12,18,6,12",
+        (t400, t800, t1200, t222, t444) == (8, 12, 18, 6, 12),
+    )
+    checks.check(
+        "theorem-2-small-pair",
+        "12 t(4,0,0)^2 > 16 t(2,2,2)^2 holds (768 > 576)",
+        reverse_small and left_small == 768 and right_small == 576,
+    )
+    checks.check(
+        "theorem-2-doubled-pair",
+        "12 t(8,0,0)^2 > 16 t(4,4,4)^2 fails (1728 > 2304 is false)",
+        (not reverse_double) and left_double == 1728 and right_double == 2304,
+    )
+    checks.check(
+        "scale-survival",
+        "body-diagonal reverse does not survive the doubled pair on B_12(0)",
+        reverse_small and not reverse_double,
+    )
+    checks.check(
+        "one-dijkstra",
+        "a single origin Dijkstra assigned a finite time to every ball site",
+        len(distances) == len(sites) and all(distances[site] >= 0 for site in sites),
+    )
+    checks.check(
+        "note-reports-times",
+        "the note reports the five computed times and both displayed comparisons",
+        "t(4,0,0)=8" in note
+        and "t(8,0,0)=12" in note
+        and "t(12,0,0)=18" in note
+        and "t(2,2,2)=6" in note
+        and "t(4,4,4)=12" in note
+        and "768 > 576" in note
+        and "1728 > 2304" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays the (0,1,1) scores and does not adopt them",
+        "Displayed, not adopted" in note
+        and "do not write (0,1,1) into Admissibility" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the current axiom memo still names Admissibility and does not contain the hop-cost rule",
+        "Admissibility" in axiom
+        and "Lattice" in axiom
+        and "Qubit" in axiom
+        and "Record" in axiom
+        and "both weights 1 or support drop" not in axiom
+        and "(0,1,1)" not in axiom,
+    )
+    checks.check(
+        "claim-scope",
+        "the note states the required claim_scope",
+        "Body-diagonal reverse under the named (0,1,1) hop-cost on B_12(0) is reported"
+        in note,
+    )
+    checks.check(
+        "forbidden-tokens",
+        "the note avoids the forbidden tokens",
+        "G_N" not in note
+        and "1/r" not in note
+        and "1/r^2" not in note
+        and "Lattice-named" not in note
+        and "not a TOE" not in note,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not claim uniqueness of the named rule",
+        "Uniqueness is not required" in note
+        and "unique hop-cost" not in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under (0,1,1): t(4,0,0)=8, t(8,0,0)=12, t(12,0,0)=18, t(2,2,2)=6, t(4,4,4)=12. 12 t(4,0,0)^2>16 t(2,2,2)^2 holds; 12 t(8,0,0)^2>16 t(4,4,4)^2 fails. Displayed, not adopted.

## Runner

`scripts/clause_011_reverse_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.