### PR TITLE
feat(ridk11): ridge-slide same-k holds at k=11: t=23 vs t=37

### DIFF
--- a/docs/RIDGE_SLIDE_SAMEK_K11_B33_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/RIDGE_SLIDE_SAMEK_K11_B33_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,190 @@
+---
+claim_id: ridge_slide_samek_k11_b33_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=11 under the named ridge-slide hop-cost on B_33(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/ridge_slide_samek_k11_b33_2026_08_15.py
+---
+
+# Named Ridge-Slide Same-k Reverse At k=11 On B_33(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_33(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=11`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/ridge_slide_samek_k11_b33_2026_08_15.py`](../scripts/ridge_slide_samek_k11_b33_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named ridge-slide hop-cost `ρ3` is scored independently on `B_33(0)`.
+The ball is not leftover of a larger-ball table: one origin Dijkstra is run
+on this ball. Same-`k` reverse under `ρ3` is already scored at `k=10` and
+`k=12`. The residual scored here is whether `ρ3` still reverses at `k=11`
+on `B_33(0)`. First display. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_33(0)`, let `ν` be the
+support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. Let `μ` be the corridor-slide rule
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The displayed rule `ρ3` is
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The extra clause is a ridge slide: both ends have support `3`, and the
+destination has exactly two unit coordinates. It is not the all-`3→3`
+body-slide tax.
+
+One Dijkstra from the origin on `B_33(0)` (50183 sites; 50182 nonzero) gives
+
+`t(11,0,0) = 23`, `t(11,11,11) = 37`.
+
+The displayed same-`k` comparison at `k=11` is
+
+`t(11,0,0)^2 / 121  ?  t(11,11,11)^2 / 363`,
+
+which is `529/121` versus `1369/363`, or equivalently `1587 > 1369`. The
+inequality holds. Same-`k` reverse holds at `k=11`. The
+displayed rule is not adopted. Independently, the axis
+endpoint of this ball is `t(33,0,0) = 49`. The shared axis site
+`t(30,0,0) = 42` is a `ρ3` score on this ball, not a `μ` leftover.
+
+The pair is not leftover of `μ`: the same sites under `μ` are `21` versus
+`35`, and the extra ridge-slide clause is what changes both arrivals. On
+the ridge hop `(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and exactly two
+`|w_i| = 1`, so `μ = 1` while `ρ3 = 3`. Therefore `μ` cannot price the ridge slide,
+and the `ρ3` scores below are not a leftover of `μ`. The extra clause is
+live on the ball: `t(2,2,2)` is `10` under `ρ3` and `8` under `μ`, so
+`10` versus `8`. The site `(11,11,11)` has ℓ¹ norm `33`, so it is absent
+from `B_30(0)`. The `B_33(0)` table is therefore not leftover of the `B_30(0)` times.
+
+The rule is displayed, not adopted. Do not write `ρ3` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the two-unit-height ridge clause, and
+the arrival function `t` are separately displayed mathematical inputs. No
+axiom text is edited.
+
+## Named Rule
+
+Let `B_33(0) = { v ∈ Z^3 : |v|_1 ≤ 33 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_33(0)`,
+`t(v)` is the least sum of `ρ3` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses the three support-drop clauses and the
+axis-hugging `2→2` slide. On the ridge slide `(1,1,1) → (2,1,1)` one has
+`|σ_v|=|σ_w|=3` and exactly two `|w_i|=1`, so `μ = 1` while `ρ3 = 3`.
+Therefore `μ` cannot price the ridge slide. The same extra clause prices
+the corridor hop `(1,-1,-1) → (2,-1,-1)` at `3`. On the body hop
+`(1,0,0) → (1,1,0)` both `μ` and `ρ3` cost `1`. On the interior `3→3`
+hop `(2,2,2) → (3,2,2)` the destination has no unit coordinate, so both
+`μ` and `ρ3` cost `1`.
+
+## Theorem 1 — Arrivals `t(11,0,0)` And `t(11,11,11)` On `B_33(0)`
+
+One origin Dijkstra on `B_33(0)` returns the integer arrivals
+
+| site | `t_ρ3` |
+|---|---:|
+| `(11,0,0)` | `23` |
+| `(11,11,11)` | `37` |
+
+Every listed site lies in `B_33(0)`. The site `(11,11,11)` has ℓ¹ norm `33`,
+so it is absent from `B_30(0)`. The pair is computed on `B_33(0)`, not
+copied from a smaller-ball table and not copied from the `μ` pair
+`21` versus `35`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `23` is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, hugging corridor-slide `3` onto `(2,1,0)`,
+non-hugging face hop `1` onto `(2,2,0)`, nine support-preserving
+cost-`1` face hops to `(11,2,0)`, hugging slide `3` onto `(11,1,0)`, and
+support-drop `3` onto `(11,0,0)`, summing to `23`. That walk is a witness
+of cost `23`, not a uniqueness claim.
+
+A witness body walk of cost `37` is the same prefix of cost `8` to
+`(2,2,0)`, nine cost-`1` face hops to `(11,2,0)`, nine cost-`1` face
+hops to `(11,11,0)`, enter-body `1` onto `(11,11,1)`, and ten
+support-preserving cost-`1` body hops to `(11,11,11)`, summing to `37`.
+Those last hops have dest with only one absolute coordinate equal to `1`,
+so they are not ridge slides. That walk is a witness of cost `37`, not a
+uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=11`
+
+The Euclidean-normalized comparison at `k=11` is
+
+`t(11,0,0)^2 / 121  ?  t(11,11,11)^2 / 363`,
+
+equivalently `3 t(11,0,0)^2 ? t(11,11,11)^2`. Substituting the computed times
+gives `3 · 23^2 = 1587` and `37^2 = 1369`, so
+
+`1587 > 1369` is true; `1587 > 1369` holds.
+
+Arrival per Euclidean length is larger at `(11,0,0)` than at `(11,11,11)`.
+Same-`k` reverse at `k=11` is yes. The comparison is
+displayed, not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ρ3` is a displayed scoring device on `B_33(0)`. Do not write `ρ3`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_33(0) for one named hop-cost at k=11. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_33(0) for the displayed rule ρ3 at k=11; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ρ3` among hop-costs that score the same-`k` pair at `k=11`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_33(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=11`.
+- Any reuse of a larger-ball arrival table as a substitute for the
+  radius-`33` Dijkstra.
+- Any reuse of the `μ` arrival table as a substitute for the `ρ3` Dijkstra.
+- Membership of `ρ3` as a physical hop-cost. Reverse at `k=11` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16341,6 +16341,10 @@
   "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
    "deps_hash": "785ba75e68d8",
    "out_degree": 5
+  },
+  "ridge_slide_samek_k11_b33_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ring_family_uniformity_cycle737_bounded_theorem_note_2026-07-28": {
    "deps_hash": "f38aec7a66e3",

--- a/logs/runner-cache/ridge_slide_samek_k11_b33_2026_08_15.txt
+++ b/logs/runner-cache/ridge_slide_samek_k11_b33_2026_08_15.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/ridge_slide_samek_k11_b33_2026_08_15.py
+runner_sha256: cce81f645936eb87a400575c9bc980efc4b697a97f68a95fc3651276de93e88e
+input_fingerprint_sha256: fb996e7284e1c0ee708ccec6fb3a300bc699dc48bbb9ff959fb68b2a14037040
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.41
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/RIDGE_SLIDE_SAMEK_K11_B33_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=11 under the named ridge-slide hop-cost on B_33(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ρ3 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 50183
+t(11,0,0) 23
+t(11,11,11) 37
+t(11,0,0)^2/121 529/121
+t(11,11,11)^2/363 1369/363
+3t_axis^2 1587
+t_body^2 1369
+reverse True
+t(33,0,0) 49
+t(30,0,0) 42
+t(2,2,2) 10
+dijkstra_calls 1
+witness_rho3_costs [3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_rho3_sum 23
+rho3_ridge 3
+mu_ridge 1
+rho3_interior 1
+mu_interior 1
+PASS: t-11000-111111 t(11,0,0)=23 and t(11,11,11)=37
+PASS: reverse-k11 t(11,0,0)^2/121 > t(11,11,11)^2/363 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b33 B_33(0) has 50183 sites and 50182 nonzero sites
+PASS: reachable every site of B_33(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: independent-b33-dijkstra axis endpoint t(33,0,0)=49 and the note scores B_33 independently
+PASS: not-leftover-of-mu ρ3 prices the ridge-slide hop at 3 while μ prices it at 1
+PASS: not-leftover-of-b30 (11,11,11) lies outside B_30(0) and the note says so
+PASS: ridge-not-all-body ρ3 does not tax a 3→3 hop whose dest has fewer than two unit coords
+PASS: seed-and-ridge-slide-clauses ν clauses, corridor-slide, and ridge 3→3 cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/ridge_slide_samek_k11_b33_2026_08_15.py
+++ b/scripts/ridge_slide_samek_k11_b33_2026_08_15.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=11 under ρ3 on B_33(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/RIDGE_SLIDE_SAMEK_K11_B33_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/RIDGE_SLIDE_SAMEK_K11_B33_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=11 under the named "
+    "ridge-slide hop-cost on B_33(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 23
+T_BODY_REP = 37
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_height_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_height_count(w) == 2:
+        return 3
+    return 1
+
+
+def dijkstra_rho3(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + rho3_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ρ3 is not written into Admissibility",
+        "Do not write `ρ3` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(33)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_rho3(sites)
+    t11000 = dist[(11, 0, 0)]
+    t111111 = dist[(11, 11, 11)]
+    t3300 = dist[(33, 0, 0)]
+    t3000 = dist[(30, 0, 0)]
+    t222 = dist[(2, 2, 2)]
+    reverse = 3 * t11000 * t11000 > t111111 * t111111
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+        *[(x, 2, 0) for x in range(3, 12)],
+        (11, 1, 0),
+        (11, 0, 0),
+    )
+    witness_rho3_costs = [rho3_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    interior_hop = ((2, 2, 2), (3, 2, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(11,0,0) {t11000}")
+    print(f"t(11,11,11) {t111111}")
+    print(f"t(11,0,0)^2/121 {t11000 * t11000}/121")
+    print(f"t(11,11,11)^2/363 {t111111 * t111111}/363")
+    print(f"3t_axis^2 {3 * t11000 * t11000}")
+    print(f"t_body^2 {t111111 * t111111}")
+    print(f"reverse {reverse}")
+    print(f"t(33,0,0) {t3300}")
+    print(f"t(30,0,0) {t3000}")
+    print(f"t(2,2,2) {t222}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_rho3_costs {witness_rho3_costs}")
+    print(f"witness_rho3_sum {sum(witness_rho3_costs)}")
+    print(f"rho3_ridge {rho3_cost(*ridge_hop)}")
+    print(f"mu_ridge {mu_cost(*ridge_hop)}")
+    print(f"rho3_interior {rho3_cost(*interior_hop)}")
+    print(f"mu_interior {mu_cost(*interior_hop)}")
+
+    checks.check(
+        "t-11000-111111",
+        f"t(11,0,0)={T_AXIS_REP} and t(11,11,11)={T_BODY_REP}",
+        t11000 == T_AXIS_REP and t111111 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k11",
+        "t(11,0,0)^2/121 > t(11,11,11)^2/363 holds",
+        reverse
+        and 3 * t11000 * t11000 == 1587
+        and t111111 * t111111 == 1369
+        and "1587 > 1369" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b33",
+        "B_33(0) has 50183 sites and 50182 nonzero sites",
+        len(sites) == 50183 and len(nonzero) == 50182 and all(l1(v) <= 33 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_33(0) is reached",
+        len(dist) == 50183,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`23`" in note
+        and "`37`" in note
+        and "`(11,0,0)`" in note
+        and "`(11,11,11)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1587 > 1369" in note,
+    )
+    checks.check(
+        "independent-b33-dijkstra",
+        "axis endpoint t(33,0,0)=49 and the note scores B_33 independently",
+        t3300 == 49
+        and l1((11, 11, 11)) == 33
+        and (11, 11, 11) in dist
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "ρ3 prices the ridge-slide hop at 3 while μ prices it at 1",
+        rho3_cost(*ridge_hop) == 3
+        and mu_cost(*ridge_hop) == 1
+        and sum(witness_rho3_costs) == 23
+        and t11000 == 23
+        and t111111 == 37
+        and t222 == 10
+        and t3300 == 49
+        and t11000 != 21
+        and t111111 != 35
+        and "cannot price the ridge slide" in note
+        and "21` versus `35" in note
+        and "10` versus `8" in note,
+    )
+    checks.check(
+        "not-leftover-of-b30",
+        "(11,11,11) lies outside B_30(0) and the note says so",
+        l1((11, 11, 11)) == 33
+        and (11, 11, 11) in dist
+        and t3300 == 49
+        and t3000 == 42
+        and t3000 != 40
+        and t3300 != 47
+        and "absent from `B_30(0)`" in note
+        and "not leftover of the `B_30(0)` times" in note,
+    )
+    checks.check(
+        "ridge-not-all-body",
+        "ρ3 does not tax a 3→3 hop whose dest has fewer than two unit coords",
+        rho3_cost(*interior_hop) == 1
+        and mu_cost(*interior_hop) == 1
+        and unit_height_count((3, 2, 2)) == 0
+        and "exactly two" in note,
+    )
+    checks.check(
+        "seed-and-ridge-slide-clauses",
+        "ν clauses, corridor-slide, and ridge 3→3 cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1",
+        rho3_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (2, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (2, 1, 0)) == 3
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((1, -1, -1), (2, -1, -1)) == 3
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((2, 2, 2), (3, 2, 2)) == 1
+        and rho3_cost((11, 11, 1), (11, 11, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ρ3(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under the named ridge-slide hop-cost ρ3 holds at k=11 on B_33(0): t(11,0,0)=23 vs t(11,11,11)=37. First display. Displayed, not adopted. Do not write ρ3 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/ridge_slide_samek_k11_b33_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.