### PR TITLE
feat(hugk10): corridor-slide same-k holds at k=10: t=20 vs t=32

### DIFF
--- a/docs/CORRIDOR_SLIDE_SAMEK_K10_B30_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CORRIDOR_SLIDE_SAMEK_K10_B30_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,167 @@
+---
+claim_id: corridor_slide_samek_k10_b30_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=10 under the named corridor-slide hop-cost on B_30(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/corridor_slide_samek_k10_b30_2026_08_15.py
+---
+
+# Named Corridor-Slide Same-k Reverse At k=10 On B_30(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_30(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=10`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/corridor_slide_samek_k10_b30_2026_08_15.py`](../scripts/corridor_slide_samek_k10_b30_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named corridor-slide hop-cost `μ` is the already scored support-drop
+rule `ν` plus cost `3` on a `2→2` hop whose destination has least nonzero
+absolute coordinate equal to `1` (an axis-hugging slide). Same-`k` reverse
+under `μ` holds at `k=8` (`18` versus `26`) and at `k=7` (`17` versus `23`).
+Same-`k` reverse under `ν` fails at `k=10` (`16` versus `32`). The cheap
+`ν` axis walk to `(10,0,0)` slides along a weight-`2` corridor with dest
+height `1`, then drops onto the axis. That corridor hop costs `1` under
+`ν`. `μ` prices that hop at `3`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_30(0)`, the displayed
+rule `μ` is
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`,
+
+where `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the corridor slide. Those four clauses are the whole
+rule.
+
+One Dijkstra from the origin on `B_30(0)` (37881 sites; 37880 nonzero) gives
+
+`t(10,0,0) = 20`, `t(10,10,10) = 32`.
+
+The displayed same-`k` comparison at `k=10` is
+
+`t(10,0,0)^2 / 100  ?  t(10,10,10)^2 / 300`,
+
+which is `400/100` versus `1024/300`, or equivalently `1200 > 1024`. The
+inequality holds. Same-`k` reverse at `k=10` under `μ` is yes. Independently,
+the new axis site is `t(30,0,0) = 44`. The shared axis site
+`t(27,0,0) = 37` is a `μ` score on this ball, not a `ν` leftover.
+
+The pair is not leftover of `ν`: the same sites under `ν` are `16` versus
+`32`, and the extra corridor-slide clause is what changes the axis time.
+The site `(10,10,10)` has ℓ¹ norm `30`, so it is absent from `B_27(0)`. The
+`B_30(0)` table is therefore not leftover of the `B_27(0)` times.
+
+The rule is displayed, not adopted. Do not write `μ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_30(0) = { v ∈ Z^3 : |v|_1 ≤ 30 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_30(0)`,
+`t(v)` is the least sum of `μ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ν` uses only the first three clauses of `μ`. On the
+corridor-slide hop `(1,1,0) → (2,1,0)` one has `|σ| : 2 → 2` and least
+nonzero `|w_i| = 1`, so `ν = 1` while `μ = 3`. Therefore `ν` cannot price corridor slide,
+and the `μ` scores below are not a leftover of `ν`.
+
+## Theorem 1 — Arrivals `t(10,0,0)` And `t(10,10,10)` On `B_30(0)`
+
+One origin Dijkstra on `B_30(0)` returns the integer arrivals
+
+| site | `t_μ` |
+|---|---:|
+| `(10,0,0)` | `20` |
+| `(10,10,10)` | `32` |
+
+Every listed site lies in `B_30(0)`. The site `(10,10,10)` has ℓ¹ norm `30`,
+so it is absent from `B_27(0)`. The pair is computed on `B_30(0)`, not
+copied from a smaller-ball table and not copied from the `ν` pair
+`16` versus `32`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `20` is seed-exit `3` onto `(1,0,0)`,
+support-increase `1` onto `(1,1,0)`, support-increase `1` onto `(1,1,1)`,
+nine support-preserving cost-`1` body hops to `(10,1,1)`, and two
+support-drops `3` then `3` onto `(10,0,0)`, summing to `20`. That walk is
+a witness of cost `20`, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=10`
+
+The Euclidean-normalized comparison at `k=10` is
+
+`t(10,0,0)^2 / 100  ?  t(10,10,10)^2 / 300`,
+
+equivalently `3 t(10,0,0)^2 ? t(10,10,10)^2`. Substituting the computed times
+gives `3 · 20^2 = 1200` and `32^2 = 1024`, so
+
+`1200 > 1024`.
+
+Arrival per Euclidean length is larger at `(10,0,0)` than at `(10,10,10)`.
+Same-`k` reverse at `k=10` under `μ` is yes. The comparison is displayed,
+not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μ` is a displayed scoring device on `B_30(0)`. Do not write `μ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_30(0) for one named hop-cost at k=10. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_30(0) for the displayed rule μ at k=10; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μ` among hop-costs that reverse the same-`k` pair at `k=10`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_30(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=10`.
+- Any reuse of the `ν` arrival table as a substitute for the `μ` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2689,6 +2689,10 @@
   "correlator_cycle_phases_readback_blind_or_state_contingent_bounded_note_2026-06-12": {
    "deps_hash": "7b707271a9a8",
    "out_degree": 2
+  },
+  "corridor_slide_samek_k10_b30_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cosmological_constant_result_2026-04-12": {
    "deps_hash": "bdad8aef31d8",

--- a/logs/runner-cache/corridor_slide_samek_k10_b30_2026_08_15.txt
+++ b/logs/runner-cache/corridor_slide_samek_k10_b30_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/corridor_slide_samek_k10_b30_2026_08_15.py
+runner_sha256: cd6210b803ce2aefa86a8287854b8a368c26a61cc064ce32b38ea1511d3180e6
+input_fingerprint_sha256: e4c118234e0f757a9080091fba3e6ebf5853226477d4e153fb49f2e70db43a8c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CORRIDOR_SLIDE_SAMEK_K10_B30_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=10 under the named corridor-slide hop-cost on B_30(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 37881
+t(10,0,0) 20
+t(10,10,10) 32
+t(10,0,0)^2/100 400/100
+t(10,10,10)^2/300 1024/300
+3t_axis^2 1200
+t_body^2 1024
+reverse True
+t(30,0,0) 44
+t(27,0,0) 37
+dijkstra_calls 1
+witness_mu_costs [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_mu_sum 20
+PASS: t-1000-101010 t(10,0,0)=20 and t(10,10,10)=32
+PASS: reverse-k10 t(10,0,0)^2/100 > t(10,10,10)^2/300 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b30 B_30(0) has 37881 sites and 37880 nonzero sites
+PASS: reachable every site of B_30(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-nu μ prices the corridor-slide hop at 3 while ν prices it at 1
+PASS: not-leftover-of-b27 (10,10,10) lies outside B_27(0) and the note says so
+PASS: seed-and-corridor-clauses seed-exit, both-weights-1, support-drop, and corridor-slide cost 3; other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/corridor_slide_samek_k10_b30_2026_08_15.py
+++ b/scripts/corridor_slide_samek_k10_b30_2026_08_15.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=10 under μ on B_30(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/CORRIDOR_SLIDE_SAMEK_K10_B30_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CORRIDOR_SLIDE_SAMEK_K10_B30_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=10 under the named "
+    "corridor-slide hop-cost on B_30(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 20
+T_BODY_REP = 32
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def dijkstra_mu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + mu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μ is not written into Admissibility",
+        "Do not write `μ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(30)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_mu(sites)
+    t1000 = dist[(10, 0, 0)]
+    t101010 = dist[(10, 10, 10)]
+    t3000 = dist[(30, 0, 0)]
+    t2700 = dist[(27, 0, 0)]
+    reverse = 3 * t1000 * t1000 > t101010 * t101010
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (3, 1, 1),
+        (4, 1, 1),
+        (5, 1, 1),
+        (6, 1, 1),
+        (7, 1, 1),
+        (8, 1, 1),
+        (9, 1, 1),
+        (10, 1, 1),
+        (10, 1, 0),
+        (10, 0, 0),
+    )
+    witness_mu_costs = [mu_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    print(f"n_sites {len(sites)}")
+    print(f"t(10,0,0) {t1000}")
+    print(f"t(10,10,10) {t101010}")
+    print(f"t(10,0,0)^2/100 {t1000 * t1000}/100")
+    print(f"t(10,10,10)^2/300 {t101010 * t101010}/300")
+    print(f"3t_axis^2 {3 * t1000 * t1000}")
+    print(f"t_body^2 {t101010 * t101010}")
+    print(f"reverse {reverse}")
+    print(f"t(30,0,0) {t3000}")
+    print(f"t(27,0,0) {t2700}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_mu_costs {witness_mu_costs}")
+    print(f"witness_mu_sum {sum(witness_mu_costs)}")
+
+    checks.check(
+        "t-1000-101010",
+        f"t(10,0,0)={T_AXIS_REP} and t(10,10,10)={T_BODY_REP}",
+        t1000 == T_AXIS_REP and t101010 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k10",
+        "t(10,0,0)^2/100 > t(10,10,10)^2/300 holds",
+        reverse
+        and 3 * t1000 * t1000 == 1200
+        and t101010 * t101010 == 1024
+        and "1200 > 1024" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b30",
+        "B_30(0) has 37881 sites and 37880 nonzero sites",
+        len(sites) == 37881 and len(nonzero) == 37880 and all(l1(v) <= 30 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_30(0) is reached",
+        len(dist) == 37881,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`20`" in note
+        and "`32`" in note
+        and "`(10,0,0)`" in note
+        and "`(10,10,10)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1200 > 1024" in note,
+    )
+    checks.check(
+        "not-leftover-of-nu",
+        "μ prices the corridor-slide hop at 3 while ν prices it at 1",
+        mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and nu_cost((1, 1, 0), (2, 1, 0)) == 1
+        and sum(witness_mu_costs) == 20
+        and t1000 == 20
+        and t101010 == 32
+        and t1000 != 16
+        and "cannot price corridor slide" in note
+        and "16` versus `32" in note,
+    )
+    checks.check(
+        "not-leftover-of-b27",
+        "(10,10,10) lies outside B_27(0) and the note says so",
+        l1((10, 10, 10)) == 30
+        and (10, 10, 10) in dist
+        and t3000 == 44
+        and t2700 == 37
+        and t2700 != 33
+        and t2700 != 41
+        and "absent from `B_27(0)`" in note
+        and "not leftover of the `B_27(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-corridor-clauses",
+        "seed-exit, both-weights-1, support-drop, and corridor-slide cost 3; other hops cost 1",
+        mu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and mu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and mu_cost((1, 1, 1), (2, 1, 1)) == 1
+        and mu_cost((2, 2, 0), (3, 2, 0)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_30(0) under mu, t(10,0,0)=20 and t(10,10,10)=32. 1200>1024. Linear arrivals still reverse. Displayed, not adopted.

## Runner

`scripts/corridor_slide_samek_k10_b30_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.