### PR TITLE
feat(entk2): enter-body recovers k=2 reverse: t=6 vs t=10

### DIFF
--- a/docs/ENTER_BODY_SAMEK_K2_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/ENTER_BODY_SAMEK_K2_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,174 @@
+---
+claim_id: enter_body_samek_k2_b8_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=2 under the named enter-body hop-cost on B_8(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/enter_body_samek_k2_b8_2026_08_15.py
+---
+
+# Named Enter-Body Same-k Reverse At k=2 On B_8(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_8(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=2`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/enter_body_samek_k2_b8_2026_08_15.py`](../scripts/enter_body_samek_k2_b8_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named enter-body hop-cost `ε` is the already scored corridor-slide
+rule `μ` plus cost `3` on a `2→3` hop. `ε` kills same-`k` reverse at
+`k=1` (`3` versus `7`) and holds at `k=7`. The residual scored here is
+whether reverse recovers at `k=2` on `B_8(0)`. The ball is
+not leftover of a larger-ball table: one origin Dijkstra is run on this
+ball.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_8(0)`, let `ν` be the
+support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. The corridor-slide rule `μ` is
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The displayed rule `ε` is
+
+`ε(v→w) = 3` if `μ` would be `3` or `(|σ_v|=2` and `|σ_w|=3)`, else `1`.
+
+The extra clause is the enter-body `2→3` hop. Those clauses are the whole
+rule.
+
+One Dijkstra from the origin on `B_8(0)` (833 sites; 832 nonzero) gives
+
+`t(2,0,0) = 6`, `t(2,2,2) = 10`.
+
+The displayed same-`k` comparison at `k=2` is
+
+`t(2,0,0)^2 / 4  ?  t(2,2,2)^2 / 12`,
+
+which is `36/4` versus `100/12`, or equivalently `108 > 100`. The
+inequality holds. Same-`k` reverse recovers at `k=2`. Independently, the
+axis endpoint of this ball is `t(8,0,0) = 24`. The `B_8(0)` table is
+not leftover of the `B_6(0)` times.
+
+The pair is not leftover of `μ`. On the enter-body hop
+`(1,1,0) → (1,1,1)` one has `|σ| : 2 → 3`, so `μ = 1` while `ε = 3`.
+A `μ` witness to `(2,2,2)` along the same sites would sum to `8`; `ε`
+scores `10`. The same sites under `μ` are `6` versus `8`. Therefore `μ`
+cannot price the enter-body hop, and the `ε` scores below are not a
+leftover of `μ`.
+
+The rule is displayed, not adopted. Do not write `ε` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_8(0) = { v ∈ Z^3 : |v|_1 ≤ 8 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_8(0)`,
+`t(v)` is the least sum of `ε` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses the three support-drop clauses of `ν` plus the
+axis-hugging `2→2` slide. On the enter-body hop `(1,1,0) → (1,1,1)` one
+has `|σ| : 2 → 3`, so `μ = 1` while `ε = 3`. Therefore `μ` cannot price
+the enter-body hop.
+
+## Theorem 1 — Arrivals `t(2,0,0)` And `t(2,2,2)` On `B_8(0)`
+
+One origin Dijkstra on `B_8(0)` returns the integer arrivals
+
+| site | `t_ε` |
+|---|---:|
+| `(2,0,0)` | `6` |
+| `(2,2,2)` | `10` |
+
+Every listed site lies in `B_8(0)`. The site `(2,2,2)` has ℓ¹ norm `6`.
+The pair is computed on `B_8(0)`, not copied from a larger-ball table,
+not leftover of the `B_6(0)` times, and not copied from the `μ` pair
+`6` versus `8`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness walk to `(2,0,0)` is seed-exit `3` onto `(1,0,0)` and the
+both-weights-`1` hop of cost `3` onto `(2,0,0)`, summing to `6`. A
+witness walk to `(2,2,2)` is seed-exit `3` onto `(1,0,0)`, body `1→2` of
+cost `1` onto `(1,1,0)`, enter-body `2→3` of cost `3` onto `(1,1,1)`,
+and three support-preserving cost-`1` body hops onto `(2,1,1)`,
+`(2,2,1)`, and `(2,2,2)`, summing to `10`. Those walks are witnesses,
+not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=2`
+
+The Euclidean-normalized comparison at `k=2` is
+
+`t(2,0,0)^2 / 4  ?  t(2,2,2)^2 / 12`,
+
+equivalently `3 t(2,0,0)^2 ? t(2,2,2)^2`. Substituting the computed times
+gives `3 · 6^2 = 108` and `10^2 = 100`, so
+
+`108 > 100`.
+
+Arrival per Euclidean length is larger at `(2,0,0)` than at `(2,2,2)`.
+Same-`k` reverse at `k=2` under `ε` is yes. Reverse recovers at `k=2`.
+The comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ε` is a displayed scoring device on `B_8(0)`. Do not write `ε`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_8(0) for one named hop-cost at k=2. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_8(0) for the displayed rule ε at k=2; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ε` among hop-costs that score the same-`k` pair at `k=2`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_8(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=2`.
+- Any reuse of a larger-ball arrival table, or of the `μ` pair, as a
+  substitute for the radius-`8` Dijkstra.
+- Membership of `ε` as a physical hop-cost. Reverse recovers at `k=2` on
+  this ball; that is a displayed exclusion test, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -4457,6 +4457,10 @@
   "enforced_dual_rail_lock_cycle745_bounded_theorem_note_2026-07-28": {
    "deps_hash": "423f1f549b6b",
    "out_degree": 4
+  },
+  "enter_body_samek_k2_b8_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ep_record_stiffness_conditional_shared_coupling_template_note_2026-06-07": {
    "deps_hash": "69a1ede16473",

--- a/logs/runner-cache/enter_body_samek_k2_b8_2026_08_15.txt
+++ b/logs/runner-cache/enter_body_samek_k2_b8_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/enter_body_samek_k2_b8_2026_08_15.py
+runner_sha256: 12f4cf3f9b6f66c239bfbf610ba43a2d3bc3a020e12c9bcf8a0029338b1f21af
+input_fingerprint_sha256: 543678f4367e7969626349bbb520c298822d408e1d0dc400fdece81c0a533c84
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/ENTER_BODY_SAMEK_K2_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=2 under the named enter-body hop-cost on B_8(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ε is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 833
+t(2,0,0) 6
+t(2,2,2) 10
+t(2,0,0)^2/4 36/4
+t(2,2,2)^2/12 100/12
+3t_axis^2 108
+t_body^2 100
+reverse True
+t(8,0,0) 24
+dijkstra_calls 1
+eps_enter 3
+mu_enter 1
+eps_hug 3
+mu_hug 3
+witness_axis_costs [3, 3]
+witness_body_costs [3, 1, 3, 1, 1, 1]
+PASS: t-200-222 t(2,0,0)=6 and t(2,2,2)=10
+PASS: reverse-k2 t(2,0,0)^2/4 > t(2,2,2)^2/12 holds
+PASS: recover-k2 same-k reverse recovers at k=2
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b8 B_8(0) has 833 sites and 832 nonzero sites
+PASS: reachable every site of B_8(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: independent-b8-dijkstra axis endpoint t(8,0,0)=24 and the note scores B_8 independently
+PASS: not-leftover-of-mu μ prices the enter-body hop at 1 while ε prices it at 3
+PASS: enter-body-clauses μ clauses and 2→3 cost 3; 1→2 and non-hugging 2→2 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/enter_body_samek_k2_b8_2026_08_15.py
+++ b/scripts/enter_body_samek_k2_b8_2026_08_15.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=2 under ε on B_8(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/ENTER_BODY_SAMEK_K2_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/ENTER_BODY_SAMEK_K2_B8_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=2 under the named "
+    "enter-body hop-cost on B_8(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 6
+T_BODY_REP = 10
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def min_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and min_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def eps_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3 or (support_size(v) == 2 and support_size(w) == 3):
+        return 3
+    return 1
+
+
+def dijkstra_eps(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + eps_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ε is not written into Admissibility",
+        "Do not write `ε` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(8)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_eps(sites)
+    t200 = dist[(2, 0, 0)]
+    t222 = dist[(2, 2, 2)]
+    t800 = dist[(8, 0, 0)]
+    reverse = 3 * t200 * t200 > t222 * t222
+    enter_hop = ((1, 1, 0), (1, 1, 1))
+    hug_hop = ((1, 1, 0), (2, 1, 0))
+    witness_axis = ((0, 0, 0), (1, 0, 0), (2, 0, 0))
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        (2, 2, 2),
+    )
+    witness_axis_costs = [eps_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    witness_body_costs = [eps_cost(a, b) for a, b in zip(witness_body, witness_body[1:])]
+    print(f"n_sites {len(sites)}")
+    print(f"t(2,0,0) {t200}")
+    print(f"t(2,2,2) {t222}")
+    print(f"t(2,0,0)^2/4 {t200 * t200}/4")
+    print(f"t(2,2,2)^2/12 {t222 * t222}/12")
+    print(f"3t_axis^2 {3 * t200 * t200}")
+    print(f"t_body^2 {t222 * t222}")
+    print(f"reverse {reverse}")
+    print(f"t(8,0,0) {t800}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"eps_enter {eps_cost(*enter_hop)}")
+    print(f"mu_enter {mu_cost(*enter_hop)}")
+    print(f"eps_hug {eps_cost(*hug_hop)}")
+    print(f"mu_hug {mu_cost(*hug_hop)}")
+    print(f"witness_axis_costs {witness_axis_costs}")
+    print(f"witness_body_costs {witness_body_costs}")
+
+    checks.check(
+        "t-200-222",
+        f"t(2,0,0)={T_AXIS_REP} and t(2,2,2)={T_BODY_REP}",
+        t200 == T_AXIS_REP and t222 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k2",
+        "t(2,0,0)^2/4 > t(2,2,2)^2/12 holds",
+        reverse
+        and 3 * t200 * t200 == 108
+        and t222 * t222 == 100
+        and "108 > 100" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "recover-k2",
+        "same-k reverse recovers at k=2",
+        reverse and "recovers at `k=2`" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b8",
+        "B_8(0) has 833 sites and 832 nonzero sites",
+        len(sites) == 833 and len(nonzero) == 832 and all(l1(v) <= 8 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_8(0) is reached",
+        len(dist) == 833,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`6`" in note
+        and "`10`" in note
+        and "`(2,0,0)`" in note
+        and "`(2,2,2)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "108 > 100" in note,
+    )
+    checks.check(
+        "independent-b8-dijkstra",
+        "axis endpoint t(8,0,0)=24 and the note scores B_8 independently",
+        t800 == 24
+        and l1((2, 2, 2)) == 6
+        and (2, 2, 2) in dist
+        and "not leftover of a larger-ball table" in note
+        and "not leftover of the `B_6(0)` times" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "μ prices the enter-body hop at 1 while ε prices it at 3",
+        eps_cost(*enter_hop) == 3
+        and mu_cost(*enter_hop) == 1
+        and sum(witness_body_costs) == 10
+        and sum(witness_axis_costs) == 6
+        and t200 == 6
+        and t222 == 10
+        and t222 != 8
+        and "cannot price the enter-body hop" in note
+        and "`6` versus `8`" in note,
+    )
+    checks.check(
+        "enter-body-clauses",
+        "μ clauses and 2→3 cost 3; 1→2 and non-hugging 2→2 cost 1",
+        eps_cost((0, 0, 0), (1, 0, 0)) == 3
+        and eps_cost((1, 0, 0), (2, 0, 0)) == 3
+        and eps_cost((1, 0, 0), (1, 1, 0)) == 1
+        and eps_cost((1, 1, 0), (1, 0, 0)) == 3
+        and eps_cost((1, 1, 0), (1, 1, 1)) == 3
+        and eps_cost((1, 1, 0), (2, 1, 0)) == 3
+        and eps_cost((2, 2, 0), (3, 2, 0)) == 1
+        and eps_cost((1, 1, 1), (2, 1, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ε(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_8(0) under epsilon, t(2,0,0)=6 and t(2,2,2)=10. Reverse fails only at k=1. Displayed, not adopted.

## Runner

`scripts/enter_body_samek_k2_b8_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.