### PR TITLE
feat(ratio011): (0,1,1) same-k reverse fails at k=1; holds at k=2,3,4

### DIFF
--- a/docs/CLAUSE_011_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,171 @@
+---
+claim_id: clause_011_scale_ratios_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Axis and body-diagonal arrival ratios under the named (0,1,1) hop-cost on B_12(0) are reported for k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_scale_ratios_b12_2026_08_15.py
+---
+
+# Named (0,1,1) Same-k Axis And Body Ratios On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact same-`k` axis versus body-diagonal arrival ratios under
+one named hop-cost on the finite 12-hop neighborhood of the origin in
+the cubic nearest-neighbor graph. The rule is displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_scale_ratios_b12_2026_08_15.py`](../scripts/clause_011_scale_ratios_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Let `B_12(0)` be the set of sites of `Z^3` whose nearest-neighbor graph
+distance from the origin is at most 12. That set has 2625 sites and is
+used only as a finite domain bound. It is not a hop-cost.
+
+Hops are the six nearest-neighbor steps that remain inside `B_12(0)`.
+Write `|σ_v|` for the support of a site (the number of nonzero
+coordinates). The named clause-toggle `(0,1,1)` assigns
+
+```text
+cost(v→w) = 3  if |σ_v|=|σ_w|=1 or |σ_w|<|σ_v|,
+          = 1  otherwise.
+```
+
+Seed-exit therefore costs 1. Axis 1-skeleton hops and support-drop hops
+cost 3. Every other admitted hop costs 1. The rule is cheaper at
+seed-exit than a rule that prices seed-exit at 3. The rule is not
+written into Admissibility: do not write (0,1,1) into Admissibility.
+Do not attach L1. Uniqueness is not required.
+
+One Dijkstra from the origin yields the same-`k` arrivals
+
+| `k` | `t(k,0,0)` | `t(k,k,k)` | `t(k,0,0)^2 / k^2` | `t(k,k,k)^2 / (3k^2)` | reverse |
+|---|---:|---:|---:|---:|---|
+| `1` | `1` | `3` | `1` | `3` | no |
+| `2` | `4` | `6` | `4` | `3` | yes |
+| `3` | `7` | `9` | `49/9` | `3` | yes |
+| `4` | `8` | `12` | `4` | `3` | yes |
+
+For `k=1` the displayed test
+
+`t(1,0,0)^2 / 1^2 > t(1,1,1)^2 / (3·1^2)`
+
+fails. For each of `k=2,3,4` the same-`k` reverse holds. The cheaper
+rival therefore does not keep same-`k` reverse at every listed scale.
+The table is same-`k`; it is not the doubled pairing
+`(4,0,0)` versus `(2,2,2)` and `(8,0,0)` versus `(4,4,4)`. Displayed,
+not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under
+lattice translations and proper cubic rotations.
+
+The axiom set supplies the cubic nearest-neighbor graph. It does not
+supply a hop-cost, a same-`k` reverse test, or a preferred
+clause-toggle. This note therefore treats `(0,1,1)` as a separately
+named finite scoring rule. The note does not write `(0,1,1)` into
+Admissibility and does not enlarge the axiom set.
+
+Record is not used. No readout, formation site, or scalar collection
+functional enters the arrival times.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Eight same-k arrival times and four displayed reverse inequalities are exact outputs of one Dijkstra on the named finite graph; the hop-cost is a disclosed scoring rule, not an axiom, and same-k reverse fails at k=1."
+trace_class: compute
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) under the named (0,1,1) hop-cost at k=1..4; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+`B_12(0)` is the closed 12-hop neighborhood of the origin. Every hop
+used below is a nearest-neighbor step whose endpoints both lie in that
+set. One Dijkstra computes the named arrival time `t(v)` from the
+origin to each site.
+
+The four displayed inequalities compare axis and body-diagonal sites
+that share the same scale `k`, after Euclidean length `k` on the axis
+and `k√3` on the body diagonal. The comparison is displayed only. It is
+not a derived continuum law and is not attached as an L1 hop-cost.
+
+## Theorem 1
+
+On `B_12(0)` under the named `(0,1,1)` hop-cost,
+
+`t(1,0,0)=1`, `t(1,1,1)=3`,
+`t(2,0,0)=4`, `t(2,2,2)=6`,
+`t(3,0,0)=7`, `t(3,3,3)=9`,
+`t(4,0,0)=8`, and `t(4,4,4)=12`.
+
+Each value is the Dijkstra arrival time. The `k=1` axis value equals
+the seed-exit cost 1. The `k=2` and `k=3` axis values equal the
+axis-skeleton sums `1+3` and `1+3+3`. The `k=4` axis value `8` is
+strictly smaller than the axis-skeleton sum `1+3+3+3=10`, so a
+support-raising detour is cheaper than staying on the axis. Each
+body-diagonal value equals the nearest-neighbor hop count `3k`, because
+a monotone support-nondecreasing path from the origin uses only cost-1
+hops.
+
+## Theorem 2
+
+The displayed same-`k` test is
+
+`t(k,0,0)^2 / k^2  ?  t(k,k,k)^2 / (3k^2)`,
+
+equivalently `3 t(k,0,0)^2 ? t(k,k,k)^2`. Substituting the computed
+times gives
+
+| `k` | `3 t(k,0,0)^2` | `t(k,k,k)^2` | reverse |
+|---|---:|---:|---|
+| `1` | `3` | `9` | `3 > 9` is false |
+| `2` | `48` | `36` | `48 > 36` |
+| `3` | `147` | `81` | `147 > 81` |
+| `4` | `192` | `144` | `192 > 144` |
+
+Same-`k` reverse therefore fails at `k=1` and holds at `k=2,3,4` on
+this same finite domain. The cheaper rival does not keep same-`k`
+reverse at every `k=1..4`. Displayed, not adopted.
+
+## Theorem 3
+
+The note does not write `(0,1,1)` into Admissibility. Do not attach L1.
+Uniqueness is not required. The current axiom memo is not edited.
+
+## What This Does Not Claim
+
+- It does not adopt the `(0,1,1)` hop-cost as framework content.
+- It does not claim that same-`k` reverse holds at every listed scale.
+- It does not claim that the named rule is the only reverser.
+- It does not identify `t` with nearest-neighbor hop count on the axis.
+- It does not replace the doubled pairing
+  `(4,0,0)`/`(2,2,2)` and `(8,0,0)`/`(4,4,4)` by this same-`k` table.
+- It does not supply a physical clock, a continuum metric, or a Record
+  readout of the arrival times.
+
+## Reproducibility
+
+```text
+python3 scripts/clause_011_scale_ratios_b12_2026_08_15.py
+```
+
+The runner prints the eight times, the four displayed comparisons, and
+`TOTAL: PASS=<n> FAIL=<n>`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2329,6 +2329,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_scale_ratios_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_scale_ratios_b12_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_scale_ratios_b12_2026_08_15.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_scale_ratios_b12_2026_08_15.py
+runner_sha256: d57c02837c87ee74b29f8a71b1b313267e76f1e5b116e22624b35d0ac3868c2a
+input_fingerprint_sha256: d0b923ab26ab25e7cea44c9f27e9e94ad37d3d5663d62d5c5419cb64487b5d32
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; hop-costs are the named (0,1,1) rule on the finite 12-hop neighborhood B_12(0)
+package_local_integrity_reads: the note and current minimal axiom are read; no cache or governance surface is written
+negative_scope: the named rule is displayed, not adopted; it is not written into Admissibility and is not attached as an L1 hop-cost
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/CLAUSE_011_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static literal pair and both files exist
+PASS: ball-b12-only B_12(0) is the 12-hop neighborhood of the origin and contains every named target
+PASS: clause-011-local seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1
+n_sites 2625
+dijkstra_calls 1
+dijkstra_count=1
+k 1 t(1,0,0)=1 t(1,1,1)=3 3t_axis^2=3 t_body^2=9 reverse=False
+k 2 t(2,0,0)=4 t(2,2,2)=6 3t_axis^2=48 t_body^2=36 reverse=True
+k 3 t(3,0,0)=7 t(3,3,3)=9 3t_axis^2=147 t_body^2=81 reverse=True
+k 4 t(4,0,0)=8 t(4,4,4)=12 3t_axis^2=192 t_body^2=144 reverse=True
+PASS: theorem-1-times the eight same-k arrival times are the Dijkstra values 1,3,4,6,7,9,8,12
+PASS: theorem-2-k1 t(1,0,0)^2/1^2 > t(1,1,1)^2/(3*1^2) fails (3 > 9 is false)
+PASS: theorem-2-k2 t(2,0,0)^2/2^2 > t(2,2,2)^2/(3*2^2) holds (48 > 36)
+PASS: theorem-2-k3 t(3,0,0)^2/3^2 > t(3,3,3)^2/(3*3^2) holds (147 > 81)
+PASS: theorem-2-k4 t(4,0,0)^2/4^2 > t(4,4,4)^2/(3*4^2) holds (192 > 144)
+PASS: not-all-scales-reverse the cheaper rival does not keep same-k reverse at every k=1..4
+PASS: one-dijkstra exactly one origin Dijkstra assigned a finite time to every ball site
+PASS: note-reports-times the note reports the eight computed times
+PASS: note-reports-reverse-products the note records the four integer reverse products
+PASS: displayed-not-adopted the note displays the (0,1,1) scores and does not adopt them
+PASS: admissibility-unedited the current axiom memo still names Admissibility and does not contain the hop-cost rule
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: claim-scope the note states the required claim_scope
+PASS: forbidden-tokens the note avoids the forbidden tokens
+PASS: uniqueness-not-required the note does not claim uniqueness of the named rule
+PASS: same-k-not-doubled-pairing the note scores same-k pairs, not the doubled pairing
+PASS: not-attach-l1 the displayed rule is not attached to L1
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_scale_ratios_b12_2026_08_15.py
+++ b/scripts/clause_011_scale_ratios_b12_2026_08_15.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Named (0,1,1) same-k axis/body-diagonal ratios on B_12(0).
+
+One Dijkstra from the origin. Displayed, not adopted. No axiom edit,
+no cache write, no L1 hop-cost attachment.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_NAME = "CLAUSE_011_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+NOTE_PATH = ROOT / "docs" / NOTE_NAME
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BALL_RADIUS = 12
+SCALES = (1, 2, 3, 4)
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+def nn_radius(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def in_ball(site: tuple[int, int, int]) -> bool:
+    return nn_radius(site) <= BALL_RADIUS
+
+
+def support_size(site: tuple[int, int, int]) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(src: tuple[int, int, int], dst: tuple[int, int, int]) -> int:
+    """Rule (0,1,1): cost 3 iff both weights 1 or support drop, else 1."""
+    src_support = support_size(src)
+    dst_support = support_size(dst)
+    both_weights_one = src_support == 1 and dst_support == 1
+    support_drop = dst_support < src_support
+    if both_weights_one or support_drop:
+        return 3
+    return 1
+
+
+def ball_sites() -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-BALL_RADIUS, BALL_RADIUS + 1):
+        for y in range(-BALL_RADIUS, BALL_RADIUS + 1):
+            remain = BALL_RADIUS - abs(x) - abs(y)
+            if remain < 0:
+                continue
+            for z in range(-remain, remain + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def neighbors(site: tuple[int, int, int]) -> list[tuple[int, int, int]]:
+    x, y, z = site
+    out: list[tuple[int, int, int]] = []
+    for dx, dy, dz in NEIGHBOR_STEPS:
+        nxt = (x + dx, y + dy, z + dz)
+        if in_ball(nxt):
+            out.append(nxt)
+    return out
+
+
+def dijkstra_from_origin(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    dist = {origin: 0}
+    heap = [(0, origin)]
+    while heap:
+        cost_here, site = heapq.heappop(heap)
+        if cost_here != dist[site]:
+            continue
+        for nxt in neighbors(site):
+            cand = cost_here + hop_cost(site, nxt)
+            if cand < dist.get(nxt, 10**9):
+                dist[nxt] = cand
+                heapq.heappush(heap, (cand, nxt))
+    if len(dist) != len(sites):
+        raise RuntimeError("Dijkstra did not reach every site of B_12(0)")
+    return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def audit_paths_are_static_literals() -> bool:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names:
+                value = node.value
+                if not isinstance(value, ast.Tuple):
+                    return False
+                return all(
+                    isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    for elt in value.elts
+                )
+    return False
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; hop-costs are the named (0,1,1) "
+        "rule on the finite 12-hop neighborhood B_12(0)"
+    )
+    print(
+        "package_local_integrity_reads: the note and current minimal axiom "
+        "are read; no cache or governance surface is written"
+    )
+    print(
+        "negative_scope: the named rule is displayed, not adopted; it is "
+        "not written into Admissibility and is not attached as an L1 hop-cost"
+    )
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static literal pair and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_SCALE_RATIOS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and audit_paths_are_static_literals()
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball_sites()
+    targets = tuple((k, 0, 0) for k in SCALES) + tuple((k, k, k) for k in SCALES)
+    checks.check(
+        "ball-b12-only",
+        "B_12(0) is the 12-hop neighborhood of the origin and contains every named target",
+        len(sites) == 2625
+        and all(in_ball(site) for site in targets)
+        and (4, 4, 4) in sites
+        and (13, 0, 0) not in set(sites)
+        and nn_radius((4, 4, 4)) == 12,
+    )
+
+    checks.check(
+        "clause-011-local",
+        "seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1",
+        hop_cost((0, 0, 0), (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (2, 1, 0)) == 1
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    distances = dijkstra_from_origin(sites)
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print("dijkstra_count=1")
+
+    rows: list[tuple[int, int, int, int, int, bool]] = []
+    for k in SCALES:
+        t_axis = distances[(k, 0, 0)]
+        t_body = distances[(k, k, k)]
+        left = 3 * t_axis * t_axis
+        right = t_body * t_body
+        reverse = left > right
+        rows.append((k, t_axis, t_body, left, right, reverse))
+        print(
+            f"k {k} t({k},0,0)={t_axis} t({k},{k},{k})={t_body} "
+            f"3t_axis^2={left} t_body^2={right} reverse={reverse}"
+        )
+
+    computed = {k: (t_axis, t_body) for k, t_axis, t_body, _l, _r, _rev in rows}
+    reverse_by_k = {k: rev for k, _a, _b, _l, _r, rev in rows}
+
+    checks.check(
+        "theorem-1-times",
+        "the eight same-k arrival times are the Dijkstra values 1,3,4,6,7,9,8,12",
+        computed
+        == {
+            1: (1, 3),
+            2: (4, 6),
+            3: (7, 9),
+            4: (8, 12),
+        },
+    )
+    checks.check(
+        "theorem-2-k1",
+        "t(1,0,0)^2/1^2 > t(1,1,1)^2/(3*1^2) fails (3 > 9 is false)",
+        (not reverse_by_k[1]) and rows[0][3] == 3 and rows[0][4] == 9,
+    )
+    checks.check(
+        "theorem-2-k2",
+        "t(2,0,0)^2/2^2 > t(2,2,2)^2/(3*2^2) holds (48 > 36)",
+        reverse_by_k[2] and rows[1][3] == 48 and rows[1][4] == 36,
+    )
+    checks.check(
+        "theorem-2-k3",
+        "t(3,0,0)^2/3^2 > t(3,3,3)^2/(3*3^2) holds (147 > 81)",
+        reverse_by_k[3] and rows[2][3] == 147 and rows[2][4] == 81,
+    )
+    checks.check(
+        "theorem-2-k4",
+        "t(4,0,0)^2/4^2 > t(4,4,4)^2/(3*4^2) holds (192 > 144)",
+        reverse_by_k[4] and rows[3][3] == 192 and rows[3][4] == 144,
+    )
+    checks.check(
+        "not-all-scales-reverse",
+        "the cheaper rival does not keep same-k reverse at every k=1..4",
+        (not reverse_by_k[1])
+        and reverse_by_k[2]
+        and reverse_by_k[3]
+        and reverse_by_k[4],
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one origin Dijkstra assigned a finite time to every ball site",
+        DIJKSTRA_CALLS == 1
+        and len(distances) == len(sites)
+        and all(distances[site] >= 0 for site in sites),
+    )
+    checks.check(
+        "note-reports-times",
+        "the note reports the eight computed times",
+        "t(1,0,0)=1" in note
+        and "t(1,1,1)=3" in note
+        and "t(2,0,0)=4" in note
+        and "t(2,2,2)=6" in note
+        and "t(3,0,0)=7" in note
+        and "t(3,3,3)=9" in note
+        and "t(4,0,0)=8" in note
+        and "t(4,4,4)=12" in note,
+    )
+    checks.check(
+        "note-reports-reverse-products",
+        "the note records the four integer reverse products",
+        "3 > 9" in note
+        and "48 > 36" in note
+        and "147 > 81" in note
+        and "192 > 144" in note
+        and "is false" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays the (0,1,1) scores and does not adopt them",
+        "Displayed, not adopted" in note
+        and "do not write (0,1,1) into Admissibility" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the current axiom memo still names Admissibility and does not contain the hop-cost rule",
+        "Admissibility" in axiom
+        and "Lattice" in axiom
+        and "Qubit" in axiom
+        and "Record" in axiom
+        and "both weights 1 or support drop" not in axiom
+        and "(0,1,1)" not in axiom,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "claim-scope",
+        "the note states the required claim_scope",
+        "Axis and body-diagonal arrival ratios under the named (0,1,1) hop-cost on B_12(0) are reported"
+        in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-tokens",
+        "the note avoids the forbidden tokens",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not claim uniqueness of the named rule",
+        "Uniqueness is not required" in note
+        and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "same-k-not-doubled-pairing",
+        "the note scores same-k pairs, not the doubled pairing",
+        "same-`k`" in note
+        and "not the doubled pairing" in note
+        and "(8,0,0)" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under (0,1,1): t(1,0,0)=1 vs t(1,1,1)=3 does not reverse. k=2,3,4 same-k pairs do reverse. Cheap seed-exit costs the k=1 bar that nu keeps. Displayed, not adopted.

## Runner

`scripts/clause_011_scale_ratios_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.