### PR TITLE
feat(011bk16): (0,1,1) body reverse on B16 is yes yes no no no

### DIFF
--- a/docs/CLAUSE_011_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,228 @@
+---
+claim_id: clause_011_body_reverse_vs_k_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Body-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_16(0) is reported for k=1..5. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py
+---
+
+# Named (0,1,1) Body-Diagonal Reverse Versus Scale k On B_16(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact arrival times under one named hop-cost on the finite
+16-hop neighborhood of the origin in the cubic nearest-neighbor graph,
+scored only for the face-orthogonal body census pairing
+`((2k,0,0),(k,k,k))` at every integer `k=1,2,3,4,5`. The rule is
+displayed, not adopted.
+**Primary runner:**
+[`scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py`](../scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Let `B_16(0)` be the set of sites of `Z^3` whose nearest-neighbor graph
+distance from the origin is at most 16. That set has 6017 sites and is
+used only as a finite domain bound. It is not a hop-cost.
+
+Hops are the six nearest-neighbor steps that remain inside `B_16(0)`.
+Write `σ_v` for the support of a site (the set of nonzero coordinates).
+The named clause-toggle `(0,1,1)` assigns
+
+```text
+cost(v→w) = 3  if |σ_v|=|σ_w|=1 or |σ_w|<|σ_v|,
+          = 1  otherwise.
+```
+
+Seed-exit therefore costs 1. Axis 1-skeleton hops and support-drop hops
+cost 3. Every other admitted hop costs 1. The rule is not written into
+Admissibility: do not write (0,1,1) into Admissibility. Do not attach L1.
+
+One Dijkstra from the origin yields the body-census arrivals
+
+| `k` | site axis | `t(2k,0,0)` | site body | `t(k,k,k)` | `12 t(2k,0,0)^2` | `16 t(k,k,k)^2` | reverse |
+|---|---|---:|---|---:|---:|---:|---|
+| `1` | `(2,0,0)` | `4` | `(1,1,1)` | `3` | `192` | `144` | yes |
+| `2` | `(4,0,0)` | `8` | `(2,2,2)` | `6` | `768` | `576` | yes |
+| `3` | `(6,0,0)` | `10` | `(3,3,3)` | `9` | `1200` | `1296` | no |
+| `4` | `(8,0,0)` | `12` | `(4,4,4)` | `12` | `1728` | `2304` | no |
+| `5` | `(10,0,0)` | `14` | `(5,5,5)` | `15` | `2352` | `3600` | no |
+
+```text
+t(2,0,0)=4
+t(1,1,1)=3
+t(4,0,0)=8
+t(2,2,2)=6
+t(6,0,0)=10
+t(3,3,3)=9
+t(8,0,0)=12
+t(4,4,4)=12
+t(10,0,0)=14
+t(5,5,5)=15
+```
+
+The displayed reverse tests are
+
+```text
+12 t(2,0,0)^2 = 192 > 144 = 16 t(1,1,1)^2     yes
+12 t(4,0,0)^2 = 768 > 576 = 16 t(2,2,2)^2     yes
+12 t(6,0,0)^2 = 1200 > 1296 = 16 t(3,3,3)^2   no
+12 t(8,0,0)^2 = 1728 > 2304 = 16 t(4,4,4)^2   no
+12 t(10,0,0)^2 = 2352 > 3600 = 16 t(5,5,5)^2  no
+```
+
+Body-diagonal reverse holds at `k=1,2` and fails at `k=3,4,5`. The
+`k=5` row is an additional scale on `B_16(0)`, not leftover of the
+smaller pairings. Uniqueness is not required. Displayed, not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under
+lattice translations and proper cubic rotations.
+
+The axiom set supplies the cubic nearest-neighbor graph. It does not
+supply a hop-cost, a body-diagonal reverse test, or a preferred
+clause-toggle. This note therefore treats `(0,1,1)` as a separately
+named finite scoring rule. The note does not write `(0,1,1)` into
+Admissibility and does not enlarge the axiom set.
+
+Record is not used. No readout, formation site, or scalar collection
+functional enters the arrival times.
+
+## Exact Objects
+
+`B_16(0)` is the closed 16-hop neighborhood of the origin. Every hop
+used below is a nearest-neighbor step whose endpoints both lie in that
+set. One Dijkstra computes the named arrival time `t(v)` from the
+origin to each site.
+
+The pairing is not the same-`k` axis / body pair `(k,0,0)` versus
+`(k,k,k)`. It is the face-orthogonal body census
+`((2k,0,0),(k,k,k))`. The comparison is displayed only. It is not a
+derived continuum law and is not attached as an L1 hop-cost.
+
+## Theorem 1
+
+On `B_16(0)` under the named `(0,1,1)` hop-cost, one origin Dijkstra
+returns
+
+`t(2,0,0)=4`, `t(1,1,1)=3`, `t(4,0,0)=8`, `t(2,2,2)=6`,
+`t(6,0,0)=10`, `t(3,3,3)=9`, `t(8,0,0)=12`, `t(4,4,4)=12`,
+`t(10,0,0)=14`, and `t(5,5,5)=15`.
+
+Each value is the Dijkstra arrival time. Witnessing paths of those
+costs exist. The walk
+
+`0 → (1,0,0) → (2,0,0)`
+
+has hop-costs `1,3` and sum `4`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1)`
+
+has hop-costs `1,1,1` and sum `3`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (4,0,0)`
+
+has hop-costs `1,1,1,1,1,3` and sum `8`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2)`
+
+has hop-costs `1,1,1,1,1,1` and sum `6`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (6,0,0)`
+
+has hop-costs `1,1,1,1,1,1,1,3` and sum `10`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2) → (3,2,2) → (3,3,2) → (3,3,3)`
+
+has hop-costs `1,1,1,1,1,1,1,1,1` and sum `9`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (8,0,0)`
+
+has hop-costs `1,1,1,1,1,1,1,1,1,3` and sum `12`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2) → (3,2,2) → (3,3,2) → (3,3,3) → (4,3,3) → (4,4,3) → (4,4,4)`
+
+has hop-costs `1,1,1,1,1,1,1,1,1,1,1,1` and sum `12`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (9,1,0) → (10,1,0) → (10,0,0)`
+
+has hop-costs `1,1,1,1,1,1,1,1,1,1,1,3` and sum `14`. The walk
+
+`0 → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (2,2,1) → (2,2,2) → (3,2,2) → (3,3,2) → (3,3,3) → (4,3,3) → (4,4,3) → (4,4,4) → (5,4,4) → (5,5,4) → (5,5,5)`
+
+has hop-costs `1,1,1,1,1,1,1,1,1,1,1,1,1,1,1` and sum `15`.
+
+The table is computed on `B_16(0)`, not copied from four named pairs.
+
+## Theorem 2
+
+For each `k=1,2,3,4,5` the displayed comparison is whether
+
+`12 t(2k,0,0)^2 > 16 t(k,k,k)^2`.
+
+Substituting the computed times gives
+
+`12 t(2,0,0)^2 = 192 > 144 = 16 t(1,1,1)^2`,
+
+`12 t(4,0,0)^2 = 768 > 576 = 16 t(2,2,2)^2`,
+
+`12 t(6,0,0)^2 = 1200 > 1296` is false, since `16 t(3,3,3)^2 = 1296`,
+
+`12 t(8,0,0)^2 = 1728 > 2304` is false, since `16 t(4,4,4)^2 = 2304`,
+
+and
+
+`12 t(10,0,0)^2 = 2352 > 3600` is false, since `16 t(5,5,5)^2 = 3600`.
+
+Body-diagonal reverse therefore holds at the small scales `k=1,2` and
+fails at `k=3,4,5` on this same finite domain. Fail is already present
+at `k=3`; it is not isolated at the doubled diamond. Displayed, not
+adopted.
+
+## Theorem 3
+
+The note does not write `(0,1,1)` into Admissibility. Do not attach L1.
+Uniqueness is not required. The current axiom memo is not edited.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Ten arrival times and five displayed reverse inequalities are exact outputs of one Dijkstra on the named finite graph; the hop-cost is a disclosed scoring rule, not an axiom, and reverse holds at k=1,2 and fails at k=3,4,5."
+trace_class: compute
+artifact_role: theorem
+conditional_surface_status: "exact on B_16(0) under the named (0,1,1) hop-cost at k=1..5 on ((2k,0,0),(k,k,k)); displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Does Not Claim
+
+- It does not adopt the `(0,1,1)` hop-cost as framework content.
+- It does not claim that reverse survives every integer scale.
+- It does not claim that the named rule is the only reverser.
+- It does not identify `t` with nearest-neighbor hop count.
+- It does not supply a physical clock, a continuum metric, or a Record
+  readout of the arrival times.
+- It does not score any pair other than `((2k,0,0),(k,k,k))`.
+- It does not substitute four named pairs for the five-scale census.
+
+## Reproducibility
+
+```text
+python3 scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py
+```
+
+The runner prints the ten times, the five displayed comparisons, and
+`TOTAL: PASS=<n> FAIL=<n>`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15746,
- "node_count": 5547,
+ "edge_count": 15747,
+ "node_count": 5548,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2333,6 +2333,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_body_reverse_vs_k_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_body_reverse_vs_k_b16_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_body_reverse_vs_k_b16_2026_08_15.txt
@@ -1,0 +1,45 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py
+runner_sha256: 0c6e087888380afdb894b65cbfa5d2115855668c5c4078186d364a25671ef146
+input_fingerprint_sha256: 8deb3cb7fb32049b45f963d7818358fe1a6117f44326255969a134c5d56ba492
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+external_scientific_inputs: none; hop-costs are the named (0,1,1) rule on the finite 16-hop neighborhood B_16(0)
+package_local_integrity_reads: the note and current minimal axiom are read; no cache or governance surface is written
+negative_scope: the named rule is displayed, not adopted; it is not written into Admissibility and is not attached as an L1 hop-cost
+claim_scope: Body-diagonal reverse versus integer scale k under the named (0,1,1) hop-cost on B_16(0) is reported for k=1..5. Displayed, not adopted.
+cache_write: false
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static literal pair and both files exist
+PASS: ball-b16-only B_16(0) is the 16-hop neighborhood of the origin and contains every named target
+PASS: clause-011-local seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1
+dijkstra_count=1
+k 1 t(2,0,0)=4 t(1,1,1)=3 12 t(2k,0,0)^2=192 16 t(k,k,k)^2=144 reverse=True
+PASS: theorem-1-k1 t(2,0,0)=4 and t(1,1,1)=3
+PASS: theorem-2-k1 12 t(2,0,0)^2 > 16 t(1,1,1)^2 is True
+k 2 t(4,0,0)=8 t(2,2,2)=6 12 t(2k,0,0)^2=768 16 t(k,k,k)^2=576 reverse=True
+PASS: theorem-1-k2 t(4,0,0)=8 and t(2,2,2)=6
+PASS: theorem-2-k2 12 t(4,0,0)^2 > 16 t(2,2,2)^2 is True
+k 3 t(6,0,0)=10 t(3,3,3)=9 12 t(2k,0,0)^2=1200 16 t(k,k,k)^2=1296 reverse=False
+PASS: theorem-1-k3 t(6,0,0)=10 and t(3,3,3)=9
+PASS: theorem-2-k3 12 t(6,0,0)^2 > 16 t(3,3,3)^2 is False
+k 4 t(8,0,0)=12 t(4,4,4)=12 12 t(2k,0,0)^2=1728 16 t(k,k,k)^2=2304 reverse=False
+PASS: theorem-1-k4 t(8,0,0)=12 and t(4,4,4)=12
+PASS: theorem-2-k4 12 t(8,0,0)^2 > 16 t(4,4,4)^2 is False
+k 5 t(10,0,0)=14 t(5,5,5)=15 12 t(2k,0,0)^2=2352 16 t(k,k,k)^2=3600 reverse=False
+PASS: theorem-1-k5 t(10,0,0)=14 and t(5,5,5)=15
+PASS: theorem-2-k5 12 t(10,0,0)^2 > 16 t(5,5,5)^2 is False
+PASS: one-dijkstra exactly one origin Dijkstra assigned a finite time to every ball site
+PASS: reverse-bits-match computed reverse bits match the five-scale census yes,yes,no,no,no
+PASS: note-reports-times the note reports the ten computed times and the five displayed comparisons
+PASS: displayed-not-adopted the note displays the (0,1,1) scores and does not adopt them
+PASS: admissibility-unedited the current axiom memo still names Admissibility and does not contain the hop-cost rule
+PASS: claim-scope the note states the required claim_scope
+PASS: forbidden-tokens the note avoids the forbidden tokens
+PASS: uniqueness-not-required the note does not claim uniqueness of the named rule
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py
+++ b/scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Named (0,1,1) body-diagonal reverse versus scale k on B_16(0).
+
+One Dijkstra from the origin. Displayed, not adopted. No axiom edit,
+no cache write, no L1 hop-cost attachment.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_NAME = "CLAUSE_011_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+NOTE_PATH = ROOT / "docs" / NOTE_NAME
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Body-diagonal reverse versus integer scale k under the "
+    "named (0,1,1) hop-cost on B_16(0) is reported for k=1..5. "
+    "Displayed, not adopted."
+)
+
+BALL_RADIUS = 16
+SCALES = (1, 2, 3, 4, 5)
+# (k, t(2k,0,0), t(k,k,k), reverse)
+REPORTED = (
+    (1, 4, 3, True),
+    (2, 8, 6, True),
+    (3, 10, 9, False),
+    (4, 12, 12, False),
+    (5, 14, 15, False),
+)
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIJKSTRA_CALLS = 0
+
+
+def nn_radius(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def in_ball(site: tuple[int, int, int]) -> bool:
+    return nn_radius(site) <= BALL_RADIUS
+
+
+def support_size(site: tuple[int, int, int]) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(src: tuple[int, int, int], dst: tuple[int, int, int]) -> int:
+    """Rule (0,1,1): cost 3 iff both weights 1 or support drop, else 1."""
+    src_support = support_size(src)
+    dst_support = support_size(dst)
+    both_weights_one = src_support == 1 and dst_support == 1
+    support_drop = dst_support < src_support
+    if both_weights_one or support_drop:
+        return 3
+    return 1
+
+
+def ball_sites() -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-BALL_RADIUS, BALL_RADIUS + 1):
+        for y in range(-BALL_RADIUS, BALL_RADIUS + 1):
+            remain = BALL_RADIUS - abs(x) - abs(y)
+            if remain < 0:
+                continue
+            for z in range(-remain, remain + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def neighbors(site: tuple[int, int, int]) -> list[tuple[int, int, int]]:
+    x, y, z = site
+    out: list[tuple[int, int, int]] = []
+    for dx, dy, dz in NEIGHBOR_STEPS:
+        nxt = (x + dx, y + dy, z + dz)
+        if in_ball(nxt):
+            out.append(nxt)
+    return out
+
+
+def dijkstra_from_origin(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    dist = {origin: 0}
+    heap = [(0, origin)]
+    while heap:
+        cost_here, site = heapq.heappop(heap)
+        if cost_here != dist[site]:
+            continue
+        for nxt in neighbors(site):
+            cand = cost_here + hop_cost(site, nxt)
+            if cand < dist.get(nxt, 10**9):
+                dist[nxt] = cand
+                heapq.heappush(heap, (cand, nxt))
+    if len(dist) != len(sites):
+        raise RuntimeError("Dijkstra did not reach every site of B_16(0)")
+    return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def audit_paths_are_static_literals() -> bool:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names:
+                value = node.value
+                if not isinstance(value, ast.Tuple):
+                    return False
+                return all(
+                    isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    for elt in value.elts
+                )
+    return False
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; hop-costs are the named (0,1,1) "
+        "rule on the finite 16-hop neighborhood B_16(0)"
+    )
+    print(
+        "package_local_integrity_reads: the note and current minimal axiom "
+        "are read; no cache or governance surface is written"
+    )
+    print(
+        "negative_scope: the named rule is displayed, not adopted; it is "
+        "not written into Admissibility and is not attached as an L1 hop-cost"
+    )
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print("cache_write: false")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static literal pair and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_BODY_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and audit_paths_are_static_literals()
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball_sites()
+    named_targets = tuple((2 * k, 0, 0) for k in SCALES) + tuple(
+        (k, k, k) for k in SCALES
+    )
+    checks.check(
+        "ball-b16-only",
+        "B_16(0) is the 16-hop neighborhood of the origin and contains every named target",
+        len(sites) == 6017
+        and all(in_ball(site) for site in named_targets)
+        and (10, 0, 0) in sites
+        and (5, 5, 5) in sites
+        and (17, 0, 0) not in set(sites),
+    )
+
+    checks.check(
+        "clause-011-local",
+        "seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1",
+        hop_cost((0, 0, 0), (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (2, 1, 0)) == 1
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    distances = dijkstra_from_origin(sites)
+    print("dijkstra_count=1")
+
+    all_match = True
+    for k, t_axis_rep, t_body_rep, reverse_rep in REPORTED:
+        t_axis = distances[(2 * k, 0, 0)]
+        t_body = distances[(k, k, k)]
+        lhs = 12 * t_axis * t_axis
+        rhs = 16 * t_body * t_body
+        reverse = lhs > rhs
+        all_match = all_match and reverse == reverse_rep
+        print(
+            f"k {k} t({2 * k},0,0)={t_axis} t({k},{k},{k})={t_body} "
+            f"12 t(2k,0,0)^2={lhs} 16 t(k,k,k)^2={rhs} reverse={reverse}"
+        )
+        checks.check(
+            f"theorem-1-k{k}",
+            f"t({2 * k},0,0)={t_axis_rep} and t({k},{k},{k})={t_body_rep}",
+            t_axis == t_axis_rep and t_body == t_body_rep,
+        )
+        checks.check(
+            f"theorem-2-k{k}",
+            f"12 t({2 * k},0,0)^2 > 16 t({k},{k},{k})^2 is {reverse_rep}",
+            reverse == reverse_rep and (lhs > rhs) == reverse,
+        )
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one origin Dijkstra assigned a finite time to every ball site",
+        DIJKSTRA_CALLS == 1
+        and len(distances) == len(sites)
+        and all(distances[site] >= 0 for site in sites),
+    )
+    checks.check(
+        "reverse-bits-match",
+        "computed reverse bits match the five-scale census yes,yes,no,no,no",
+        all_match,
+    )
+    checks.check(
+        "note-reports-times",
+        "the note reports the ten computed times and the five displayed comparisons",
+        "t(2,0,0)=4" in note
+        and "t(1,1,1)=3" in note
+        and "t(4,0,0)=8" in note
+        and "t(2,2,2)=6" in note
+        and "t(6,0,0)=10" in note
+        and "t(3,3,3)=9" in note
+        and "t(8,0,0)=12" in note
+        and "t(4,4,4)=12" in note
+        and "t(10,0,0)=14" in note
+        and "t(5,5,5)=15" in note
+        and "192 > 144" in note
+        and "768 > 576" in note
+        and "1200 > 1296" in note
+        and "1728 > 2304" in note
+        and "2352 > 3600" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays the (0,1,1) scores and does not adopt them",
+        "Displayed, not adopted" in note
+        and "do not write (0,1,1) into Admissibility" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the current axiom memo still names Admissibility and does not contain the hop-cost rule",
+        "Admissibility" in axiom
+        and "Lattice" in axiom
+        and "Qubit" in axiom
+        and "Record" in axiom
+        and "both weights 1 or support drop" not in axiom
+        and "(0,1,1)" not in axiom,
+    )
+    checks.check(
+        "claim-scope",
+        "the note states the required claim_scope",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "forbidden-tokens",
+        "the note avoids the forbidden tokens",
+        "G_N" not in note
+        and "1/r" not in note
+        and "1/r^2" not in note
+        and "Lattice-named" not in note
+        and "not a TOE" not in note,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not claim uniqueness of the named rule",
+        "Uniqueness is not required" in note
+        and "unique hop-cost" not in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_16(0) under (0,1,1), doubled pairing reverses at k=1,2 and fails at k=3,4,5. Same pattern as nu. Displayed, not adopted.

## Runner

`scripts/clause_011_body_reverse_vs_k_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.