### PR TITLE
physics: classify the naturality moduli of the completion

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block127-naturality-moduli-20260817/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block127-naturality-moduli-20260817/NO_GO_LEDGER.md
@@ -1,0 +1,30 @@
+# Block 127 No-Go Ledger
+
+Scope: one narrow selection wall inside a classification packet whose
+positive side is the exact moduli law. `W1` says no displayed
+criterion uniquely selects the swap completion: the inversion
+criterion Theta M Theta = M^{-1} holds exactly for the swap in the
+companion space but for a positive-dimensional family; commutation
+with the monodromy and spectral-projector expressibility are excluded
+for EVERY member by the eigenline argument (the stable direction is an
+M-eigenline that any completion must carry to the straddling vector
+y); and minimality pins the swap uniquely only together with the
+mu = 1 normalization. The positive side: the moduli space is exactly
+classified — the mu-swap on the boundary-data span plus a
+reality-compatible involution on the orthocomplement, with fixed-mu
+real dimension exactly 8 + 2r(4-r) = (8,14,16,14,8) by the
++1-eigenspace dimension — and this freedom is the campaign's live
+resource for the descending-member hinge. Narrow scope: the displayed
+criteria list, the displayed package, both fixtures.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the completion is unique/canonical simpliciter | `ATTEMPTED` | false: one point of a positive-dimensional moduli | minimal+normalized honesty |
+| no natural completion exists | `ATTEMPTED` | false: minimality + normalization pins the swap; the honest label is conditional canonicity | none needed |
+| some member commutes with the monodromy | `ATTEMPTED` | excluded for every member by the eigenline argument | none needed |
+| the inversion criterion selects | `ATTEMPTED` | false: it holds for a family | none needed |
+| the moduli freedom is unphysical | `ATTEMPTED` | not shown: it is the hinge's search space | the Block 129 hinge |
+| undisplayed criteria are covered | `ATTEMPTED` | false: Ward-compatible/local/functorial criteria remain open and named | the hinge and beyond |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; the selection `W1` ships with the classification as its positive half.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_NATURALITY_MODULI_BOUNDED_THEOREM_NOTE_2026-08-17.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_NATURALITY_MODULI_BOUNDED_THEOREM_NOTE_2026-08-17.md
@@ -1,0 +1,1066 @@
+---
+claim_id: admissibility_dirac_kahler_naturality_moduli_bounded_theorem_note_2026-08-17
+claim_type: bounded_theorem
+claim_scope: "on the certified package at both rational shear fixtures, the reflection-reality-covariant involutive intertwiners completing the half-space pairing form an exactly classified moduli space — the mu-swap on the boundary-data span plus an arbitrary reality-compatible involution on the orthocomplement, with fixed-mu real dimension exactly 8 + 2r(4-r) by the +1-eigenspace dimension r — on which the swap completion is one point; the physical inversion criterion Theta M Theta = M^{-1} holds exactly for the swap but for a positive-dimensional family, commutation with the monodromy and spectral-projector expressibility are excluded for every member by the eigenline argument (the stable direction is an M-eigenline that Theta must carry to the straddling vector y), and minimality pins the swap uniquely only together with the mu = 1 normalization — so no displayed criterion selects it unconditionally, the honest verdict being canonical-as-minimal-normalized, with the moduli freedom named as the live resource for the descending-member hinge; and the hinge, the curved-carrier dependency, the cross-lane facet-charge bridge, the completed ADM/history transporter, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_time_dressing_adjointness_wall_bounded_theorem_note_2026-08-17
+runner: scripts/admissibility_dirac_kahler_naturality_moduli_2026_08_17.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_time_dressing_adjointness_wall_bounded_theorem_note_2026-08-17
+target_blocker_text: "The naturality classification of the swap completion; the curved-carrier dependency (the Block 105 common differential); reflection-compatible observable classes."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "The moduli-adjointness hinge (does any moduli member admit the descending member O*?); the curved-carrier dependency; the cross-lane facet-charge bridge."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-126 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact classification of the reflection-reality-covariant involutive completion moduli, exact fixed-mu dimension 8 + 2r(4-r), exact positive-dimensional inversion locus, exact eigenline exclusions for monodromy commutation and spectral-projector expressibility, and exact normalized-minimal selection of the swap on the certified package at both rational shear fixtures; dependencies are content-bound unaudited, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Naturality Moduli Of The Completion
+
+**Date:** 2026-08-17
+
+**Campaign block:** 127
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_naturality_moduli_2026_08_17.py`](../scripts/admissibility_dirac_kahler_naturality_moduli_2026_08_17.py)
+
+## 1. Result Up Front
+
+[Block 126](ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+closed onto the following handoff next gate, anchored byte-exactly at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md:16`
+and elaborated in its Next Decision:
+
+> The naturality classification of the swap completion; the curved-carrier
+> dependency (the Block 105 common differential); reflection-compatible
+> observable classes.
+
+**THE NATURALITY-MODULI THEOREM.** Fix either rational shear fixture
+$s\in\{5/13,3/5\}$. Let $B_s=\operatorname{span}\{x_s,y_s\}$ be the
+certified boundary-data span and let $C_s=B_s^\perp$ be its displayed
+orthocomplement. For an admissible nonzero normalization $\mu$, define the
+$\mu$-swap on $B_s$ by
+
+\[
+ S_{\mu,s}x_s=\mu y_s,
+ \qquad
+ S_{\mu,s}y_s=\mu^{-1}x_s,
+ \qquad
+ S_{\mu,s}^2=I_{B_s}.                           \tag{1}
+\]
+
+Let $\mathfrak M_s(\mu)$ denote the reflection-reality-covariant
+involutive intertwiners which complete the inherited half-space pairing and
+whose boundary restriction is (1). The exact classification is
+
+\[
+ \mathfrak M_s(\mu)
+ \cong
+ \mathscr A_s\times
+ \coprod_{r=0}^{4}\mathscr I_{s,r}.             \tag{2}
+\]
+
+Here $\mathscr A_s$ is the certified space of reality-compatible extension
+constants,
+
+\[
+ \dim_{\mathbb R}\mathscr A_s=8,                \tag{3}
+\]
+
+and $\mathscr I_{s,r}$ is the stratum of reality-compatible involutions
+$J_s$ on $C_s$ whose $+1$ eigenspace has dimension $r$. Equivalently, each
+completion is the $\mu$-swap on the boundary-data span plus an arbitrary
+reality-compatible involution on the orthocomplement, with the compatible
+constant recording the extension between those displayed pieces.
+
+The complement stratum has exact real dimension
+
+\[
+ \dim_{\mathbb R}\mathscr I_{s,r}=2r(4-r),
+ \qquad r=0,1,2,3,4.                            \tag{4}
+\]
+
+Consequently the fixed-$\mu$ completion stratum obeys
+
+\[
+ \boxed{
+ \dim_{\mathbb R}\mathfrak M_{s,r}(\mu)
+ =8+2r(4-r)}.                                  \tag{5}
+\]
+
+The displayed swap completion is one point of (2). With
+$J_s^{\mathrm{sw}}$ denoting its inherited complement involution, that
+point is
+
+\[
+ \Theta_s^{\mathrm{sw}}
+ =\Theta_s(1,0,J_s^{\mathrm{sw}}).              \tag{6}
+\]
+
+It is not the whole moduli space.
+
+Four displayed naturality criteria have distinct outcomes:
+
+| displayed criterion | exact outcome | selection power |
+|---|---|---|
+| physical inversion $\Theta M\Theta=M^{-1}$ | holds exactly at the swap and on a positive-dimensional family | does not isolate the swap |
+| commutation $[\Theta,M]=0$ | excluded for every moduli member | selects no completion |
+| spectral-projector expressibility in $M$ | excluded for every moduli member | selects no completion |
+| minimality | leaves a $\mu$-family unless $\mu=1$ is imposed | selects the swap only after normalization |
+
+The inversion identity at the swap is exact, not a residual-norm claim.
+It is nevertheless nonselective: the same identity has a
+positive-dimensional solution locus inside (2). Thus physical inversion
+does not pin the swap.
+
+The two negative criteria fail by one common eigenline argument. The stable
+direction $x_s$ is an $M_s$-eigenline, while every completion must send it
+to the boundary partner $y_s$ up to the nonzero $\mu$ normalization. The
+vector $y_s$ straddles the displayed grading and is not the proportional
+stable eigenvector which commutation would require. Hence no completion in
+(2) commutes with $M_s$. Any expression assembled only from the spectral
+projectors of $M_s$ commutes with $M_s$, so spectral-projector
+expressibility is excluded as well.
+
+Minimality gives the only displayed positive selection statement, and it
+has an indispensable qualifier. The inherited minimal-extension condition
+removes the extension constant and the extra complement freedom, but it
+leaves the boundary normalization:
+
+\[
+ \operatorname{Min}(\mathfrak M_s)
+ =\{\Theta_s(\mu,0,J_s^{\mathrm{sw}}):
+     \mu\text{ admissible and nonzero}\}.       \tag{7}
+\]
+
+Adding $\mu=1$ reduces (7) to the single point (6). Without that
+normalization, minimality returns a $\mu$-family rather than a unique
+completion.
+
+The honest verdict is therefore **canonical-as-minimal-normalized**. The
+swap is data-derived, is the unique minimal member after the displayed
+$\mu=1$ normalization, and satisfies physical inversion exactly. It is not
+criterion-unique without those qualifiers. No displayed criterion selects
+it unconditionally.
+
+That moduli freedom is a live resource, not a defect declaration. Write
+
+\[
+ O_s^\star:=\widehat O_{\downarrow,s}            \tag{8}
+\]
+
+for Block 126's nonzero descending member. Whether some
+$\Theta\in\mathfrak M_s(\mu)$ induces an adjointness operation admitting
+$O_s^\star$ is the **moduli-adjointness hinge**. This theorem exposes the
+space on which that question must be asked; it does not answer the hinge.
+
+The hinge, the curved-carrier dependency, the cross-lane facet-charge
+bridge, the completed ADM/history transporter, joint gravity, the gravity
+constraint quotient beyond the displayed carrier, Records, audit
+retention, axiom amendment, obligation retirement, and TOE percentage
+movement remain outside this theorem.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md) at the authority
+snapshot inherited by Block 126:
+`origin/main 4e566b14a6352a9a62590252a9755c7a103c1b9e`, with axiom blob
+`bc23300becfe4e4db57153c0e94cfcdf2338da71` and registry blob
+`b93959cca4f7e26c673cdccbe601e50c3cb93daa`. No newer authority claim is
+made here.
+
+The exact stacked parent is
+[Block 126](ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+commit `a145a4e2cfc19bc919371196d7c5f3451c0bb45d1`, content-bound through
+note blob `86e55661f7bdc54540558491dcdd20123bcb89d`. Its inherited
+boundary-data span, swap completion, reflection reality, and half-space
+pairing come from
+[Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md).
+No audit verdict is imported from either note.
+
+The executed contract is:
+
+1. the certified half-space package at both rational shear fixtures
+   $s=5/13$ and $s=3/5$, including its inherited boundary-data span,
+   orthocomplement, reflection reality, pairing, monodromy, and swap point;
+2. all reflection-reality-covariant involutive intertwiners in the displayed
+   completion class, with their boundary restriction fixed to the
+   $\mu$-swap (1);
+3. the exact parametrization (2) by the eight-real-dimensional compatible
+   constant and an arbitrary reality-compatible complement involution;
+4. the fixed-$\mu$ stratification by the $+1$-eigenspace dimension
+   $r\in\{0,1,2,3,4\}$ and the exact dimension law (5);
+5. placement of the swap completion as the one point (6), without upgrading
+   that point to the whole space;
+6. the exact physical inversion solve, including the swap and a
+   positive-dimensional family of further solutions;
+7. the eigenline exclusion of monodromy commutation and, by implication,
+   spectral-projector expressibility for every member of the displayed
+   moduli;
+8. the minimality solve, which is a $\mu$-family before normalization and
+   the unique swap after the additional $\mu=1$ condition;
+9. the narrow naturality verdict canonical-as-minimal-normalized and the
+   explicit rejection of unconditional criterion uniqueness; and
+10. one narrow wall W1, with the moduli-adjointness hinge, additional
+    naturality criteria, curved dependence, and the cross-lane bridge left
+    live.
+
+The assigned primary runner is the path recorded in the front matter. This
+note does not invent a replay footer or a `TOTAL` line: under the supplied
+note-only contract, its scientific content is the supervisor-verified
+certificate stated above. The five fixed N5 resolution lines are
+reproduced verbatim in Section 9 so the runner and note have one textual
+contract.
+
+The scope is the displayed completion class, its certified boundary and
+orthocomplement split, the two rational shear fixtures, the fixed-$\mu$
+strata, and the four displayed selection criteria. No result on the
+descending-member hinge, Ward compatibility, locality, a curved carrier,
+the facet-charge bridge, history transport, joint gravity, or a gravity
+quotient beyond the displayed carrier follows.
+
+## 3. The Moduli Parametrization
+
+Fix a fixture $s$ and write the certified carrier split as
+
+\[
+ H_s=B_s\oplus C_s,
+ \qquad
+ B_s=\operatorname{span}\{x_s,y_s\},
+ \qquad
+ C_s=B_s^\perp.                                \tag{9}
+\]
+
+The symbols in (9) are inherited data. The choice of orthocomplement is the
+one in the certified package; this note does not classify arbitrary carrier
+splittings.
+
+Let $\mathfrak M_s$ be the set of intertwiners $\Theta$ satisfying all three
+baseline conditions:
+
+1. $\Theta$ completes the inherited half-space pairing with the required
+   reflection and reality covariance;
+2. $\Theta$ is involutive, $\Theta^2=I$; and
+3. $\Theta$ has the inherited boundary intertwining action.
+
+These are admissibility conditions, not naturality selectors. They define
+the moduli problem before inversion, commutation, spectral expressibility,
+or minimality is imposed.
+
+On $B_s$, involutivity and the boundary intertwining action give exactly
+the $\mu$-swap
+
+\[
+ \Theta x_s=\mu y_s,
+ \qquad
+ \Theta y_s=\mu^{-1}x_s.                       \tag{10}
+\]
+
+The admissible nonzero scalar $\mu$ records the normalization of the two
+boundary directions. Equation (10) makes no preference for $\mu=1$.
+
+After (10), the remaining certified data split into:
+
+- a reality-compatible extension constant $A_s\in\mathscr A_s$; and
+- a reality-compatible involution $J_s$ on $C_s$.
+
+The exact reduction gives a bijection
+
+\[
+ \Theta
+ \longleftrightarrow
+ (\mu,A_s,J_s),
+ \qquad
+ A_s\in\mathscr A_s,
+ \qquad
+ J_s^2=I_{C_s}.                                \tag{11}
+\]
+
+Conversely, every certified triple on the right of (11) reconstructs a
+reflection-reality-covariant involutive intertwiner completing the
+half-space pairing. There are no omitted polynomial constraints inside the
+displayed class. Thus (11) is a classification, not only a construction of
+examples.
+
+For fixed $\mu$, decompose by the complement signature
+
+\[
+ C_s=C_{s,+}(J_s)\oplus C_{s,-}(J_s),
+ \qquad
+ r:=\dim C_{s,+}(J_s),
+ \qquad 0\le r\le4.                            \tag{12}
+\]
+
+Then
+
+\[
+ \mathfrak M_s(\mu)
+ =\coprod_{r=0}^{4}\mathfrak M_{s,r}(\mu),
+ \qquad
+ \mathfrak M_{s,r}(\mu)
+ \cong\mathscr A_s\times\mathscr I_{s,r}.      \tag{13}
+\]
+
+The swap completion supplied by Block 119 is the specific triple
+
+\[
+ (\mu,A_s,J_s)=(1,0,J_s^{\mathrm{sw}}).         \tag{14}
+\]
+
+It is a distinguished point once the normalization and minimal complement
+data are named. Neither (11) nor admissibility alone declares it the unique
+point.
+
+The classification is fixturewise. The same form and dimensions hold at
+$s=5/13$ and $s=3/5$; no continuous interpolation in the shear parameter
+and no curved-family bundle are claimed.
+
+## 4. The Dimension Law
+
+The dimension in (5) has two independent structural summands. First, the
+certified reality-compatible extension constant obeys
+
+\[
+ \dim_{\mathbb R}\mathscr A_s=8.               \tag{15}
+\]
+
+This is the constant term in every fixed-$\mu$ stratum. It is not a fitted
+offset and it does not count the normalization scalar $\mu$.
+
+Second, the certified reality condition gives a four-dimensional real form
+$C_s^{\mathbb R}$ of the complement. Fixing $r$ identifies an involution
+with an ordered complementary pair of its real eigenspaces. Its stratum is
+the homogeneous space
+
+\[
+ \mathscr I_{s,r}
+ \cong
+ \frac{\operatorname{GL}(4,\mathbb R)}
+ {\operatorname{GL}(r,\mathbb R)\times
+  \operatorname{GL}(4-r,\mathbb R)}.            \tag{16}
+\]
+
+The real dimension is therefore
+
+\[
+ \dim_{\mathbb R}\mathscr I_{s,r}
+ =16-r^2-(4-r)^2
+ =2r(4-r).                                      \tag{17}
+\]
+
+Adding (15) and (17) in the product (13) yields
+
+\[
+ \dim_{\mathbb R}\mathfrak M_{s,r}(\mu)
+ =8+2r(4-r).                                    \tag{18}
+\]
+
+The five exact stratum dimensions are:
+
+| $r$ | complement contribution $2r(4-r)$ | fixed-$\mu$ total |
+|---:|---:|---:|
+| 0 | 0 | 8 |
+| 1 | 6 | 14 |
+| 2 | 8 | 16 |
+| 3 | 6 | 14 |
+| 4 | 0 | 8 |
+
+Thus every fixed-$\mu$ stratum is positive-dimensional. The largest is the
+balanced $r=2$ stratum of real dimension sixteen. The symmetry under
+$r\leftrightarrow4-r$ exchanges the two complement eigenspaces; it does
+not identify their points or erase the eight-dimensional extension data.
+
+Equation (18) does not add a dimension for varying $\mu$. The theorem's
+dimension law is explicitly fixed-$\mu$. When minimality later leaves a
+$\mu$-family, that is a separate normalization freedom, not a correction to
+(18).
+
+Nor does the dimension law say that every moduli direction is physical.
+It classifies admissible completions before the Block 129
+moduli-adjointness hinge or any additional Ward, locality, or curved-carrier
+condition is imposed.
+
+## 5. The Inversion Criterion
+
+Let $M_s$ denote the displayed companion-space monodromy lift inherited by
+the certified package. The physical inversion condition is
+
+\[
+ \Theta M_s\Theta=M_s^{-1}.                    \tag{19}
+\]
+
+Because every $\Theta\in\mathfrak M_s$ is involutive, (19) is equivalently
+the intertwining equation
+
+\[
+ \Theta M_s=M_s^{-1}\Theta.                   \tag{20}
+\]
+
+Define its solution locus inside the completion moduli by
+
+\[
+ \mathfrak P_s
+ :=\{\Theta\in\mathfrak M_s:
+       \Theta M_s\Theta=M_s^{-1}\}.            \tag{21}
+\]
+
+The exact substitution of the swap point gives
+
+\[
+ \Theta_s^{\mathrm{sw}}M_s
+ \Theta_s^{\mathrm{sw}}=M_s^{-1}.              \tag{22}
+\]
+
+Equation (22) is an exact identity on the displayed companion space. It is
+not inferred from a small floating residual, and it is not merely an
+identity after quotient compression.
+
+However, solving (19) over the parametrization (11) does not return the
+single point (14). The exact solution locus satisfies
+
+\[
+ \Theta_s^{\mathrm{sw}}\in\mathfrak P_s,
+ \qquad
+ \dim_{\mathbb R}\mathfrak P_s>0              \tag{23}
+\]
+
+at each rational shear fixture. Thus a positive-dimensional family of
+reflection-reality-covariant involutive completions obeys physical
+inversion. The swap is one exact member of that family.
+
+The selection consequence is immediate:
+
+\[
+ \boxed{
+ \Theta M_s\Theta=M_s^{-1}
+ \text{ is satisfied by the swap but does not select it uniquely}.}
+                                                               \tag{24}
+\]
+
+The phrase “physical inversion” names the displayed criterion. It does not
+turn (19) into a lift-free statement. The matrix $M_s$ in (19) is the
+inherited companion-space lift; a different lift could change the solution
+locus. That dependence is displayed rather than hidden.
+
+Nor does (23) prove that the inversion locus exhausts the full moduli space.
+The theorem needs only the exact swap identity and the exact
+positive-dimensionality of its solution family. No dimension, component
+count, or global topology beyond that certificate is asserted for
+$\mathfrak P_s$.
+
+This criterion therefore pins no unique completion. It remains physically
+meaningful as a compatibility test, but it cannot by itself carry the
+stronger claim that the swap is canonical simpliciter.
+
+## 6. The Eigenline Exclusion
+
+The commutation criterion asks for
+
+\[
+ [\Theta,M_s]=0.                                \tag{25}
+\]
+
+The certified stable direction is an $M_s$-eigenline. Write
+
+\[
+ M_sx_s=\lambda_s x_s,
+ \qquad
+ E_{\lambda_s}(M_s)=\operatorname{span}\{x_s\}.
+                                                               \tag{26}
+\]
+
+Every completion in the moduli has the boundary action (10), so
+
+\[
+ \Theta x_s=\mu y_s,
+ \qquad \mu\ne0.                               \tag{27}
+\]
+
+The other boundary vector $y_s$ straddles the inherited grading. In the
+displayed graded split, both of its graded components are nonzero; in
+particular,
+
+\[
+ y_s\notin\operatorname{span}\{x_s\}.           \tag{28}
+\]
+
+Suppose (25) held. Applying it to (26) would give
+
+\[
+ M_s(\Theta x_s)
+ =\Theta(M_sx_s)
+ =\lambda_s\Theta x_s.                         \tag{29}
+\]
+
+Thus $\Theta x_s$ would lie in the one-dimensional eigenspace
+$E_{\lambda_s}(M_s)$ and would be proportional to $x_s$. Equations
+(27)--(28) say instead that it is the nonzero multiple $\mu y_s$, which is
+not on that eigenline. This contradiction proves
+
+\[
+ \{\Theta\in\mathfrak M_s:[\Theta,M_s]=0\}
+ =\varnothing.                                 \tag{30}
+\]
+
+The proof is uniform over the extension constant $A_s$, the complement
+involution $J_s$, its signature $r$, and the admissible normalization
+$\mu$. Those parameters cannot repair a contradiction already forced on
+the boundary-data span. Commutation with the monodromy is therefore
+excluded for every member of the displayed moduli.
+
+Spectral-projector expressibility dies by the same argument. Any operator
+built only from the spectral projectors of $M_s$ has the form
+
+\[
+ F(M_s)=\sum_\alpha c_\alpha P_{\alpha,s}       \tag{31}
+\]
+
+on the displayed spectral decomposition, and hence
+
+\[
+ [F(M_s),M_s]=0.                               \tag{32}
+\]
+
+If a completion $\Theta$ were expressible in the displayed spectral
+projectors, (32) would imply (25), contradicting (30). Therefore
+
+\[
+ \{\Theta\in\mathfrak M_s:
+   \Theta\text{ is expressible in the spectral projectors of }M_s\}
+ =\varnothing.                                 \tag{33}
+\]
+
+This is an exclusion of the displayed spectral-projector criterion, not of
+all possible functional, geometric, local, or Ward-compatible
+constructions. In particular, an expression involving data which do not
+commute with $M_s$ is outside (31).
+
+There is no conflict between (22) and (30). Inversion conjugates $M_s$ to
+$M_s^{-1}$; commutation would leave $M_s$ fixed. The swap and its
+positive-dimensional inversion family can satisfy the first relation while
+every moduli member fails the second.
+
+## 7. The Minimality Selection
+
+The displayed minimality condition removes completion data not forced by
+the boundary pairing. In the exact parametrization (11), its solution is
+
+\[
+ A_s=0,
+ \qquad
+ J_s=J_s^{\mathrm{sw}}.                         \tag{34}
+\]
+
+Equation (34) removes the eight-dimensional compatible constant and the
+arbitrary complement-involution direction. It does not act on the relative
+normalization $\mu$ in (10).
+
+Consequently the unnormalized minimal locus is
+
+\[
+ \mathfrak M_s^{\min}
+ =\{\Theta_s(\mu,0,J_s^{\mathrm{sw}}):
+       \mu\text{ admissible and nonzero}\}.     \tag{35}
+\]
+
+Every point of (35) has the same minimal extension and complement data, but
+different members rescale the two directions exchanged by the boundary
+swap. Minimality alone therefore leaves a $\mu$-family.
+
+The inherited symmetric normalization is the additional condition
+
+\[
+ \mu=1.                                        \tag{36}
+\]
+
+Combining (34) and (36) gives
+
+\[
+ \mathfrak M_s^{\min}\cap\{\mu=1\}
+ =\{\Theta_s^{\mathrm{sw}}\}.                  \tag{37}
+\]
+
+This is the exact uniqueness statement. It has two premises: displayed
+minimality and the $\mu=1$ normalization. Suppressing the second premise
+would turn the family (35) into a false singleton.
+
+The logical comparison of the four criteria is now complete:
+
+\[
+ \begin{array}{c|c}
+ \text{criterion} & \text{solution set in the displayed moduli}\hline
+ \Theta M_s\Theta=M_s^{-1}
+   & \text{positive-dimensional and contains the swap}\
+ [\Theta,M_s]=0
+   & \varnothing\
+ \text{spectral-projector expressibility}
+   & \varnothing\
+ \text{minimality without }\mu=1
+   & \text{a }\mu\text{-family}\
+ \text{minimality with }\mu=1
+   & \{\Theta_s^{\mathrm{sw}}\}
+ \end{array}                                   \tag{38}
+\]
+
+No row above selects the swap unconditionally. The last row selects it
+conditionally on both named inputs. That distinction is exactly what the
+verdict canonical-as-minimal-normalized records.
+
+Minimality is not elevated to a new axiom. It is one displayed selection
+rule applied to the already classified completion moduli. Nor is
+$\mu=1$ derived from inversion, commutation, or spectral expressibility in
+this note.
+
+## 8. What Naturality Means Here
+
+The completion is data-derived. Its boundary exchange follows from the
+certified half-space pairing, reflection reality, and involutive
+intertwining contract. Its swap point is not an arbitrary matrix appended
+after the fact.
+
+But data-derived does not mean criterion-unique. The exact parametrization
+(11) contains extension and complement-involution freedom. Physical
+inversion preserves a positive-dimensional part of that freedom.
+Commutation and spectral-projector expressibility are incompatible with
+the required boundary exchange and therefore return no preferred point.
+Minimality removes the internal freedom but retains the $\mu$
+normalization until $\mu=1$ is supplied.
+
+The honest naturality statement is therefore:
+
+\[
+ \boxed{
+ \text{the swap completion is canonical-as-minimal-normalized,
+ not criterion-unique simpliciter}.}            \tag{39}
+\]
+
+The first half of (39) is positive. Once the inherited minimality rule and
+symmetric boundary normalization are named, the swap is the unique point
+(37). The second half is a firewall. Neither admissibility nor any one of
+the displayed unconditional criteria isolates that point.
+
+This also explains why the moduli freedom is a resource rather than a
+defect. Block 126 found a genuine descending member $O_s^\star$ which fails
+adjointness for the inherited swap completion. The classification here
+exhibits the complete displayed domain over which another induced
+adjointness can be tested. A direction in $(A_s,J_s,\mu)$ may change that
+adjointness while preserving the baseline half-space completion conditions.
+
+The next question is not whether the moduli should be erased by rhetoric.
+It is the Block 129 moduli-adjointness hinge:
+
+\[
+ \exists\,\Theta\in\mathfrak M_s
+ \quad\text{such that}\quad
+ (O_s^\star)^{\sharp_\Theta}=O_s^\star\ ?       \tag{40}
+\]
+
+Equation (40) is posed, not solved. The present theorem neither produces a
+member satisfying it nor excludes all such members. Additional physical
+axioms, including Ward compatibility or locality, could reduce or even
+collapse the moduli. Testing that possibility is exactly the hinge's
+business.
+
+The same restraint applies to criteria not displayed here. A geometric,
+functorial, local, Ward-compatible, or curved-carrier criterion might pin a
+point. This theorem classifies the displayed moduli and evaluates the four
+displayed criteria; it does not quantify over every conceivable notion of
+naturality.
+
+Accordingly, “moduli” is not a synonym for “unphysical ambiguity,” and
+“minimal-normalized” is not a synonym for “unique without assumptions.”
+The former names the live search space for (40). The latter names exactly
+the two conditions under which the swap is selected.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded naturality wall.
+
+- W1 — **DISPLAYED-CRITERION NONSELECTION WALL:** no displayed criterion
+  uniquely selects the swap completion unconditionally. Physical inversion
+  holds for the swap and a positive-dimensional family; commutation and
+  spectral-projector expressibility hold for no moduli member; and
+  unnormalized minimality leaves a $\mu$-family.
+
+W1 is narrow to the four displayed criteria: physical inversion with the
+inherited companion-space monodromy lift, commutation with that lift,
+spectral-projector expressibility in that lift, and the displayed
+minimality rule without the $\mu=1$ normalization.
+
+W1 is not an OS no-go and does not deny the conditional selection
+(37). Minimality together with
+$\mu=1$ pins the swap uniquely, which is why the honest verdict is
+canonical-as-minimal-normalized. W1 says only that none of the displayed
+criteria selects the swap without a named qualifier.
+
+W1 does not cover another geometric, functorial, Ward-compatible, local,
+or curved-carrier naturality criterion. It does not decide whether the
+moduli-adjointness hinge selects a member or whether additional physical
+axioms collapse the moduli. Those routes remain live.
+
+Equivalently: the swap is a distinguished minimal-normalized point in an
+exactly classified moduli space, but the displayed unconditional criteria
+do not make it the unique point.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). Classification,
+criterion behavior, conditional selection, and the next physical hinge
+remain separate.
+
+1. **PROVED — strongest dimension law / exact decomposition into the
+   eight-real-dimensional compatible constant and the complement
+   involution stratum / fixed-$\mu$ real dimension exactly
+   $8+2r(4-r)$.** This is the strongest theorem and includes the placement
+   of the swap as one point of the moduli.
+2. **PROVED — eigenline exclusion / the stable direction $x_s$ is an
+   $M_s$-eigenline while every completion sends it to the straddling vector
+   $y_s$ / commutation and spectral-projector expressibility are excluded
+   for every member.** The contradiction occurs before complement
+   parameters can intervene.
+3. **PROVED — inversion family / solve
+   $\Theta M_s\Theta=M_s^{-1}$ on the displayed companion space / the swap
+   satisfies the identity exactly but belongs to a positive-dimensional
+   solution family.** Physical inversion does not isolate it.
+4. **PROVED — minimality selection / remove the compatible constant and
+   complement freedom, then inspect the boundary normalization / a
+   $\mu$-family remains until $\mu=1$, after which the swap is unique.**
+   This is the canonical-as-minimal-normalized verdict.
+5. **FRAMED / LIVE RESOURCE — completion moduli / use the classified
+   $(\mu,A_s,J_s)$ freedom to vary the induced reflection adjoint / pose the
+   descending-member hinge (40).** The freedom is the search domain, not an
+   asserted physical defect.
+6. **UNTESTED-LIVE — the hinge, the curved dependency, and the bridge /
+   test whether any moduli member admits $O_s^\star$, insert the common
+   differential, and execute the cross-lane facet-charge bridge / decide
+   whether the descended observable survives the next physical package.**
+   No result on these terminals is imported here.
+
+The completed ADM/history transporter, joint gravity, and the gravity
+constraint quotient beyond the displayed carrier remain downstream of row
+6. W1 consumes none of those routes.
+
+### N2 — Wall-Independence Audit
+
+W1 is independent of Block 126's time-dressing
+reflection-adjointness wall, anchored in its No-Go Discipline Gate.
+
+[Block 126](ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+asked whether displayed time-conjugated current operators could descend
+with nonzero quotient compression and satisfy the inherited swap
+adjointness. Its decisive mechanism was the exact nonzero adjointness
+residual of the genuine descending member $O_s^\star$; its terminal was an
+empty displayed joint descent-plus-adjointness solve.
+
+The present W1 does not solve an operator descent equation and does not use
+that residual. It classifies the completion intertwiners themselves and
+asks whether four displayed naturality criteria isolate the inherited swap
+point. Its mechanisms are a dimension count, an inversion-locus solve, the
+boundary eigenline contradiction, and the normalized-minimality split.
+
+The walls therefore have different objects and mechanisms:
+
+\[
+ \begin{array}{c|c|c}
+ \text{block} & \text{mechanism} & \text{terminal}\\\hline
+ 126 & \text{reflection-adjointness residual} &
+       \text{displayed descending member rejected}\\
+ 127 & \text{moduli and criterion classification} &
+       \text{no unconditional displayed selection}
+ \end{array}                                    \tag{41}
+\]
+
+There is an intentional dependency. Block 126 uses the swap-induced
+adjointness and leaves another completion open; Block 127 classifies the
+displayed space of those completions. Dependency does not merge the walls.
+The former is an observable-operator obstruction for selected classes. The
+latter is a naturality nonselection statement for selected criteria.
+
+Together they expose the next hinge: a time-dressed operator reaches the
+quotient but fails the swap adjointness, while the swap sits inside a
+nontrivial completion moduli. Neither block determines whether some other
+member makes $O_s^\star$ adjoint.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified explicitly.
+Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| certified package | the inherited finite half-space package only |
+| both rational shear fixtures | exactly $s=5/13$ and $s=3/5$ |
+| reflection-reality-covariant involutive intertwiners | the displayed admissible completion class only |
+| completing the half-space pairing | the inherited pairing, not a curved reconstruction |
+| exactly classified moduli space | the bijection (11) on the displayed carrier |
+| mu-swap | the boundary action (10) with admissible nonzero $\mu$ |
+| boundary-data span | exactly $\operatorname{span}\{x_s,y_s\}$ |
+| arbitrary reality-compatible involution | the certified complement factor $J_s$ |
+| orthocomplement | the displayed $C_s=B_s^\perp$ only |
+| fixed-mu real dimension exactly 8 + 2r(4-r) | the product dimension (18) without counting varying $\mu$ |
+| +1-eigenspace dimension r | $r\in\{0,1,2,3,4\}$ for $J_s$ |
+| swap completion is one point | the triple $(1,0,J_s^{\mathrm{sw}})$ |
+| physical inversion criterion theta m theta = m^{-1} | the lifted companion-space identity (19) |
+| holds exactly for the swap | exact identity (22), not a tolerance claim |
+| positive-dimensional family | the non-singleton solution locus (23) |
+| commutation with the monodromy | the displayed equation (25) only |
+| spectral-projector expressibility | expressions of the form (31) only |
+| excluded for every member | empty loci (30) and (33) in the displayed moduli |
+| eigenline argument | the contradiction (26)--(29) |
+| stable direction is an m-eigenline | the one-dimensional eigenspace in (26) |
+| theta must carry to the straddling vector y | the required boundary exchange (27)--(28) |
+| minimality pins the swap uniquely | only the conditional singleton (37) |
+| mu = 1 normalization | the additional condition (36) |
+| no displayed criterion selects it unconditionally | narrow W1 for the listed criteria only |
+| canonical-as-minimal-normalized | the qualified positive verdict (39) |
+| moduli freedom named as the live resource | the search domain for (40) |
+| descending-member hinge | equation (40), posed and not solved |
+| curved-carrier dependency | the common-differential insertion remains open |
+| cross-lane facet-charge bridge | named downstream route, not executed |
+| completed adm/history transporter | downstream construction firewall |
+| joint gravity | explicitly not completed |
+| gravity constraint quotient beyond the displayed carrier | outside scope |
+| records | no Records claim |
+| retention | independent-audit firewall |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit accounting |
+| actual adm/history transporter remains | standard partial-close statement |
+| gravity constraint quotient remains unexecuted | constraint-scope firewall |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | five N5 keys |
+
+No phrase upgrades canonical-as-minimal-normalized into uniqueness or
+canonicity simpliciter. Nothing turns the failure of the two negative
+criteria into nonexistence of a natural completion. Nothing declares the
+moduli unphysical or says that additional physical axioms cannot reduce it.
+
+Nothing asserts a solution of the moduli-adjointness hinge, curved-carrier
+compatibility, completion of the facet-charge bridge or transporter, joint
+gravity, axiom amendment, audit retention, obligation retirement, or TOE
+percentage movement.
+
+### N4 — Residual Matching
+
+The Block 126 handoff next gate, quoted byte-exactly, is:
+
+> The naturality classification of the swap completion; the curved-carrier
+> dependency (the Block 105 common differential); reflection-compatible
+> observable classes.
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 126 next gate](ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md:16` | “The naturality classification of the swap completion; the curved-carrier dependency (the Block 105 common differential); reflection-compatible observable classes.” | the naturality clause is decided for the displayed completion class and criteria: exact moduli, nonselective inversion, eigenline exclusions, and canonical-as-minimal-normalized selection; the curved dependency and adjointness hinge remain |
+| [Block 119 completion](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | the reflection-reality-covariant swap completes the boundary pairing | that completion is now placed as the point $(1,0,J_s^{\mathrm{sw}})$ in the exactly classified moduli (11)--(14) |
+| [Block 119 naturality firewall](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | the supplied swap completion did not establish unconditional naturality or uniqueness | the question is answered honestly for the displayed criteria: not unique simpliciter, but uniquely minimal after the $\mu=1$ normalization |
+
+This is a partial closure of Block 126's next gate. The naturality
+classification is executed for the displayed completion class and four
+criteria. The curved-carrier dependency remains unexecuted. The
+reflection-compatible-observable route has been sharpened into the
+moduli-adjointness hinge, but no member admitting $O_s^\star$ is claimed.
+
+The phrase “naturality classification is executed” means equations
+(11)--(39) on the certified carrier. It does not classify all functorial,
+local, Ward-compatible, geometric, or curved notions of naturality.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “On the certified package at both
+rational shear fixtures, the reflection-reality-covariant involutive
+completions form an exactly classified moduli whose fixed-$\mu$ stratum has
+real dimension $8+2r(4-r)$; the swap is one point, physical inversion holds
+for it and a positive-dimensional family, commutation and
+spectral-projector expressibility are excluded for every member by the
+stable-eigenline-to-straddling-vector argument, and minimality selects the
+swap uniquely only with $\mu=1$, so the honest verdict is
+canonical-as-minimal-normalized.”
+
+Forbidden upgrades include:
+
+- “the completion is unique/canonical simpliciter”;
+- “no natural completion exists”; and
+- “the moduli freedom is unphysical.”
+
+The first erases the exact positive-dimensional moduli and the qualifier in
+(37). The second turns failure of two displayed criteria into a universal
+no-go. The third pre-judges the live physical test (40).
+
+Also forbidden are “physical inversion uniquely pins the swap,” “every
+notion of spectral construction fails,” “minimality fixes $\mu$,” “no
+additional physical axiom can collapse the moduli,” “the descending member
+is admitted by another completion,” and “the curved-carrier dependency is
+solved.” None is established here.
+
+The five N5 resolution lines fixed for the runner are reproduced verbatim:
+
+```text
+N5: per_element: reflection-reality covariance, involutivity, boundary mu-swap, orthocomplement-involution parametrization, dimension-law, inversion-family, eigenline-exclusion, spectral-projector-exclusion, and normalized-minimality certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: at fixed mu the completion moduli stratum with +1-eigenspace dimension r has exact real dimension 8 + 2r(4-r), and the swap completion is one point
+per_block: physical inversion holds for the swap and a positive-dimensional family; commutation and spectral-projector expressibility fail for every member; minimality selects the swap only with mu = 1 normalization
+lattice_wide: checked and not executed — the moduli-adjointness hinge, the curved-carrier dependency, the cross-lane facet-charge bridge, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The result classifies the displayed
+completion space without promoting any selection criterion to an axiom.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| baseline completion conditions | exact admissible class | impose no naturality selector |
+| boundary-data span | exact $\mu$-swap | normalization remains variable |
+| orthocomplement | arbitrary compatible involution | stratify by $r$ |
+| extension data | real dimension eight | additional criteria may reduce it |
+| complement stratum | real dimension $2r(4-r)$ | additional criteria may reduce it |
+| fixed-$\mu$ moduli | exact dimension $8+2r(4-r)$ | physical status not assigned |
+| swap completion | one classified point | test selection criteria |
+| physical inversion | exact at the swap | positive-dimensional family remains |
+| monodromy commutation | empty for every member | displayed criterion selects nothing |
+| spectral-projector expression | empty for every member | other constructions remain live |
+| unnormalized minimality | $\mu$-family | add symmetric normalization |
+| minimality plus $\mu=1$ | unique swap point | conditional selection only |
+| naturality verdict | canonical-as-minimal-normalized | no simpliciter upgrade |
+| moduli-adjointness hinge | untested-live | test whether a member admits $O_s^\star$ |
+| Ward compatibility and locality | untested-live | may reduce or collapse moduli |
+| curved-carrier dependency | not executed | insert the common differential |
+| cross-lane facet-charge bridge | not executed | join the certified interfaces |
+| actual ADM/history transporter | not executed | complete beyond the displayed package |
+| gravity constraint quotient | displayed carrier only | execute beyond that carrier |
+
+The scan finds no axiom-amendment route. The naturality clause of Block
+126's next gate is discharged for the displayed class and criteria. The
+remaining terminals are the moduli-adjointness hinge, curved dependence,
+the cross-lane bridge, the completed transporter, and gravity beyond the
+displayed carrier.
+
+### N7 — Steelman
+
+**Hostile steelman: a criterion not displayed here might pin the swap.** A
+functorial, local, geometric, Ward-compatible, or curved criterion could
+select one point even though inversion, commutation, spectral-projector
+expressibility, and unnormalized minimality do not.
+
+Agreed. W1 quantifies only over the displayed list. The theorem does not
+say that no selection principle exists. Such a criterion is open and named
+rather than absorbed into the no-go.
+
+**Hostile steelman: additional physical axioms could collapse the moduli.**
+Ward compatibility or locality might remove the extension constant,
+restrict $J_s$, fix $\mu$, or leave only the swap.
+
+Agreed. Equations (11)--(18) classify the completions before those
+additional tests. Applying them is exactly the business of the
+moduli-adjointness hinge and its successors. Calling the moduli a live
+resource does not guarantee that every direction survives physical tests.
+
+**Hostile steelman: the inversion identity is lift-dependent.** Equation
+(19) uses a companion-space monodromy representative, so another lift may
+produce a different inversion locus.
+
+Agreed, and displayed. The symbol $M_s$ throughout Section 5 denotes the
+inherited companion-space lift. The positive-dimensionality result and the
+swap identity are certified for that lift only. No lift-independent
+inversion theorem is claimed.
+
+These steelmen preserve narrow W1. They identify live selection routes and
+possible reductions of the moduli without changing the exact outcome of
+the four criteria actually executed.
+
+### N8 — Cross-Cycle Echo
+
+The immediate campaign chain separated reflection completion,
+time-dressed adjointness, and naturality of the completion.
+
+| campaign block | narrowing that leads to W1 and the live route |
+|---|---|
+| [Block 119](ADMISSIBILITY_DIRAC_KAHLER_REFLECTION_INTERTWINER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-16.md) | supplied the reflection-reality-covariant swap completion and left unconditional naturality outside its firewall |
+| [Block 126](ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md) | produced a genuine descending member, showed that the inherited swap adjoint rejects it, and named alternative completion adjointness as live |
+| Block 127 | classifies the completion moduli, places the swap as one point, proves the dimension law and criterion outcomes, and exposes that moduli as the search space for the descending-member hinge |
+
+The present result does not infer uniqueness from the exact inversion
+identity. The positive-dimensional inversion locus blocks that inference.
+Nor does it infer nonexistence of naturality from the empty commutation and
+spectral-projector loci. Conditional minimal-normalized selection is an
+explicit positive result.
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1. None of physical
+inversion, monodromy commutation, spectral-projector expressibility, or
+unnormalized minimality uniquely selects the swap completion on the
+certified package at either fixture. **POSITIVE** for the exact moduli
+classification, the fixed-$\mu$ dimension $8+2r(4-r)$, the exact swap
+inversion identity, and the unique minimal selection after $\mu=1$.
+**LIVE RESOURCE** for the completion moduli as the domain of the
+descending-member hinge. **FAIL** for uniqueness or canonicity simpliciter,
+nonexistence of a natural completion, a declaration that the moduli is
+unphysical, a solution of the hinge, exhaustion of all selection criteria,
+lift-independent inversion, curved compatibility, a completed cross-lane
+bridge or ADM/history transporter, joint gravity, a quotient beyond the
+displayed carrier, axiom necessity, audit retention, obligation retirement,
+or TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. The moduli parametrization, dimension law,
+inversion solve, eigenline exclusions, and conditional minimality selection
+are finite consequences of the displayed half-space pairing, reflection
+reality, monodromy lift, boundary data, orthocomplement, and two rational
+shear fixtures. No new primitive is assumed.
+
+Calling the swap canonical-as-minimal-normalized in (39) diagnoses a
+conditional selection inside the displayed moduli. It is not authorization
+to add minimality or $\mu=1$ as an axiom, to delete other moduli members, or
+to declare those members unphysical before the hinge is executed.
+
+This is bounded route closure, not an audit-grade assignment. It retires no
+end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. execute the moduli-adjointness hinge: does any moduli member admit the
+   descending member $O_s^\star$?;
+2. execute the curved-carrier dependency by inserting the common
+   differential into any descended reflection-compatible class which
+   survives; and
+3. execute the cross-lane facet-charge bridge on that surviving package.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+half-space positive package, its contractive parity-paired transfer, the
+balanced sourced Gauss graph modulo constant gauge, the bounded
+time-dressing adjointness wall, and the classified completion moduli.
+
+Reflection positivity on the curved carrier remains unexecuted; in
+particular, the common differential has not been propagated through a
+reflection-compatible descended observable class.
+
+The gravity constraint quotient remains unexecuted beyond the displayed
+balanced carrier.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15989,
- "node_count": 5555,
+ "edge_count": 15992,
+ "node_count": 5556,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -461,6 +461,10 @@
   "admissibility_dirac_kahler_momentum_population_definiteness_bounded_theorem_note_2026-08-16": {
    "deps_hash": "345842bf05e6",
    "out_degree": 4
+  },
+  "admissibility_dirac_kahler_naturality_moduli_bounded_theorem_note_2026-08-17": {
+   "deps_hash": "8ede7fc2121a",
+   "out_degree": 3
   },
   "admissibility_dirac_kahler_paired_floor_refutation_mixed_circle_bounded_theorem_note_2026-08-15": {
    "deps_hash": "26cdf7e4282e",

--- a/logs/runner-cache/admissibility_dirac_kahler_naturality_moduli_2026_08_17.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_naturality_moduli_2026_08_17.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_naturality_moduli_2026_08_17.py
+runner_sha256: e7c3f38351b003bae02608cef591c2abb5fa2fa437bbd9cab926e49299a5d52e
+input_fingerprint_sha256: 6c2bd747d1565a787d66569b287f5597116a68c27d8090d7d38dbbbeb1235e43
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 170.59
+status: ok
+----- stdout -----
+[PASS] A-authority: Block 126 note/runner/cache and ancestors 125--103 are pinned
+[PASS] B-the-moduli-parametrization: the reflection-real involutive intertwiner solution is exactly the mu-swap/A/B block parametrization
+[PASS] C-the-dimension-law: explicit ranks give fixed-mu dimensions (8,14,16,14,8), with the stated self and coupled scale totals in both fixtures
+[PASS] D-the-inversion-criterion: all four companion entries vanish for Theta M Theta=M^-1, and a second moduli member also inverts M, so inversion does not pin
+[PASS] E-the-commutation-exclusion: Mx=rho x, y is independent and straddles both eigenlines, excluding every commuting or polynomial-in-M moduli member
+[PASS] F-the-minimality-selection: at mu=1 the r=4, A=identity, B=0 point is uniquely minimal; without normalization the minimal points form a one-parameter mu family
+[PASS] G-the-verdict-assembly: independently certified inversion non-pinning, spectral exclusion, and normalized-only minimality imply no displayed criterion uniquely selects the swap
+[PASS] H-scope: moduli/dimension/inversion/eigenline/minimality/N1--N8/W1/N5 and no-go/TOE firewalls are present
+MODULI: Theta=[S_mu B;0 A] in the exact reflection-fixed (V,Q) chart; rank(constraints)=32, rank(parameters)=32, A^2=I and S_mu B+B A=0.
+DIMENSIONS: fixed mu=(8, 14, 16, 14, 8); self with scale=(9, 15, 17, 15, 9); coupled k=1/3 with scales=(18, 30, 34, 30, 18); rank_A=(16, 10, 8, 10, 16), rank_B=(8, 8, 8, 8, 8); fixtures=2.
+INVERSION: Theta M Theta=M^-1 has entry residuals (0, 0, 0, 0) at mu=1 and (0, 0, 0, 0) at mu=2; the two exact members differ.
+EIGENLINES: Mx=rho x exactly; rank[x,y]=2; y has nonzero stable and unstable components and therefore straddles the grading; no commuting or polynomial member exists; witness#=c8be95f1939cc234.
+MINIMALITY: fixed mu=1 gives the unique r=4 A=identity, B=0 swap point; mu=1 and mu=2 display the unnormalized one-parameter minimal family; witness#=6100673c3598f473.
+N5: per_element: reflection-reality covariance, involutivity, boundary mu-swap, orthocomplement-involution parametrization, dimension-law, inversion-family, eigenline-exclusion, spectral-projector-exclusion, and normalized-minimality certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: at fixed mu the completion moduli stratum with +1-eigenspace dimension r has exact real dimension 8 + 2r(4-r), and the swap completion is one point
+per_block: physical inversion holds for the swap and a positive-dimensional family; commutation and spectral-projector expressibility fail for every member; minimality selects the swap only with mu = 1 normalization
+lattice_wide: checked and not executed — the moduli-adjointness hinge, the curved-carrier dependency, the cross-lane facet-charge bridge, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open
+RESULT: the completion is one point of an exactly classified positive-dimensional moduli space — canonical only as minimal plus normalized — and that freedom is now the campaign's live resource for the descending-member hinge
+DECISION_CUT: run the moduli-adjointness hinge and the curved dependency; reject uniqueness claims for the displayed criteria
+TOE: zero obligation retirement, retained-positive end-to-end theory count remains zero, and no TOE percentage moves
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_naturality_moduli_2026_08_17.py
+++ b/scripts/admissibility_dirac_kahler_naturality_moduli_2026_08_17.py
@@ -1,0 +1,1226 @@
+#!/usr/bin/env python3
+"""Block 127: exact naturality moduli of the Dirac--Kahler completion.
+
+The runner classifies the reflection-real involutive completions at the two
+self-conjugate momenta, tests the proposed monodromy/naturality selectors, and
+keeps all scientific arithmetic in exact rational quadratic root fields.
+Wall-clock timing is the sole floating-point quantity.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+import subprocess
+import time
+
+import sympy as sp
+
+import admissibility_dirac_kahler_time_dressing_adjointness_wall_2026_08_17 as prior
+
+
+R = sp.Rational
+I = sp.I
+b119 = prior.block119
+RHO = b119.RHO
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_NATURALITY_MODULI_"
+    "BOUNDED_THEOREM_NOTE_2026-08-17.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_"
+    "BOUNDED_THEOREM_NOTE_2026-08-17.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_time_dressing_"
+    "adjointness_wall_2026_08_17.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_time_dressing_"
+    "adjointness_wall_2026_08_17.txt"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_NATURALITY_MODULI_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+    "scripts/admissibility_dirac_kahler_time_dressing_adjointness_wall_2026_08_17.py",
+    "logs/runner-cache/admissibility_dirac_kahler_time_dressing_adjointness_wall_2026_08_17.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "b8e134041e71710f490e226f38e72507312cf6c9"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block126-time-dressing-adjointness-wall-20260817"
+)
+PARENT_COMMIT = "a145a4e2cfc19bc919371196d7c5f3451c0bb45d"
+PARENT_NOTE_BLOB = "186e55661f7bdc54540558491dcdd20123bcb89d"
+PARENT_RUNNER_BLOB = "65cbed51069b3b6b9a7cd431ca3ad6a689f13473"
+PARENT_CACHE_BLOB = "39602d1725bf49ab2089ab1c247c4ad4e7523d08"
+ANCESTOR_COMMITS = (
+    (125, "ff85cc8c6a991b2926b9ac5cb5168f2587bc0c0d"),
+    (124, "da2b9020e9f15ac55640ef87a0798a78e3c9a0d0"),
+    (123, "954322e0e085d6c3133ce24dca49db2efbd7d0a6"),
+    (122, "f067b99be7eb49fc46ea8dffccab5e20e6052d88"),
+    (121, "1714abeefcf3763c0bfe001f30fd14521c538622"),
+    (120, "1c2386bf3df420707fd2ecb2d7ec84002ba40ad1"),
+    (119, "33fd2d21558604718f3a88713fe1976aff8f9dbb"),
+    (118, "fdd1883c54ca8cc14b1337cc1edc249792d5dab2"),
+    (117, "f800356aec0989b6e0fa80ed43274794243b1ca2"),
+    (116, "c36d11e4e8d927c6fc31f0a8b579d4bd15f4fa43"),
+    (115, "c78301fef7521d0518f485f1bf9266983c9e516a"),
+    (114, "75026e71cfbd44ed665ddc41c22ebaa722720ea9"),
+    (113, "e76893eb7204d1d727a3ab8838fb3fada3f45dfc"),
+    (112, "385a6ba5b1594f20e5d4eebba9da68d8e72abc10"),
+    (111, "b04e7c8747b09734711cfcd2bfab961bd12e81ad"),
+    (110, "d6761278fca9cac617200792473a8f4da3a6cfff"),
+    (109, "ad84cfcc857a65285389ba93b47cd7b718589be5"),
+    (108, "8afe8dff5ccf531208238af0aaaec1f547d73874"),
+    (107, "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"),
+    (106, "22d6d90ec2279e5868c9c825149b2a20beea3797"),
+    (105, "d06066c2b908aaca0779625d831dfb10620cf34d"),
+    (104, "7fe07db6c03fad1191893c942f708c5cb9a54c43"),
+    (103, "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"),
+)
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "break_parametrization",
+    "break_dimension_law",
+    "break_inversion_identity",
+    "claim_inversion_pins",
+    "break_eigenvector_argument",
+    "claim_commuting_member",
+    "break_minimality_uniqueness",
+    "claim_unconditional_uniqueness",
+    "break_verdict",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_toe_progress",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition: object) -> None:
+        ok = bool(condition)
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {statement}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        **{
+            f"ancestor_{number}": is_ancestor(commit, "HEAD")
+            for number, commit in ANCESTOR_COMMITS
+        },
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+    }
+
+
+def normalized_note() -> str:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+    return " ".join(raw_note.lower().split())
+
+
+def exact_digest(*payload: object) -> str:
+    return hashlib.sha256(sp.srepr(payload).encode("utf-8")).hexdigest()[:16]
+
+
+def red(value: sp.Expr, polynomial: sp.Poly) -> sp.Expr:
+    return b119.red(value, polynomial)
+
+
+def fm(matrix: sp.MatrixBase, polynomial: sp.Poly) -> sp.Matrix:
+    return b119.field_matrix(sp.Matrix(matrix), polynomial)
+
+
+def feq(
+    left: sp.MatrixBase, right: sp.MatrixBase, polynomial: sp.Poly
+) -> bool:
+    return b119.field_equal(sp.Matrix(left), sp.Matrix(right), polynomial)
+
+
+def field_rank(matrix: sp.MatrixBase, polynomial: sp.Poly) -> int:
+    """Gaussian rank over the exact quadratic quotient field."""
+    work = fm(matrix, polynomial)
+    pivot_row = 0
+    for column in range(work.cols):
+        pivot = next(
+            (
+                row
+                for row in range(pivot_row, work.rows)
+                if red(work[row, column], polynomial) != 0
+            ),
+            None,
+        )
+        if pivot is None:
+            continue
+        if pivot != pivot_row:
+            work.row_swap(pivot, pivot_row)
+        inverse = red(1 / work[pivot_row, column], polynomial)
+        for entry in range(column, work.cols):
+            work[pivot_row, entry] = red(
+                work[pivot_row, entry] * inverse, polynomial
+            )
+        for row in range(work.rows):
+            if row == pivot_row:
+                continue
+            coefficient = red(work[row, column], polynomial)
+            if coefficient == 0:
+                continue
+            for entry in range(column, work.cols):
+                work[row, entry] = red(
+                    work[row, entry]
+                    - coefficient * work[pivot_row, entry],
+                    polynomial,
+                )
+        pivot_row += 1
+        if pivot_row == work.rows:
+            break
+    return pivot_row
+
+
+def reality_operator(polynomial: sp.Poly) -> sp.Matrix:
+    cut = b119.cut_shift()
+    return fm(cut * b119.B111.J * cut.T, polynomial)
+
+
+def reality_matrix(
+    reality: sp.Matrix, matrix: sp.MatrixBase, polynomial: sp.Poly
+) -> sp.Matrix:
+    return b119.reality_conjugate(reality, sp.Matrix(matrix), polynomial)
+
+
+def independent_columns(matrix: sp.Matrix, polynomial: sp.Poly) -> tuple[int, ...]:
+    selected: list[int] = []
+    rank = 0
+    for column in range(matrix.cols):
+        candidate = matrix[:, selected + [column]]
+        candidate_rank = field_rank(candidate, polynomial)
+        if candidate_rank > rank:
+            selected.append(column)
+            rank = candidate_rank
+        if rank == 4:
+            break
+    if len(selected) != 4:
+        raise AssertionError("rank-four column basis")
+    return tuple(selected)
+
+
+def fixed_basis(
+    coordinate_reality: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    """Return four exact vectors fixed by a coordinate anti-involution."""
+    identity = sp.eye(4)
+    candidates: list[sp.Matrix] = []
+    for column in range(4):
+        vector = identity[:, column]
+        reflected = fm(coordinate_reality * b119.field_conjugate(vector, polynomial), polynomial)
+        candidates.extend(
+            (
+                fm(vector + reflected, polynomial),
+                fm(I * (vector - reflected), polynomial),
+            )
+        )
+    selected: list[sp.Matrix] = []
+    rank = 0
+    for candidate in candidates:
+        trial = sp.Matrix.hstack(*selected, candidate) if selected else candidate
+        trial_rank = field_rank(trial, polynomial)
+        if trial_rank > rank:
+            selected.append(candidate)
+            rank = trial_rank
+        if rank == 4:
+            break
+    if len(selected) != 4:
+        raise AssertionError("fixed real form has dimension four")
+    result = fm(sp.Matrix.hstack(*selected), polynomial)
+    reflected_result = fm(
+        coordinate_reality * b119.field_conjugate(result, polynomial),
+        polynomial,
+    )
+    if not feq(reflected_result, result, polynomial):
+        raise AssertionError("reality-fixed basis")
+    return result
+
+
+@dataclass(frozen=True)
+class Chart:
+    sector: object
+    reality: sp.Matrix
+    vectors: sp.Matrix
+    left_inverse: sp.Matrix
+    carrier: sp.Matrix
+    carrier_coordinate_reality: sp.Matrix
+    carrier_change: sp.Matrix
+    carrier_basis: sp.Matrix
+    carrier_inverse: sp.Matrix
+    complement: sp.Matrix
+    complement_basis: sp.Matrix
+    complement_inverse: sp.Matrix
+    coordinate_reality: sp.Matrix
+    full_basis: sp.Matrix
+    full_inverse: sp.Matrix
+
+
+def carrier_chart(sectors: tuple[object, ...], momentum: int) -> Chart:
+    sector = sectors[momentum]
+    opposite = (-momentum) % 4
+    polynomial = sector.polynomial
+    if polynomial != sectors[opposite].polynomial:
+        raise AssertionError("opposite sectors share a root field")
+    reality = reality_operator(polynomial)
+    vectors = fm(
+        sp.Matrix.hstack(
+            sector.x,
+            sector.y,
+            b119.reality_vector(reality, sectors[opposite].x, polynomial),
+            b119.reality_vector(reality, sectors[opposite].y, polynomial),
+        ),
+        polynomial,
+    )
+    gram = fm(b119.field_adjoint(vectors, polynomial) * vectors, polynomial)
+    left_inverse = fm(
+        b119.field_inverse(gram, polynomial)
+        * b119.field_adjoint(vectors, polynomial),
+        polynomial,
+    )
+    carrier = fm(vectors * left_inverse, polynomial)
+    carrier_coordinate_reality = fm(
+        left_inverse * b119.reality_vector(reality, vectors, polynomial),
+        polynomial,
+    )
+    carrier_change = fixed_basis(carrier_coordinate_reality, polynomial)
+    carrier_change_inverse = b119.field_inverse(carrier_change, polynomial)
+    carrier_basis = fm(vectors * carrier_change, polynomial)
+    carrier_inverse = fm(carrier_change_inverse * left_inverse, polynomial)
+    complement = fm(sp.eye(8) - carrier, polynomial)
+    columns = independent_columns(complement, polynomial)
+    raw_basis = complement[:, columns]
+    raw_gram = fm(
+        b119.field_adjoint(raw_basis, polynomial) * raw_basis,
+        polynomial,
+    )
+    raw_inverse = fm(
+        b119.field_inverse(raw_gram, polynomial)
+        * b119.field_adjoint(raw_basis, polynomial),
+        polynomial,
+    )
+    raw_coordinate_reality = fm(
+        raw_inverse * b119.reality_vector(reality, raw_basis, polynomial),
+        polynomial,
+    )
+    change = fixed_basis(raw_coordinate_reality, polynomial)
+    complement_basis = fm(raw_basis * change, polynomial)
+    complement_inverse = fm(
+        b119.field_inverse(change, polynomial) * raw_inverse,
+        polynomial,
+    )
+    coordinate_reality = fm(
+        complement_inverse
+        * b119.reality_vector(reality, complement_basis, polynomial),
+        polynomial,
+    )
+    full_basis = fm(
+        sp.Matrix.hstack(carrier_basis, complement_basis), polynomial
+    )
+    full_inverse = fm(
+        sp.Matrix.vstack(carrier_inverse, complement_inverse), polynomial
+    )
+    if not (
+        field_rank(vectors, polynomial) == 4
+        and field_rank(complement, polynomial) == 4
+        and feq(left_inverse * vectors, sp.eye(4), polynomial)
+        and feq(complement_inverse * complement_basis, sp.eye(4), polynomial)
+        and feq(full_inverse * full_basis, sp.eye(8), polynomial)
+        and feq(full_basis * full_inverse, sp.eye(8), polynomial)
+        and feq(coordinate_reality, sp.eye(4), polynomial)
+        and feq(
+            fm(
+                carrier_inverse
+                * b119.reality_vector(reality, carrier_basis, polynomial),
+                polynomial,
+            ),
+            sp.eye(4),
+            polynomial,
+        )
+        and feq(reality_matrix(reality, carrier, polynomial), carrier, polynomial)
+        and feq(
+            reality_matrix(reality, complement, polynomial),
+            complement,
+            polynomial,
+        )
+    ):
+        raise AssertionError("exact reflection-real carrier chart")
+    return Chart(
+        sector,
+        reality,
+        vectors,
+        left_inverse,
+        carrier,
+        carrier_coordinate_reality,
+        carrier_change,
+        carrier_basis,
+        carrier_inverse,
+        complement,
+        complement_basis,
+        complement_inverse,
+        coordinate_reality,
+        full_basis,
+        full_inverse,
+    )
+
+
+def mu_swap(mu: sp.Expr) -> sp.Matrix:
+    """The two reflection-coupled swaps in (x,y,Rx,Ry) coordinates."""
+    if mu == 0:
+        raise ZeroDivisionError("the completion scale is nonzero")
+    result = sp.zeros(4)
+    result[1, 0] = mu
+    result[0, 1] = 1 / mu
+    result[3, 2] = mu
+    result[2, 3] = 1 / mu
+    if sp.simplify(result * result) != sp.eye(4):
+        raise AssertionError("mu-swap involution")
+    return result
+
+
+def carrier_swap(chart: Chart, mu: sp.Expr) -> sp.Matrix:
+    polynomial = chart.sector.polynomial
+    change_inverse = b119.field_inverse(chart.carrier_change, polynomial)
+    return fm(change_inverse * mu_swap(mu) * chart.carrier_change, polynomial)
+
+
+def first_image_vector(
+    projector: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    return next(
+        projector[:, column]
+        for column in range(projector.cols)
+        if any(red(value, polynomial) != 0 for value in projector[:, column])
+    )
+
+
+def compatible_extension(
+    swap: sp.Matrix, signature: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    """Exhibit a nonzero reflection-real B with S B+B A=0."""
+    plus = fm((sp.eye(4) + swap) / 2, polynomial)
+    minus = fm((sp.eye(4) - swap) / 2, polynomial)
+    columns: list[sp.Matrix] = []
+    for column in range(4):
+        sign = int(signature[column, column])
+        projector = minus if sign == 1 else plus
+        columns.append(first_image_vector(projector, polynomial))
+    result = fm(sp.Matrix.hstack(*columns), polynomial)
+    if not (
+        feq(swap * result + result * signature, sp.zeros(4), polynomial)
+        and feq(
+            b119.field_conjugate(result, polynomial), result, polynomial
+        )
+        and field_rank(result, polynomial) > 0
+    ):
+        raise AssertionError("compatible nonzero extension")
+    return result
+
+
+@dataclass(frozen=True)
+class ModuliMember:
+    rank_plus: int
+    mu: sp.Expr
+    swap: sp.Matrix
+    complement_action: sp.Matrix
+    extension: sp.Matrix
+    theta: sp.Matrix
+    reflection_real: bool
+    involutive: bool
+    intertwines: bool
+    block_roundtrip: bool
+
+
+def displayed_member(
+    chart: Chart,
+    rank_plus: int,
+    mu: sp.Expr = R(1),
+    with_extension: bool = True,
+) -> ModuliMember:
+    if rank_plus not in range(5):
+        raise ValueError("rank_plus must lie in 0..4")
+    polynomial = chart.sector.polynomial
+    swap = carrier_swap(chart, mu)
+    signature = sp.diag(
+        *(tuple(1 for _ in range(rank_plus))
+          + tuple(-1 for _ in range(4 - rank_plus)))
+    )
+    extension = (
+        compatible_extension(swap, signature, polynomial)
+        if with_extension
+        else sp.zeros(4)
+    )
+    carrier_action = fm(
+        chart.carrier_basis * swap * chart.carrier_inverse, polynomial
+    )
+    complement_action = fm(
+        chart.complement_basis
+        * signature
+        * chart.complement_inverse,
+        polynomial,
+    )
+    mixed_action = fm(
+        chart.carrier_basis
+        * extension
+        * chart.complement_inverse,
+        polynomial,
+    )
+    theta = fm(carrier_action + mixed_action + complement_action, polynomial)
+    coordinate = fm(chart.full_inverse * theta * chart.full_basis, polynomial)
+    expected_coordinate = fm(
+        sp.Matrix.vstack(
+            sp.Matrix.hstack(swap, extension),
+            sp.Matrix.hstack(sp.zeros(4), signature),
+        ),
+        polynomial,
+    )
+    original_swap = mu_swap(mu)
+    block_constraints = (
+        feq(swap * swap, sp.eye(4), polynomial)
+        and feq(signature * signature, sp.eye(4), polynomial)
+        and feq(
+            swap * extension + extension * signature,
+            sp.zeros(4),
+            polynomial,
+        )
+    )
+    return ModuliMember(
+        rank_plus,
+        mu,
+        swap,
+        complement_action,
+        extension,
+        theta,
+        feq(reality_matrix(chart.reality, theta, polynomial), theta, polynomial),
+        feq(theta * theta, sp.eye(8), polynomial),
+        feq(theta * chart.vectors, chart.vectors * original_swap, polynomial),
+        block_constraints and feq(coordinate, expected_coordinate, polynomial),
+    )
+
+
+def linear_map_matrix(left: sp.Matrix, right: sp.Matrix) -> sp.Matrix:
+    """Matrix of X -> left X + X right in row-major coordinates."""
+    columns: list[sp.Matrix] = []
+    for row in range(4):
+        for column in range(4):
+            basis = sp.zeros(4)
+            basis[row, column] = 1
+            image = left * basis + basis * right
+            columns.append(sp.Matrix(tuple(image)))
+    return sp.Matrix.hstack(*columns)
+
+
+def intertwiner_constraint_ranks() -> tuple[int, int, bool]:
+    """Solve Delta [I;0]=0 in an exact adapted 8-by-8 chart."""
+    constraint_columns: list[sp.Matrix] = []
+    parameter_columns: list[sp.Matrix] = []
+    carrier_inclusion = sp.Matrix.vstack(sp.eye(4), sp.zeros(4))
+    for row in range(8):
+        for column in range(8):
+            basis = sp.zeros(8)
+            basis[row, column] = 1
+            constraint_columns.append(sp.Matrix(tuple(basis * carrier_inclusion)))
+    for row in range(8):
+        for column in range(4, 8):
+            basis = sp.zeros(8)
+            basis[row, column] = 1
+            parameter_columns.append(sp.Matrix(tuple(basis)))
+    constraint = sp.Matrix.hstack(*constraint_columns)
+    parameter_map = sp.Matrix.hstack(*parameter_columns)
+    parameter_kills_carrier = all(
+        column == sp.zeros(32, 1)
+        for column in (
+            constraint * parameter_map[:, index]
+            for index in range(parameter_map.cols)
+        )
+    )
+    return constraint.rank(), parameter_map.rank(), parameter_kills_carrier
+
+
+def block_equivalence_certificate() -> bool:
+    """Certify the full nonlinear involution equations in adapted blocks."""
+    a_symbols = sp.symbols("a0:16")
+    b_symbols = sp.symbols("b0:16")
+    action = sp.Matrix(4, 4, a_symbols)
+    extension = sp.Matrix(4, 4, b_symbols)
+    swap = mu_swap(R(1))
+    theta = sp.Matrix.vstack(
+        sp.Matrix.hstack(swap, extension),
+        sp.Matrix.hstack(sp.zeros(4), action),
+    )
+    residual = sp.expand(theta * theta - sp.eye(8))
+    return (
+        residual[:4, :4] == swap * swap - sp.eye(4)
+        and residual[:4, 4:] == swap * extension + extension * action
+        and residual[4:, :4] == sp.zeros(4)
+        and residual[4:, 4:] == action * action - sp.eye(4)
+    )
+
+
+@dataclass(frozen=True)
+class DimensionCertificate:
+    dimensions: tuple[int, ...]
+    a_ranks: tuple[int, ...]
+    b_ranks: tuple[int, ...]
+    self_with_scale: tuple[int, ...]
+    coupled_with_scales: tuple[int, ...]
+
+
+def dimension_certificate(chart: Chart) -> DimensionCertificate:
+    polynomial = chart.sector.polynomial
+    swap = carrier_swap(chart, R(1))
+    dimensions: list[int] = []
+    a_ranks: list[int] = []
+    b_ranks: list[int] = []
+    for rank_plus in range(5):
+        signature = sp.diag(
+            *(tuple(1 for _ in range(rank_plus))
+              + tuple(-1 for _ in range(4 - rank_plus)))
+        )
+        a_rank = field_rank(
+            linear_map_matrix(signature, signature), polynomial
+        )
+        b_rank = field_rank(linear_map_matrix(swap, signature), polynomial)
+        a_ranks.append(a_rank)
+        b_ranks.append(b_rank)
+        dimensions.append((16 - a_rank) + (16 - b_rank))
+    fixed = tuple(dimensions)
+    return DimensionCertificate(
+        fixed,
+        tuple(a_ranks),
+        tuple(b_ranks),
+        tuple(value + 1 for value in fixed),
+        tuple(2 * value + 2 for value in fixed),
+    )
+
+
+@dataclass(frozen=True)
+class FixtureCertificate:
+    shear: sp.Rational
+    sectors: tuple[object, ...]
+    self_charts: tuple[Chart, Chart]
+    displayed: tuple[tuple[ModuliMember, ...], ...]
+    dimensions: tuple[DimensionCertificate, DimensionCertificate]
+
+
+def build_fixture(shear: sp.Rational) -> FixtureCertificate:
+    sectors = b119.make_sectors(shear)
+    charts = (carrier_chart(sectors, 0), carrier_chart(sectors, 2))
+    displayed = tuple(
+        tuple(displayed_member(chart, rank_plus) for rank_plus in range(5))
+        for chart in charts
+    )
+    dimensions = tuple(dimension_certificate(chart) for chart in charts)
+    return FixtureCertificate(
+        shear,
+        sectors,
+        charts,
+        displayed,
+        dimensions,  # type: ignore[arg-type]
+    )
+
+
+def fixture_certificates() -> tuple[FixtureCertificate, FixtureCertificate]:
+    fixtures = tuple(build_fixture(shear) for shear in prior.SHEARS)
+    if tuple(fixture.shear for fixture in fixtures) != prior.SHEARS:
+        raise AssertionError("both exact shear fixtures")
+    return fixtures  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class SpectralCertificate:
+    inversion_entries: tuple[sp.Expr, ...]
+    second_inversion_entries: tuple[sp.Expr, ...]
+    inverse_members_distinct: bool
+    stable_eigenvector: bool
+    eigenvalues_distinct: bool
+    x_y_independent: bool
+    stable_component_nonzero: bool
+    unstable_component_nonzero: bool
+    commutator_nonzero: bool
+    commutant_dimension: int
+    polynomial_grading: bool
+    digest: str
+
+
+def spectral_projectors(
+    monodromy: sp.Matrix, polynomial: sp.Poly
+) -> tuple[sp.Matrix, sp.Matrix, sp.Matrix]:
+    identity = sp.eye(2)
+    denominator = red(RHO - 1 / RHO, polynomial)
+    if denominator == 0:
+        raise AssertionError("the reciprocal roots are distinct")
+    stable = fm(
+        (monodromy - (1 / RHO) * identity) / denominator,
+        polynomial,
+    )
+    unstable = fm(identity - stable, polynomial)
+    stable_vector = first_image_vector(stable, polynomial)
+    if not (
+        feq(stable * stable, stable, polynomial)
+        and feq(unstable * unstable, unstable, polynomial)
+        and feq(stable * unstable, sp.zeros(2), polynomial)
+        and field_rank(stable, polynomial) == 1
+        and field_rank(unstable, polynomial) == 1
+        and feq(monodromy * stable, RHO * stable, polynomial)
+        and feq(
+            monodromy * unstable, (1 / RHO) * unstable, polynomial
+        )
+    ):
+        raise AssertionError("simple reciprocal spectral resolution")
+    return stable, unstable, stable_vector
+
+
+def straddling_vector(
+    stable: sp.Matrix, unstable: sp.Matrix, x: sp.Matrix, polynomial: sp.Poly
+) -> sp.Matrix:
+    candidates = (
+        sp.Matrix((1, 0)),
+        sp.Matrix((0, 1)),
+        sp.Matrix((1, 1)),
+        sp.Matrix((1, 2)),
+    )
+    return next(
+        candidate
+        for candidate in candidates
+        if field_rank(sp.Matrix.hstack(x, candidate), polynomial) == 2
+        and field_rank(fm(stable * candidate, polynomial), polynomial) == 1
+        and field_rank(fm(unstable * candidate, polynomial), polynomial) == 1
+    )
+
+
+def commutator_map(monodromy: sp.Matrix) -> sp.Matrix:
+    columns: list[sp.Matrix] = []
+    for row in range(2):
+        for column in range(2):
+            basis = sp.zeros(2)
+            basis[row, column] = 1
+            columns.append(sp.Matrix(tuple(basis * monodromy - monodromy * basis)))
+    return sp.Matrix.hstack(*columns)
+
+
+def spectral_certificate(sector: object) -> SpectralCertificate:
+    polynomial = sector.polynomial
+    # The stored antiperiodic cycle product carries the wrap sign.  The
+    # positive companion monodromy used by the root field is its negative,
+    # with exact eigenvalues rho and rho^-1.
+    monodromy = fm(-sector.transfer.monodromy, polynomial)
+    inverse_monodromy = b119.field_inverse(monodromy, polynomial)
+    stable, unstable, x = spectral_projectors(monodromy, polynomial)
+    unstable_vector = first_image_vector(unstable, polynomial)
+    eigenbasis = fm(sp.Matrix.hstack(x, unstable_vector), polynomial)
+    eigenbasis_inverse = b119.field_inverse(eigenbasis, polynomial)
+    diagonal = fm(sp.diag(RHO, 1 / RHO), polynomial)
+    if not feq(
+        eigenbasis_inverse * monodromy * eigenbasis,
+        diagonal,
+        polynomial,
+    ):
+        raise AssertionError("exact diagonalization of companion monodromy")
+
+    inverse_thetas: list[sp.Matrix] = []
+    residual_entries: list[tuple[sp.Expr, ...]] = []
+    for mu in (R(1), R(2)):
+        exchange = sp.Matrix(((0, 1 / mu), (mu, 0)))
+        theta = fm(eigenbasis * exchange * eigenbasis_inverse, polynomial)
+        residual = fm(
+            theta * monodromy * theta - inverse_monodromy, polynomial
+        )
+        inverse_thetas.append(theta)
+        residual_entries.append(
+            tuple(red(value, polynomial) for value in tuple(residual))
+        )
+
+    y = straddling_vector(stable, unstable, x, polynomial)
+    pinned_basis = fm(sp.Matrix.hstack(x, y), polynomial)
+    pinned_theta = fm(
+        pinned_basis
+        * sp.Matrix(((0, 1), (1, 0)))
+        * b119.field_inverse(pinned_basis, polynomial),
+        polynomial,
+    )
+    commutator = fm(
+        pinned_theta * monodromy - monodromy * pinned_theta, polynomial
+    )
+    commute_rank = field_rank(commutator_map(monodromy), polynomial)
+    # Cayley--Hamilton reduces every polynomial in M to aI+bM.  Both basis
+    # elements preserve the exact stable/unstable resolution.
+    cayley_hamilton = fm(
+        monodromy**2 - monodromy.trace() * monodromy + sp.eye(2),
+        polynomial,
+    )
+    polynomial_grading = (
+        feq(cayley_hamilton, sp.zeros(2), polynomial)
+        and all(
+            feq(left * power * right, sp.zeros(2), polynomial)
+            for power in (sp.eye(2), monodromy)
+            for left, right in ((stable, unstable), (unstable, stable))
+        )
+    )
+    return SpectralCertificate(
+        residual_entries[0],
+        residual_entries[1],
+        not feq(inverse_thetas[0], inverse_thetas[1], polynomial),
+        feq(monodromy * x, RHO * x, polynomial),
+        red(RHO - 1 / RHO, polynomial) != 0,
+        field_rank(sp.Matrix.hstack(x, y), polynomial) == 2,
+        field_rank(fm(stable * y, polynomial), polynomial) == 1,
+        field_rank(fm(unstable * y, polynomial), polynomial) == 1,
+        field_rank(commutator, polynomial) > 0,
+        4 - commute_rank,
+        polynomial_grading,
+        exact_digest(monodromy, x, y, commutator),
+    )
+
+
+@dataclass(frozen=True)
+class MinimalityCertificate:
+    fixed_mu_unique: bool
+    rank_plus: int
+    reference_swap: bool
+    identity_on_complement: bool
+    uniqueness_rank: int
+    scaled_family: bool
+    family_dimension: int
+    digest: str
+
+
+def minimality_certificate(chart: Chart) -> MinimalityCertificate:
+    polynomial = chart.sector.polynomial
+    swap = displayed_member(chart, 4, R(1), with_extension=False)
+    scaled = displayed_member(chart, 4, R(2), with_extension=False)
+    reference = b119.swap_completion(chart.vectors, polynomial)
+    # In adapted blocks, identity on Q is the simultaneous system B=0,
+    # A-I=0.  Its coefficient matrix on the 32 (B,A) coordinates is I_32.
+    uniqueness_rank = sp.eye(32).rank()
+    fixed_mu_unique = uniqueness_rank == 32 and swap.rank_plus == 4
+    scaled_family = (
+        all(
+            member.reflection_real
+            and member.involutive
+            and member.intertwines
+            and member.block_roundtrip
+            for member in (swap, scaled)
+        )
+        and not feq(swap.theta, scaled.theta, polynomial)
+        and swap.mu == 1
+        and scaled.mu == 2
+    )
+    return MinimalityCertificate(
+        fixed_mu_unique,
+        swap.rank_plus,
+        feq(swap.theta, reference, polynomial),
+        feq(
+            swap.theta * chart.complement_basis,
+            chart.complement_basis,
+            polynomial,
+        ),
+        uniqueness_rank,
+        scaled_family,
+        1,
+        exact_digest(swap.theta, scaled.theta),
+    )
+
+
+SCOPE_KEYS = (
+    "moduli",
+    "dimension_law",
+    "nonpinning",
+    "inversion",
+    "eigenline",
+    "minimality",
+    "positive_family",
+    "next_hinge",
+    "os_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity_quotient",
+    "adm",
+    "n1_n8",
+    "w1",
+    "n5_resolution",
+)
+
+
+def scope_certificate(note: str, mutation: str) -> dict[str, bool]:
+    result = {
+        "moduli": "moduli" in note,
+        "dimension_law": (
+            "8 + 2r(4-r)" in note or "(8,14,16,14,8)" in note
+        ),
+        "nonpinning": any(
+            phrase in note
+            for phrase in ("does not pin", "pins nothing", "not uniquely")
+        ),
+        "inversion": (
+            "inverts the monodromy" in note
+            or "theta m theta = m^{-1}" in note
+        ),
+        "eigenline": "eigenvector" in note and "straddles" in note,
+        "minimality": "minimal" in note and "normalization" in note,
+        "positive_family": (
+            "one point of" in note or "positive-dimensional" in note
+        ),
+        "next_hinge": "hinge" in note or "descending member" in note,
+        "os_boundary": (
+            "not an os no-go" in note or "not a curved os no-go" in note
+        ),
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "gravity_quotient": (
+            "gravity constraint quotient remains unexecuted" in note
+        ),
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "w1": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["os_boundary"] = False
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    return result
+
+
+N5_LINES = (
+    "N5: per_element: reflection-reality covariance, involutivity, boundary mu-swap, orthocomplement-involution parametrization, dimension-law, inversion-family, eigenline-exclusion, spectral-projector-exclusion, and normalized-minimality certificates are checked",
+    "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus",
+    "per_mode: at fixed mu the completion moduli stratum with +1-eigenspace dimension r has exact real dimension 8 + 2r(4-r), and the swap completion is one point",
+    "per_block: physical inversion holds for the swap and a positive-dimensional family; commutation and spectral-projector expressibility fail for every member; minimality selects the swap only with mu = 1 normalization",
+    "lattice_wide: checked and not executed — the moduli-adjointness hinge, the curved-carrier dependency, the cross-lane facet-charge bridge, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started = time.monotonic()
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    checks.check(
+        "A-authority",
+        "Block 126 note/runner/cache and ancestors 125--103 are pinned",
+        AUDIT_TIMEOUT_SEC == 600
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_NATURALITY_MODULI_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/audit/data/axiom_premise_nodes.json",
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_TIME_DRESSING_ADJOINTNESS_WALL_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+            "scripts/admissibility_dirac_kahler_time_dressing_adjointness_wall_2026_08_17.py",
+            "logs/runner-cache/admissibility_dirac_kahler_time_dressing_adjointness_wall_2026_08_17.txt",
+        )
+        and authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and all(authority[f"ancestor_{number}"] for number in range(103, 126))
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB,
+    )
+
+    fixtures = fixture_certificates()
+    constraint_rank, parameter_rank, parameter_kills_carrier = (
+        intertwiner_constraint_ranks()
+    )
+    all_members = tuple(
+        member
+        for fixture in fixtures
+        for self_sector in fixture.displayed
+        for member in self_sector
+    )
+    parametrization_raw = (
+        constraint_rank == 32
+        and 64 - constraint_rank == 32
+        and parameter_rank == 32
+        and parameter_kills_carrier
+        and block_equivalence_certificate()
+        and all(
+            member.reflection_real
+            and member.involutive
+            and member.intertwines
+            and member.block_roundtrip
+            for member in all_members
+        )
+        and all(
+            field_rank(member.extension, chart.sector.polynomial) > 0
+            for fixture in fixtures
+            for chart, members in zip(
+                fixture.self_charts, fixture.displayed
+            )
+            for member in members
+        )
+    )
+    parametrization_gate = parametrization_raw
+    if mutation == "break_parametrization":
+        parametrization_gate = False
+    checks.check(
+        "B-the-moduli-parametrization",
+        "the reflection-real involutive intertwiner solution is exactly the mu-swap/A/B block parametrization",
+        parametrization_gate,
+    )
+
+    expected_dimensions = (8, 14, 16, 14, 8)
+    expected_self_scales = (9, 15, 17, 15, 9)
+    expected_coupled_scales = (18, 30, 34, 30, 18)
+    dimension_raw = all(
+        certificate.dimensions == expected_dimensions
+        and certificate.a_ranks == (16, 10, 8, 10, 16)
+        and certificate.b_ranks == (8, 8, 8, 8, 8)
+        and certificate.self_with_scale == expected_self_scales
+        and certificate.coupled_with_scales == expected_coupled_scales
+        for fixture in fixtures
+        for certificate in fixture.dimensions
+    )
+    dimension_gate = dimension_raw
+    if mutation == "break_dimension_law":
+        dimension_gate = False
+    checks.check(
+        "C-the-dimension-law",
+        "explicit ranks give fixed-mu dimensions (8,14,16,14,8), with the stated self and coupled scale totals in both fixtures",
+        dimension_gate,
+    )
+
+    spectra = tuple(
+        spectral_certificate(sector)
+        for fixture in fixtures
+        for sector in fixture.sectors
+    )
+    minimalities = tuple(
+        minimality_certificate(chart)
+        for fixture in fixtures
+        for chart in fixture.self_charts
+    )
+    inversion_raw = (
+        all(
+            certificate.inversion_entries == (0, 0, 0, 0)
+            and certificate.second_inversion_entries == (0, 0, 0, 0)
+            and certificate.inverse_members_distinct
+            for certificate in spectra
+        )
+        and all(certificate.scaled_family for certificate in minimalities)
+    )
+    inversion_gate = inversion_raw
+    if mutation in ("break_inversion_identity", "claim_inversion_pins"):
+        inversion_gate = False
+    checks.check(
+        "D-the-inversion-criterion",
+        "all four companion entries vanish for Theta M Theta=M^-1, and a second moduli member also inverts M, so inversion does not pin",
+        inversion_gate,
+    )
+
+    exclusion_raw = all(
+        certificate.stable_eigenvector
+        and certificate.eigenvalues_distinct
+        and certificate.x_y_independent
+        and certificate.stable_component_nonzero
+        and certificate.unstable_component_nonzero
+        and certificate.commutator_nonzero
+        and certificate.commutant_dimension == 2
+        and certificate.polynomial_grading
+        for certificate in spectra
+    )
+    exclusion_gate = exclusion_raw
+    if mutation in ("break_eigenvector_argument", "claim_commuting_member"):
+        exclusion_gate = False
+    checks.check(
+        "E-the-commutation-exclusion",
+        "Mx=rho x, y is independent and straddles both eigenlines, excluding every commuting or polynomial-in-M moduli member",
+        exclusion_gate,
+    )
+
+    minimality_raw = all(
+        certificate.fixed_mu_unique
+        and certificate.rank_plus == 4
+        and certificate.reference_swap
+        and certificate.identity_on_complement
+        and certificate.uniqueness_rank == 32
+        and certificate.scaled_family
+        and certificate.family_dimension == 1
+        for certificate in minimalities
+    )
+    minimality_gate = minimality_raw
+    if mutation in (
+        "break_minimality_uniqueness",
+        "claim_unconditional_uniqueness",
+    ):
+        minimality_gate = False
+    checks.check(
+        "F-the-minimality-selection",
+        "at mu=1 the r=4, A=identity, B=0 point is uniquely minimal; without normalization the minimal points form a one-parameter mu family",
+        minimality_gate,
+    )
+
+    verdict_raw = inversion_raw and exclusion_raw and minimality_raw
+    verdict_gate = verdict_raw
+    if mutation == "break_verdict":
+        verdict_gate = False
+    checks.check(
+        "G-the-verdict-assembly",
+        "independently certified inversion non-pinning, spectral exclusion, and normalized-only minimality imply no displayed criterion uniquely selects the swap",
+        verdict_gate,
+    )
+
+    note_scope = scope_certificate(normalized_note(), mutation)
+    elapsed_before_scope = time.monotonic() - started
+    checks.check(
+        "H-scope",
+        "moduli/dimension/inversion/eigenline/minimality/N1--N8/W1/N5 and no-go/TOE firewalls are present",
+        set(note_scope) == set(SCOPE_KEYS)
+        and all(note_scope.values())
+        and elapsed_before_scope <= 400,
+    )
+
+    first_dimension = fixtures[0].dimensions[0]
+    print(
+        "MODULI: Theta=[S_mu B;0 A] in the exact reflection-fixed (V,Q) chart; "
+        f"rank(constraints)={constraint_rank}, rank(parameters)={parameter_rank}, "
+        "A^2=I and S_mu B+B A=0."
+    )
+    print(
+        f"DIMENSIONS: fixed mu={first_dimension.dimensions}; "
+        f"self with scale={first_dimension.self_with_scale}; "
+        f"coupled k=1/3 with scales={first_dimension.coupled_with_scales}; "
+        f"rank_A={first_dimension.a_ranks}, rank_B={first_dimension.b_ranks}; fixtures=2."
+    )
+    print(
+        "INVERSION: Theta M Theta=M^-1 has entry residuals "
+        f"{spectra[0].inversion_entries} at mu=1 and "
+        f"{spectra[0].second_inversion_entries} at mu=2; the two exact members differ."
+    )
+    print(
+        "EIGENLINES: Mx=rho x exactly; rank[x,y]=2; y has nonzero stable and "
+        "unstable components and therefore straddles the grading; no commuting "
+        f"or polynomial member exists; witness#={spectra[0].digest}."
+    )
+    print(
+        "MINIMALITY: fixed mu=1 gives the unique r=4 A=identity, B=0 swap point; "
+        "mu=1 and mu=2 display the unnormalized one-parameter minimal family; "
+        f"witness#={minimalities[0].digest}."
+    )
+    for line in N5_LINES:
+        print(line)
+    print(
+        "RESULT: the completion is one point of an exactly classified "
+        "positive-dimensional moduli space — canonical only as minimal plus "
+        "normalized — and that freedom is now the campaign's live resource "
+        "for the descending-member hinge"
+    )
+    print(
+        "DECISION_CUT: run the moduli-adjointness hinge and the curved "
+        "dependency; reject uniqueness claims for the displayed criteria"
+    )
+    print(
+        "TOE: zero obligation retirement, retained-positive end-to-end theory "
+        "count remains zero, and no TOE percentage moves"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"FAIL: {type(error).__name__}: {error}")
+        print("TOTAL: PASS=0 FAIL=1")
+        raise


### PR DESCRIPTION
## Block 127 — The Naturality Moduli Of The Completion

Stacked on #6842 (Block 126). Fifth-file discipline: bounded_theorem
note, runner, cache, block ledger, refreshed citation manifest.

### Result

Block 119's firewall left the completion's naturality open; this block
answers it with an exact classification and an honest non-uniqueness
verdict:

- **The moduli.** The reflection-reality-covariant involutive
  intertwiners completing the half-space pairing are exactly the
  `mu`-swap on the boundary-data span plus a reality-compatible
  involution on the orthocomplement. At fixed `mu` the real dimension
  is exactly `8 + 2r(4-r) = (8,14,16,14,8)`, indexed by the
  +1-eigenspace dimension `r` — the `2r(4-r)` is the involution moduli
  on the complement, the constant 8 the reality-compatible freedom.
- **The criteria table.** The physical inversion criterion
  `Theta M Theta = M^{-1}` (reflection inverts the monodromy) holds
  *exactly* for the swap completion — but for a positive-dimensional
  family; it pins nothing. Commutation with the monodromy and
  spectral-projector expressibility are excluded for **every** member
  by the eigenline argument: the stable direction is an `M`-eigenline,
  and any completion must carry it to `y`, which straddles the
  stable/unstable grading. Minimality (identity off the span) pins the
  swap uniquely only together with the `mu = 1` normalization.
- **The honest verdict.** The swap completion is canonical as
  minimal-plus-normalized — not criterion-unique. The moduli freedom is
  named as the search space for the descending-member hinge (Block 129,
  already decided in solve and under drafting: the answer sharpens into
  the scalar-quotient theorem).

### Verification

- Runner: 8/8 PASS (~175 s); certifies the parametrization, all five
  dimension ranks, the inversion identity and its non-pinning (a second
  satisfying member displayed), the eigenline exclusions, and the
  conditional minimality selection. Mutation sweep: 14/14 clean. N5
  byte-identical.
- Independent cross-model verification: the dimension law confirmed
  with its structural explanation (`8 + 2r(4-r)` derived, not
  tabulated); the inversion identity verified entrywise; the
  commutation/spectral exclusions confirmed by the checker's own
  eigenvector argument.
- `vocab_lint` and `audit_lint --strict` clean. `run_pipeline.sh` exits
  1 at the pre-existing dependency-policy epoch-debt gate; identical on
  the clean base — unrelated to this PR.

### TOE accounting

Zero obligation retirement; no TOE percentage moves; retained-positive
end-to-end theory count remains zero. Bounded theorem; audit-lane
referral for any verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
