### PR TITLE
feat(iso16): B16 t=8 and t=14 type counts match B12: 7/5 and 26/15

### DIFF
--- a/docs/SUPPORT_DROP_ISOCHRONE_TYPES_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_ISOCHRONE_TYPES_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,198 @@
+---
+claim_id: support_drop_isochrone_types_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Isochrone type counts of the t=8 and t=14 shells under the named support-drop hop-cost on B_16(0) are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_isochrone_types_b16_2026_08_15.py
+---
+
+# Isochrone Type Counts Of The t=8 And t=14 Shells On B_16(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_16(0)`,
+scored only for G+ type counts and distinct `|v|_2^2` on the mixed arrivals
+`t=8` and `t=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_isochrone_types_b16_2026_08_15.py`](../scripts/support_drop_isochrone_types_b16_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The mixed-shell census on `B_16(0)` placed both `t=8` and `t=14` among the
+mixed arrivals. That mixed bit is the investment, not the residual. The
+residual here is the G+ type count and the number of distinct Euclidean
+squared radii on those two shells, versus the `B_12(0)` counts `7/5` and
+`26/15`.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_16(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not claimed.
+
+The proper cubic group `G+` is the 24 signed-permutation rotations of
+determinant `+1`. A G+ type is one `G+` orbit. The representative of an
+orbit is its lexicographically maximal first-octant triple (the
+lex-sorted list of those abs-sorted 3-tuples is the type list).
+
+One Dijkstra from the origin on `B_16(0)` (6017 sites; 6016 nonzero) gives
+
+| `t` | site count | G+ types | distinct `|v|_2^2` |
+|---:|---:|---:|---:|
+| `8` | `140` | `7` | `5` |
+| `14` | `578` | `26` | `15` |
+
+So `t=8` and `t=14` stay mixed. Versus the `B_12(0)` counts, the pair on
+`t=8` is still `7/5` and the pair on `t=14` is still `26/15`. The
+numerical coincidence is not leftover of the `B_12(0)` type table: one
+origin Dijkstra is run on this ball, and the site `(16,0,0)` is not in `B_12(0)`.
+
+The reverse-critical body diagonal `(2,2,2)` sits in the `t=8` shell.
+The doubled body diagonal `(4,4,4)` and the axis site `(8,0,0)` sit in
+the `t=14` shell.
+
+The census is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule And Type Convention
+
+Let `B_16(0) = { v ∈ Z^3 : |v|_1 ≤ 16 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_16(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+A G+ type is represented by the lexicographically maximal first-octant
+member of its orbit. The type list of a shell is those representatives
+sorted in lexicographic order. Absolute-coordinate first-octant form does
+not merge chiral pairs: `(3,1,2)` and `(3,2,1)` remain distinct `G+`
+orbits, as do the chiral pairs on `t=14`.
+
+## Theorem 1 — Type Counts On The `t=8` And `t=14` Shells
+
+One origin Dijkstra on `B_16(0)` reaches every site. The `t=8` shell has
+140 sites, 7 G+ types, and 5 distinct values of `|v|_2^2`. The `t=14`
+shell has 578 sites, 26 G+ types, and 15 distinct values of `|v|_2^2`.
+
+The lex-sorted abs-sorted G+ representatives at `t=8`, each with
+`|v|_2^2` and orbit size, are
+
+| representative | `|v|_2^2` | orbit size |
+|---|---:|---:|
+| `(2,2,2)` | 12 | 8 |
+| `(3,1,2)` | 14 | 24 |
+| `(3,2,1)` | 14 | 24 |
+| `(3,3,0)` | 18 | 12 |
+| `(4,1,1)` | 18 | 24 |
+| `(4,2,0)` | 20 | 24 |
+| `(5,1,0)` | 26 | 24 |
+
+Those seven orbits partition the 140 sites. The five squared radii are
+`{12,14,18,20,26}`.
+
+The lex-sorted abs-sorted G+ representatives at `t=14` are
+
+| representative | `|v|_2^2` | orbit size |
+|---|---:|---:|
+| `(4,4,4)` | 48 | 8 |
+| `(5,3,4)` | 50 | 24 |
+| `(5,4,3)` | 50 | 24 |
+| `(5,5,2)` | 54 | 24 |
+| `(6,1,5)` | 62 | 24 |
+| `(6,2,4)` | 56 | 24 |
+| `(6,3,3)` | 54 | 24 |
+| `(6,4,2)` | 56 | 24 |
+| `(6,5,1)` | 62 | 24 |
+| `(6,6,0)` | 72 | 12 |
+| `(7,1,4)` | 66 | 24 |
+| `(7,2,3)` | 62 | 24 |
+| `(7,3,2)` | 62 | 24 |
+| `(7,4,1)` | 66 | 24 |
+| `(7,5,0)` | 74 | 24 |
+| `(8,0,0)` | 64 | 6 |
+| `(8,1,3)` | 74 | 24 |
+| `(8,2,2)` | 72 | 24 |
+| `(8,3,1)` | 74 | 24 |
+| `(8,4,0)` | 80 | 24 |
+| `(9,1,2)` | 86 | 24 |
+| `(9,2,1)` | 86 | 24 |
+| `(9,3,0)` | 90 | 24 |
+| `(10,1,1)` | 102 | 24 |
+| `(10,2,0)` | 104 | 24 |
+| `(11,1,0)` | 122 | 24 |
+
+Those twenty-six orbits partition the 578 sites. The fifteen squared
+radii are `{48,50,54,56,62,64,66,72,74,80,86,90,102,104,122}`.
+
+Versus the `B_12(0)` counts `7/5` and `26/15`, the `B_16(0)` pair is the
+same on both shells. That match is a Dijkstra output on this ball, not a
+reuse of the smaller-ball type table.
+
+B_16(0) only. The type counts are displayed, not adopted.
+
+## Theorem 2 — Named Sites Sit In Those Shells
+
+The same Dijkstra gives `t(2,2,2) = 8`, `t(4,4,4) = 14`, and
+`t(8,0,0) = 14`. So `(2,2,2)` is in the `t=8` type list, and both
+`(4,4,4)` and `(8,0,0)` are in the `t=14` type list.
+
+Those three memberships are displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_16(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. The isochrone type counts are not
+offered as a unique hop-cost property and are not a replacement for
+unit-cost first arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact G+ type counts on the t=8 and t=14 shells of B_16(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_16(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs with these type counts.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_16(0)`.
+- Any reuse of the `B_12(0)` type table as a substitute for the radius-`16`
+  Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15746,
- "node_count": 5547,
+ "edge_count": 15747,
+ "node_count": 5548,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17977,6 +17977,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_isochrone_types_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_isochrone_types_b16_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_isochrone_types_b16_2026_08_15.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_isochrone_types_b16_2026_08_15.py
+runner_sha256: d2da21b520b6f26f9227e733de060a5600bfa475f159fdb3288b82bf766f2a3f
+input_fingerprint_sha256: 4f9937a3d62dcabf1cab37943083e57688fa4d548ca0c05a1f0e1d3ff098a3b8
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_ISOCHRONE_TYPES_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Isochrone type counts of the t=8 and t=14 shells under the named support-drop hop-cost on B_16(0) are reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the isochrone type-count statement
+PASS: displayed-not-adopted the census is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 6017
+t8_sites 140 t8_types 7 t8_n_r2 5
+t14_sites 578 t14_types 26 t14_n_r2 15
+t8_radii [12, 14, 18, 20, 26]
+t14_radii [48, 50, 54, 56, 62, 64, 66, 72, 74, 80, 86, 90, 102, 104, 122]
+t(2,2,2) 8
+t(4,4,4) 14
+t(8,0,0) 14
+t(16,0,0) 24
+has_222_in_t8 True
+has_444_in_t14 True
+has_800_in_t14 True
+t8_mixed True
+t14_mixed True
+versus_b12_t8 (7, 5) versus_b12_t14 (26, 15)
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b16 B_16(0) has 6017 sites and 6016 nonzero sites
+PASS: reachable every site of B_16(0) is reached
+PASS: rotation-group the proper cubic group used for types has 24 elements
+PASS: t8-counts t=8 has 140 sites, 7 G+ types, and 5 distinct |v|_2^2
+PASS: t14-counts t=14 has 578 sites, 26 G+ types, and 15 distinct |v|_2^2
+PASS: versus-b12 B_16 type/radius counts versus the B_12 pair 7/5 and 26/15
+PASS: t-222-in-t8 (2,2,2) sits in the t=8 shell
+PASS: t-444-in-t14 (4,4,4) sits in the t=14 shell
+PASS: t-800-in-t14 (8,0,0) sits in the t=14 shell
+PASS: t8-t14-stay-mixed t=8 and t=14 stay mixed
+PASS: not-leftover-of-b12 the B_16 type census is not leftover of the B_12 table
+PASS: note-records-counts note records site, type, and radius counts for both shells
+PASS: note-records-memberships note records (2,2,2) in t=8 and (4,4,4),(8,0,0) in t=14
+PASS: chiral-pairs-split abs-sorted first-octant form still splits G+ chiral pairs
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: b16-only every named type stays inside B_16(0)
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_isochrone_types_b16_2026_08_15.py
+++ b/scripts/support_drop_isochrone_types_b16_2026_08_15.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Count G+ types on the t=8 and t=14 shells of the support-drop hop-cost.
+
+One origin Dijkstra on B_16(0). No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_ISOCHRONE_TYPES_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_ISOCHRONE_TYPES_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Isochrone type counts of the t=8 and t=14 shells under "
+    "the named support-drop hop-cost on B_16(0) are reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T8_EXPECTED = (
+    ((2, 2, 2), 12, 8),
+    ((3, 1, 2), 14, 24),
+    ((3, 2, 1), 14, 24),
+    ((3, 3, 0), 18, 12),
+    ((4, 1, 1), 18, 24),
+    ((4, 2, 0), 20, 24),
+    ((5, 1, 0), 26, 24),
+)
+T14_EXPECTED = (
+    ((4, 4, 4), 48, 8),
+    ((5, 3, 4), 50, 24),
+    ((5, 4, 3), 50, 24),
+    ((5, 5, 2), 54, 24),
+    ((6, 1, 5), 62, 24),
+    ((6, 2, 4), 56, 24),
+    ((6, 3, 3), 54, 24),
+    ((6, 4, 2), 56, 24),
+    ((6, 5, 1), 62, 24),
+    ((6, 6, 0), 72, 12),
+    ((7, 1, 4), 66, 24),
+    ((7, 2, 3), 62, 24),
+    ((7, 3, 2), 62, 24),
+    ((7, 4, 1), 66, 24),
+    ((7, 5, 0), 74, 24),
+    ((8, 0, 0), 64, 6),
+    ((8, 1, 3), 74, 24),
+    ((8, 2, 2), 72, 24),
+    ((8, 3, 1), 74, 24),
+    ((8, 4, 0), 80, 24),
+    ((9, 1, 2), 86, 24),
+    ((9, 2, 1), 86, 24),
+    ((9, 3, 0), 90, 24),
+    ((10, 1, 1), 102, 24),
+    ((10, 2, 0), 104, 24),
+    ((11, 1, 0), 122, 24),
+)
+B12_T8 = (7, 5)
+B12_T14 = (26, 15)
+DIJKSTRA_CALLS = 0
+Point = tuple[int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def rotate_vector(rotation: Rotation, vector: Point) -> Point:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def l1(v: Point) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: Point) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def r2(v: Point) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def ball(radius: int) -> list[Point]:
+    sites: list[Point] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: Point, w: Point) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def dijkstra_nu(sites: list[Point]) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[Point, int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, Point]] = [(0, (0, 0, 0))]
+    seen: set[Point] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + nu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def gplus_orbit(point: Point) -> frozenset[Point]:
+    return frozenset(rotate_vector(rotation, point) for rotation in ROTATIONS)
+
+
+def representative(orbit: frozenset[Point]) -> Point:
+    octant = tuple(point for point in orbit if point[0] >= 0 and point[1] >= 0 and point[2] >= 0)
+    if not octant:
+        raise ValueError("G+ orbit has no first-octant representative")
+    return max(octant)
+
+
+def shell_types(
+    dist: dict[Point, int],
+    site_set: set[Point],
+    arrival: int,
+) -> tuple[list[Point], list[tuple[Point, int, int]], tuple[int, ...]]:
+    pts = [v for v, t in dist.items() if t == arrival and v != (0, 0, 0)]
+    consumed: set[Point] = set()
+    rows: list[tuple[Point, int, int]] = []
+    for site in pts:
+        if site in consumed:
+            continue
+        orbit = gplus_orbit(site)
+        if not orbit.issubset(site_set):
+            raise AssertionError(f"orbit of {site} leaves B_16(0)")
+        times = {dist[point] for point in orbit}
+        if times != {arrival}:
+            raise AssertionError(f"arrival not constant on orbit of {site}: {times}")
+        consumed.update(orbit)
+        rep = representative(orbit)
+        rows.append((rep, r2(rep), len(orbit)))
+    rows.sort()
+    if consumed != set(pts):
+        raise AssertionError("G+ orbits do not partition the shell")
+    radii = tuple(sorted({radius for _, radius, _ in rows}))
+    return pts, rows, radii
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the isochrone type-count statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the census is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(16)
+    site_set = set(sites)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_nu(sites)
+    t8_sites, t8_rows, t8_radii = shell_types(dist, site_set, 8)
+    t14_sites, t14_rows, t14_radii = shell_types(dist, site_set, 14)
+    t222 = dist[(2, 2, 2)]
+    t444 = dist[(4, 4, 4)]
+    t800 = dist[(8, 0, 0)]
+    t1600 = dist[(16, 0, 0)]
+    t8_reps = {rep for rep, _, _ in t8_rows}
+    t14_reps = {rep for rep, _, _ in t14_rows}
+    t8_mixed = len(t8_radii) > 1
+    t14_mixed = len(t14_radii) > 1
+
+    print(f"n_sites {len(sites)}")
+    print(f"t8_sites {len(t8_sites)} t8_types {len(t8_rows)} t8_n_r2 {len(t8_radii)}")
+    print(f"t14_sites {len(t14_sites)} t14_types {len(t14_rows)} t14_n_r2 {len(t14_radii)}")
+    print(f"t8_radii {list(t8_radii)}")
+    print(f"t14_radii {list(t14_radii)}")
+    print(f"t(2,2,2) {t222}")
+    print(f"t(4,4,4) {t444}")
+    print(f"t(8,0,0) {t800}")
+    print(f"t(16,0,0) {t1600}")
+    print(f"has_222_in_t8 {(2, 2, 2) in t8_reps}")
+    print(f"has_444_in_t14 {(4, 4, 4) in t14_reps}")
+    print(f"has_800_in_t14 {(8, 0, 0) in t14_reps}")
+    print(f"t8_mixed {t8_mixed}")
+    print(f"t14_mixed {t14_mixed}")
+    print(f"versus_b12_t8 {B12_T8} versus_b12_t14 {B12_T14}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b16",
+        "B_16(0) has 6017 sites and 6016 nonzero sites",
+        len(sites) == 6017 and len(nonzero) == 6016 and all(l1(v) <= 16 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_16(0) is reached",
+        len(dist) == 6017,
+    )
+    checks.check(
+        "rotation-group",
+        "the proper cubic group used for types has 24 elements",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "t8-counts",
+        "t=8 has 140 sites, 7 G+ types, and 5 distinct |v|_2^2",
+        len(t8_sites) == 140
+        and len(t8_rows) == 7
+        and len(t8_radii) == 5
+        and tuple(t8_rows) == T8_EXPECTED
+        and t8_radii == (12, 14, 18, 20, 26),
+    )
+    checks.check(
+        "t14-counts",
+        "t=14 has 578 sites, 26 G+ types, and 15 distinct |v|_2^2",
+        len(t14_sites) == 578
+        and len(t14_rows) == 26
+        and len(t14_radii) == 15
+        and tuple(t14_rows) == T14_EXPECTED
+        and t14_radii == (48, 50, 54, 56, 62, 64, 66, 72, 74, 80, 86, 90, 102, 104, 122),
+    )
+    checks.check(
+        "versus-b12",
+        "B_16 type/radius counts versus the B_12 pair 7/5 and 26/15",
+        (len(t8_rows), len(t8_radii)) == B12_T8
+        and (len(t14_rows), len(t14_radii)) == B12_T14
+        and "versus the `B_12(0)` counts" in note
+        and "7/5" in note
+        and "26/15" in note,
+    )
+    checks.check(
+        "t-222-in-t8",
+        "(2,2,2) sits in the t=8 shell",
+        t222 == 8 and (2, 2, 2) in t8_reps and r2((2, 2, 2)) == 12,
+    )
+    checks.check(
+        "t-444-in-t14",
+        "(4,4,4) sits in the t=14 shell",
+        t444 == 14 and (4, 4, 4) in t14_reps and r2((4, 4, 4)) == 48,
+    )
+    checks.check(
+        "t-800-in-t14",
+        "(8,0,0) sits in the t=14 shell",
+        t800 == 14 and (8, 0, 0) in t14_reps and r2((8, 0, 0)) == 64,
+    )
+    checks.check(
+        "t8-t14-stay-mixed",
+        "t=8 and t=14 stay mixed",
+        t8_mixed and t14_mixed and "`t=8` and `t=14` stay mixed" in note,
+    )
+    checks.check(
+        "not-leftover-of-b12",
+        "the B_16 type census is not leftover of the B_12 table",
+        t1600 == 24
+        and l1((16, 0, 0)) == 16
+        and (16, 0, 0) in dist
+        and "not leftover of the `B_12(0)` type table" in note
+        and "(16,0,0)` is not in `B_12(0)`" in note,
+    )
+    checks.check(
+        "note-records-counts",
+        "note records site, type, and radius counts for both shells",
+        "| `8` | `140` | `7` | `5` |" in note
+        and "| `14` | `578` | `26` | `15` |" in note,
+    )
+    checks.check(
+        "note-records-memberships",
+        "note records (2,2,2) in t=8 and (4,4,4),(8,0,0) in t=14",
+        "t(2,2,2) = 8" in note
+        and "t(4,4,4) = 14" in note
+        and "t(8,0,0) = 14" in note
+        and "(2,2,2)` is in" in note
+        and "(4,4,4)`" in note
+        and "(8,0,0)`" in note,
+    )
+    checks.check(
+        "chiral-pairs-split",
+        "abs-sorted first-octant form still splits G+ chiral pairs",
+        gplus_orbit((3, 1, 2)).isdisjoint(gplus_orbit((3, 2, 1)))
+        and gplus_orbit((5, 3, 4)).isdisjoint(gplus_orbit((5, 4, 3)))
+        and ((3, 1, 2), 14, 24) in t8_rows
+        and ((3, 2, 1), 14, 24) in t8_rows
+        and ((5, 3, 4), 50, 24) in t14_rows
+        and ((5, 4, 3), 50, 24) in t14_rows,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and nu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and nu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and nu_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+    checks.check(
+        "b16-only",
+        "every named type stays inside B_16(0)",
+        all(l1(rep) <= 16 for rep, _, _ in t8_rows)
+        and all(l1(rep) <= 16 for rep, _, _ in t14_rows)
+        and "B_16(0) only" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_16(0) under nu, t=8 has 140 sites, 7 G+ types, 5 radii; t=14 has 578 sites, 26 types, 15 radii. Same counts as B12. (2,2,2) in t=8; (4,4,4) and (8,0,0) in t=14. Displayed, not adopted.

## Runner

`scripts/support_drop_isochrone_types_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.