### PR TITLE
feat(hugax): corridor-slide restores same-k at k=7: t=17 vs t=23

### DIFF
--- a/docs/CORRIDOR_SLIDE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CORRIDOR_SLIDE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,175 @@
+---
+claim_id: corridor_slide_samek_k7_b21_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=7 under the named corridor-slide hop-cost on B_21(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/corridor_slide_samek_k7_b21_2026_08_15.py
+---
+
+# Named Corridor-Slide Same-k Reverse At k=7 On B_21(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_21(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=7`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/corridor_slide_samek_k7_b21_2026_08_15.py`](../scripts/corridor_slide_samek_k7_b21_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named corridor-slide hop-cost `μ` is the already scored support-drop
+rule `ν` plus cost `3` on a `2→2` hop whose destination has least nonzero
+absolute coordinate equal to `1` (an axis-hugging face slide). Same-`k`
+reverse under `ν` fails at `k=7` (`13` versus `23`). The leave-axis rule
+`λ` restores reverse at `k=7` (`15` versus `25`) by pricing the `|σ|=1→2`
+hop, but that same `1→2` clause hits the `k=1` body hop and not a long
+corridor. The `1→2` hop is not an extra clause of `μ`.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_21(0)`, the displayed
+comparator `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The displayed rule `μ` is
+
+`μ(v→w) = 3` if `ν(v→w)` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The first three clauses are those of `ν`: seed-exit, both weights `1`, and
+support drop. The fourth clause is the axis-hugging `2→2` slide. Those four
+clauses are the whole rule.
+
+One Dijkstra from the origin on `B_21(0)` (13287 sites; 13286 nonzero) gives
+
+`t(7,0,0) = 17`, `t(7,7,7) = 23`.
+
+The displayed same-`k` comparison at `k=7` is
+
+`t(7,0,0)^2 / 49  ?  t(7,7,7)^2 / 147`,
+
+which is `289/49` versus `529/147`, or equivalently `867 > 529`. The
+inequality holds. Same-`k` reverse at `k=7` under `μ` is yes. Independently,
+the new axis site is `t(21,0,0) = 35`. The shared axis site
+`t(18,0,0) = 28` is a `μ` score on this ball, not a `ν` leftover.
+
+The pair is not leftover of `ν`: the same sites under `ν` are `13` and
+`23`, and `507 > 529` fails. The extra corridor-slide clause is what
+changes the axis arrival. On the hugging hop `(1,1,0) → (2,1,0)` one has
+`|σ| : 2 → 2` and least nonzero `|w_i| = 1`, so `ν = 1` while `μ = 3`.
+The leave-axis hop `(0,-1,0) → (1,-1,0)` stays at cost `1` under both
+`ν` and `μ`. Therefore `ν` cannot price the axis-hugging slide, and the
+`μ` scores below are not a leftover of `ν`. The site `(7,7,7)` has ℓ¹
+norm `21`, so it is absent from `B_18(0)`. The `B_21(0)` table is
+therefore not leftover of a smaller-ball table.
+
+The rule is displayed, not adopted. Do not write `μ` or `ν` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate test, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_21(0) = { v ∈ Z^3 : |v|_1 ≤ 21 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_21(0)`,
+`t(v)` is the least sum of `μ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ν` uses only the first three clauses of `μ`. On the
+axis-hugging slide `(1,1,0) → (2,1,0)` one has `|σ| : 2 → 2` and least
+nonzero `|w_i| = 1`, so `ν = 1` while `μ = 3`. Therefore `ν` cannot price
+the corridor slide, and the `μ` scores below are not a leftover of `ν`.
+
+## Theorem 1 — Arrivals `t(7,0,0)` And `t(7,7,7)` On `B_21(0)`
+
+One origin Dijkstra on `B_21(0)` returns the integer arrivals
+
+| site | `t_μ` |
+|---|---:|
+| `(7,0,0)` | `17` |
+| `(7,7,7)` | `23` |
+
+Every listed site lies in `B_21(0)`. The site `(7,7,7)` has ℓ¹ norm `21`,
+so it is absent from `B_18(0)`. The pair is computed on `B_21(0)`, not
+copied from a smaller-ball table and not copied from the `ν` pair
+`13` versus `23`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness walk of cost `17` from `0` to `(7,0,0)` is seed-exit `3` onto
+`(0,-1,0)`, leave-axis `1` onto `(0,-1,-1)`, enter-body `1` onto
+`(1,-1,-1)`, six support-preserving cost-`1` body hops to `(7,-1,-1)`,
+support-drop `3` onto `(7,-1,0)`, and support-drop `3` onto `(7,0,0)`,
+summing to `17`. That walk is a witness of cost `17`, not a uniqueness
+claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=7`
+
+The Euclidean-normalized comparison at `k=7` is
+
+`t(7,0,0)^2 / 49  ?  t(7,7,7)^2 / 147`,
+
+equivalently `3 t(7,0,0)^2 ? t(7,7,7)^2`. Substituting the computed times
+gives `3 · 17^2 = 867` and `23^2 = 529`, so
+
+`867 > 529` is true.
+
+Arrival per Euclidean length is larger at `(7,0,0)` than at `(7,7,7)`.
+Same-`k` reverse at `k=7` under `μ` is yes. The comparison is displayed,
+not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μ` is a displayed scoring device on `B_21(0)`. Do not write `μ` or `ν` into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_21(0) for one named hop-cost at k=7. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_21(0) for the displayed rule μ at k=7; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μ` among hop-costs that reverse the same-`k` pair at `k=7`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_21(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=7`.
+- Any reuse of the `ν` arrival table as a substitute for the `μ` Dijkstra.
+- Any adoption of the leave-axis `1→2` clause as part of `μ`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2689,6 +2689,10 @@
   "correlator_cycle_phases_readback_blind_or_state_contingent_bounded_note_2026-06-12": {
    "deps_hash": "7b707271a9a8",
    "out_degree": 2
+  },
+  "corridor_slide_samek_k7_b21_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cosmological_constant_result_2026-04-12": {
    "deps_hash": "bdad8aef31d8",

--- a/logs/runner-cache/corridor_slide_samek_k7_b21_2026_08_15.txt
+++ b/logs/runner-cache/corridor_slide_samek_k7_b21_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/corridor_slide_samek_k7_b21_2026_08_15.py
+runner_sha256: 1739209805f8d0c2a16ce018200bc5cd6dcdf02918520b4b6491172bd216b746
+input_fingerprint_sha256: bc41ea1c1b946c850b1dd9cffe61b29b431a8bea76dd124bae8d85b22952fcf1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CORRIDOR_SLIDE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=7 under the named corridor-slide hop-cost on B_21(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μ and ν are not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 13287
+t(7,0,0) 17
+t(7,7,7) 23
+t(7,0,0)^2/49 289/49
+t(7,7,7)^2/147 529/147
+3t_axis^2 867
+t_body^2 529
+reverse True
+t(21,0,0) 35
+t(18,0,0) 28
+dijkstra_calls 1
+mu_hug 3
+nu_hug 1
+mu_leave 1
+nu_leave 1
+PASS: t-700-777 t(7,0,0)=17 and t(7,7,7)=23
+PASS: reverse-k7 t(7,0,0)^2/49 > t(7,7,7)^2/147 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b21 B_21(0) has 13287 sites and 13286 nonzero sites
+PASS: reachable every site of B_21(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-nu μ prices the axis-hugging 2→2 hop at 3 while ν prices it at 1
+PASS: not-leftover-of-b18 (7,7,7) lies outside B_18(0) and the note says so
+PASS: seed-and-slide-clauses ν clauses and hugging 2→2 cost 3; 1→2 and non-hugging 2→2 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/corridor_slide_samek_k7_b21_2026_08_15.py
+++ b/scripts/corridor_slide_samek_k7_b21_2026_08_15.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=7 under μ on B_21(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/CORRIDOR_SLIDE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CORRIDOR_SLIDE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=7 under the named "
+    "corridor-slide hop-cost on B_21(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 17
+T_BODY_REP = 23
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def dijkstra_mu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + mu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μ and ν are not written into Admissibility",
+        "Do not write `μ` or `ν` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(21)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_mu(sites)
+    t700 = dist[(7, 0, 0)]
+    t777 = dist[(7, 7, 7)]
+    t2100 = dist[(21, 0, 0)]
+    t1800 = dist[(18, 0, 0)]
+    reverse = 3 * t700 * t700 > t777 * t777
+    hug_hop = ((1, 1, 0), (2, 1, 0))
+    leave_hop = ((0, -1, 0), (1, -1, 0))
+    print(f"n_sites {len(sites)}")
+    print(f"t(7,0,0) {t700}")
+    print(f"t(7,7,7) {t777}")
+    print(f"t(7,0,0)^2/49 {t700 * t700}/49")
+    print(f"t(7,7,7)^2/147 {t777 * t777}/147")
+    print(f"3t_axis^2 {3 * t700 * t700}")
+    print(f"t_body^2 {t777 * t777}")
+    print(f"reverse {reverse}")
+    print(f"t(21,0,0) {t2100}")
+    print(f"t(18,0,0) {t1800}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"mu_hug {mu_cost(*hug_hop)}")
+    print(f"nu_hug {nu_cost(*hug_hop)}")
+    print(f"mu_leave {mu_cost(*leave_hop)}")
+    print(f"nu_leave {nu_cost(*leave_hop)}")
+
+    checks.check(
+        "t-700-777",
+        f"t(7,0,0)={T_AXIS_REP} and t(7,7,7)={T_BODY_REP}",
+        t700 == T_AXIS_REP and t777 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k7",
+        "t(7,0,0)^2/49 > t(7,7,7)^2/147 holds",
+        reverse
+        and 3 * t700 * t700 == 867
+        and t777 * t777 == 529
+        and "867 > 529" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b21",
+        "B_21(0) has 13287 sites and 13286 nonzero sites",
+        len(sites) == 13287 and len(nonzero) == 13286 and all(l1(v) <= 21 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_21(0) is reached",
+        len(dist) == 13287,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`17`" in note
+        and "`23`" in note
+        and "`(7,0,0)`" in note
+        and "`(7,7,7)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "867 > 529" in note,
+    )
+    checks.check(
+        "not-leftover-of-nu",
+        "μ prices the axis-hugging 2→2 hop at 3 while ν prices it at 1",
+        mu_cost(*hug_hop) == 3
+        and nu_cost(*hug_hop) == 1
+        and mu_cost(*leave_hop) == 1
+        and nu_cost(*leave_hop) == 1
+        and t700 == 17
+        and t777 == 23
+        and "cannot price" in note
+        and "13` versus `23" in note,
+    )
+    checks.check(
+        "not-leftover-of-b18",
+        "(7,7,7) lies outside B_18(0) and the note says so",
+        l1((7, 7, 7)) == 21
+        and (7, 7, 7) in dist
+        and t2100 == 35
+        and t1800 == 28
+        and "absent from `B_18(0)`" in note,
+    )
+    checks.check(
+        "seed-and-slide-clauses",
+        "ν clauses and hugging 2→2 cost 3; 1→2 and non-hugging 2→2 cost 1",
+        mu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and mu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mu_cost((2, 2, 0), (3, 2, 0)) == 1
+        and mu_cost((1, 1, 1), (2, 1, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μ(v→w)" not in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_21(0) under mu (nu plus cost 3 on axis-hugging 2-to-2 slides), t(7,0,0)=17 and t(7,7,7)=23. 867>529. Body stays at the nu time 23. Displayed, not adopted.

## Runner

`scripts/corridor_slide_samek_k7_b21_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.