### PR TITLE
feat(hugwhy13): t(13,0,0)=23 vs t(13,13,13)=41 paths of the mu wall

### DIFF
--- a/docs/CORRIDOR_SLIDE_WHY_SAMEK_K13_FAILS_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/CORRIDOR_SLIDE_WHY_SAMEK_K13_FAILS_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,263 @@
+---
+claim_id: corridor_slide_why_samek_k13_fails_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Lex-first shortest paths to (13,0,0) and (13,13,13) under the named corridor-slide hop-cost on B_39(0) are named. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py
+---
+
+# Lex-First Shortest Paths To (13,0,0) And (13,13,13) On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_39(0)`,
+restricted to naming a lex-first shortest walk from `0` to `(13,0,0)` and a
+lex-first shortest walk from `0` to `(13,13,13)`, and displaying the same-`k`
+reverse comparison at `k=13`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py`](../scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The same named corridor-slide hop-cost `μ` already scored on `B_39(0)` is
+scored independently here by naming lex-first shortest paths to both
+same-`k` sites at `k=13`. Same-`k` reverse under `μ` holds at `k=1` through
+`k=12` and fails at `k=13` (`23` versus `41`). The pair of walks is not leftover of the two
+arrival integers: one origin Dijkstra is run on this ball, and the two
+site sequences are named.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_39(0)`, the displayed
+comparator `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The displayed rule `μ` is
+
+`μ(v→w) = 3` if `ν(v→w)` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The first three clauses are those of `ν`: seed-exit, both weights `1`, and
+support drop. The fourth clause is the axis-hugging `2→2` slide. Those four
+clauses are the whole rule. Uniqueness is not claimed.
+
+One origin Dijkstra on `B_39(0)` (82239 sites; 82238 nonzero) gives
+
+`t(13,0,0) = 23`, `t(13,13,13) = 41`.
+
+The site `(13,13,13)` has ℓ¹ norm `39`, so it is absent from `B_36(0)`. The
+`B_39(0)` table is therefore not leftover of a smaller-ball table.
+
+Among all walks of cost `23` from `0` to `(13,0,0)`, the lexicographically
+first sequence of sites is
+
+`(0,0,0) → (0,-1,0) → (0,-1,-1) → (1,-1,-1) → (2,-1,-1) → (3,-1,-1) → (4,-1,-1) → (5,-1,-1) → (6,-1,-1) → (7,-1,-1) → (8,-1,-1) → (9,-1,-1) → (10,-1,-1) → (11,-1,-1) → (12,-1,-1) → (13,-1,-1) → (13,-1,0) → (13,0,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3` and running costs
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 20, 23` summing to `23`. After the seed-exit
+the walk leaves the axis into the body, travels along the line
+`y = z = -1`, and then pays two support-drop hops of cost `3`.
+
+Among all walks of cost `41` from `0` to `(13,13,13)`, the lexicographically
+first sequence of sites is
+
+`(0,0,0) → (0,0,1) → (0,1,1) → (1,1,1) → (1,1,2) → (1,1,3) → (1,1,4) → (1,1,5) → (1,1,6) → (1,1,7) → (1,1,8) → (1,1,9) → (1,1,10) → (1,1,11) → (1,1,12) → (1,1,13) → (1,2,13) → (1,3,13) → (1,4,13) → (1,5,13) → (1,6,13) → (1,7,13) → (1,8,13) → (1,9,13) → (1,10,13) → (1,11,13) → (1,12,13) → (1,13,13) → (2,13,13) → (3,13,13) → (4,13,13) → (5,13,13) → (6,13,13) → (7,13,13) → (8,13,13) → (9,13,13) → (10,13,13) → (11,13,13) → (12,13,13) → (13,13,13)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1`
+and running costs
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41`
+summing to `41`. That walk never uses the support-drop clause and never uses
+the axis-hugging `2→2` slide.
+
+The displayed same-`k` comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+which is `529/169` versus `1681/507`, or equivalently `1587 > 1681`. The
+inequality does not hold: `1587 < 1681`. Same-`k` reverse at `k=13` under
+`μ` is no. The comparison is displayed, not adopted.
+
+The pair is not leftover of `ν`: the same sites under `ν` are `19` versus
+`41`, and `1083 > 1681` fails. The extra corridor-slide clause is what
+changes the axis arrival. On the hugging hop `(1,1,0) → (2,1,0)` one has
+`|σ| : 2 → 2` and least nonzero `|w_i| = 1`, so `ν = 1` while `μ = 3`.
+The face corridor that stays at `|σ|=2` with a unit transverse coordinate
+is therefore priced by `μ` and not by `ν`. The leave-axis hop
+`(0,-1,0) → (1,-1,0)` stays at cost `1` under both `ν` and `μ`. Therefore
+`ν` cannot price the axis-hugging slide, and the `μ` walks below are not
+a leftover of `ν`.
+
+The rule is displayed, not adopted. Do not write `μ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate test, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_39(0) = { v ∈ Z^3 : |v|_1 ≤ 39 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_39(0)`,
+`t(v)` is the least sum of `μ` along a directed path from `0` to `v` in
+that graph.
+
+A walk is lex-first among shortest walks to a named site when its sequence
+of sites is the least tuple of integer triples, compared coordinatewise,
+among all walks of cost `t` of that site.
+
+The comparator `ν` uses only the first three clauses of `μ`. On the
+axis-hugging slide `(1,1,0) → (2,1,0)` one has `|σ| : 2 → 2` and least
+nonzero `|w_i| = 1`, so `ν = 1` while `μ = 3`. Therefore `ν` cannot price
+the corridor slide, and the `μ` scores below are not a leftover of `ν`.
+
+## Theorem 1 — Arrivals And Lex-First Shortest Paths
+
+One origin Dijkstra on `B_39(0)` returns the integer arrivals
+
+| site | `t_μ` |
+|---|---:|
+| `(13,0,0)` | `23` |
+| `(13,13,13)` | `41` |
+
+Every listed site lies in `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39`,
+so it is absent from `B_36(0)`. The pair is computed on `B_39(0)`, not
+copied from a smaller-ball table and not copied from the `ν` pair
+`19` versus `41`. These values are Dijkstra outputs, not fitted scalars.
+
+The lex-first walk of cost `23` to `(13,0,0)` is the eighteen-site walk recorded
+above. The seventeen hop-costs are seed-exit `3` from `(0,0,0)` onto
+`(0,-1,0)`, one support-increase cost-`1` step `(0,-1,0) → (0,-1,-1)`
+into the face, one support-increase cost-`1` step
+`(0,-1,-1) → (1,-1,-1)` into the body, twelve support-preserving cost-`1`
+body hops along `y = z = -1` from `(1,-1,-1)` to `(13,-1,-1)`, a
+support-drop `3` from `(13,-1,-1)` onto `(13,-1,0)`, and a support-drop
+`3` from `(13,-1,0)` onto `(13,0,0)`. The running costs after each hop are
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 20, 23`.
+
+That route is forced by the corridor-slide clause. The two-coordinate
+face walk that is cheapest under `ν`,
+
+`(0,0,0) → (0,-1,0) → (1,-1,0) → (2,-1,0) → (3,-1,0) → (4,-1,0) → (5,-1,0) → (6,-1,0) → (7,-1,0) → (8,-1,0) → (9,-1,0) → (10,-1,0) → (11,-1,0) → (12,-1,0) → (13,-1,0) → (13,0,0)`,
+
+has hop-costs `3, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3` under `μ` and sums to `43`.
+Each hop `(n,-1,0) → (n+1,-1,0)` for `n ≥ 1` is a `2→2` slide whose
+destination has least nonzero absolute coordinate `1`, so `μ` prices it
+at `3` while `ν` prices it at `1`. The lex-first `μ` walk therefore
+enters the body, where those slides are not charged, and pays two
+support-drops at the end instead of a cheap face corridor.
+
+The same axis cost is realized by later walks that stay in the positive
+half-space, for example
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (3,1,1) → (4,1,1) → (5,1,1) → (6,1,1) → (7,1,1) → (8,1,1) → (9,1,1) → (10,1,1) → (11,1,1) → (12,1,1) → (13,1,1) → (13,1,0) → (13,0,0)`
+
+with hop-costs `3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3`. That walk is also shortest, but
+`(0,-1,0)` precedes `(1,0,0)`, so it is not lex-first.
+
+The lex-first walk of cost `41` to `(13,13,13)` is the forty-site walk
+recorded above. The thirty-nine hop-costs are seed-exit `3` from `(0,0,0)`
+onto `(0,0,1)`, two support-increase cost-`1` steps
+`(0,0,1) → (0,1,1) → (1,1,1)`, and then thirty-six support-preserving or
+support-increase cost-`1` steps that fill the remaining coordinates of
+`(13,13,13)`. No hop on that walk drops support, and no hop is an
+axis-hugging `2→2` slide. The running costs after each hop are
+`3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41`.
+
+The same body-diagonal cost is realized by later walks that start into
+the positive `x` half-space, for example
+
+`(0,0,0) → (1,0,0) → (1,1,0) → (1,1,1) → (2,1,1) → (3,1,1) → (4,1,1) → (5,1,1) → (6,1,1) → (7,1,1) → (8,1,1) → (9,1,1) → (10,1,1) → (11,1,1) → (12,1,1) → (13,1,1) → (13,2,1) → (13,3,1) → (13,4,1) → (13,5,1) → (13,6,1) → (13,7,1) → (13,8,1) → (13,9,1) → (13,10,1) → (13,11,1) → (13,12,1) → (13,13,1) → (13,13,2) → (13,13,3) → (13,13,4) → (13,13,5) → (13,13,6) → (13,13,7) → (13,13,8) → (13,13,9) → (13,13,10) → (13,13,11) → (13,13,12) → (13,13,13)`
+
+with hop-costs `3` then thirty-eight cost-`1` steps. That walk is also shortest,
+but `(0,0,1)` precedes `(1,0,0)`, so it is not lex-first.
+
+A walk that starts toward `-x` is lex-smaller than the named axis walk,
+but it is not shortest. The twenty-site walk
+
+`(0,0,0) → (-1,0,0) → (-1,-1,0) → (-1,-1,-1) → (0,-1,-1) → (1,-1,-1) → (2,-1,-1) → (3,-1,-1) → (4,-1,-1) → (5,-1,-1) → (6,-1,-1) → (7,-1,-1) → (8,-1,-1) → (9,-1,-1) → (10,-1,-1) → (11,-1,-1) → (12,-1,-1) → (13,-1,-1) → (13,-1,0) → (13,0,0)`
+
+pays an extra support-drop `3` on `(-1,-1,-1) → (0,-1,-1)` when it
+crosses the plane `x = 0` and briefly drops from three nonzero
+coordinates to two. Its hop-costs sum to `27`, which is strictly larger
+than `t(13,0,0) = 23`.
+
+This names the two paths. It is not leftover of the two arrival integers.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=13`
+
+The Euclidean-normalized comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+equivalently `3 t(13,0,0)^2 ? t(13,13,13)^2`. Substituting the computed times
+gives `3 · 23^2 = 1587` and `41^2 = 1681`, so
+
+`1587 > 1681` is false; `1587 < 1681`.
+
+Arrival per Euclidean length is not larger at `(13,0,0)` than at
+`(13,13,13)`. Same-`k` reverse at `k=13` under `μ` is no. The comparison
+is displayed, not adopted. The inequality does not hold.
+
+The named walks show why reverse fails under `μ` at `k=13`: the axis
+lex-first walk under `μ` cannot use the cheap `|σ|=2` face corridor that
+produces `t(13,0,0) = 19` under `ν`. It must enter the body and pay two
+support-drops, raising the axis arrival to `23` while the body-diagonal
+arrival stays `41`. That raise is enough for reverse through `k=12` and
+not enough at `k=13`. Then `1587 < 1681`.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μ` is a displayed scoring device on `B_39(0)`. Do not write `μ`
+into Admissibility. Do not attach L1. The exhibited walks are one shortest
+path to each named site under that displayed rule. Uniqueness is not claimed
+among hop-costs, and the walks are not offered as a replacement
+for unit-cost first arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exhibited lex-first shortest walks to (13,0,0) and (13,13,13) on the finite ball B_39(0) under one named hop-cost, with the displayed same-k reverse comparison at k=13. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_39(0) for the displayed rule μ at k=13; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μ` among hop-costs that score the same-`k` pair at `k=13`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_39(0)`.
+- Any reuse of the two arrival integers as a substitute for exhibiting the
+  two walks.
+- Any reuse of the `ν` arrival table as a substitute for the `μ` Dijkstra.
+- Any second Dijkstra.
+- Any adoption of the leave-axis `1→2` clause as part of `μ`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2689,6 +2689,10 @@
   "correlator_cycle_phases_readback_blind_or_state_contingent_bounded_note_2026-06-12": {
    "deps_hash": "7b707271a9a8",
    "out_degree": 2
+  },
+  "corridor_slide_why_samek_k13_fails_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "cosmological_constant_result_2026-04-12": {
    "deps_hash": "bdad8aef31d8",

--- a/logs/runner-cache/corridor_slide_why_samek_k13_fails_b39_2026_08_15.txt
+++ b/logs/runner-cache/corridor_slide_why_samek_k13_fails_b39_2026_08_15.txt
@@ -1,0 +1,65 @@
+===== runner cache v1 =====
+runner: scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py
+runner_sha256: cdcfe45ac58466bf04cff273a3376efded1f496ba37660adeb69435608eec7f3
+input_fingerprint_sha256: 2414aef91bdd80fb29660ee65e1e68009881c6d968635577acb82ed4828b2baf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.62
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/CORRIDOR_SLIDE_WHY_SAMEK_K13_FAILS_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Lex-first shortest paths to (13,0,0) and (13,13,13) under the named corridor-slide hop-cost on B_39(0) are named. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the named-path statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 82239
+t(13,0,0) 23
+t(13,13,13) 41
+lex_first_axis (0,0,0) → (0,-1,0) → (0,-1,-1) → (1,-1,-1) → (2,-1,-1) → (3,-1,-1) → (4,-1,-1) → (5,-1,-1) → (6,-1,-1) → (7,-1,-1) → (8,-1,-1) → (9,-1,-1) → (10,-1,-1) → (11,-1,-1) → (12,-1,-1) → (13,-1,-1) → (13,-1,0) → (13,0,0)
+lex_first_body (0,0,0) → (0,0,1) → (0,1,1) → (1,1,1) → (1,1,2) → (1,1,3) → (1,1,4) → (1,1,5) → (1,1,6) → (1,1,7) → (1,1,8) → (1,1,9) → (1,1,10) → (1,1,11) → (1,1,12) → (1,1,13) → (1,2,13) → (1,3,13) → (1,4,13) → (1,5,13) → (1,6,13) → (1,7,13) → (1,8,13) → (1,9,13) → (1,10,13) → (1,11,13) → (1,12,13) → (1,13,13) → (2,13,13) → (3,13,13) → (4,13,13) → (5,13,13) → (6,13,13) → (7,13,13) → (8,13,13) → (9,13,13) → (10,13,13) → (11,13,13) → (12,13,13) → (13,13,13)
+hop_costs_axis 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3
+hop_costs_body 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+running_cost_axis [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 20, 23]
+running_cost_body [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41]
+t(13,0,0)^2/169 529/169
+t(13,13,13)^2/507 1681/507
+3t_axis^2 1587
+t_body^2 1681
+reverse False
+dijkstra_calls 1
+mu_hug 3
+nu_hug 1
+mu_leave 1
+nu_leave 1
+face_corridor_mu 43
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b39 B_39(0) has 82239 sites and 82238 nonzero sites
+PASS: t-13000-131313 t(13,0,0)=23 and t(13,13,13)=41
+PASS: valid-walks the exhibited walks are nearest-neighbor walks in B_39(0) from 0 to the two sites
+PASS: hop-costs-match recorded hop-costs equal μ on successive sites and sum to the arrivals
+PASS: running-cost running costs are the partial sums of the hop-costs
+PASS: shortest each walk cost equals the Dijkstra arrival, so each walk is shortest
+PASS: lex-first-paths the Dijkstra reconstructions are the named lex-first site sequences
+PASS: lex-first-beats-later-shortest later cost-matching walks exist and are strictly lex-later
+PASS: lex-smaller-is-not-shortest a lex-smaller axis walk that starts toward -x costs more than 23
+PASS: reverse-k13 t(13,0,0)^2/169 > t(13,13,13)^2/507 does not hold
+PASS: note-records-paths note records the lex-first sites, hop-costs, and running costs
+PASS: note-records-times note records the two computed arrivals
+PASS: not-leftover-of-the-two-times the walks are not leftover of the two arrival integers
+PASS: not-leftover-of-nu μ prices the axis-hugging 2→2 hop at 3 while ν prices it at 1
+PASS: seed-and-slide-clauses ν clauses and hugging 2→2 cost 3; 1→2 and non-hugging 2→2 cost 1
+PASS: not-leftover-of-b36 (13,13,13) lies outside B_36(0) and the note says so
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py
+++ b/scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Exhibit lex-first shortest walks to (13,0,0) and (13,13,13) under μ on B_39(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/CORRIDOR_SLIDE_WHY_SAMEK_K13_FAILS_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/CORRIDOR_SLIDE_WHY_SAMEK_K13_FAILS_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Lex-first shortest paths to (13,0,0) and (13,13,13) under "
+    "the named corridor-slide hop-cost on B_39(0) are named. "
+    "Displayed, not adopted."
+)
+AXIS = (13, 0, 0)
+BODY = (13, 13, 13)
+NEIGH = ((-1, 0, 0), (0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0), (1, 0, 0))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 23
+T_BODY_REP = 41
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> set[tuple[int, int, int]]:
+    sites: set[tuple[int, int, int]] = set()
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.add((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def hop_costs(path: tuple[tuple[int, int, int], ...]) -> list[int]:
+    return [mu_cost(a, b) for a, b in zip(path, path[1:])]
+
+
+def format_path(path: tuple[tuple[int, int, int], ...]) -> str:
+    return " → ".join(f"({v[0]},{v[1]},{v[2]})" for v in path)
+
+
+def format_costs(costs: list[int]) -> str:
+    return ", ".join(str(c) for c in costs)
+
+
+def is_walk(path: tuple[tuple[int, int, int], ...], sites: set[tuple[int, int, int]]) -> bool:
+    if not path:
+        return False
+    for a, b in zip(path, path[1:]):
+        if a not in sites or b not in sites:
+            return False
+        if l1((a[0] - b[0], a[1] - b[1], a[2] - b[2])) != 1:
+            return False
+    return True
+
+
+def running_costs(costs: list[int]) -> list[int]:
+    running: list[int] = []
+    acc = 0
+    for c in costs:
+        acc += c
+        running.append(acc)
+    return running
+
+
+def dijkstra_lex_first(
+    sites: set[tuple[int, int, int]],
+    targets: set[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], tuple[int, tuple[tuple[int, int, int], ...]]]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    origin = (0, 0, 0)
+    heap: list[tuple[int, tuple[tuple[int, int, int], ...]]] = [(0, (origin,))]
+    seen: set[tuple[int, int, int]] = set()
+    found: dict[tuple[int, int, int], tuple[int, tuple[tuple[int, int, int], ...]]] = {}
+    while heap:
+        dist, path = heapq.heappop(heap)
+        v = path[-1]
+        if v in seen:
+            continue
+        seen.add(v)
+        if v in targets:
+            found[v] = (dist, path)
+            if len(found) == len(targets):
+                return found
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in sites or w in seen:
+                continue
+            heapq.heappush(heap, (dist + mu_cost(v, w), path + (w,)))
+    missing = targets - set(found)
+    raise RuntimeError(f"targets unreachable: {missing}")
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the named-path statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μ is not written into Admissibility",
+        "Do not write `μ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(39)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    found = dijkstra_lex_first(sites, {AXIS, BODY})
+    t13000, path_axis = found[AXIS]
+    t131313, path_body = found[BODY]
+    costs_axis = hop_costs(path_axis)
+    costs_body = hop_costs(path_body)
+    running_axis = running_costs(costs_axis)
+    running_body = running_costs(costs_body)
+    path_axis_text = format_path(path_axis)
+    path_body_text = format_path(path_body)
+    cost_axis_text = format_costs(costs_axis)
+    cost_body_text = format_costs(costs_body)
+    running_axis_text = format_costs(running_axis)
+    running_body_text = format_costs(running_body)
+    reverse = 3 * t13000 * t13000 > t131313 * t131313
+
+    later_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        *[(x, 1, 1) for x in range(2, 14)],
+        (13, 1, 0),
+        (13, 0, 0),
+    )
+    later_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        *[(x, 1, 1) for x in range(2, 14)],
+        *[(13, y, 1) for y in range(2, 14)],
+        *[(13, 13, z) for z in range(2, 14)],
+    )
+    smaller_not_shortest_axis = (
+        (0, 0, 0),
+        (-1, 0, 0),
+        (-1, -1, 0),
+        (-1, -1, -1),
+        (0, -1, -1),
+        *[(x, -1, -1) for x in range(1, 14)],
+        (13, -1, 0),
+        (13, 0, 0),
+    )
+    face_corridor = (
+        (0, 0, 0),
+        (0, -1, 0),
+        *[(x, -1, 0) for x in range(1, 14)],
+        (13, 0, 0),
+    )
+    expected_axis = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (0, -1, -1),
+        *[(x, -1, -1) for x in range(1, 14)],
+        (13, -1, 0),
+        (13, 0, 0),
+    )
+    expected_body = (
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 1),
+        (1, 1, 1),
+        *[(1, 1, z) for z in range(2, 14)],
+        *[(1, y, 13) for y in range(2, 14)],
+        *[(x, 13, 13) for x in range(2, 14)],
+    )
+    expected_axis_costs = [3] + [1] * 14 + [3, 3]
+    expected_body_costs = [3] + [1] * 38
+    expected_axis_running = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 20, 23]
+    expected_body_running = list(range(3, 42))
+    hug_hop = ((1, 1, 0), (2, 1, 0))
+    leave_hop = ((0, -1, 0), (1, -1, 0))
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(13,0,0) {t13000}")
+    print(f"t(13,13,13) {t131313}")
+    print(f"lex_first_axis {path_axis_text}")
+    print(f"lex_first_body {path_body_text}")
+    print(f"hop_costs_axis {cost_axis_text}")
+    print(f"hop_costs_body {cost_body_text}")
+    print(f"running_cost_axis {running_axis}")
+    print(f"running_cost_body {running_body}")
+    print(f"t(13,0,0)^2/169 {t13000 * t13000}/169")
+    print(f"t(13,13,13)^2/507 {t131313 * t131313}/507")
+    print(f"3t_axis^2 {3 * t13000 * t13000}")
+    print(f"t_body^2 {t131313 * t131313}")
+    print(f"reverse {reverse}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"mu_hug {mu_cost(*hug_hop)}")
+    print(f"nu_hug {nu_cost(*hug_hop)}")
+    print(f"mu_leave {mu_cost(*leave_hop)}")
+    print(f"nu_leave {nu_cost(*leave_hop)}")
+    print(f"face_corridor_mu {sum(hop_costs(face_corridor))}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b39",
+        "B_39(0) has 82239 sites and 82238 nonzero sites",
+        len(sites) == 82239 and len(nonzero) == 82238 and all(l1(v) <= 39 for v in sites),
+    )
+    checks.check(
+        "t-13000-131313",
+        f"t(13,0,0)={T_AXIS_REP} and t(13,13,13)={T_BODY_REP}",
+        t13000 == T_AXIS_REP and t131313 == T_BODY_REP,
+    )
+    checks.check(
+        "valid-walks",
+        "the exhibited walks are nearest-neighbor walks in B_39(0) from 0 to the two sites",
+        path_axis[0] == (0, 0, 0)
+        and path_axis[-1] == AXIS
+        and path_body[0] == (0, 0, 0)
+        and path_body[-1] == BODY
+        and is_walk(path_axis, sites)
+        and is_walk(path_body, sites),
+    )
+    checks.check(
+        "hop-costs-match",
+        "recorded hop-costs equal μ on successive sites and sum to the arrivals",
+        costs_axis == expected_axis_costs
+        and costs_body == expected_body_costs
+        and sum(costs_axis) == 23
+        and sum(costs_body) == 41,
+    )
+    checks.check(
+        "running-cost",
+        "running costs are the partial sums of the hop-costs",
+        running_axis == expected_axis_running and running_body == expected_body_running,
+    )
+    checks.check(
+        "shortest",
+        "each walk cost equals the Dijkstra arrival, so each walk is shortest",
+        sum(costs_axis) == t13000 and sum(costs_body) == t131313,
+    )
+    checks.check(
+        "lex-first-paths",
+        "the Dijkstra reconstructions are the named lex-first site sequences",
+        path_axis == expected_axis and path_body == expected_body,
+    )
+    checks.check(
+        "lex-first-beats-later-shortest",
+        "later cost-matching walks exist and are strictly lex-later",
+        is_walk(later_axis, sites)
+        and is_walk(later_body, sites)
+        and sum(hop_costs(later_axis)) == 23
+        and sum(hop_costs(later_body)) == 41
+        and path_axis < later_axis
+        and path_body < later_body,
+    )
+    checks.check(
+        "lex-smaller-is-not-shortest",
+        "a lex-smaller axis walk that starts toward -x costs more than 23",
+        is_walk(smaller_not_shortest_axis, sites)
+        and smaller_not_shortest_axis < path_axis
+        and sum(hop_costs(smaller_not_shortest_axis)) > 23,
+    )
+    checks.check(
+        "reverse-k13",
+        "t(13,0,0)^2/169 > t(13,13,13)^2/507 does not hold",
+        (not reverse)
+        and 3 * t13000 * t13000 == 1587
+        and t131313 * t131313 == 1681
+        and "1587 < 1681" in note
+        and "inequality does not hold" in note,
+    )
+    checks.check(
+        "note-records-paths",
+        "note records the lex-first sites, hop-costs, and running costs",
+        path_axis_text in note
+        and path_body_text in note
+        and cost_axis_text in note
+        and cost_body_text in note
+        and running_axis_text in note
+        and running_body_text in note,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`23`" in note
+        and "`41`" in note
+        and "`(13,0,0)`" in note
+        and "`(13,13,13)`" in note,
+    )
+    checks.check(
+        "not-leftover-of-the-two-times",
+        "the walks are not leftover of the two arrival integers",
+        "not leftover of the two arrival integers" in note
+        and not reverse
+        and path_axis != path_body,
+    )
+    checks.check(
+        "not-leftover-of-nu",
+        "μ prices the axis-hugging 2→2 hop at 3 while ν prices it at 1",
+        mu_cost(*hug_hop) == 3
+        and nu_cost(*hug_hop) == 1
+        and mu_cost(*leave_hop) == 1
+        and nu_cost(*leave_hop) == 1
+        and t13000 == 23
+        and t131313 == 41
+        and is_walk(face_corridor, sites)
+        and sum(hop_costs(face_corridor)) == 43
+        and "cannot price" in note
+        and "19` versus `41" in note,
+    )
+    checks.check(
+        "seed-and-slide-clauses",
+        "ν clauses and hugging 2→2 cost 3; 1→2 and non-hugging 2→2 cost 1",
+        mu_cost((0, 0, 0), (0, -1, 0)) == 3
+        and mu_cost((0, -1, 0), (0, -1, -1)) == 1
+        and mu_cost((0, -1, -1), (1, -1, -1)) == 1
+        and mu_cost((13, -1, -1), (13, -1, 0)) == 3
+        and mu_cost((13, -1, 0), (13, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mu_cost((2, 2, 0), (3, 2, 0)) == 1
+        and mu_cost((1, 1, 1), (2, 1, 1)) == 1
+        and all(c == 1 for c in costs_body[1:]),
+    )
+    checks.check(
+        "not-leftover-of-b36",
+        "(13,13,13) lies outside B_36(0) and the note says so",
+        l1((13, 13, 13)) == 39
+        and (13, 13, 13) in found
+        and "absent from `B_36(0)`" in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μ(v→w)" not in axiom
+        and "ν(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_39(0) under mu, lex-first paths to the k=13 pair are named. Reverse fails 1587<1681. Displayed, not adopted.

## Runner

`scripts/corridor_slide_why_samek_k13_fails_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.