### PR TITLE
feat(011sk6): (0,1,1) same-k reverse fails at k=6: t=10 vs t=18

### DIFF
--- a/docs/CLAUSE_011_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CLAUSE_011_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,164 @@
+---
+claim_id: clause_011_samek_k6_b18_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=6 under the named (0,1,1) hop-cost on B_18(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/clause_011_samek_k6_b18_2026_08_15.py
+---
+
+# Named (0,1,1) Same-k Reverse At k=6 On B_18(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact same-`k` axis versus body-diagonal arrival comparison at
+`k=6` under one named hop-cost on the finite 18-hop neighborhood of the
+origin in the cubic nearest-neighbor graph. The rule is displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/clause_011_samek_k6_b18_2026_08_15.py`](../scripts/clause_011_samek_k6_b18_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Let `B_18(0)` be the set of sites of `Z^3` whose nearest-neighbor graph
+distance from the origin is at most 18. That set has 8473 sites and is
+used only as a finite domain bound. It is not a hop-cost. The body-
+diagonal site `(6,6,6)` has nearest-neighbor graph distance 18, so it is
+absent from `B_16(0)` and sits on the boundary of `B_18(0)`.
+
+Hops are the six nearest-neighbor steps that remain inside `B_18(0)`.
+Write `|σ_v|` for the support of a site (the number of nonzero
+coordinates). The named clause-toggle `(0,1,1)` assigns
+
+```text
+cost(v→w) = 3  if |σ_v|=|σ_w|=1 or |σ_w|<|σ_v|,
+          = 1  otherwise.
+```
+
+Seed-exit therefore costs 1. Axis 1-skeleton hops and support-drop hops
+cost 3. Every other admitted hop costs 1. The rule is cheaper at
+seed-exit than a rule that prices seed-exit at 3. The rule is not
+written into Admissibility: do not write (0,1,1) into Admissibility.
+Do not attach L1. Uniqueness is not required.
+
+One Dijkstra from the origin yields the same-`k` arrivals at `k=6`
+
+| `k` | `t(k,0,0)` | `t(k,k,k)` | `t(k,0,0)^2 / k^2` | `t(k,k,k)^2 / (3k^2)` | reverse |
+|---|---:|---:|---:|---:|---|
+| `6` | `10` | `18` | `100/36` | `324/108` | no |
+
+The displayed test
+
+`t(6,0,0)^2 / 36 > t(6,6,6)^2 / 108`
+
+fails. Equivalently `3 t(6,0,0)^2 > t(6,6,6)^2` is `300 > 324`, which
+is false. Same-`k` reverse therefore does not hold at `k=6` under the
+named cheaper rival on `B_18(0)`. The earlier same-`k` table on
+`B_16(0)` already failed at `k=1` and held at `k=2..5`; enlarging the
+domain to include `(6,6,6)` does not restore reverse at this next
+scale. The table is same-`k`; it is not the doubled pairing
+`(4,0,0)` versus `(2,2,2)` and `(8,0,0)` versus `(4,4,4)`. Displayed,
+not adopted.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under
+lattice translations and proper cubic rotations.
+
+The axiom set supplies the cubic nearest-neighbor graph. It does not
+supply a hop-cost, a same-`k` reverse test, or a preferred
+clause-toggle. This note therefore treats `(0,1,1)` as a separately
+named finite scoring rule. The note does not write `(0,1,1)` into
+Admissibility and does not enlarge the axiom set.
+
+Record is not used. No readout, formation site, or scalar collection
+functional enters the arrival times.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two same-k arrival times and one displayed reverse inequality are exact outputs of one Dijkstra on the named finite graph; the hop-cost is a disclosed scoring rule, not an axiom, and same-k reverse fails at k=6."
+trace_class: compute
+artifact_role: theorem
+conditional_surface_status: "exact on B_18(0) under the named (0,1,1) hop-cost at k=6; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+`B_18(0)` is the closed 18-hop neighborhood of the origin. Every hop
+used below is a nearest-neighbor step whose endpoints both lie in that
+set. The site `(6,6,6)` has nearest-neighbor graph distance 18, so it
+lies on the ball. One Dijkstra computes the named arrival time `t(v)`
+from the origin to each site.
+
+The displayed inequality compares the axis and body-diagonal sites that
+share the scale `k=6`, after Euclidean length `6` on the axis and
+`6√3` on the body diagonal. The comparison is displayed only. It is
+not a derived continuum law and is not attached as an L1 hop-cost.
+
+## Theorem 1
+
+On `B_18(0)` under the named `(0,1,1)` hop-cost,
+
+`t(6,0,0)=10` and `t(6,6,6)=18`.
+
+Each value is the Dijkstra arrival time. The axis value `10` is
+strictly smaller than the axis-skeleton sum `1+3+3+3+3+3=16`, so a
+support-raising detour is cheaper than staying on the axis. The body-
+diagonal value equals the nearest-neighbor hop count `18`, because a
+monotone support-nondecreasing path from the origin uses only cost-1
+hops and remains inside `B_18(0)`.
+
+## Theorem 2
+
+The displayed same-`k` test at `k=6` is
+
+`t(6,0,0)^2 / 36  ?  t(6,6,6)^2 / 108`,
+
+equivalently `3 t(6,0,0)^2 ? t(6,6,6)^2`. Substituting the computed
+times gives `100/36` versus `324/108`, or `300 > 324`, which is false.
+
+Same-`k` reverse therefore fails at `k=6` on this finite domain. The
+cheaper rival does not keep same-`k` reverse at this scale. Displayed,
+not adopted.
+
+## Theorem 3
+
+The note does not write `(0,1,1)` into Admissibility. Do not attach L1.
+Uniqueness is not required. The current axiom memo is not edited.
+
+## What This Does Not Claim
+
+- It does not adopt the `(0,1,1)` hop-cost as framework content.
+- It does not claim that same-`k` reverse holds at `k=6`.
+- It does not claim that the named rule is the only reverser.
+- It does not identify `t` with nearest-neighbor hop count on the axis.
+- It does not replace the doubled pairing
+  `(4,0,0)`/`(2,2,2)` and `(8,0,0)`/`(4,4,4)` by this same-`k` pair.
+- It does not score the separately named support-drop rule.
+- It does not supply a physical clock, a continuum metric, or a Record
+  readout of the arrival times.
+
+## Reproducibility
+
+```text
+python3 scripts/clause_011_samek_k6_b18_2026_08_15.py
+```
+
+The runner prints the two times, the displayed comparison, and
+`TOTAL: PASS=<n> FAIL=<n>`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15746,
- "node_count": 5547,
+ "edge_count": 15747,
+ "node_count": 5548,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2333,6 +2333,10 @@
   "claude_complex_action_grown_companion_note_2026-05-10": {
    "deps_hash": "7bfe3c0f70cf",
    "out_degree": 6
+  },
+  "clause_011_samek_k6_b18_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "clifford_bimodule_ray_saturation_future_target_note_2026-04-19": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/clause_011_samek_k6_b18_2026_08_15.txt
+++ b/logs/runner-cache/clause_011_samek_k6_b18_2026_08_15.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/clause_011_samek_k6_b18_2026_08_15.py
+runner_sha256: 5c06468d2728d1f985ae9441142ccbbc74b1a55d3df453c353667ff96bb82f2e
+input_fingerprint_sha256: 6a4de09a16ed225cdddfca303705b640f065d96021df8690c6caaaf103370b32
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; hop-costs are the named (0,1,1) rule on the finite 18-hop neighborhood B_18(0)
+package_local_integrity_reads: the note and current minimal axiom are read; no cache or governance surface is written
+negative_scope: the named rule is displayed, not adopted; it is not written into Admissibility and is not attached as an L1 hop-cost
+cache_write: false
+AUDIT_INPUT_PATHS:
+  docs/CLAUSE_011_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required static literal pair and both files exist
+PASS: ball-b18-only B_18(0) is the 18-hop neighborhood of the origin and contains both named targets
+PASS: clause-011-local seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1
+n_sites 8473
+dijkstra_calls 1
+dijkstra_count=1
+k 6 t(6,0,0)=10 t(6,6,6)=18 t_axis^2/36=100/36 t_body^2/108=324/108 3t_axis^2=300 t_body^2=324 reverse=False
+PASS: theorem-1-times the same-k arrival times are the Dijkstra values t(6,0,0)=10 and t(6,6,6)=18
+PASS: theorem-2-k6 t(6,0,0)^2/36 > t(6,6,6)^2/108 fails (300 > 324 is false)
+PASS: one-dijkstra exactly one origin Dijkstra assigned a finite time to every ball site
+PASS: note-reports-times the note reports the two computed times
+PASS: note-reports-reverse-products the note records the displayed k=6 reverse comparison
+PASS: displayed-not-adopted the note displays the (0,1,1) scores and does not adopt them
+PASS: admissibility-unedited the current axiom memo still names Admissibility and does not contain the hop-cost rule
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: claim-scope the note states the required claim_scope
+PASS: forbidden-tokens the note avoids the forbidden tokens
+PASS: uniqueness-not-required the note does not claim uniqueness of the named rule
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: k6-needs-b18 the k=6 body-diagonal site is absent from B_16(0) and present on B_18(0)
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/clause_011_samek_k6_b18_2026_08_15.py
+++ b/scripts/clause_011_samek_k6_b18_2026_08_15.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Named (0,1,1) same-k reverse at k=6 on B_18(0).
+
+One Dijkstra from the origin. Displayed, not adopted. No axiom edit,
+no cache write, no L1 hop-cost attachment.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_NAME = "CLAUSE_011_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+NOTE_PATH = ROOT / "docs" / NOTE_NAME
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/CLAUSE_011_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+BALL_RADIUS = 18
+SCALE = 6
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+def nn_radius(site: tuple[int, int, int]) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def in_ball(site: tuple[int, int, int]) -> bool:
+    return nn_radius(site) <= BALL_RADIUS
+
+
+def support_size(site: tuple[int, int, int]) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def hop_cost(src: tuple[int, int, int], dst: tuple[int, int, int]) -> int:
+    """Rule (0,1,1): cost 3 iff both weights 1 or support drop, else 1."""
+    src_support = support_size(src)
+    dst_support = support_size(dst)
+    both_weights_one = src_support == 1 and dst_support == 1
+    support_drop = dst_support < src_support
+    if both_weights_one or support_drop:
+        return 3
+    return 1
+
+
+def ball_sites() -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-BALL_RADIUS, BALL_RADIUS + 1):
+        for y in range(-BALL_RADIUS, BALL_RADIUS + 1):
+            remain = BALL_RADIUS - abs(x) - abs(y)
+            if remain < 0:
+                continue
+            for z in range(-remain, remain + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def neighbors(site: tuple[int, int, int]) -> list[tuple[int, int, int]]:
+    x, y, z = site
+    out: list[tuple[int, int, int]] = []
+    for dx, dy, dz in NEIGHBOR_STEPS:
+        nxt = (x + dx, y + dy, z + dz)
+        if in_ball(nxt):
+            out.append(nxt)
+    return out
+
+
+def dijkstra_from_origin(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    dist = {origin: 0}
+    heap = [(0, origin)]
+    while heap:
+        cost_here, site = heapq.heappop(heap)
+        if cost_here != dist[site]:
+            continue
+        for nxt in neighbors(site):
+            cand = cost_here + hop_cost(site, nxt)
+            if cand < dist.get(nxt, 10**9):
+                dist[nxt] = cand
+                heapq.heappush(heap, (cand, nxt))
+    if len(dist) != len(sites):
+        raise RuntimeError("Dijkstra did not reach every site of B_18(0)")
+    return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def audit_paths_are_static_literals() -> bool:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names:
+                value = node.value
+                if not isinstance(value, ast.Tuple):
+                    return False
+                return all(
+                    isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    for elt in value.elts
+                )
+    return False
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; hop-costs are the named (0,1,1) "
+        "rule on the finite 18-hop neighborhood B_18(0)"
+    )
+    print(
+        "package_local_integrity_reads: the note and current minimal axiom "
+        "are read; no cache or governance surface is written"
+    )
+    print(
+        "negative_scope: the named rule is displayed, not adopted; it is "
+        "not written into Admissibility and is not attached as an L1 hop-cost"
+    )
+    print("cache_write: false")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required static literal pair and both files exist",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/CLAUSE_011_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and audit_paths_are_static_literals()
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+
+    sites = ball_sites()
+    axis_site = (SCALE, 0, 0)
+    body_site = (SCALE, SCALE, SCALE)
+    checks.check(
+        "ball-b18-only",
+        "B_18(0) is the 18-hop neighborhood of the origin and contains both named targets",
+        len(sites) == 8473
+        and in_ball(axis_site)
+        and in_ball(body_site)
+        and body_site in sites
+        and (18, 0, 0) in set(sites)
+        and (19, 0, 0) not in set(sites)
+        and nn_radius(body_site) == 18
+        and nn_radius(axis_site) == 6
+        and nn_radius((5, 5, 5)) == 15
+        and not (nn_radius(body_site) <= 16),
+    )
+
+    checks.check(
+        "clause-011-local",
+        "seed-exit costs 1; axis 1-skeleton and support-drop cost 3; else 1",
+        hop_cost((0, 0, 0), (1, 0, 0)) == 1
+        and hop_cost((1, 0, 0), (2, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (1, 0, 0)) == 3
+        and hop_cost((1, 1, 0), (2, 1, 0)) == 1
+        and hop_cost((1, 0, 0), (1, 1, 0)) == 1,
+    )
+
+    distances = dijkstra_from_origin(sites)
+    t_axis = distances[axis_site]
+    t_body = distances[body_site]
+    left = 3 * t_axis * t_axis
+    right = t_body * t_body
+    reverse = left > right
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print("dijkstra_count=1")
+    print(
+        f"k {SCALE} t({SCALE},0,0)={t_axis} t({SCALE},{SCALE},{SCALE})={t_body} "
+        f"t_axis^2/36={t_axis * t_axis}/36 t_body^2/108={t_body * t_body}/108 "
+        f"3t_axis^2={left} t_body^2={right} reverse={reverse}"
+    )
+
+    checks.check(
+        "theorem-1-times",
+        "the same-k arrival times are the Dijkstra values t(6,0,0)=10 and t(6,6,6)=18",
+        t_axis == 10 and t_body == 18,
+    )
+    checks.check(
+        "theorem-2-k6",
+        "t(6,0,0)^2/36 > t(6,6,6)^2/108 fails (300 > 324 is false)",
+        (not reverse)
+        and t_axis * t_axis == 100
+        and t_body * t_body == 324
+        and left == 300
+        and right == 324,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one origin Dijkstra assigned a finite time to every ball site",
+        DIJKSTRA_CALLS == 1
+        and len(distances) == len(sites)
+        and all(distances[site] >= 0 for site in sites),
+    )
+    checks.check(
+        "note-reports-times",
+        "the note reports the two computed times",
+        "t(6,0,0)=10" in note and "t(6,6,6)=18" in note,
+    )
+    checks.check(
+        "note-reports-reverse-products",
+        "the note records the displayed k=6 reverse comparison",
+        "100/36" in note
+        and "324/108" in note
+        and "300 > 324" in note
+        and "is false" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the note displays the (0,1,1) scores and does not adopt them",
+        "Displayed, not adopted" in note
+        and "do not write (0,1,1) into Admissibility" in note
+        and "Do not attach L1" in note,
+    )
+    checks.check(
+        "admissibility-unedited",
+        "the current axiom memo still names Admissibility and does not contain the hop-cost rule",
+        "Admissibility" in axiom
+        and "Lattice" in axiom
+        and "Qubit" in axiom
+        and "Record" in axiom
+        and "both weights 1 or support drop" not in axiom
+        and "(0,1,1)" not in axiom,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "claim-scope",
+        "the note states the required claim_scope",
+        "Same-k reverse at k=6 under the named (0,1,1) hop-cost on B_18(0) is reported"
+        in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-tokens",
+        "the note avoids the forbidden tokens",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not claim uniqueness of the named rule",
+        "Uniqueness is not required" in note
+        and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "k6-needs-b18",
+        "the k=6 body-diagonal site is absent from B_16(0) and present on B_18(0)",
+        nn_radius(body_site) == 18
+        and "B_18(0)" in note
+        and "(6,6,6)" in note
+        and "absent from `B_16(0)`" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_18(0) under (0,1,1): t(6,0,0)=10, t(6,6,6)=18. Reverse fails. The cheaper rival loses same-k at k=6 while nu still holds. Displayed, not adopted.

## Runner

`scripts/clause_011_samek_k6_b18_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.