### PR TITLE
feat(riddbl): ridge-slide doubled pairing holds k=1..4

### DIFF
--- a/docs/RIDGE_SLIDE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/RIDGE_SLIDE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,222 @@
+---
+claim_id: ridge_slide_doubled_pairing_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Doubled-axis versus body-diagonal reverse under the named ridge-slide hop-cost on B_12(0) is reported for available k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py
+---
+
+# Named Ridge-Slide Doubled Pairing On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only for the doubled pairing `((2k,0,0),(k,k,k))` at each
+available integer `k=1,2,3,4`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py`](../scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named ridge-slide hop-cost `ρ3` is the already scored corridor-slide
+rule `μ` plus cost `3` on a `3→3` hop whose destination has exactly two
+coordinates of absolute value `1`. Doubled pairing reverse under `μ`
+holds at every available `k=1..4`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+comparator `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The displayed comparator `μ` is
+
+`μ(v→w) = 3` if `ν(v→w)` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The displayed rule `ρ3` is
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The extra clause is a ridge slide: both ends have support `3`, and the
+destination has exactly two unit coordinates. It is not the all-`3→3`
+body-slide tax. Those clauses are the whole rule.
+
+For each `k=1,2,3,4` both `(2k,0,0)` and `(k,k,k)` lie in `B_12(0)`, so
+no pair is omitted. One Dijkstra from the origin on `B_12(0)` (2625 sites;
+2624 nonzero) gives
+
+| `k` | site axis | `t(2k,0,0)` | site body | `t(k,k,k)` | `t(2k,0,0)^2/(4k^2)` | `t(k,k,k)^2/(3k^2)` | reverse |
+|---|---|---:|---|---:|---|---|---|
+| `1` | `(2,0,0)` | `6` | `(1,1,1)` | `5` | `36/4` | `25/3` | yes |
+| `2` | `(4,0,0)` | `12` | `(2,2,2)` | `10` | `144/16` | `100/12` | yes |
+| `3` | `(6,0,0)` | `18` | `(3,3,3)` | `13` | `324/36` | `169/27` | yes |
+| `4` | `(8,0,0)` | `20` | `(4,4,4)` | `16` | `400/64` | `256/48` | yes |
+
+Equivalently, `3 t(2k,0,0)^2 ? 4 t(k,k,k)^2` is `108 > 100`, `432 > 400`,
+`972 > 676`, and `1200 > 1024`. The inequality holds at every available
+`k=1..4`. Independently, the new axis site is `t(12,0,0) = 28`.
+
+The pair table is not leftover of `μ`: the same sites under `μ` are
+`6,12,16,18` versus `5,8,11,14`. The extra ridge-slide clause changes
+the body arrivals at `k=2,3,4` and the axis arrivals at `k=3,4`. On the
+ridge hop `(1,1,1) → (2,1,1)` one has `|σ_v|=|σ_w|=3` and exactly two
+`|w_i|=1`, so `μ = 1` while `ρ3 = 3`. Therefore `μ` cannot price the
+ridge slide. On the interior `3→3` hop `(2,2,2) → (3,2,2)` the destination
+has no unit coordinate, so both `μ` and `ρ3` cost `1`. The site `(4,4,4)`
+has ℓ¹ norm `12`, so it is absent from `B_11(0)`. The `B_12(0)` table is
+therefore not leftover of a smaller-ball table.
+
+The rule is displayed, not adopted. Do not write `ρ3` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the ridge unit-coordinate test, and the arrival function `t` are separately
+displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `ρ3` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses the three support-drop clauses and the
+axis-hugging `2→2` slide. On the ridge slide `(1,1,1) → (2,1,1)` one has
+`|σ_v|=|σ_w|=3` and exactly two `|w_i|=1`, so `μ = 1` while `ρ3 = 3`.
+Therefore `μ` cannot price the ridge slide, and the `ρ3` scores below are
+not a leftover of `μ`. The same extra clause prices the corridor hop
+`(1,-1,-1) → (2,-1,-1)` at `3`. On the interior `3→3` hop
+`(2,2,2) → (3,2,2)` the destination has no unit coordinate, so both
+`μ` and `ρ3` cost `1`.
+
+The pairing is not the same-`k` axis / body pair `(k,0,0)` versus
+`(k,k,k)`. It is the doubled pairing `((2k,0,0),(k,k,k))`.
+
+## Theorem 1 — Arrivals For Each Available `k=1..4`
+
+One origin Dijkstra on `B_12(0)` returns the integer arrivals
+
+| site | `t_ρ3` |
+|---|---:|
+| `(2,0,0)` | `6` |
+| `(1,1,1)` | `5` |
+| `(4,0,0)` | `12` |
+| `(2,2,2)` | `10` |
+| `(6,0,0)` | `18` |
+| `(3,3,3)` | `13` |
+| `(8,0,0)` | `20` |
+| `(4,4,4)` | `16` |
+
+Every listed site lies in `B_12(0)`. The site `(4,4,4)` has ℓ¹ norm `12`,
+so it is absent from `B_11(0)`. The pair is computed on `B_12(0)`, not
+copied from a smaller-ball table and not copied from the `μ` table
+`6,12,16,18` versus `5,8,11,14`. These values are Dijkstra outputs, not
+fitted scalars.
+
+A witness walk of cost `6` from `0` to `(2,0,0)` is seed-exit `3` onto
+`(1,0,0)` and both-weights-`1` cost `3` onto `(2,0,0)`, summing to `6`.
+A witness walk of cost `5` from `0` to `(1,1,1)` is seed-exit `3` onto
+`(0,0,1)`, leave-axis `1` onto `(0,1,1)`, and enter-body `1` onto
+`(1,1,1)`, summing to `5`. A witness walk of cost `12` from `0` to
+`(4,0,0)` is four both-weights-`1` axis hops
+`0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0)` of costs `3,3,3,3`, summing
+to `12`. A witness walk of cost `10` from `0` to `(2,2,2)` is seed-exit
+`3` onto `(0,0,1)`, leave-axis `1` onto `(0,1,1)`, corridor-slide `3` onto
+`(0,1,2)`, non-hugging `2→2` of cost `1` onto `(0,2,2)`, enter-body `1`
+onto `(1,2,2)`, and support-preserving cost-`1` body hop onto `(2,2,2)`,
+summing to `10`. A witness walk of cost `18` from `0` to `(6,0,0)` is
+six both-weights-`1` axis hops
+`0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0) → (5,0,0) → (6,0,0)` of
+costs `3,3,3,3,3,3`, summing to `18`. A witness walk of cost `13` from
+`0` to `(3,3,3)` is seed-exit `3` onto `(0,0,1)`, leave-axis `1` onto
+`(0,1,1)`, corridor-slide `3` onto `(0,1,2)`, three non-hugging `2→2`
+hops of cost `1` to `(0,3,3)`, enter-body `1` onto `(1,3,3)`, and two
+support-preserving cost-`1` body hops to `(3,3,3)`, summing to `13`.
+A witness walk of cost `20` from `0` to `(8,0,0)` is seed-exit `3` onto
+`(0,-1,0)`, leave-axis `1` onto `(1,-1,0)`, corridor-slide `3` onto
+`(1,-2,0)`, seven non-hugging `2→2` hops of cost `1` to `(8,-2,0)`,
+corridor-slide `3` onto `(8,-1,0)`, and support-drop `3` onto `(8,0,0)`,
+summing to `20`. A witness walk of cost `16` from `0` to `(4,4,4)` is
+seed-exit `3` onto `(0,0,1)`, leave-axis `1` onto `(0,1,1)`,
+corridor-slide `3` onto `(0,1,2)`, five non-hugging `2→2` hops of cost
+`1` to `(0,4,4)`, enter-body `1` onto `(1,4,4)`, and three
+support-preserving cost-`1` body hops to `(4,4,4)`, summing to `16`.
+Those walks are witnesses of the listed costs, not uniqueness claims.
+
+## Theorem 2 — Reverse At Each Available Doubled Pair
+
+For each available `k=1,2,3,4` the Euclidean-normalized comparison is
+
+`t(2k,0,0)^2 / (4k^2)  ?  t(k,k,k)^2 / (3k^2)`,
+
+equivalently `3 t(2k,0,0)^2 ? 4 t(k,k,k)^2`. Substituting the computed
+times gives
+
+| `k` | `3 t(2k,0,0)^2` | `4 t(k,k,k)^2` | reverse |
+|---|---:|---:|---|
+| `1` | `108` | `100` | `108 > 100` |
+| `2` | `432` | `400` | `432 > 400` |
+| `3` | `972` | `676` | `972 > 676` |
+| `4` | `1200` | `1024` | `1200 > 1024` |
+
+Arrival per Euclidean length is larger at `(2k,0,0)` than at `(k,k,k)` for
+every available `k=1..4`. Doubled pairing reverse under `ρ3` is yes at each
+of those four scales. The comparison is displayed, not adopted. The
+inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ρ3` is a displayed scoring device on `B_12(0)`. Do not write `ρ3`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+doubled-pairing reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer doubled-pairing arrivals and reverse comparison on the finite ball B_12(0) for one named hop-cost at available k=1..4. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule ρ3 at available k=1..4 on ((2k,0,0),(k,k,k)); no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ρ3` among hop-costs that reverse the doubled pairing at
+  any available `k`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any score for a pair that is not `((2k,0,0),(k,k,k))`.
+- Any reuse of the `μ` arrival table as a substitute for the `ρ3` Dijkstra.
+- Any omitted pair among `k=1..4`: both sites of each pair lie in `B_12(0)`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16341,6 +16341,10 @@
   "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
    "deps_hash": "785ba75e68d8",
    "out_degree": 5
