### PR TITLE
feat(ridk6): ridge-slide same-k holds at k=6: t=18 vs t=22

### DIFF
--- a/docs/RIDGE_SLIDE_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/RIDGE_SLIDE_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,174 @@
+---
+claim_id: ridge_slide_samek_k6_b18_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=6 under the named ridge-slide hop-cost on B_18(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/ridge_slide_samek_k6_b18_2026_08_15.py
+---
+
+# Named Ridge-Slide Same-k Reverse At k=6 On B_18(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_18(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=6`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/ridge_slide_samek_k6_b18_2026_08_15.py`](../scripts/ridge_slide_samek_k6_b18_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named ridge-slide hop-cost `ρ3` already reverse-holds at `k=1` and at
+`k=7`. The residual scored here is the same named rule on `B_18(0)` at
+`k=6`. The comparator corridor-slide rule `μ` holds same-`k` reverse at
+`k=6` by `16` versus `20`. The displayed extra clause of `ρ3` is cost `3`
+on a `3→3` hop whose destination has exactly two coordinates of absolute
+value `1`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_18(0)`, let `ν` be
+the support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. Let `μ` be the corridor-slide rule that costs
+`3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|`
+equals `1)`, else `1`. The displayed rule `ρ3` is
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The extra clause is a ridge slide: both ends have support `3`, and the
+destination still has exactly two unit coordinates. Those clauses are the
+whole rule.
+
+One Dijkstra from the origin on `B_18(0)` (8473 sites; 8472 nonzero)
+gives
+
+`t(6,0,0) = 18`, `t(6,6,6) = 22`.
+
+The displayed same-`k` comparison at `k=6` is
+
+`t(6,0,0)^2 / 36  ?  t(6,6,6)^2 / 108`,
+
+which is `324/36` versus `484/108`, or equivalently `972 > 484`. The
+inequality holds. Same-`k` reverse at `k=6` under `ρ3` is yes.
+Independently, the new axis site is `t(18,0,0) = 34`. The shared axis
+site `t(16,0,0) = 28` is a `ρ3` score on this ball, not a `μ` leftover.
+
+The pair is not leftover of `μ`: the same sites under `μ` are `16` versus `20`,
+and the extra ridge-slide clause is what changes both times. The
+site `(6,6,6)` has ℓ¹ norm `18`, so it is absent from `B_16(0)`. The
+`B_18(0)` table is therefore not leftover of the `B_16(0)` times.
+
+The rule is displayed, not adopted. Do not write `ρ3` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the two-unit-coordinate clause, and
+the arrival function `t` are separately displayed mathematical inputs. No
+axiom text is edited.
+
+## Named Rule
+
+Let `B_18(0) = { v ∈ Z^3 : |v|_1 ≤ 18 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_18(0)`,
+`t(v)` is the least sum of `ρ3` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `μ` uses only the first four clauses of `ρ3`. On the
+ridge-slide hop `(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and exactly two
+`|w_i|` equal `1`, so `μ = 1` while `ρ3 = 3`. Therefore `μ` cannot price ridge slide,
+and the `ρ3` scores below are not a leftover of `μ`.
+
+## Theorem 1 — Arrivals `t(6,0,0)` And `t(6,6,6)` On `B_18(0)`
+
+One origin Dijkstra on `B_18(0)` returns the integer arrivals
+
+| site | `t_ρ3` |
+|---|---:|
+| `(6,0,0)` | `18` |
+| `(6,6,6)` | `22` |
+
+Every listed site lies in `B_18(0)`. The site `(6,6,6)` has ℓ¹ norm `18`,
+so it is absent from `B_16(0)`. The pair is computed on `B_18(0)`, not
+copied from a smaller-ball table and not copied from the `μ` pair
+`16` versus `20`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `18` is seed-exit `3` onto `(0,-1,0)`,
+support-increase `1` onto `(1,-1,0)`, corridor-slide `3` onto `(1,-2,0)`,
+five support-preserving cost-`1` height-`2` slides to `(6,-2,0)`,
+corridor-slide `3` onto `(6,-1,0)`, and support-drop `3` onto `(6,0,0)`,
+summing to `18`. A witness body walk of cost `22` is seed-exit `3` onto
+`(0,0,1)`, support-increase `1` onto `(0,1,1)`, corridor-slide `3` onto
+`(0,1,2)`, nine support-preserving cost-`1` face hops to `(0,6,6)`,
+support-increase `1` onto `(1,6,6)`, and five support-preserving cost-`1`
+body hops onto `(6,6,6)`, summing to `22`. Those walks are witnesses, not
+a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=6`
+
+The Euclidean-normalized comparison at `k=6` is
+
+`t(6,0,0)^2 / 36  ?  t(6,6,6)^2 / 108`,
+
+equivalently `3 t(6,0,0)^2 ? t(6,6,6)^2`. Substituting the computed times
+gives `3 · 18^2 = 972` and `22^2 = 484`, so
+
+`972 > 484`.
+
+Arrival per Euclidean length is larger at `(6,0,0)` than at `(6,6,6)`.
+Same-`k` reverse at `k=6` under `ρ3` is yes. The comparison is displayed,
+not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ρ3` is a displayed scoring device on `B_18(0)`. Do not write
+`ρ3` into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_18(0) for one named hop-cost at k=6. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_18(0) for the displayed rule ρ3 at k=6; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ρ3` among hop-costs that reverse the same-`k` pair at `k=6`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_18(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=6`.
+- Any reuse of the `μ` arrival table as a substitute for the `ρ3` Dijkstra.
+- Any reuse of the `B_16(0)` arrival table as a substitute for the
+  radius-`18` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16341,6 +16341,10 @@
   "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
    "deps_hash": "785ba75e68d8",
    "out_degree": 5
+  },
+  "ridge_slide_samek_k6_b18_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ring_family_uniformity_cycle737_bounded_theorem_note_2026-07-28": {
    "deps_hash": "f38aec7a66e3",

--- a/logs/runner-cache/ridge_slide_samek_k6_b18_2026_08_15.txt
+++ b/logs/runner-cache/ridge_slide_samek_k6_b18_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/ridge_slide_samek_k6_b18_2026_08_15.py
+runner_sha256: 5ad0944f28063ee7038f61d618c07bd4bd0d5d3a752015320d45c78196ca0fd8
+input_fingerprint_sha256: 0824cf7c8138230accafcdb9814a8518beb5a00d5073eff60a6bb068c1e315bc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/RIDGE_SLIDE_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=6 under the named ridge-slide hop-cost on B_18(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ρ3 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 8473
+t(6,0,0) 18
+t(6,6,6) 22
+t(6,0,0)^2/36 324/36
+t(6,6,6)^2/108 484/108
+3t_axis^2 972
+t_body^2 484
+reverse True
+t(18,0,0) 34
+t(16,0,0) 28
+dijkstra_calls 1
+witness_rho3_costs [3, 1, 3, 1, 1, 1, 1, 1, 3, 3]
+witness_rho3_sum 18
+PASS: t-600-666 t(6,0,0)=18 and t(6,6,6)=22
+PASS: reverse-k6 t(6,0,0)^2/36 > t(6,6,6)^2/108 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b18 B_18(0) has 8473 sites and 8472 nonzero sites
+PASS: reachable every site of B_18(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-mu ρ3 prices the ridge-slide hop at 3 while μ prices it at 1
+PASS: not-leftover-of-b16 (6,6,6) lies outside B_16(0) and the note says so
+PASS: seed-and-ridge-clauses seed-exit, both-weights-1, support-drop, corridor-slide, and ridge-slide cost 3; other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/ridge_slide_samek_k6_b18_2026_08_15.py
+++ b/scripts/ridge_slide_samek_k6_b18_2026_08_15.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=6 under ρ3 on B_18(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/RIDGE_SLIDE_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/RIDGE_SLIDE_SAMEK_K6_B18_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=6 under the named "
+    "ridge-slide hop-cost on B_18(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 18
+T_BODY_REP = 22
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def dijkstra_rho3(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + rho3_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ρ3 is not written into Admissibility",
+        "Do not write `ρ3` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(18)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_rho3(sites)
+    t600 = dist[(6, 0, 0)]
+    t666 = dist[(6, 6, 6)]
+    t1800 = dist[(18, 0, 0)]
+    t1600 = dist[(16, 0, 0)]
+    reverse = 3 * t600 * t600 > t666 * t666
+    witness_axis = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (1, -2, 0),
+        (2, -2, 0),
+        (3, -2, 0),
+        (4, -2, 0),
+        (5, -2, 0),
+        (6, -2, 0),
+        (6, -1, 0),
+        (6, 0, 0),
+    )
+    witness_rho3_costs = [rho3_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    print(f"n_sites {len(sites)}")
+    print(f"t(6,0,0) {t600}")
+    print(f"t(6,6,6) {t666}")
+    print(f"t(6,0,0)^2/36 {t600 * t600}/36")
+    print(f"t(6,6,6)^2/108 {t666 * t666}/108")
+    print(f"3t_axis^2 {3 * t600 * t600}")
+    print(f"t_body^2 {t666 * t666}")
+    print(f"reverse {reverse}")
+    print(f"t(18,0,0) {t1800}")
+    print(f"t(16,0,0) {t1600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_rho3_costs {witness_rho3_costs}")
+    print(f"witness_rho3_sum {sum(witness_rho3_costs)}")
+
+    checks.check(
+        "t-600-666",
+        f"t(6,0,0)={T_AXIS_REP} and t(6,6,6)={T_BODY_REP}",
+        t600 == T_AXIS_REP and t666 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k6",
+        "t(6,0,0)^2/36 > t(6,6,6)^2/108 holds",
+        reverse
+        and 3 * t600 * t600 == 972
+        and t666 * t666 == 484
+        and "972 > 484" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b18",
+        "B_18(0) has 8473 sites and 8472 nonzero sites",
+        len(sites) == 8473 and len(nonzero) == 8472 and all(l1(v) <= 18 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_18(0) is reached",
+        len(dist) == 8473,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`18`" in note
+        and "`22`" in note
+        and "`(6,0,0)`" in note
+        and "`(6,6,6)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "972 > 484" in note,
+    )
+    checks.check(
+        "not-leftover-of-mu",
+        "ρ3 prices the ridge-slide hop at 3 while μ prices it at 1",
+        rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and mu_cost((1, 1, 1), (2, 1, 1)) == 1
+        and sum(witness_rho3_costs) == 18
+        and t600 == 18
+        and t666 == 22
+        and t600 != 16
+        and t666 != 20
+        and "cannot price ridge slide" in note
+        and "16` versus `20" in note,
+    )
+    checks.check(
+        "not-leftover-of-b16",
+        "(6,6,6) lies outside B_16(0) and the note says so",
+        l1((6, 6, 6)) == 18
+        and (6, 6, 6) in dist
+        and t1800 == 34
+        and t1600 == 28
+        and t1600 != 26
+        and t1800 != 32
+        and "absent from `B_16(0)`" in note
+        and "not leftover of the `B_16(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-ridge-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, and ridge-slide cost 3; other hops cost 1",
+        rho3_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (2, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (2, 1, 0)) == 3
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and rho3_cost((2, 2, 1), (3, 2, 1)) == 1
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((2, 1, 1), (1, 1, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named ridge-slide hop-cost ρ3 holds at k=6 on B_18(0): t(6,0,0)=18 vs t(6,6,6)=22. First display. Displayed, not adopted. Do not write ρ3 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/ridge_slide_samek_k6_b18_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.