### PR TITLE
feat(bodyk): body reverse vs k on B12 is yes yes no no

### DIFF
--- a/docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,193 @@
+---
+claim_id: support_drop_body_reverse_vs_k_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Body-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_12(0) is reported for k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py
+---
+
+# Named Support-Drop Body Reverse Versus Scale k On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only for the face-orthogonal body census pairing
+`((2k,0,0),(k,k,k))` at every integer `k=1,2,3,4`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py`](../scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_12(0)` (2625 sites) gives the body-census
+arrivals
+
+| `k` | site axis | `t(2k,0,0)` | site body | `t(k,k,k)` | `12 t(2k,0,0)^2` | `16 t(k,k,k)^2` | reverse |
+|---|---|---:|---|---:|---:|---:|---|
+| `1` | `(2,0,0)` | `6` | `(1,1,1)` | `5` | `432` | `400` | yes |
+| `2` | `(4,0,0)` | `10` | `(2,2,2)` | `8` | `1200` | `1024` | yes |
+| `3` | `(6,0,0)` | `12` | `(3,3,3)` | `11` | `1728` | `1936` | no |
+| `4` | `(8,0,0)` | `14` | `(4,4,4)` | `14` | `2352` | `3136` | no |
+
+Equivalently, `t(2k,0,0)^2 / (4k^2) > t(k,k,k)^2 / (3k^2)` holds at
+`k=1` (`9 > 25/3`) and at `k=2` (`25/4 > 16/3`), and fails at `k=3`
+(`4 > 121/27` fails) and at `k=4` (`49/16 > 49/12` fails). Reverse is
+not leftover of the two named pairs `((4,0,0),(2,2,2))` and
+`((8,0,0),(4,4,4))`: the `k=1` and `k=3` rows are additional scales.
+
+The rule is displayed, not adopted. It is not written into Admissibility.
+It is not attached to L1. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+The axis-skeleton comparator `α` uses only the first two clauses of `ν`.
+On the support-drop hop `(1,1,0) → (1,0,0)` one has `|σ| : 2 → 1`, so
+`α = 1` while `ν = 3`. Therefore `α` cannot price support drop, and the
+`ν` scores below are not a leftover of `α`.
+
+The pairing is not the same-`k` axis / body pair `(k,0,0)` versus
+`(k,k,k)`. It is the face-orthogonal body census
+`((2k,0,0),(k,k,k))`.
+
+## Theorem 1 — Arrivals For Each `k=1..4`
+
+One origin Dijkstra on `B_12(0)` returns the integer arrivals
+
+| site | `t_ν` |
+|---|---:|
+| `(2,0,0)` | `6` |
+| `(1,1,1)` | `5` |
+| `(4,0,0)` | `10` |
+| `(2,2,2)` | `8` |
+| `(6,0,0)` | `12` |
+| `(3,3,3)` | `11` |
+| `(8,0,0)` | `14` |
+| `(4,4,4)` | `14` |
+
+Every listed site lies in `B_12(0)`. Witnessing paths of those `ν`-costs
+exist. The walk
+
+`0 → (1,0,0) → (2,0,0)`
+
+has hop-costs `3,3` and sum `6`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1)`
+
+has hop-costs `3,1,1` and sum `5`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (4,0,0)`
+
+has hop-costs `3,1,1,1,1,3` and sum `10`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2)`
+
+has hop-costs `3,1,1,1,1,1` and sum `8`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (6,0,0)`
+
+has hop-costs `3,1,1,1,1,1,1,3` and sum `12`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2) → (3,2,2) → (3,3,2) → (3,3,3)`
+
+has hop-costs `3,1,1,1,1,1,1,1,1` and sum `11`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (8,0,0)`
+
+has hop-costs `3,1,1,1,1,1,1,1,1,3` and sum `14`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2) → (3,2,2) → (3,3,2) → (3,3,3) → (4,3,3) → (4,4,3) → (4,4,4)`
+
+has hop-costs `3,1,1,1,1,1,1,1,1,1,1,1` and sum `14`.
+
+The table is computed on `B_12(0)`, not copied from two named pairs.
+
+## Theorem 2 — Reverse Bit At Each Scale
+
+For each `k=1,2,3,4` the Euclidean-normalized comparison is
+
+`t(2k,0,0)^2 / (4k^2)  ?  t(k,k,k)^2 / (3k^2)`,
+
+equivalently `12 t(2k,0,0)^2 ? 16 t(k,k,k)^2`. Substituting the computed
+times gives
+
+| `k` | `12 t(2k,0,0)^2` | `16 t(k,k,k)^2` | reverse |
+|---|---:|---:|---|
+| `1` | `432` | `400` | `432 > 400` |
+| `2` | `1200` | `1024` | `1200 > 1024` |
+| `3` | `1728` | `1936` | `1728 > 1936` fails |
+| `4` | `2352` | `3136` | `2352 > 3136` fails |
+
+Arrival per Euclidean length is larger at `(2k,0,0)` than at `(k,k,k)` for
+`k=1,2` and is not larger for `k=3,4`. Fail is already present at `k=3`;
+it is not isolated at the doubled diamond. The comparison is displayed,
+not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_12(0)`. It is not written
+into Admissibility. It is not attached to L1. Do not write `ν` into
+Admissibility. Do not attach L1. It is not a replacement for unit-cost
+first arrival, and it is not offered as the unique hop-cost with
+body-census reverse at any `k`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer body-census arrivals and reverse bits on the finite ball B_12(0) for one named hop-cost at k=1..4. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule ν at k=1..4 on ((2k,0,0),(k,k,k)); no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs that reverse any body-census pair.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any score for a pair that is not `((2k,0,0),(k,k,k))`.
+- Any leftover of the two named pairs `((4,0,0),(2,2,2))` and
+  `((8,0,0),(4,4,4))` as a substitute for the four-scale census.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_body_reverse_vs_k_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_body_reverse_vs_k_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_body_reverse_vs_k_b12_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py
+runner_sha256: ca3a333dc5e56d4ecef29ce746c4a3e9d8388f733998e2f4a5caf6df419a7aca
+input_fingerprint_sha256: 36c5e177d06fca881fcac0a29df5fb7629c10acacc3aa7e36595d26a93123b78
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Body-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_12(0) is reported for k=1..4. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+dijkstra_calls 1
+k 1 t(2,0,0) 6 t(1,1,1) 5 12t_axis^2 432 16t_body^2 400 reverse True
+PASS: t-k1 t(2,0,0)=6 and t(1,1,1)=5
+PASS: reverse-k1 12 t(2,0,0)^2 > 16 t(1,1,1)^2 is True
+k 2 t(4,0,0) 10 t(2,2,2) 8 12t_axis^2 1200 16t_body^2 1024 reverse True
+PASS: t-k2 t(4,0,0)=10 and t(2,2,2)=8
+PASS: reverse-k2 12 t(4,0,0)^2 > 16 t(2,2,2)^2 is True
+k 3 t(6,0,0) 12 t(3,3,3) 11 12t_axis^2 1728 16t_body^2 1936 reverse False
+PASS: t-k3 t(6,0,0)=12 and t(3,3,3)=11
+PASS: reverse-k3 12 t(6,0,0)^2 > 16 t(3,3,3)^2 is False
+k 4 t(8,0,0) 14 t(4,4,4) 14 12t_axis^2 2352 16t_body^2 3136 reverse False
+PASS: t-k4 t(8,0,0)=14 and t(4,4,4)=14
+PASS: reverse-k4 12 t(8,0,0)^2 > 16 t(4,4,4)^2 is False
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and is the ℓ¹ ball of radius 12
+PASS: reachable every site of B_12(0) is reached
+PASS: reverse-bits-match computed reverse bits match the four-scale census
+PASS: note-records-times note records the eight computed arrivals
+PASS: note-records-reverse-products note records the four integer reverse products
+PASS: not-leftover-of-two-named-pairs k=1 and k=3 are additional scales, not leftover of two named pairs
+PASS: not-leftover-of-alpha α cannot price the support-drop hop (1,1,0)→(1,0,0)
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py
+++ b/scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Score body-diagonal reverse versus scale k under ν on B_12(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Body-diagonal reverse versus integer scale k under the named "
+    "support-drop hop-cost on B_12(0) is reported for k=1..4. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+# (k, t(2k,0,0), t(k,k,k), reverse)
+REPORTED = ((1, 6, 5, True), (2, 10, 8, True), (3, 12, 11, False), (4, 14, 14, False))
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def alpha_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1):
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "not written into Admissibility" in note
+        and "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "not attached to L1" in note
+        and "Do not attach L1" in note
+        and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    dist = dijkstra_nu(sites)
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    all_match = True
+    for k, t_axis_rep, t_body_rep, reverse_rep in REPORTED:
+        t_axis = dist[(2 * k, 0, 0)]
+        t_body = dist[(k, k, k)]
+        lhs = 12 * t_axis * t_axis
+        rhs = 16 * t_body * t_body
+        reverse = lhs > rhs
+        all_match = all_match and reverse == reverse_rep
+        print(
+            f"k {k} t({2 * k},0,0) {t_axis} t({k},{k},{k}) {t_body} "
+            f"12t_axis^2 {lhs} 16t_body^2 {rhs} reverse {reverse}"
+        )
+        checks.check(
+            f"t-k{k}",
+            f"t({2 * k},0,0)={t_axis_rep} and t({k},{k},{k})={t_body_rep}",
+            t_axis == t_axis_rep and t_body == t_body_rep,
+        )
+        checks.check(
+            f"reverse-k{k}",
+            f"12 t({2 * k},0,0)^2 > 16 t({k},{k},{k})^2 is {reverse_rep}",
+            reverse == reverse_rep and (lhs > rhs) == reverse,
+        )
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and is the ℓ¹ ball of radius 12",
+        len(sites) == 2625 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "reverse-bits-match",
+        "computed reverse bits match the four-scale census",
+        all_match,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the eight computed arrivals",
+        all(
+            f"`{t_axis}`" in note and f"`{t_body}`" in note
+            for _k, t_axis, t_body, _rev in REPORTED
+        )
+        and "`(2,0,0)`" in note
+        and "`(6,0,0)`" in note
+        and "`(8,0,0)`" in note
+        and "`(4,4,4)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the four integer reverse products",
+        "432 > 400" in note
+        and "1200 > 1024" in note
+        and "1728 > 1936" in note
+        and "2352 > 3136" in note,
+    )
+    checks.check(
+        "not-leftover-of-two-named-pairs",
+        "k=1 and k=3 are additional scales, not leftover of two named pairs",
+        l1((2, 0, 0)) == 2
+        and l1((1, 1, 1)) == 3
+        and l1((6, 0, 0)) == 6
+        and l1((3, 3, 3)) == 9
+        and "not leftover of the two named pairs" in note
+        and "k=1` and `k=3` rows are additional scales" in note,
+    )
+    checks.check(
+        "not-leftover-of-alpha",
+        "α cannot price the support-drop hop (1,1,0)→(1,0,0)",
+        nu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and alpha_cost((1, 1, 0), (1, 0, 0)) == 1
+        and "cannot price support drop" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and nu_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu, ((2k,0,0),(k,k,k)) reverses at k=1,2 and fails at k=3,4. Same-k reverse is a different pairing. Displayed, not adopted.

## Runner

`scripts/support_drop_body_reverse_vs_k_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.