### PR TITLE
feat(entk1): enter-body kills k=1 reverse: t=3 vs t=7

### DIFF
--- a/docs/ENTER_BODY_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/ENTER_BODY_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,172 @@
+---
+claim_id: enter_body_samek_k1_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=1 under the named enter-body hop-cost on B_6(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/enter_body_samek_k1_b6_2026_08_15.py
+---
+
+# Named Enter-Body Same-k Reverse At k=1 On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_6(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=1`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/enter_body_samek_k1_b6_2026_08_15.py`](../scripts/enter_body_samek_k1_b6_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named enter-body hop-cost `ε` is the already scored corridor-slide
+rule `μ` plus cost `3` on a `2→3` hop. `φ` matches `μ` at `k=1`, `7`,
+`13`. Cheap large-`k` axis walks can use interior 3-support, so pricing
+the enter-body hop is the named residual. The ball is
+not leftover of a larger-ball table: one origin Dijkstra is run on this
+ball.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_6(0)`, let `ν` be the
+support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. The corridor-slide rule `μ` is
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The displayed rule `ε` is
+
+`ε(v→w) = 3` if `μ` would be `3` or `(|σ_v|=2` and `|σ_w|=3)`, else `1`.
+
+The extra clause is the enter-body `2→3` hop. Those clauses are the whole
+rule.
+
+One Dijkstra from the origin on `B_6(0)` (377 sites; 376 nonzero) gives
+
+`t(1,0,0) = 3`, `t(1,1,1) = 7`.
+
+The displayed same-`k` comparison at `k=1` is
+
+`t(1,0,0)^2 / 1  ?  t(1,1,1)^2 / 3`,
+
+which is `9/1` versus `49/3`, or equivalently `27 > 49`. The inequality
+does not hold. Same-`k` reverse does not hold at `k=1`. The small-`k` bar
+is not killed. Independently, the axis endpoint of this ball is
+`t(6,0,0) = 18`.
+
+The pair is not leftover of `μ` or of `φ`. Under both `μ` and `φ` the same
+sites are `3` and `5`, and `27 > 25` holds. On the enter-body hop
+`(1,1,0) → (1,1,1)` one has `|σ| : 2 → 3`, so `μ = 1` and `φ = 1` while
+`ε = 3`. Therefore `μ` cannot price the enter-body hop, `φ` cannot price
+the enter-body hop, and the `ε` scores below are not a leftover of `μ` or
+`φ`.
+
+The rule is displayed, not adopted. Do not write `ε` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_6(0)`,
+`t(v)` is the least sum of `ε` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses the three support-drop clauses of `ν` plus the
+axis-hugging `2→2` slide. On the enter-body hop `(1,1,0) → (1,1,1)` one
+has `|σ| : 2 → 3`, so `μ = 1` while `ε = 3`. Therefore `μ` cannot price
+the enter-body hop. The all-face-slide comparator `φ` prices every
+`2→2` hop at `3` and still prices this `2→3` hop at `1`, so `φ` cannot
+price the enter-body hop.
+
+## Theorem 1 — Arrivals `t(1,0,0)` And `t(1,1,1)` On `B_6(0)`
+
+One origin Dijkstra on `B_6(0)` returns the integer arrivals
+
+| site | `t_ε` |
+|---|---:|
+| `(1,0,0)` | `3` |
+| `(1,1,1)` | `7` |
+
+Every listed site lies in `B_6(0)`. The pair is computed on `B_6(0)`, not
+copied from a larger-ball table and not copied from the `μ` pair
+`3` versus `5`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness walk to `(1,0,0)` is the seed-exit of cost `3`. A witness walk
+to `(1,1,1)` is seed-exit `3` onto `(1,0,0)`, body `1→2` of cost `1` onto
+`(1,1,0)`, and enter-body `2→3` of cost `3` onto `(1,1,1)`, summing to
+`7`. Those walks are witnesses, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=1`
+
+The Euclidean-normalized comparison at `k=1` is
+
+`t(1,0,0)^2 / 1  ?  t(1,1,1)^2 / 3`,
+
+equivalently `3 t(1,0,0)^2 ? t(1,1,1)^2`. Substituting the computed times
+gives `3 · 3^2 = 27` and `7^2 = 49`, so
+
+`27 > 49` is false; `27 < 49`.
+
+Arrival per Euclidean length is smaller at `(1,0,0)` than at `(1,1,1)`.
+Same-`k` reverse at `k=1` is no. The small-`k` bar is not killed. The
+comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ε` is a displayed scoring device on `B_6(0)`. Do not write `ε`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_6(0) for one named hop-cost at k=1. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_6(0) for the displayed rule ε at k=1; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ε` among hop-costs that score the same-`k` pair at `k=1`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_6(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=1`.
+- Any reuse of a larger-ball arrival table, or of the `μ` or `φ` pair, as
+  a substitute for the radius-`6` Dijkstra.
+- Membership of `ε` as a physical hop-cost. The small-`k` bar is not
+  killed on this ball; that is a displayed exclusion test, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4457,6 +4457,10 @@
   "enforced_dual_rail_lock_cycle745_bounded_theorem_note_2026-07-28": {
    "deps_hash": "423f1f549b6b",
    "out_degree": 4
+  },
+  "enter_body_samek_k1_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ep_record_stiffness_conditional_shared_coupling_template_note_2026-06-07": {
    "deps_hash": "69a1ede16473",

--- a/logs/runner-cache/enter_body_samek_k1_b6_2026_08_15.txt
+++ b/logs/runner-cache/enter_body_samek_k1_b6_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/enter_body_samek_k1_b6_2026_08_15.py
+runner_sha256: 224449fb7c68ddf80fc0258b9434cfcc3bca0a256ae8e6993b2b7c2cdc9f836e
+input_fingerprint_sha256: aa2c57fd9bbd1aa11e073dc929d543227e911516654be3e6f08a4dddc0eb448a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/ENTER_BODY_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=1 under the named enter-body hop-cost on B_6(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ε is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 377
+t(1,0,0) 3
+t(1,1,1) 7
+t(1,0,0)^2/1 9/1
+t(1,1,1)^2/3 49/3
+3t_axis^2 27
+t_body^2 49
+reverse False
+t(6,0,0) 18
+dijkstra_calls 1
+eps_enter 3
+mu_enter 1
+phi_enter 1
+eps_hug 3
+mu_hug 3
+PASS: t-100-111 t(1,0,0)=3 and t(1,1,1)=7
+PASS: reverse-k1 t(1,0,0)^2/1 > t(1,1,1)^2/3 is false
+PASS: small-k-bar-not-killed the small-k bar is not killed at k=1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b6 B_6(0) has 377 sites and 376 nonzero sites
+PASS: reachable every site of B_6(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: independent-b6-dijkstra axis endpoint t(6,0,0)=18 and the note scores B_6 independently
+PASS: not-leftover-of-mu μ prices the enter-body hop at 1 while ε prices it at 3
+PASS: not-leftover-of-phi φ matches μ at k=1 and cannot price the enter-body hop
+PASS: enter-body-clauses μ clauses and 2→3 cost 3; 1→2 and non-hugging 2→2 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/enter_body_samek_k1_b6_2026_08_15.py
+++ b/scripts/enter_body_samek_k1_b6_2026_08_15.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=1 under ε on B_6(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/ENTER_BODY_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/ENTER_BODY_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=1 under the named "
+    "enter-body hop-cost on B_6(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 3
+T_BODY_REP = 7
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def min_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and min_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def phi_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3 or (support_size(v) == 2 and support_size(w) == 2):
+        return 3
+    return 1
+
+
+def eps_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3 or (support_size(v) == 2 and support_size(w) == 3):
+        return 3
+    return 1
+
+
+def dijkstra_eps(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + eps_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ε is not written into Admissibility",
+        "Do not write `ε` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(6)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_eps(sites)
+    t100 = dist[(1, 0, 0)]
+    t111 = dist[(1, 1, 1)]
+    t600 = dist[(6, 0, 0)]
+    reverse = 3 * t100 * t100 > t111 * t111
+    enter_hop = ((1, 1, 0), (1, 1, 1))
+    hug_hop = ((1, 1, 0), (2, 1, 0))
+    print(f"n_sites {len(sites)}")
+    print(f"t(1,0,0) {t100}")
+    print(f"t(1,1,1) {t111}")
+    print(f"t(1,0,0)^2/1 {t100 * t100}/1")
+    print(f"t(1,1,1)^2/3 {t111 * t111}/3")
+    print(f"3t_axis^2 {3 * t100 * t100}")
+    print(f"t_body^2 {t111 * t111}")
+    print(f"reverse {reverse}")
+    print(f"t(6,0,0) {t600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"eps_enter {eps_cost(*enter_hop)}")
+    print(f"mu_enter {mu_cost(*enter_hop)}")
+    print(f"phi_enter {phi_cost(*enter_hop)}")
+    print(f"eps_hug {eps_cost(*hug_hop)}")
+    print(f"mu_hug {mu_cost(*hug_hop)}")
+
+    checks.check(
+        "t-100-111",
+        f"t(1,0,0)={T_AXIS_REP} and t(1,1,1)={T_BODY_REP}",
+        t100 == T_AXIS_REP and t111 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k1",
+        "t(1,0,0)^2/1 > t(1,1,1)^2/3 is false",
+        (not reverse)
+        and 3 * t100 * t100 == 27
+        and t111 * t111 == 49
+        and "27 > 49" in note
+        and "does not hold" in note,
+    )
+    checks.check(
+        "small-k-bar-not-killed",
+        "the small-k bar is not killed at k=1",
+        (not reverse) and "small-`k` bar is not killed" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b6",
+        "B_6(0) has 377 sites and 376 nonzero sites",
+        len(sites) == 377 and len(nonzero) == 376 and all(l1(v) <= 6 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        len(dist) == 377,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`3`" in note
+        and "`7`" in note
+        and "`(1,0,0)`" in note
+        and "`(1,1,1)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "27 > 49" in note and "27 < 49" in note,
+    )
+    checks.check(
+        "independent-b6-dijkstra",
+        "axis endpoint t(6,0,0)=18 and the note scores B_6 independently",
+        t600 == 18
+        and l1((1, 1, 1)) == 3
+        and (1, 1, 1) in dist
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "μ prices the enter-body hop at 1 while ε prices it at 3",
+        eps_cost(*enter_hop) == 3
+        and mu_cost(*enter_hop) == 1
+        and t100 == 3
+        and t111 == 7
+        and "cannot price the enter-body hop" in note
+        and "`3` versus `5`" in note,
+    )
+    checks.check(
+        "not-leftover-of-phi",
+        "φ matches μ at k=1 and cannot price the enter-body hop",
+        eps_cost(*enter_hop) == 3
+        and phi_cost(*enter_hop) == 1
+        and mu_cost(*enter_hop) == 1
+        and "φ` matches `μ`" in note
+        and "φ` cannot price" in note,
+    )
+    checks.check(
+        "enter-body-clauses",
+        "μ clauses and 2→3 cost 3; 1→2 and non-hugging 2→2 cost 1",
+        eps_cost((0, 0, 0), (1, 0, 0)) == 3
+        and eps_cost((1, 0, 0), (2, 0, 0)) == 3
+        and eps_cost((1, 0, 0), (1, 1, 0)) == 1
+        and eps_cost((1, 1, 0), (1, 0, 0)) == 3
+        and eps_cost((1, 1, 0), (1, 1, 1)) == 3
+        and eps_cost((1, 1, 0), (2, 1, 0)) == 3
+        and eps_cost((2, 2, 0), (3, 2, 0)) == 1
+        and eps_cost((1, 1, 1), (2, 1, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ε(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_6(0) under epsilon, t(1,0,0)=3 and t(1,1,1)=7. 27<49. The 2-to-3 hop into (1,1,1) is the kill. Displayed, not adopted.

## Runner

`scripts/enter_body_samek_k1_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.