### PR TITLE
feat(011facek): (0,1,1) face reverse vs k is yes yes yes yes no yes

### DIFF
--- a/docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,473 @@
+---
+claim_id: clause_011_face_reverse_vs_k_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_12(0) is reported for k=1..6. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py
+---
+
+# Clause `(0,1,1)` Face Reverse Versus Integer Scale k On The Radius-Twelve Ball
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one directed Dijkstra on the nearest-neighbor graph of the closed
+radius-twelve ball under the named clause-toggle with cheap seed-exit and
+expensive axis-one and support-drop hops. Face reverse versus integer scale
+$k$ is reported for $k=1,\ldots,6$. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py`](../scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Work on the cubic lattice `Z^3` with nearest-neighbor adjacency. Write
+`B_12(0)` for the closed ball `{v ∈ Z^3 : |v|_1 ≤ 12}`. This set has exactly
+`2625` sites. Hops that would leave the ball are absent. For a site `v`, write
+`σ_v` for the set of nonzero coordinates and write the inward weight
+`w(v) = |σ_v|`.
+
+A directed nearest-neighbor hop `v → u` is classified by three named clauses:
+
+- seed-exit when `w(v) = 0`,
+- both-weights-one (axis-one) when `w(v) = w(u) = 1`,
+- support-drop when `w(u) < w(v)`.
+
+The displayed clause-toggle `(s,a,d) = (0,1,1)` charges cost `3` if
+both-weights-one holds or support-drop holds, and charges cost `1` otherwise.
+Seed-exit is therefore cheap. This is a finite named hop-cost on `B_12(0)`. It
+is not written into Admissibility, and it is not attached to L1.
+
+One origin Dijkstra returns the in-ball arrivals
+
+```text
+t(2,0,0)=4,    t(4,0,0)=8,    t(6,0,0)=10,
+t(8,0,0)=12,   t(10,0,0)=14,  t(12,0,0)=18,
+t(1,1,0)=2,    t(2,2,0)=4,    t(3,3,0)=6,
+t(4,4,0)=8,    t(5,5,0)=10,   t(6,6,0)=12.
+```
+
+For each $k=1,\ldots,6$, reverse means the displayed comparison
+
+$$
+\frac{t(2k,0,0)^2}{4k^2}>\frac{t(k,k,0)^2}{2k^2}
+$$
+
+holds, equivalently $t(k,k,0)^2\cdot 4k^2<t(2k,0,0)^2\cdot 2k^2$. The bit is
+displayed, not adopted.
+
+| $k$ | pair | axis $t^2/|v|_2^2$ | face $t^2/|v|_2^2$ | reverse |
+|---|---|---|---|---|
+| $1$ | $((2,0,0),(1,1,0))$ | $16/4=4$ | $4/2=2$ | yes |
+| $2$ | $((4,0,0),(2,2,0))$ | $64/16=4$ | $16/8=2$ | yes |
+| $3$ | $((6,0,0),(3,3,0))$ | $100/36=25/9$ | $36/18=2$ | yes |
+| $4$ | $((8,0,0),(4,4,0))$ | $144/64=9/4$ | $64/32=2$ | yes |
+| $5$ | $((10,0,0),(5,5,0))$ | $196/100=49/25$ | $100/50=2$ | no |
+| $6$ | $((12,0,0),(6,6,0))$ | $324/144=9/4$ | $144/72=2$ | yes |
+
+Exact integer comparisons:
+
+- 4 t(1,1,0)^2 = 16 < 32 = 2 t(2,0,0)^2
+- 16 t(2,2,0)^2 = 256 < 512 = 8 t(4,0,0)^2
+- 36 t(3,3,0)^2 = 1296 < 1800 = 18 t(6,0,0)^2
+- 64 t(4,4,0)^2 = 4096 < 4608 = 32 t(8,0,0)^2
+- 100 t(5,5,0)^2 = 10000 > 9800 = 50 t(10,0,0)^2
+- 144 t(6,6,0)^2 = 20736 < 23328 = 72 t(12,0,0)^2
+
+The reverse bit is therefore not the same for every $k=1,\ldots,6$. Reverse
+holds at $k=1,2,3,4,6$ and fails at $k=5$. The cheaper rival does not stay
+reversed at $k=5$. The three even-$k$ face pairs already scored on this ball
+under this toggle do not determine $t(2,0,0)$, $t(1,1,0)$, $t(6,0,0)$,
+$t(3,3,0)$, $t(10,0,0)$, or $t(5,5,0)$. The $k=1,3,5$ times are
+independent Dijkstra outputs on $B_{12}(0)$. Uniqueness is not claimed among hop-costs.
+Displayed, not adopted. Do not attach L1.
+
+Literal score lines used by the runner:
+
+- t(2,0,0)=4
+- t(4,0,0)=8
+- t(6,0,0)=10
+- t(8,0,0)=12
+- t(10,0,0)=14
+- t(12,0,0)=18
+- t(1,1,0)=2
+- t(2,2,0)=4
+- t(3,3,0)=6
+- t(4,4,0)=8
+- t(5,5,0)=10
+- t(6,6,0)=12
+- (12,1,0) is outside B_12(0)
+- Do not write (0,1,1) into Admissibility
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_12(0) reports the named (0,1,1) arrivals and the six face-versus-axis reverse bits versus integer scale k. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: clause_011_face_reverse_vs_k_b12
+target_blocker_text: "does (0,1,1) keep the same face reverse bit for every k=1..6 on B_12(0), including k=5"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the B_12(0) face reverse bits versus k; do not write the clause-toggle into Admissibility and do not attach L1"
+conditional_surface_status: "exact for the named (0,1,1) hop-cost on B_12(0); other clause triples, other radii, and any physical selector remain unclaimed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target And Proof Obligations
+
+**Exact target.** On `B_12(0)` under the named `(0,1,1)` hop-cost, report
+$t(2k,0,0)$ and $t(k,k,0)$ for each $k=1,\ldots,6$. Score whether
+$t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$. Do not write `(0,1,1)` into
+Admissibility. Do not attach L1.
+
+| Obligation | Disposition |
+|---|---|
+| named `(0,1,1)` hop-cost on `B_12(0)` | defined here; executed in Theorem 1 |
+| twelve in-ball arrivals at the six scales | proved here in Theorem 1 |
+| face reverse versus integer scale $k$ | Theorem 2: yes/yes/yes/yes/no/yes |
+| clause-toggle not written into Admissibility | Theorem 3 |
+| L1 not attached | Theorem 3 |
+
+## Inputs And Import Boundary
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the
+  cubic nearest-neighbor substrate and the one-fixed-rule Admissibility
+  sentence. As the registered `minimal_axioms` premise, it is not a
+  bounded-status source.
+- The three clause names (seed-exit, both-weights-one, support-drop) and the
+  toggle `(s,a,d) = (0,1,1)` are displayed mathematical hypotheses, not
+  framework-derived physical selectors.
+- No approved primitive is used. Scale reference, kinetic isotropy, and
+  realized-state evaluation are not inputs.
+- External empirical or literature inputs:** none.
+- Uniform graph-length, which charges `1` on every nearest-neighbor hop, is a
+  disclosed contrast only. It is not attached.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom. It does not choose a Hamiltonian or
+transfer operator, supply transition-probability or weight values, select a
+scalar or nonzero kinetic branch, assert a Dirac-square carrier, define a time
+metric, or provide a record-production process or physical persistence
+dynamics.
+
+Record is quoted only to keep formation and readout outside the hop-cost:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility does not supply the formation site, probability, or rate. It
+also does not name a hop-cost, a two-point arrival table, or a preferred
+clause-toggle.
+
+## Objects
+
+Let `e_1 = (1,0,0)`, `e_2 = (0,1,0)`, `e_3 = (0,0,1)`. The six nearest-neighbor
+shifts are `±e_1`, `±e_2`, `±e_3`. The closed ball is
+
+```text
+B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }.
+```
+
+It contains exactly `2625` sites. The directed graph used here has an edge
+`v → u` precisely when `u − v` is one of the six shifts and both endpoints
+lie in `B_12(0)`.
+
+Inward weight: `w(v) = |σ_v|`, the number of nonzero coordinates of `v`.
+Then `w(0) = 0`, `w(±e_i) = 1`, `w((2,2,0)) = 2`, and `w((5,5,0)) = 2`.
+
+Named hop-cost for the displayed triple `(s,a,d) = (0,1,1)`:
+
+```text
+c(v → u) = 3  if  (w(v) = w(u) = 1)  or  (w(u) < w(v)),
+c(v → u) = 1  otherwise.
+```
+
+Seed-exit hops have `w(v) = 0` and therefore cost `1` under this triple.
+Axis-one hops and support-drop hops cost `3`.
+
+Arrival time `t(v)` is the minimum sum of hop-costs over directed walks from
+`0` to `v` that remain in `B_12(0)`. One Dijkstra computation from the origin
+produces every in-ball `t(v)` used below.
+
+The Euclidean squared length is `|v|_2^2 = v_1^2 + v_2^2 + v_3^2`. Face reverse
+on an ordered pair `(a,b)` in which `b` has strictly more nonzero coordinates
+than `a` means
+
+```text
+t(b)^2 |a|_2^2 < t(a)^2 |b|_2^2.
+```
+
+For each integer $k=1,\ldots,6$ the ordered pair is $((2k,0,0),(k,k,0))$. The
+second site is the more-diagonal site. The pair is reverse when
+$t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$.
+
+The three even-$k$ face pairs $((4,0,0),(2,2,0))$, $((8,0,0),(4,4,0))$, and
+$((12,0,0),(6,6,0))$ cover only $k=2,4,6$. They do not determine the $k=1,3,5$
+times. The $k=1,\ldots,6$ table is therefore not leftover of those three pairs.
+
+## Theorem 1 — Named arrivals at each scale
+
+**Statement.** Under the named `(0,1,1)` hop-cost on `B_12(0)`, for each
+$k=1,\ldots,6$,
+
+```text
+t(2,0,0)=4,    t(1,1,0)=2,
+t(4,0,0)=8,    t(2,2,0)=4,
+t(6,0,0)=10,   t(3,3,0)=6,
+t(8,0,0)=12,   t(4,4,0)=8,
+t(10,0,0)=14,  t(5,5,0)=10,
+t(12,0,0)=18,  t(6,6,0)=12.
+```
+
+These twelve values are Dijkstra outputs, not fitted scalars.
+
+**Proof.** The directed graph is finite. Dijkstra's algorithm from the origin
+computes every in-ball arrival. The runner executes that single computation
+and reads the twelve listed sites.
+
+Witnessing walks of those costs exist inside the ball. The walk
+
+`(0,0,0) → (1,0,0) → (2,0,0)`
+
+has hop-costs `(1,3)` and sum `4`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0)`
+
+has hop-costs `(1,1)` and sum `2`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (4,0,0)`
+
+has hop-costs `(1,1,1,1,1,3)` and sum `8`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (2,2,0)`
+
+has hop-costs `(1,1,1,1)` and sum `4`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (6,0,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,3)` and sum `10`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (3,2,0) → (3,3,0)`
+
+has hop-costs `(1,1,1,1,1,1)` and sum `6`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (8,0,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,1,1,3)` and sum `12`. The site `(8,1,0)` has
+`|v|_1 = 9` and therefore lies in `B_12(0)`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (4,2,0) → (4,3,0) → (4,4,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,1)` and sum `8`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (9,1,0) → (10,1,0) → (10,0,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,1,1,1,1,3)` and sum `14`. The site `(10,1,0)`
+has `|v|_1 = 11` and therefore lies in `B_12(0)`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (5,2,0) → (5,3,0) → (5,4,0) → (5,5,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,1,1,1)` and sum `10`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (9,1,0) → (10,1,0) → (11,1,0) → (11,0,0) → (12,0,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,1,1,1,1,1,3,3)` and sum `18`. The last two hops
+are forced by the ball: `(12,1,0)` has `|v|_1 = 13` and is therefore outside
+`B_12(0)`, so the axis site `(12,0,0)` cannot be entered by a single
+support-drop from `(12,1,0)`. The walk
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (6,2,0) → (6,3,0) → (6,4,0) → (6,5,0) → (6,6,0)`
+
+has hop-costs `(1,1,1,1,1,1,1,1,1,1,1,1)` and sum `12`.
+
+## Theorem 2 — Reverse bit versus integer scale k
+
+**Statement.** For each $k=1,\ldots,6$ the displayed comparison is whether
+$t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$. The six bits are:
+
+- $k=1$: $t(1,1,0)^2/|(1,1,0)|_2^2=2<4=t(2,0,0)^2/|(2,0,0)|_2^2$ (yes)
+- $k=2$: $t(2,2,0)^2/|(2,2,0)|_2^2=2<4=t(4,0,0)^2/|(4,0,0)|_2^2$ (yes)
+- $k=3$: $t(3,3,0)^2/|(3,3,0)|_2^2=2<25/9=t(6,0,0)^2/|(6,0,0)|_2^2$ (yes)
+- $k=4$: $t(4,4,0)^2/|(4,4,0)|_2^2=2<9/4=t(8,0,0)^2/|(8,0,0)|_2^2$ (yes)
+- $k=5$: $t(5,5,0)^2/|(5,5,0)|_2^2=2\not<49/25=t(10,0,0)^2/|(10,0,0)|_2^2$ (no)
+- $k=6$: $t(6,6,0)^2/|(6,6,0)|_2^2=2<9/4=t(12,0,0)^2/|(12,0,0)|_2^2$ (yes)
+
+The bit is not the same for every $k$. Reverse holds at $k=4$ and fails at
+$k=5$. The cheaper rival does not stay reversed at $k=5$. The three even-$k$
+pairs do not determine the $k=1,3,5$ times or the $k=5$ fail.
+
+These reverse bits are displayed, not adopted.
+
+**Proof.** Substitute the Theorem 1 arrivals. The more-diagonal site is the
+one with strictly more nonzero coordinates. The integer comparisons in
+Result Up Front are exactly $t(b)^2 |a|_2^2 < t(a)^2 |b|_2^2$ when reverse
+holds, and the opposite inequality at $k=5$:
+$100\,t(5,5,0)^2=10000>9800=50\,t(10,0,0)^2$.
+
+Uniform graph-length on the same six pairs gives arrivals equal to `|v|_1`
+and does not reverse: the more-diagonal site then has the larger density
+after cancelling the common hop count against `|v|_2^2`. That comparator is
+not attached.
+
+## Theorem 3 — Not written into Admissibility; L1 not attached
+
+**Statement.** Do not write `(0,1,1)` into Admissibility. Do not attach L1.
+Uniqueness is not claimed among hop-costs.
+
+**Proof.** Admissibility, as quoted above, supplies one fixed nearest-neighbor
+rule that determines a local possibility distribution from nearest-neighbor
+conditions. It does not name inward weights, seed-exit, axis-one hops,
+support-drop, or a numerical hop-cost. Inserting `(s,a,d) = (0,1,1)` into
+that sentence would be an axiom edit. This note proposes none.
+
+L1 here means the uniform graph-length comparator that charges `1` on every
+nearest-neighbor hop and therefore gives arrivals `|v|_1`. Attaching that
+comparator as a parent of the reverse bits, or rewriting the bits as leftover
+of those integers, would attach a different rule. The six face pairs reverse
+under the named toggle at five scales and do not reverse under graph-length.
+
+No later selector is forbidden. The claim is only that the present score does
+not perform the selection.
+
+## Boundary And Non-Claims
+
+- The note does not claim that `(0,1,1)` is the unique reversing
+  clause-toggle, nor that it minimizes any variance.
+- The note does not extend the ball past radius twelve.
+- The note does not identify hop-cost with a Record readout, a formation
+  rate, or a nearest-neighbor possibility law.
+- The note does not attach L1, and it does not treat the three even-$k$ face
+  pairs as a substitute for the six-scale Dijkstra table.
+- The note does not propose axiom text.
+- Face-diagonal reverse versus $k$ is not claimed outside $B_{12}(0)$ and is
+  not claimed for any hop-cost other than the named `(0,1,1)`.
+
+## Imports Table
+
+| Input | Role | Status language |
+|---|---|---|
+| live axiom memo | cubic nearest-neighbor substrate; Admissibility does not name a hop-cost | registered `minimal_axioms` premise |
+| displayed `(0,1,1)` toggle | finite hop-cost hypothesis | displayed, not adopted |
+| uniform graph-length | disclosed contrast only | not attached |
+
+No approved primitive is consumed.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the $k$-scale residual for the cheap-seed face pairs: the twelve arrivals and the six reverse bits are produced. |
+| V2 | Current `origin/main` has no landed source note scoring these `(0,1,1)` reverse bits versus $k=1,\ldots,6$ on `B_12(0)`. |
+| V3 | The graph, costs, and one Dijkstra are finite and exact. No observational input is used. |
+| V4 | The $k=1,3,5$ times are new relative to the three even-$k$ face pairs. Reverse fails at $k=5$. |
+| V5 | The toggle is displayed, not adopted. It is not a physical time, not an Admissibility edit, and not a uniqueness theorem. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: this score does not write `(0,1,1)` into
+Admissibility and does not attach L1. No global impossibility for a later
+hop-cost selector is claimed. These are scope boundaries, not impossibility.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| named `(0,1,1)` Dijkstra on `B_12(0)` | charge axis-one and support-drop only | executed; yields the displayed arrivals |
+| reuse the three even-$k$ pairs | copy $k=2,4,6$ as a six-scale table | false; $k=1,3,5$ times are new |
+| charge seed-exit as well | use the triple `(1,1,1)` | different arrivals; not this claim |
+| uniform graph-length | charge `1` on every hop | no face reverse on the six pairs; not attached |
+| write the toggle into Admissibility | treat hop-cost as the axiom's nearest-neighbor rule | axiom edit; not derived |
+| later selector among reversing triples | uniqueness or variance ranking | live route; not claimed here |
+
+### N2 — wall independence
+
+The missing physical selector, the missing identification of hop-cost with
+Admissibility, and the missing uniqueness statement are distinct residuals.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball radius, the three clause names, the toggle `(0,1,1)`, the reverse
+predicates, and the listed sites are declared. Uniform graph-length is used
+only as a disclosed contrast.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate and
+does not name a hop-cost. The residual is therefore a score under a
+displayed hypothesis, matching those sources.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | named hops and inward-weight clauses | no continuum interpolation |
+| per site | arrivals at the twelve in-ball targets | no lattice-wide time law |
+| per mode | exact integer reverse tests versus $k$ | no spectral claim |
+| per block | one Dijkstra on `B_12(0)` | no selector among all reversing triples |
+| lattice wide | checked and not executed | no Admissibility edit; L1 not attached |
+
+### N6 — live partial-closure paths
+
+Live routes include a later derivation that would select a hop-cost from
+Admissibility, a comparison among several reversing triples, and a
+Record-typed reading of arrival. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once the even-$k$ arrivals $t(4,0,0)=8$, $t(8,0,0)=12$,
+$t(12,0,0)=18$, $t(2,2,0)=4$, $t(4,4,0)=8$, and $t(6,6,0)=12$ are known,
+the six-scale reverse bits are leftover.
+
+**Answer:** The $k=1,3,5$ times are not among those six values. In particular
+$t(10,0,0)=14$ and $t(5,5,0)=10$ are new, and they are the pair that fails
+reverse. Those facts are not determined by the even-$k$ face times.
+
+### N8 — cross-cycle echo
+
+A seed-exit-expensive support-drop rule and a three-pair even-$k$ census are
+different objects. This note does not import their arrivals as premises. It
+recomputes the `(0,1,1)` arrivals on `B_12(0)` from the named cost at every
+integer scale $k=1,\ldots,6$.
+
+**Gate disposition:** PASS for the twelve in-ball arrivals, the six reverse
+bits versus $k$, and the narrow non-adoption statements. FAIL / DO NOT SHIP
+for “Admissibility is `(0,1,1)`,” “L1 is the physical time,” or “no other
+reversing rule exists.”
+
+## Primary Runner
+
+The primary runner builds `B_12(0)`, evaluates the named hop-cost, computes
+arrivals by one Dijkstra, checks the twelve in-ball times and the six reverse
+bits versus $k$, pins the current axiom wording, and runs mutation controls
+that replace the named toggle by uniform graph-length or by an expensive
+seed-exit on a witnessing walk. It authors no audit verdict.
+
+## claim_scope
+
+Face-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_12(0) is reported for k=1..6. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2329,6 +2329,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_face_reverse_vs_k_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_face_reverse_vs_k_b12_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_face_reverse_vs_k_b12_2026_08_15.txt
@@ -1,0 +1,88 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py
+runner_sha256: 4548d32574ab4313529782d16ccb5b350df99003320547c53f56cb16a7684dd2
+input_fingerprint_sha256: 4f5ae3500fc5cea47be2f024f5e702b3fe770eb60d9adc9961805f29f6185a1d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count_budget: 1
+claim_scope: Face-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_12(0) is reported for k=1..6. Displayed, not adopted.
+external_scientific_inputs: current Lattice and Admissibility wording; no observations or fits
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: named (0,1,1) hop-cost on B_12(0) with one origin Dijkstra
+negative_scope: displayed, not adopted; not written into Admissibility; L1 not attached
+PASS: audit-inputs declared source-bound inputs exist as the required string-literal tuple
+PASS: audit-input-literals AUDIT_INPUT_PATHS is a static two-string literal in this runner
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current one-fixed-rule wording is pinned
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: ball-cardinality B_12(0) has exactly 2625 integer sites
+PASS: targets-inside the twelve scored sites lie in B_12(0) and (12,1,0) does not
+PASS: clause-identity seed-exit is cheap and axis-one and support-drop cost 3
+PASS: one-dijkstra exactly one Dijkstra computation is used
+PASS: finite-times every in-ball target is reached by a finite path
+arrival_times:
+  t(2, 0, 0)=4  t^2/|v|_2^2=16/4
+  t(1, 1, 0)=2  t^2/|v|_2^2=4/2
+  t(4, 0, 0)=8  t^2/|v|_2^2=64/16
+  t(2, 2, 0)=4  t^2/|v|_2^2=16/8
+  t(6, 0, 0)=10  t^2/|v|_2^2=100/36
+  t(3, 3, 0)=6  t^2/|v|_2^2=36/18
+  t(8, 0, 0)=12  t^2/|v|_2^2=144/64
+  t(4, 4, 0)=8  t^2/|v|_2^2=64/32
+  t(10, 0, 0)=14  t^2/|v|_2^2=196/100
+  t(5, 5, 0)=10  t^2/|v|_2^2=100/50
+  t(12, 0, 0)=18  t^2/|v|_2^2=324/144
+  t(6, 6, 0)=12  t^2/|v|_2^2=144/72
+PASS: time-200 computed t(2,0,0)=4 is written in the note
+PASS: time-400 computed t(4,0,0)=8 is written in the note
+PASS: time-600 computed t(6,0,0)=10 is written in the note
+PASS: time-800 computed t(8,0,0)=12 is written in the note
+PASS: time-1000 computed t(10,0,0)=14 is written in the note
+PASS: time-1200 computed t(12,0,0)=18 is written in the note
+PASS: time-110 computed t(1,1,0)=2 is written in the note
+PASS: time-220 computed t(2,2,0)=4 is written in the note
+PASS: time-330 computed t(3,3,0)=6 is written in the note
+PASS: time-440 computed t(4,4,0)=8 is written in the note
+PASS: time-550 computed t(5,5,0)=10 is written in the note
+PASS: time-660 computed t(6,6,0)=12 is written in the note
+reverse_bits:
+  k=1 (2, 0, 0) vs (1, 1, 0): reverse=True (4*4=16 vs 16*2=32)
+PASS: reverse-k1 k=1 reverse bit is True and the comparison is written
+  k=2 (4, 0, 0) vs (2, 2, 0): reverse=True (16*16=256 vs 64*8=512)
+PASS: reverse-k2 k=2 reverse bit is True and the comparison is written
+  k=3 (6, 0, 0) vs (3, 3, 0): reverse=True (36*36=1296 vs 100*18=1800)
+PASS: reverse-k3 k=3 reverse bit is True and the comparison is written
+  k=4 (8, 0, 0) vs (4, 4, 0): reverse=True (64*64=4096 vs 144*32=4608)
+PASS: reverse-k4 k=4 reverse bit is True and the comparison is written
+  k=5 (10, 0, 0) vs (5, 5, 0): reverse=False (100*100=10000 vs 196*50=9800)
+PASS: reverse-k5 k=5 reverse bit is False and the comparison is written
+  k=6 (12, 0, 0) vs (6, 6, 0): reverse=True (144*144=20736 vs 324*72=23328)
+PASS: reverse-k6 k=6 reverse bit is True and the comparison is written
+PASS: witnessing-paths named in-ball walks realize the arrivals used in the k=1,2,5,6 reverse bits
+PASS: bit-not-constant the reverse bit is not the same for every k=1..6
+PASS: keeps-k4-fails-k5 k=4 remains reverse and k=5 fails reverse
+PASS: not-even-k-leftover the k=1..6 census is not leftover of the three even-k face pairs
+PASS: graph-length-contrast uniform graph-length does not reverse the six face pairs and is not attached
+PASS: mutation-seed-exit charging seed-exit 3 changes the opening hop of the axis witness
+PASS: note-contract machine fields, exhibition wording, N1-N8, and forbidden-phrase hygiene hold
+PASS: claim-scope front matter keeps the dispatch claim_scope
+PASS: not-in-admissibility (0,1,1) is not written into Admissibility
+PASS: forbidden-phrases forbidden phrases are absent from the note and from runner prose
+PASS: axiom-untouched the axiom memo is an input only
+per_element: inward-weight clauses and hop-costs are evaluated on named directed nearest-neighbor edges
+per_site: arrivals are read at the twelve in-ball face and axis targets
+per_mode: reverse is the exact integer comparison versus integer scale k
+per_block: one Dijkstra on B_12(0) and the named (0,1,1) hop-cost
+lattice_wide: checked and not executed — no Admissibility edit and L1 is not attached
+TOTAL: PASS=40 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py
+++ b/scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Face reverse versus integer scale k under the named (0,1,1) hop-cost on B_12(0).
+
+One origin Dijkstra. Seed-exit is cheap; both-weights-one and support-drop
+cost 3. The rule is displayed, not adopted. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Face-diagonal reverse versus integer scale k under the named "
+    "(0,1,1) hop-cost on B_12(0) is reported for k=1..6. "
+    "Displayed, not adopted."
+)
+RADIUS = 12
+SCALES = (1, 2, 3, 4, 5, 6)
+ORIGIN = (0, 0, 0)
+CLAUSE_011 = (0, 1, 1)
+SHIFTS: tuple[tuple[int, int, int], ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+Point = tuple[int, int, int]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def l1_norm(site: Point) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def l2sq(site: Point) -> int:
+    return site[0] * site[0] + site[1] * site[1] + site[2] * site[2]
+
+
+def inward_weight(site: Point) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def ball_sites(radius: int = RADIUS) -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+BALL = ball_sites()
+
+
+def neighbors(site: Point) -> tuple[Point, ...]:
+    return tuple(dest for shift in SHIFTS if (dest := add(site, shift)) in BALL)
+
+
+def hop_clauses(src: Point, dest: Point) -> tuple[bool, bool, bool]:
+    source_weight = inward_weight(src)
+    dest_weight = inward_weight(dest)
+    seed_exit = source_weight == 0
+    both_weights_one = source_weight == 1 and dest_weight == 1
+    support_drop = dest_weight < source_weight
+    return seed_exit, both_weights_one, support_drop
+
+
+def hop_cost(src: Point, dest: Point, clauses: tuple[int, int, int] = CLAUSE_011) -> int:
+    seed_exit, both_weights_one, support_drop = hop_clauses(src, dest)
+    seed_bit, axis_bit, drop_bit = clauses
+    if (seed_bit and seed_exit) or (axis_bit and both_weights_one) or (drop_bit and support_drop):
+        return 3
+    return 1
+
+
+def dijkstra_from(source: Point, clauses: tuple[int, int, int] = CLAUSE_011) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    dist = {source: 0}
+    heap: list[tuple[int, Point]] = [(0, source)]
+    while heap:
+        cost, site = heappop(heap)
+        if cost != dist[site]:
+            continue
+        for dest in neighbors(site):
+            candidate = cost + hop_cost(site, dest, clauses)
+            if dest not in dist or candidate < dist[dest]:
+                dist[dest] = candidate
+                heappush(heap, (candidate, dest))
+    return dist
+
+
+def path_cost(path: tuple[Point, ...], clauses: tuple[int, int, int] = CLAUSE_011) -> int:
+    return sum(hop_cost(path[index], path[index + 1], clauses) for index in range(len(path) - 1))
+
+
+def axis_site(k: int) -> Point:
+    return (2 * k, 0, 0)
+
+
+def face_site(k: int) -> Point:
+    return (k, k, 0)
+
+
+def is_reverse(times: dict[Point, int], k: int) -> bool:
+    axis = axis_site(k)
+    face = face_site(k)
+    return times[axis] * times[axis] * l2sq(face) > times[face] * times[face] * l2sq(axis)
+
+
+def main() -> int:
+    checks = Checks()
+    note = (ROOT / AUDIT_INPUT_PATHS[0]).read_text(encoding="utf-8")
+    axiom = (ROOT / AUDIT_INPUT_PATHS[1]).read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count_budget: 1")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print("external_scientific_inputs: current Lattice and Admissibility wording; no observations or fits")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: named (0,1,1) hop-cost on B_12(0) with one origin Dijkstra")
+    print("negative_scope: displayed, not adopted; not written into Admissibility; L1 not attached")
+
+    checks.check(
+        "audit-inputs",
+        "declared source-bound inputs exist as the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and NOTE_REL in source
+        and AXIOM_REL in source,
+    )
+    checks.check(
+        "audit-input-literals",
+        "AUDIT_INPUT_PATHS is a static two-string literal in this runner",
+        'AUDIT_INPUT_PATHS = (\n    "docs/CLAUSE_011_FACE_REVERSE_VS_K_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in source,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_fixed = "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check(
+        "source-admissibility",
+        "current one-fixed-rule wording is pinned",
+        admissibility_fixed in normalized_axiom
+        and admissibility_sentence in normalized_axiom
+        and admissibility_sentence in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+
+    targets = tuple(axis_site(k) for k in SCALES) + tuple(face_site(k) for k in SCALES)
+    checks.check("ball-cardinality", "B_12(0) has exactly 2625 integer sites", len(BALL) == 2625)
+    checks.check(
+        "targets-inside",
+        "the twelve scored sites lie in B_12(0) and (12,1,0) does not",
+        all(site in BALL for site in targets)
+        and (12, 1, 0) not in BALL
+        and l1_norm((12, 1, 0)) == 13
+        and (10, 1, 0) in BALL
+        and (8, 1, 0) in BALL,
+    )
+    checks.check(
+        "clause-identity",
+        "seed-exit is cheap and axis-one and support-drop cost 3",
+        hop_cost(ORIGIN, (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    arrivals = dijkstra_from(ORIGIN)
+    checks.check("one-dijkstra", "exactly one Dijkstra computation is used", DIJKSTRA_CALLS == 1)
+    checks.check(
+        "finite-times",
+        "every in-ball target is reached by a finite path",
+        all(site in arrivals for site in targets),
+    )
+
+    print("arrival_times:")
+    for k in SCALES:
+        for site in (axis_site(k), face_site(k)):
+            time = arrivals[site]
+            print(f"  t{site}={time}  t^2/|v|_2^2={time * time}/{l2sq(site)}")
+
+    expected_times = {
+        (2, 0, 0): 4,
+        (4, 0, 0): 8,
+        (6, 0, 0): 10,
+        (8, 0, 0): 12,
+        (10, 0, 0): 14,
+        (12, 0, 0): 18,
+        (1, 1, 0): 2,
+        (2, 2, 0): 4,
+        (3, 3, 0): 6,
+        (4, 4, 0): 8,
+        (5, 5, 0): 10,
+        (6, 6, 0): 12,
+    }
+    for site, expected in expected_times.items():
+        token = f"t({site[0]},{site[1]},{site[2]})={expected}"
+        checks.check(
+            f"time-{site[0]}{site[1]}{site[2]}",
+            f"computed {token} is written in the note",
+            token in note and arrivals[site] == expected,
+            residual=arrivals[site],
+        )
+
+    expected_bits = {
+        1: True,
+        2: True,
+        3: True,
+        4: True,
+        5: False,
+        6: True,
+    }
+    comparison_tokens = {
+        1: "4 t(1,1,0)^2 = 16 < 32 = 2 t(2,0,0)^2",
+        2: "16 t(2,2,0)^2 = 256 < 512 = 8 t(4,0,0)^2",
+        3: "36 t(3,3,0)^2 = 1296 < 1800 = 18 t(6,0,0)^2",
+        4: "64 t(4,4,0)^2 = 4096 < 4608 = 32 t(8,0,0)^2",
+        5: "100 t(5,5,0)^2 = 10000 > 9800 = 50 t(10,0,0)^2",
+        6: "144 t(6,6,0)^2 = 20736 < 23328 = 72 t(12,0,0)^2",
+    }
+    print("reverse_bits:")
+    bits: list[bool] = []
+    for k in SCALES:
+        axis = axis_site(k)
+        face = face_site(k)
+        bit = is_reverse(arrivals, k)
+        bits.append(bit)
+        ta, tb = arrivals[axis], arrivals[face]
+        print(
+            f"  k={k} {axis} vs {face}: reverse={bit} "
+            f"({tb * tb}*{l2sq(axis)}={tb * tb * l2sq(axis)} vs "
+            f"{ta * ta}*{l2sq(face)}={ta * ta * l2sq(face)})"
+        )
+        dens_ok = ta * ta * (2 * k * k) > tb * tb * (4 * k * k)
+        checks.check(
+            f"reverse-k{k}",
+            f"k={k} reverse bit is {expected_bits[k]} and the comparison is written",
+            bit is expected_bits[k]
+            and dens_ok is expected_bits[k]
+            and comparison_tokens[k] in note
+            and inward_weight(face) > inward_weight(axis),
+        )
+
+    axis_k1 = (ORIGIN, (1, 0, 0), (2, 0, 0))
+    face_k1 = (ORIGIN, (1, 0, 0), (1, 1, 0))
+    axis_k2 = (ORIGIN, (1, 0, 0), (1, 1, 0), (2, 1, 0), (3, 1, 0), (4, 1, 0), (4, 0, 0))
+    face_k2 = (ORIGIN, (1, 0, 0), (1, 1, 0), (2, 1, 0), (2, 2, 0))
+    axis_k5 = (
+        ORIGIN,
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (3, 1, 0),
+        (4, 1, 0),
+        (5, 1, 0),
+        (6, 1, 0),
+        (7, 1, 0),
+        (8, 1, 0),
+        (9, 1, 0),
+        (10, 1, 0),
+        (10, 0, 0),
+    )
+    face_k5 = (
+        ORIGIN,
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (3, 1, 0),
+        (4, 1, 0),
+        (5, 1, 0),
+        (5, 2, 0),
+        (5, 3, 0),
+        (5, 4, 0),
+        (5, 5, 0),
+    )
+    axis_k6 = (
+        ORIGIN,
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (3, 1, 0),
+        (4, 1, 0),
+        (5, 1, 0),
+        (6, 1, 0),
+        (7, 1, 0),
+        (8, 1, 0),
+        (9, 1, 0),
+        (10, 1, 0),
+        (11, 1, 0),
+        (11, 0, 0),
+        (12, 0, 0),
+    )
+    checks.check(
+        "witnessing-paths",
+        "named in-ball walks realize the arrivals used in the k=1,2,5,6 reverse bits",
+        path_cost(axis_k1) == arrivals[(2, 0, 0)]
+        and path_cost(face_k1) == arrivals[(1, 1, 0)]
+        and path_cost(axis_k2) == arrivals[(4, 0, 0)]
+        and path_cost(face_k2) == arrivals[(2, 2, 0)]
+        and path_cost(axis_k5) == arrivals[(10, 0, 0)]
+        and path_cost(face_k5) == arrivals[(5, 5, 0)]
+        and path_cost(axis_k6) == arrivals[(12, 0, 0)]
+        and all(
+            site in BALL
+            for site in axis_k1 + face_k1 + axis_k2 + face_k2 + axis_k5 + face_k5 + axis_k6
+        )
+        and "(12,1,0)" in note
+        and "outside B_12(0)" in note,
+    )
+
+    checks.check(
+        "bit-not-constant",
+        "the reverse bit is not the same for every k=1..6",
+        bits == [True, True, True, True, False, True]
+        and "not the same for every" in note
+        and "does not stay reversed at $k=5$" in note,
+    )
+    checks.check(
+        "keeps-k4-fails-k5",
+        "k=4 remains reverse and k=5 fails reverse",
+        bits[3] is True
+        and bits[4] is False
+        and "holds at $k=4$" in note
+        and "fails at $k=5$" in note,
+    )
+    checks.check(
+        "not-even-k-leftover",
+        "the k=1..6 census is not leftover of the three even-k face pairs",
+        "not leftover of those three pairs" in note
+        and "independent Dijkstra" in note
+        and arrivals[(1, 1, 0)] == 2
+        and arrivals[(3, 3, 0)] == 6
+        and arrivals[(5, 5, 0)] == 10
+        and arrivals[(10, 0, 0)] == 14
+        and l1_norm((12, 0, 0)) == 12
+        and l1_norm((6, 6, 0)) == 12,
+    )
+    checks.check(
+        "graph-length-contrast",
+        "uniform graph-length does not reverse the six face pairs and is not attached",
+        all(
+            not is_reverse({axis_site(k): l1_norm(axis_site(k)), face_site(k): l1_norm(face_site(k))}, k)
+            for k in SCALES
+        )
+        and (l1_norm((4, 0, 0)), l1_norm((2, 2, 0))) != (arrivals[(4, 0, 0)], arrivals[(2, 2, 0)])
+        and "Do not attach L1" in note,
+    )
+    expensive_axis_open = hop_cost(ORIGIN, (1, 0, 0), (1, 1, 1))
+    checks.check(
+        "mutation-seed-exit",
+        "charging seed-exit 3 changes the opening hop of the axis witness",
+        expensive_axis_open == 3
+        and path_cost(axis_k2, (1, 1, 1)) != arrivals[(4, 0, 0)],
+    )
+
+    allowed_retained = ("audit_required_before_effective_retained: true", "bare_retained_allowed: false")
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    required = (
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "trace_class: frontier_discovery",
+        'hypothetical_axiom_status: "no edit"',
+        "Displayed, not adopted",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "not written into Admissibility",
+        "Do not attach L1",
+        "Uniqueness is not claimed",
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, exhibition wording, N1-N8, and forbidden-phrase hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and not any(phrase in note for phrase in FORBIDDEN)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "Codex" not in note
+        and "toe-lphys" not in note,
+        residual=[phrase for phrase in required if phrase not in note],
+    )
+    checks.check(
+        "claim-scope",
+        "front matter keeps the dispatch claim_scope",
+        CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "(0,1,1) is not written into Admissibility",
+        "Do not write (0,1,1) into Admissibility" in note
+        and "not written into Admissibility" in note
+        and "There is one fixed nearest-neighbor admissibility rule" in axiom,
+    )
+    forbidden_hits = [phrase for phrase in FORBIDDEN if phrase in note or phrase in source.split("FORBIDDEN =", 1)[0]]
+    checks.check(
+        "forbidden-phrases",
+        "forbidden phrases are absent from the note and from runner prose",
+        forbidden_hits == [],
+        residual=forbidden_hits,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only",
+        "### Admissibility / Local Constraint" in axiom
+        and "(0,1,1)" not in axiom,
+    )
+
+    print("per_element: inward-weight clauses and hop-costs are evaluated on named directed nearest-neighbor edges")
+    print("per_site: arrivals are read at the twelve in-ball face and axis targets")
+    print("per_mode: reverse is the exact integer comparison versus integer scale k")
+    print("per_block: one Dijkstra on B_12(0) and the named (0,1,1) hop-cost")
+    print("lattice_wide: checked and not executed — no Admissibility edit and L1 is not attached")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_12(0) under (0,1,1), face pair ((2k,0,0),(k,k,0)) reverses at k=1,2,3,4,6 and fails only at k=5. The cheaper rival keeps the k=4 face that nu loses, and loses k=5. Displayed, not adopted.

## Runner

`scripts/clause_011_face_reverse_vs_k_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.