### PR TITLE
feat(why22): t(16,0,0)=22 via detour that leaves B16 at (16,-1,0)

### DIFF
--- a/docs/SUPPORT_DROP_WHY_T1600_IS_22_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_WHY_T1600_IS_22_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,169 @@
+---
+claim_id: support_drop_why_t1600_is_22_b18_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "A lex-first shortest path to (16,0,0) under the named support-drop hop-cost on B_18(0) is named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py
+---
+
+# Lex-First Shortest Path To (16,0,0) On B_18(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_18(0)`,
+restricted to naming a lex-first shortest walk from `0` to `(16,0,0)` and
+the first site on that walk with `|v|_1 > 16`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py`](../scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost `ν` already scored on `B_16(0)` is
+scored independently on `B_18(0)`. The ball is not leftover of the two
+times: one origin Dijkstra is run on this ball, and a lex-first shortest
+path is named.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_18(0)`, the displayed
+rule `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first clause is seed-exit. The second is both weights `1`. The third is
+support drop. Those three clauses are the whole rule. Uniqueness is not
+claimed.
+
+One origin Dijkstra on `B_18(0)` (8473 sites; 8472 nonzero) gives
+`t(16,0,0) = 22`. Among all walks of that cost, the lexicographically first
+sequence of sites is
+
+`(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (5,-1,0) → (6,-1,0) → (7,-1,0) → (8,-1,0) → (9,-1,0) → (10,-1,0) → (11,-1,0) → (12,-1,0) → (13,-1,0) → (14,-1,0) → (15,-1,0) → (16,-1,0) → (16,0,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3` and
+running costs `3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 22`
+summing to `22`.
+
+The first site on that path with `|v|_1 > 16` is `(16,-1,0)`, which has
+ℓ¹ norm `17`. It is reached by the support-preserving hop
+`(15,-1,0) → (16,-1,0)` of cost `1`. The path does not stay in `B_16`.
+The next hop is the support-drop `(16,-1,0) → (16,0,0)` of cost `3`.
+
+On `B_16(0)` the site `(16,-1,0)` is absent. A displayed axis-parallel
+comparison walk that stays in `B_16(0)` is
+
+`(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (5,-1,0) → (6,-1,0) → (7,-1,0) → (8,-1,0) → (9,-1,0) → (10,-1,0) → (11,-1,0) → (12,-1,0) → (13,-1,0) → (14,-1,0) → (15,-1,0) → (15,0,0) → (16,0,0)`,
+
+with hop-costs `3` then fifteen cost-`1` steps then support-drop `3` then
+both-weights-`1` cost `3`, summing to `24`. That walk is displayed, not
+adopted, and is not a second Dijkstra. The pair of integers `24` and `22`
+is not the claim: the claim is the named path and the first site that
+leaves `B_16`.
+
+The rule is displayed, not adopted. Do not write `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_18(0) = { v ∈ Z^3 : |v|_1 ≤ 18 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_18(0)`,
+`t(v)` is the least sum of `ν` along a directed path from `0` to `v` in
+that graph.
+
+A walk is lex-first among shortest walks when its sequence of sites is
+the least tuple of integer triples, compared coordinatewise, among all
+walks of cost `t(16,0,0)`.
+
+The axis-skeleton comparator `α` uses only the first two clauses of `ν`.
+On the support-drop hop `(16,-1,0) → (16,0,0)` one has `|σ| : 2 → 1`, so
+`α = 1` while `ν = 3`. Therefore `α` cannot price support drop, and the
+`ν` scores below are not a leftover of `α`.
+
+## Theorem 1 — Arrival `t(16,0,0)` And A Lex-First Shortest Path
+
+On `B_18(0)` the computed arrival is `t(16,0,0) = 22`. The lex-first walk
+of that cost is the nineteen-site walk recorded above. The eighteen
+hop-costs are seed-exit `3` from `(0,0,0)` onto `(0,-1,0)`, one
+support-increase cost-`1` step `(0,-1,0) → (1,-1,0)`, fifteen
+support-preserving cost-`1` steps along the line `y = -1` from
+`(1,-1,0)` to `(16,-1,0)`, and a final support-drop `3` from
+`(16,-1,0)` onto `(16,0,0)`. The running costs after each hop are
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 22`.
+
+The same cost is realized by later walks that stay in the positive
+half-space, for example
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (2,1,0) → (3,1,0) → (4,1,0) → (5,1,0) → (6,1,0) → (7,1,0) → (8,1,0) → (9,1,0) → (10,1,0) → (11,1,0) → (12,1,0) → (13,1,0) → (14,1,0) → (15,1,0) → (16,1,0) → (16,0,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3`. That
+walk is also shortest, but `(0,-1,0)` precedes `(1,0,0)`, so it is not
+lex-first.
+
+This names a path. It is not leftover of the two times.
+
+## Theorem 2 — First Site With `|v|_1 > 16`
+
+On the lex-first walk the first site with `|v|_1 > 16` is `(16,-1,0)`,
+with ℓ¹ norm `17`. Every earlier site has ℓ¹ norm at most `16`. The
+leaving hop is `(15,-1,0) → (16,-1,0)`. The path does not stay in
+`B_16`. Displayed, not adopted.
+
+The integer `22` is therefore not the `B_16(0)` axis arrival `24`. The
+extra site `(16,-1,0)` is available only because the ball is `B_18(0)`.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ν` is a displayed scoring device on `B_18(0)`. Do not write `ν`
+into Admissibility. Do not attach L1. The exhibited walk is one shortest
+path under that displayed rule. Uniqueness is not claimed among hop-costs,
+and the walk is not offered as a replacement for unit-cost first arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "An exhibited lex-first shortest walk on the finite ball B_18(0) under one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_18(0) for the displayed rule ν; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ν` among hop-costs with this arrival or this walk.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_18(0)`.
+- Any reuse of the integers `22` and `24` as a substitute for exhibiting
+  the walk.
+- Any second Dijkstra on `B_16(0)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15746,
- "node_count": 5547,
+ "edge_count": 15747,
+ "node_count": 5548,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17977,6 +17977,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_why_t1600_is_22_b18_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_why_t1600_is_22_b18_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_why_t1600_is_22_b18_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py
+runner_sha256: ee4e762c906f326f034b89c1198e2c9852acd5f7d66e779d174a3dde0b1b70ab
+input_fingerprint_sha256: b56d8d4701e74be12713725ad457834ff1dd9124074b10194b19d10976b5057b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_WHY_T1600_IS_22_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: A lex-first shortest path to (16,0,0) under the named support-drop hop-cost on B_18(0) is named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the named-path statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ν is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 8473
+t(16,0,0) 22
+lex_first_path (0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (5,-1,0) → (6,-1,0) → (7,-1,0) → (8,-1,0) → (9,-1,0) → (10,-1,0) → (11,-1,0) → (12,-1,0) → (13,-1,0) → (14,-1,0) → (15,-1,0) → (16,-1,0) → (16,0,0)
+hop_costs 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3
+running_cost [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 22]
+hop_sum 22
+first_site_l1_gt_16 (17, (16, -1, 0))
+dijkstra_calls 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b18 B_18(0) has 8473 sites and 8472 nonzero sites
+PASS: t-1600 t(16,0,0) on B_18(0) equals 22
+PASS: valid-walk the exhibited walk is a nearest-neighbor walk in B_18(0) from 0 to (16,0,0)
+PASS: hop-costs-match recorded hop-costs equal ν on successive sites and sum to 22
+PASS: running-cost running costs are the partial sums of the hop-costs
+PASS: shortest the walk cost equals the Dijkstra arrival, so the walk is shortest
+PASS: lex-first-path the Dijkstra reconstruction is the named lex-first site sequence
+PASS: first-site-leaves-b16 the first site with |v|_1 > 16 is (16,-1,0)
+PASS: lex-first-beats-later-shortest a later cost-22 walk exists and is strictly lex-later
+PASS: lex-smaller-is-not-shortest a lex-smaller walk that starts toward -x costs more than 22
+PASS: b16-comparison-walk a displayed B_16-staying walk to (16,0,0) costs 24 and is not a Dijkstra
+PASS: note-records-path note records the lex-first sites, hop-costs, and running costs
+PASS: note-records-exit note records the first site that leaves B_16
+PASS: not-leftover-of-the-two-times the walk is not leftover of the two times
+PASS: not-leftover-of-alpha α cannot price the support-drop hop (16,-1,0)→(16,0,0)
+PASS: seed-and-axis-clauses seed-exit and support-drop cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py
+++ b/scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Exhibit the lex-first shortest 0→(16,0,0) walk under ν on B_18(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SUPPORT_DROP_WHY_T1600_IS_22_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_WHY_T1600_IS_22_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "A lex-first shortest path to (16,0,0) under the named "
+    "support-drop hop-cost on B_18(0) is named. "
+    "Displayed, not adopted."
+)
+TARGET = (16, 0, 0)
+NEIGH = ((-1, 0, 0), (0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0), (1, 0, 0))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_1600_REP = 22
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> set[tuple[int, int, int]]:
+    sites: set[tuple[int, int, int]] = set()
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.add((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def alpha_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1):
+        return 3
+    return 1
+
+
+def hop_costs(path: tuple[tuple[int, int, int], ...]) -> list[int]:
+    return [nu_cost(a, b) for a, b in zip(path, path[1:])]
+
+
+def format_path(path: tuple[tuple[int, int, int], ...]) -> str:
+    return " → ".join(f"({v[0]},{v[1]},{v[2]})" for v in path)
+
+
+def format_costs(costs: list[int]) -> str:
+    return ", ".join(str(c) for c in costs)
+
+
+def is_walk(path: tuple[tuple[int, int, int], ...], sites: set[tuple[int, int, int]]) -> bool:
+    if not path:
+        return False
+    for a, b in zip(path, path[1:]):
+        if a not in sites or b not in sites:
+            return False
+        if l1((a[0] - b[0], a[1] - b[1], a[2] - b[2])) != 1:
+            return False
+    return True
+
+
+def first_site_outside_b16(
+    path: tuple[tuple[int, int, int], ...],
+) -> tuple[int, tuple[int, int, int]] | None:
+    for i, v in enumerate(path):
+        if l1(v) > 16:
+            return i, v
+    return None
+
+
+def dijkstra_lex_first(
+    sites: set[tuple[int, int, int]],
+    target: tuple[int, int, int],
+) -> tuple[int, tuple[tuple[int, int, int], ...]]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    start_path = (origin,)
+    heap: list[tuple[int, tuple[tuple[int, int, int], ...]]] = [(0, start_path)]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        dist, path = heapq.heappop(heap)
+        v = path[-1]
+        if v in seen:
+            continue
+        seen.add(v)
+        if v == target:
+            return dist, path
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in sites or w in seen:
+                continue
+            heapq.heappush(heap, (dist + nu_cost(v, w), path + (w,)))
+    raise RuntimeError(f"target {target} unreachable")
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the named-path statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ν is not written into Admissibility",
+        "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(18)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    t1600, path = dijkstra_lex_first(sites, TARGET)
+    costs = hop_costs(path)
+    path_text = format_path(path)
+    cost_text = format_costs(costs)
+    running = []
+    acc = 0
+    for c in costs:
+        acc += c
+        running.append(acc)
+    running_text = format_costs(running)
+    exit_site = first_site_outside_b16(path)
+    later_shortest = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (3, 1, 0),
+        (4, 1, 0),
+        (5, 1, 0),
+        (6, 1, 0),
+        (7, 1, 0),
+        (8, 1, 0),
+        (9, 1, 0),
+        (10, 1, 0),
+        (11, 1, 0),
+        (12, 1, 0),
+        (13, 1, 0),
+        (14, 1, 0),
+        (15, 1, 0),
+        (16, 1, 0),
+        (16, 0, 0),
+    )
+    smaller_not_shortest = (
+        (0, 0, 0),
+        (-1, 0, 0),
+        (-1, -1, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (2, -1, 0),
+        (3, -1, 0),
+        (4, -1, 0),
+        (5, -1, 0),
+        (6, -1, 0),
+        (7, -1, 0),
+        (8, -1, 0),
+        (9, -1, 0),
+        (10, -1, 0),
+        (11, -1, 0),
+        (12, -1, 0),
+        (13, -1, 0),
+        (14, -1, 0),
+        (15, -1, 0),
+        (16, -1, 0),
+        (16, 0, 0),
+    )
+    b16_comparison = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (2, -1, 0),
+        (3, -1, 0),
+        (4, -1, 0),
+        (5, -1, 0),
+        (6, -1, 0),
+        (7, -1, 0),
+        (8, -1, 0),
+        (9, -1, 0),
+        (10, -1, 0),
+        (11, -1, 0),
+        (12, -1, 0),
+        (13, -1, 0),
+        (14, -1, 0),
+        (15, -1, 0),
+        (15, 0, 0),
+        (16, 0, 0),
+    )
+    expected_path = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (2, -1, 0),
+        (3, -1, 0),
+        (4, -1, 0),
+        (5, -1, 0),
+        (6, -1, 0),
+        (7, -1, 0),
+        (8, -1, 0),
+        (9, -1, 0),
+        (10, -1, 0),
+        (11, -1, 0),
+        (12, -1, 0),
+        (13, -1, 0),
+        (14, -1, 0),
+        (15, -1, 0),
+        (16, -1, 0),
+        (16, 0, 0),
+    )
+    expected_costs = [3] + [1] * 16 + [3]
+    expected_running = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 22]
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(16,0,0) {t1600}")
+    print(f"lex_first_path {path_text}")
+    print(f"hop_costs {cost_text}")
+    print(f"running_cost {running}")
+    print(f"hop_sum {sum(costs)}")
+    print(f"first_site_l1_gt_16 {exit_site}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b18",
+        "B_18(0) has 8473 sites and 8472 nonzero sites",
+        len(sites) == 8473 and len(nonzero) == 8472 and all(l1(v) <= 18 for v in sites),
+    )
+    checks.check(
+        "t-1600",
+        "t(16,0,0) on B_18(0) equals 22",
+        t1600 == T_1600_REP,
+    )
+    checks.check(
+        "valid-walk",
+        "the exhibited walk is a nearest-neighbor walk in B_18(0) from 0 to (16,0,0)",
+        path[0] == (0, 0, 0) and path[-1] == TARGET and is_walk(path, sites),
+    )
+    checks.check(
+        "hop-costs-match",
+        "recorded hop-costs equal ν on successive sites and sum to 22",
+        costs == expected_costs and sum(costs) == 22,
+    )
+    checks.check(
+        "running-cost",
+        "running costs are the partial sums of the hop-costs",
+        running == expected_running,
+    )
+    checks.check(
+        "shortest",
+        "the walk cost equals the Dijkstra arrival, so the walk is shortest",
+        sum(costs) == t1600,
+    )
+    checks.check(
+        "lex-first-path",
+        "the Dijkstra reconstruction is the named lex-first site sequence",
+        path == expected_path,
+    )
+    checks.check(
+        "first-site-leaves-b16",
+        "the first site with |v|_1 > 16 is (16,-1,0)",
+        exit_site == (17, (16, -1, 0))
+        and l1((16, -1, 0)) == 17
+        and all(l1(v) <= 16 for v in path[:17]),
+    )
+    checks.check(
+        "lex-first-beats-later-shortest",
+        "a later cost-22 walk exists and is strictly lex-later",
+        is_walk(later_shortest, sites)
+        and sum(hop_costs(later_shortest)) == 22
+        and path < later_shortest,
+    )
+    checks.check(
+        "lex-smaller-is-not-shortest",
+        "a lex-smaller walk that starts toward -x costs more than 22",
+        is_walk(smaller_not_shortest, sites)
+        and smaller_not_shortest < path
+        and sum(hop_costs(smaller_not_shortest)) > 22,
+    )
+    checks.check(
+        "b16-comparison-walk",
+        "a displayed B_16-staying walk to (16,0,0) costs 24 and is not a Dijkstra",
+        is_walk(b16_comparison, sites)
+        and all(l1(v) <= 16 for v in b16_comparison)
+        and (16, -1, 0) not in b16_comparison
+        and sum(hop_costs(b16_comparison)) == 24
+        and l1((16, -1, 0)) == 17,
+    )
+    checks.check(
+        "note-records-path",
+        "note records the lex-first sites, hop-costs, and running costs",
+        path_text in note and cost_text in note and running_text in note,
+    )
+    checks.check(
+        "note-records-exit",
+        "note records the first site that leaves B_16",
+        "`(16,-1,0)`" in note
+        and "`17`" in note
+        and "(15,-1,0) → (16,-1,0)" in note
+        and "does not stay in `B_16`" in note,
+    )
+    checks.check(
+        "not-leftover-of-the-two-times",
+        "the walk is not leftover of the two times",
+        "not leftover of the two times" in note
+        and t1600 == 22
+        and t1600 != 24,
+    )
+    checks.check(
+        "not-leftover-of-alpha",
+        "α cannot price the support-drop hop (16,-1,0)→(16,0,0)",
+        nu_cost((16, -1, 0), (16, 0, 0)) == 3
+        and alpha_cost((16, -1, 0), (16, 0, 0)) == 1
+        and "cannot price support drop" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and support-drop cost 3; support increase costs 1",
+        nu_cost((0, 0, 0), (0, -1, 0)) == 3
+        and nu_cost((0, -1, 0), (1, -1, 0)) == 1
+        and nu_cost((15, -1, 0), (16, -1, 0)) == 1
+        and nu_cost((16, -1, 0), (16, 0, 0)) == 3
+        and nu_cost((15, 0, 0), (16, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_18(0) under nu, lex-first path hop-costs 3+1^16+3=22. First site with |v|_1>16 is (16,-1,0). Displayed, not adopted.

## Runner

`scripts/support_drop_why_t1600_is_22_b18_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.