+  },
+  "ridge_slide_doubled_pairing_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ring_family_uniformity_cycle737_bounded_theorem_note_2026-07-28": {
    "deps_hash": "f38aec7a66e3",

--- a/logs/runner-cache/ridge_slide_doubled_pairing_b12_2026_08_15.txt
+++ b/logs/runner-cache/ridge_slide_doubled_pairing_b12_2026_08_15.txt
@@ -1,0 +1,57 @@
+===== runner cache v1 =====
+runner: scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py
+runner_sha256: 08a30f60d1d202e183b6b5a26d4227c3fe2e5dc7f2d68732b79a0c14eb3d0583
+input_fingerprint_sha256: 1b384ce03bd0cb60ac8d1f03420d15b2fe163f22d41f7d0c6bda431cf154996a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/RIDGE_SLIDE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Doubled-axis versus body-diagonal reverse under the named ridge-slide hop-cost on B_12(0) is reported for available k=1..4. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ρ3 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+dijkstra_calls 1
+t(12,0,0) 28
+rho3_ridge 3
+mu_ridge 1
+rho3_interior 1
+mu_interior 1
+k 1 t(2,0,0) 6 t(1,1,1) 5 t_axis^2/(4k^2) 36/4 t_body^2/(3k^2) 25/3 3t_axis^2 108 4t_body^2 100 reverse True
+PASS: t-k1 t(2,0,0)=6 and t(1,1,1)=5
+PASS: reverse-k1 t(2,0,0)^2/(4k^2) > t(1,1,1)^2/(3k^2) is True
+k 2 t(4,0,0) 12 t(2,2,2) 10 t_axis^2/(4k^2) 144/16 t_body^2/(3k^2) 100/12 3t_axis^2 432 4t_body^2 400 reverse True
+PASS: t-k2 t(4,0,0)=12 and t(2,2,2)=10
+PASS: reverse-k2 t(4,0,0)^2/(4k^2) > t(2,2,2)^2/(3k^2) is True
+k 3 t(6,0,0) 18 t(3,3,3) 13 t_axis^2/(4k^2) 324/36 t_body^2/(3k^2) 169/27 3t_axis^2 972 4t_body^2 676 reverse True
+PASS: t-k3 t(6,0,0)=18 and t(3,3,3)=13
+PASS: reverse-k3 t(6,0,0)^2/(4k^2) > t(3,3,3)^2/(3k^2) is True
+k 4 t(8,0,0) 20 t(4,4,4) 16 t_axis^2/(4k^2) 400/64 t_body^2/(3k^2) 256/48 3t_axis^2 1200 4t_body^2 1024 reverse True
+PASS: t-k4 t(8,0,0)=20 and t(4,4,4)=16
+PASS: reverse-k4 t(8,0,0)^2/(4k^2) > t(4,4,4)^2/(3k^2) is True
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: reachable every site of B_12(0) is reached
+PASS: pairs-available both sites of each k=1..4 pair lie in B_12(0)
+PASS: reverse-bits-match computed reverse bits match the four-scale census
+PASS: note-records-times note records the eight computed arrivals
+PASS: note-records-reverse-products note records the four integer reverse products
+PASS: not-leftover-of-mu ρ3 prices the ridge 3→3 hop at 3 while μ prices it at 1
+PASS: not-leftover-of-b11 (4,4,4) lies outside B_11(0) and the note says so
+PASS: seed-and-ridge-slide-clauses ν clauses, corridor-slide, and ridge 3→3 cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py
+++ b/scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Score doubled pairing reverse under ρ3 on B_12(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/RIDGE_SLIDE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/RIDGE_SLIDE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Doubled-axis versus body-diagonal reverse under the named "
+    "ridge-slide hop-cost on B_12(0) is reported for available "
+    "k=1..4. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+# (k, t(2k,0,0), t(k,k,k), reverse)
+REPORTED = ((1, 6, 5, True), (2, 12, 10, True), (3, 18, 13, True), (4, 20, 16, True))
+REVERSE_PRODUCTS = ("108 > 100", "432 > 400", "972 > 676", "1200 > 1024")
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def dijkstra_rho3(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + rho3_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ρ3 is not written into Admissibility",
+        "Do not write `ρ3` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_rho3(sites)
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    interior_hop = ((2, 2, 2), (3, 2, 2))
+    t1200 = dist[(12, 0, 0)]
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"t(12,0,0) {t1200}")
+    print(f"rho3_ridge {rho3_cost(*ridge_hop)}")
+    print(f"mu_ridge {mu_cost(*ridge_hop)}")
+    print(f"rho3_interior {rho3_cost(*interior_hop)}")
+    print(f"mu_interior {mu_cost(*interior_hop)}")
+
+    all_match = True
+    available = True
+    for k, t_axis_rep, t_body_rep, reverse_rep in REPORTED:
+        axis = (2 * k, 0, 0)
+        body = (k, k, k)
+        in_ball = l1(axis) <= 12 and l1(body) <= 12
+        available = available and in_ball
+        t_axis = dist[axis]
+        t_body = dist[body]
+        lhs = 3 * t_axis * t_axis
+        rhs = 4 * t_body * t_body
+        reverse = lhs > rhs
+        all_match = all_match and reverse == reverse_rep
+        print(
+            f"k {k} t({2 * k},0,0) {t_axis} t({k},{k},{k}) {t_body} "
+            f"t_axis^2/(4k^2) {t_axis * t_axis}/{4 * k * k} "
+            f"t_body^2/(3k^2) {t_body * t_body}/{3 * k * k} "
+            f"3t_axis^2 {lhs} 4t_body^2 {rhs} reverse {reverse}"
+        )
+        checks.check(
+            f"t-k{k}",
+            f"t({2 * k},0,0)={t_axis_rep} and t({k},{k},{k})={t_body_rep}",
+            in_ball and t_axis == t_axis_rep and t_body == t_body_rep,
+        )
+        checks.check(
+            f"reverse-k{k}",
+            f"t({2 * k},0,0)^2/(4k^2) > t({k},{k},{k})^2/(3k^2) is {reverse_rep}",
+            reverse == reverse_rep and (lhs > rhs) == reverse,
+        )
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == 2625 and len(nonzero) == 2624 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "pairs-available",
+        "both sites of each k=1..4 pair lie in B_12(0)",
+        available
+        and l1((8, 0, 0)) == 8
+        and l1((4, 4, 4)) == 12
+        and "no pair is omitted" in note,
+    )
+    checks.check(
+        "reverse-bits-match",
+        "computed reverse bits match the four-scale census",
+        all_match,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the eight computed arrivals",
+        all(
+            f"`{t_axis}`" in note and f"`{t_body}`" in note
+            for _k, t_axis, t_body, _rev in REPORTED
+        )
+        and "`(2,0,0)`" in note
+        and "`(6,0,0)`" in note
+        and "`(8,0,0)`" in note
+        and "`(4,4,4)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the four integer reverse products",
+        all(product in note for product in REVERSE_PRODUCTS),
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "ρ3 prices the ridge 3→3 hop at 3 while μ prices it at 1",
+        rho3_cost(*ridge_hop) == 3
+        and mu_cost(*ridge_hop) == 1
+        and rho3_cost(*interior_hop) == 1
+        and mu_cost(*interior_hop) == 1
+        and "cannot price the ridge slide" in note
+        and "6,12,16,18" in note
+        and "5,8,11,14" in note,
+    )
+    checks.check(
+        "not-leftover-of-b11",
+        "(4,4,4) lies outside B_11(0) and the note says so",
+        l1((4, 4, 4)) == 12
+        and (4, 4, 4) in dist
+        and t1200 == 28
+        and "absent from `B_11(0)`" in note,
+    )
+    checks.check(
+        "seed-and-ridge-slide-clauses",
+        "ν clauses, corridor-slide, and ridge 3→3 cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1",
+        rho3_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (2, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (2, 1, 0)) == 3
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((1, -1, -1), (2, -1, -1)) == 3
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((2, 2, 2), (3, 2, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Doubled pairing reverse under named ridge-slide hop-cost ρ3 holds at every available k=1..4 on B_12(0). First display. Displayed, not adopted. Do not write ρ3 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/ridge_slide_doubled_pairing_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.