### PR TITLE
feat(facek18): on B18, nu face reverse still holds k=1..3 and fails k=4..8

### DIFF
--- a/docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,321 @@
+---
+claim_id: support_drop_face_reverse_vs_k_b18_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_18(0) is reported for available k=1..8. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py
+---
+
+# Face-Diagonal Reverse Versus Integer Scale k Under The Support-Drop Hop-Cost On B_18(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one directed Dijkstra on the nearest-neighbor graph of the
+ball $B_{18}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 18\}$ for the named support-drop
+hop-cost $\nu$. Face-diagonal reverse versus integer scale $k$ is reported
+for each available $k=1,\ldots,8$. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py`](../scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named support-drop hop-cost $\nu$ already scored on $B_{16}(0)$ for
+$k=1,\ldots,8$ (bits yes/yes/yes/no/no/no/no/no) is scored here independently
+on $B_{18}(0)$ against integer scale $k$ for every pair
+$((2k,0,0),(k,k,0))$ whose both sites lie in $B_{18}(0)$. For $k=1,\ldots,8$
+every such site is in the ball, so no pair is omitted. The eight bits are not
+leftover of the $B_{16}(0)$ face-versus-$k$ table: $t(16,0,0)=22$ on this ball
+is not the $B_{16}(0)$ value $24$. The larger ball admits the corridor hop
+$(16,1,0)\to(16,0,0)$ with $|(16,1,0)|_1=17$, a site absent from $B_{16}(0)$.
+The $k=8$ axis time is an independent Dijkstra output on $B_{18}(0)$.
+
+Let $\sigma_v=\{i\in\{1,2,3\}:v_i\neq 0\}$ and write $|\sigma_v|$ for its
+cardinality. On every nearest-neighbor hop $v\to w$ that remains inside
+$B_{18}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 18\}$, the named support-drop hop-cost is
+
+$$
+\nu(v\to w)=
+\begin{cases}
+3 & \text{if }|\sigma_v|=0\text{ or }(|\sigma_v|=|\sigma_w|=1)\text{ or }|\sigma_w|<|\sigma_v|,\\
+1 & \text{otherwise.}
+\end{cases}
+$$
+
+Uniqueness is not claimed among hop-costs. A single Dijkstra computation from
+the origin on this directed weighted graph returns the arrival times
+
+$$
+t(2,0,0)=6,\qquad t(4,0,0)=10,\qquad t(6,0,0)=12,\qquad t(8,0,0)=14,
+$$
+$$
+t(10,0,0)=16,\qquad t(12,0,0)=18,\qquad t(14,0,0)=20,\qquad t(16,0,0)=22,
+$$
+$$
+t(1,1,0)=4,\qquad t(2,2,0)=6,\qquad t(3,3,0)=8,\qquad t(4,4,0)=10,
+$$
+$$
+t(5,5,0)=12,\qquad t(6,6,0)=14,\qquad t(7,7,0)=16,\qquad t(8,8,0)=18.
+$$
+
+For each available $k=1,\ldots,8$, reverse means the displayed comparison
+
+$$
+\frac{t(2k,0,0)^2}{4k^2}>\frac{t(k,k,0)^2}{2k^2}
+$$
+
+holds, equivalently $t(k,k,0)^2\cdot 4k^2<t(2k,0,0)^2\cdot 2k^2$. The bit is
+displayed, not adopted.
+
+| $k$ | pair | axis $t^2/|v|_2^2$ | face $t^2/|v|_2^2$ | reverse |
+|---|---|---|---|---|
+| $1$ | $((2,0,0),(1,1,0))$ | $36/4=9$ | $16/2=8$ | yes |
+| $2$ | $((4,0,0),(2,2,0))$ | $100/16=25/4$ | $36/8=9/2$ | yes |
+| $3$ | $((6,0,0),(3,3,0))$ | $144/36=4$ | $64/18=32/9$ | yes |
+| $4$ | $((8,0,0),(4,4,0))$ | $196/64=49/16$ | $100/32=25/8$ | no |
+| $5$ | $((10,0,0),(5,5,0))$ | $256/100=64/25$ | $144/50=72/25$ | no |
+| $6$ | $((12,0,0),(6,6,0))$ | $324/144=9/4$ | $196/72=49/18$ | no |
+| $7$ | $((14,0,0),(7,7,0))$ | $400/196=100/49$ | $256/98=128/49$ | no |
+| $8$ | $((16,0,0),(8,8,0))$ | $484/256=121/64$ | $324/128=81/32$ | no |
+
+Exact integer comparisons:
+
+- $4\,t(1,1,0)^2=64<72=2\,t(2,0,0)^2$
+- $16\,t(2,2,0)^2=576<800=8\,t(4,0,0)^2$
+- $36\,t(3,3,0)^2=2304<2592=18\,t(6,0,0)^2$
+- $64\,t(4,4,0)^2=6400>6272=32\,t(8,0,0)^2$
+- $100\,t(5,5,0)^2=14400>12800=50\,t(10,0,0)^2$
+- $144\,t(6,6,0)^2=28224>23328=72\,t(12,0,0)^2$
+- $196\,t(7,7,0)^2=50176>39200=98\,t(14,0,0)^2$
+- $256\,t(8,8,0)^2=82944>61952=128\,t(16,0,0)^2$
+
+The reverse bit is therefore not the same for every available $k=1,\ldots,8$.
+Reverse holds at $k=1,2,3$ and fails at $k=4,5,6,7,8$. The $k=3$ bit still
+holds on $B_{18}(0)$: $32/9<4$. The $k=8$ fail is scored with the cheapened
+axis time $t(16,0,0)=22$, not with the $B_{16}(0)$ value $24$. These eight
+bits are not leftover of the $B_{16}(0)$ table. The score is displayed, not
+adopted. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility is not a dynamics axiom. It does not choose a Hamiltonian or
+transfer operator, supply transition-probability or weight values, select a
+scalar or nonzero kinetic branch, assert a Dirac-square carrier, define a time
+metric, or provide a record-production process or physical persistence
+dynamics.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The named hop-cost $\nu$ is a displayed scoring rule on the nearest-neighbor
+graph of $B_{18}(0)$. It is not written into Admissibility. It is not attached to L1.
+It supplies no time metric, no Record formation rule, and no physical hop law.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Arrival times and eight face-versus-axis reverse bits versus integer scale k on B_18(0) are finite exact Dijkstra values for a named hop-cost; the hop-cost is displayed, not adopted."
+trace_class: upstream_support
+target_claim_id: support_drop_face_reverse_vs_k_b18_bounded_theorem_note_2026-08-15
+target_blocker_text: "the named hop-cost is displayed, not adopted, and is not Admissibility content"
+source_of_blocker_text: this note
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the face-versus-axis reverse bits versus k as a displayed B_18(0) score; do not write nu into Admissibility."
+conditional_surface_status: "exact for the named support-drop hop-cost on B_18(0); not adopted as a law"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write $0=(0,0,0)$ and $B_{18}(0)=\{v\in\mathbb{Z}^3:|v|_1\le 18\}$. This set has
+$8473$ sites, of which $8472$ are nonzero. The directed graph is the
+nearest-neighbor graph of $\mathbb{Z}^3$ induced on $B_{18}(0)$: from $v$ there
+is an edge to $w=v\pm e_i$ exactly when $w\in B_{18}(0)$.
+
+The support $\sigma_v$ and the hop-cost $\nu$ are as in Result Up Front. In
+words: seed exit from the origin costs $3$; every hop that stays on a
+coordinate axis costs $3$; every hop that strictly drops the number of
+nonzero coordinates costs $3$; every other in-ball nearest-neighbor hop
+costs $1$.
+
+Arrival time $t(v)$ is the least $\nu$-length of a directed path from $0$ to
+$v$ in this graph. One Dijkstra computation from the origin produces every
+$t(v)$ used below.
+
+The Euclidean squared length is $|v|_2^2=v_1^2+v_2^2+v_3^2$. The displayed
+comparison density is $t(v)^2/|v|_2^2$ at $v\neq 0$. For each integer
+$k=1,\ldots,8$ the ordered pair is $((2k,0,0),(k,k,0))$. Both sites have
+$\ell^1$ norm at most $16$, so both lie in $B_{18}(0)$ and no pair is omitted.
+The second site is the more-diagonal site (strictly more nonzero coordinates).
+The pair is reverse when
+
+$$
+t(k,k,0)^2\cdot|(2k,0,0)|_2^2 < t(2k,0,0)^2\cdot|(k,k,0)|_2^2,
+$$
+
+which is the same comparison as $t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$.
+
+The $B_{16}(0)$ face-versus-$k$ table uses $t(16,0,0)=24$ forced by the
+radius-$16$ wall: the only in-ball neighbor of $(16,0,0)$ on that ball is
+$(15,0,0)$. It does not determine $t(16,0,0)$ on $B_{18}(0)$. The $k=1,\ldots,8$
+table is therefore not leftover of the $B_{16}(0)$ face-versus-$k$ bits.
+
+## Theorem 1 — Named Arrival Times At Each Available Scale
+
+On $B_{18}(0)$ under $\nu$, for each $k=1,\ldots,8$ the sites $(2k,0,0)$ and
+$(k,k,0)$ lie in the ball, so both times are reported and none is omitted:
+
+$$
+\begin{align*}
+t(2,0,0)&=6,& t(1,1,0)&=4,\\
+t(4,0,0)&=10,& t(2,2,0)&=6,\\
+t(6,0,0)&=12,& t(3,3,0)&=8,\\
+t(8,0,0)&=14,& t(4,4,0)&=10,\\
+t(10,0,0)&=16,& t(5,5,0)&=12,\\
+t(12,0,0)&=18,& t(6,6,0)&=14,\\
+t(14,0,0)&=20,& t(7,7,0)&=16,\\
+t(16,0,0)&=22,& t(8,8,0)&=18.
+\end{align*}
+$$
+
+These sixteen values are Dijkstra outputs, not fitted scalars.
+
+Witnessing paths of those $\nu$-costs exist. The walk
+
+$0\to(1,0,0)\to(2,0,0)$
+
+has hop-costs $3,3$ and sum $6$. The walk
+
+$0\to(1,0,0)\to(1,1,0)$
+
+has hop-costs $3,1$ and sum $4$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(4,0,0)$
+
+has hop-costs $3,1,1,1,1,3$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(2,2,0)$
+
+has hop-costs $3,1,1,1$ and sum $6$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(6,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,3$ and sum $12$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(2,3,0)\to(3,3,0)$
+
+has hop-costs $3,1,1,1,1,1$ and sum $8$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(8,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,3$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(2,4,0)\to(3,4,0)\to(4,4,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1$ and sum $10$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(10,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,3$ and sum $16$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(2,5,0)\to(3,5,0)\to(4,5,0)\to(5,5,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1$ and sum $12$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(11,1,0)\to(12,1,0)\to(12,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,1,3$ and sum $18$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(1,6,0)\to(2,6,0)\to(3,6,0)\to(4,6,0)\to(5,6,0)\to(6,6,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1$ and sum $14$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(11,1,0)\to(12,1,0)\to(13,1,0)\to(14,1,0)\to(14,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,3$ and sum $20$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(1,6,0)\to(1,7,0)\to(2,7,0)\to(3,7,0)\to(4,7,0)\to(5,7,0)\to(6,7,0)\to(7,7,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,1,1$ and sum $16$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(2,1,0)\to(3,1,0)\to(4,1,0)\to(5,1,0)\to(6,1,0)\to(7,1,0)\to(8,1,0)\to(9,1,0)\to(10,1,0)\to(11,1,0)\to(12,1,0)\to(13,1,0)\to(14,1,0)\to(15,1,0)\to(16,1,0)\to(16,0,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,3$ and sum $22$. The walk
+
+$0\to(1,0,0)\to(1,1,0)\to(1,2,0)\to(1,3,0)\to(1,4,0)\to(1,5,0)\to(1,6,0)\to(1,7,0)\to(1,8,0)\to(2,8,0)\to(3,8,0)\to(4,8,0)\to(5,8,0)\to(6,8,0)\to(7,8,0)\to(8,8,0)$
+
+has hop-costs $3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1$ and sum $18$.
+
+The site $(16,1,0)$ has $\ell^1$ norm $17$, so it is not in $B_{16}(0)$. The
+last hop $(16,1,0)\to(16,0,0)$ is the support-drop of cost $3$ that cheapens
+$t(16,0,0)$ from the wall value $24$ to $22$.
+
+## Theorem 2 — Reverse Bit Versus Integer Scale k
+
+For each available $k=1,\ldots,8$ the displayed comparison is whether
+$t(2k,0,0)^2/(4k^2)>t(k,k,0)^2/(2k^2)$. The eight bits are:
+
+- $k=1$: $t(1,1,0)^2/|(1,1,0)|_2^2=8<9=t(2,0,0)^2/|(2,0,0)|_2^2$ (yes)
+- $k=2$: $t(2,2,0)^2/|(2,2,0)|_2^2=9/2<25/4=t(4,0,0)^2/|(4,0,0)|_2^2$ (yes)
+- $k=3$: $t(3,3,0)^2/|(3,3,0)|_2^2=32/9<4=t(6,0,0)^2/|(6,0,0)|_2^2$ (yes)
+- $k=4$: $t(4,4,0)^2/|(4,4,0)|_2^2=25/8\not<49/16=t(8,0,0)^2/|(8,0,0)|_2^2$ (no)
+- $k=5$: $t(5,5,0)^2/|(5,5,0)|_2^2=72/25\not<64/25=t(10,0,0)^2/|(10,0,0)|_2^2$ (no)
+- $k=6$: $t(6,6,0)^2/|(6,6,0)|_2^2=49/18\not<9/4=t(12,0,0)^2/|(12,0,0)|_2^2$ (no)
+- $k=7$: $t(7,7,0)^2/|(7,7,0)|_2^2=128/49\not<100/49=t(14,0,0)^2/|(14,0,0)|_2^2$ (no)
+- $k=8$: $t(8,8,0)^2/|(8,8,0)|_2^2=81/32\not<121/64=t(16,0,0)^2/|(16,0,0)|_2^2$ (no)
+
+The $k=3$ bit still holds. Reverse holds at $k=1,2,3$ and fails at
+$k=4,5,6,7,8$. The $B_{16}(0)$ table does not determine the $k=8$ axis time
+on this ball.
+
+These reverse bits are displayed, not adopted.
+
+## Theorem 3 — Not Admissibility, Not Attached To L1
+
+Do not write $\nu$ into Admissibility. Do not write `ν` into Admissibility.
+Admissibility names one fixed nearest-neighbor rule for the local possibility
+distribution. It does not supply hop weights, a time metric, or an
+arrival-time comparison.
+
+Do not attach L1. The named hop-cost is not attached to L1 and is not
+offered as a replacement for unit-cost first arrival. No uniqueness claim is
+made among hop-costs.
+
+## What This Note Does Not Claim
+
+- $\nu$ is not an axiom, not an approved primitive, and not a derived law.
+- The reverse bits are not promoted to a continuum speed, a physical clock,
+  or a Record readout.
+- Face-diagonal reverse versus $k$ is not claimed outside $B_{18}(0)$ and is
+  not claimed for any hop-cost other than the named $\nu$.
+- L1 is not adopted and is not attached to Admissibility.
+- The $B_{16}(0)$ face-versus-$k$ table is not reused as a substitute for
+  the eight-scale Dijkstra table on $B_{18}(0)$.
+- Uniqueness among hop-costs is not claimed.
+
+## claim_scope
+
+Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_18(0) is reported for available k=1..8. Displayed, not adopted.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15746,
- "node_count": 5547,
+ "edge_count": 15747,
+ "node_count": 5548,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17977,6 +17977,10 @@
   "supplied_three_label_target_apportionment_comparator_bounded_theorem_note_2026-07-30": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "support_drop_face_reverse_vs_k_b18_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "susceptibility_density_vanishes_identically_1d_ibp_bounded_theorem_note_2026-06-12": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/support_drop_face_reverse_vs_k_b18_2026_08_15.txt
+++ b/logs/runner-cache/support_drop_face_reverse_vs_k_b18_2026_08_15.txt
@@ -1,0 +1,88 @@
+===== runner cache v1 =====
+runner: scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py
+runner_sha256: ab3a63d69dcbd2b5d0fdc0738677e1af7095779d68360da2a70b9df90071a4b5
+input_fingerprint_sha256: 8bef151a5e6ba53336c173156f5b5a51ff3eebb1089f87559fe7ae7b4bafb6ea
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+dijkstra_count_budget: 1
+claim_scope: Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_18(0) is reported for available k=1..8. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the source note and the axiom memo
+PASS: audit-input-literals AUDIT_INPUT_PATHS is a static two-string literal in this runner
+PASS: ball-cardinality B_18(0) has 8473 sites and 8472 nonzero sites
+PASS: one-dijkstra exactly one Dijkstra computation is used
+PASS: all-k-available every k=1..8 pair lies in B_18(0); none omitted
+PASS: finite-times every available target is reached by a finite path
+arrival_times:
+  t(2, 0, 0)=6  t^2/|v|_2^2=36/4
+  t(1, 1, 0)=4  t^2/|v|_2^2=16/2
+  t(4, 0, 0)=10  t^2/|v|_2^2=100/16
+  t(2, 2, 0)=6  t^2/|v|_2^2=36/8
+  t(6, 0, 0)=12  t^2/|v|_2^2=144/36
+  t(3, 3, 0)=8  t^2/|v|_2^2=64/18
+  t(8, 0, 0)=14  t^2/|v|_2^2=196/64
+  t(4, 4, 0)=10  t^2/|v|_2^2=100/32
+  t(10, 0, 0)=16  t^2/|v|_2^2=256/100
+  t(5, 5, 0)=12  t^2/|v|_2^2=144/50
+  t(12, 0, 0)=18  t^2/|v|_2^2=324/144
+  t(6, 6, 0)=14  t^2/|v|_2^2=196/72
+  t(14, 0, 0)=20  t^2/|v|_2^2=400/196
+  t(7, 7, 0)=16  t^2/|v|_2^2=256/98
+  t(16, 0, 0)=22  t^2/|v|_2^2=484/256
+  t(8, 8, 0)=18  t^2/|v|_2^2=324/128
+PASS: time-200 computed t(2,0,0)=6 is written in the note
+PASS: time-110 computed t(1,1,0)=4 is written in the note
+PASS: time-400 computed t(4,0,0)=10 is written in the note
+PASS: time-220 computed t(2,2,0)=6 is written in the note
+PASS: time-600 computed t(6,0,0)=12 is written in the note
+PASS: time-330 computed t(3,3,0)=8 is written in the note
+PASS: time-800 computed t(8,0,0)=14 is written in the note
+PASS: time-440 computed t(4,4,0)=10 is written in the note
+PASS: time-1000 computed t(10,0,0)=16 is written in the note
+PASS: time-550 computed t(5,5,0)=12 is written in the note
+PASS: time-1200 computed t(12,0,0)=18 is written in the note
+PASS: time-660 computed t(6,6,0)=14 is written in the note
+PASS: time-1400 computed t(14,0,0)=20 is written in the note
+PASS: time-770 computed t(7,7,0)=16 is written in the note
+PASS: time-1600 computed t(16,0,0)=22 is written in the note
+PASS: time-880 computed t(8,8,0)=18 is written in the note
+reverse_bits:
+  k=1 (2, 0, 0) vs (1, 1, 0): reverse=True (16*4=64 vs 36*2=72)
+PASS: reverse-k1 k=1 reverse bit is computed and the integer comparison is written
+  k=2 (4, 0, 0) vs (2, 2, 0): reverse=True (36*16=576 vs 100*8=800)
+PASS: reverse-k2 k=2 reverse bit is computed and the integer comparison is written
+  k=3 (6, 0, 0) vs (3, 3, 0): reverse=True (64*36=2304 vs 144*18=2592)
+PASS: reverse-k3 k=3 reverse bit is computed and the integer comparison is written
+  k=4 (8, 0, 0) vs (4, 4, 0): reverse=False (100*64=6400 vs 196*32=6272)
+PASS: reverse-k4 k=4 reverse bit is computed and the integer comparison is written
+  k=5 (10, 0, 0) vs (5, 5, 0): reverse=False (144*100=14400 vs 256*50=12800)
+PASS: reverse-k5 k=5 reverse bit is computed and the integer comparison is written
+  k=6 (12, 0, 0) vs (6, 6, 0): reverse=False (196*144=28224 vs 324*72=23328)
+PASS: reverse-k6 k=6 reverse bit is computed and the integer comparison is written
+  k=7 (14, 0, 0) vs (7, 7, 0): reverse=False (256*196=50176 vs 400*98=39200)
+PASS: reverse-k7 k=7 reverse bit is computed and the integer comparison is written
+  k=8 (16, 0, 0) vs (8, 8, 0): reverse=False (324*256=82944 vs 484*128=61952)
+PASS: reverse-k8 k=8 reverse bit is computed and the integer comparison is written
+PASS: k3-still-holds k=3 reverse still holds on B_18(0)
+PASS: bits-yes-yes-yes-no-no-no-no-no reverse holds at k=1,2,3 and fails at k=4,5,6,7,8
+PASS: not-b16-leftover the k=1..8 census is not leftover of the B_16(0) facek table
+PASS: source-lattice Lattice nearest-neighbor wording is pinned in the axiom memo and the note
+PASS: source-admissibility Admissibility distribution wording and non-dynamics clause are pinned
+PASS: nu-not-admissibility the note refuses to write nu into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: displayed-not-adopted claim_scope and displayed-not-adopted wording are present
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-phrases forbidden phrases are absent from the note and from runner prose
+PASS: axiom-untouched the axiom memo is an input only
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+TOTAL: PASS=43 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py
+++ b/scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Face-diagonal reverse versus integer scale k under the named support-drop hop-cost on B_18(0)."""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+RADIUS = 18
+SCALES = (1, 2, 3, 4, 5, 6, 7, 8)
+NEIGHBOR_STEPS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+CLAIM_SCOPE = (
+    "Face-diagonal reverse versus integer scale k under the named "
+    "support-drop hop-cost on B_18(0) is reported for available k=1..8. "
+    "Displayed, not adopted."
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def l2sq(v: tuple[int, int, int]) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return sum(1 for x in v if x != 0)
+
+
+def nu(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sv = support_size(v)
+    sw = support_size(w)
+    if sv == 0 or (sv == 1 and sw == 1) or sw < sv:
+        return 3
+    return 1
+
+
+def ball_sites(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_from_origin(
+    sites: set[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    inf = 10**9
+    dist = {site: inf for site in sites}
+    dist[origin] = 0
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, origin)]
+    while heap:
+        cost, v = heapq.heappop(heap)
+        if cost != dist[v]:
+            continue
+        for step in NEIGHBOR_STEPS:
+            w = (v[0] + step[0], v[1] + step[1], v[2] + step[2])
+            if w not in sites:
+                continue
+            nxt = cost + nu(v, w)
+            if nxt < dist[w]:
+                dist[w] = nxt
+                heapq.heappush(heap, (nxt, w))
+    return dist
+
+
+def flatten(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_site(k: int) -> tuple[int, int, int]:
+    return (2 * k, 0, 0)
+
+
+def face_site(k: int) -> tuple[int, int, int]:
+    return (k, k, 0)
+
+
+def is_reverse(
+    times: dict[tuple[int, int, int], int],
+    k: int,
+) -> bool:
+    axis = axis_site(k)
+    face = face_site(k)
+    ta = times[axis]
+    tb = times[face]
+    return ta * ta * l2sq(face) > tb * tb * l2sq(axis)
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print("dijkstra_count_budget: 1")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the source note and the axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/SUPPORT_DROP_FACE_REVERSE_VS_K_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "audit-input-literals",
+        "AUDIT_INPUT_PATHS is a static two-string literal in this runner",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+
+    sites_list = ball_sites(RADIUS)
+    sites = set(sites_list)
+    checks.check(
+        "ball-cardinality",
+        "B_18(0) has 8473 sites and 8472 nonzero sites",
+        len(sites_list) == 8473 and (0, 0, 0) in sites and len(sites) == 8473,
+    )
+
+    available: list[int] = []
+    omitted: list[int] = []
+    for k in SCALES:
+        if axis_site(k) in sites and face_site(k) in sites:
+            available.append(k)
+        else:
+            omitted.append(k)
+    targets = tuple(axis_site(k) for k in available) + tuple(face_site(k) for k in available)
+    times = dijkstra_from_origin(sites)
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra computation is used",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "all-k-available",
+        "every k=1..8 pair lies in B_18(0); none omitted",
+        available == list(SCALES) and omitted == [] and all(l1(v) <= 18 for v in targets),
+    )
+    checks.check(
+        "finite-times",
+        "every available target is reached by a finite path",
+        all(times[v] < 10**9 for v in targets) and len(times) == 8473,
+    )
+
+    print("arrival_times:")
+    computed: dict[tuple[int, int, int], int] = {}
+    for k in available:
+        for v in (axis_site(k), face_site(k)):
+            computed[v] = times[v]
+            print(f"  t{v}={times[v]}  t^2/|v|_2^2={times[v] ** 2}/{l2sq(v)}")
+
+    for v, expected in computed.items():
+        token = f"t({v[0]},{v[1]},{v[2]})={expected}"
+        checks.check(
+            f"time-{v[0]}{v[1]}{v[2]}",
+            f"computed {token} is written in the note",
+            token in note,
+            residual=times[v],
+        )
+
+    comparison_left_gt = {
+        1: r"4\,t(1,1,0)^2=64<72=2\,t(2,0,0)^2",
+        2: r"16\,t(2,2,0)^2=576<800=8\,t(4,0,0)^2",
+        3: r"36\,t(3,3,0)^2=2304<2592=18\,t(6,0,0)^2",
+        4: r"64\,t(4,4,0)^2=6400>6272=32\,t(8,0,0)^2",
+        5: r"100\,t(5,5,0)^2=14400>12800=50\,t(10,0,0)^2",
+        6: r"144\,t(6,6,0)^2=28224>23328=72\,t(12,0,0)^2",
+        7: r"196\,t(7,7,0)^2=50176>39200=98\,t(14,0,0)^2",
+        8: r"256\,t(8,8,0)^2=82944>61952=128\,t(16,0,0)^2",
+    }
+    print("reverse_bits:")
+    bits: list[bool] = []
+    for k in available:
+        axis = axis_site(k)
+        face = face_site(k)
+        bit = is_reverse(times, k)
+        bits.append(bit)
+        ta, tb = times[axis], times[face]
+        left = tb * tb * (4 * k * k)
+        right = ta * ta * (2 * k * k)
+        dens_ok = ta * ta * (2 * k * k) > tb * tb * (4 * k * k)
+        print(
+            f"  k={k} {axis} vs {face}: reverse={bit} "
+            f"({tb * tb}*{l2sq(axis)}={left} vs "
+            f"{ta * ta}*{l2sq(face)}={right})"
+        )
+        checks.check(
+            f"reverse-k{k}",
+            f"k={k} reverse bit is computed and the integer comparison is written",
+            dens_ok is bit and comparison_left_gt[k] in note,
+        )
+
+    checks.check(
+        "k3-still-holds",
+        "k=3 reverse still holds on B_18(0)",
+        bits[available.index(3)] is True
+        and times[(6, 0, 0)] == 12
+        and times[(3, 3, 0)] == 8
+        and "$k=3$ bit still holds" in note,
+    )
+    checks.check(
+        "bits-yes-yes-yes-no-no-no-no-no",
+        "reverse holds at k=1,2,3 and fails at k=4,5,6,7,8",
+        bits == [True, True, True, False, False, False, False, False]
+        and "holds at $k=1,2,3$" in note
+        and "fails at $k=4,5,6,7,8$" in note,
+    )
+    checks.check(
+        "not-b16-leftover",
+        "the k=1..8 census is not leftover of the B_16(0) facek table",
+        "not leftover of the $B_{16}(0)$" in note
+        and times[(16, 0, 0)] == 22
+        and times[(16, 0, 0)] != 24
+        and l1((16, 1, 0)) == 17
+        and (16, 1, 0) in sites
+        and times[(16, 1, 0)] + 3 == times[(16, 0, 0)]
+        and nu((16, 1, 0), (16, 0, 0)) == 3
+        and "$(16,1,0)" in note,
+    )
+
+    flat_note = flatten(note)
+    flat_axiom = flatten(axiom)
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor "
+        "adjacency, standard translations, and proper cubic rotations about each site."
+    )
+    admissibility_quote = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    not_dynamics = "Admissibility is not a dynamics axiom."
+    checks.check(
+        "source-lattice",
+        "Lattice nearest-neighbor wording is pinned in the axiom memo and the note",
+        lattice_quote in flat_axiom and lattice_quote in flat_note,
+    )
+    checks.check(
+        "source-admissibility",
+        "Admissibility distribution wording and non-dynamics clause are pinned",
+        admissibility_quote in flat_axiom
+        and admissibility_quote in flat_note
+        and not_dynamics in axiom
+        and not_dynamics in note,
+    )
+    checks.check(
+        "nu-not-admissibility",
+        "the note refuses to write nu into Admissibility",
+        "It is not written into Admissibility." in note
+        and "Do not write $\\nu$ into Admissibility." in note
+        and "Do not write `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "not attached to L1" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "claim_scope and displayed-not-adopted wording are present",
+        CLAIM_SCOPE in note and "displayed, not adopted" in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden_hits = [
+        phrase
+        for phrase in FORBIDDEN
+        if phrase in note or phrase in source.split("FORBIDDEN =", 1)[0]
+    ]
+    checks.check(
+        "forbidden-phrases",
+        "forbidden phrases are absent from the note and from runner prose",
+        not forbidden_hits,
+        residual=forbidden_hits,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only",
+        "### Admissibility / Local Constraint" in axiom
+        and "ν(v→w)" not in axiom,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        nu((0, 0, 0), (1, 0, 0)) == 3
+        and nu((1, 0, 0), (2, 0, 0)) == 3
+        and nu((1, 0, 0), (1, 1, 0)) == 1
+        and nu((1, 1, 0), (1, 0, 0)) == 3,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_18(0), t(16,0,0)=22 not 24. Face reverse holds at k=1,2,3 and fails at k=4..8. The k=3 bit survives the cheaper axis. Displayed, not adopted.

## Runner

`scripts/support_drop_face_reverse_vs_k_b18_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.