### PR TITLE
feat(hrk13): height-ridge same-k holds at k=13: t=25 vs t=43

### DIFF
--- a/docs/HEIGHT_RIDGE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/HEIGHT_RIDGE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,193 @@
+---
+claim_id: height_ridge_samek_k13_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=13 under the named height-ridge hop-cost on B_39(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/height_ridge_samek_k13_b39_2026_08_15.py
+---
+
+# Named Height-Ridge Same-k Reverse At k=13 On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_39(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=13`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/height_ridge_samek_k13_b39_2026_08_15.py`](../scripts/height_ridge_samek_k13_b39_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named height-ridge hop-cost `ζ` is the already scored ridge-slide
+rule `ρ3` plus cost `3` on a `3→3` hop whose destination has exactly two
+absolute coordinates equal to `m`, with `m` the least absolute coordinate
+and `m ≥ 2` (a height-`m` ridge). Same-`k` reverse under `ρ3` holds at
+`k=13` (`25` versus `43`). The residual scored here is whether `ζ` still
+reverses at `k=13` on `B_39(0)`. First display of `ζ` at `k=13`.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_39(0)`, the displayed
+rule `ζ` is
+
+`ζ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `m` and `m = min_j |w_j|` and `m ≥ 2)`, else `1`,
+
+where `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly
+two `|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is the unit-height ridge slide. The sixth clause is the height-`m`
+ridge for `m ≥ 2`. Those six clauses are the whole rule.
+
+One Dijkstra from the origin on `B_39(0)` (82239 sites; 82238 nonzero) gives
+
+`t(13,0,0) = 25`, `t(13,13,13) = 43`.
+
+The displayed same-`k` comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+which is `625/169` versus `1849/507`, or equivalently `1875 > 1849`. The
+inequality holds. Same-`k` reverse at `k=13` under `ζ` is yes.
+Independently, the new axis site is `t(39,0,0) = 55`. The shared axis
+site `t(36,0,0) = 48` is a `ζ` score on this ball.
+
+The same-`k` pair under `ρ3` is also `25` versus `43`. That match is not
+a leftover of a `ρ3` table: the extra height-`m` ridge clause is live on
+the ball. On the height-`2` ridge hop `(2,2,2) → (3,2,2)` one has
+`|σ| : 3 → 3`, exactly two `|w_i|` equal to `2`, and `min_j |w_j| = 2`,
+so `ρ3 = 1` while `ζ = 3`. Therefore `ρ3` cannot price the height-`m`
+ridge. The same hop is a `ζ` cost-`3` step, and `t(3,2,2) = 13` under
+`ζ`. A cheapest `ζ` walk to `(13,13,13)` uses no height-`m` ridge hop,
+so the same-`k` pair stays `25` versus `43`. The site `(13,13,13)` has
+ℓ¹ norm `39`, so it is absent from `B_36(0)`. The `B_39(0)` table is
+therefore not leftover of the `B_36(0)` times.
+
+The rule is displayed, not adopted. Do not write `ζ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the unit-height ridge clause, the
+height-`m` ridge clause for `m ≥ 2`, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_39(0) = { v ∈ Z^3 : |v|_1 ≤ 39 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_39(0)`,
+`t(v)` is the least sum of `ζ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses only the first five clauses of `ζ`. On the
+height-`2` ridge hop `(2,2,2) → (3,2,2)` one has `|σ| : 3 → 3` and
+exactly two `|w_i|` equal to the least absolute coordinate `2`, so
+`ρ3 = 1` while `ζ = 3`. Therefore `ρ3` cannot price the height-`m`
+ridge, and the `ζ` scores below are not a leftover of `ρ3`. On the
+unit-height ridge hop `(1,1,1) → (2,1,1)` both `ρ3` and `ζ` cost `3`.
+On the interior body hop `(13,13,1) → (13,13,2)` the destination has
+only one absolute coordinate equal to its least absolute coordinate, so
+both `ρ3` and `ζ` cost `1`.
+
+## Theorem 1 — Arrivals `t(13,0,0)` And `t(13,13,13)` On `B_39(0)`
+
+One origin Dijkstra on `B_39(0)` returns the integer arrivals
+
+| site | `t_ζ` |
+|---|---:|
+| `(13,0,0)` | `25` |
+| `(13,13,13)` | `43` |
+
+Every listed site lies in `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39`,
+so it is absent from `B_36(0)`. The pair is computed on `B_39(0)`, not
+copied from a smaller-ball table and not copied from a `ρ3` table. These
+values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `25` is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, hugging corridor-slide `3` onto `(2,1,0)`,
+non-hugging face hop `1` onto `(2,2,0)`, eleven support-preserving
+cost-`1` face hops to `(13,2,0)`, hugging slide `3` onto `(13,1,0)`, and
+support-drop `3` onto `(13,0,0)`, summing to `25`. That walk is a witness
+of cost `25`, not a uniqueness claim.
+
+A witness body walk of cost `43` is the same prefix of cost `8` to
+`(2,2,0)`, eleven cost-`1` face hops to `(13,2,0)`, eleven cost-`1` face
+hops to `(13,13,0)`, enter-body `1` onto `(13,13,1)`, and twelve
+support-preserving cost-`1` body hops to `(13,13,13)`, summing to `43`.
+Those last hops have dest with only one absolute coordinate equal to the
+least absolute coordinate, or with all three equal, so they are not
+height-`m` ridges. That walk is a witness of cost `43`, not a uniqueness
+claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=13`
+
+The Euclidean-normalized comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+equivalently `3 t(13,0,0)^2 ? t(13,13,13)^2`. Substituting the computed times
+gives `3 · 25^2 = 1875` and `43^2 = 1849`, so
+
+`1875 > 1849` is true; `1875 > 1849` holds.
+
+Arrival per Euclidean length is larger at `(13,0,0)` than at
+`(13,13,13)`. Same-`k` reverse at `k=13` under `ζ` is yes. The comparison
+is displayed, not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ζ` is a displayed scoring device on `B_39(0)`. Do not write `ζ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_39(0) for one named hop-cost at k=13. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_39(0) for the displayed rule ζ at k=13; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ζ` among hop-costs that reverse the same-`k` pair at `k=13`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_39(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=13`.
+- Any reuse of a `ρ3` arrival table as a substitute for the `ζ` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6629,6 +6629,10 @@
   "heat_kernel_unique_diffusion_kernel_among_candidate_gauge_actions_narrow_theorem_note_2026-06-08": {
    "deps_hash": "7b79e2bc121e",
    "out_degree": 3
+  },
+  "height_ridge_samek_k13_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "hermitian_lift_theta_h_pk_bounded_narrow_theorem_note_2026-05-17": {
    "deps_hash": "df15e3194fcf",

--- a/logs/runner-cache/height_ridge_samek_k13_b39_2026_08_15.txt
+++ b/logs/runner-cache/height_ridge_samek_k13_b39_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/height_ridge_samek_k13_b39_2026_08_15.py
+runner_sha256: f3f7febacb87db2ad94104106318937e1bb19689c3092b52e9f63973c05e9f26
+input_fingerprint_sha256: dbf6e5646f62210a0987406602744657094fc11614f5e8333555ef488001b898
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.73
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/HEIGHT_RIDGE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=13 under the named height-ridge hop-cost on B_39(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ζ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 82239
+t(13,0,0) 25
+t(13,13,13) 43
+t(13,0,0)^2/169 625/169
+t(13,13,13)^2/507 1849/507
+3t_axis^2 1875
+t_body^2 1849
+reverse True
+t(39,0,0) 55
+t(36,0,0) 48
+t(3,2,2) 13
+dijkstra_calls 1
+witness_zeta_axis [3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_zeta_axis_sum 25
+witness_zeta_body_sum 43
+zeta_ridge 3
+rho3_ridge 3
+zeta_height_ridge 3
+rho3_height_ridge 1
+zeta_interior_body 1
+rho3_interior_body 1
+PASS: t-13000-131313 t(13,0,0)=25 and t(13,13,13)=43
+PASS: reverse-k13 t(13,0,0)^2/169 > t(13,13,13)^2/507 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b39 B_39(0) has 82239 sites and 82238 nonzero sites
+PASS: reachable every site of B_39(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-rho3 ζ prices the height-m ridge hop at 3 while ρ3 prices it at 1
+PASS: not-leftover-of-b36 (13,13,13) lies outside B_36(0) and the note says so
+PASS: seed-and-height-ridge-clauses seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide, and height-m ridge cost 3; other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/height_ridge_samek_k13_b39_2026_08_15.py
+++ b/scripts/height_ridge_samek_k13_b39_2026_08_15.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=13 under ζ on B_39(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/HEIGHT_RIDGE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/HEIGHT_RIDGE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=13 under the named "
+    "height-ridge hop-cost on B_39(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 25
+T_BODY_REP = 43
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def height_count(v: tuple[int, int, int], m: int) -> int:
+    return int(abs(v[0]) == m) + int(abs(v[1]) == m) + int(abs(v[2]) == m)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and height_count(w, 1) == 2:
+        return 3
+    return 1
+
+
+def zeta_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        m = min(abs(w[0]), abs(w[1]), abs(w[2]))
+        if m >= 2 and height_count(w, m) == 2:
+            return 3
+    return 1
+
+
+def dijkstra_zeta(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + zeta_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ζ is not written into Admissibility",
+        "Do not write `ζ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(39)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_zeta(sites)
+    t13000 = dist[(13, 0, 0)]
+    t131313 = dist[(13, 13, 13)]
+    t3900 = dist[(39, 0, 0)]
+    t3600 = dist[(36, 0, 0)]
+    t322 = dist[(3, 2, 2)]
+    reverse = 3 * t13000 * t13000 > t131313 * t131313
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+        *[(x, 2, 0) for x in range(3, 14)],
+        (13, 1, 0),
+        (13, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+        *[(x, 2, 0) for x in range(3, 14)],
+        *[(13, y, 0) for y in range(3, 14)],
+        (13, 13, 1),
+        *[(13, 13, z) for z in range(2, 14)],
+    )
+    witness_zeta_axis = [zeta_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    witness_zeta_body = [zeta_cost(a, b) for a, b in zip(witness_body, witness_body[1:])]
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    height_ridge_hop = ((2, 2, 2), (3, 2, 2))
+    interior_body_hop = ((13, 13, 1), (13, 13, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(13,0,0) {t13000}")
+    print(f"t(13,13,13) {t131313}")
+    print(f"t(13,0,0)^2/169 {t13000 * t13000}/169")
+    print(f"t(13,13,13)^2/507 {t131313 * t131313}/507")
+    print(f"3t_axis^2 {3 * t13000 * t13000}")
+    print(f"t_body^2 {t131313 * t131313}")
+    print(f"reverse {reverse}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(36,0,0) {t3600}")
+    print(f"t(3,2,2) {t322}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_zeta_axis {witness_zeta_axis}")
+    print(f"witness_zeta_axis_sum {sum(witness_zeta_axis)}")
+    print(f"witness_zeta_body_sum {sum(witness_zeta_body)}")
+    print(f"zeta_ridge {zeta_cost(*ridge_hop)}")
+    print(f"rho3_ridge {rho3_cost(*ridge_hop)}")
+    print(f"zeta_height_ridge {zeta_cost(*height_ridge_hop)}")
+    print(f"rho3_height_ridge {rho3_cost(*height_ridge_hop)}")
+    print(f"zeta_interior_body {zeta_cost(*interior_body_hop)}")
+    print(f"rho3_interior_body {rho3_cost(*interior_body_hop)}")
+
+    checks.check(
+        "t-13000-131313",
+        f"t(13,0,0)={T_AXIS_REP} and t(13,13,13)={T_BODY_REP}",
+        t13000 == T_AXIS_REP and t131313 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k13",
+        "t(13,0,0)^2/169 > t(13,13,13)^2/507 holds",
+        reverse
+        and 3 * t13000 * t13000 == 1875
+        and t131313 * t131313 == 1849
+        and "1875 > 1849" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b39",
+        "B_39(0) has 82239 sites and 82238 nonzero sites",
+        len(sites) == 82239 and len(nonzero) == 82238 and all(l1(v) <= 39 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_39(0) is reached",
+        len(dist) == 82239,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`25`" in note
+        and "`43`" in note
+        and "`(13,0,0)`" in note
+        and "`(13,13,13)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1875 > 1849" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "ζ prices the height-m ridge hop at 3 while ρ3 prices it at 1",
+        zeta_cost(*height_ridge_hop) == 3
+        and rho3_cost(*height_ridge_hop) == 1
+        and zeta_cost(*ridge_hop) == 3
+        and rho3_cost(*ridge_hop) == 3
+        and sum(witness_zeta_axis) == 25
+        and sum(witness_zeta_body) == 43
+        and t13000 == 25
+        and t131313 == 43
+        and t322 == 13
+        and "cannot price the height-`m`" in note
+        and "25` versus `43" in note
+        and "`t(3,2,2) = 13`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b36",
+        "(13,13,13) lies outside B_36(0) and the note says so",
+        l1((13, 13, 13)) == 39
+        and (13, 13, 13) in dist
+        and t3900 == 55
+        and t3600 == 48
+        and "absent from `B_36(0)`" in note
+        and "not leftover of the `B_36(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-height-ridge-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide, and height-m ridge cost 3; other hops cost 1",
+        zeta_cost((0, 0, 0), (1, 0, 0)) == 3
+        and zeta_cost((1, 0, 0), (2, 0, 0)) == 3
+        and zeta_cost((1, 1, 0), (1, 0, 0)) == 3
+        and zeta_cost((1, 1, 0), (2, 1, 0)) == 3
+        and zeta_cost((1, 1, 1), (2, 1, 1)) == 3
+        and zeta_cost((2, 2, 2), (3, 2, 2)) == 3
+        and zeta_cost((1, 0, 0), (1, 1, 0)) == 1
+        and zeta_cost((1, 1, 0), (1, 1, 1)) == 1
+        and zeta_cost((2, 2, 0), (3, 2, 0)) == 1
+        and zeta_cost(*interior_body_hop) == 1
+        and zeta_cost((13, 13, 12), (13, 13, 13)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ζ(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named height-ridge hop-cost ζ holds at k=13 on B_39(0): t(13,0,0)=25 vs t(13,13,13)=43. First display. Displayed, not adopted. Do not write ζ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/height_ridge_samek_k13_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.