### PR TITLE
feat(fallk1): all-face-slide keeps k=1 reverse: t=3 vs t=5

### DIFF
--- a/docs/ALL_FACE_SLIDE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/ALL_FACE_SLIDE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,159 @@
+---
+claim_id: all_face_slide_samek_k1_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=1 under the named all-face-slide hop-cost on B_6(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/all_face_slide_samek_k1_b6_2026_08_15.py
+---
+
+# Named All-Face-Slide Same-k Reverse At k=1 On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_6(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=1`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/all_face_slide_samek_k1_b6_2026_08_15.py`](../scripts/all_face_slide_samek_k1_b6_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named all-face-slide hop-cost `φ` is scored on `B_6(0)` at the first
+same-`k` scale `k=1`. One origin Dijkstra is run on this ball.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. Let `ν`
+be the named support-drop rule
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+On a directed nearest-neighbor hop `v → w` still inside `B_6(0)`, the
+displayed rule `φ` is
+
+`φ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2)`, else `1`.
+
+Equivalently, `φ` is `ν` plus cost `3` on every `2→2` hop. The first
+inherited clause is seed-exit. The second is both weights `1`. The third
+is support drop. The extra clause prices every face-parallel slide. Those
+four clauses are the whole rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_6(0)` (377 sites; 376 nonzero) gives
+
+`t(1,0,0) = 3`, `t(1,1,1) = 5`.
+
+The displayed same-`k` comparison at `k=1` is
+
+`t(1,0,0)^2 / 1  ?  t(1,1,1)^2 / 3`,
+
+which is `9/1` versus `25/3`, or equivalently `27 > 25`. The inequality
+holds. Same-`k` reverse holds at `k=1` under `φ`. Independently, the far
+axis site is `t(6,0,0) = 18`.
+
+The same-`k` pair at `k=1` does not use a `2→2` hop on a geodesic, so the
+two arrivals coincide with the `ν` arrivals. The rule is still not leftover of `ν`:
+on the face slide `(2,2,0) → (3,2,0)` one has `|σ| : 2 → 2`, so
+`ν = 1` while `φ = 3`. The corridor-slide comparator `μ` prices a `2→2`
+hop only when the least nonzero `|w_i|` equals `1`; on that same hop
+`μ = 1` while `φ = 3`. Therefore `μ` cannot price every face slide, and
+the `φ` scores below are not a leftover of `μ`.
+
+The rule is displayed, not adopted. Do not write `φ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_6(0)`,
+`t(v)` is the least sum of `φ` along a directed path from `0` to `v` in
+that graph.
+
+The site `(1,0,0)` has ℓ¹ norm `1`. The site `(1,1,1)` has ℓ¹ norm `3`.
+Both lie in `B_6(0)`. The table is computed by one origin Dijkstra on
+`B_6(0)`, not copied from a smaller-ball table.
+
+## Theorem 1 — Arrivals `t(1,0,0)` And `t(1,1,1)` On `B_6(0)`
+
+One origin Dijkstra on `B_6(0)` returns the integer arrivals
+
+| site | `t_φ` |
+|---|---:|
+| `(1,0,0)` | `3` |
+| `(1,1,1)` | `5` |
+
+Every listed site lies in `B_6(0)`. The pair is computed on `B_6(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=1`
+
+The Euclidean-normalized comparison at `k=1` is
+
+`t(1,0,0)^2 / 1  ?  t(1,1,1)^2 / 3`,
+
+equivalently `3 t(1,0,0)^2 ? t(1,1,1)^2`. Substituting the computed times
+gives `3 · 3^2 = 27` and `5^2 = 25`, so
+
+`27 > 25`.
+
+Arrival per Euclidean length is larger at `(1,0,0)` than at `(1,1,1)`.
+Same-`k` reverse at `k=1` is yes. The comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `φ` is a displayed scoring device on `B_6(0)`. Do not write `φ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_6(0) for one named hop-cost at k=1. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_6(0) for the displayed rule φ at k=1; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `φ` among hop-costs that reverse the same-`k` pair at `k=1`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_6(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=1`.
+- Any reuse of a smaller-ball arrival table as a substitute for the
+  radius-`6` Dijkstra.
+- Any adoption of `φ` as a physical law, or any identification with the
+  support-drop rule `ν` or the corridor-slide rule `μ`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -801,6 +801,10 @@
   "ai_methodology_note_2026-04-25": {
    "deps_hash": "3eac15647514",
    "out_degree": 18
+  },
+  "all_face_slide_samek_k1_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "allorders_b4_marginal_protection_symmetry_theorem_note_2026-06-14": {
    "deps_hash": "b5763395fdbe",

--- a/logs/runner-cache/all_face_slide_samek_k1_b6_2026_08_15.txt
+++ b/logs/runner-cache/all_face_slide_samek_k1_b6_2026_08_15.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/all_face_slide_samek_k1_b6_2026_08_15.py
+runner_sha256: 38e5c2b1fe0f66c66e1e580def503d4aa804c667156e192f151f81f817b6c9eb
+input_fingerprint_sha256: 6a2d5fed53647ce7cdd4840d2affc9cb0b0b445c3832585e2ecf6945160b6ef6
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/ALL_FACE_SLIDE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=1 under the named all-face-slide hop-cost on B_6(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility φ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 377
+t(1,0,0) 3
+t(1,1,1) 5
+t(1,0,0)^2/1 9/1
+t(1,1,1)^2/3 25/3
+3t_axis^2 27
+t_body^2 25
+reverse True
+t(6,0,0) 18
+dijkstra_calls 1
+PASS: t-100-111 t(1,0,0)=3 and t(1,1,1)=5
+PASS: reverse-k1 t(1,0,0)^2/1 > t(1,1,1)^2/3
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b6 B_6(0) has 377 sites and 376 nonzero sites
+PASS: reachable every site of B_6(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-nu ν cannot price the all-face slide (2,2,0)→(3,2,0)
+PASS: not-leftover-of-mu μ cannot price every face slide; (2,2,0)→(3,2,0) has μ=1
+PASS: seed-and-face-clauses seed-exit, both-weights-1, support drop, and every 2→2 hop cost 3
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/all_face_slide_samek_k1_b6_2026_08_15.py
+++ b/scripts/all_face_slide_samek_k1_b6_2026_08_15.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=1 under φ on B_6(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/ALL_FACE_SLIDE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/ALL_FACE_SLIDE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=1 under the named "
+    "all-face-slide hop-cost on B_6(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 3
+T_BODY_REP = 5
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def phi_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3 or (support_size(v) == 2 and support_size(w) == 2):
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero = [abs(coord) for coord in w if coord != 0]
+        if nonzero and min(nonzero) == 1:
+            return 3
+    return 1
+
+
+def dijkstra_phi(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + phi_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "φ is not written into Admissibility",
+        "Do not write `φ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(6)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_phi(sites)
+    t100 = dist[(1, 0, 0)]
+    t111 = dist[(1, 1, 1)]
+    t600 = dist[(6, 0, 0)]
+    reverse = 3 * t100 * t100 > t111 * t111
+    print(f"n_sites {len(sites)}")
+    print(f"t(1,0,0) {t100}")
+    print(f"t(1,1,1) {t111}")
+    print(f"t(1,0,0)^2/1 {t100 * t100}/1")
+    print(f"t(1,1,1)^2/3 {t111 * t111}/3")
+    print(f"3t_axis^2 {3 * t100 * t100}")
+    print(f"t_body^2 {t111 * t111}")
+    print(f"reverse {reverse}")
+    print(f"t(6,0,0) {t600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "t-100-111",
+        f"t(1,0,0)={T_AXIS_REP} and t(1,1,1)={T_BODY_REP}",
+        t100 == T_AXIS_REP and t111 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k1",
+        "t(1,0,0)^2/1 > t(1,1,1)^2/3",
+        reverse
+        and 3 * t100 * t100 == 27
+        and t111 * t111 == 25
+        and "27 > 25" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b6",
+        "B_6(0) has 377 sites and 376 nonzero sites",
+        len(sites) == 377 and len(nonzero) == 376 and all(l1(v) <= 6 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        len(dist) == 377,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`3`" in note
+        and "`5`" in note
+        and "`(1,0,0)`" in note
+        and "`(1,1,1)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "27 > 25" in note,
+    )
+    checks.check(
+        "not-leftover-of-nu",
+        "ν cannot price the all-face slide (2,2,0)→(3,2,0)",
+        phi_cost((2, 2, 0), (3, 2, 0)) == 3
+        and nu_cost((2, 2, 0), (3, 2, 0)) == 1
+        and "not leftover of `ν`" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "μ cannot price every face slide; (2,2,0)→(3,2,0) has μ=1",
+        phi_cost((2, 2, 0), (3, 2, 0)) == 3
+        and mu_cost((2, 2, 0), (3, 2, 0)) == 1
+        and mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and "cannot price every face slide" in note,
+    )
+    checks.check(
+        "seed-and-face-clauses",
+        "seed-exit, both-weights-1, support drop, and every 2→2 hop cost 3",
+        phi_cost((0, 0, 0), (1, 0, 0)) == 3
+        and phi_cost((1, 0, 0), (2, 0, 0)) == 3
+        and phi_cost((1, 0, 0), (1, 1, 0)) == 1
+        and phi_cost((1, 1, 0), (1, 1, 1)) == 1
+        and phi_cost((1, 1, 0), (1, 0, 0)) == 3
+        and phi_cost((1, 1, 0), (2, 1, 0)) == 3
+        and phi_cost((2, 2, 0), (3, 2, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "φ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_6(0) under phi, t(1,0,0)=3 and t(1,1,1)=5. 27>25. Same pair as mu. Displayed, not adopted.

## Runner

`scripts/all_face_slide_samek_k1_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.