### PR TITLE
feat(hrface): height-ridge face reverse holds k=1..8 on B16

### DIFF
--- a/docs/HEIGHT_RIDGE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/HEIGHT_RIDGE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,243 @@
+---
+claim_id: height_ridge_face_reverse_vs_k_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face-diagonal reverse versus integer scale k under the named height-ridge hop-cost on B_16(0) is reported for available k=1..8. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py
+---
+
+# Named Height-Ridge Face Reverse Versus Integer Scale k On B_16(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_16(0)`,
+scored only for the face-diagonal reverse comparison at every available
+integer scale `k=1..8`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py`](../scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named height-ridge hop-cost `ζ` is scored independently on `B_16(0)`.
+The ball is not leftover of a larger-ball table: one origin Dijkstra is run
+on this ball. Face reverse under the ridge-slide rule `ρ3` holds at every
+`k=1..8`. The new clause taxes height-`m` ridges for `m ≥ 2`. This is the
+first display of the face-versus-axis bits versus integer scale `k` for
+`ζ`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_16(0)`, let `ν` be the
+support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. Let `μ` be the corridor-slide rule
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+Let `ρ3` be the ridge-slide rule
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The displayed rule `ζ` is
+
+`ζ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `m` and `m = min_j |w_j|` and `m ≥ 2)`, else `1`.
+
+The extra clause is a height-`m` ridge: both ends have support `3`, the
+destination has least absolute coordinate `m ≥ 2`, and exactly two
+coordinates have that least absolute value. It is not a tax on every
+`3→3` hop.
+
+A pair `((2k,0,0),(k,k,0))` is available when both sites lie in `B_16(0)`.
+That is `| (2k,0,0) |_1 = 2k ≤ 16` and `| (k,k,0) |_1 = 2k ≤ 16`, so every
+`k=1..8` is available. No scale is omitted.
+
+One Dijkstra from the origin on `B_16(0)` (6017 sites; 6016 nonzero) gives
+
+`t(2,0,0) = 6`, `t(4,0,0) = 12`, `t(6,0,0) = 18`, `t(8,0,0) = 20`,
+`t(10,0,0) = 22`, `t(12,0,0) = 24`, `t(14,0,0) = 26`, `t(16,0,0) = 32`,
+
+`t(1,1,0) = 4`, `t(2,2,0) = 8`, `t(3,3,0) = 10`, `t(4,4,0) = 12`,
+`t(5,5,0) = 14`, `t(6,6,0) = 16`, `t(7,7,0) = 18`, `t(8,8,0) = 20`.
+
+For each available `k`, the displayed face-diagonal comparison is whether
+
+`t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2)`,
+
+equivalently `t(2k,0,0)^2 > 2 t(k,k,0)^2`. The bits are
+
+| `k` | pair | axis `t^2/|v|_2^2` | face `t^2/|v|_2^2` | reverse |
+|---|---|---|---|---|
+| `1` | `((2,0,0),(1,1,0))` | `36/4=9` | `16/2=8` | yes |
+| `2` | `((4,0,0),(2,2,0))` | `144/16=9` | `64/8=8` | yes |
+| `3` | `((6,0,0),(3,3,0))` | `324/36=9` | `100/18=50/9` | yes |
+| `4` | `((8,0,0),(4,4,0))` | `400/64=25/4` | `144/32=9/2` | yes |
+| `5` | `((10,0,0),(5,5,0))` | `484/100=121/25` | `196/50=98/25` | yes |
+| `6` | `((12,0,0),(6,6,0))` | `576/144=4` | `256/72=32/9` | yes |
+| `7` | `((14,0,0),(7,7,0))` | `676/196=169/49` | `324/98=162/49` | yes |
+| `8` | `((16,0,0),(8,8,0))` | `1024/256=4` | `400/128=25/8` | yes |
+
+Exact integer comparisons `t(2k,0,0)^2 ? 2 t(k,k,0)^2`:
+
+- `k=1`: `36 > 32` holds
+- `k=2`: `144 > 128` holds
+- `k=3`: `324 > 200` holds
+- `k=4`: `400 > 288` holds
+- `k=5`: `484 > 392` holds
+- `k=6`: `576 > 512` holds
+- `k=7`: `676 > 648` holds
+- `k=8`: `1024 > 800` holds
+
+Reverse holds at every available `k=1..8`. The pair arrivals match the
+`ρ3` face-versus-`k` table on the same ball, but the score is not leftover
+of that table: the extra height-ridge clause is live off the face. On the
+height-`2` ridge `(2,2,2) → (3,2,2)` one has `|σ_v|=|σ_w|=3`,
+`m = min_j |w_j| = 2`, and exactly two `|w_i|` equal `2`, so `ρ3 = 1`
+while `ζ = 3`. Therefore `ρ3` cannot price the height-`m` ridge.
+Independently, `t(2,2,2) = 10` and `t(3,2,2) = 13` under `ζ`. The last hop
+of that witness is the taxed height-`2` ridge of cost `3`. The axis
+endpoint of this ball is `t(16,0,0) = 32`. The site `(16,-1,-1)` lies
+outside `B_16(0)`. The only in-ball neighbor of `(16,0,0)` is `(15,0,0)`,
+so the last hop is the both-weights-`1` axis step of cost `3`.
+
+The rule is displayed, not adopted. Do not write `ζ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the height-`m` ridge test, and the arrival function `t` are separately
+displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_16(0) = { v ∈ Z^3 : |v|_1 ≤ 16 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_16(0)`,
+`t(v)` is the least sum of `ζ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses the three support-drop clauses, the axis-hugging
+`2→2` slide, and the unit-height ridge. On the height-`2` ridge
+`(2,2,2) → (3,2,2)` one has `|σ_v|=|σ_w|=3`, `m = 2`, and exactly two
+`|w_i| = 2`, so `ρ3 = 1` while `ζ = 3`. Therefore `ρ3` cannot price the
+height-`m` ridge. The same extra clause prices `(2,2,2) → (2,2,3)` at `3`
+and `(3,3,3) → (4,3,3)` at `3`. On the unit-height ridge
+`(1,1,1) → (2,1,1)` both `ρ3` and `ζ` cost `3`. On the face hop
+`(1,0,0) → (1,1,0)` both cost `1`. On the non-ridge interior `3→3` hop
+`(4,3,2) → (5,3,2)` the destination has least absolute coordinate `2` at
+only one coordinate, so both `ρ3` and `ζ` cost `1`.
+
+## Theorem 1 — Arrivals `t(2k,0,0)` And `t(k,k,0)` On `B_16(0)`
+
+One origin Dijkstra on `B_16(0)` returns the integer arrivals
+
+| site | `t_ζ` |
+|---|---:|
+| `(2,0,0)` | `6` |
+| `(1,1,0)` | `4` |
+| `(4,0,0)` | `12` |
+| `(2,2,0)` | `8` |
+| `(6,0,0)` | `18` |
+| `(3,3,0)` | `10` |
+| `(8,0,0)` | `20` |
+| `(4,4,0)` | `12` |
+| `(10,0,0)` | `22` |
+| `(5,5,0)` | `14` |
+| `(12,0,0)` | `24` |
+| `(6,6,0)` | `16` |
+| `(14,0,0)` | `26` |
+| `(7,7,0)` | `18` |
+| `(16,0,0)` | `32` |
+| `(8,8,0)` | `20` |
+
+Every listed site lies in `B_16(0)`. No `k=1..8` pair is omitted. The
+sixteen values are computed on `B_16(0)`, not copied from a larger-ball
+table and not copied from the `ρ3` pair table. These values are Dijkstra
+outputs, not fitted scalars.
+
+A witness walk to `(2,0,0)` is seed-exit `3` onto `(1,0,0)` and both-weights-`1`
+axis hop `3` onto `(2,0,0)`, summing to `6`. A witness walk to `(1,1,0)` is
+seed-exit `3` onto `(0,1,0)` and body `1→2` of cost `1` onto `(1,1,0)`,
+summing to `4`. A witness walk to `(6,0,0)` is seed-exit `3` onto
+`(0,1,0)`, body `1` onto `(1,1,0)`, hugging slide `3` onto `(2,1,0)`,
+face hop `1` onto `(2,2,0)`, four support-preserving cost-`1` face hops
+to `(6,2,0)`, hugging slide `3` onto `(6,1,0)`, and support-drop `3` onto
+`(6,0,0)`, summing to `18`. A witness walk to `(3,3,0)` is seed-exit `3`
+onto `(0,1,0)`, body `1` onto `(1,1,0)`, hugging slide `3` onto `(1,2,0)`,
+then three cost-`1` face hops onto `(3,3,0)`, summing to `10`. A witness
+walk to `(3,2,2)` is seed-exit `3` onto `(0,0,1)`, both-weights-`1` axis
+hop `3` onto `(0,0,2)`, four support-preserving cost-`1` hops onto
+`(2,2,2)`, and the height-`2` ridge `3` onto `(3,2,2)`, summing to `13`.
+Those walks are witnesses, not a uniqueness claim.
+
+## Theorem 2 — Face Reverse Versus Available Integer Scale `k`
+
+The Euclidean-normalized comparison at each available `k` is
+
+`t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2)`,
+
+equivalently `t(2k,0,0)^2 > 2 t(k,k,0)^2`. Substituting the computed times
+gives the eight bits of Result Up Front. In particular the `k=6`
+comparison is `576/144` versus `256/72`, or `576 > 512`, so `k=6` still
+holds, and the `k=7` comparison is `676/196` versus `324/98`, or
+`676 > 648`, so `k=7` still holds.
+
+Arrival per Euclidean length is larger at `(2k,0,0)` than at `(k,k,0)` for
+every available `k=1..8`. The comparison is displayed, not adopted. The
+inequality holds at each available scale.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ζ` is a displayed scoring device on `B_16(0)`. Do not write `ζ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+face reverse at any `k`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer face-versus-axis arrivals and reverse bits versus available integer scale k on the finite ball B_16(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_16(0) for the displayed rule ζ at available k=1..8; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ζ` among hop-costs that score the face-versus-axis bits
+  at any `k`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_16(0)`.
+- Any score for a pair that is not an available face-versus-axis pair
+  `((2k,0,0),(k,k,0))` at `k=1..8`.
+- Any reuse of a `ρ3` arrival table as a substitute for the `ζ` Dijkstra.
+- Any reuse of a larger-ball arrival table as a substitute for the
+  radius-`16` Dijkstra.
+- Membership of `ζ` as a physical hop-cost. Face reverse versus `k` on
+  this ball is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -6629,6 +6629,10 @@
   "heat_kernel_unique_diffusion_kernel_among_candidate_gauge_actions_narrow_theorem_note_2026-06-08": {
    "deps_hash": "7b79e2bc121e",
    "out_degree": 3
+  },
+  "height_ridge_face_reverse_vs_k_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "hermitian_lift_theta_h_pk_bounded_narrow_theorem_note_2026-05-17": {
    "deps_hash": "df15e3194fcf",

--- a/logs/runner-cache/height_ridge_face_reverse_vs_k_b16_2026_08_15.txt
+++ b/logs/runner-cache/height_ridge_face_reverse_vs_k_b16_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py
+runner_sha256: 49a3ee2e1a64ffb6381859182f93cd3c06738beeec5d39473c8e2d8bfe9608ec
+input_fingerprint_sha256: f55ab0e02620bf0293d7e2b8bd9669c5a7907c01c4a7672976a789efcc0792bf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/HEIGHT_RIDGE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Face-diagonal reverse versus integer scale k under the named height-ridge hop-cost on B_16(0) is reported for available k=1..8. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ζ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 6017
+available_k [1, 2, 3, 4, 5, 6, 7, 8]
+k=1 t(2, 0, 0)=6 t(1, 1, 0)=4 axis_dens 36/4 face_dens 16/2 cmp 36 ? 32 reverse True
+k=2 t(4, 0, 0)=12 t(2, 2, 0)=8 axis_dens 144/16 face_dens 64/8 cmp 144 ? 128 reverse True
+k=3 t(6, 0, 0)=18 t(3, 3, 0)=10 axis_dens 324/36 face_dens 100/18 cmp 324 ? 200 reverse True
+k=4 t(8, 0, 0)=20 t(4, 4, 0)=12 axis_dens 400/64 face_dens 144/32 cmp 400 ? 288 reverse True
+k=5 t(10, 0, 0)=22 t(5, 5, 0)=14 axis_dens 484/100 face_dens 196/50 cmp 484 ? 392 reverse True
+k=6 t(12, 0, 0)=24 t(6, 6, 0)=16 axis_dens 576/144 face_dens 256/72 cmp 576 ? 512 reverse True
+k=7 t(14, 0, 0)=26 t(7, 7, 0)=18 axis_dens 676/196 face_dens 324/98 cmp 676 ? 648 reverse True
+k=8 t(16, 0, 0)=32 t(8, 8, 0)=20 axis_dens 1024/256 face_dens 400/128 cmp 1024 ? 800 reverse True
+t(2,2,2) 10
+t(3,2,2) 13
+t(16,0,0) 32
+dijkstra_calls 1
+zeta_height_ridge 3
+rho3_height_ridge 1
+zeta_interior 1
+PASS: t-pairs computed arrivals match the displayed B_16(0) table
+PASS: reverse-bits displayed reverse bits match t(2k,0,0)^2 > 2 t(k,k,0)^2
+PASS: all-k-hold face reverse holds under ζ at every available k=1..8
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b16 B_16(0) has 6017 sites and 6016 nonzero sites
+PASS: reachable every site of B_16(0) is reached
+PASS: available-k-1-8 every k=1..8 pair lies in B_16(0); none omitted
+PASS: not-leftover-of-rho3 ζ prices the height-2 ridge 3→3 hop at 3 while ρ3 prices it at 1
+PASS: height-ridge-not-all-body ζ does not tax a 3→3 hop whose dest is not a height-m ridge
+PASS: seed-and-height-ridge-clauses ν clauses, corridor-slide, unit ridge, and height-m ridge cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py
+++ b/scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Score face reverse versus k under ζ on B_16(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/HEIGHT_RIDGE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/HEIGHT_RIDGE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Face-diagonal reverse versus integer scale k under the named "
+    "height-ridge hop-cost on B_16(0) is reported for available "
+    "k=1..8. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+SCALES = (1, 2, 3, 4, 5, 6, 7, 8)
+EXPECTED_AXIS = {
+    1: 6,
+    2: 12,
+    3: 18,
+    4: 20,
+    5: 22,
+    6: 24,
+    7: 26,
+    8: 32,
+}
+EXPECTED_FACE = {
+    1: 4,
+    2: 8,
+    3: 10,
+    4: 12,
+    5: 14,
+    6: 16,
+    7: 18,
+    8: 20,
+}
+EXPECTED_REVERSE = {
+    1: True,
+    2: True,
+    3: True,
+    4: True,
+    5: True,
+    6: True,
+    7: True,
+    8: True,
+}
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def min_abs(v: tuple[int, int, int]) -> int:
+    return min(abs(v[0]), abs(v[1]), abs(v[2]))
+
+
+def min_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def abs_count_eq(v: tuple[int, int, int], m: int) -> int:
+    return int(abs(v[0]) == m) + int(abs(v[1]) == m) + int(abs(v[2]) == m)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and min_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def zeta_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        m = min_abs(w)
+        if m >= 2 and abs_count_eq(w, m) == 2:
+            return 3
+    return 1
+
+
+def dijkstra_zeta(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + zeta_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def axis_site(k: int) -> tuple[int, int, int]:
+    return (2 * k, 0, 0)
+
+
+def face_site(k: int) -> tuple[int, int, int]:
+    return (k, k, 0)
+
+
+def available(k: int, radius: int) -> bool:
+    return l1(axis_site(k)) <= radius and l1(face_site(k)) <= radius
+
+
+def is_reverse(t_axis: int, t_face: int) -> bool:
+    return t_axis * t_axis > 2 * t_face * t_face
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ζ is not written into Admissibility",
+        "Do not write `ζ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(16)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    available_ks = [k for k in SCALES if available(k, 16)]
+    dist = dijkstra_zeta(sites)
+    t222 = dist[(2, 2, 2)]
+    t322 = dist[(3, 2, 2)]
+    t1600 = dist[(16, 0, 0)]
+    print(f"n_sites {len(sites)}")
+    print(f"available_k {available_ks}")
+    bits: dict[int, bool] = {}
+    for k in available_ks:
+        axis = axis_site(k)
+        face = face_site(k)
+        t_axis = dist[axis]
+        t_face = dist[face]
+        bit = is_reverse(t_axis, t_face)
+        bits[k] = bit
+        print(
+            f"k={k} t{axis}={t_axis} t{face}={t_face} "
+            f"axis_dens {t_axis * t_axis}/{4 * k * k} "
+            f"face_dens {t_face * t_face}/{2 * k * k} "
+            f"cmp {t_axis * t_axis} ? {2 * t_face * t_face} reverse {bit}"
+        )
+    print(f"t(2,2,2) {t222}")
+    print(f"t(3,2,2) {t322}")
+    print(f"t(16,0,0) {t1600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"zeta_height_ridge {zeta_cost((2, 2, 2), (3, 2, 2))}")
+    print(f"rho3_height_ridge {rho3_cost((2, 2, 2), (3, 2, 2))}")
+    print(f"zeta_interior {zeta_cost((4, 3, 2), (5, 3, 2))}")
+
+    times_ok = all(
+        dist[axis_site(k)] == EXPECTED_AXIS[k] and dist[face_site(k)] == EXPECTED_FACE[k]
+        for k in available_ks
+    )
+    checks.check(
+        "t-pairs",
+        "computed arrivals match the displayed B_16(0) table",
+        times_ok
+        and all(f"`t({2 * k},0,0) = {EXPECTED_AXIS[k]}`" in note for k in SCALES)
+        and all(f"`t({k},{k},0) = {EXPECTED_FACE[k]}`" in note for k in SCALES),
+    )
+    checks.check(
+        "reverse-bits",
+        "displayed reverse bits match t(2k,0,0)^2 > 2 t(k,k,0)^2",
+        bits == {k: EXPECTED_REVERSE[k] for k in available_ks}
+        and "36 > 32" in note
+        and "144 > 128" in note
+        and "324 > 200" in note
+        and "400 > 288" in note
+        and "484 > 392" in note
+        and "576 > 512" in note
+        and "676 > 648" in note
+        and "1024 > 800" in note,
+    )
+    checks.check(
+        "all-k-hold",
+        "face reverse holds under ζ at every available k=1..8",
+        all(bits[k] is True for k in available_ks)
+        and "every available `k=1..8`" in note
+        and "576 > 512" in note
+        and "676 > 648" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b16",
+        "B_16(0) has 6017 sites and 6016 nonzero sites",
+        len(sites) == 6017 and len(nonzero) == 6016 and all(l1(v) <= 16 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_16(0) is reached",
+        len(dist) == 6017,
+    )
+    checks.check(
+        "available-k-1-8",
+        "every k=1..8 pair lies in B_16(0); none omitted",
+        available_ks == list(SCALES)
+        and all(axis_site(k) in dist and face_site(k) in dist for k in SCALES)
+        and "No scale is omitted" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "ζ prices the height-2 ridge 3→3 hop at 3 while ρ3 prices it at 1",
+        zeta_cost((2, 2, 2), (3, 2, 2)) == 3
+        and rho3_cost((2, 2, 2), (3, 2, 2)) == 1
+        and t222 == 10
+        and t322 == 13
+        and t1600 == 32
+        and "cannot price the height-`m` ridge" in note
+        and "`t(3,2,2) = 13`" in note,
+    )
+    checks.check(
+        "height-ridge-not-all-body",
+        "ζ does not tax a 3→3 hop whose dest is not a height-m ridge",
+        zeta_cost((4, 3, 2), (5, 3, 2)) == 1
+        and rho3_cost((4, 3, 2), (5, 3, 2)) == 1
+        and abs_count_eq((5, 3, 2), min_abs((5, 3, 2))) == 1
+        and "not a tax on every" in note,
+    )
+    checks.check(
+        "seed-and-height-ridge-clauses",
+        "ν clauses, corridor-slide, unit ridge, and height-m ridge cost 3; 1→2, 2→3, and non-ridge 3→3 cost 1",
+        zeta_cost((0, 0, 0), (1, 0, 0)) == 3
+        and zeta_cost((1, 0, 0), (2, 0, 0)) == 3
+        and zeta_cost((1, 1, 0), (1, 0, 0)) == 3
+        and zeta_cost((1, 1, 0), (2, 1, 0)) == 3
+        and zeta_cost((1, 1, 1), (2, 1, 1)) == 3
+        and zeta_cost((2, 2, 2), (3, 2, 2)) == 3
+        and zeta_cost((2, 2, 2), (2, 2, 3)) == 3
+        and zeta_cost((3, 3, 3), (4, 3, 3)) == 3
+        and zeta_cost((1, 0, 0), (1, 1, 0)) == 1
+        and zeta_cost((1, 1, 0), (1, 1, 1)) == 1
+        and zeta_cost((2, 2, 0), (3, 2, 0)) == 1
+        and zeta_cost((4, 3, 2), (5, 3, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ζ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Face reverse under named height-ridge hop-cost ζ holds at every available k=1..8 on B_16(0). Pair arrivals match ρ3; extra clause live off the face. First display. Displayed, not adopted. Do not write ζ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/height_ridge_face_reverse_vs_k_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.