### PR TITLE
feat(e2k13): late-enter-body misses the k=13 wall: t=23 vs t=41

### DIFF
--- a/docs/LATE_ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/LATE_ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,182 @@
+---
+claim_id: late_enter_body_samek_k13_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=13 under the named late-enter-body hop-cost on B_39(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/late_enter_body_samek_k13_b39_2026_08_15.py
+---
+
+# Named Late-Enter-Body Same-k Reverse At k=13 On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_39(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=13`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/late_enter_body_samek_k13_b39_2026_08_15.py`](../scripts/late_enter_body_samek_k13_b39_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named late-enter-body hop-cost `ε2` is the already scored corridor-slide
+rule `μ` plus cost `3` on a `2→3` hop whose destination has `max_i |w_i| ≥ 2`.
+Same-`k` reverse under `μ` fails at `k=13` (`23` versus `41`). The all
+`2→3` enter-body rule `ε` restores that pair to `25` versus `43`. The extra
+`ε2` clause prices only the late enter-body hop. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_39(0)`, the displayed
+rule `ε2` is
+
+`ε2(v→w) = 3` if `μ` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and
+`max_i |w_i| ≥ 2)`, else `1`,
+
+where `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is late enter-body. Those five clauses are the whole rule. The
+early enter-body hop `(1,1,0) → (1,1,1)` has `max_i |w_i| = 1`, so it
+stays at cost `1`.
+
+One Dijkstra from the origin on `B_39(0)` (82239 sites; 82238 nonzero) gives
+
+`t(13,0,0) = 23`, `t(13,13,13) = 41`.
+
+The displayed same-`k` comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+which is `529/169` versus `1681/507`, or equivalently `1587 > 1681`. The
+inequality does not hold: `1587 < 1681`. Same-`k` reverse at `k=13` under
+`ε2` is no. The `μ` fail at the `k=13` wall continues under `ε2`.
+Independently, the new axis site is `t(39,0,0) = 53`. The shared axis site
+`t(36,0,0) = 46` is an `ε2` score on this ball.
+
+The pair coincides with the already scored `μ` pair `23` versus `41`. On
+the late enter-body hop `(2,1,0) → (2,1,1)` one has `|σ| : 2 → 3` and
+`max_i |w_i| = 2`, so `μ = 1` while `ε2 = 3`. Therefore `μ` cannot price late enter-body.
+The displayed rule is not `μ` even though these two arrivals coincide. The pair is not leftover of `ε`: the same sites under
+`ε` are `25` versus `43`, and `ε` cannot leave early enter-body cheap.
+The site `(13,13,13)` has ℓ¹ norm `39`, so it is absent from `B_36(0)`.
+The `B_39(0)` table is therefore not leftover of the `B_36(0)` times.
+
+The rule is displayed, not adopted. Do not write `ε2` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the late-enter-body max-coordinate
+clause, and the arrival function `t` are separately displayed mathematical
+inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_39(0) = { v ∈ Z^3 : |v|_1 ≤ 39 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_39(0)`,
+`t(v)` is the least sum of `ε2` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses only the first four clauses of `ε2`. On the
+late enter-body hop `(2,1,0) → (2,1,1)` one has `|σ| : 2 → 3` and
+`max_i |w_i| = 2`, so `μ = 1` while `ε2 = 3`. Therefore `μ` cannot price late enter-body,
+and the displayed rule is not a rewrite of `μ`. The
+comparator `ε` prices every `2→3` hop at `3`, including
+`(1,1,0) → (1,1,1)`. That early hop stays at cost `1` under `ε2`.
+
+## Theorem 1 — Arrivals `t(13,0,0)` And `t(13,13,13)` On `B_39(0)`
+
+One origin Dijkstra on `B_39(0)` returns the integer arrivals
+
+| site | `t_ε2` |
+|---|---:|
+| `(13,0,0)` | `23` |
+| `(13,13,13)` | `41` |
+
+Every listed site lies in `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39`,
+so it is absent from `B_36(0)`. The pair is computed on `B_39(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars. They coincide with the `μ` pair `23` versus `41` and they
+are not the `ε` pair `25` versus `43`.
+
+A witness axis walk of cost `23` is seed-exit `3` onto `(1,0,0)`,
+support-increase `1` onto `(1,1,0)`, early enter-body `1` onto `(1,1,1)`,
+twelve support-preserving cost-`1` body hops to `(13,1,1)`, and two
+support-drops `3` then `3` onto `(13,0,0)`, summing to `23`. That walk is
+a witness of cost `23`, not a uniqueness claim.
+
+A witness body walk of cost `41` is the same prefix of cost `5` to
+`(1,1,1)` and thirty-six support-preserving cost-`1` body hops to
+`(13,13,13)`, summing to `41`. That walk is a witness of cost `41`, not a
+uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=13`
+
+The Euclidean-normalized comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+equivalently `3 t(13,0,0)^2 ? t(13,13,13)^2`. Substituting the computed times
+gives `3 · 23^2 = 1587` and `41^2 = 1681`, so
+
+`1587 < 1681`.
+
+Arrival per Euclidean length is not larger at `(13,0,0)` than at
+`(13,13,13)`. Same-`k` reverse at `k=13` under `ε2` is no. The comparison
+is displayed, not adopted. The inequality does not hold.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ε2` is a displayed scoring device on `B_39(0)`. Do not write `ε2`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_39(0) for one named hop-cost at k=13. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_39(0) for the displayed rule ε2 at k=13; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ε2` among hop-costs that score the same-`k` pair at `k=13`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_39(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=13`.
+- Any reuse of the `μ` arrival table as a substitute for the `ε2` Dijkstra.
+- Any claim that the late-enter-body clause changes the `k=13` pair.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11817,6 +11817,10 @@
   "lanes_open_science_03_quark_mass_retention_open_lane_2026-04-26_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "late_enter_body_samek_k13_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "lattice_3d_dense_refinement_reconciliation_note": {
    "deps_hash": "bc5f8211bba0",

--- a/logs/runner-cache/late_enter_body_samek_k13_b39_2026_08_15.txt
+++ b/logs/runner-cache/late_enter_body_samek_k13_b39_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/late_enter_body_samek_k13_b39_2026_08_15.py
+runner_sha256: dd4871e86650956945857de8e432a35f7aeb1fe28cfe3bf6390511721b8084e3
+input_fingerprint_sha256: 42cb238eed8c059c724d01812f3a7338d93b0583328b8b26e038a7def6a2188d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.49
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/LATE_ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=13 under the named late-enter-body hop-cost on B_39(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ε2 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 82239
+t(13,0,0) 23
+t(13,13,13) 41
+t(13,0,0)^2/169 529/169
+t(13,13,13)^2/507 1681/507
+3t_axis^2 1587
+t_body^2 1681
+reverse False
+t(39,0,0) 53
+t(36,0,0) 46
+dijkstra_calls 1
+witness_eps2_costs [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_eps2_sum 23
+eps2_late 3
+mu_late 1
+eps2_early 1
+eps_early 3
+PASS: t-13000-131313 t(13,0,0)=23 and t(13,13,13)=41
+PASS: reverse-k13 t(13,0,0)^2/169 > t(13,13,13)^2/507 does not hold
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b39 B_39(0) has 82239 sites and 82238 nonzero sites
+PASS: reachable every site of B_39(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-mu ε2 prices the late enter-body hop at 3 while μ prices it at 1
+PASS: not-leftover-of-eps ε2 leaves the early enter-body hop at 1 while ε prices it at 3
+PASS: not-leftover-of-b36 (13,13,13) lies outside B_36(0) and the note says so
+PASS: seed-and-late-enter-body-clauses seed-exit, both-weights-1, support-drop, corridor-slide, and late enter-body cost 3; early enter-body and other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/late_enter_body_samek_k13_b39_2026_08_15.py
+++ b/scripts/late_enter_body_samek_k13_b39_2026_08_15.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=13 under ε2 on B_39(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/LATE_ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/LATE_ENTER_BODY_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=13 under the named "
+    "late-enter-body hop-cost on B_39(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 23
+T_BODY_REP = 41
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def epsilon_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 3:
+        return 3
+    return 1
+
+
+def eps2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 3 and max(abs(c) for c in w) >= 2:
+        return 3
+    return 1
+
+
+def dijkstra_eps2(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + eps2_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ε2 is not written into Admissibility",
+        "Do not write `ε2` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(39)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_eps2(sites)
+    t13000 = dist[(13, 0, 0)]
+    t131313 = dist[(13, 13, 13)]
+    t3900 = dist[(39, 0, 0)]
+    t3600 = dist[(36, 0, 0)]
+    reverse = 3 * t13000 * t13000 > t131313 * t131313
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        *[(x, 1, 1) for x in range(2, 14)],
+        (13, 1, 0),
+        (13, 0, 0),
+    )
+    witness_eps2_costs = [eps2_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    late_hop = ((2, 1, 0), (2, 1, 1))
+    early_hop = ((1, 1, 0), (1, 1, 1))
+    print(f"n_sites {len(sites)}")
+    print(f"t(13,0,0) {t13000}")
+    print(f"t(13,13,13) {t131313}")
+    print(f"t(13,0,0)^2/169 {t13000 * t13000}/169")
+    print(f"t(13,13,13)^2/507 {t131313 * t131313}/507")
+    print(f"3t_axis^2 {3 * t13000 * t13000}")
+    print(f"t_body^2 {t131313 * t131313}")
+    print(f"reverse {reverse}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(36,0,0) {t3600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_eps2_costs {witness_eps2_costs}")
+    print(f"witness_eps2_sum {sum(witness_eps2_costs)}")
+    print(f"eps2_late {eps2_cost(*late_hop)}")
+    print(f"mu_late {mu_cost(*late_hop)}")
+    print(f"eps2_early {eps2_cost(*early_hop)}")
+    print(f"eps_early {epsilon_cost(*early_hop)}")
+
+    checks.check(
+        "t-13000-131313",
+        f"t(13,0,0)={T_AXIS_REP} and t(13,13,13)={T_BODY_REP}",
+        t13000 == T_AXIS_REP and t131313 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k13",
+        "t(13,0,0)^2/169 > t(13,13,13)^2/507 does not hold",
+        (not reverse)
+        and 3 * t13000 * t13000 == 1587
+        and t131313 * t131313 == 1681
+        and "1587 < 1681" in note
+        and "inequality does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b39",
+        "B_39(0) has 82239 sites and 82238 nonzero sites",
+        len(sites) == 82239 and len(nonzero) == 82238 and all(l1(v) <= 39 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_39(0) is reached",
+        len(dist) == 82239,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`23`" in note
+        and "`41`" in note
+        and "`(13,0,0)`" in note
+        and "`(13,13,13)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1587 < 1681" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "ε2 prices the late enter-body hop at 3 while μ prices it at 1",
+        eps2_cost(*late_hop) == 3
+        and mu_cost(*late_hop) == 1
+        and sum(witness_eps2_costs) == 23
+        and t13000 == 23
+        and t131313 == 41
+        and "cannot price late enter-body" in note
+        and "23` versus `41" in note,
+    )
+    checks.check(
+        "not-leftover-of-eps",
+        "ε2 leaves the early enter-body hop at 1 while ε prices it at 3",
+        eps2_cost(*early_hop) == 1
+        and epsilon_cost(*early_hop) == 3
+        and t13000 != 25
+        and t131313 != 43
+        and "cannot leave early enter-body cheap" in note
+        and "25` versus `43" in note,
+    )
+    checks.check(
+        "not-leftover-of-b36",
+        "(13,13,13) lies outside B_36(0) and the note says so",
+        l1((13, 13, 13)) == 39
+        and (13, 13, 13) in dist
+        and t3900 == 53
+        and t3600 == 46
+        and t3600 != 48
+        and t3900 != 51
+        and "absent from `B_36(0)`" in note
+        and "not leftover of the `B_36(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-late-enter-body-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, and late enter-body cost 3; early enter-body and other hops cost 1",
+        eps2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and eps2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and eps2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and eps2_cost((1, 1, 0), (2, 1, 0)) == 3
+        and eps2_cost((2, 1, 0), (2, 1, 1)) == 3
+        and eps2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and eps2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and eps2_cost((1, 1, 1), (2, 1, 1)) == 1
+        and eps2_cost((2, 2, 0), (3, 2, 0)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ε2(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_39(0) under eps2, t(13,0,0)=23 and t(13,13,13)=41. 1587<1681. Same pair as mu. The unit-cube 2-to-3 spare is why. Displayed, not adopted.

## Runner

`scripts/late_enter_body_samek_k13_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.