### PR TITLE
feat(t14mix): t=14 holds both (8,0,0) and (4,4,4); 26 G+ types

### DIFF
--- a/docs/SUPPORT_DROP_T14_SHELL_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_T14_SHELL_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,167 @@
+---
+claim_id: support_drop_t14_shell_types_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "G+ types of the t=14 shell under the named support-drop hop-cost on B_12(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_t14_shell_types_b12_2026_08_15.py
+---
+
+# G+ Types Of The t=14 Shell On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only by naming the G+ types of the arrival shell `t=14` and by
+asking whether the doubled axis `(8,0,0)` shares that shell with `(4,4,4)`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_t14_shell_types_b12_2026_08_15.py`](../scripts/support_drop_t14_shell_types_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The isochrone type-count census on `B_12(0)` reported that the `t=14`
+shell has 26 G+ types, 15 distinct `|v|_2^2`, and holds `(4,4,4)`. Those
+26/15 counts are the investment, not the residual. The residual here is
+the lex-sorted list of abs-sorted G+ representatives, each with its site
+count, and the yes-or-no question of whether the doubled axis `(8,0,0)`
+sits in the same shell.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not claimed.
+
+The proper cubic group `G+` is the 24 signed-permutation rotations of
+determinant `+1`. A G+ type is one `G+` orbit. The representative of an
+orbit is its lexicographically maximal first-octant triple (the
+lex-sorted list of those abs-sorted 3-tuples is the type list).
+
+One Dijkstra from the origin on `B_12(0)` (2625 sites; 2624 nonzero) gives
+a `t=14` shell of 578 sites. Those sites partition into the 26 G+ types
+named in Theorem 1. The same arrival function gives `t(8,0,0) = 14` and
+`t(4,4,4) = 14`, so the doubled axis and the doubled body diagonal sit
+in the same shell.
+
+These named types are not leftover of the 26/15 counts: a pair of
+integers does not name the representatives or decide whether `(8,0,0)`
+shares the shell.
+
+The census is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule And Type Convention
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+A G+ type is represented by the lexicographically maximal first-octant
+member of its orbit. The type list of a shell is those representatives
+sorted in lexicographic order. Absolute-coordinate first-octant form does
+not merge chiral pairs: `(5,3,4)` and `(5,4,3)` remain distinct `G+`
+orbits.
+
+## Theorem 1 — Named G+ Types On The t=14 Shell
+
+One origin Dijkstra on `B_12(0)` reaches every site. The `t=14` shell has
+578 sites. The lex-sorted abs-sorted G+ representatives, each with site
+count, are
+
+| representative | site count |
+|---|---:|
+| `(4,4,4)` | 8 |
+| `(5,3,4)` | 24 |
+| `(5,4,3)` | 24 |
+| `(5,5,2)` | 24 |
+| `(6,1,5)` | 24 |
+| `(6,2,4)` | 24 |
+| `(6,3,3)` | 24 |
+| `(6,4,2)` | 24 |
+| `(6,5,1)` | 24 |
+| `(6,6,0)` | 12 |
+| `(7,1,4)` | 24 |
+| `(7,2,3)` | 24 |
+| `(7,3,2)` | 24 |
+| `(7,4,1)` | 24 |
+| `(7,5,0)` | 24 |
+| `(8,0,0)` | 6 |
+| `(8,1,3)` | 24 |
+| `(8,2,2)` | 24 |
+| `(8,3,1)` | 24 |
+| `(8,4,0)` | 24 |
+| `(9,1,2)` | 24 |
+| `(9,2,1)` | 24 |
+| `(9,3,0)` | 24 |
+| `(10,1,1)` | 24 |
+| `(10,2,0)` | 24 |
+| `(11,1,0)` | 24 |
+
+Those twenty-six orbits partition the 578 sites.
+
+B_12(0) only. The named types are displayed, not adopted.
+
+## Theorem 2 — Doubled Axis And Doubled Body Diagonal
+
+The same Dijkstra gives `t(8,0,0) = 14` and `t(4,4,4) = 14`. So `(8,0,0)` and `(4,4,4)` both have `t=14`, and both appear in the type list of Theorem 1.
+
+Both facts are displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_12(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. The named G+ types are not offered
+as a unique hop-cost property and are not a replacement for unit-cost
+first arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The t=14 G+ types of B_12(0) are named for one displayed hop-cost, including the shared-shell fact for (8,0,0) and (4,4,4). The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs with this type list.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any reuse of the 26/15 counts as a substitute for the named type list.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17969,6 +17969,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_t14_shell_types_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_t14_shell_types_b12_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_t14_shell_types_b12_2026_08_15.txt
@@ -1,0 +1,73 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_t14_shell_types_b12_2026_08_15.py
+runner_sha256: e717a74a1cff6f4cd936e12b1b7c09e2dd41bb019953f921233a9bedc25285a7
+input_fingerprint_sha256: 6fe0632a29f2daa7c01a2fb564d334100b2b1874b4a2d9b8948b67770f14ecb3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_T14_SHELL_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: G+ types of the t=14 shell under the named support-drop hop-cost on B_12(0) are named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the t=14 type-naming statement
+PASS: displayed-not-adopted the census is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+t14_sites 578 t14_types 26
+t(8,0,0) 14
+t(4,4,4) 14
+same_shell True
+t14_types_named
+  (4, 4, 4) 8
+  (5, 3, 4) 24
+  (5, 4, 3) 24
+  (5, 5, 2) 24
+  (6, 1, 5) 24
+  (6, 2, 4) 24
+  (6, 3, 3) 24
+  (6, 4, 2) 24
+  (6, 5, 1) 24
+  (6, 6, 0) 12
+  (7, 1, 4) 24
+  (7, 2, 3) 24
+  (7, 3, 2) 24
+  (7, 4, 1) 24
+  (7, 5, 0) 24
+  (8, 0, 0) 6
+  (8, 1, 3) 24
+  (8, 2, 2) 24
+  (8, 3, 1) 24
+  (8, 4, 0) 24
+  (9, 1, 2) 24
+  (9, 2, 1) 24
+  (9, 3, 0) 24
+  (10, 1, 1) 24
+  (10, 2, 0) 24
+  (11, 1, 0) 24
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: reachable every site of B_12(0) is reached
+PASS: rotation-group the proper cubic group used for types has 24 elements
+PASS: t14-named-types t=14 has 578 sites in 26 named G+ types with the computed site counts
+PASS: t-800-and-444 (8,0,0) and (4,4,4) both have t=14
+PASS: not-leftover-of-counts named types are not leftover of the 26/15 counts
+PASS: note-records-types note records every lex-sorted representative with its site count
+PASS: note-records-shared-shell note records that (8,0,0) and (4,4,4) both have t=14
+PASS: chiral-pairs-split abs-sorted first-octant form still splits G+ chiral pairs
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: b12-only every named type stays inside B_12(0)
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_t14_shell_types_b12_2026_08_15.py
+++ b/scripts/support_drop_t14_shell_types_b12_2026_08_15.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Name G+ types on the t=14 shell of the support-drop hop-cost.
+
+One origin Dijkstra on B_12(0). No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_T14_SHELL_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_T14_SHELL_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "G+ types of the t=14 shell under "
+    "the named support-drop hop-cost on B_12(0) are named. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T14_EXPECTED = (
+    ((4, 4, 4), 8),
+    ((5, 3, 4), 24),
+    ((5, 4, 3), 24),
+    ((5, 5, 2), 24),
+    ((6, 1, 5), 24),
+    ((6, 2, 4), 24),
+    ((6, 3, 3), 24),
+    ((6, 4, 2), 24),
+    ((6, 5, 1), 24),
+    ((6, 6, 0), 12),
+    ((7, 1, 4), 24),
+    ((7, 2, 3), 24),
+    ((7, 3, 2), 24),
+    ((7, 4, 1), 24),
+    ((7, 5, 0), 24),
+    ((8, 0, 0), 6),
+    ((8, 1, 3), 24),
+    ((8, 2, 2), 24),
+    ((8, 3, 1), 24),
+    ((8, 4, 0), 24),
+    ((9, 1, 2), 24),
+    ((9, 2, 1), 24),
+    ((9, 3, 0), 24),
+    ((10, 1, 1), 24),
+    ((10, 2, 0), 24),
+    ((11, 1, 0), 24),
+)
+DIJKSTRA_CALLS = 0
+Point = tuple[int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def rotate_vector(rotation: Rotation, vector: Point) -> Point:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def l1(v: Point) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: Point) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[Point]:
+    sites: list[Point] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: Point, w: Point) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[Point]) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[Point, int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, Point]] = [(0, (0, 0, 0))]
+    seen: set[Point] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def gplus_orbit(point: Point) -> frozenset[Point]:
+    return frozenset(rotate_vector(rotation, point) for rotation in ROTATIONS)
+
+
+def representative(orbit: frozenset[Point]) -> Point:
+    octant = tuple(point for point in orbit if point[0] >= 0 and point[1] >= 0 and point[2] >= 0)
+    if not octant:
+        raise ValueError("G+ orbit has no first-octant representative")
+    return max(octant)
+
+
+def shell_types(
+    dist: dict[Point, int],
+    site_set: set[Point],
+    arrival: int,
+) -> tuple[list[Point], list[tuple[Point, int]]]:
+    pts = [v for v, t in dist.items() if t == arrival and v != (0, 0, 0)]
+    consumed: set[Point] = set()
+    rows: list[tuple[Point, int]] = []
+    for site in pts:
+        if site in consumed:
+            continue
+        orbit = gplus_orbit(site)
+        if not orbit.issubset(site_set):
+            raise AssertionError(f"orbit of {site} leaves B_12(0)")
+        times = {dist[point] for point in orbit}
+        if times != {arrival}:
+            raise AssertionError(f"arrival not constant on orbit of {site}: {times}")
+        consumed.update(orbit)
+        rows.append((representative(orbit), len(orbit)))
+    rows.sort()
+    if consumed != set(pts):
+        raise AssertionError("G+ orbits do not partition the shell")
+    return pts, rows
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the t=14 type-naming statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the census is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    site_set = set(sites)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_nu(sites)
+    t14_sites, t14_rows = shell_types(dist, site_set, 14)
+    t800 = dist[(8, 0, 0)]
+    t444 = dist[(4, 4, 4)]
+    t14_reps = {rep for rep, _ in t14_rows}
+
+    print(f"n_sites {len(sites)}")
+    print(f"t14_sites {len(t14_sites)} t14_types {len(t14_rows)}")
+    print(f"t(8,0,0) {t800}")
+    print(f"t(4,4,4) {t444}")
+    print(f"same_shell {t800 == 14 and t444 == 14}")
+    print("t14_types_named")
+    for rep, count in t14_rows:
+        print(f"  {rep} {count}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == 2625 and len(nonzero) == 2624 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "rotation-group",
+        "the proper cubic group used for types has 24 elements",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "t14-named-types",
+        "t=14 has 578 sites in 26 named G+ types with the computed site counts",
+        len(t14_sites) == 578
+        and len(t14_rows) == 26
+        and tuple(t14_rows) == T14_EXPECTED
+        and sum(count for _, count in t14_rows) == 578,
+    )
+    checks.check(
+        "t-800-and-444",
+        "(8,0,0) and (4,4,4) both have t=14",
+        t800 == 14
+        and t444 == 14
+        and (8, 0, 0) in t14_reps
+        and (4, 4, 4) in t14_reps,
+    )
+    checks.check(
+        "not-leftover-of-counts",
+        "named types are not leftover of the 26/15 counts",
+        "not leftover of the 26/15 counts" in note
+        and "does not name the representatives" in note,
+    )
+    checks.check(
+        "note-records-types",
+        "note records every lex-sorted representative with its site count",
+        all(
+            f"| `({rep[0]},{rep[1]},{rep[2]})` | {count} |" in note
+            for rep, count in t14_rows
+        ),
+    )
+    checks.check(
+        "note-records-shared-shell",
+        "note records that (8,0,0) and (4,4,4) both have t=14",
+        "t(8,0,0) = 14" in note
+        and "t(4,4,4) = 14" in note
+        and "(8,0,0)` and `(4,4,4)` both have `t=14" in note,
+    )
+    checks.check(
+        "chiral-pairs-split",
+        "abs-sorted first-octant form still splits G+ chiral pairs",
+        gplus_orbit((5, 3, 4)).isdisjoint(gplus_orbit((5, 4, 3)))
+        and ((5, 3, 4), 24) in t14_rows
+        and ((5, 4, 3), 24) in t14_rows,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and nu_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+    checks.check(
+        "b12-only",
+        "every named type stays inside B_12(0)",
+        all(l1(rep) <= 12 for rep, _ in t14_rows)
+        and "B_12(0) only" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under nu, t(8,0,0)=t(4,4,4)=14. The t=14 shell has 578 sites and 26 named G+ types including (8,0,0). Displayed, not adopted.

## Runner

`scripts/support_drop_t14_shell_types_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.