### PR TITLE
feat(011k1): k=1 same-k fail is cheap seed-exit: t(1,0,0)=1 vs t(1,1,1)=3

### DIFF
--- a/docs/CLAUSE_011_WHY_K1_SAMEK_FAILS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_WHY_K1_SAMEK_FAILS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,267 @@
+---
+claim_id: clause_011_why_k1_samek_fails_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Lex-first shortest paths to (1,0,0) and (1,1,1) under the named (0,1,1) hop-cost on B_12(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py
+---
+
+# Why The Named (0,1,1) Same-k Reverse Fails At k=1 On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra for the named (0,1,1) hop-cost on the finite ball
+`B_12(0)`. Lex-first shortest paths to `(1,0,0)` and `(1,1,1)` are named.
+The same-k reverse comparison and first-hop costs are displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py`](../scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py)
+
+## Result Up Front
+
+On the finite cubic box
+
+`B_12(0) = { x in Z^3 : max(|x_1|,|x_2|,|x_3|) <= 12 }`,
+
+equip nearest-neighbor hops with the named `(0,1,1)` hop-cost: the weight of a
+site is its support size, and a hop costs `3` if and only if both weights are
+`1` or the hop is a support drop; otherwise the hop costs `1`. One Dijkstra
+from the origin yields
+
+`t(1,0,0)=1`, `t(1,1,1)=3`.
+
+A lex-first shortest path to each target is
+
+`(0,0,0)->(1,0,0)`
+
+and
+
+`(0,0,0)->(0,0,1)->(0,1,1)->(1,1,1)`.
+
+Uniqueness is not required: six shortest paths reach `(1,1,1)`. The residual
+names the lex-first path only.
+
+The displayed same-k reverse
+
+`t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3`
+
+fails because `1 > 3` is false. Both lex-first first hops have cost `1`. That
+cheap seed-exit is why the k=1 comparison fails. The same displayed comparison
+holds at `k=2,3,4` on this ball (`16>12`, `49>27`, `64>48`). Those later
+values are comparison context only.
+
+Do not write (0,1,1) into Admissibility. Do not attach L1. Displayed, not
+adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility sentences used only as domain language are
+quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+The named `(0,1,1)` hop-cost is a separately supplied finite comparison rule
+on `B_12(0)`. It is not an edit of that Admissibility sentence and is not
+written into the axiom memo.
+
+## Exact Objects
+
+Sites are points of `Z^3` restricted to `B_12(0)`. Adjacency is the six-neighbor
+relation. The support of `x` is the set of coordinates with `x_i != 0`. The
+weight of `x` is the support size `s(x)`. A hop `u -> v` is a support drop
+when `s(v) < s(u)`.
+
+The named `(0,1,1)` hop-cost is
+
+```text
+c(u,v) = 3  if s(u)=s(v)=1 or s(v)<s(u),
+c(u,v) = 1  otherwise.
+```
+
+Every origin-adjacent hop has `s(0)=0` and `s(v)=1`, so it costs `1`. That is
+the cheap seed-exit.
+
+`t(x)` is the Dijkstra distance from the origin in this weighted graph. The
+search is executed once. Paths are sequences of sites in `B_12(0)`. Among
+shortest paths to a named target, the lex-first path is the lexicographically
+least vertex sequence, using ordinary integer order on coordinate triples.
+
+## Theorem 1 — Named Distances And Lex-First Paths
+
+The single origin Dijkstra on `B_12(0)` returns
+
+`t(1,0,0)=1`, `t(1,1,1)=3`.
+
+The unique shortest path to `(1,0,0)` is the seed-exit hop
+`(0,0,0)->(1,0,0)`.
+
+The six shortest paths to `(1,1,1)` are the six increasing coordinate orders.
+The lex-first among them is
+
+`(0,0,0)->(0,0,1)->(0,1,1)->(1,1,1)`.
+
+No uniqueness claim is made for general targets.
+
+## Theorem 2 — Displayed Same-k Reverse And First-Hop Costs
+
+Write the displayed comparison
+
+`t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3`.
+
+Substituting the Theorem 1 values gives `1 > 3`, which fails. The first hop of
+each lex-first path has cost `1`. Replacing the cheap seed-exit by a cost-`3`
+origin hop would change those first-hop costs; that mutation is not the named
+rule.
+
+On the same Dijkstra output the displayed comparison holds at `k=2,3,4`:
+
+| `k` | `t(k,0,0)` | `t(k,k,k)` | left | right | holds |
+|---:|---:|---:|---:|---:|:---:|
+| 1 | 1 | 3 | 1 | 3 | no |
+| 2 | 4 | 6 | 16 | 12 | yes |
+| 3 | 7 | 9 | 49 | 27 | yes |
+| 4 | 8 | 12 | 64 | 48 | yes |
+
+Displayed, not adopted. The table is not a selected law, not an Admissibility
+clause, and not a continuum kernel.
+
+## Theorem 3 — No Admissibility Write And No L1 Attachment
+
+Do not write (0,1,1) into Admissibility. The current axiom already names one
+fixed nearest-neighbor admissibility rule and does not name this hop-cost.
+
+Do not attach L1. The taxicab length of `(4,0,0)` is `4`, while
+`t(4,0,0)=8` under the named rule, because axis continuation after the seed
+exit has both weights `1`. The residual is the lex-first `(0,1,1)` paths on
+`B_12(0)`, not a taxicab identification.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_12(0) names t(1,0,0), t(1,1,1), and the lex-first shortest paths. The same-k reverse and first-hop costs are displayed, not adopted."
+trace_class: residual_naming
+target_claim_id: clause_011_why_k1_samek_fails_b12
+target_blocker_text: "name the lex-first (0,1,1) paths that make the k=1 same-k reverse fail"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the (0,1,1) hop-cost displayed only; do not write it into Admissibility and do not attach L1."
+conditional_surface_status: "exact on B_12(0) for the named hop-cost; not an axiom clause"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target And Obligation Graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility wording | quoted; no edit |
+| named (0,1,1) hop-cost | separately supplied; displayed only |
+| one Dijkstra on B_12(0) | executed by the primary runner |
+| t(1,0,0) and t(1,1,1) | named |
+| lex-first shortest paths | named |
+| uniqueness of shortest paths | not required |
+| same-k reverse at k=1 | displayed failure |
+| first-hop costs | displayed; both 1 |
+| write (0,1,1) into Admissibility | refused |
+| attach L1 | refused |
+
+## Boundary And Imports
+
+No observation, fitted prefactor, continuum limit, or axiom edit is imported.
+The comparison table at `k=2,3,4` is the same Dijkstra readout, not a second
+search and not a selected continuum law.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It names the k=1 residual: cheap seed-exit makes t(1,0,0)=1 while t(1,1,1)=3. |
+| V2 | Current main does not land these lex-first (0,1,1) paths on B_12(0). |
+| V3 | Distances and paths are finite exact Dijkstra output. |
+| V4 | The note is more than a restatement of Admissibility because the hop-cost is an extra named rule. |
+| V5 | Displayed, not adopted: no axiom write and no L1 attachment. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: the displayed k=1 reverse fails, and the named
+rule is not an Admissibility clause. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| named (0,1,1) hop-cost | cost 3 on both-weights-1 or support drop | executed; t(1,0,0)=1, t(1,1,1)=3 |
+| unit hop-cost | every hop costs 1 | different rule; reverse fails at every k |
+| forced expensive seed-exit | charge 3 to leave the origin | not the named rule; first-hop costs would change |
+| taxicab attachment | set t(x)=||x||_1 | refused; t(4,0,0)=8 != 4 |
+| write into Admissibility | treat the hop-cost as the axiom rule | refused |
+| infinite lattice | drop the B_12(0) cutoff | outside this theorem |
+
+### N2 — wall independence
+
+The missing axiom write, the refused L1 attachment, and the unadopted reverse
+comparison are distinct refusals. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball, the six-neighbor graph, the support-weight hop-cost, the single
+Dijkstra, and lex order are declared. Uniqueness is not assumed.
+
+### N4 — source residual matching
+
+The residual is the lex-first paths that make the k=1 reverse fail under the
+named rule. It matches that handoff and does not replace it by a taxicab claim.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | named hops and first-hop costs | no continuum kernel |
+| per site | t values and lex-first paths | no uniqueness theorem |
+| per mode | no mode calculation | no spectral claim |
+| per block | k=1 reverse; k=2,3,4 context | no adopted law |
+| lattice wide | B_12(0) only | no axiom edit |
+
+### N6 — live partial-closure paths
+
+Live routes are a separately derived hop-cost, a later comparison at larger
+`k` still inside a declared ball, or an independent reason to reject or keep
+the displayed reverse. None of those is adopted here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because the reverse holds at `k=2,3,4`, the k=1 failure is a
+ball artifact or a taxicab restatement.
+
+**Answer:** The k=1 values are the two-step and six-path listings on the
+nearest-neighbor graph. The cheap seed-exit costs `1` by the named rule, so
+`t(1,0,0)=1` is forced. `t(4,0,0)=8` is already not the taxicab length.
+Displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+This note does not import a prior L1 residual and does not feed the named
+hop-cost back into the axiom memo.
+
+**Gate disposition:** PASS for the named distances, lex-first paths, displayed
+k=1 failure, and the two refusals. FAIL / DO NOT SHIP for “the reverse is a
+law,” “Admissibility is (0,1,1),” or “t is taxicab length.”
+
+## Primary Runner
+
+The primary runner executes one Dijkstra on `B_12(0)`, names the two distances
+and lex-first paths, displays the reverse and first-hop costs, checks that the
+current axiom memo does not contain the hop-cost, and writes no cache. It
+authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15743,
- "node_count": 5545,
+ "edge_count": 15744,
+ "node_count": 5546,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2329,6 +2329,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_why_k1_samek_fails_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_why_k1_samek_fails_b12_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_why_k1_samek_fails_b12_2026_08_15.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py
+runner_sha256: 931e36b9d3702b176187f629490d1651bad16599e4c94e6cbc6f78306f9dd0af
+input_fingerprint_sha256: 97a60fd27c9966b58a7854fa7102b9c3673682c7a02ab9e6f5d2f0087b26d4b8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CLAUSE_011_WHY_K1_SAMEK_FAILS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count_budget: 1
+claim_scope: Lex-first shortest paths to (1,0,0) and (1,1,1) under the named (0,1,1) hop-cost on B_12(0) are named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and current axiom memo
+PASS: b12-domain named sites lie in the closed max-norm ball B_12(0) and radius 13 is excluded
+PASS: hop-cost-rule cost is 3 iff both support weights are 1 or the hop drops support, else 1
+PASS: cheap-seed-exit every origin-adjacent hop has cost 1
+PASS: one-dijkstra a single Dijkstra from the origin is executed
+PASS: t-100 t(1,0,0)=1
+PASS: t-111 t(1,1,1)=3
+PASS: lex-path-100 the lex-first shortest path to (1,0,0) is the single seed-exit hop
+PASS: lex-path-111 the lex-first shortest path to (1,1,1) is (0,0,0)->(0,0,1)->(0,1,1)->(1,1,1)
+PASS: uniqueness-not-required six shortest paths reach (1,1,1); the residual names the lex-first one only
+PASS: k1-reverse-fails t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3 fails because 1 > 3 is false
+PASS: k234-reverse-holds the same displayed comparison holds at k=2,3,4
+PASS: first-hop-costs both lex-first first hops have cost 1
+PASS: l1-not-attached t(4,0,0)=8 is not the taxicab length 4, so L1 is not attached
+PASS: note-contract the note names the lex-first residual, displays the reverse, and keeps the axiom unedited
+PASS: claim-scope-field YAML claim_scope matches the dispatch sentence
+PASS: not-in-admissibility the current Admissibility wording does not contain the (0,1,1) hop-cost
+PASS: displayed-not-adopted the note refuses adoption into Admissibility and refuses an L1 attachment
+PASS: forbidden-tokens the note omits the dispatch-forbidden tokens
+PASS: no-cache-surface the runner declares no cache write and the note names no cache artifact
+per_element: named hops, support weights, and first-hop costs are exact
+per_site: t values and lex-first paths are read from one origin Dijkstra on B_12(0)
+per_mode: checked and not executed — no spectral claim
+per_block: k=1 reverse is displayed; k=2,3,4 are the comparison block
+lattice_wide: checked and not executed — B_12(0) only; no axiom edit
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py
+++ b/scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Exact checks for the named (0,1,1) hop-cost on B_12(0).
+
+One Dijkstra from the origin names t(1,0,0), t(1,1,1), and the lex-first
+shortest paths. The same-k reverse comparison is displayed, not adopted.
+No cache or axiom surface is written.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from heapq import heappop, heappush
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/CLAUSE_011_WHY_K1_SAMEK_FAILS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_WHY_K1_SAMEK_FAILS_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+AXIS: Point = (1, 0, 0)
+DIAG: Point = (1, 1, 1)
+RADIUS = 12
+SHIFTS: tuple[Point, ...] = (
+    (-1, 0, 0),
+    (0, -1, 0),
+    (0, 0, -1),
+    (0, 0, 1),
+    (0, 1, 0),
+    (1, 0, 0),
+)
+CLAIM_SCOPE = (
+    "Lex-first shortest paths to (1,0,0) and (1,1,1) under the named "
+    "(0,1,1) hop-cost on B_12(0) are named. Displayed, not adopted."
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def in_ball(point: Point) -> bool:
+    return max(abs(point[0]), abs(point[1]), abs(point[2])) <= RADIUS
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def neighbors(point: Point) -> tuple[Point, ...]:
+    return tuple(cand for shift in SHIFTS if in_ball(cand := add(point, shift)))
+
+
+def support_size(point: Point) -> int:
+    return sum(coord != 0 for coord in point)
+
+
+def hop_cost(src: Point, dst: Point) -> int:
+    """Named (0,1,1) rule: cost 3 iff both weights 1 or support drop, else 1."""
+
+    src_w = support_size(src)
+    dst_w = support_size(dst)
+    if (src_w == 1 and dst_w == 1) or dst_w < src_w:
+        return 3
+    return 1
+
+
+class DijkstraOnce:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, source: Point) -> dict[Point, int]:
+        self.calls += 1
+        dist = {source: 0}
+        heap: list[tuple[int, Point]] = [(0, source)]
+        seen: set[Point] = set()
+        while heap:
+            cost, site = heappop(heap)
+            if site in seen:
+                continue
+            seen.add(site)
+            for nxt in neighbors(site):
+                trial = cost + hop_cost(site, nxt)
+                prior = dist.get(nxt)
+                if prior is None or trial < prior:
+                    dist[nxt] = trial
+                    heappush(heap, (trial, nxt))
+        return dist
+
+
+def on_shortest_paths(dist: dict[Point, int], target: Point) -> set[Point]:
+    marked = {target}
+    queue = deque([target])
+    while queue:
+        site = queue.popleft()
+        for prev in neighbors(site):
+            if prev not in dist:
+                continue
+            if dist[site] == dist[prev] + hop_cost(prev, site) and prev not in marked:
+                marked.add(prev)
+                queue.append(prev)
+    return marked
+
+
+def lex_first_path(dist: dict[Point, int], target: Point) -> tuple[Point, ...]:
+    allowed = on_shortest_paths(dist, target)
+    path = [ORIGIN]
+    site = ORIGIN
+    while site != target:
+        choices = [
+            nxt
+            for nxt in neighbors(site)
+            if nxt in allowed and dist[nxt] == dist[site] + hop_cost(site, nxt)
+        ]
+        if not choices:
+            raise RuntimeError(f"no lex successor from {site} toward {target}")
+        site = min(choices)
+        path.append(site)
+    return tuple(path)
+
+
+def shortest_path_count(dist: dict[Point, int], target: Point) -> int:
+    allowed = on_shortest_paths(dist, target)
+
+    def walk(site: Point) -> int:
+        if site == target:
+            return 1
+        return sum(
+            walk(nxt)
+            for nxt in neighbors(site)
+            if nxt in allowed and dist[nxt] == dist[site] + hop_cost(site, nxt)
+        )
+
+    return walk(ORIGIN)
+
+
+def reverse_left_right(axis_t: int, diag_t: int) -> tuple[int, int, bool]:
+    left = axis_t * axis_t
+    right = (diag_t * diag_t) // 3
+    return left, right, left > right
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_n = normalize(note)
+    axiom_n = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count_budget: 1")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+        AUDIT_INPUT_PATHS,
+    )
+
+    ball_ok = (
+        in_ball(ORIGIN)
+        and in_ball(AXIS)
+        and in_ball(DIAG)
+        and in_ball((4, 4, 4))
+        and in_ball((12, 0, 0))
+        and in_ball((-12, -12, -12))
+        and not in_ball((13, 0, 0))
+        and not in_ball((0, 0, -13))
+    )
+    checks.check(
+        "b12-domain",
+        "named sites lie in the closed max-norm ball B_12(0) and radius 13 is excluded",
+        ball_ok,
+    )
+
+    cost_table = (
+        (ORIGIN, AXIS, 1),
+        (AXIS, (2, 0, 0), 3),
+        (AXIS, (1, 1, 0), 1),
+        ((1, 1, 0), AXIS, 3),
+        ((1, 1, 0), DIAG, 1),
+        (AXIS, ORIGIN, 3),
+    )
+    checks.check(
+        "hop-cost-rule",
+        "cost is 3 iff both support weights are 1 or the hop drops support, else 1",
+        all(hop_cost(src, dst) == value for src, dst, value in cost_table),
+        [(src, dst, hop_cost(src, dst), value) for src, dst, value in cost_table],
+    )
+
+    seed_costs = tuple(hop_cost(ORIGIN, nxt) for nxt in neighbors(ORIGIN))
+    checks.check(
+        "cheap-seed-exit",
+        "every origin-adjacent hop has cost 1",
+        seed_costs == (1, 1, 1, 1, 1, 1) and len(neighbors(ORIGIN)) == 6,
+        seed_costs,
+    )
+
+    search = DijkstraOnce()
+    dist = search.distances(ORIGIN)
+    checks.check(
+        "one-dijkstra",
+        "a single Dijkstra from the origin is executed",
+        search.calls == 1 and ORIGIN in dist and AXIS in dist and DIAG in dist,
+        search.calls,
+    )
+
+    t100 = dist[AXIS]
+    t111 = dist[DIAG]
+    checks.check("t-100", "t(1,0,0)=1", t100 == 1, t100)
+    checks.check("t-111", "t(1,1,1)=3", t111 == 3, t111)
+
+    path100 = lex_first_path(dist, AXIS)
+    path111 = lex_first_path(dist, DIAG)
+    checks.check(
+        "lex-path-100",
+        "the lex-first shortest path to (1,0,0) is the single seed-exit hop",
+        path100 == (ORIGIN, AXIS),
+        path100,
+    )
+    checks.check(
+        "lex-path-111",
+        "the lex-first shortest path to (1,1,1) is (0,0,0)->(0,0,1)->(0,1,1)->(1,1,1)",
+        path111 == (ORIGIN, (0, 0, 1), (0, 1, 1), DIAG),
+        path111,
+    )
+
+    n111 = shortest_path_count(dist, DIAG)
+    checks.check(
+        "uniqueness-not-required",
+        "six shortest paths reach (1,1,1); the residual names the lex-first one only",
+        n111 == 6 and shortest_path_count(dist, AXIS) == 1,
+        n111,
+    )
+
+    left1, right1, holds1 = reverse_left_right(t100, t111)
+    checks.check(
+        "k1-reverse-fails",
+        "t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3 fails because 1 > 3 is false",
+        left1 == 1 and right1 == 3 and holds1 is False,
+        (left1, right1, holds1),
+    )
+
+    later = []
+    for k in (2, 3, 4):
+        later.append(reverse_left_right(dist[(k, 0, 0)], dist[(k, k, k)]))
+    checks.check(
+        "k234-reverse-holds",
+        "the same displayed comparison holds at k=2,3,4",
+        later == [(16, 12, True), (49, 27, True), (64, 48, True)],
+        later,
+    )
+
+    hop100 = hop_cost(path100[0], path100[1])
+    hop111 = hop_cost(path111[0], path111[1])
+    checks.check(
+        "first-hop-costs",
+        "both lex-first first hops have cost 1",
+        hop100 == 1 and hop111 == 1 and path111[1] == (0, 0, 1),
+        (hop100, hop111, path100[1], path111[1]),
+    )
+
+    t400 = dist[(4, 0, 0)]
+    checks.check(
+        "l1-not-attached",
+        "t(4,0,0)=8 is not the taxicab length 4, so L1 is not attached",
+        t400 == 8 and t400 != 4 and dist[(4, 4, 4)] == 12,
+        t400,
+    )
+
+    required = (
+        CLAIM_SCOPE,
+        "t(1,0,0)=1",
+        "t(1,1,1)=3",
+        "(0,0,0)->(1,0,0)",
+        "(0,0,0)->(0,0,1)->(0,1,1)->(1,1,1)",
+        "t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3",
+        "Displayed, not adopted",
+        "Do not write (0,1,1) into Admissibility",
+        "Do not attach L1",
+        "cheap seed-exit",
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        'hypothetical_axiom_status: "no edit"',
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "**Type:** bounded_theorem",
+    )
+    checks.check(
+        "note-contract",
+        "the note names the lex-first residual, displays the reverse, and keeps the axiom unedited",
+        all(phrase in note for phrase in required),
+        [phrase for phrase in required if phrase not in note],
+    )
+    checks.check(
+        "claim-scope-field",
+        "YAML claim_scope matches the dispatch sentence",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "the current Admissibility wording does not contain the (0,1,1) hop-cost",
+        "both weights 1 or support drop" not in axiom
+        and "named (0,1,1) hop-cost" not in axiom
+        and "There is one fixed nearest-neighbor admissibility rule" in axiom_n,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note refuses adoption into Admissibility and refuses an L1 attachment",
+        "Do not write (0,1,1) into Admissibility" in note
+        and "Do not attach L1" in note
+        and "displayed, not adopted" in note.lower()
+        and "new axiom" not in note.lower(),
+    )
+
+    checks.check(
+        "forbidden-tokens",
+        "the note omits the dispatch-forbidden tokens",
+        all(token not in note for token in FORBIDDEN),
+        [token for token in FORBIDDEN if token in note],
+    )
+    checks.check(
+        "no-cache-surface",
+        "the runner declares no cache write and the note names no cache artifact",
+        "cache_write: false" not in note
+        and "runner-cache" not in note
+        and "citation" not in note.lower(),
+    )
+
+    print("per_element: named hops, support weights, and first-hop costs are exact")
+    print("per_site: t values and lex-first paths are read from one origin Dijkstra on B_12(0)")
+    print("per_mode: checked and not executed — no spectral claim")
+    print("per_block: k=1 reverse is displayed; k=2,3,4 are the comparison block")
+    print("lattice_wide: checked and not executed — B_12(0) only; no axiom edit")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Under (0,1,1) both lex-first first hops cost 1. 1>3 fails. Same-k reverse still holds at k=2,3,4. Displayed, not adopted.

## Runner

`scripts/clause_011_why_k1_samek_fails_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.