### PR TITLE
feat(011fk16): (0,1,1) face reverse on B16 holds k=1..4 and fails k=5..8

### DIFF
--- a/docs/CLAUSE_011_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,188 @@
+---
+claim_id: clause_011_face_reverse_vs_k_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_16(0) is reported for k=1..8. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py
+---
+
+# Named (0,1,1) Face Reverse Versus Scale k On B_16(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact arrival times under one named hop-cost on the finite
+16-hop neighborhood of the origin in the cubic nearest-neighbor graph.
+Face-diagonal reverse bits for integer scale `k=1..8` are displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py`](../scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Let `B_16(0)` be the set of sites of `Z^3` whose nearest-neighbor graph
+distance from the origin is at most 16. That set has 6017 sites and is
+used only as a finite domain bound. It is not a hop-cost.
+
+Hops are the six nearest-neighbor steps that remain inside `B_16(0)`.
+Write `σ_v` for the support of a site (the set of nonzero coordinates).
+The named clause-toggle `(0,1,1)` assigns
+
+```text
+cost(v→w) = 3  if |σ_v|=|σ_w|=1 or |σ_w|<|σ_v|,
+          = 1  otherwise.
+```
+
+Seed-exit therefore costs 1. Axis 1-skeleton hops and support-drop hops
+cost 3. Every other admitted hop costs 1. The rule is not written into
+Admissibility: do not write (0,1,1) into Admissibility. Do not attach L1.
+
+One Dijkstra from the origin yields
+
+```text
+t(2,0,0)=4
+t(4,0,0)=8
+t(6,0,0)=10
+t(8,0,0)=12
+t(10,0,0)=14
+t(12,0,0)=16
+t(14,0,0)=18
+t(16,0,0)=22
+t(1,1,0)=2
+t(2,2,0)=4
+t(3,3,0)=6
+t(4,4,0)=8
+t(5,5,0)=10
+t(6,6,0)=12
+t(7,7,0)=14
+t(8,8,0)=16
+```
+
+For each integer scale `k=1..8` the displayed reverse test is
+
+```text
+t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2).
+```
+
+That comparison is equivalent to the integer test
+`t(2k,0,0)^2 > 2 t(k,k,0)^2`. The eight bits are
+
+```text
+k=1  16/4 = 4 > 2 = 4/2                 yes   16 > 8
+k=2  64/16 = 4 > 2 = 16/8               yes   64 > 32
+k=3  100/36 > 2 = 36/18                 yes   100 > 72
+k=4  144/64 = 9/4 > 2 = 64/32           yes   144 > 128
+k=5  196/100 > 2 = 100/50               no    196 > 200 is false
+k=6  256/144 > 2 = 144/72               no    256 > 288 is false
+k=7  324/196 > 2 = 196/98               no    324 > 392 is false
+k=8  484/256 > 2 = 256/128              no    484 > 512 is false
+```
+
+Reverse holds at `k=1,2,3,4` and fails at `k=5,6,7,8`. The cheaper
+rival still keeps `k=4`. Failure is not isolated at `k=5`. Uniqueness
+is not required. Displayed, not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under
+lattice translations and proper cubic rotations.
+
+The axiom set supplies the cubic nearest-neighbor graph. It does not
+supply a hop-cost, a face-diagonal reverse test, an integer scale `k`,
+or a preferred clause-toggle. This note therefore treats `(0,1,1)` as a
+separately named finite scoring rule. The note does not write `(0,1,1)`
+into Admissibility and does not enlarge the axiom set.
+
+Record is not used. No readout, formation site, or scalar collection
+functional enters the arrival times.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Sixteen arrival times and eight displayed reverse bits are exact outputs of one Dijkstra on B_16(0); the hop-cost is a disclosed scoring rule, not an axiom."
+trace_class: compute
+artifact_role: theorem
+conditional_surface_status: "exact on B_16(0) under the named (0,1,1) hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+`B_16(0)` is the closed 16-hop neighborhood of the origin. Every hop
+used below is a nearest-neighbor step whose endpoints both lie in that
+set. One Dijkstra computes the named arrival time `t(v)` from the
+origin to each site.
+
+The displayed pairs are `(2k,0,0)` versus `(k,k,0)` for each
+`k=1..8`. Each comparison is displayed only. It is not a derived
+continuum law and is not attached as an L1 hop-cost.
+
+## Theorem 1
+
+On `B_16(0)` under the named `(0,1,1)` hop-cost, the axis arrivals are
+
+`t(2,0,0)=4`, `t(4,0,0)=8`, `t(6,0,0)=10`, `t(8,0,0)=12`,
+`t(10,0,0)=14`, `t(12,0,0)=16`, `t(14,0,0)=18`, `t(16,0,0)=22`,
+
+and the face arrivals are
+
+`t(1,1,0)=2`, `t(2,2,0)=4`, `t(3,3,0)=6`, `t(4,4,0)=8`,
+`t(5,5,0)=10`, `t(6,6,0)=12`, `t(7,7,0)=14`, `t(8,8,0)=16`.
+
+Each value is the Dijkstra arrival time. Face arrivals equal the
+nearest-neighbor hop counts, because a monotone support-nondecreasing
+path from the origin to `(k,k,0)` uses only cost-1 hops. Axis arrivals
+are strictly larger than the corresponding hop counts, because the last
+step onto a 1-support site costs 3 unless a support-raising detour is
+cheaper.
+
+## Theorem 2
+
+For each `k=1..8` the displayed comparison is whether
+
+`t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2)`.
+
+The eight integer forms and bits are `16 > 8` yes, `64 > 32` yes,
+`100 > 72` yes, `144 > 128` yes, `196 > 200` no, `256 > 288` no,
+`324 > 392` no, and `484 > 512` no. Reverse therefore holds on
+`k=1..4` and fails on `k=5..8`. Displayed, not adopted.
+
+## Theorem 3
+
+The note does not write `(0,1,1)` into Admissibility. Do not attach L1.
+Uniqueness is not required. The current axiom memo is not edited.
+
+## What This Does Not Claim
+
+- It does not adopt the `(0,1,1)` hop-cost as framework content.
+- It does not claim that reverse survives every listed scale.
+- It does not claim that failure is isolated at `k=5`.
+- It does not claim that the named rule is the only reverser.
+- It does not identify `t` with nearest-neighbor hop count on the axis.
+- It does not supply a physical clock, a continuum metric, or a Record
+  readout of the arrival times.
+
+## Reproducibility
+
+```text
+python3 scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py
+```
+
+The runner prints the sixteen times, the eight displayed comparisons, and
+`TOTAL: PASS=<n> FAIL=<n>`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15745,
- "node_count": 5546,
+ "edge_count": 15746,
+ "node_count": 5547,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2333,6 +2333,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_face_reverse_vs_k_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_face_reverse_vs_k_b16_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_face_reverse_vs_k_b16_2026_08_15.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py
+runner_sha256: 582f9bb831cbc1b5a6f4f6abf03568ff53f77f0eb8f6b106f4a0385191f78f8c
+input_fingerprint_sha256: 1ba2273084ca63e9c41aae6cd76637ea1cab78b7caa927b04ab1c4872aaa1b03
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none; hop-costs are the named (0,1,1) rule on the finite 16-hop neighborhood B_16(0)
+package_local_integrity_reads: the note and current minimal axiom are read; no cache or governance surface is written
+negative_scope: the named rule is displayed, not adopted; it is not written into Admissibility and is not attached as an L1 hop-cost
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static literal pair and both files exist
+PASS: ball-b16-only B_16(0) is the 16-hop neighborhood of the origin and contains every named target
+PASS: clause-011-local seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1
+k=1 t(2,0,0)=4 t(1,1,0)=2 t_axis^2/(4k^2)=4.0 t_face^2/(2k^2)=2.0 16>8 reverse=True
+k=2 t(4,0,0)=8 t(2,2,0)=4 t_axis^2/(4k^2)=4.0 t_face^2/(2k^2)=2.0 64>32 reverse=True
+k=3 t(6,0,0)=10 t(3,3,0)=6 t_axis^2/(4k^2)=2.7777777777777777 t_face^2/(2k^2)=2.0 100>72 reverse=True
+k=4 t(8,0,0)=12 t(4,4,0)=8 t_axis^2/(4k^2)=2.25 t_face^2/(2k^2)=2.0 144>128 reverse=True
+k=5 t(10,0,0)=14 t(5,5,0)=10 t_axis^2/(4k^2)=1.96 t_face^2/(2k^2)=2.0 196>200 reverse=False
+k=6 t(12,0,0)=16 t(6,6,0)=12 t_axis^2/(4k^2)=1.7777777777777777 t_face^2/(2k^2)=2.0 256>288 reverse=False
+k=7 t(14,0,0)=18 t(7,7,0)=14 t_axis^2/(4k^2)=1.653061224489796 t_face^2/(2k^2)=2.0 324>392 reverse=False
+k=8 t(16,0,0)=22 t(8,8,0)=16 t_axis^2/(4k^2)=1.890625 t_face^2/(2k^2)=2.0 484>512 reverse=False
+dijkstra_count=1
+dijkstra_calls 1
+PASS: theorem-1-times the named arrivals are 4,8,10,12,14,16,18,22 on axis and 2,4,6,8,10,12,14,16 on face
+PASS: theorem-2-bits reverse holds at k=1..4 and fails at k=5..8
+PASS: keep-k4-not-only-k5 k=4 still reverses; failure is not isolated at k=5
+PASS: one-dijkstra exactly one origin Dijkstra assigned a finite time to every ball site
+PASS: note-reports-times the note reports every computed axis and face time
+PASS: note-reports-comparisons the note reports the eight displayed reverse comparisons
+PASS: displayed-not-adopted the note displays the (0,1,1) scores and does not adopt them
+PASS: admissibility-unedited the current axiom memo still names Admissibility and does not contain the hop-cost rule
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: claim-scope the note states the required claim_scope
+PASS: forbidden-tokens the note avoids the forbidden tokens
+PASS: uniqueness-not-required the note does not claim uniqueness of the named rule
+PASS: not-attach-l1 the displayed rule is not attached to L1
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py
+++ b/scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Named (0,1,1) hop-cost face reverse versus k on B_16(0).
+
+One Dijkstra from the origin. For each k=1..8 the arrivals t(2k,0,0)
+and t(k,k,0) and the displayed reverse bit
+t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2) are reported. Displayed,
+not adopted. No axiom edit, no cache write, no L1 hop-cost attachment.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_NAME = "CLAUSE_011_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+NOTE_PATH = ROOT / "docs" / NOTE_NAME
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BALL_RADIUS = 16
+SCALES = tuple(range(1, 9))
+AXIS_TARGETS = tuple((2 * k, 0, 0) for k in SCALES)
+FACE_TARGETS = tuple((k, k, 0) for k in SCALES)
+TARGETS = AXIS_TARGETS + FACE_TARGETS
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+DIJKSTRA_CALLS = 0
+
+EXPECTED_AXIS = (4, 8, 10, 12, 14, 16, 18, 22)
+EXPECTED_FACE = (2, 4, 6, 8, 10, 12, 14, 16)
+EXPECTED_REVERSE = (True, True, True, True, False, False, False, False)
+
+
+def nn_radius(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def in_ball(site: tuple[int, int, int]) -> bool:
+    return nn_radius(site) <= BALL_RADIUS
+
+
+def support_size(site: tuple[int, int, int]) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(src: tuple[int, int, int], dst: tuple[int, int, int]) -> int:
+    """Rule (0,1,1): cost 3 iff both weights 1 or support drop, else 1."""
+    src_support = support_size(src)
+    dst_support = support_size(dst)
+    both_weights_one = src_support == 1 and dst_support == 1
+    support_drop = dst_support < src_support
+    if both_weights_one or support_drop:
+        return 3
+    return 1
+
+
+def ball_sites() -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-BALL_RADIUS, BALL_RADIUS + 1):
+        for y in range(-BALL_RADIUS, BALL_RADIUS + 1):
+            remain = BALL_RADIUS - abs(x) - abs(y)
+            if remain < 0:
+                continue
+            for z in range(-remain, remain + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def neighbors(site: tuple[int, int, int]) -> list[tuple[int, int, int]]:
+    x, y, z = site
+    out: list[tuple[int, int, int]] = []
+    for dx, dy, dz in NEIGHBOR_STEPS:
+        nxt = (x + dx, y + dy, z + dz)
+        if in_ball(nxt):
+            out.append(nxt)
+    return out
+
+
+def dijkstra_from_origin(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    dist = {origin: 0}
+    heap = [(0, origin)]
+    while heap:
+        cost_here, site = heapq.heappop(heap)
+        if cost_here != dist[site]:
+            continue
+        for nxt in neighbors(site):
+            cand = cost_here + hop_cost(site, nxt)
+            if cand < dist.get(nxt, 10**9):
+                dist[nxt] = cand
+                heapq.heappush(heap, (cand, nxt))
+    if len(dist) != len(sites):
+        raise RuntimeError("Dijkstra did not reach every site of B_16(0)")
+    return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def audit_paths_are_static_literals() -> bool:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names:
+                value = node.value
+                if not isinstance(value, ast.Tuple):
+                    return False
+                return all(
+                    isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    for elt in value.elts
+                )
+    return False
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; hop-costs are the named (0,1,1) "
+        "rule on the finite 16-hop neighborhood B_16(0)"
+    )
+    print(
+        "package_local_integrity_reads: the note and current minimal axiom "
+        "are read; no cache or governance surface is written"
+    )
+    print(
+        "negative_scope: the named rule is displayed, not adopted; it is "
+        "not written into Admissibility and is not attached as an L1 hop-cost"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static literal pair and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and audit_paths_are_static_literals()
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball_sites()
+    site_set = set(sites)
+    checks.check(
+        "ball-b16-only",
+        "B_16(0) is the 16-hop neighborhood of the origin and contains every named target",
+        len(sites) == 6017
+        and all(in_ball(site) for site in TARGETS)
+        and (16, 0, 0) in site_set
+        and (8, 8, 0) in site_set
+        and (17, 0, 0) not in site_set
+        and (9, 8, 0) not in site_set
+        and nn_radius((8, 8, 0)) == 16
+        and nn_radius((16, 0, 0)) == 16,
+    )
+
+    checks.check(
+        "clause-011-local",
+        "seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1",
+        hop_cost((0, 0, 0), (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (2, 1, 0)) == 1
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    distances = dijkstra_from_origin(sites)
+    axis_times = tuple(distances[(2 * k, 0, 0)] for k in SCALES)
+    face_times = tuple(distances[(k, k, 0)] for k in SCALES)
+    reverse_bits = tuple(
+        axis_times[i] * axis_times[i] * (2 * k * k)
+        > face_times[i] * face_times[i] * (4 * k * k)
+        for i, k in enumerate(SCALES)
+    )
+    integer_bits = tuple(
+        axis_times[i] * axis_times[i] > 2 * face_times[i] * face_times[i]
+        for i in range(8)
+    )
+
+    for k, t_axis, t_face, bit in zip(SCALES, axis_times, face_times, reverse_bits):
+        left = t_axis * t_axis
+        right_face = t_face * t_face
+        print(
+            f"k={k} t({2 * k},0,0)={t_axis} t({k},{k},0)={t_face} "
+            f"t_axis^2/(4k^2)={left / (4 * k * k)} "
+            f"t_face^2/(2k^2)={right_face / (2 * k * k)} "
+            f"{left}>{2 * right_face} reverse={bit}"
+        )
+    print(f"dijkstra_count=1")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "theorem-1-times",
+        "the named arrivals are 4,8,10,12,14,16,18,22 on axis and 2,4,6,8,10,12,14,16 on face",
+        axis_times == EXPECTED_AXIS and face_times == EXPECTED_FACE,
+    )
+    checks.check(
+        "theorem-2-bits",
+        "reverse holds at k=1..4 and fails at k=5..8",
+        reverse_bits == EXPECTED_REVERSE and integer_bits == EXPECTED_REVERSE,
+    )
+    checks.check(
+        "keep-k4-not-only-k5",
+        "k=4 still reverses; failure is not isolated at k=5",
+        reverse_bits[3] is True and reverse_bits[4:] == (False, False, False, False),
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one origin Dijkstra assigned a finite time to every ball site",
+        DIJKSTRA_CALLS == 1
+        and len(distances) == len(sites)
+        and all(distances[site] >= 0 for site in sites),
+    )
+    checks.check(
+        "note-reports-times",
+        "the note reports every computed axis and face time",
+        all(f"t({2 * k},0,0)={axis_times[i]}" in note for i, k in enumerate(SCALES))
+        and all(f"t({k},{k},0)={face_times[i]}" in note for i, k in enumerate(SCALES)),
+    )
+    checks.check(
+        "note-reports-comparisons",
+        "the note reports the eight displayed reverse comparisons",
+        "16 > 8" in note
+        and "64 > 32" in note
+        and "100 > 72" in note
+        and "144 > 128" in note
+        and "196 > 200" in note
+        and "256 > 288" in note
+        and "324 > 392" in note
+        and "484 > 512" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays the (0,1,1) scores and does not adopt them",
+        "Displayed, not adopted" in note
+        and "do not write (0,1,1) into Admissibility" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the current axiom memo still names Admissibility and does not contain the hop-cost rule",
+        "Admissibility" in axiom
+        and "Lattice" in axiom
+        and "Qubit" in axiom
+        and "Record" in axiom
+        and "both weights 1 or support drop" not in axiom
+        and "(0,1,1)" not in axiom,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "claim-scope",
+        "the note states the required claim_scope",
+        "Face-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_16(0) is reported for k=1..8"
+        in note,
+    )
+    forbidden_hits = [token for token in FORBIDDEN if token in note]
+    checks.check(
+        "forbidden-tokens",
+        "the note avoids the forbidden tokens",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not claim uniqueness of the named rule",
+        "Uniqueness is not required" in note
+        and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_16(0) under (0,1,1), face reverse holds at k=1,2,3,4 and fails at k=5,6,7,8. The cheaper rival still keeps the k=4 face that nu loses. Displayed, not adopted.

## Runner

`scripts/clause_011_face_reverse_vs_k_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.