### PR TITLE
feat(hugk14): corridor-slide same-k fails at k=14: t=24 vs t=44

### DIFF
--- a/docs/CORRIDOR_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CORRIDOR_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,170 @@
+---
+claim_id: corridor_slide_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named corridor-slide hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/corridor_slide_samek_k14_b42_2026_08_15.py
+---
+
+# Named Corridor-Slide Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/corridor_slide_samek_k14_b42_2026_08_15.py`](../scripts/corridor_slide_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named corridor-slide hop-cost `μ` is the already scored support-drop
+rule `ν` plus cost `3` on a `2→2` hop whose destination has least nonzero
+absolute coordinate equal to `1` (an axis-hugging slide). Linear arrivals
+under `μ` for `k≥6` are `t(k,0,0)=k+10` and `t(k,k,k)=3k+2`, which already
+predict that same-`k` reverse dies at `k=13` (`23` versus `41`). The same
+formulas continue at `k=14` (`24` versus `44`). Same-`k` reverse under `ν`
+fails at `k=14` (`20` versus `44`). The cheap `ν` axis walk to `(14,0,0)`
+slides along a weight-`2` corridor with dest height `1`, then drops onto
+the axis. That corridor hop costs `1` under `ν`. `μ` prices that hop at
+`3`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rule `μ` is
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`,
+
+where `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the corridor slide. Those four clauses are the whole
+rule.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero) gives
+
+`t(14,0,0) = 24`, `t(14,14,14) = 44`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `576/196` versus `1936/588`, or equivalently `1728 > 1936`. The
+inequality does not hold. Same-`k` reverse at `k=14` under `μ` is no. The
+fail continues at `k=14` on `B_42(0)`. Independently, the new axis site is
+`t(42,0,0) = 56`. The shared axis site `t(39,0,0) = 49` is a `μ` score on
+this ball, not a `ν` leftover.
+
+The pair is not leftover of `ν`: the same sites under `ν` are `20` versus
+`44`, and the extra corridor-slide clause is what changes the axis time.
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`. The
+`B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The rule is displayed, not adopted. Do not write `μ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `μ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ν` uses only the first three clauses of `μ`. On the
+corridor-slide hop `(1,1,0) → (2,1,0)` one has `|σ| : 2 → 2` and least
+nonzero `|w_i| = 1`, so `ν = 1` while `μ = 3`. Therefore `ν` cannot price corridor slide,
+and the `μ` scores below are not a leftover of `ν`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_μ` |
+|---|---:|
+| `(14,0,0)` | `24` |
+| `(14,14,14)` | `44` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table and not copied from the `ν` pair
+`20` versus `44`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `24` is seed-exit `3` onto `(1,0,0)`,
+support-increase `1` onto `(1,1,0)`, support-increase `1` onto `(1,1,1)`,
+thirteen support-preserving cost-`1` body hops to `(14,1,1)`, and two
+support-drops `3` then `3` onto `(14,0,0)`, summing to `24`. That walk is
+a witness of cost `24`, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 24^2 = 1728` and `44^2 = 1936`, so
+
+`1728 > 1936` is false.
+
+Arrival per Euclidean length is not larger at `(14,0,0)` than at
+`(14,14,14)`. Same-`k` reverse at `k=14` under `μ` is no. The comparison
+is displayed, not adopted. The inequality does not hold.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μ` is a displayed scoring device on `B_42(0)`. Do not write `μ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule μ at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μ` among hop-costs that reverse the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of the `ν` arrival table as a substitute for the `μ` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2689,6 +2689,10 @@
   "correlator_cycle_phases_readback_blind_or_state_contingent_bounded_note_2026-06-12": {
    "deps_hash": "7b707271a9a8",
    "out_degree": 2
+  },
+  "corridor_slide_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cosmological_constant_result_2026-04-12": {
    "deps_hash": "bdad8aef31d8",

--- a/logs/runner-cache/corridor_slide_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/corridor_slide_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/corridor_slide_samek_k14_b42_2026_08_15.py
+runner_sha256: 3df6187fcdc14e1912b28ca7bb79e0ce4bf0b9e87bf2f6640b3106798072ef6f
+input_fingerprint_sha256: 93d05aa239d5b65756d7c5f14f995454963736b112b455a55be54196f96e7607
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.55
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CORRIDOR_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named corridor-slide hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 24
+t(14,14,14) 44
+t(14,0,0)^2/196 576/196
+t(14,14,14)^2/588 1936/588
+3t_axis^2 1728
+t_body^2 1936
+reverse False
+t(42,0,0) 56
+t(39,0,0) 49
+dijkstra_calls 1
+witness_mu_costs [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_mu_sum 24
+PASS: t-1400-141414 t(14,0,0)=24 and t(14,14,14)=44
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-nu μ prices the corridor-slide hop at 3 while ν prices it at 1
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: seed-and-corridor-clauses seed-exit, both-weights-1, support-drop, and corridor-slide cost 3; other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/corridor_slide_samek_k14_b42_2026_08_15.py
+++ b/scripts/corridor_slide_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under μ on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/CORRIDOR_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CORRIDOR_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named "
+    "corridor-slide hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 24
+T_BODY_REP = 44
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def dijkstra_mu(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + mu_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μ is not written into Admissibility",
+        "Do not write `μ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_mu(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    reverse = 3 * t1400 * t1400 > t141414 * t141414
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (3, 1, 1),
+        (4, 1, 1),
+        (5, 1, 1),
+        (6, 1, 1),
+        (7, 1, 1),
+        (8, 1, 1),
+        (9, 1, 1),
+        (10, 1, 1),
+        (11, 1, 1),
+        (12, 1, 1),
+        (13, 1, 1),
+        (14, 1, 1),
+        (14, 1, 0),
+        (14, 0, 0),
+    )
+    witness_mu_costs = [mu_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t1400 * t1400}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t1400 * t1400}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_mu_costs {witness_mu_costs}")
+    print(f"witness_mu_sum {sum(witness_mu_costs)}")
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t1400 == T_AXIS_REP and t141414 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold",
+        (not reverse)
+        and 3 * t1400 * t1400 == 1728
+        and t141414 * t141414 == 1936
+        and "1728 > 1936" in note
+        and "inequality does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`24`" in note
+        and "`44`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1728 > 1936" in note,
+    )
+    checks.check(
+        "not-leftover-of-nu",
+        "μ prices the corridor-slide hop at 3 while ν prices it at 1",
+        mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and nu_cost((1, 1, 0), (2, 1, 0)) == 1
+        and sum(witness_mu_costs) == 24
+        and t1400 == 24
+        and t141414 == 44
+        and t1400 != 20
+        and "cannot price corridor slide" in note
+        and "20` versus `44" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 56
+        and t3900 == 49
+        and t3900 != 45
+        and t3900 != 53
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-corridor-clauses",
+        "seed-exit, both-weights-1, support-drop, and corridor-slide cost 3; other hops cost 1",
+        mu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and mu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and mu_cost((1, 1, 1), (2, 1, 1)) == 1
+        and mu_cost((2, 2, 0), (3, 2, 0)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_42(0) under mu, t(14,0,0)=24 and t(14,14,14)=44. 1728<1936. The k=13 fail continues. Displayed, not adopted.

## Runner

`scripts/corridor_slide_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.