### PR TITLE
feat(bodyk16): on B16, nu body reverse is yes yes no no no

### DIFF
--- a/docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,273 @@
+---
+claim_id: support_drop_body_reverse_vs_k_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Body-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_16(0) is reported for k=1..5. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py
+---
+
+# Body-Diagonal Reverse Versus Integer Scale k Under The Support-Drop Hop-Cost On B_16(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one directed Dijkstra on the nearest-neighbor graph of the
+ball $B_{16}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 16\}$ for the named support-drop
+hop-cost $\nu$. Body-diagonal reverse versus integer scale $k$ is reported
+for $k=1,\ldots,5$. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py`](../scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost $\nu$ already scored on $B_{12}(0)$ for
+$k=1,\ldots,4$ (bits yes/yes/no/no) is scored here independently on
+$B_{16}(0)$ against integer scale $k$ for every pair $((2k,0,0),(k,k,k))$
+with $k=1,\ldots,5$. The five bits are not leftover of the $B_{12}(0)$
+body-versus-$k$ table: the site $(5,5,5)$ has $|v|_1=15$ and therefore lies
+outside $B_{12}(0)$. The $k=5$ times are independent Dijkstra outputs on
+$B_{16}(0)$. A larger ball cheapens some axis arrivals — the same one
+Dijkstra returns $t(12,0,0)=18$, not the $B_{12}(0)$ wall value $20$ — but
+that cheapening does not change the $k=1,\ldots,4$ body-reverse bits.
+
+Let $\sigma_v=\{i\in\{1,2,3\}:v_i\neq 0\}$ and write $|\sigma_v|$ for its
+cardinality. On every nearest-neighbor hop $v\to w$ that remains inside
+$B_{16}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 16\}$, the named support-drop hop-cost is
+
+$$
+\nu(v\to w)=
+\begin{cases}
+3 & \text{if }|\sigma_v|=0\text{ or }(|\sigma_v|=|\sigma_w|=1)\text{ or }|\sigma_w|<|\sigma_v|,\\
+1 & \text{otherwise.}
+\end{cases}
+$$
+
+A single Dijkstra computation from the origin on this directed weighted graph
+returns the arrival times
+
+$$
+t(2,0,0)=6,\qquad t(4,0,0)=10,\qquad t(6,0,0)=12,\qquad t(8,0,0)=14,\qquad t(10,0,0)=16,
+$$
+$$
+t(1,1,1)=5,\qquad t(2,2,2)=8,\qquad t(3,3,3)=11,\qquad t(4,4,4)=14,\qquad t(5,5,5)=17.
+$$
+
+For each $k=1,\ldots,5$, reverse means the displayed comparison
+
+$$
+12\,t(2k,0,0)^2>16\,t(k,k,k)^2
+$$
+
+holds, equivalently $t(2k,0,0)^2/(4k^2)>t(k,k,k)^2/(3k^2)$. The bit is
+displayed, not adopted.
+
+| $k$ | pair | axis $t^2/|v|_2^2$ | body $t^2/|v|_2^2$ | reverse |
+|---|---|---|---|---|
+| $1$ | $((2,0,0),(1,1,1))$ | $36/4=9$ | $25/3$ | yes |
+| $2$ | $((4,0,0),(2,2,2))$ | $100/16=25/4$ | $64/12=16/3$ | yes |
+| $3$ | $((6,0,0),(3,3,3))$ | $144/36=4$ | $121/27$ | no |
+| $4$ | $((8,0,0),(4,4,4))$ | $196/64=49/16$ | $196/48=49/12$ | no |
+| $5$ | $((10,0,0),(5,5,5))$ | $256/100=64/25$ | $289/75$ | no |
+
+Exact integer comparisons:
+
+- $12\,t(2,0,0)^2=432>400=16\,t(1,1,1)^2$
+- $12\,t(4,0,0)^2=1200>1024=16\,t(2,2,2)^2$
+- $12\,t(6,0,0)^2=1728<1936=16\,t(3,3,3)^2$
+- $12\,t(8,0,0)^2=2352<3136=16\,t(4,4,4)^2$
+- $12\,t(10,0,0)^2=3072<4624=16\,t(5,5,5)^2$
+
+The reverse bit is therefore not the same for every $k=1,\ldots,5$. Reverse
+holds at $k=1,2$ and fails at $k=3,4,5$. The first four bits match the
+$B_{12}(0)$ body-versus-$k$ table. The $k=5$ fail is new: $(5,5,5)$ is not
+in $B_{12}(0)$. These five bits are not leftover of the $B_{12}(0)$ table.
+The score is displayed, not adopted. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom. It does not choose a Hamiltonian or
+transfer operator, supply transition-probability or weight values, select a
+scalar or nonzero kinetic branch, assert a Dirac-square carrier, define a time
+metric, or provide a record-production process or physical persistence
+dynamics.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The named hop-cost $\nu$ is a displayed scoring rule on the nearest-neighbor
+graph of $B_{16}(0)$. It is not written into Admissibility. It is not attached to L1.
+It supplies no time metric, no Record formation rule, and no physical hop law.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Arrival times and five body-versus-axis reverse bits versus integer scale k on B_16(0) are finite exact Dijkstra values for a named hop-cost; the hop-cost is displayed, not adopted."
+trace_class: upstream_support
+target_claim_id: support_drop_body_reverse_vs_k_b16_bounded_theorem_note_2026-08-15
+target_blocker_text: "the named hop-cost is displayed, not adopted, and is not Admissibility content"
+source_of_blocker_text: this note
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the body-versus-axis reverse bits versus k as a displayed B_16(0) score; do not write nu into Admissibility."
+conditional_surface_status: "exact for the named support-drop hop-cost on B_16(0); not adopted as a law"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write $0=(0,0,0)$ and $B_{16}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 16\}$. This set has
+$6017$ sites, of which $6016$ are nonzero. The directed graph is the
+nearest-neighbor graph of $\mathbb{Z}^3$ induced on $B_{16}(0)$: from $v$ there
+is an edge to $w=v\pm e_i$ exactly when $w\in B_{16}(0)$.
+
+The support $\sigma_v$ and the hop-cost $\nu$ are as in Result Up Front. In
+words: seed exit from the origin costs $3$; every hop that stays on a
+coordinate axis costs $3$; every hop that strictly drops the number of
+nonzero coordinates costs $3$; every other in-ball nearest-neighbor hop
+costs $1$.
+
+Arrival time $t(v)$ is the least $\nu$-length of a directed path from $0$ to
+$v$ in this graph. One Dijkstra computation from the origin produces every
+$t(v)$ used below.
+
+The Euclidean squared length is $|v|_2^2=v_1^2+v_2^2+v_3^2$. The displayed
+comparison density is $t(v)^2/|v|_2^2$ at $v\neq 0$. For each integer
+$k=1,\ldots,5$ the ordered pair is $((2k,0,0),(k,k,k))$. The second site is
+the more-diagonal site (strictly more nonzero coordinates). The pair is
+reverse when
+
+$$
+12\,t(2k,0,0)^2>16\,t(k,k,k)^2,
+$$
+
+which is the same comparison as $t(2k,0,0)^2/(4k^2)>t(k,k,k)^2/(3k^2)$.
+
+The $B_{12}(0)$ body-versus-$k$ table covers only $k=1,\ldots,4$. It does not
+contain $(5,5,5)$. The $k=1,\ldots,5$ table is therefore not leftover of the
+$B_{12}(0)$ body-versus-$k$ bits.
+
+## Theorem 1 — Named Arrival Times At Each Scale
+
+On $B_{16}(0)$ under $\nu$, for each $k=1,\ldots,5$,
+
+$$
+\begin{align*}
+t(2,0,0)&=6,& t(1,1,1)&=5,\\
+t(4,0,0)&=10,& t(2,2,2)&=8,\\
+t(6,0,0)&=12,& t(3,3,3)&=11,\\
+t(8,0,0)&=14,& t(4,4,4)&=14,\\
+t(10,0,0)&=16,& t(5,5,5)&=17.
+\end{align*}
+$$
+
+These ten values are Dijkstra outputs, not fitted scalars.
+
+Witnessing paths of those $\nu$-costs exist. The walk
+
+$0\to(1,0,0)\to(2,0,0)$
+
+has hop-costs $3,3$ and sum $6$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)$
+
+has hop-costs $3,1,1$ and sum $5$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(4,0,0)$
+
+has hop-costs $3,1,1,1,1,3$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)\to(2,1,1)\to(2,2,1)\to(2,2,2)$
+
+has hop-costs $3,1,1,1,1,1$ and sum $8$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(6,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,3$ and sum $12$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)\to(2,1,1)\to(2,2,1)\to(2,2,2)\to(3,2,2)\to(3,3,2)\to(3,3,3)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1$ and sum $11$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(8,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,3$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)\to(2,1,1)\to(2,2,1)\to(2,2,2)\to(3,2,2)\to(3,3,2)\to(3,3,3)\to(4,3,3)\to(4,4,3)\to(4,4,4)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(10,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,3$ and sum $16$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,1,1)\to(2,1,1)\to(2,2,1)\to(2,2,2)\to(3,2,2)\to(3,3,2)\to(3,3,3)\to(4,3,3)\to(4,4,3)\to(4,4,4)\to(5,4,4)\to(5,5,4)\to(5,5,5)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,1,1,1$ and sum $17$.
+
+The site $(5,5,5)$ is not in $B_{12}(0)$.
+
+## Theorem 2 — Reverse Bit Versus Integer Scale k
+
+For each $k=1,\ldots,5$ the displayed comparison is whether
+$12\,t(2k,0,0)^2>16\,t(k,k,k)^2$. The five bits are:
+
+- $k=1$: $t(1,1,1)^2/|(1,1,1)|_2^2=25/3<9=t(2,0,0)^2/|(2,0,0)|_2^2$ (yes)
+- $k=2$: $t(2,2,2)^2/|(2,2,2)|_2^2=16/3<25/4=t(4,0,0)^2/|(4,0,0)|_2^2$ (yes)
+- $k=3$: $t(3,3,3)^2/|(3,3,3)|_2^2=121/27\not<4=t(6,0,0)^2/|(6,0,0)|_2^2$ (no)
+- $k=4$: $t(4,4,4)^2/|(4,4,4)|_2^2=49/12\not<49/16=t(8,0,0)^2/|(8,0,0)|_2^2$ (no)
+- $k=5$: $t(5,5,5)^2/|(5,5,5)|_2^2=289/75\not<64/25=t(10,0,0)^2/|(10,0,0)|_2^2$ (no)
+
+Reverse holds at $k=1,2$ and fails at $k=3,4,5$. The $B_{12}(0)$ table does
+not determine the $k=5$ fail on this ball.
+
+These reverse bits are displayed, not adopted.
+
+## Theorem 3 — Not Admissibility, Not Attached To L1
+
+Do not write $\nu$ into Admissibility. Admissibility names one fixed
+nearest-neighbor rule for the local possibility distribution. It does not
+supply hop weights, a time metric, or an arrival-time comparison.
+
+Do not attach L1. The named hop-cost is not attached to L1 and is not
+offered as a replacement for unit-cost first arrival. No uniqueness claim is
+made among hop-costs.
+
+## What This Note Does Not Claim
+
+- $\nu$ is not an axiom, not an approved primitive, and not a derived law.
+- The reverse bits are not promoted to a continuum speed, a physical clock,
+  or a Record readout.
+- Body-diagonal reverse versus $k$ is not claimed outside $B_{16}(0)$ and is
+  not claimed for any hop-cost other than the named $\nu$.
+- L1 is not adopted and is not attached to Admissibility.
+- The $B_{12}(0)$ body-versus-$k$ table is not reused as a substitute for
+  the five-scale Dijkstra table on $B_{16}(0)$.
+
+## claim_scope
+
+Body-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_16(0) is reported for k=1..5. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15745,
- "node_count": 5546,
+ "edge_count": 15746,
+ "node_count": 5547,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17973,6 +17973,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_body_reverse_vs_k_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_body_reverse_vs_k_b16_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_body_reverse_vs_k_b16_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py
+runner_sha256: b42281d29ef4189f5a3186c172a8dd79fce1e3c98db835d3da06fab606333e40
+input_fingerprint_sha256: 0980346b82eecf206159276c314a5dcf8005301d637b6d22dad606abe41ce812
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count_budget: 1
+claim_scope: Body-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_16(0) is reported for k=1..5. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and the axiom memo
+PASS: audit-input-literals AUDIT_INPUT_PATHS is a static two-string literal in this runner
+PASS: ball-cardinality B_16(0) has 6017 sites and 6016 nonzero sites
+PASS: one-dijkstra exactly one Dijkstra computation is used
+PASS: finite-times every target is reached by a finite path
+arrival_times:
+  t(2, 0, 0)=6  t^2/|v|_2^2=36/4
+  t(1, 1, 1)=5  t^2/|v|_2^2=25/3
+  t(4, 0, 0)=10  t^2/|v|_2^2=100/16
+  t(2, 2, 2)=8  t^2/|v|_2^2=64/12
+  t(6, 0, 0)=12  t^2/|v|_2^2=144/36
+  t(3, 3, 3)=11  t^2/|v|_2^2=121/27
+  t(8, 0, 0)=14  t^2/|v|_2^2=196/64
+  t(4, 4, 4)=14  t^2/|v|_2^2=196/48
+  t(10, 0, 0)=16  t^2/|v|_2^2=256/100
+  t(5, 5, 5)=17  t^2/|v|_2^2=289/75
+PASS: time-200 computed t(2,0,0)=6 is written in the note
+PASS: time-400 computed t(4,0,0)=10 is written in the note
+PASS: time-600 computed t(6,0,0)=12 is written in the note
+PASS: time-800 computed t(8,0,0)=14 is written in the note
+PASS: time-1000 computed t(10,0,0)=16 is written in the note
+PASS: time-111 computed t(1,1,1)=5 is written in the note
+PASS: time-222 computed t(2,2,2)=8 is written in the note
+PASS: time-333 computed t(3,3,3)=11 is written in the note
+PASS: time-444 computed t(4,4,4)=14 is written in the note
+PASS: time-555 computed t(5,5,5)=17 is written in the note
+reverse_bits:
+  k=1 (2, 0, 0) vs (1, 1, 1): reverse=True (12*36=432 vs 16*25=400)
+PASS: reverse-k1 k=1 reverse bit is True and the comparison is written
+  k=2 (4, 0, 0) vs (2, 2, 2): reverse=True (12*100=1200 vs 16*64=1024)
+PASS: reverse-k2 k=2 reverse bit is True and the comparison is written
+  k=3 (6, 0, 0) vs (3, 3, 3): reverse=False (12*144=1728 vs 16*121=1936)
+PASS: reverse-k3 k=3 reverse bit is False and the comparison is written
+  k=4 (8, 0, 0) vs (4, 4, 4): reverse=False (12*196=2352 vs 16*196=3136)
+PASS: reverse-k4 k=4 reverse bit is False and the comparison is written
+  k=5 (10, 0, 0) vs (5, 5, 5): reverse=False (12*256=3072 vs 16*289=4624)
+PASS: reverse-k5 k=5 reverse bit is False and the comparison is written
+PASS: bits-yes-yes-no-no-no reverse holds at k=1,2 and fails at k=3,4,5
+PASS: not-b12-leftover the k=5 pair is not leftover of the B_12(0) bodyk table
+PASS: source-lattice Lattice nearest-neighbor wording is pinned in the axiom memo and the note
+PASS: source-admissibility Admissibility distribution wording and non-dynamics clause are pinned
+PASS: nu-not-admissibility the note refuses to write nu into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: displayed-not-adopted claim_scope and displayed-not-adopted wording are present
+PASS: forbidden-phrases forbidden phrases are absent from the note and from runner prose
+PASS: pair-reverse-bits the five declared scales have the displayed reverse bits
+PASS: axiom-untouched the axiom memo is an input only
+TOTAL: PASS=30 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py
+++ b/scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Body-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_16(0)."""
+
+from __future__ import annotations
+
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+RADIUS = 16
+SCALES = (1, 2, 3, 4, 5)
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    "Body-diagonal reverse versus integer scale k under the "
+    "named support-drop hop-cost on B_16(0) is reported for k=1..5. "
+    "Displayed, not adopted."
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def l2sq(v: tuple[int, int, int]) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return sum(1 for x in v if x != 0)
+
+
+def nu(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sv = support_size(v)
+    sw = support_size(w)
+    if sv == 0 or (sv == 1 and sw == 1) or sw < sv:
+        return 3
+    return 1
+
+
+def ball_sites(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_from_origin(
+    sites: set[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    origin = (0, 0, 0)
+    inf = 10**9
+    dist = {site: inf for site in sites}
+    dist[origin] = 0
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, origin)]
+    while heap:
+        cost, v = heapq.heappop(heap)
+        if cost != dist[v]:
+            continue
+        for step in NEIGHBOR_STEPS:
+            w = (v[0] + step[0], v[1] + step[1], v[2] + step[2])
+            if w not in sites:
+                continue
+            nxt = cost + nu(v, w)
+            if nxt < dist[w]:
+                dist[w] = nxt
+                heapq.heappush(heap, (nxt, w))
+    return dist
+
+
+def flatten(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_site(k: int) -> tuple[int, int, int]:
+    return (2 * k, 0, 0)
+
+
+def body_site(k: int) -> tuple[int, int, int]:
+    return (k, k, k)
+
+
+def is_reverse(
+    times: dict[tuple[int, int, int], int],
+    k: int,
+) -> bool:
+    axis = axis_site(k)
+    body = body_site(k)
+    ta = times[axis]
+    tb = times[body]
+    return 12 * ta * ta > 16 * tb * tb
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count_budget: 1")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "audit-input-literals",
+        "AUDIT_INPUT_PATHS is a static two-string literal in this runner",
+        'AUDIT_INPUT_PATHS = (\n    "docs/SUPPORT_DROP_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in source,
+    )
+
+    sites_list = ball_sites(RADIUS)
+    sites = set(sites_list)
+    checks.check(
+        "ball-cardinality",
+        "B_16(0) has 6017 sites and 6016 nonzero sites",
+        len(sites_list) == 6017 and (0, 0, 0) in sites and len(sites) == 6017,
+    )
+
+    targets = tuple(axis_site(k) for k in SCALES) + tuple(body_site(k) for k in SCALES)
+    dijkstra_runs = 0
+    times = dijkstra_from_origin(sites)
+    dijkstra_runs += 1
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra computation is used",
+        dijkstra_runs == 1,
+    )
+    checks.check(
+        "finite-times",
+        "every target is reached by a finite path",
+        all(times[v] < 10**9 for v in targets),
+    )
+
+    expected_times = {
+        (2, 0, 0): 6,
+        (4, 0, 0): 10,
+        (6, 0, 0): 12,
+        (8, 0, 0): 14,
+        (10, 0, 0): 16,
+        (1, 1, 1): 5,
+        (2, 2, 2): 8,
+        (3, 3, 3): 11,
+        (4, 4, 4): 14,
+        (5, 5, 5): 17,
+    }
+    print("arrival_times:")
+    for k in SCALES:
+        for v in (axis_site(k), body_site(k)):
+            print(f"  t{v}={times[v]}  t^2/|v|_2^2={times[v] ** 2}/{l2sq(v)}")
+
+    for v, expected in expected_times.items():
+        token = f"t({v[0]},{v[1]},{v[2]})={expected}"
+        checks.check(
+            f"time-{v[0]}{v[1]}{v[2]}",
+            f"computed {token} is written in the note",
+            token in note and times[v] == expected,
+            residual=times[v],
+        )
+
+    expected_bits = {
+        1: True,
+        2: True,
+        3: False,
+        4: False,
+        5: False,
+    }
+    comparison_tokens = {
+        1: r"12\,t(2,0,0)^2=432>400=16\,t(1,1,1)^2",
+        2: r"12\,t(4,0,0)^2=1200>1024=16\,t(2,2,2)^2",
+        3: r"12\,t(6,0,0)^2=1728<1936=16\,t(3,3,3)^2",
+        4: r"12\,t(8,0,0)^2=2352<3136=16\,t(4,4,4)^2",
+        5: r"12\,t(10,0,0)^2=3072<4624=16\,t(5,5,5)^2",
+    }
+    print("reverse_bits:")
+    bits: list[bool] = []
+    for k in SCALES:
+        axis = axis_site(k)
+        body = body_site(k)
+        bit = is_reverse(times, k)
+        bits.append(bit)
+        ta, tb = times[axis], times[body]
+        print(
+            f"  k={k} {axis} vs {body}: reverse={bit} "
+            f"(12*{ta * ta}={12 * ta * ta} vs 16*{tb * tb}={16 * tb * tb})"
+        )
+        dens_ok = 12 * ta * ta > 16 * tb * tb
+        checks.check(
+            f"reverse-k{k}",
+            f"k={k} reverse bit is {expected_bits[k]} and the comparison is written",
+            bit is expected_bits[k]
+            and dens_ok is expected_bits[k]
+            and comparison_tokens[k] in note,
+        )
+
+    checks.check(
+        "bits-yes-yes-no-no-no",
+        "reverse holds at k=1,2 and fails at k=3,4,5",
+        bits == [True, True, False, False, False]
+        and "holds at $k=1,2$" in note
+        and "fails at $k=3,4,5$" in note,
+    )
+    checks.check(
+        "not-b12-leftover",
+        "the k=5 pair is not leftover of the B_12(0) bodyk table",
+        "not leftover of the $B_{12}(0)$" in note
+        and "independent Dijkstra" in note
+        and times[(5, 5, 5)] == 17
+        and l1((5, 5, 5)) == 15
+        and l1((5, 5, 5)) > 12
+        and times[(12, 0, 0)] == 18
+        and times[(12, 0, 0)] != 20,
+    )
+
+    flat_note = flatten(note)
+    flat_axiom = flatten(axiom)
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    admissibility_quote = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    not_dynamics = "Admissibility is not a dynamics axiom."
+    checks.check(
+        "source-lattice",
+        "Lattice nearest-neighbor wording is pinned in the axiom memo and the note",
+        lattice_quote in flat_axiom and lattice_quote in flat_note,
+    )
+    checks.check(
+        "source-admissibility",
+        "Admissibility distribution wording and non-dynamics clause are pinned",
+        admissibility_quote in flat_axiom
+        and admissibility_quote in flat_note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+    checks.check(
+        "nu-not-admissibility",
+        "the note refuses to write nu into Admissibility",
+        "It is not written into Admissibility." in note
+        and "Do not write $\\nu$ into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "not attached to L1" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "claim_scope and displayed-not-adopted wording are present",
+        CLAIM_SCOPE in note and "displayed, not adopted" in note,
+    )
+    forbidden_hits = [
+        phrase
+        for phrase in FORBIDDEN
+        if phrase in note or phrase in source.split("FORBIDDEN =", 1)[0]
+    ]
+    checks.check(
+        "forbidden-phrases",
+        "forbidden phrases are absent from the note and from runner prose",
+        not forbidden_hits,
+        residual=forbidden_hits,
+    )
+    checks.check(
+        "pair-reverse-bits",
+        "the five declared scales have the displayed reverse bits",
+        tuple(bits) == (True, True, False, False, False),
+        residual=bits,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_16(0), doubled pairing reverses at k=1,2 and fails at k=3,4,5. k=1..4 bits match B12; k=5 is new. Displayed, not adopted.

## Runner

`scripts/support_drop_body_reverse_vs_k_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.