### PR TITLE
feat(entk13): enter-body restores k=13 reverse: t=25 vs t=43

### DIFF
--- a/docs/ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,167 @@
+---
+claim_id: enter_body_samek_k13_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=13 under the named enter-body hop-cost on B_39(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/enter_body_samek_k13_b39_2026_08_15.py
+---
+
+# Named Enter-Body Same-k Reverse At k=13 On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_39(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=13`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/enter_body_samek_k13_b39_2026_08_15.py`](../scripts/enter_body_samek_k13_b39_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named enter-body hop-cost `ε` is the already scored corridor-slide
+rule `μ` plus cost `3` on a `2→3` hop. Same-`k` reverse under `μ` fails at
+`k=13` (`23` versus `41`). The cheap `μ` body walk to `(13,13,13)` enters
+weight-`3` from a weight-`2` face at cost `1`. `ε` prices that hop at `3`.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_39(0)`, the displayed
+rule `ε` is
+
+`ε(v→w) = 3` if `μ` would be `3` or `(|σ_v|=2` and `|σ_w|=3)`, else `1`,
+
+where `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`,
+
+and `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the corridor slide. The fifth clause is enter-body.
+Those five clauses are the whole rule.
+
+One Dijkstra from the origin on `B_39(0)` (82239 sites; 82238 nonzero) gives
+
+`t(13,0,0) = 25`, `t(13,13,13) = 43`.
+
+The displayed same-`k` comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+which is `625/169` versus `1849/507`, or equivalently `1875 > 1849`. The
+inequality holds. Same-`k` reverse at `k=13` under `ε` is yes. The `μ`
+fail at the `k=13` wall does not continue under `ε`. Independently, the
+new axis site is `t(39,0,0) = 55`. The shared axis site
+`t(36,0,0) = 48` is an `ε` score on this ball, not a `μ` leftover.
+
+The pair is not leftover of `μ`: the same sites under `μ` are `23` and
+`41`, and the extra enter-body clause is what changes both times. The
+site `(13,13,13)` has ℓ¹ norm `39`, so it is absent from `B_36(0)`. The
+`B_39(0)` table is therefore not leftover of the `B_36(0)` times.
+
+The rule is displayed, not adopted. Do not write `ε` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_39(0) = { v ∈ Z^3 : |v|_1 ≤ 39 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_39(0)`,
+`t(v)` is the least sum of `ε` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses only the first four clauses of `ε`. On the
+enter-body hop `(1,1,0) → (1,1,1)` one has `|σ| : 2 → 3`, so `μ = 1`
+while `ε = 3`. Therefore `μ` cannot price enter body, and the `ε` scores
+below are not a leftover of `μ`.
+
+## Theorem 1 — Arrivals `t(13,0,0)` And `t(13,13,13)` On `B_39(0)`
+
+One origin Dijkstra on `B_39(0)` returns the integer arrivals
+
+| site | `t_ε` |
+|---|---:|
+| `(13,0,0)` | `25` |
+| `(13,13,13)` | `43` |
+
+Every listed site lies in `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39`,
+so it is absent from `B_36(0)`. The pair is computed on `B_39(0)`, not
+copied from a smaller-ball table and not copied from the `μ` pair
+`23` versus `41`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `25` is seed-exit `3` onto `(1,0,0)`,
+support-increase `1` onto `(1,1,0)`, enter-body `3` onto `(1,1,1)`,
+twelve support-preserving cost-`1` body hops to `(13,1,1)`, and two
+support-drops `3` then `3` onto `(13,0,0)`, summing to `25`. That walk is
+a witness of cost `25`, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=13`
+
+The Euclidean-normalized comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+equivalently `3 t(13,0,0)^2 ? t(13,13,13)^2`. Substituting the computed times
+gives `3 · 25^2 = 1875` and `43^2 = 1849`, so
+
+`1875 > 1849`.
+
+Arrival per Euclidean length is larger at `(13,0,0)` than at `(13,13,13)`.
+Same-`k` reverse at `k=13` under `ε` is yes. The inequality holds. The
+comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ε` is a displayed scoring device on `B_39(0)`. Do not write `ε`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_39(0) for one named hop-cost at k=13. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_39(0) for the displayed rule ε at k=13; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ε` among hop-costs that reverse the same-`k` pair at `k=13`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_39(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=13`.
+- Any reuse of the `μ` arrival table as a substitute for the `ε` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4457,6 +4457,10 @@
   "enforced_dual_rail_lock_cycle745_bounded_theorem_note_2026-07-28": {
    "deps_hash": "423f1f549b6b",
    "out_degree": 4
+  },
+  "enter_body_samek_k13_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ep_record_stiffness_conditional_shared_coupling_template_note_2026-06-07": {
    "deps_hash": "69a1ede16473",

--- a/logs/runner-cache/enter_body_samek_k13_b39_2026_08_15.txt
+++ b/logs/runner-cache/enter_body_samek_k13_b39_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/enter_body_samek_k13_b39_2026_08_15.py
+runner_sha256: cdb53748cca842d7171e1b45ec69586de1b1dee6c8c58acb2d01ecc2742efe94
+input_fingerprint_sha256: ce1131ce714ca8afcb30b7c79cf62e500528787336c22013b0dfd256b30155ba
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.70
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=13 under the named enter-body hop-cost on B_39(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ε is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 82239
+t(13,0,0) 25
+t(13,13,13) 43
+t(13,0,0)^2/169 625/169
+t(13,13,13)^2/507 1849/507
+3t_axis^2 1875
+t_body^2 1849
+reverse True
+t(39,0,0) 55
+t(36,0,0) 48
+dijkstra_calls 1
+witness_eps_costs [3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_eps_sum 25
+PASS: t-1300-131313 t(13,0,0)=25 and t(13,13,13)=43
+PASS: reverse-k13 t(13,0,0)^2/169 > t(13,13,13)^2/507 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b39 B_39(0) has 82239 sites and 82238 nonzero sites
+PASS: reachable every site of B_39(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-mu ε prices the enter-body hop at 3 while μ prices it at 1
+PASS: not-leftover-of-b36 (13,13,13) lies outside B_36(0) and the note says so
+PASS: seed-and-enter-body-clauses seed-exit, both-weights-1, support-drop, corridor-slide, and enter-body cost 3; other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/enter_body_samek_k13_b39_2026_08_15.py
+++ b/scripts/enter_body_samek_k13_b39_2026_08_15.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=13 under ε on B_39(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=13 under the named "
+    "enter-body hop-cost on B_39(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 25
+T_BODY_REP = 43
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def epsilon_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 3:
+        return 3
+    return 1
+
+
+def dijkstra_eps(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + epsilon_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ε is not written into Admissibility",
+        "Do not write `ε` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(39)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_eps(sites)
+    t1300 = dist[(13, 0, 0)]
+    t131313 = dist[(13, 13, 13)]
+    t3900 = dist[(39, 0, 0)]
+    t3600 = dist[(36, 0, 0)]
+    reverse = 3 * t1300 * t1300 > t131313 * t131313
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        *[(x, 1, 1) for x in range(2, 14)],
+        (13, 1, 0),
+        (13, 0, 0),
+    )
+    witness_eps_costs = [epsilon_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    print(f"n_sites {len(sites)}")
+    print(f"t(13,0,0) {t1300}")
+    print(f"t(13,13,13) {t131313}")
+    print(f"t(13,0,0)^2/169 {t1300 * t1300}/169")
+    print(f"t(13,13,13)^2/507 {t131313 * t131313}/507")
+    print(f"3t_axis^2 {3 * t1300 * t1300}")
+    print(f"t_body^2 {t131313 * t131313}")
+    print(f"reverse {reverse}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(36,0,0) {t3600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_eps_costs {witness_eps_costs}")
+    print(f"witness_eps_sum {sum(witness_eps_costs)}")
+
+    checks.check(
+        "t-1300-131313",
+        f"t(13,0,0)={T_AXIS_REP} and t(13,13,13)={T_BODY_REP}",
+        t1300 == T_AXIS_REP and t131313 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k13",
+        "t(13,0,0)^2/169 > t(13,13,13)^2/507 holds",
+        reverse
+        and 3 * t1300 * t1300 == 1875
+        and t131313 * t131313 == 1849
+        and "1875 > 1849" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b39",
+        "B_39(0) has 82239 sites and 82238 nonzero sites",
+        len(sites) == 82239 and len(nonzero) == 82238 and all(l1(v) <= 39 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_39(0) is reached",
+        len(dist) == 82239,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`25`" in note
+        and "`43`" in note
+        and "`(13,0,0)`" in note
+        and "`(13,13,13)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1875 > 1849" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "ε prices the enter-body hop at 3 while μ prices it at 1",
+        epsilon_cost((1, 1, 0), (1, 1, 1)) == 3
+        and mu_cost((1, 1, 0), (1, 1, 1)) == 1
+        and sum(witness_eps_costs) == 25
+        and t1300 == 25
+        and t131313 == 43
+        and t1300 != 23
+        and t131313 != 41
+        and "cannot price enter body" in note
+        and "23` versus `41" in note,
+    )
+    checks.check(
+        "not-leftover-of-b36",
+        "(13,13,13) lies outside B_36(0) and the note says so",
+        l1((13, 13, 13)) == 39
+        and (13, 13, 13) in dist
+        and t3900 == 55
+        and t3600 == 48
+        and t3600 != 46
+        and t3600 != 42
+        and "absent from `B_36(0)`" in note
+        and "not leftover of the `B_36(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-enter-body-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, and enter-body cost 3; other hops cost 1",
+        epsilon_cost((0, 0, 0), (1, 0, 0)) == 3
+        and epsilon_cost((1, 0, 0), (2, 0, 0)) == 3
+        and epsilon_cost((1, 1, 0), (1, 0, 0)) == 3
+        and epsilon_cost((1, 1, 0), (2, 1, 0)) == 3
+        and epsilon_cost((1, 1, 0), (1, 1, 1)) == 3
+        and epsilon_cost((1, 0, 0), (1, 1, 0)) == 1
+        and epsilon_cost((1, 1, 1), (2, 1, 1)) == 1
+        and epsilon_cost((2, 2, 0), (3, 2, 0)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ε(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_39(0) under epsilon (mu plus 2-to-3 cost 3), t(13,0,0)=25 and t(13,13,13)=43. 1875>1849. The mu wall moves. Displayed, not adopted.

## Runner

`scripts/enter_body_samek_k13_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.