### PR TITLE
feat(k6fail): k=6 face fail on B16: t(12,0,0)=18 vs t(6,6,0)=14

### DIFF
--- a/docs/SUPPORT_DROP_WHY_FACE_K6_FAILS_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_WHY_FACE_K6_FAILS_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,202 @@
+---
+claim_id: support_drop_why_face_k6_fails_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Lex-first shortest paths to (12,0,0) and (6,6,0) under the named support-drop hop-cost on B_16(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py
+---
+
+# Lex-First Paths And Last Hops For The k=6 Face Reverse On B_16(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_16(0)`,
+restricted to naming a lex-first shortest walk from `0` to `(12,0,0)`, a
+lex-first shortest walk from `0` to `(6,6,0)`, the last hops of those
+walks, and the displayed k=6 comparison
+`t(12,0,0)^2 / 144 > t(6,6,0)^2 / 72`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py`](../scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_16(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not
+claimed.
+
+One origin Dijkstra on `B_16(0)` (6017 sites) gives `t(12,0,0) = 18` and
+`t(6,6,0) = 14`. Among all walks of those costs, the lexicographically
+first sequences of sites are
+
+`(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (5,-1,0) → (6,-1,0) → (7,-1,0) → (8,-1,0) → (9,-1,0) → (10,-1,0) → (11,-1,0) → (12,-1,0) → (12,0,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3` and running
+costs `3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18` summing to `18`,
+and
+
+`(0,0,0) → (0,1,0) → (1,1,0) → (1,2,0) → (1,3,0) → (1,4,0) → (1,5,0) → (1,6,0) → (2,6,0) → (3,6,0) → (4,6,0) → (5,6,0) → (6,6,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1` and running costs
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14` summing to `14`.
+
+The last hops that make `t = 18` versus `t = 14` are the support-drop
+`(12,-1,0) → (12,0,0)` of cost `3`, versus the support-preserving face
+step `(5,6,0) → (6,6,0)` of cost `1`. After the hop onto `(12,-1,0)` the
+axis walk has already spent `15`; that one cost-`3` hop raises the
+arrival to `18`. The site `(12,-1,0)` has ℓ¹ norm `13` and therefore lies
+in `B_16(0)`, so the walk can stay on the line `y = -1` through `x = 12`
+and drop support only once. The face walk never drops support and never
+travels on a coordinate axis after seed-exit, so its last hop stays
+cost `1` and the arrival stays `14`.
+
+The displayed k=6 comparison is
+
+`t(12,0,0)^2 / 144 = 324/144 = 9/4` versus
+`t(6,6,0)^2 / 72 = 196/72 = 49/18`,
+
+equivalently `72 · 324 = 23328 < 28224 = 144 · 196`. Then
+`9/4 = 40.5/18 < 49/18`, so
+
+`t(12,0,0)^2 / 144 > t(6,6,0)^2 / 72`
+
+fails. Face reverse therefore fails at `k = 6` on `B_16(0)`, because
+`t(12,0,0)` is `18`. That no bit is displayed, not adopted. The two
+walks and their last hops are not leftover of the no bit.
+
+The in-ball neighbors of `(12,0,0)` are `(11,0,0)`, `(13,0,0)`,
+`(12,-1,0)`, `(12,1,0)`, `(12,0,-1)`, and `(12,0,1)`. Each incoming hop
+from those six sites has cost `3` under `ν`. The in-ball neighbors of
+`(6,6,0)` are `(5,6,0)`, `(7,6,0)`, `(6,5,0)`, `(6,7,0)`, `(6,6,-1)`,
+and `(6,6,1)`. Incoming hops from the four face-plane sites have
+cost `1`; incoming hops from `(6,6,-1)` and `(6,6,1)` are support drops
+of cost `3`.
+
+The rule is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_16(0) = { v ∈ Z^3 : |v|_1 ≤ 16 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_16(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+A walk is lex-first among shortest walks to a named site when its sequence
+of sites is the least tuple of integer triples, compared coordinatewise,
+among all walks of cost `t` at that site.
+
+Face reverse at integer scale `k = 6` means the displayed comparison
+`t(12,0,0)^2 / 144 > t(6,6,0)^2 / 72`. The pair is not leftover of the
+no bit: naming the two lex-first walks and the last hops is a separate
+finite exhibit.
+
+## Theorem 1 — Arrivals And Lex-First Shortest Walks
+
+On `B_16(0)` the computed arrivals are `t(12,0,0) = 18` and
+`t(6,6,0) = 14`. The lex-first walk of cost `18` to `(12,0,0)` is the
+fifteen-site walk recorded above. The fourteen hop-costs are seed-exit
+`3`, twelve support-preserving or support-increasing cost-`1` steps along
+the line `y = -1` from `(0,-1,0)` to `(12,-1,0)`, and a final support-drop
+`3` from `(12,-1,0)` onto `(12,0,0)`. The running costs after each hop are
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18`.
+
+The lex-first walk of cost `14` to `(6,6,0)` is the thirteen-site walk
+recorded above. The twelve hop-costs are seed-exit `3` onto `(0,1,0)` and
+then eleven support-preserving or support-increasing cost-`1` steps that
+stay off the axes, ending at `(6,6,0)`. The running costs after each hop
+are `3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14`.
+
+The same axis cost is realized by later walks, for example
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (9,1,0) → (10,1,0) → (11,1,0) → (12,1,0) → (12,0,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3`. That walk is
+also shortest, but `(0,-1,0)` precedes `(1,0,0)`, so it is not lex-first.
+The same face cost is realized by
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (1,2,0) → (1,3,0) → (1,4,0) → (1,5,0) → (1,6,0) → (2,6,0) → (3,6,0) → (4,6,0) → (5,6,0) → (6,6,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1`. That walk is also
+shortest, but `(0,1,0)` precedes `(1,0,0)`, so it is not lex-first.
+
+This names two paths. It is not leftover of the no bit.
+
+## Theorem 2 — Displayed k=6 Reverse Fails
+
+Whether
+
+`t(12,0,0)^2 / 144 > t(6,6,0)^2 / 72`
+
+holds is a displayed comparison, not an adopted law. Substituting the
+Dijkstra arrivals gives `324/144 = 9/4` and `196/72 = 49/18`. Then
+`9/4 = 40.5/18 < 49/18`, so the inequality fails. The integer form is
+`72 · 324 = 23328 < 28224 = 144 · 196`.
+
+The last hops named in Theorem 1 are what make the two arrivals `18` and
+`14`. They are not a restatement of this no bit.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_16(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. The exhibited walks are shortest
+paths under that displayed rule. Uniqueness is not claimed among hop-costs,
+and the walks are not offered as a replacement for unit-cost first arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exhibited lex-first shortest walks to (12,0,0) and (6,6,0) on the finite ball B_16(0) under one named hop-cost, together with a displayed k=6 comparison that fails. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_16(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs with these arrivals or these walks.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_16(0)`.
+- Any reuse of the k=6 no bit as a substitute for exhibiting the walks.
+
+## claim_scope
+
+Lex-first shortest paths to (12,0,0) and (6,6,0) under the named support-drop hop-cost on B_16(0) are named. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15745,
- "node_count": 5546,
+ "edge_count": 15746,
+ "node_count": 5547,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17973,6 +17973,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_why_face_k6_fails_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_why_face_k6_fails_b16_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_why_face_k6_fails_b16_2026_08_15.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py
+runner_sha256: 0897e8444e5087463a1c97c4a0171d7fa5d9b457d727627206b35eb99422e538
+input_fingerprint_sha256: 7f8cbb78a7e61744574cabd234999df65f74b8368b048a45170324179e672ca9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_WHY_FACE_K6_FAILS_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Lex-first shortest paths to (12,0,0) and (6,6,0) under the named support-drop hop-cost on B_16(0) are named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the named-paths statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 6017
+t(12,0,0) 18
+t(6,6,0) 14
+lex_first_1200 (0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (5,-1,0) → (6,-1,0) → (7,-1,0) → (8,-1,0) → (9,-1,0) → (10,-1,0) → (11,-1,0) → (12,-1,0) → (12,0,0)
+hop_costs_1200 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3
+running_1200 [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18]
+last_hop_1200 (12, -1, 0) -> (12, 0, 0) cost 3
+lex_first_660 (0,0,0) → (0,1,0) → (1,1,0) → (1,2,0) → (1,3,0) → (1,4,0) → (1,5,0) → (1,6,0) → (2,6,0) → (3,6,0) → (4,6,0) → (5,6,0) → (6,6,0)
+hop_costs_660 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+running_660 [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+last_hop_660 (5, 6, 0) -> (6, 6, 0) cost 1
+k6_reverse 324/144 > 196/72 is False
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b16 B_16(0) has 6017 sites
+PASS: t-1200 t(12,0,0) on B_16(0) equals 18
+PASS: t-660 t(6,6,0) on B_16(0) equals 14
+PASS: valid-walk-1200 the axis walk is a nearest-neighbor walk in B_16(0) from 0 to (12,0,0)
+PASS: valid-walk-660 the face walk is a nearest-neighbor walk in B_16(0) from 0 to (6,6,0)
+PASS: lex-first-path-1200 the Dijkstra reconstruction is the named lex-first walk to (12,0,0)
+PASS: lex-first-path-660 the Dijkstra reconstruction is the named lex-first walk to (6,6,0)
+PASS: hop-costs-1200 axis hop-costs equal ν on successive sites and sum to 18
+PASS: hop-costs-660 face hop-costs equal ν on successive sites and sum to 14
+PASS: last-hops-make-t last hops are support-drop cost 3 versus face cost 1
+PASS: axis-interior-last-step (12,0,0) has six in-ball neighbors, each of cost 3
+PASS: face-interior-last-step (6,6,0) has six in-ball neighbors; face-plane in-hops cost 1
+PASS: k6-reverse-fails t(12,0,0)^2 / 144 > t(6,6,0)^2 / 72 fails as a displayed bit
+PASS: lex-first-beats-later-shortest later cost-matching walks exist and are strictly lex-later
+PASS: note-records-paths note records both lex-first sites, hop-costs, running costs, and last hops
+PASS: not-leftover-of-the-no-bit the walks are not leftover of the no bit
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py
+++ b/scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Exhibit lex-first shortest walks to (12,0,0) and (6,6,0) under ν.
+
+One origin Dijkstra on B_16(0). No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_WHY_FACE_K6_FAILS_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_WHY_FACE_K6_FAILS_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Lex-first shortest paths to (12,0,0) and (6,6,0) under "
+    "the named support-drop hop-cost on B_16(0) are named. "
+    "Displayed, not adopted."
+)
+TARGET_AXIS = (12, 0, 0)
+TARGET_FACE = (6, 6, 0)
+NEIGH = ((-1, 0, 0), (0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0), (1, 0, 0))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> set[tuple[int, int, int]]:
+    sites: set[tuple[int, int, int]] = set()
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.add((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def hop_costs(path: tuple[tuple[int, int, int], ...]) -> list[int]:
+    return [nu_cost(a, b) for a, b in zip(path, path[1:])]
+
+
+def running_costs(costs: list[int]) -> list[int]:
+    out: list[int] = []
+    acc = 0
+    for c in costs:
+        acc += c
+        out.append(acc)
+    return out
+
+
+def format_path(path: tuple[tuple[int, int, int], ...]) -> str:
+    return " → ".join(f"({v[0]},{v[1]},{v[2]})" for v in path)
+
+
+def format_costs(costs: list[int]) -> str:
+    return ", ".join(str(c) for c in costs)
+
+
+def is_walk(path: tuple[tuple[int, int, int], ...], sites: set[tuple[int, int, int]]) -> bool:
+    if not path:
+        return False
+    for a, b in zip(path, path[1:]):
+        if a not in sites or b not in sites:
+            return False
+        if l1((a[0] - b[0], a[1] - b[1], a[2] - b[2])) != 1:
+            return False
+    return True
+
+
+def in_ball_neighbors(
+    v: tuple[int, int, int],
+    sites: set[tuple[int, int, int]],
+) -> set[tuple[int, int, int]]:
+    vx, vy, vz = v
+    return {
+        (vx + dx, vy + dy, vz + dz)
+        for dx, dy, dz in NEIGH
+        if (vx + dx, vy + dy, vz + dz) in sites
+    }
+
+
+def dijkstra_lex_first(
+    sites: set[tuple[int, int, int]],
+    targets: frozenset[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], tuple[int, tuple[tuple[int, int, int], ...]]]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    heap: list[tuple[int, tuple[tuple[int, int, int], ...]]] = [(0, (origin,))]
+    seen: set[tuple[int, int, int]] = set()
+    found: dict[tuple[int, int, int], tuple[int, tuple[tuple[int, int, int], ...]]] = {}
+    while heap and len(found) < len(targets):
+        dist, path = heapq.heappop(heap)
+        v = path[-1]
+        if v in seen:
+            continue
+        seen.add(v)
+        if v in targets:
+            found[v] = (dist, path)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in sites or w in seen:
+                continue
+            heapq.heappush(heap, (dist + nu_cost(v, w), path + (w,)))
+    missing = targets - found.keys()
+    if missing:
+        raise RuntimeError(f"targets unreachable: {sorted(missing)}")
+    return found
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the named-paths statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(16)
+    arrivals = dijkstra_lex_first(sites, frozenset({TARGET_AXIS, TARGET_FACE}))
+    t1200, path_axis = arrivals[TARGET_AXIS]
+    t660, path_face = arrivals[TARGET_FACE]
+    costs_axis = hop_costs(path_axis)
+    costs_face = hop_costs(path_face)
+    run_axis = running_costs(costs_axis)
+    run_face = running_costs(costs_face)
+    path_axis_text = format_path(path_axis)
+    path_face_text = format_path(path_face)
+    cost_axis_text = format_costs(costs_axis)
+    cost_face_text = format_costs(costs_face)
+    run_axis_text = format_costs(run_axis)
+    run_face_text = format_costs(run_face)
+
+    expected_axis = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (2, -1, 0),
+        (3, -1, 0),
+        (4, -1, 0),
+        (5, -1, 0),
+        (6, -1, 0),
+        (7, -1, 0),
+        (8, -1, 0),
+        (9, -1, 0),
+        (10, -1, 0),
+        (11, -1, 0),
+        (12, -1, 0),
+        (12, 0, 0),
+    )
+    expected_face = (
+        (0, 0, 0),
+        (0, 1, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (1, 3, 0),
+        (1, 4, 0),
+        (1, 5, 0),
+        (1, 6, 0),
+        (2, 6, 0),
+        (3, 6, 0),
+        (4, 6, 0),
+        (5, 6, 0),
+        (6, 6, 0),
+    )
+    expected_axis_costs = [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3]
+    expected_face_costs = [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    later_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (3, 1, 0),
+        (4, 1, 0),
+        (5, 1, 0),
+        (6, 1, 0),
+        (7, 1, 0),
+        (8, 1, 0),
+        (9, 1, 0),
+        (10, 1, 0),
+        (11, 1, 0),
+        (12, 1, 0),
+        (12, 0, 0),
+    )
+    later_face = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (1, 3, 0),
+        (1, 4, 0),
+        (1, 5, 0),
+        (1, 6, 0),
+        (2, 6, 0),
+        (3, 6, 0),
+        (4, 6, 0),
+        (5, 6, 0),
+        (6, 6, 0),
+    )
+    axis_nbrs = in_ball_neighbors(TARGET_AXIS, sites)
+    face_nbrs = in_ball_neighbors(TARGET_FACE, sites)
+    reverse = (t1200 * t1200) * 72 > (t660 * t660) * 144
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(12,0,0) {t1200}")
+    print(f"t(6,6,0) {t660}")
+    print(f"lex_first_1200 {path_axis_text}")
+    print(f"hop_costs_1200 {cost_axis_text}")
+    print(f"running_1200 {run_axis}")
+    print(f"last_hop_1200 {path_axis[-2]} -> {path_axis[-1]} cost {costs_axis[-1]}")
+    print(f"lex_first_660 {path_face_text}")
+    print(f"hop_costs_660 {cost_face_text}")
+    print(f"running_660 {run_face}")
+    print(f"last_hop_660 {path_face[-2]} -> {path_face[-1]} cost {costs_face[-1]}")
+    print(f"k6_reverse {t1200 * t1200}/144 > {t660 * t660}/72 is {reverse}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b16",
+        "B_16(0) has 6017 sites",
+        len(sites) == 6017 and all(l1(v) <= 16 for v in sites),
+    )
+    checks.check(
+        "t-1200",
+        "t(12,0,0) on B_16(0) equals 18",
+        t1200 == 18,
+    )
+    checks.check(
+        "t-660",
+        "t(6,6,0) on B_16(0) equals 14",
+        t660 == 14,
+    )
+    checks.check(
+        "valid-walk-1200",
+        "the axis walk is a nearest-neighbor walk in B_16(0) from 0 to (12,0,0)",
+        path_axis[0] == (0, 0, 0)
+        and path_axis[-1] == TARGET_AXIS
+        and is_walk(path_axis, sites),
+    )
+    checks.check(
+        "valid-walk-660",
+        "the face walk is a nearest-neighbor walk in B_16(0) from 0 to (6,6,0)",
+        path_face[0] == (0, 0, 0)
+        and path_face[-1] == TARGET_FACE
+        and is_walk(path_face, sites),
+    )
+    checks.check(
+        "lex-first-path-1200",
+        "the Dijkstra reconstruction is the named lex-first walk to (12,0,0)",
+        path_axis == expected_axis,
+    )
+    checks.check(
+        "lex-first-path-660",
+        "the Dijkstra reconstruction is the named lex-first walk to (6,6,0)",
+        path_face == expected_face,
+    )
+    checks.check(
+        "hop-costs-1200",
+        "axis hop-costs equal ν on successive sites and sum to 18",
+        costs_axis == expected_axis_costs and sum(costs_axis) == 18 == t1200,
+    )
+    checks.check(
+        "hop-costs-660",
+        "face hop-costs equal ν on successive sites and sum to 14",
+        costs_face == expected_face_costs and sum(costs_face) == 14 == t660,
+    )
+    checks.check(
+        "last-hops-make-t",
+        "last hops are support-drop cost 3 versus face cost 1",
+        path_axis[-2] == (12, -1, 0)
+        and path_axis[-1] == TARGET_AXIS
+        and costs_axis[-1] == 3
+        and run_axis[-2] == 15
+        and run_axis[-1] == 18
+        and path_face[-2] == (5, 6, 0)
+        and path_face[-1] == TARGET_FACE
+        and costs_face[-1] == 1
+        and run_face[-1] == 14
+        and nu_cost((12, -1, 0), (12, 0, 0)) == 3
+        and nu_cost((5, 6, 0), (6, 6, 0)) == 1
+        and l1((12, -1, 0)) == 13
+        and (12, -1, 0) in sites,
+    )
+    checks.check(
+        "axis-interior-last-step",
+        "(12,0,0) has six in-ball neighbors, each of cost 3",
+        axis_nbrs
+        == {(11, 0, 0), (13, 0, 0), (12, -1, 0), (12, 1, 0), (12, 0, -1), (12, 0, 1)}
+        and all(nu_cost(nbr, TARGET_AXIS) == 3 for nbr in axis_nbrs),
+    )
+    checks.check(
+        "face-interior-last-step",
+        "(6,6,0) has six in-ball neighbors; face-plane in-hops cost 1",
+        face_nbrs
+        == {(5, 6, 0), (7, 6, 0), (6, 5, 0), (6, 7, 0), (6, 6, -1), (6, 6, 1)}
+        and nu_cost((5, 6, 0), TARGET_FACE) == 1
+        and nu_cost((7, 6, 0), TARGET_FACE) == 1
+        and nu_cost((6, 5, 0), TARGET_FACE) == 1
+        and nu_cost((6, 7, 0), TARGET_FACE) == 1
+        and nu_cost((6, 6, -1), TARGET_FACE) == 3
+        and nu_cost((6, 6, 1), TARGET_FACE) == 3,
+    )
+    checks.check(
+        "k6-reverse-fails",
+        "t(12,0,0)^2 / 144 > t(6,6,0)^2 / 72 fails as a displayed bit",
+        (not reverse)
+        and t1200 * t1200 == 324
+        and t660 * t660 == 196
+        and 72 * 324 == 23328
+        and 144 * 196 == 28224
+        and 23328 < 28224,
+    )
+    checks.check(
+        "lex-first-beats-later-shortest",
+        "later cost-matching walks exist and are strictly lex-later",
+        is_walk(later_axis, sites)
+        and sum(hop_costs(later_axis)) == 18
+        and path_axis < later_axis
+        and is_walk(later_face, sites)
+        and sum(hop_costs(later_face)) == 14
+        and path_face < later_face,
+    )
+    checks.check(
+        "note-records-paths",
+        "note records both lex-first sites, hop-costs, running costs, and last hops",
+        path_axis_text in note
+        and path_face_text in note
+        and cost_axis_text in note
+        and cost_face_text in note
+        and run_axis_text in note
+        and run_face_text in note
+        and "(12,-1,0) → (12,0,0)" in note
+        and "(5,6,0) → (6,6,0)" in note
+        and "t(12,0,0) = 18" in note
+        and "t(6,6,0) = 14" in note
+        and "23328" in note
+        and "28224" in note,
+    )
+    checks.check(
+        "not-leftover-of-the-no-bit",
+        "the walks are not leftover of the no bit",
+        "not leftover of the no bit" in note and (not reverse),
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_16(0) under nu, t(12,0,0)=18 and t(6,6,0)=14. The B12 reverse at k=6 fails once the axis is cheapened. Displayed, not adopted.

## Runner

`scripts/support_drop_why_face_k6_fails_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.