### PR TITLE
feat(011meet12): (0,1,1) B6-union still meets at (1,0,0) t=1; worse var than l1

### DIFF
--- a/docs/TWO_SEED_CLAUSE_011_MEET_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_SEED_CLAUSE_011_MEET_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,160 @@
+---
+claim_id: two_seed_clause_011_meet_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Two-seed meetings under the named (0,1,1) hop-cost on the B_6 union are scored vs ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_seed_clause_011_meet_b6_2026_08_15.py
+---
+
+# Two-Seed Meetings Under The Named `(0,1,1)` Hop-Cost On The `B_6` Union
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** two seeds `s0=(0,0,0)` and `s1=(2,0,0)` on the union
+`B_6(0) ∪ B_6((2,0,0))`, with fronts grown by the named clause-toggle
+`(0,1,1)` using inward weights relative to the seed being grown.
+First-meeting sites and the equal-arrival midplane are scored against
+unit-cost ℓ¹. Displayed, not adopted. Not leftover of the B_4 union:
+the host, arrivals, meeting set, and midplane variances are computed
+on the `B_6` union.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_seed_clause_011_meet_b6_2026_08_15.py`](../scripts/two_seed_clause_011_meet_b6_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same two seeds and the same named diamond reverser `(0,1,1)` are
+grown on the larger union `B_6(0) ∪ B_6((2,0,0))`. The question is
+whether the first meeting stays `(1,0,0)` and whether midplane
+population variance of `|v-s0|_2/t0` still loses to unit-cost ℓ¹.
+Uniqueness among hop-costs is not required.
+
+Write `|σ_s(v)|` for the number of nonzero coordinates of `v-s`. That
+integer is the inward weight of `v` relative to the seed `s` being
+grown. On a directed nearest-neighbor hop `v → w` still inside the
+union, the displayed rule relative to `s` is
+
+`(0,1,1)_s(v→w) = 3` if `(|σ_s(v)|=|σ_s(w)|=1)` or
+`|σ_s(w)| < |σ_s(v)|`, else `1`.
+
+The first clause is both inward weights `1`. The second is support
+drop. Seed-exit (`|σ_s(v)|=0`) is off, so it costs `1`. Those are the
+whole rule.
+
+Let `t0` and `t1` be the least path costs from `s0` and `s1` under
+`(0,1,1)` relative to that seed. One pair of Dijkstras on the 523-site
+union gives a first-meeting set
+
+`M = { v : t0(v)=t1(v)` and no neighbor is strictly earlier for both `}`.
+
+The lex-first meeting site is `(1,0,0)` at time `t=1`, and `|M|=1`.
+The first meeting therefore stays the matching-member front
+`{(1,0,0)}`. The cheap seed-exit is what keeps the meeting time at `1`.
+
+The equal-arrival midplane is `{ v : t0(v)=t1(v) }`. Population
+variances of `|v-s0|_2/t0` on each law's own midplane are
+
+`var_(0,1,1) = 0.00928264138161`, `var_ℓ¹ = 0.00818042204172`.
+
+The ℓ¹ variance is strictly smaller. The midplane under `(0,1,1)` has
+69 sites; the midplane under ℓ¹ has 61 sites.
+
+The rule is displayed, not adopted. It is not written into Admissibility.
+It is not attached to L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+Lattice supplies the six-neighbor graph and the two balls. Admissibility
+supplies none of the hop costs. The integers `3` and `1`, the seed-relative
+support-size clauses, and the two arrival functions are separately
+displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule And Domain
+
+Let `B_6(s) = { v ∈ Z^3 : |v-s|_1 ≤ 6 }`. The host is the union
+`B_6(0) ∪ B_6((2,0,0))`, which has 523 sites. Directed edges are the
+six nearest-neighbor steps whose both ends lie in the union.
+
+For the seed `s0`, inward weight is `|σ_{s0}(v)|`. For the seed `s1`,
+inward weight is `|σ_{s1}(v)|`. Each Dijkstra uses only the copy of
+`(0,1,1)` relative to the seed it grows. Unit-cost ℓ¹ arrival is the
+closed form `t_ℓ¹_s(v) = |v-s|_1`; it is not obtained from a third
+Dijkstra.
+
+A neighbor `w` of `v` is strictly earlier for both if `t0(w)<t0(v)` and
+`t1(w)<t1(v)`. First-meeting sites are the equal-arrival sites with no
+such neighbor.
+
+The eight sites
+
+`(0,±2,0)`, `(0,0,±2)`, `(2,±2,0)`, `(2,0,±2)`
+
+lie on the `(0,1,1)` midplane and not on the ℓ¹ midplane `x=1`.
+
+## Theorem 1 — Lex-First Meeting Site
+
+One pair of Dijkstras returns integer arrivals with first-meeting set
+`M = { (1,0,0) }`. The lex-first meeting site and its time are
+
+`(1,0,0)` at `t0=t1=1`.
+
+So `|M|=1`. The first meeting stays a matching-member front. Under
+unit-cost ℓ¹ the same meeting definition also yields the singleton
+`{(1,0,0)}`, at time `1`. Uniqueness is not claimed among hop-costs.
+
+## Theorem 2 — Midplane Variance Of `|v-s0|_2/t0`
+
+On the equal-arrival midplane of each law, let `r(v) = |v-s0|_2 / t0(v)`
+and write population variance `(1/n) ∑ (r − mean)^2`. The runner computes
+
+`var_(0,1,1) = 0.00928264138161` on 69 sites,
+`var_ℓ¹ = 0.00818042204172` on 61 sites.
+
+So `var_ℓ¹ < var_(0,1,1)`. The cheaper reverser does not tighten the
+two-seed midplane ratio below ℓ¹.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `(0,1,1)` is a displayed scoring device on the two-seed `B_6`
+union. It is not written into Admissibility. It is not attached to L1.
+It is not a replacement for unit-cost first arrival, and it is not
+offered as the unique hop-cost with a two-seed matching-member front.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer two-seed arrivals and a midplane population-variance comparison on B_6(0)∪B_6((2,0,0)) for the named (0,1,1) hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on the two-seed B_6 union for the displayed rule (0,1,1); no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `(0,1,1)` among hop-costs with a matching-member first
+  meeting.
+- That `(0,1,1)` beats ℓ¹ on two-seed midplane variance.
+- Any leftover of a `B_4` union computation in place of the `B_6` host.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off the union `B_6(0) ∪ B_6((2,0,0))`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18617,6 +18617,10 @@
   "two_seam_forest_gauge_polyakov_holonomy_preservation_bounded_theorem_note_2026-07-12": {
    "deps_hash": "5fc9a31251f2",
    "out_degree": 3
+  },
+  "two_seed_clause_011_meet_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_sign_comparison_note_2026-04-10": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/two_seed_clause_011_meet_b6_2026_08_15.txt
+++ b/logs/runner-cache/two_seed_clause_011_meet_b6_2026_08_15.txt
@@ -1,0 +1,50 @@
+===== runner cache v1 =====
+runner: scripts/two_seed_clause_011_meet_b6_2026_08_15.py
+runner_sha256: e73e1f58135d4c4d8285e78701a137b5ec61df46f5e898b12850fdf23e7f82c5
+input_fingerprint_sha256: 7b48588b9206766302fb873e41b5f3e1504c6dce27fe4a544d8aefc4ed64ef3d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/TWO_SEED_CLAUSE_011_MEET_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Two-seed meetings under the named (0,1,1) hop-cost on the B_6 union are scored vs ℓ¹. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility (0,1,1) is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+PASS: not-leftover-b4 the host is the B_6 union, not leftover of the B_4 union
+n_sites 523
+lex_first (1, 0, 0)
+meet_t 1
+|M| 1
+n_mid_011 69
+n_mid_l1 61
+var_011 0.00928264138161
+var_l1 0.00818042204172
+dijkstra_calls 2
+PASS: one-pair-dijkstra exactly one pair of Dijkstras ran
+PASS: union-b6 the union B_6(0)∪B_6((2,0,0)) has 523 sites
+PASS: reachable every site of the union is reached from both seeds
+PASS: lex-first-meeting lex-first meeting site is (1,0,0) at t=1
+PASS: meeting-cardinality |M| = 1
+PASS: matching-member-front first meeting stays the matching-member front (1,0,0)
+PASS: note-records-meeting note records the lex-first meeting site, time, and |M|
+PASS: var-011 midplane population variance under (0,1,1) matches the reported value
+PASS: var-l1 midplane population variance under ℓ¹ matches the reported value
+PASS: var-l1-smaller var(|v-s0|_2/t0) is strictly smaller under ℓ¹ than under (0,1,1)
+PASS: note-records-variances note records both midplane variances and the comparison
+PASS: seed-relative-clauses seed-exit is cheap; both-weights-1 and support drop cost 3
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_seed_clause_011_meet_b6_2026_08_15.py
+++ b/scripts/two_seed_clause_011_meet_b6_2026_08_15.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Score two-seed meetings under the named (0,1,1) hop-cost on the B_6 union.
+
+One pair of Dijkstras on B_6(0)∪B_6((2,0,0)). No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+import math
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/TWO_SEED_CLAUSE_011_MEET_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_SEED_CLAUSE_011_MEET_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Two-seed meetings under the named (0,1,1) hop-cost on the "
+    "B_6 union are scored vs ℓ¹. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+S0 = (0, 0, 0)
+S1 = (2, 0, 0)
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+VAR_011_REPORTED = 0.00928264138161
+VAR_L1_REPORTED = 0.00818042204172
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int], seed: tuple[int, int, int] = S0) -> int:
+    return abs(v[0] - seed[0]) + abs(v[1] - seed[1]) + abs(v[2] - seed[2])
+
+
+def support_size(v: tuple[int, int, int], seed: tuple[int, int, int]) -> int:
+    return int(v[0] != seed[0]) + int(v[1] != seed[1]) + int(v[2] != seed[2])
+
+
+def l2(v: tuple[int, int, int], seed: tuple[int, int, int] = S0) -> float:
+    dx = v[0] - seed[0]
+    dy = v[1] - seed[1]
+    dz = v[2] - seed[2]
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+def ball(center: tuple[int, int, int], radius: int) -> list[tuple[int, int, int]]:
+    cx, cy, cz = center
+    sites: list[tuple[int, int, int]] = []
+    for x in range(cx - radius, cx + radius + 1):
+        for y in range(cy - radius, cy + radius + 1):
+            rem = radius - abs(x - cx) - abs(y - cy)
+            for z in range(cz - rem, cz + rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def clause_011_cost(
+    v: tuple[int, int, int],
+    w: tuple[int, int, int],
+    seed: tuple[int, int, int],
+) -> int:
+    sigma_v = support_size(v, seed)
+    sigma_w = support_size(w, seed)
+    if (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_011(
+    sites: set[tuple[int, int, int]],
+    seed: tuple[int, int, int],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    dist: dict[tuple[int, int, int], int] = {seed: 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, seed)]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in sites:
+                continue
+            nd = d + clause_011_cost(v, w, seed)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def first_meetings(
+    sites: list[tuple[int, int, int]],
+    site_set: set[tuple[int, int, int]],
+    t0: dict[tuple[int, int, int], int],
+    t1: dict[tuple[int, int, int], int],
+) -> list[tuple[int, int, int]]:
+    meetings: list[tuple[int, int, int]] = []
+    for v in sites:
+        if t0[v] != t1[v]:
+            continue
+        vx, vy, vz = v
+        earlier_both = False
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            if t0[w] < t0[v] and t1[w] < t1[v]:
+                earlier_both = True
+                break
+        if not earlier_both:
+            meetings.append(v)
+    return meetings
+
+
+def population_variance(values: list[float]) -> float:
+    n = len(values)
+    mean = math.fsum(values) / n
+    return math.fsum((x - mean) ** 2 for x in values) / n
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "(0,1,1) is not written into Admissibility",
+        "not written into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "not attached to L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "not-leftover-b4",
+        "the host is the B_6 union, not leftover of the B_4 union",
+        "Not leftover of the B_4 union" in note or "not leftover of the B_4 union" in note,
+    )
+
+    sites = sorted(set(ball(S0, 6)) | set(ball(S1, 6)))
+    site_set = set(sites)
+    t0 = dijkstra_011(site_set, S0)
+    t1 = dijkstra_011(site_set, S1)
+    mid_011 = [v for v in sites if t0[v] == t1[v]]
+    meetings = first_meetings(sites, site_set, t0, t1)
+    lex_first = min(meetings)
+    meet_t = t0[lex_first]
+    var_011 = population_variance([l2(v, S0) / t0[v] for v in mid_011])
+
+    mid_l1 = [v for v in sites if l1(v, S0) == l1(v, S1)]
+    var_l1 = population_variance([l2(v, S0) / l1(v, S0) for v in mid_l1])
+
+    print(f"n_sites {len(sites)}")
+    print(f"lex_first {lex_first}")
+    print(f"meet_t {meet_t}")
+    print(f"|M| {len(meetings)}")
+    print(f"n_mid_011 {len(mid_011)}")
+    print(f"n_mid_l1 {len(mid_l1)}")
+    print(f"var_011 {var_011:.14f}")
+    print(f"var_l1 {var_l1:.14f}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-pair-dijkstra",
+        "exactly one pair of Dijkstras ran",
+        DIJKSTRA_CALLS == 2,
+    )
+    checks.check(
+        "union-b6",
+        "the union B_6(0)∪B_6((2,0,0)) has 523 sites",
+        len(sites) == 523
+        and all(l1(v, S0) <= 6 or l1(v, S1) <= 6 for v in sites)
+        and any(l1(v, S0) == 6 and l1(v, S1) > 4 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of the union is reached from both seeds",
+        len(t0) == 523 and len(t1) == 523,
+    )
+    checks.check(
+        "lex-first-meeting",
+        "lex-first meeting site is (1,0,0) at t=1",
+        lex_first == (1, 0, 0) and meet_t == 1 and t1[lex_first] == 1,
+    )
+    checks.check(
+        "meeting-cardinality",
+        "|M| = 1",
+        meetings == [(1, 0, 0)],
+    )
+    checks.check(
+        "matching-member-front",
+        "first meeting stays the matching-member front (1,0,0)",
+        meetings == [(1, 0, 0)] and "matching-member front" in note,
+    )
+    checks.check(
+        "note-records-meeting",
+        "note records the lex-first meeting site, time, and |M|",
+        "(1,0,0)" in note and "t=1" in note and "|M|=1" in note,
+    )
+    checks.check(
+        "var-011",
+        "midplane population variance under (0,1,1) matches the reported value",
+        abs(var_011 - VAR_011_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-l1",
+        "midplane population variance under ℓ¹ matches the reported value",
+        abs(var_l1 - VAR_L1_REPORTED) < 5e-14,
+    )
+    checks.check(
+        "var-l1-smaller",
+        "var(|v-s0|_2/t0) is strictly smaller under ℓ¹ than under (0,1,1)",
+        var_l1 < var_011,
+    )
+    checks.check(
+        "note-records-variances",
+        "note records both midplane variances and the comparison",
+        "0.00928264138161" in note
+        and "0.00818042204172" in note
+        and "var_ℓ¹ < var_(0,1,1)" in note,
+    )
+    checks.check(
+        "seed-relative-clauses",
+        "seed-exit is cheap; both-weights-1 and support drop cost 3",
+        clause_011_cost(S0, (1, 0, 0), S0) == 1
+        and clause_011_cost(S1, (1, 0, 0), S1) == 1
+        and clause_011_cost((1, 1, 0), (1, 0, 0), S0) == 3
+        and clause_011_cost((3, 1, 0), (3, 0, 0), S1) == 3
+        and clause_011_cost((1, 0, 0), (1, 1, 0), S0) == 1
+        and clause_011_cost((1, 0, 0), (2, 0, 0), S0) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "(0,1,1)_s(v→w)" not in axiom
+        and "clause_011_cost" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_6(0) union B_6((2,0,0)) under (0,1,1): unique first meeting (1,0,0) at t=1. Midplane var_(0,1,1)=0.00928 > var_l1=0.00818. Displayed, not adopted.

## Runner

`scripts/two_seed_clause_011_meet_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.