### PR TITLE
feat(ridmeet): ridge-slide two-seed meet |M|=1 vars 0

### DIFF
--- a/docs/RIDGE_SLIDE_TWO_SEED_MEET_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/RIDGE_SLIDE_TWO_SEED_MEET_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,307 @@
+---
+claim_id: ridge_slide_two_seed_meet_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Two-seed meeting-set arrival-speed variance under the named ridge-slide hop-cost on B_12(0)∪B_12((2,0,0)) is compared to ℓ¹. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py
+---
+
+# Two-Seed Meeting-Set Variance Under Ridge-Slide On The B_12 Union
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the named ridge-slide hop-cost `ρ3`, grown from each of two
+seeds on the finite union `B_12(0)∪B_12((2,0,0))`, the first-meeting set of
+the two arrival fields, and the population variance of `|v-s0|_2/t0` on
+that set versus the unit-cost comparison. No hop-cost is written into
+Admissibility. L1 is not attached.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py`](../scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named ridge-slide hop-cost `ρ3` is the already scored corridor-slide
+rule `μ` plus cost `3` on a `3→3` hop whose destination has exactly two
+coordinates of absolute value `1` (a ridge slide). On one seed, `ρ3` is
+the displayed same-`k` ridge-slide scorer. The corridor-slide two-seed
+meeting set on these same seeds at radius `12` is drafted as a singleton
+with both arrival-speed variances `0`. The residual here is the first
+display of that same two-seed meeting set under `ρ3`. Uniqueness is not claimed.
+Uniqueness not required.
+
+Two Dijkstras, one from each seed, with hop-costs grown from each seed,
+produce identical first-meeting data for `ρ3`:
+
+lex-first meeting site `(1,0,0)`, arrival `t=3`, `|M|=1`.
+
+The unit-cost comparison `ℓ¹` has the same first-meeting site `(1,0,0)` at
+`t=1`, again with `|M|=1`. On a singleton meeting set the arrival-speed
+variance is exactly `0` under both scores. The two displayed variances
+therefore tie. Ordered by the names `l1` then `rho3`, the lex-first
+minimizer is `ℓ¹`. The scores are displayed, not adopted. Do not write `ρ3`
+into Admissibility. Do not attach L1.
+
+The `ρ3` meeting time `3` is not a leftover of the unit-cost time `1`. The
+site `(12,0,0)` lies in this union and is absent from the radius-`6` union.
+The equal-arrival set under `ρ3` has `313` sites, not the corridor-slide
+count `713`, so the table is not leftover of `μ`. The extra ridge clause is
+live: `μ` cannot price the ridge slide, and the body-adjacent site
+`(1,2,2)` arrives at `9` under `ρ3`.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom does not supply hop-cost values. It does not
+supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+None of Record is used to select a hop-cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two finite seed-relative Dijkstras and the first-meeting-set arrival-speed variances on B_12(0)∪B_12((2,0,0)) are exact; no hop-cost is adopted and L1 is not attached."
+trace_class: frontier_discovery
+target_claim_id: ridge_slide_two_seed_meet_b12
+target_blocker_text: "compare two-seed meeting-set arrival-speed variance of ρ3 versus ℓ¹ on B_12(0)∪B_12((2,0,0))"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the meeting-set scores displayed. Do not write ρ3 into Admissibility. Do not attach L1."
+conditional_surface_status: "exact for the named hop-cost and the unit-cost comparison on the induced union graph; no physical law is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `s0=(0,0,0)` and `s1=(2,0,0)`. The executed domain is the union
+
+`B_12(0)∪B_12((2,0,0)) = { v ∈ Z^3 : |v|_1 ≤ 12 or |v-s1|_1 ≤ 12 }`.
+
+This set has 3203 sites. Each separate ball has 2625 sites. The executed graph
+is the induced nearest-neighbor graph on the union: a directed hop `v→w`
+exists when `w-v` is a signed axis unit and `w` lies in the union.
+
+The coordinate support is `σ_v={i : v_i ≠ 0}`. Its cardinality is the
+weight. On a hop `v→w` measured from the seed being grown:
+
+- seed-exit means `|σ_v|=0`,
+- both-weights-1 means `|σ_v|=|σ_w|=1`,
+- support-drop means `|σ_w| < |σ_v|`,
+- corridor-slide means `|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1`,
+- ridge-slide means `|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1`.
+
+The already scored corridor-slide rule `μ` prices a hop at `3` on the first
+four clauses and at `1` otherwise. The named cost `ρ3`, grown from seed
+`s`, prices the hop `v→w` by the already scored one-seed rule on the
+translated points `v-s` and `w-s`:
+
+`ρ3_s(v→w) = 3` if `μ` would be `3` on `v-s → w-s` or `(|σ_{v-s}|=|σ_{w-s}|=3`
+and exactly two `|(w-s)_i|` equal `1)`, else `1`.
+
+The extra clause is a ridge slide. It is not the all-`3→3` body-slide tax.
+On `(1,1,1) → (2,1,1)` one has `|σ_v|=|σ_w|=3` and exactly two `|w_i|=1`,
+so `μ = 1` while `ρ3 = 3`. Therefore `μ` cannot price the ridge slide. On
+the interior `3→3` hop `(2,2,2) → (3,2,2)` the destination has no unit
+coordinate, so both `μ` and `ρ3` cost `1`.
+
+The unit-cost comparison `ℓ¹` prices every executed hop at `1`. Its arrivals
+are the taxicab norms from each seed; no third or fourth Dijkstra is run.
+
+Arrival times `t0` and `t1` are the least path costs from `s0` and `s1`
+under the named rule. The meeting set is
+
+`M = { v : t0(v)=t1(v) and no neighbor w is strictly earlier for both }`,
+
+where "strictly earlier for both" means `t0(w)<t0(v)` and `t1(w)<t1(v)`.
+Uniqueness of a meeting site is not required.
+
+The compared statistic on `M` is the population variance of `|v-s0|_2/t0`.
+If `|M|≥2` both variances are compared. If `|M|=1` both variances are `0`.
+Equivalently the second moment `Q = |v-s0|_2^2 / t0^2` is reported. This
+note does not attach L1.
+
+## Theorem 1 — Lex-First Meeting Site, Arrival, And `|M|`
+
+Every union site is reached from both seeds under `ρ3`. The equal-arrival
+set has `313` sites under `ρ3` and `265` sites under `ℓ¹`, but every
+equal-arrival site other than `(1,0,0)` has a neighbor strictly earlier
+for both clocks. Therefore
+
+`M_ρ3 = {(1,0,0)}`,
+
+the lex-first meeting site is `(1,0,0)`, its arrival is `t=3`, and
+`|M|=1`.
+
+A witness walk of cost `3` from `s0` is the seed-exit hop
+`(0,0,0) → (1,0,0)`. A witness walk of cost `3` from `s1` is the
+seed-exit hop `(2,0,0) → (1,0,0)`. Those walks are witnesses, not a
+uniqueness claim among paths.
+
+Under `ℓ¹` the same definition yields `M_ℓ¹ = {(1,0,0)}` at `t=1`. The
+midplane `|x|=|x-2|` is the plane `x=1`, and every other site of that
+plane has a neighbor strictly earlier for both taxicab clocks.
+
+## Theorem 2 — Meeting-Set Arrival-Speed Variance
+
+Because `|M|=1`, both displayed population variances are `0`. No
+`|M|≥2` comparison of `var(|v-s0|_2/t0)` is available on this union.
+
+On `M_ρ3` the single speed is `|s0-offset|_2 / 3 = 1/3`, so the second
+moment is `1/9` and the population variance is `0`.
+
+On `M_ℓ¹` the single speed is `1/1 = 1`, so the second moment is
+`1` and the population variance is `0`.
+
+Both meeting-set variances are therefore `0`. The score `ρ3` does not beat
+`ℓ¹` on `M`. The lex-first minimizer among the names `l1` and `rho3` is
+`ℓ¹`. The comparison is displayed, not adopted.
+
+The pair is not a leftover of one-seed variance: the first-meeting front
+under the stated neighbor test is a singleton for both named costs, so the
+one-seed reverse distinction does not survive as a variance gap on this
+two-seed meeting set. The pair is not leftover of corridor-slide meeting:
+the equal-arrival set under `ρ3` is `313` sites, not `713`, and
+`t0(1,2,2)=9` because a least-cost walk uses a ridge `3→3` hop.
+
+## Theorem 3 — No Admissibility Write, L1 Not Attached
+
+Do not write `ρ3` into Admissibility. The current admissibility rule remains
+the quoted nearest-neighbor distribution constraint. The ridge-slide
+clauses and the unit-cost comparison are scoring rules on the finite union,
+not a replacement of that axiom.
+
+Do not attach L1. No formation law, occupancy member, or locked-set filling
+rule is identified with either hop-cost.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether two-seed meeting-set variance under ρ3 beats ℓ¹ on the B_12 union. |
+| V2 | Current main has no landed two-seed meeting-set variance for ridge-slide on B_12. |
+| V3 | The two Dijkstras, the meeting set, and the singleton variances are finite and exact. |
+| V4 | The comparison is not an axiom rewrite: Admissibility is left unchanged. |
+| V5 | Displayed scores are not a physical hop-cost or formation law. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: these two meeting-set scores are compared
+on the stated union and are not adopted. No uniqueness of a physical law
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| `ρ3` | seed-relative ridge-slide | executed; `|M|=1`, `var=0`, `t=3` |
+| `ℓ¹` | unit hop-cost | executed; `|M|=1`, `var=0`, `t=1`; lex-first name |
+| corridor-slide `μ` | omit the ridge clause | different residual; equal-arrival `713`; not this `M` count |
+| other meeting tests | keep the whole equal-arrival midplane | different residual; not this `M` |
+| unrestricted `Z^3` paths | leave the union and return | outside the declared domain |
+| adopt a score | write `ρ3` into Admissibility | forbidden; not executed |
+| attach L1 | identify a score with a formation member | forbidden; not executed |
+
+### N2 — wall independence
+
+Union restriction, seed-relative hop-cost, the first-meeting test, the
+speed statistic, and axiom non-adoption are distinct. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The union, the induced graph, seed-relative `ρ3`, the neighbor test for
+`M`, population variance, and lex-first among the two names are declared.
+No continuum limit, no physical clock, and no formation rate are assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate and the
+distribution sentence. It does not name hop-cost clauses. The residual is
+a finite comparison on that substrate, not an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each of the 3203 union sites | no other union |
+| per site | two arrivals under `ρ3`, taxicab under `ℓ¹` | no physical tick identification |
+| per mode | no spectral calculation | no mode exhaustion |
+| per block | two Dijkstras and two singleton variances | no law selection |
+| lattice wide | checked and not executed | no infinite-volume score |
+
+### N6 — live partial-closure paths
+
+Live routes are a derived hop-cost, a reason to adopt one of the two
+scores, a still larger-radius union, and a separately derived formation
+law. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because corridor-slide meeting on this union is a singleton,
+ridge-slide should either enlarge `M` by delaying body sites or produce a
+strictly smaller arrival-speed variance than `ℓ¹`.
+
+**Answer:** Under the stated neighbor test the first-meeting front remains
+the singleton `{(1,0,0)}`. The equal-arrival set shrinks from `713` under
+`μ` to `313` under `ρ3`, so the extra clause is live, but it does not
+enlarge `M`. Population variance on a singleton is `0` for every positive
+arrival.
+
+### N8 — cross-cycle echo
+
+The one-seed ridge-slide reverse at `k=1` is not reused as a lemma. The
+corridor-slide B_12 singleton is not copied as a substitute for the two
+Dijkstras on this union. The two scores are computed here. L1 remains
+unattached.
+
+**Gate disposition:** PASS for the reported meeting site, `|M|`, the two
+variances, the displayed lex-first minimizer `ℓ¹`, and the refusal to
+adopt a hop-cost or attach L1. FAIL / DO NOT SHIP for writing `ρ3` into
+Admissibility, attaching L1, or claiming a unique physical law.
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ρ3` among hop-costs with this meeting set.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)∪B_12((2,0,0))`.
+- Any adoption of the one-seed reverse as a two-seed variance gap.
+- Any claim that `|M|≥2` on this union.
+
+## Primary Runner
+
+The primary runner rebuilds the union, runs the two seed-relative
+Dijkstras, rebuilds the unit-cost meeting set from taxicab norms,
+recomputes the second moments and singleton variances, checks the
+lex-first minimizer, and pins the current axiom wording together with the
+non-adoption sentences. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16341,6 +16341,10 @@
   "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
    "deps_hash": "785ba75e68d8",
    "out_degree": 5
+  },
+  "ridge_slide_two_seed_meet_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ring_family_uniformity_cycle737_bounded_theorem_note_2026-07-28": {
    "deps_hash": "f38aec7a66e3",

--- a/logs/runner-cache/ridge_slide_two_seed_meet_b12_2026_08_15.txt
+++ b/logs/runner-cache/ridge_slide_two_seed_meet_b12_2026_08_15.txt
@@ -1,0 +1,58 @@
+===== runner cache v1 =====
+runner: scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py
+runner_sha256: deeba2e77e197a95c41d88673e6855de3321bf422d52d6bf57814a77ca8f669e
+input_fingerprint_sha256: 3b8b081712250239081dd6c9359fde8470ba91df2cc7b7428fe1297461dfb480
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.15
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/RIDGE_SLIDE_TWO_SEED_MEET_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Two-seed meeting-set arrival-speed variance under the named ridge-slide hop-cost on B_12(0)∪B_12((2,0,0)) is compared to ℓ¹. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ρ3 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the note and runner
+PASS: union-cardinality the executed domain is the 3203-site union B_12(0)∪B_12((2,0,0))
+n_sites 3203
+|E_rho3| 313
+meet_rho3 ((1, 0, 0),)
+t_rho3 3
+|M_rho3| 1
+|E_l1| 265
+meet_l1 ((1, 0, 0),)
+t_l1 1
+|M_l1| 1
+Q_rho3 1/9
+Q_l1 1/1
+var_rho3 0
+var_l1 0
+lex_first_minimizer l1
+dijkstra_calls 2
+PASS: two-dijkstras exactly two Dijkstras ran and every union site is reached
+PASS: l1-taxicab unit hop-cost arrivals equal the taxicab norms from each seed
+PASS: meeting-set lex-first ρ3 meeting site is (1,0,0) at t=3 with |M|=1
+PASS: l1-meeting-set lex-first ℓ¹ meeting site is (1,0,0) at t=1 with |M|=1
+PASS: singleton-meeting |M|=1 on the B_12 union under ρ3 and under ℓ¹; equal-arrival is 313 versus 265
+PASS: variances both singleton meeting-set arrival-speed variances are 0
+PASS: lex-first-minimizer the lex-first minimizer among the tied scores is ℓ¹
+PASS: note-records-meeting note records the lex-first site, its t, and |M|
+PASS: seed-relative ρ3 is grown from each seed: exit from (2,0,0) costs 3, not the global 1→2 price
+PASS: seed-and-ridge-slide-clauses ν clauses, corridor-slide, and ridge 3→3 cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1
+PASS: not-leftover-of-l1 ρ3 meeting time is 3 while ℓ¹ meeting time is 1, so the ρ3 score is not a unit-cost leftover
+PASS: not-leftover-of-mu ρ3 prices the ridge 3→3 hop at 3 while μ prices it at 1, and t(1,2,2)=9
+PASS: not-leftover-of-b6 the B_12 union is larger than the B_6 union and the equal-arrival set is 313, but M stayed a singleton
+PASS: source-axioms current Lattice, Admissibility, and Record wording is pinned
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py
+++ b/scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Two-seed meeting-set variance of ρ3 versus ℓ¹ on B_12(0)∪B_12((2,0,0)).
+
+Two seed-relative Dijkstras under ρ3. ℓ¹ arrivals are taxicab. No cache write.
+No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+from fractions import Fraction
+from heapq import heappop, heappush
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/RIDGE_SLIDE_TWO_SEED_MEET_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/RIDGE_SLIDE_TWO_SEED_MEET_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Two-seed meeting-set arrival-speed variance under the named "
+    "ridge-slide hop-cost on B_12(0)∪B_12((2,0,0)) is compared "
+    "to ℓ¹. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+S0 = (0, 0, 0)
+S1 = (2, 0, 0)
+RADIUS = 12
+UNION_COUNT = 3203
+BALL_COUNT = 2625
+EQUAL_RHO3 = 313
+EQUAL_L1 = 265
+MEET_SITE = (1, 0, 0)
+T_RHO3 = 3
+T_L1 = 1
+MEET_CARD = 1
+Q_RHO3 = (1, 9)
+Q_L1 = (1, 1)
+DIJKSTRA_CALLS = 0
+
+Point = tuple[int, int, int]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(point: Point, seed: Point = S0) -> int:
+    return abs(point[0] - seed[0]) + abs(point[1] - seed[1]) + abs(point[2] - seed[2])
+
+
+def l2sq(point: Point, seed: Point = S0) -> int:
+    return (point[0] - seed[0]) ** 2 + (point[1] - seed[1]) ** 2 + (point[2] - seed[2]) ** 2
+
+
+def support_size(point: Point) -> int:
+    return int(point[0] != 0) + int(point[1] != 0) + int(point[2] != 0)
+
+
+def least_nonzero_abs(point: Point) -> int | None:
+    nonzero = [abs(coord) for coord in point if coord != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(point: Point) -> int:
+    return int(abs(point[0]) == 1) + int(abs(point[1]) == 1) + int(abs(point[2]) == 1)
+
+
+def shifted(point: Point, seed: Point) -> Point:
+    return (point[0] - seed[0], point[1] - seed[1], point[2] - seed[2])
+
+
+def nu_cost(source: Point, target: Point) -> int:
+    sigma_v = support_size(source)
+    sigma_w = support_size(target)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(source: Point, target: Point) -> int:
+    if nu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(target) == 2 and least_nonzero_abs(target) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(source: Point, target: Point) -> int:
+    if mu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(target) == 3 and unit_coord_count(target) == 2:
+        return 3
+    return 1
+
+
+def rho3_from_seed(source: Point, target: Point, seed: Point) -> int:
+    return rho3_cost(shifted(source, seed), shifted(target, seed))
+
+
+def ball(center: Point, radius: int) -> list[Point]:
+    sites: list[Point] = []
+    extent = range(-radius, radius + 1)
+    cx, cy, cz = center
+    for dx, dy, dz in product(extent, repeat=3):
+        if abs(dx) + abs(dy) + abs(dz) <= radius:
+            sites.append((cx + dx, cy + dy, cz + dz))
+    return sites
+
+
+def union_sites() -> list[Point]:
+    return sorted(set(ball(S0, RADIUS)) | set(ball(S1, RADIUS)))
+
+
+def neighbors(site: Point, site_set: set[Point]) -> list[Point]:
+    out: list[Point] = []
+    x, y, z = site
+    for dx, dy, dz in NEIGH:
+        nxt = (x + dx, y + dy, z + dz)
+        if nxt in site_set:
+            out.append(nxt)
+    return out
+
+
+def dijkstra(sites: list[Point], seed: Point, cost_fn) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist = {seed: 0}
+    heap: list[tuple[int, Point]] = [(0, seed)]
+    while heap:
+        current, site = heappop(heap)
+        if current != dist[site]:
+            continue
+        for nxt in neighbors(site, site_set):
+            trial = current + cost_fn(site, nxt)
+            prior = dist.get(nxt)
+            if prior is None or trial < prior:
+                dist[nxt] = trial
+                heappush(heap, (trial, nxt))
+    return dist
+
+
+def equal_arrival_set(
+    sites: list[Point],
+    t0: dict[Point, int],
+    t1: dict[Point, int],
+) -> tuple[Point, ...]:
+    return tuple(sorted(site for site in sites if t0[site] == t1[site]))
+
+
+def meeting_set(
+    sites: list[Point],
+    t0: dict[Point, int],
+    t1: dict[Point, int],
+) -> tuple[Point, ...]:
+    site_set = set(sites)
+    found: list[Point] = []
+    for site in sites:
+        if t0[site] != t1[site]:
+            continue
+        earlier = False
+        for nxt in neighbors(site, site_set):
+            if t0[nxt] < t0[site] and t1[nxt] < t1[site]:
+                earlier = True
+                break
+        if not earlier:
+            found.append(site)
+    return tuple(sorted(found))
+
+
+def second_moment(meet: tuple[Point, ...], t0: dict[Point, int]) -> tuple[int, int]:
+    moment = Fraction(0)
+    for site in meet:
+        arrival = t0[site]
+        moment += Fraction(l2sq(site, S0), arrival * arrival)
+    moment /= len(meet)
+    return moment.numerator, moment.denominator
+
+
+def arrival_speed_variance(meet: tuple[Point, ...], t0: dict[Point, int]) -> Fraction:
+    if len(meet) <= 1:
+        return Fraction(0)
+    speeds = [Fraction(l2sq(site, S0)).sqrt() / t0[site] for site in meet]
+    mean = sum(speeds, Fraction(0)) / len(meet)
+    return sum((speed - mean) ** 2 for speed in speeds) / len(meet)
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS" for target in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    normalized_note = " ".join(note.split())
+    normalized_axiom = " ".join(axiom.split())
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in normalized_note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ρ3 is not written into Admissibility",
+        "Do not write `ρ3` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note and "Uniqueness not required" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note or token in source]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the note and runner",
+        forbidden_hits == [],
+    )
+
+    sites = union_sites()
+    site_set = set(sites)
+    b0 = ball(S0, RADIUS)
+    b1 = ball(S1, RADIUS)
+    checks.check(
+        "union-cardinality",
+        "the executed domain is the 3203-site union B_12(0)∪B_12((2,0,0))",
+        len(sites) == UNION_COUNT
+        and len(b0) == BALL_COUNT
+        and len(b1) == BALL_COUNT
+        and S0 in site_set
+        and S1 in site_set
+        and MEET_SITE in site_set
+        and (12, 0, 0) in site_set
+        and (12, 0, 0) not in set(ball(S0, 6)) | set(ball(S1, 6))
+        and all(l1(v, S0) <= RADIUS or l1(v, S1) <= RADIUS for v in sites),
+    )
+
+    t0 = dijkstra(sites, S0, lambda src, dst: rho3_from_seed(src, dst, S0))
+    t1 = dijkstra(sites, S1, lambda src, dst: rho3_from_seed(src, dst, S1))
+    t0_l1 = {site: l1(site, S0) for site in sites}
+    t1_l1 = {site: l1(site, S1) for site in sites}
+    equal_rho3 = equal_arrival_set(sites, t0, t1)
+    equal_l1 = equal_arrival_set(sites, t0_l1, t1_l1)
+    meet_rho3 = meeting_set(sites, t0, t1)
+    meet_l1 = meeting_set(sites, t0_l1, t1_l1)
+    q_rho3 = second_moment(meet_rho3, t0)
+    q_l1 = second_moment(meet_l1, t0_l1)
+    var_rho3 = arrival_speed_variance(meet_rho3, t0)
+    var_l1 = arrival_speed_variance(meet_l1, t0_l1)
+    named = {"l1": var_l1, "rho3": var_rho3}
+    lex_first = min(named, key=lambda name: (named[name], name))
+
+    print(f"n_sites {len(sites)}")
+    print(f"|E_rho3| {len(equal_rho3)}")
+    print(f"meet_rho3 {meet_rho3}")
+    print(f"t_rho3 {t0[MEET_SITE]}")
+    print(f"|M_rho3| {len(meet_rho3)}")
+    print(f"|E_l1| {len(equal_l1)}")
+    print(f"meet_l1 {meet_l1}")
+    print(f"t_l1 {t0_l1[MEET_SITE]}")
+    print(f"|M_l1| {len(meet_l1)}")
+    print(f"Q_rho3 {q_rho3[0]}/{q_rho3[1]}")
+    print(f"Q_l1 {q_l1[0]}/{q_l1[1]}")
+    print(f"var_rho3 {var_rho3}")
+    print(f"var_l1 {var_l1}")
+    print(f"lex_first_minimizer {lex_first}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "two-dijkstras",
+        "exactly two Dijkstras ran and every union site is reached",
+        DIJKSTRA_CALLS == 2 and len(t0) == UNION_COUNT and len(t1) == UNION_COUNT,
+    )
+    checks.check(
+        "l1-taxicab",
+        "unit hop-cost arrivals equal the taxicab norms from each seed",
+        all(t0_l1[site] == l1(site, S0) and t1_l1[site] == l1(site, S1) for site in sites),
+    )
+    checks.check(
+        "meeting-set",
+        "lex-first ρ3 meeting site is (1,0,0) at t=3 with |M|=1",
+        meet_rho3 == (MEET_SITE,)
+        and t0[MEET_SITE] == T_RHO3
+        and t1[MEET_SITE] == T_RHO3
+        and len(meet_rho3) == MEET_CARD,
+    )
+    checks.check(
+        "l1-meeting-set",
+        "lex-first ℓ¹ meeting site is (1,0,0) at t=1 with |M|=1",
+        meet_l1 == (MEET_SITE,)
+        and t0_l1[MEET_SITE] == T_L1
+        and t1_l1[MEET_SITE] == T_L1
+        and len(meet_l1) == MEET_CARD,
+    )
+    checks.check(
+        "singleton-meeting",
+        "|M|=1 on the B_12 union under ρ3 and under ℓ¹; equal-arrival is 313 versus 265",
+        len(meet_rho3) == 1
+        and len(meet_l1) == 1
+        and len(equal_rho3) == EQUAL_RHO3
+        and len(equal_l1) == EQUAL_L1
+        and len(equal_rho3) > 1
+        and "`313`" in note,
+    )
+    checks.check(
+        "variances",
+        "both singleton meeting-set arrival-speed variances are 0",
+        q_rho3 == Q_RHO3
+        and q_l1 == Q_L1
+        and var_rho3 == 0
+        and var_l1 == 0
+        and "`0`" in note
+        and "`1/9`" in note
+        and "`1`" in note,
+    )
+    checks.check(
+        "lex-first-minimizer",
+        "the lex-first minimizer among the tied scores is ℓ¹",
+        lex_first == "l1" and "lex-first minimizer" in note and "`ℓ¹`" in note,
+    )
+    checks.check(
+        "note-records-meeting",
+        "note records the lex-first site, its t, and |M|",
+        "`(1,0,0)`" in note
+        and "`3`" in note
+        and "`|M|=1`" in note
+        and "## Theorem 1" in note
+        and "## Theorem 2" in note
+        and "## Theorem 3" in note,
+    )
+    checks.check(
+        "seed-relative",
+        "ρ3 is grown from each seed: exit from (2,0,0) costs 3, not the global 1→2 price",
+        rho3_from_seed(S1, (2, 1, 0), S1) == 3
+        and rho3_cost(S1, (2, 1, 0)) == 1
+        and rho3_from_seed(S0, (1, 0, 0), S0) == 3
+        and rho3_from_seed(S1, MEET_SITE, S1) == 3
+        and "grown from each seed" in note,
+    )
+    checks.check(
+        "seed-and-ridge-slide-clauses",
+        "ν clauses, corridor-slide, and ridge 3→3 cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1",
+        rho3_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (2, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 1, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and rho3_cost((1, 1, 0), (2, 1, 0)) == 3
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((1, -1, -1), (2, -1, -1)) == 3
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((2, 2, 2), (3, 2, 2)) == 1,
+    )
+    checks.check(
+        "not-leftover-of-l1",
+        "ρ3 meeting time is 3 while ℓ¹ meeting time is 1, so the ρ3 score is not a unit-cost leftover",
+        t0[MEET_SITE] == 3
+        and t0_l1[MEET_SITE] == 1
+        and t0[MEET_SITE] != t0_l1[MEET_SITE]
+        and "not a leftover" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "ρ3 prices the ridge 3→3 hop at 3 while μ prices it at 1, and t(1,2,2)=9",
+        rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and mu_cost((1, 1, 1), (2, 1, 1)) == 1
+        and t0[(1, 2, 2)] == 9
+        and t1[(1, 2, 2)] == 9
+        and "cannot price the ridge slide" in note
+        and "`9`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b6",
+        "the B_12 union is larger than the B_6 union and the equal-arrival set is 313, but M stayed a singleton",
+        (12, 0, 0) in site_set
+        and l1((12, 0, 0), S0) == 12
+        and len(equal_rho3) == 313
+        and len(meet_rho3) == 1
+        and "absent from the radius-`6` union" in note
+        and "`313`" in note,
+    )
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+    checks.check(
+        "source-axioms",
+        "current Lattice, Admissibility, and Record wording is pinned",
+        lattice_sentence in normalized_axiom
+        and lattice_sentence in note
+        and admissibility_sentence in normalized_axiom
+        and admissibility_sentence in normalized_note
+        and formation_boundary in normalized_axiom
+        and formation_boundary in normalized_note
+        and all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ρ3(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two-seed meeting set under named ridge-slide hop-cost ρ3 on the B_12 union is a singleton at (1,0,0), t=3; both arrival-speed variances 0. First display. Displayed, not adopted. Do not write ρ3 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/ridge_slide_two_seed_meet_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.