### PR TITLE
feat(facek): face reverse vs k on B12 is yes yes yes no no yes

### DIFF
--- a/docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,285 @@
+---
+claim_id: support_drop_face_reverse_vs_k_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_12(0) is reported for k=1..6. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py
+---
+
+# Face-Diagonal Reverse Versus Integer Scale k Under The Support-Drop Hop-Cost On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one directed Dijkstra on the nearest-neighbor graph of the
+ball $B_{12}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 12\}$ for the named support-drop
+hop-cost $\nu$. Face-diagonal reverse versus integer scale $k$ is reported
+for $k=1,\ldots,6$. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py`](../scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost $\nu$ already scored on the four named
+pairs of the $B_{12}(0)$ face-diagonal census is scored here against integer
+scale $k$ for every pair $((2k,0,0),(k,k,0))$ with $k=1,\ldots,6$. The six
+bits are not leftover of those four named pairs: the pairs at $k=1,3,5$ are
+not among them, and the $k=5$ fail is not a restatement of the $k=4$ fail.
+The $k=1,3,5$ times are independent Dijkstra outputs on $B_{12}(0)$.
+
+Let $\sigma_v=\{i\in\{1,2,3\}:v_i\neq 0\}$ and write $|\sigma_v|$ for its
+cardinality. On every nearest-neighbor hop $v\to w$ that remains inside
+$B_{12}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 12\}$, the named support-drop hop-cost is
+
+$$
+\nu(v\to w)=
+\begin{cases}
+3 & \text{if }|\sigma_v|=0\text{ or }(|\sigma_v|=|\sigma_w|=1)\text{ or }|\sigma_w|<|\sigma_v|,\\
+1 & \text{otherwise.}
+\end{cases}
+$$
+
+A single Dijkstra computation from the origin on this directed weighted graph
+returns the arrival times
+
+$$
+t(2,0,0)=6,\qquad t(4,0,0)=10,\qquad t(6,0,0)=12,
+$$
+$$
+t(8,0,0)=14,\qquad t(10,0,0)=16,\qquad t(12,0,0)=20,
+$$
+$$
+t(1,1,0)=4,\qquad t(2,2,0)=6,\qquad t(3,3,0)=8,
+$$
+$$
+t(4,4,0)=10,\qquad t(5,5,0)=12,\qquad t(6,6,0)=14.
+$$
+
+For each $k=1,\ldots,6$, reverse means the displayed comparison
+
+$$
+\frac{t(2k,0,0)^2}{4k^2}>\frac{t(k,k,0)^2}{2k^2}
+$$
+
+holds, equivalently $t(k,k,0)^2\cdot 4k^2<t(2k,0,0)^2\cdot 2k^2$. The bit is
+displayed, not adopted.
+
+| $k$ | pair | axis $t^2/|v|_2^2$ | face $t^2/|v|_2^2$ | reverse |
+|---|---|---|---|---|
+| $1$ | $((2,0,0),(1,1,0))$ | $36/4=9$ | $16/2=8$ | yes |
+| $2$ | $((4,0,0),(2,2,0))$ | $100/16=25/4$ | $36/8=9/2$ | yes |
+| $3$ | $((6,0,0),(3,3,0))$ | $144/36=4$ | $64/18=32/9$ | yes |
+| $4$ | $((8,0,0),(4,4,0))$ | $196/64=49/16$ | $100/32=25/8$ | no |
+| $5$ | $((10,0,0),(5,5,0))$ | $256/100=64/25$ | $144/50=72/25$ | no |
+| $6$ | $((12,0,0),(6,6,0))$ | $400/144=25/9$ | $196/72=49/18$ | yes |
+
+Exact integer comparisons:
+
+- $4\,t(1,1,0)^2=64<72=2\,t(2,0,0)^2$
+- $16\,t(2,2,0)^2=576<800=8\,t(4,0,0)^2$
+- $36\,t(3,3,0)^2=2304<2592=18\,t(6,0,0)^2$
+- $64\,t(4,4,0)^2=6400>6272=32\,t(8,0,0)^2$
+- $100\,t(5,5,0)^2=14400>12800=50\,t(10,0,0)^2$
+- $144\,t(6,6,0)^2=28224<28800=72\,t(12,0,0)^2$
+
+The reverse bit is therefore not the same for every $k=1,\ldots,6$. The fail
+is not isolated at $k=4$: reverse fails at $k=4$ and $k=5$, and holds at
+$k=1,2,3,6$. These six bits are not leftover of the four named pairs. The
+score is displayed, not adopted. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom. It does not choose a Hamiltonian or
+transfer operator, supply transition-probability or weight values, select a
+scalar or nonzero kinetic branch, assert a Dirac-square carrier, define a time
+metric, or provide a record-production process or physical persistence
+dynamics.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The named hop-cost $\nu$ is a displayed scoring rule on the nearest-neighbor
+graph of $B_{12}(0)$. It is not written into Admissibility. It is not attached to L1.
+It supplies no time metric, no Record formation rule, and no physical hop law.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Arrival times and six face-versus-axis reverse bits versus integer scale k on B_12(0) are finite exact Dijkstra values for a named hop-cost; the hop-cost is displayed, not adopted."
+trace_class: upstream_support
+target_claim_id: support_drop_face_reverse_vs_k_b12_bounded_theorem_note_2026-08-15
+target_blocker_text: "the named hop-cost is displayed, not adopted, and is not Admissibility content"
+source_of_blocker_text: this note
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the face-versus-axis reverse bits versus k as a displayed B_12(0) score; do not write nu into Admissibility."
+conditional_surface_status: "exact for the named support-drop hop-cost on B_12(0); not adopted as a law"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write $0=(0,0,0)$ and $B_{12}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 12\}$. This set has
+$2625$ sites, of which $2624$ are nonzero. The directed graph is the
+nearest-neighbor graph of $\mathbb{Z}^3$ induced on $B_{12}(0)$: from $v$ there
+is an edge to $w=v\pm e_i$ exactly when $w\in B_{12}(0)$.
+
+The support $\sigma_v$ and the hop-cost $\nu$ are as in Result Up Front. In
+words: seed exit from the origin costs $3$; every hop that stays on a
+coordinate axis costs $3$; every hop that strictly drops the number of
+nonzero coordinates costs $3$; every other in-ball nearest-neighbor hop
+costs $1$.
+
+Arrival time $t(v)$ is the least $\nu$-length of a directed path from $0$ to
+$v$ in this graph. One Dijkstra computation from the origin produces every
+$t(v)$ used below.
+
+The Euclidean squared length is $|v|_2^2=v_1^2+v_2^2+v_3^2$. The displayed
+comparison density is $t(v)^2/|v|_2^2$ at $v\neq 0$. For each integer
+$k=1,\ldots,6$ the ordered pair is $((2k,0,0),(k,k,0))$. The second site is
+the more-diagonal site (strictly more nonzero coordinates). The pair is
+reverse when
+
+$$
+t(k,k,0)^2\cdot|(2k,0,0)|_2^2 < t(2k,0,0)^2\cdot|(k,k,0)|_2^2,
+$$
+
+which is the same comparison as $t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$.
+
+The four named pairs of the prior $B_{12}(0)$ face-diagonal census are
+$((4,0,0),(2,2,0))$, $((8,0,0),(4,4,0))$, $((12,0,0),(6,6,0))$, and
+$((4,0,0),(2,2,2))$. Those pairs cover only $k=2,4,6$ among the face pairs
+and one body pair. They do not determine $t(2,0,0)$, $t(1,1,0)$, $t(6,0,0)$,
+$t(3,3,0)$, $t(10,0,0)$, or $t(5,5,0)$. The $k=1,\ldots,6$ table is therefore
+not leftover of the four named pairs.
+
+## Theorem 1 — Named Arrival Times At Each Scale
+
+On $B_{12}(0)$ under $\nu$, for each $k=1,\ldots,6$,
+
+$$
+\begin{align*}
+t(2,0,0)&=6,& t(1,1,0)&=4,\\
+t(4,0,0)&=10,& t(2,2,0)&=6,\\
+t(6,0,0)&=12,& t(3,3,0)&=8,\\
+t(8,0,0)&=14,& t(4,4,0)&=10,\\
+t(10,0,0)&=16,& t(5,5,0)&=12,\\
+t(12,0,0)&=20,& t(6,6,0)&=14.
+\end{align*}
+$$
+
+These twelve values are Dijkstra outputs, not fitted scalars.
+
+Witnessing paths of those $\nu$-costs exist. The walk
+
+$0\to(1,0,0)\to(2,0,0)$
+
+has hop-costs $3,3$ and sum $6$. The walk
+
+$0\to(1,0,0)\to(1,1,0)$
+
+has hop-costs $3,1$ and sum $4$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(4,0,0)$
+
+has hop-costs $3,1,1,1,1,3$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(2,2,0)$
+
+has hop-costs $3,1,1,1$ and sum $6$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(6,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,3$ and sum $12$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(2,3,0)\to(3,3,0)$
+
+has hop-costs $3,1,1,1,1,1$ and sum $8$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(8,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,3$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(2,4,0)\to(3,4,0)\to(4,4,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(10,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,3$ and sum $16$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(2,5,0)\to(3,5,0)\to(4,5,0)\to(5,5,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1$ and sum $12$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(11,1,0)\to(11,0,0)\to(12,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,3,3$ and sum $20$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(1,6,0)\to(2,6,0)\to(3,6,0)\to(4,6,0)\to(5,6,0)\to(6,6,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1$ and sum $14$.
+
+## Theorem 2 — Reverse Bit Versus Integer Scale k
+
+For each $k=1,\ldots,6$ the displayed comparison is whether
+$t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$. The six bits are:
+
+- $k=1$: $t(1,1,0)^2/|(1,1,0)|_2^2=8<9=t(2,0,0)^2/|(2,0,0)|_2^2$ (yes)
+- $k=2$: $t(2,2,0)^2/|(2,2,0)|_2^2=9/2<25/4=t(4,0,0)^2/|(4,0,0)|_2^2$ (yes)
+- $k=3$: $t(3,3,0)^2/|(3,3,0)|_2^2=32/9<4=t(6,0,0)^2/|(6,0,0)|_2^2$ (yes)
+- $k=4$: $t(4,4,0)^2/|(4,4,0)|_2^2=25/8\not<49/16=t(8,0,0)^2/|(8,0,0)|_2^2$ (no)
+- $k=5$: $t(5,5,0)^2/|(5,5,0)|_2^2=72/25\not<64/25=t(10,0,0)^2/|(10,0,0)|_2^2$ (no)
+- $k=6$: $t(6,6,0)^2/|(6,6,0)|_2^2=49/18<25/9=t(12,0,0)^2/|(12,0,0)|_2^2$ (yes)
+
+The fail is not isolated at $k=4$. The four named pairs do not determine the
+$k=1,3,5$ times or the $k=5$ fail.
+
+These reverse bits are displayed, not adopted.
+
+## Theorem 3 — Not Admissibility, Not Attached To L1
+
+Do not write $\nu$ into Admissibility. Admissibility names one fixed
+nearest-neighbor rule for the local possibility distribution. It does not
+supply hop weights, a time metric, or an arrival-time comparison.
+
+Do not attach L1. The named hop-cost is not attached to L1 and is not
+offered as a replacement for unit-cost first arrival. No uniqueness claim is
+made among hop-costs.
+
+## What This Note Does Not Claim
+
+- $\nu$ is not an axiom, not an approved primitive, and not a derived law.
+- The reverse bits are not promoted to a continuum speed, a physical clock,
+  or a Record readout.
+- Face-diagonal reverse versus $k$ is not claimed outside $B_{12}(0)$ and is
+  not claimed for any hop-cost other than the named $\nu$.
+- L1 is not adopted and is not attached to Admissibility.
+- The four named pairs of the prior face-diagonal census are not reused as a
+  substitute for the six-scale Dijkstra table.
+
+## claim_scope
+
+Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_12(0) is reported for k=1..6. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_face_reverse_vs_k_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_face_reverse_vs_k_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_face_reverse_vs_k_b12_2026_08_15.txt
@@ -1,0 +1,72 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py
+runner_sha256: 8fba09b22a0a2ae0b27d83fbab0ff1b3ae4d47b395a49d4c7ef450b05f26ccd9
+input_fingerprint_sha256: e2f53116d91e52995538245650b7a9bebe5453533b1cb03033239463e295460f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count_budget: 1
+claim_scope: Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_12(0) is reported for k=1..6. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and the axiom memo
+PASS: audit-input-literals AUDIT_INPUT_PATHS is a static two-string literal in this runner
+PASS: ball-cardinality B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: one-dijkstra exactly one Dijkstra computation is used
+PASS: finite-times every target is reached by a finite path
+arrival_times:
+  t(2, 0, 0)=6  t^2/|v|_2^2=36/4
+  t(1, 1, 0)=4  t^2/|v|_2^2=16/2
+  t(4, 0, 0)=10  t^2/|v|_2^2=100/16
+  t(2, 2, 0)=6  t^2/|v|_2^2=36/8
+  t(6, 0, 0)=12  t^2/|v|_2^2=144/36
+  t(3, 3, 0)=8  t^2/|v|_2^2=64/18
+  t(8, 0, 0)=14  t^2/|v|_2^2=196/64
+  t(4, 4, 0)=10  t^2/|v|_2^2=100/32
+  t(10, 0, 0)=16  t^2/|v|_2^2=256/100
+  t(5, 5, 0)=12  t^2/|v|_2^2=144/50
+  t(12, 0, 0)=20  t^2/|v|_2^2=400/144
+  t(6, 6, 0)=14  t^2/|v|_2^2=196/72
+PASS: time-200 computed t(2,0,0)=6 is written in the note
+PASS: time-400 computed t(4,0,0)=10 is written in the note
+PASS: time-600 computed t(6,0,0)=12 is written in the note
+PASS: time-800 computed t(8,0,0)=14 is written in the note
+PASS: time-1000 computed t(10,0,0)=16 is written in the note
+PASS: time-1200 computed t(12,0,0)=20 is written in the note
+PASS: time-110 computed t(1,1,0)=4 is written in the note
+PASS: time-220 computed t(2,2,0)=6 is written in the note
+PASS: time-330 computed t(3,3,0)=8 is written in the note
+PASS: time-440 computed t(4,4,0)=10 is written in the note
+PASS: time-550 computed t(5,5,0)=12 is written in the note
+PASS: time-660 computed t(6,6,0)=14 is written in the note
+reverse_bits:
+  k=1 (2, 0, 0) vs (1, 1, 0): reverse=True (16*4=64 vs 36*2=72)
+PASS: reverse-k1 k=1 reverse bit is True and the comparison is written
+  k=2 (4, 0, 0) vs (2, 2, 0): reverse=True (36*16=576 vs 100*8=800)
+PASS: reverse-k2 k=2 reverse bit is True and the comparison is written
+  k=3 (6, 0, 0) vs (3, 3, 0): reverse=True (64*36=2304 vs 144*18=2592)
+PASS: reverse-k3 k=3 reverse bit is True and the comparison is written
+  k=4 (8, 0, 0) vs (4, 4, 0): reverse=False (100*64=6400 vs 196*32=6272)
+PASS: reverse-k4 k=4 reverse bit is False and the comparison is written
+  k=5 (10, 0, 0) vs (5, 5, 0): reverse=False (144*100=14400 vs 256*50=12800)
+PASS: reverse-k5 k=5 reverse bit is False and the comparison is written
+  k=6 (12, 0, 0) vs (6, 6, 0): reverse=True (196*144=28224 vs 400*72=28800)
+PASS: reverse-k6 k=6 reverse bit is True and the comparison is written
+PASS: fail-not-isolated-at-k4 reverse fails at k=4 and k=5, so the fail is not isolated at k=4
+PASS: not-four-named-pair-leftover the k=1..6 census is not leftover of the four named pairs
+PASS: source-lattice Lattice nearest-neighbor wording is pinned in the axiom memo and the note
+PASS: source-admissibility Admissibility distribution wording and non-dynamics clause are pinned
+PASS: nu-not-admissibility the note refuses to write nu into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: displayed-not-adopted claim_scope and displayed-not-adopted wording are present
+PASS: forbidden-phrases forbidden phrases are absent from the note and from runner prose
+PASS: pair-reverse-bits the six declared scales have the displayed reverse bits
+PASS: axiom-untouched the axiom memo is an input only
+TOTAL: PASS=33 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py
+++ b/scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_12(0)."""
+
+from __future__ import annotations
+
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+RADIUS = 12
+SCALES = (1, 2, 3, 4, 5, 6)
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    "Face-diagonal reverse versus integer scale k under the named "
+    "support-drop hop-cost on B_12(0) is reported for k=1..6. "
+    "Displayed, not adopted."
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def l2sq(v: tuple[int, int, int]) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return sum(1 for x in v if x != 0)
+
+
+def nu(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sv = support_size(v)
+    sw = support_size(w)
+    if sv == 0 or (sv == 1 and sw == 1) or sw < sv:
+        return 3
+    return 1
+
+
+def ball_sites(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_from_origin(
+    sites: set[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    origin = (0, 0, 0)
+    inf = 10**9
+    dist = {site: inf for site in sites}
+    dist[origin] = 0
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, origin)]
+    while heap:
+        cost, v = heapq.heappop(heap)
+        if cost != dist[v]:
+            continue
+        for step in NEIGHBOR_STEPS:
+            w = (v[0] + step[0], v[1] + step[1], v[2] + step[2])
+            if w not in sites:
+                continue
+            nxt = cost + nu(v, w)
+            if nxt < dist[w]:
+                dist[w] = nxt
+                heapq.heappush(heap, (nxt, w))
+    return dist
+
+
+def flatten(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_site(k: int) -> tuple[int, int, int]:
+    return (2 * k, 0, 0)
+
+
+def face_site(k: int) -> tuple[int, int, int]:
+    return (k, k, 0)
+
+
+def is_reverse(
+    times: dict[tuple[int, int, int], int],
+    k: int,
+) -> bool:
+    axis = axis_site(k)
+    face = face_site(k)
+    ta = times[axis]
+    tb = times[face]
+    return ta * ta * l2sq(face) > tb * tb * l2sq(axis)
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count_budget: 1")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "audit-input-literals",
+        "AUDIT_INPUT_PATHS is a static two-string literal in this runner",
+        'AUDIT_INPUT_PATHS = (\n    "docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in source,
+    )
+
+    sites_list = ball_sites(RADIUS)
+    sites = set(sites_list)
+    checks.check(
+        "ball-cardinality",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites_list) == 2625 and (0, 0, 0) in sites and len(sites) == 2625,
+    )
+
+    targets = tuple(axis_site(k) for k in SCALES) + tuple(face_site(k) for k in SCALES)
+    dijkstra_runs = 0
+    times = dijkstra_from_origin(sites)
+    dijkstra_runs += 1
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra computation is used",
+        dijkstra_runs == 1,
+    )
+    checks.check(
+        "finite-times",
+        "every target is reached by a finite path",
+        all(times[v] < 10**9 for v in targets),
+    )
+
+    expected_times = {
+        (2, 0, 0): 6,
+        (4, 0, 0): 10,
+        (6, 0, 0): 12,
+        (8, 0, 0): 14,
+        (10, 0, 0): 16,
+        (12, 0, 0): 20,
+        (1, 1, 0): 4,
+        (2, 2, 0): 6,
+        (3, 3, 0): 8,
+        (4, 4, 0): 10,
+        (5, 5, 0): 12,
+        (6, 6, 0): 14,
+    }
+    print("arrival_times:")
+    for k in SCALES:
+        for v in (axis_site(k), face_site(k)):
+            print(f"  t{v}={times[v]}  t^2/|v|_2^2={times[v] ** 2}/{l2sq(v)}")
+
+    for v, expected in expected_times.items():
+        token = f"t({v[0]},{v[1]},{v[2]})={expected}"
+        checks.check(
+            f"time-{v[0]}{v[1]}{v[2]}",
+            f"computed {token} is written in the note",
+            token in note and times[v] == expected,
+            residual=times[v],
+        )
+
+    expected_bits = {
+        1: True,
+        2: True,
+        3: True,
+        4: False,
+        5: False,
+        6: True,
+    }
+    comparison_tokens = {
+        1: r"4\,t(1,1,0)^2=64<72=2\,t(2,0,0)^2",
+        2: r"16\,t(2,2,0)^2=576<800=8\,t(4,0,0)^2",
+        3: r"36\,t(3,3,0)^2=2304<2592=18\,t(6,0,0)^2",
+        4: r"64\,t(4,4,0)^2=6400>6272=32\,t(8,0,0)^2",
+        5: r"100\,t(5,5,0)^2=14400>12800=50\,t(10,0,0)^2",
+        6: r"144\,t(6,6,0)^2=28224<28800=72\,t(12,0,0)^2",
+    }
+    print("reverse_bits:")
+    bits: list[bool] = []
+    for k in SCALES:
+        axis = axis_site(k)
+        face = face_site(k)
+        bit = is_reverse(times, k)
+        bits.append(bit)
+        ta, tb = times[axis], times[face]
+        print(
+            f"  k={k} {axis} vs {face}: reverse={bit} "
+            f"({tb * tb}*{l2sq(axis)}={tb * tb * l2sq(axis)} vs "
+            f"{ta * ta}*{l2sq(face)}={ta * ta * l2sq(face)})"
+        )
+        dens_ok = ta * ta * (2 * k * k) > tb * tb * (4 * k * k)
+        checks.check(
+            f"reverse-k{k}",
+            f"k={k} reverse bit is {expected_bits[k]} and the comparison is written",
+            bit is expected_bits[k]
+            and dens_ok is expected_bits[k]
+            and comparison_tokens[k] in note,
+        )
+
+    checks.check(
+        "fail-not-isolated-at-k4",
+        "reverse fails at k=4 and k=5, so the fail is not isolated at k=4",
+        bits == [True, True, True, False, False, True]
+        and "not isolated at $k=4$" in note
+        and "fails at $k=4$ and $k=5$" in note,
+    )
+    checks.check(
+        "not-four-named-pair-leftover",
+        "the k=1..6 census is not leftover of the four named pairs",
+        "not leftover of the four named pairs" in note
+        and "independent Dijkstra" in note
+        and times[(1, 1, 0)] == 4
+        and times[(3, 3, 0)] == 8
+        and times[(5, 5, 0)] == 12
+        and times[(10, 0, 0)] == 16
+        and l1((12, 0, 0)) == 12
+        and l1((6, 6, 0)) == 12,
+    )
+
+    flat_note = flatten(note)
+    flat_axiom = flatten(axiom)
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    admissibility_quote = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    not_dynamics = "Admissibility is not a dynamics axiom."
+    checks.check(
+        "source-lattice",
+        "Lattice nearest-neighbor wording is pinned in the axiom memo and the note",
+        lattice_quote in flat_axiom and lattice_quote in flat_note,
+    )
+    checks.check(
+        "source-admissibility",
+        "Admissibility distribution wording and non-dynamics clause are pinned",
+        admissibility_quote in flat_axiom
+        and admissibility_quote in flat_note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+    checks.check(
+        "nu-not-admissibility",
+        "the note refuses to write nu into Admissibility",
+        "It is not written into Admissibility." in note
+        and "Do not write $\\nu$ into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "not attached to L1" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "claim_scope and displayed-not-adopted wording are present",
+        CLAIM_SCOPE in note and "displayed, not adopted" in note,
+    )
+    forbidden_hits = [
+        phrase
+        for phrase in FORBIDDEN
+        if phrase in note or phrase in source.split("FORBIDDEN =", 1)[0]
+    ]
+    checks.check(
+        "forbidden-phrases",
+        "forbidden phrases are absent from the note and from runner prose",
+        not forbidden_hits,
+        residual=forbidden_hits,
+    )
+    checks.check(
+        "pair-reverse-bits",
+        "the six declared scales have the displayed reverse bits",
+        tuple(bits) == (True, True, True, False, False, True),
+        residual=bits,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu, face pair ((2k,0,0),(k,k,0)) reverses at k=1,2,3,6 and fails at k=4 and k=5. Fail is not isolated at k=4. Displayed, not adopted.

## Runner

`scripts/support_drop_face_reverse_vs_k_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.