### PR TITLE
physics: complete the measurement theory on the two-block algebra

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block133-two-block-states-dynamics-20260817/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block133-two-block-states-dynamics-20260817/NO_GO_LEDGER.md
@@ -1,0 +1,37 @@
+# Block 133 No-Go Ledger
+
+Scope: the measurement theory of the certified package — a
+positive-dominant packet whose boundary wall keeps the frames and the
+sector's reach honest. THE POSITIVE: the state space is the
+five-dimensional convex body of paired symmetric disc states (one
+projective-line family of pure states per block); the CERTIFIED-FRAME
+vacuum is the biased central mixture with direction weights
+proportional to the boundary-vector norms — the conjugate block
+maximally mixed by force (equal norms from the entrywise conjugation)
+while the per-sector-real block is biased and the block totals are
+unequal; momentum generates rate-two counter-rotating quadrature
+dynamics in the two blocks (generator differences -2 and +2) with the
+diagonal four-dimensional subalgebra conserved; and the balanced
+gravity sector is the FULL free-phase equator whose invariant
+observables are exactly span{I, Z} — because the Y quadrature is not
+an admissible element of the real symmetric algebra, the phase freedom
+is invisible to every observable. `W1` (the boundary): the clean
+quarter-trace vacuum is a NORMALIZED-FRAME statement requiring two
+moves including the field-leaving square-root equalization (Block
+132's certificate); and the balanced sector measures only the
+two-dimensional span{I, Z}. Exact expectations and momentum selection
+rules are certified; no tensor-product structure or additional
+dynamical law is claimed. Narrow scope: the displayed algebra,
+conditions, and fixtures.
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the vacuum is maximally mixed | `ATTEMPTED` | frame-dependent: true only after two normalizations, one outside the certified field | the ledger is displayed |
+| the balanced sector measures the full algebra | `ATTEMPTED` | false: span{I, Z} only — the X component is averaged out by the free phase | none needed |
+| the phase freedom is physical on this algebra | `ATTEMPTED` | invisible: Y is not an admissible observable | richer algebras/carriers |
+| a tensor-product structure exists | `ATTEMPTED` | not claimed: the blocks are direct summands, not factors | future structure work |
+| the dynamics has independent content | `ATTEMPTED` | the transfer is central; the dynamical content is the momentum action and selection rules, displayed | none needed |
+| the measurement theory extends beyond the displayed carrier | `ATTEMPTED` | not shown: the fixture's four positive directions only | richer carriers |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; the positive-dominant `W1` ships with the frame ledger displayed.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_STATES_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-17.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_STATES_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-17.md
@@ -1,0 +1,1214 @@
+---
+claim_id: admissibility_dirac_kahler_two_block_states_dynamics_bounded_theorem_note_2026-08-17
+claim_type: bounded_theorem
+claim_scope: "on the certified two-block observable algebra at both rational shear fixtures the measurement theory is complete — the state space is the five-dimensional convex body of paired symmetric disc states with one projective-line family of pure states per block, the certified-frame vacuum is the biased central mixture with direction weights proportional to the boundary-vector norms (the conjugate block maximally mixed by force, the per-sector-real block biased, the block totals unequal) whose clean quarter-trace presentation requires exactly two admissible normalizations including the field-leaving square-root equalization, momentum generates rate-two counter-rotating quadrature dynamics with the diagonal four-dimensional subalgebra conserved, and the balanced gravity sector is the full free-phase equator whose invariant observables are exactly the identity and the z direction because the y quadrature is not an admissible element of the real symmetric algebra — with exact expectations and momentum selection rules certified and no tensor-product structure or additional dynamical law claimed — and the common differential, the flip work order, richer carriers, the completed ADM/history transporter, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, retention, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+depends_on:
+  - admissibility_dirac_kahler_two_block_observable_algebra_bounded_theorem_note_2026-08-17
+runner: scripts/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_two_block_observable_algebra_bounded_theorem_note_2026-08-17
+target_blocker_text: "States and dynamics on the two-block algebra; the flip work order; the common nilpotent differential."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "The common nilpotent differential; the flip work order; richer carriers beyond the displayed fixture."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-132 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact state-space, vacuum-weight, normalization-ledger, momentum-counter-rotation, balanced-equator, expectation, and selection-rule calculations complete the measurement theory on the certified four-direction carrier, while the common differential, the flip work order, and richer carriers remain unexecuted, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# States And Dynamics On The Two-Block Algebra
+
+**Date:** 2026-08-17
+
+**Campaign block:** 133
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.py`](../scripts/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.py)
+
+## 1. Result Up Front
+
+[Block 132](ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+closed onto the following handoff next gate, anchored byte-exactly at
+`docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md:16`
+and elaborated in its Next Decision:
+
+> States and dynamics on the two-block algebra; the flip work order; the
+> common nilpotent differential.
+
+**THE TWO-BLOCK STATES-AND-DYNAMICS THEOREM.** On the certified two-block
+observable algebra at each of the two rational shear fixtures, eight exact
+facts hold.
+
+1. Every state is represented uniquely by a pair of positive real symmetric
+   two-by-two density blocks whose traces sum to one. In subnormalized Bloch
+   coordinates this is a five-dimensional convex body made from two coupled
+   closed discs.
+2. Its extreme points are exactly two disjoint projective-line families: one
+   rank-one real state in the \((0,2)\) block or one rank-one real state in the
+   \((1,3)\) block. A state with weight in both central blocks is not pure.
+3. The vacuum built from the certified boundary frame is not maximally mixed.
+   Its four direction weights are the exact boundary-vector norms divided by
+   their sum. Conjugation forces equal \((1,3)\) weights, while the
+   per-sector-real \((0,2)\) weights and the two block totals are unequal.
+4. A clean quarter-trace frame-vacuum requires two independent relative
+   normalizations: equalize the \((0,2)\) norms by the square root that leaves
+   the certified field, then equalize the common \((1,3)\) norm with the even
+   block. A common overall rescaling is immaterial.
+5. Momentum counter-rotates the two blocks' quadrature planes at angular rate
+   two: the oriented signs are \(d_{02}=-2\) and \(d_{13}=+2\). The
+   four-dimensional diagonal subalgebra spanned by the two block identities
+   and two \(Z\) directions is fixed.
+6. The \(Y\) quadrature needed to close that rotation is Hermitian but not
+   real symmetric. Thus the momentum calculation is exact in the displayed
+   complex envelope, but it does not invent an automorphism group of the
+   real symmetric algebra.
+7. The balanced gravity class is the full free-phase equator
+   \((|1\rangle+e^{i\phi}|3\rangle)/\sqrt2\), not merely its two real points.
+   Its momentum-invariant admissible observables are exactly
+   \(\operatorname{span}_{\mathbb R}\{I_{13},Z_{13}\}\); the missing
+   \(Y_{13}\) quadrature makes the sine orientation invisible.
+8. The state expectations and momentum selection rules are exact. The
+   construction is a direct-sum measurement theory, not a tensor-product
+   factorization, and no dynamical law beyond supplied momentum conjugation is
+   claimed.
+
+This completes the measurement theory on the certified four-direction
+carrier. “Completes” means the complete positive normalized state space,
+its
+pure boundary, the two precisely distinguished frame vacua, the exact
+momentum response, and the measurable content of the displayed balanced
+gravity class. It does not mean that a larger carrier or an end-to-end theory
+has been constructed.
+
+Two checker refinements are substantive rather than rhetorical. First, the
+certified-frame vacuum keeps the exact inherited norm bias: it is not the
+quarter-trace state. The quarter-trace formula belongs to a separately
+normalized frame obtained only after two normalization moves (the two
+moves of the displayed ledger).
+Second, balance fixes the two magnitudes but leaves their relative phase free,
+so the gravity class is the entire complex equator. Its restriction to the
+real symmetric algebra cannot see the sine quadrature.
+
+The resulting picture is exact and bounded. States form the five-dimensional
+join of two symmetric discs. Momentum counter-rotates the \((0,2)\) and
+\((1,3)\) quadrature planes with signs \((-2,+2)\) and fixes the diagonal
+four-dimensional subalgebra. Balanced gravity supplies a free-phase equator
+with the exact expectations and invariant-observable test given below.
+
+The common differential, the cell-cutting flip work order, richer carriers,
+the completed ADM/history transporter, joint gravity, the gravity constraint
+quotient beyond the displayed carrier, Records, audit retention, axiom
+amendment, obligation retirement, and TOE percentage movement remain outside
+this theorem.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md), inherited
+content-bound through the certified chain. No newer authority claim is made
+here, and no audit verdict is imported.
+
+The exact trace and algebra parent is
+[Block 132](ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md).
+It supplies the certified algebra
+
+\[
+ \mathcal O_{\rm two}
+ =\mathcal O_{02}\oplus\mathcal O_{13}
+ \cong\operatorname{Sym}_2(\mathbb R)
+       \oplus\operatorname{Sym}_2(\mathbb R),                 \tag{1}
+\]
+
+the two scalar transfer blocks, the exact boundary-vector norms, the forced
+odd-pair norm equality, the even-pair norm gauge and field caveat, and the
+momentum labels. Block 132 expressly leaves states and dynamics live; it does
+not supply the measurement theorem proved here.
+
+[Block 131](ADMISSIBILITY_DIRAC_KAHLER_CONJUGATE_PAIR_OBSERVABLE_SPACE_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+is the conjugate-pair authority. Its forced relation
+\(y_3=\overline{y_1}\) has the physical consequence that the certified vacuum
+is conditionally maximally mixed on the \((1,3)\) block.
+
+[Block 124](ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+is the displayed balanced-gravity class authority. The present note gives
+that class its exact measurable content; it does not enlarge the gravity
+carrier or complete joint gravity.
+
+The executed contract is:
+
+1. the certified two-block algebra at both rational shear fixtures;
+2. the complete positive normalized functional space under the trace pairing;
+3. its five-dimensional subnormalized-disc coordinates;
+4. the complete extreme-point classification, one
+   \(\mathbb{RP}^1\) family per block;
+5. the certified-frame vacuum and all four exact norm weights;
+6. the forced \((1,3)\) conditional maximal mixing, the \((0,2)\) bias, and
+   the unequal central block weights;
+7. the two-move normalization ledger and its field-leaving first move;
+8. the normalized-frame quarter-trace state and the frame distinction;
+9. the exact rate-two block counter-rotation with oriented signs
+   \(d_{02}=-2\) and \(d_{13}=+2\);
+10. the fixed four-dimensional diagonal subalgebra and exact commutator
+    selection rule;
+11. the balanced free-phase equator, its exact expectations, and the
+    \(Y\)-exclusion; and
+12. one narrow wall W1, leaving the common differential, the flip work order,
+    and richer carriers live.
+
+The assigned primary runner is the path recorded in the front matter. This
+note does not invent a replay footer or a `TOTAL` line. The five fixed N5
+resolution lines are reproduced in Section 9 as the textual contract
+specified for that runner.
+
+The scope is the two certified rational shear fixtures and the displayed
+four-direction positive carrier only. The complex two-by-two envelope below
+is bookkeeping for supplied momentum conjugation and gravity phase; it is not
+a claim of a richer physical carrier. No tensor-product structure, common
+differential, new Hamiltonian, general-shear interpolation, or transporter
+completion follows.
+
+## 3. The State Space
+
+Fix one of the two certified rational shear fixtures and suppress its label.
+In the normalized real frames of Block 132, use
+
+\[
+ I=\begin{pmatrix}1&0\\0&1\end{pmatrix},\qquad
+ X=\begin{pmatrix}0&1\\1&0\end{pmatrix},\qquad
+ Z=\begin{pmatrix}1&0\\0&-1\end{pmatrix}.       \tag{2}
+\]
+
+Every observable has a unique form
+
+\[
+ A=A_{02}\oplus A_{13},\qquad
+ A_b=a_bI+b_bX+c_bZ,\qquad b\in\{02,13\}.       \tag{3}
+\]
+
+A state is a positive normalized real linear functional on the Jordan
+algebra (1). Under the trace pairing it has a unique pair of real symmetric
+positive-semidefinite density blocks,
+
+\[
+ \omega(A)=\operatorname{Tr}(R_{02}A_{02})
+           +\operatorname{Tr}(R_{13}A_{13}),
+ \qquad R_{02},R_{13}\succeq0,\qquad
+ \operatorname{Tr}R_{02}+\operatorname{Tr}R_{13}=1.           \tag{4}
+\]
+
+Indeed, positivity on the squares in each symmetric block makes the trace
+representer positive semidefinite, and any pair in (4) is positive because
+
+\[
+ \operatorname{Tr}(R_b B_b^2)\ge0
+ \quad\text{for every real symmetric }B_b.                    \tag{5}
+\]
+
+Write the two blocks in subnormalized Bloch coordinates:
+
+\[
+ R_b=\frac12\left(w_bI+x_bX+z_bZ\right).                      \tag{6}
+\]
+
+The eigenvalues are
+
+\[
+ \lambda_{b,\pm}
+ =\frac12\left(w_b\pm\sqrt{x_b^2+z_b^2}\right),              \tag{7}
+\]
+
+so (4) is equivalent, in both directions, to
+
+\[
+ \boxed{
+ \begin{aligned}
+  &w_{02}\ge0,\quad w_{13}\ge0,\quad w_{02}+w_{13}=1,\\
+  &x_{02}^2+z_{02}^2\le w_{02}^2,\qquad
+   x_{13}^2+z_{13}^2\le w_{13}^2.
+ \end{aligned}}                                               \tag{8}
+\]
+
+Thus the state space is the five-dimensional convex body of paired symmetric
+disc states: two three-dimensional positive cones cut by one trace
+hyperplane. For a fixed nonzero block weight \(w_b\), the conditional state
+is the closed unit disc
+\((x_b/w_b)^2+(z_b/w_b)^2\le1\). At \(w_b=0\), positivity forces that disc to
+collapse to its apex.
+
+The exact expectation formula is
+
+\[
+ \boxed{
+ \omega(A)
+ =\sum_{b\in\{02,13\}}
+   \left(w_ba_b+x_bb_b+z_bc_b\right).}                         \tag{9}
+\]
+
+Equation (9) is the complete measurement rule for the displayed algebra. It
+contains no fitted coefficient and no unlisted tensor factor.
+
+The extreme points can also be classified in both directions. If both
+central weights are positive, then
+
+\[
+ \omega=w_{02}\widehat\omega_{02}
+       +w_{13}\widehat\omega_{13}                             \tag{10}
+\]
+
+is a nontrivial convex decomposition into states supported on the two
+central blocks. If the only occupied block has a rank-two density, its
+spectral decomposition is again nontrivial. Hence a pure state must occupy
+one block and have rank one there. Conversely such a rank-one state is
+extreme.
+
+For a real unit vector
+
+\[
+ v(\theta)=\begin{pmatrix}\cos\theta\\\sin\theta\end{pmatrix},
+ \qquad \theta\sim\theta+\pi,
+\]
+
+the rank-one density is
+
+\[
+ v(\theta)v(\theta)^T
+ =\frac12\left(I+\sin(2\theta)X+\cos(2\theta)Z\right).        \tag{11}
+\]
+
+Therefore
+
+\[
+ \boxed{\operatorname{Pure}(\mathfrak S(\mathcal O_{\rm two}))
+ =\mathbb{RP}^1_{02}\;\sqcup\;\mathbb{RP}^1_{13}.}           \tag{12}
+\]
+
+There is one projective-line family of pure states per block. The disjoint
+union in (12), the variable central weight in (8), and the convex splitting
+in (10) are direct-sum facts. They do not define two subsystems or a
+tensor-product state space.
+
+## 4. The Certified Vacuum
+
+Let \(N_p>0\) be the exact reflection-quotient norm of the certified boundary
+vector \(y_p\), as in Block 132. Use the two pinned positive norms
+
+\[
+ \boxed{
+ q_0:=N_0,\qquad q_1:=N_1,\qquad
+ N_2=g_{02}q_0,\qquad N_3=q_1,\qquad
+ g_{02}>0,\quad g_{02}\ne1.}                                \tag{13}
+\]
+
+The relation \(N_3=q_1=N_1\) is forced by conjugation. The inequality follows
+from the certified nonsquare result for \(g_{02}\), since \(1\) is a square.
+Define
+
+\[
+ \mathcal N:=q_0(1+g_{02})+2q_1.                            \tag{14}
+\]
+
+The vacuum attached to the supplied boundary frame is the normalized frame
+functional
+
+\[
+ \Omega_{\rm cert}(A)
+ :=\frac1{\mathcal N}\sum_{p\in\{0,2,1,3\}}
+       \langle y_p,A y_p\rangle.                              \tag{15}
+\]
+
+Orthogonality of the four displayed directions gives the exact density
+blocks
+
+\[
+ \boxed{
+ R_{02}^{\rm cert}=\frac1{\mathcal N}
+   \begin{pmatrix}q_0&0\\0&g_{02}q_0\end{pmatrix},\qquad
+ R_{13}^{\rm cert}=\frac{q_1}{\mathcal N}I.}                 \tag{16}
+\]
+
+Equivalently, in literal momentum order \((0,1,2,3)\),
+
+\[
+ D_{\rm cert}
+ =\frac1{\mathcal N}
+   \operatorname{diag}(q_0,q_1,g_{02}q_0,q_1).               \tag{16a}
+\]
+
+The exact fixture pins make \(q_0,q_1\), and hence all four entries, positive
+at both rational shears. No decimal reconstruction enters (13)--(16a).
+
+Equivalently, for the four directional idempotents
+
+\[
+ E_0=\frac12(I_{02}+Z_{02}),\quad
+ E_2=\frac12(I_{02}-Z_{02}),\quad
+ E_1=\frac12(I_{13}+Z_{13}),\quad
+ E_3=\frac12(I_{13}-Z_{13}),
+\]
+
+the exact direction weights are
+
+\[
+ \boxed{
+ \Omega_{\rm cert}(E_0)=\frac{q_0}{\mathcal N},\quad
+ \Omega_{\rm cert}(E_2)=\frac{g_{02}q_0}{\mathcal N},\quad
+ \Omega_{\rm cert}(E_1)=\Omega_{\rm cert}(E_3)
+ =\frac{q_1}{\mathcal N}.}
+                                                               \tag{17}
+\]
+
+They are proportional to the boundary-vector norms, not postulated equal
+probabilities. The central block weights and the even imbalance are
+
+\[
+ \boxed{
+ W_{02}=\frac{q_0(1+g_{02})}{\mathcal N},\qquad
+ W_{13}=\frac{2q_1}{\mathcal N},\qquad
+ W_{02}\ne W_{13},}                                          \tag{18}
+\]
+
+\[
+ \boxed{
+ \Delta_{02}:=\Omega_{\rm cert}(Z_{02})
+ =\frac{q_0(1-g_{02})}{\mathcal N}\ne0.}                    \tag{19}
+\]
+
+The exact fixture calculations certify the final inequality in (18) at both
+rational shears. It is logically separate from \(N_0\ne N_2\).
+
+Conditioning (16) on each central block makes the two reality regimes
+transparent:
+
+\[
+ \frac{R_{13}^{\rm cert}}{W_{13}}=\frac12I,\qquad
+ \frac{R_{02}^{\rm cert}}{W_{02}}
+ =\frac1{1+g_{02}}\begin{pmatrix}1&0\\0&g_{02}\end{pmatrix}
+ =\frac12\left(I+\frac{1-g_{02}}{1+g_{02}}Z\right).          \tag{20}
+\]
+
+Thus the conjugate block is maximally mixed by force, the per-sector-real
+block is biased, and the block totals are unequal. For a general observable
+(3), the exact certified-vacuum expectation is
+
+\[
+ \boxed{
+ \Omega_{\rm cert}(A)
+ =W_{02}a_{02}+\Delta_{02}c_{02}+W_{13}a_{13}.}               \tag{21}
+\]
+
+Both pair-mixing expectations vanish, as does the odd \(Z\) expectation.
+Equations (17)--(21) are the biased certified vacuum theorem. In particular,
+calling this state maximally mixed would erase both exact inequalities.
+
+## 5. The Normalization Ledger
+
+The clean quarter-trace frame requires exactly two independent relative
+normalizations. A common positive rescaling of all four directions cancels
+from the normalized frame functional and is not a third move.
+
+**Move 1 — equalize the per-sector-real pair.** Hold \(y_0\) fixed and set
+
+\[
+ y_2' =g_{02}^{-1/2}y_2,\qquad
+ N_2'=g_{02}^{-1}N_2=N_0.                                    \tag{22}
+\]
+
+This is admissible because the two even directions may be rescaled by
+independent nonzero real numbers. It is exactly the field-leaving
+square-root equalization certified in
+[Block 132](ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md):
+\(g_{02}^{-1/2}\) does not lie in the certified root field and is available
+after adjoining the positive square root.
+
+**Move 2 — equalize the two blocks.** After (22), keep the even block fixed
+and apply the common positive odd-pair rescaling
+
+\[
+ y_1'=c_{13}y_1,\qquad y_3'=c_{13}y_3,\qquad
+ c_{13}:=\sqrt{\frac{q_0}{q_1}}.                             \tag{23}
+\]
+
+The common real factor preserves \(y_3'=\overline{y_1'}\) and gives
+
+\[
+ N_1'=N_3'=c_{13}^2q_1=q_0.                                 \tag{24}
+\]
+
+No claim about the smallest exact field containing \(c_{13}\) is needed.
+Equation (23) is an admissible real frame normalization. Equations (22)--(24)
+fix the two independent norm ratios; only an irrelevant common scale remains.
+
+All four normalized-frame direction norms are equal. The frame-vacuum built
+from that new frame is therefore
+
+\[
+ \boxed{
+ \Omega_{\rm norm}(A)
+ =\frac14\left(\operatorname{Tr}A_{02}
+                +\operatorname{Tr}A_{13}\right),}            \tag{25}
+\]
+
+with
+
+\[
+ \Omega_{\rm norm}(E_p)=\frac14,\qquad
+ \Omega_{\rm norm}(I_{02})=\Omega_{\rm norm}(I_{13})=\frac12.
+                                                               \tag{26}
+\]
+
+The ledger prevents a frame conflation. The supplied certified frame is
+canonical for the inherited exact package and for \(\Omega_{\rm cert}\),
+including its norm-ratio bias. The fully normalized frame is canonical for
+the clean unit-Gram matrix presentation and for its own quarter-trace
+frame-vacuum \(\Omega_{\rm norm}\). Equation (25) is not a coordinate rewrite
+of (21): changing the generating frame changes the frame functional. In
+particular, an invertible coordinate change applied to one fixed state could
+not change its expectations on the central idempotents.
+
+## 6. The Momentum Dynamics
+
+The rate-two rotation is most transparent in the minimal complex Hermitian
+envelope used only for this calculation. Add the Pauli quadrature
+
+\[
+ Y=\begin{pmatrix}0&-i\\i&0\end{pmatrix}.                     \tag{27}
+\]
+
+Unlike \(I,X,Z\), the matrix \(Y\) is not real symmetric and therefore is not
+an element of either admissible observable block in (1). The certified
+oriented momentum differences have opposite signs:
+
+\[
+ \boxed{d_{02}=0-2=-2,\qquad d_{13}=3-1=+2,\qquad
+        \sigma_b:=\frac{d_b}{2}\in\{-1,+1\}.}                \tag{28}
+\]
+
+The certified quadrature orientations are \((2,0)\) for the even block and
+\((1,3)\) for the conjugate block; this is why the two ordered differences
+have opposite signs. A common additive momentum in either block contributes
+only a scalar phase. With
+
+\[
+ \alpha_t(A_b):=e^{itP_b}A_be^{-itP_b},
+\]
+
+direct conjugation gives, block by block,
+
+\[
+ \boxed{
+ \begin{aligned}
+  \alpha_t(X_b)
+    &=\cos(2t)X_b+\sigma_b\sin(2t)Y_b,\\
+  \alpha_t(Y_b)
+    &=-\sigma_b\sin(2t)X_b+\cos(2t)Y_b,\\
+  \alpha_t(I_b)&=I_b,\qquad \alpha_t(Z_b)=Z_b.
+ \end{aligned}}                                               \tag{29}
+\]
+
+In particular, the two quadrature planes counter-rotate:
+
+\[
+ \boxed{
+ \begin{array}{ll}
+  X_{02}(t)=\cos(2t)X_{02}-\sin(2t)Y_{02},&
+  Y_{02}(t)=\sin(2t)X_{02}+\cos(2t)Y_{02},\\
+  X_{13}(t)=\cos(2t)X_{13}+\sin(2t)Y_{13},&
+  Y_{13}(t)=-\sin(2t)X_{13}+\cos(2t)Y_{13}.
+ \end{array}}                                                  \tag{30}
+\]
+
+Both angular speeds have magnitude two; the signs are \((-2,+2)\), not a
+shared orientation. This is the precise rate-two counter-rotating quadrature
+dynamics.
+
+For a complex-envelope density block
+
+\[
+ R_b^{\mathbb C}
+ =\frac12\left(w_bI+x_bX+y_bY+z_bZ\right),\qquad
+ x_b^2+y_b^2+z_b^2\le w_b^2,
+\]
+
+the dual state orbit
+\(\omega_t(A):=\omega(\alpha_t(A))\) has exact coordinates
+
+\[
+ \boxed{
+ \begin{pmatrix}x_b(t)\\y_b(t)\end{pmatrix}
+ =\begin{pmatrix}\cos(2t)&\sigma_b\sin(2t)\\
+                 -\sigma_b\sin(2t)&\cos(2t)
+   \end{pmatrix}
+   \begin{pmatrix}x_b\\y_b\end{pmatrix},\qquad
+ w_b(t)=w_b,\quad z_b(t)=z_b.}                               \tag{31}
+\]
+
+The exact conserved admissible algebra is
+
+\[
+ \boxed{
+ \mathcal D
+ :=\operatorname{span}_{\mathbb R}
+   \{I_{02},Z_{02},I_{13},Z_{13}\},\qquad
+ \dim_{\mathbb R}\mathcal D=4.}                              \tag{32}
+\]
+
+Indeed, for the real symmetric observable (3),
+
+\[
+ [P_b,A_b]=-2i\sigma_b b_bY_b,\qquad
+ \boxed{
+ [P,A]=0
+ \quad\Longleftrightarrow\quad b_{02}=b_{13}=0
+ \quad\Longleftrightarrow\quad A\in\mathcal D.}              \tag{33}
+\]
+
+This is the exact momentum selection rule. Pair-diagonal matrix elements are
+conserved, and an allowed pair-mixing \(X_b\) direction has momentum change
+of magnitude two and is sent toward the excluded \(Y_b\) quadrature with the
+block sign in (30).
+
+For a fixed complex-envelope density displayed above, the expectation of the
+real observable (3) at time \(t\) is
+
+\[
+ \boxed{
+ \omega_t(A)=\sum_b\left[
+   w_ba_b+z_bc_b+
+   b_b\bigl(x_b\cos(2t)+\sigma_by_b\sin(2t)\bigr)
+ \right].}                                                    \tag{34}
+\]
+
+The state on the real algebra determines \(w_b,x_b,z_b\), but it does not
+measure the invisible \(y_b\). For the unique real trace representer in (4),
+the canonical complex embedding has \(y_b=0\), and (34) reduces exactly to
+
+\[
+ \omega_t^{\rm real}(A)
+ =\sum_b\left(w_ba_b+z_bc_b+b_bx_b\cos(2t)\right).             \tag{35}
+\]
+
+Equations (28)--(35) certify the supplied momentum response and its selection
+rules. The restricted maps \(x_b\mapsto x_b\cos(2t)\) do not compose as a
+one-parameter group on the five-dimensional real state body. Choosing a
+different unmeasured \(y_b\), or projecting after every time step, would be
+extra dynamical input. No such additional law is claimed.
+
+## 7. The Balanced Equator
+
+The balanced class supplied by
+[Block 124](ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+has equal nonzero magnitudes in the \((1,3)\) pair. After quotienting the
+common phase and normalizing, its displayed class map is
+
+\[
+ [(c_1,c_3)]_{\rm bal},\quad |c_1|=|c_3|\ne0,\quad
+ \frac{c_3}{c_1}=e^{i\phi}
+ \quad\longmapsto\quad
+ |g_\phi\rangle
+ :=\frac{|1\rangle+e^{i\phi}|3\rangle}{\sqrt2},
+ \quad \phi\in\mathbb R/2\pi\mathbb Z.                      \tag{36}
+\]
+
+Thus the corrected identification is the full free-phase equator, not the
+two real rays obtained by setting \(\phi\in\{0,\pi\}\). Allowing a fixed
+nonzero visibility \(0<r\le1\), its balanced envelope density is
+
+\[
+ G_{r,\phi}
+ =\frac12\left(I_{13}+r\cos\phi\,X_{13}
+                       +r\sin\phi\,Y_{13}\right).            \tag{37}
+\]
+
+The normalized rays (36) have \(r=1\); smaller positive \(r\) records the
+same full free-phase orbit at reduced coherence. Momentum acts without
+leaving either orbit:
+
+\[
+ U_{13}(t)|g_\phi\rangle
+ \sim |g_{\phi-2t}\rangle.                                  \tag{38}
+\]
+
+For every admissible odd-block observable
+
+\[
+ A_{13}=aI_{13}+bX_{13}+cZ_{13},
+\]
+
+the exact expectation is
+
+\[
+ \boxed{\operatorname{Tr}(G_{r,\phi}A_{13})
+ =a+rb\cos\phi,\qquad
+ \langle Z_{13}\rangle_{r,\phi}=0,\quad
+ \langle X_{13}\rangle_{r,\phi}=r\cos\phi.}                 \tag{39}
+\]
+
+The missing sine datum would be
+\(\operatorname{Tr}(G_{r,\phi}Y_{13})=r\sin\phi\), but
+\(Y_{13}\notin\mathcal O_{13}\). The real symmetric algebra consequently
+identifies \(\phi\) with \(-\phi\) in all its expectations. The phase freedom
+invisible to a real symmetric algebra is precisely this sine orientation,
+not the cosine dependence in (39).
+
+The Y quadrature is not an admissible element of the real symmetric algebra.
+
+An admissible observable is invariant along the whole momentum-shifted
+equator exactly when its expectation in (39) is independent of \(\phi\). Hence
+
+\[
+ \boxed{
+ \mathcal O_{13}^{\rm bal,inv}
+ =\operatorname{span}_{\mathbb R}\{I_{13},Z_{13}\}.}         \tag{40}
+\]
+
+The \(Z\) expectation happens to vanish on every balanced ray, but \(Z\)
+remains a distinct conserved observable. The \(X\) expectation varies, and
+no admissible \(Y\) is available to close its rate-two rotation. This is the
+precise sense in which the balanced sector measures only the two-dimensional
+span \(\{I,Z\}\) invariantly.
+
+There is no conflict between (12) and (36). Equation (12) classifies pure
+states of the real Jordan algebra. Equation (36) classifies pure rays in the
+displayed complex gravity carrier. Restricting (37) to real symmetric
+observables gives
+
+\[
+ G_{r,\phi}\big|_{\mathcal O_{13}}
+ \longleftrightarrow
+ \frac12\left(I_{13}+r\cos\phi\,X_{13}\right),               \tag{41}
+\]
+
+which is an interior real-algebra state unless \(r=1\) and
+\(\phi\in\{0,\pi\}\). The full equator survives as the gravity class, while
+its real-algebra measurement image forgets the excluded sine quadrature.
+
+## 8. The Summary Table And The Honest Closer
+
+The exact basis summary has six rows. Here “balanced-measurable” means
+phase-invariant on the displayed Block 124 class; “null” means that the
+gravity class has no support in the even block.
+
+| observable | \(P\)-conserving | balanced-measurable | certified-frame vacuum value |
+|---|---|---|---|
+| \(I_{02}\) | yes | null | \(\dfrac{q_0(g_{02}+1)}{g_{02}q_0+q_0+2q_1}\) |
+| \(Z_{02}\) | yes | null | \(\dfrac{-q_0(g_{02}-1)}{g_{02}q_0+q_0+2q_1}\) |
+| \(X_{02}\) | no | null | \(0\) |
+| \(I_{13}\) | yes | yes | \(\dfrac{2q_1}{g_{02}q_0+q_0+2q_1}\) |
+| \(Z_{13}\) | yes | yes | \(0\) |
+| \(X_{13}\) | no | no | \(0\) |
+
+The \(X_{13}\) expectation at a fixed phase is \(r\cos\phi\), but it is not
+phase-invariant and therefore receives “no” in the balanced-measurable
+column. The table simultaneously records the exact conserving selection
+rule, the balanced invariant measurement content, and all six
+certified-vacuum basis expectations.
+
+The exact expectation and momentum selection rules are therefore:
+
+\[
+ \omega(A)=\sum_b(w_ba_b+x_bb_b+z_bc_b),\qquad
+ [P,A]=0\Longleftrightarrow A\in\mathcal D,                   \tag{42}
+\]
+
+with the certified-vacuum specialization (21), normalized-frame
+specialization (25), dynamical response (34)--(35), and balanced
+specialization (39). Equations (8), (12), (16), (25), (30), and (40) supply,
+respectively, the state body, pure boundary, certified vacuum,
+normalized-frame vacuum, counter-rotation, and balanced invariant algebra.
+These formulas exhaust the measurement content asserted here.
+
+The direct sum in (1) has two central alternatives. Its state space is their
+convex join, and a pure state occupies only one alternative. Nothing in those
+facts supplies a factorization
+\(\mathcal H_A\otimes\mathcal H_B\), product states, entanglement, partial
+traces, or a tensor-product observable algebra. A four-dimensional carrier is
+not by itself a pair of two-level subsystems.
+
+Likewise, supplied momentum conjugation is the only dynamics used. The
+complex envelope records the quadrature that the real algebra omits; it is
+not enlarged into a richer observable algebra. No dissipative projection,
+Hamiltonian selection beyond \(P\), common differential, or additional
+dynamical law is claimed.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded, positive-dominant dual wall.
+
+- W1 — **CERTIFIED-FRAME BIAS AND REAL-ALGEBRA PHASE WALL:** the measurement
+  theory is complete on the displayed two-block algebra, but the certified
+  frame's vacuum is **NOT** maximally mixed—the quarter-trace form is a
+  normalized-frame statement after two relative moves—and the balanced
+  sector measures only the two-dimensional span
+  \(\operatorname{span}_{\mathbb R}\{I,Z\}\) invariantly because \(Y\) is not
+  an admissible real symmetric observable.
+
+W1 is positive-dominant because its central terminal is the constructed
+five-dimensional state body with exact vacua, expectations, momentum
+response, pure-state boundary, and gravity-equator measurement map. Its two
+boundaries prevent the certified and normalized frames from being conflated
+and prevent an excluded complex quadrature from being counted as an
+admissible observable.
+
+The certified frame's vacuum is NOT maximally mixed. The quarter-trace form is
+a normalized-frame statement. The balanced sector measures only the
+two-dimensional span{I, Z} invariantly; it does not measure the full algebra
+without a phase reference.
+
+The scope remains narrow. The wall concerns the certified two-block algebra
+at two rational shear fixtures and the displayed gravity class only. Momentum
+conjugation is evaluated exactly, but no extra autonomous dynamics on the real
+state body is added. The common differential, the flip work order, and richer
+carriers remain live.
+
+The normalized quarter-trace state is legitimate in its stated frame; W1
+does not prohibit that normalization. The free-phase equator is likewise
+legitimate in the displayed complex gravity carrier; W1 classifies only what
+its real symmetric measurement algebra can distinguish and conserve.
+
+W1 is not an OS no-go and not a curved OS no-go.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). The certified vacuum,
+normalization ledger, momentum orbit, balanced class, complete summary, and
+live forward work remain separate.
+
+1. **(a) PROVED — biased certified-vacuum theorem / form the normalized frame
+   functional from the four supplied boundary vectors / direction weights are
+   \(N_p/\mathcal N\), the \((1,3)\) conditional state is \(I/2\), the
+   \((0,2)\)
+   conditional state is biased, and the two central block totals are
+   unequal.** This is the strongest route because it fixes the actual
+   inherited-frame vacuum and blocks the unqualified quarter-trace upgrade.
+2. **(b) PROVED — normalization ledger / quotient the four positive norm
+   scales by one common irrelevant scale while respecting both reality
+   regimes / exactly two relative moves produce equal norms and the clean
+   quarter-trace frame-vacuum.** The even-pair move uses the certified-field-
+   leaving square root from Block 132.
+3. **(c) PROVED — counter-rotation / conjugate the two oriented
+   momentum-gap-two blocks in the complex Hermitian envelope / the
+   \((0,2)\) and \((1,3)\) quadrature planes rotate oppositely at rate two,
+   with signs \((-2,+2)\), while the four-dimensional diagonal algebra is
+   fixed.** No second Hamiltonian or projection rule is introduced.
+4. **(d) PROVED — equator plus \(Y\)-exclusion / display the balanced class
+   by
+   its free relative phase and restrict its density to real symmetric
+   observables / the class is the full free-phase equator, its sine orientation
+   is invisible, and its invariant admissible algebra is exactly
+   \(\operatorname{span}_{\mathbb R}\{I,Z\}\).** This corrects a reduction to
+   two real phase choices.
+5. **(e) PROVED — summary table / combine the state classification, four
+   certified norm weights, two frame vacua, expectation formulas, and
+   commutator test / the complete bounded measurement content is the six rows
+   of Section 8, with no tensor structure.** Each row has an explicit scope
+   boundary.
+6. **(f) UNTESTED-LIVE — forward construction / build the common nilpotent
+   differential, execute the flip work order, and test richer carriers / decide
+   whether these displayed state and momentum results participate in one
+   larger physical dynamics.** None of those terminals is imported.
+
+The completed ADM/history transporter, joint gravity, and the gravity
+constraint quotient beyond the displayed carrier remain downstream of row
+(f). W1 consumes none of those routes.
+
+### N2 — Wall-Independence Audit
+
+W1 is independent of Block 132's algebra-classification wall while depending
+on that algebra as its input object.
+
+[Block 132](ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md)
+classified which endomorphisms are admissible. Its mechanisms were the second
+degeneracy, separate reality regimes, exact square-class test, blockwise
+adjointness, and even-odd transfer-rate split. Its terminal was the
+six-dimensional algebra \(\operatorname{Sym}_2(\mathbb R)^{\oplus2}\), with
+states and dynamics expressly unconstructed.
+
+The present W1 classifies positive normalized functionals on that algebra,
+the certified and normalized frame-vacua, and the supplied momentum action on
+their quadratures. Its new mechanisms are the positive trace dual, convex
+extremality, exact norm weighting, the two-ratio normalization quotient, and
+restriction of the complex phase orbit to the real symmetric algebra. Its
+terminal is a five-dimensional measurement theory with a precise phase wall.
+
+The two walls therefore have distinct objects, mechanisms, and terminals:
+
+\[
+ \begin{array}{c|c|c|c}
+ \text{block} & \text{object} & \text{mechanism} & \text{terminal}\\\hline
+ 132 & \text{admissible endomorphisms} &
+       \text{reality, adjoint, transfer} &
+       \operatorname{Sym}_2(\mathbb R)^{\oplus2}\\
+ 133 & \text{states and supplied momentum action} &
+       \text{positive trace dual, norm weights, phase restriction} &
+       \text{five-dimensional state body plus W1}
+ \end{array}                                                   \tag{43}
+\]
+
+There is an intentional trace dependency. Without Block 132 there is no
+certified algebra on which to classify states. But Block 132 neither computes
+the density body, selects a vacuum, distinguishes the two frame-vacua,
+integrates momentum conjugation, nor identifies the full balanced equator.
+Conversely, none of the present state calculations changes Block 132's
+six-dimensional algebra or its field caveat.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified explicitly.
+Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| certified two-block observable algebra | exactly Block 132's displayed direct-sum algebra |
+| both rational shear fixtures | exactly the two supplied fixtures, with no interpolation |
+| on the certified two-block observable algebra at both rational shear fixtures | the theorem's complete finite quantifier |
+| measurement theory is complete | the state, expectation, frame, and supplied-momentum results in Sections 3--8 |
+| the measurement theory is complete | completion on the displayed algebra, not an end-to-end theory |
+| state space | positive normalized functionals under the trace pairing |
+| five-dimensional convex body | the two six-parameter symmetric density blocks cut by positivity and one trace equation |
+| paired symmetric disc states | the two subnormalized Bloch discs in (8) |
+| the state space is the five-dimensional convex body of paired symmetric disc states | the both-ways classification (4)--(8) |
+| one projective-line family of pure states per block | the two components of (12), not a cross-block superposition |
+| certified-frame vacuum | the frame functional in (15) |
+| biased central mixture | the unequal central weights (18) together with the conditional states (20) |
+| direction weights proportional to the boundary-vector norms | the four exact ratios in (17) |
+| the certified-frame vacuum is the biased central mixture with direction weights proportional to the boundary-vector norms | equations (14)--(21), not equal prior probabilities |
+| conjugate block maximally mixed by force | the first equality in (20), forced by \(N_1=N_3\) |
+| the conjugate block maximally mixed by force | conditional odd-block maximal mixing, not total four-direction mixing |
+| per-sector-real block biased | the nonzero even \(Z\) coordinate in (19)--(20) |
+| the per-sector-real block biased | the certified-frame inequality only |
+| block totals unequal | the exact final inequality in (18) |
+| the block totals unequal | unequal central weights, not unequal algebra dimensions |
+| the conjugate block maximally mixed by force, the per-sector-real block biased, the block totals unequal | the three certified-vacuum refinements kept logically distinct |
+| clean quarter-trace presentation | the normalized-frame formula (25) |
+| exactly two admissible normalizations | the two independent relative moves (22)--(24) |
+| field-leaving square-root equalization | the \(g_{02}^{-1/2}\) move in (22) |
+| the field-leaving square-root equalization | Block 132's exact nonsquare caveat carried into the ledger |
+| clean quarter-trace presentation requires exactly two admissible normalizations including the field-leaving square-root equalization | the complete Section 5 ledger, modulo a common irrelevant scale |
+| whose clean quarter-trace presentation requires exactly two admissible normalizations including the field-leaving square-root equalization | the scope sentence's frame distinction, not a rewrite of the certified vacuum |
+| momentum generates rate-two counter-rotating quadrature dynamics | equations (28)--(31) in the displayed complex envelope |
+| rate-two counter-rotating quadrature dynamics | oppositely oriented \((0,2)\) and \((1,3)\) rotations with signs \((-2,+2)\) |
+| momentum counter-rotates the two blocks' quadratures at rate two | the exact per-mode statement emitted in the N5 contract |
+| diagonal four-dimensional subalgebra conserved | the fixed algebra \(\mathcal D\) in (32)--(33) |
+| the diagonal four-dimensional subalgebra conserved | both block identities and both \(Z\) directions |
+| momentum generates rate-two counter-rotating quadrature dynamics with the diagonal four-dimensional subalgebra conserved | the exact momentum theorem, not an added law |
+| balanced gravity sector | Block 124's displayed equal-magnitude \((1,3)\) class |
+| full free-phase equator | all \(\phi\in\mathbb R/2\pi\mathbb Z\) in (36), not two points |
+| the balanced gravity sector is the full free-phase equator | the corrected class identification (36)--(37) |
+| invariant observables | observables with phase-independent expectation along (38) |
+| exactly the identity and the z direction | the two-dimensional fixed algebra in (40) |
+| invariant observables are exactly the identity and the z direction | necessity and sufficiency from (39) |
+| y quadrature | the Hermitian imaginary matrix in (27) |
+| y quadrature is not an admissible element of the real symmetric algebra | the exact reason the real algebra is not closed under quadrature rotation |
+| the y quadrature is not an admissible element of the real symmetric algebra | \(Y\notin\operatorname{Sym}_2(\mathbb R)\), not an approximate suppression |
+| the balanced gravity sector is the full free-phase equator whose invariant observables are exactly the identity and the z direction because the y quadrature is not an admissible element of the real symmetric algebra | the complete corrected gravity measurement statement (36)--(41) |
+| exact expectations | equations (9), (21), (25), (35), and (39) |
+| momentum selection rules | equation (33), with gap two in each block |
+| exact expectations and momentum selection rules certified | the summary identities in (42) and their specializations |
+| no tensor-product structure | the direct-sum and convex-join boundary after (42) |
+| additional dynamical law | any rule beyond the supplied momentum conjugation |
+| no tensor-product structure or additional dynamical law claimed | the two independent honest closers in Section 8 |
+| the certified frame's vacuum is not maximally mixed | W1's inherited-frame boundary, distinct from the normalized frame |
+| the certified-frame vacuum is not maximally mixed | the hyphenated scope form of the same boundary |
+| the quarter-trace form is a normalized-frame statement | W1's exact frame qualifier |
+| the balanced sector measures only the two-dimensional span{i, z} | W1's invariant-measurement boundary in plain-text scope form |
+| the balanced gravity sector measures only the two-dimensional span{i,z} | the gravity-qualified plain-text form of (40) |
+| the phase freedom invisible to a real symmetric algebra | the sine orientation omitted by the admissible algebra |
+| differences (-2,+2) | the two exact oriented momentum gaps in (28) |
+| full bloch equator | the runner's compact name for the free-phase orbit (37) |
+| full free-relative-phase bloch equator | the equal-magnitude class with unrestricted relative phase |
+| phi-invariant admissible observables are exactly span{i,z} | the plain-text form of (40) |
+| y is not an admissible sym_2(r) observable | the plain-text exclusion certified by (27) |
+| exact expectations and selection rules are complete on the direct sum | the six-row table and equations (9), (33), and (39) |
+| no tensor-product structure is claimed | the exact direct-sum firewall |
+| no additional dynamical law is claimed | the projected-cosine non-group firewall |
+| the certified package's measurement physics is complete with exact expectations and selection rules | the bounded per-block N5 terminal |
+| no-go discipline verdict | the adjudication at the end of N8 |
+| pass only for narrow w1 | no broader positive or negative terminal |
+| no-go discipline verdict: pass only for narrow w1 | the exact combined verdict in plain-text scope form |
+| the differential and richer carriers live | W1 leaves both downstream construction classes open |
+| the common differential and richer carriers remain live | the explicit common-program boundary |
+| common differential | the unexecuted common nilpotent construction |
+| the common differential | the first next-decision route, still live |
+| flip work order | the unexecuted cell-cutting enumeration |
+| the flip work order | the second next-decision route, still live |
+| richer carriers | extensions beyond the displayed fixture and bookkeeping envelope |
+| completed adm/history transporter | downstream construction firewall |
+| the completed adm/history transporter | the scope sentence's transporter firewall |
+| joint gravity | explicitly not completed |
+| gravity constraint quotient beyond the displayed carrier | outside scope |
+| the gravity constraint quotient beyond the displayed carrier | no quotient completion follows from the state theorem |
+| records | no Records claim |
+| retention | independent-audit firewall |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| are not claimed | applies to every downstream item in the scope sentence |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit accounting |
+| actual adm/history transporter remains | standard partial-close statement |
+| actual adm/history transporter remains open | the runner's compact TOE firewall |
+| gravity constraint quotient remains unexecuted | constraint-scope firewall |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | five N5 keys |
+
+No phrase turns the five-dimensional state body into the state space of every
+carrier. Nothing converts the direct sum into a tensor product, the complex
+bookkeeping envelope into a richer admissible algebra, or the supplied
+momentum orbit into an autonomous real-algebra dynamics.
+
+Nothing calls the certified vacuum maximally mixed. Nothing says the balanced
+sector measures the full algebra invariantly. Nothing asserts that the common
+differential exists, the flip work order has run, the actual transporter is
+complete, or joint gravity follows. Nothing asserts axiom amendment,
+effective audit retention, obligation retirement, or TOE percentage movement.
+
+### N4 — Residual Matching
+
+The Block 132 handoff next gate, quoted byte-exactly, is:
+
+> States and dynamics on the two-block algebra; the flip work order; the
+> common nilpotent differential.
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 132 next gate](ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md:16` | “States and dynamics on the two-block algebra; the flip work order; the common nilpotent differential.” | STATES AND SUPPLIED MOMENTUM DYNAMICS COMPLETED: the first clause now has its exact state body, vacua, expectations, counter-rotation, and selection rules; the flip work order and common differential remain live |
+| [Block 124 gravity class](ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md) | the displayed sourced quotient occupies the balanced \((1,3)\) class | ITS CLASS NOW HAS ITS EXACT MEASURABLE CONTENT: the full free-phase equator maps to (37), with expectations (39), sine blindness, and invariant algebra \(\operatorname{span}\{I,Z\}\) |
+| [Block 131 forced conjugation](ADMISSIBILITY_DIRAC_KAHLER_CONJUGATE_PAIR_OBSERVABLE_SPACE_BOUNDED_THEOREM_NOTE_2026-08-17.md) | the \((1,3)\) boundary representatives and norms are conjugation-coupled | THE FORCED CONJUGATION'S PHYSICAL CONSEQUENCE IS THE \((1,3)\) MAXIMAL MIXING: equal exact norm weights give the conditional density \(I/2\) in (20) |
+
+This is a partial closure of Block 132's next gate. States and the exact
+response to the already supplied momentum generator are now classified on
+the full two-block algebra. No new common differential or cell-cutting
+dynamics is constructed, so the other two clauses remain live.
+
+The Block 124 match supplies measurement content on its displayed class, not
+a new gravity carrier. The Block 131 match exposes a state-level consequence
+of forced conjugation, not a change to its observable classification.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “On the certified two-block observable
+algebra at both rational shear fixtures, the state space is exactly the
+five-dimensional convex body of paired symmetric disc states with one
+projective-line pure family per block; the certified-frame vacuum has exact
+direction weights \(N_p/\mathcal N\), forced conditional maximal mixing on
+the
+conjugate block, bias on the per-sector-real block, and unequal block totals;
+exactly two admissible relative normalizations give the normalized-frame
+quarter-trace state, with the even equalization leaving the certified field;
+and supplied momentum conjugation counter-rotates the two block quadratures
+at rate two with signs \((-2,+2)\), fixes the four-dimensional diagonal
+algebra, and maps the balanced gravity
+class around its full free-phase equator, whose invariant admissible
+observables are exactly \(\operatorname{span}_{\mathbb R}\{I,Z\}\) because
+\(Y\) is excluded.”
+
+Forbidden upgrades include:
+
+- “the vacuum is maximally mixed” without a normalized-frame qualifier;
+- “the balanced sector measures the full algebra”; and
+- “a tensor structure exists”.
+
+The first replaces the certified-frame state (16) by the distinct
+normalized-frame state (25). The second ignores both the invariant test (40)
+and the excluded \(Y\) quadrature. The third turns a direct sum with central
+classical alternatives into an unproved factorization.
+
+Also forbidden are “every carrier has this state space,” “the complex
+envelope is an admissible observable algebra,” “momentum defines a closed
+automorphism group of the real symmetric algebra,” “the common differential
+has been constructed,” “the flip work order is complete,” and “the
+gravity constraint quotient is complete beyond the displayed carrier.”
+None is established here.
+
+The five N5 resolution lines fixed for the runner are reproduced verbatim:
+
+```text
+N5: per_element: exact state-space, vacuum-weight, normalization, orbit, equator, and summary certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: the certified vacuum is a biased central mixture with the conjugate block maximally mixed by force and the per-sector-real block biased, while momentum counter-rotates the two blocks' quadratures at rate two
+per_block: the balanced gravity sector is the full bloch equator whose invariant observables are exactly the identity and z because the y quadrature is not an admissible observable — the certified package's measurement physics is complete with exact expectations and selection rules
+lattice_wide: checked and not executed — the common nilpotent differential, the flip work order, richer carriers, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The result follows from Block 132's
+finite two-block algebra and exact norm data, the positive trace dual of real
+symmetric matrices, elementary convexity, and direct two-by-two momentum
+conjugation. Neither a common differential nor a tensor factorization is
+adopted as an axiom.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| two rational shear fixtures | exact certified package | no interpolation or general-shear state theorem |
+| state space | equations (4)--(9), five-dimensional paired-disc body | no claim for an undisplayed carrier |
+| pure states | equation (12), one \(\mathbb{RP}^1\) family per block | no cross-center coherent pure state |
+| certified vacuum | exact weights (17), conditional states (20), unequal totals (18) | no unqualified maximal-mixing claim |
+| normalization ledger | exactly two relative moves; (22) leaves the certified field | no conflation of the two frame-vacua |
+| momentum dynamics | exact rate-two block counter-rotation (28)--(31), signs \((-2,+2)\) | no autonomous real-algebra law beyond supplied conjugation |
+| diagonal conservation | \(\mathcal D=\operatorname{span}\{I_{02},Z_{02},I_{13},Z_{13}\}\) | every \(X\) mixer has nonzero momentum commutator |
+| balanced gravity | full equator (36), expectations (39), invariants (40) | sine phase is invisible because \(Y\) is inadmissible |
+| common differential | **UNTESTED-LIVE** | construct the common nilpotent carrier |
+| cell-cutting flip work order | **UNTESTED-LIVE** | execute the pre/post and reversibility table |
+| richer carriers | **UNTESTED-LIVE** | test state and phase structure beyond the displayed fixture |
+| actual ADM/history transporter | not executed | complete beyond the displayed packages |
+| gravity constraint quotient | displayed carrier only | execute beyond that carrier |
+
+The scan finds no axiom-amendment route. Block 132's first next-gate clause is
+closed only on its certified algebra and only for the supplied momentum
+action. The common differential and flip work order remain live. Richer
+carriers, the actual transporter, and gravity beyond the displayed carrier
+remain downstream.
+
+### N7 — Steelman
+
+**Hostile steelman: the certified-vacuum bias could be an artifact of the
+\(y\)-normalization pivot convention.** A different nonzero component used to
+write each stable boundary vector might change its printed norm and make the
+weights look equal.
+
+No. Equations (15)--(17) use ratios of the actual certified-frame norms, and
+the frame functional is transported covariantly when a mere pivot coordinate
+chart changes. The normalized weights \(N_p/\mathcal N\) are therefore
+pivot-covariant.
+Within that frame, \(N_1=N_3\) is forced by conjugation, while
+\(N_0\ne N_2\) follows from the exact nonsquare ratio; the \((1,3)\) equality
+versus \((0,2)\) inequality is convention-free. An active rescaling of one
+frame vector is different: it constructs the new frame-vacuum recorded in
+Section 5 rather than rewriting \(\Omega_{\rm cert}\). The exact unequal block
+totals are separately certified in (18).
+
+**Hostile steelman: the equator identification depends on the Block 124 class
+map.** Equal magnitudes alone do not say which quotient class is being called
+gravity.
+
+Correct, and the dependence is displayed rather than hidden. The source is
+[Block 124](ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md),
+and equation (36) writes its map explicitly from the balanced class with
+\(c_3/c_1=e^{i\phi}\) to the normalized ray. The present theorem computes the
+measurement content of that mapped class. It does not rederive the class
+assignment or extend it to another carrier.
+
+**Hostile steelman: “measurement theory” on a four-dimensional displayed
+space is modest.** A finite direct sum cannot by itself support claims about
+the full field theory, histories, or joint gravity.
+
+Agreed. Here the phrase means complete states and expectations for the exact
+six-dimensional observable algebra on four displayed positive directions,
+plus the response to its supplied momentum labels. It means no more. The
+finite fixture quantifier, direct-sum boundary, missing \(Y\), absent common
+differential, and unexecuted richer-carrier tests remain explicit.
+
+These steelmen preserve narrow W1. They distinguish a coordinate pivot from
+an active frame normalization, expose the Block 124 dependency, and keep the
+measurement claim at the exact size of the carrier.
+
+### N8 — Cross-Cycle Echo
+
+The certified chain narrows from a sourced balanced class and a forced
+conjugate pair to the complete two-block algebra, then opens exactly the state
+and supplied-momentum measurement theory on that algebra.
+
+| source | narrowing that leads to W1 and the live common program |
+|---|---|
+| [Block 124](ADMISSIBILITY_DIRAC_KAHLER_SOURCED_QUOTIENT_EXECUTION_BOUNDED_THEOREM_NOTE_2026-08-17.md) | supplies the displayed balanced gravity class whose phase map is written in (36) |
+| [Block 131](ADMISSIBILITY_DIRAC_KAHLER_CONJUGATE_PAIR_OBSERVABLE_SPACE_BOUNDED_THEOREM_NOTE_2026-08-17.md) | forces conjugate-pair norm equality, whose state-level consequence is odd-block maximal mixing |
+| [Block 132](ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md) | supplies the two symmetric blocks, exact even norm ratio and field caveat, cross-block exclusion, and momentum labels |
+| Block 133 | proves the paired-disc state body, two projective-line pure families, biased certified vacuum, two-move normalized vacuum, momentum response, and balanced-equator measurement map |
+
+The echo is deliberately bounded. The conjugate norm equality becomes
+conditional maximal mixing, not a four-direction trace state. The even norm
+gauge becomes one required normalization move, not a reason to erase the
+certified-frame bias. The gravity class gains exact measurable content, not
+an enlarged quotient or joint dynamics.
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1. On the certified
+two-block observable algebra at both rational shear fixtures, the state space
+is exactly the five-dimensional paired-disc body (8), with pure boundary
+(12), certified vacuum (16), and exact expectations (9). **POSITIVE** for the
+forced conjugate-block maximal mixing, per-sector-real bias, unequal block
+totals, two-move normalization ledger, quarter-trace normalized-frame state,
+rate-two block counter-rotation with signs \((-2,+2)\), four-dimensional
+conserved diagonal algebra,
+full free-phase gravity equator, \(Y\)-exclusion, and exact momentum selection
+rule. **CHECKER-CREDITED** for the exact norm pins, state-space dimension,
+orbit signs, balanced expectation, and six-row basis table. **BOUNDARY** for
+the distinction between certified and normalized
+frame-vacua and for the restriction of the complex phase orbit to real
+symmetric measurements. **LIVE** for the common differential, the flip work
+order, and richer carriers. **FAIL** for an unqualified maximally mixed
+vacuum, full-algebra invariant measurement by the balanced sector, tensor
+structure, an added autonomous dynamical law, a completed differential or
+transporter, joint gravity, a quotient beyond the displayed carrier, axiom
+necessity, audit retention, obligation retirement, or TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. The state body is the positive normalized
+trace dual of Block 132's finite real symmetric algebra. The pure-state
+classification is elementary convexity, and both vacuum formulas follow from
+the exact supplied norms and two admissible frame choices. No state postulate
+is added.
+
+The complex Hermitian envelope is not adopted as an observable extension or
+a richer carrier. It records the \(Y\) quadrature generated when the supplied
+diagonal momentum acts on \(X\), and it displays the free phase already
+present in the Block 124 gravity class. The admissible algebra remains real
+symmetric.
+
+Momentum is not elevated into a complete dynamical axiom. Equations
+(28)--(35) are its exact conjugation consequences. Because a real-algebra
+state does not measure the omitted \(Y\) coordinate, no extension-independent
+autonomous flow is inferred.
+
+This is bounded route closure, not an audit-grade assignment. It retires no
+end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. derive the common nilpotent differential or its exact connection residual
+   and test whether the transfer, observable, and cell-cutting structures can
+   occupy one carrier;
+2. execute the cell-cutting flip work order with pre-and-post facet charges,
+   support types, achieved deltas, reverse partners, and same-cost-class
+   reversibility; and
+3. test richer carriers beyond the displayed fixture without importing a
+   tensor factor, an omitted phase quadrature, or a state law by convention.
+
+The exact next gate is: “The common nilpotent differential; the flip work
+order; richer carriers beyond the displayed fixture.”
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+flat half-space positive package and the two-block state-and-observable
+carrier without a common nilpotent differential.
+
+The completed measurement theory does not supply the common differential.
+The cell-cutting flip work order remains unexecuted, and richer carriers have
+not been tested beyond the displayed fixture.
+
+The gravity constraint quotient remains unexecuted beyond the displayed
+carrier.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16016,
- "node_count": 5561,
+ "edge_count": 16020,
+ "node_count": 5562,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -533,6 +533,10 @@
   "admissibility_dirac_kahler_two_block_observable_algebra_bounded_theorem_note_2026-08-17": {
    "deps_hash": "1ed6a588bb94",
    "out_degree": 5
+  },
+  "admissibility_dirac_kahler_two_block_states_dynamics_bounded_theorem_note_2026-08-17": {
+   "deps_hash": "b79692048c4c",
+   "out_degree": 4
   },
   "admissibility_dirac_kahler_wick_phase_fine_site_staggered_os_lorentz_boundary_bounded_theorem_note_2026-08-14": {
    "deps_hash": "825cb5c969e8",

--- a/logs/runner-cache/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.py
+runner_sha256: 3548e51cac2164a3c0fdbe7e7b6b3dd96f267b57f80dc0bfdb4aed2efc8e87cb
+input_fingerprint_sha256: 34947b322d9c2b75868755cad5ee1d51d087f51d86d058aaf831e538656cc216
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 58.19
+status: ok
+----- stdout -----
+[PASS] A-authority: Block 132 blobs, ancestors 131--103, and landed Block 119 runner/cache are pinned
+[PASS] B-the-state-space: displayed linear algebra gives dim 5, two Bloch disks, and the two RP^1 pure families, fixture-independently
+[PASS] C-the-certified-vacuum: both fixtures give pinned positive direction weights, a biased central mixture, and only block (1,3) maximally mixed
+[PASS] D-the-normalization-ledger: exactly two positive real moves give Tr/4 and preserve involutivity and positivity; Block 132 supplies the nonsquare import
+[PASS] E-the-momentum-orbits: e^{itP} rotates the two quadrature planes at rate 2 with differences (-2,+2), while the conserving algebra is diagonal R^4
+[PASS] F-the-balanced-equator: |c_1|=|c_3| gives the full free-relative-phase Bloch equator; phi-invariant admissible observables are exactly span{I,Z}
+[PASS] G-the-summary-table: the six basis rows have exact conserving, balanced-measurable, and certified-frame vacuum columns with no tensor claim
+[PASS] H-scope: frame, orbit, equator, exclusion, N1--N8/W1/N5, no-go, and TOE firewalls are present
+AUTHORITY: Block132 parent=0236823bed5b648ad8357e5d1b79bdfe1be36c39; note/runner/cache and Block119 pins exact
+STATE: D_02=w(I+x_02 X+z_02 Z)/2, D_13=(1-w)(I+x_13 X+z_13 Z)/2; 0<=w<=1, x_j^2+z_j^2<=1; affine dim=5; fixture-independent
+PURE: w=1 or 0 and rho=vv^T/(v^Tv), v~-v; each boundary family is RP^1 and an interior central mixture is not pure
+VACUUM-PIN c=5/13: literal exact q0,q1 pins; q2=g02*q0; q3=q1; positive direction intervals and unequal block-total intervals
+VACUUM-PIN c=3/5: literal exact q0,q1 pins; q2=g02*q0; q3=q1; positive direction intervals and unequal block-total intervals
+CERTIFIED FRAME: D_cert=diag(q0,q1,g02*q0,q1)/N, N=q0(1+g02)+2q1; W02=q0(1+g02)/N != W13=2q1/N; rho02=diag(1,g02)/(1+g02) is biased, rho13=I/2
+NORMALIZED FRAME: two moves: y2->y2/sqrt(g02) (Block132 certifies sqrt(g02) notin Q(rho)), then (y1,y3)->sqrt(q0/q1)(y1,y3); the result is Tr_4/4
+ORBITS: d02=-2: X->cos(2t)X-sin(2t)Y; d13=+2: X->cos(2t)X+sin(2t)Y; the Y rotations have the opposite matching signs; I,Z fixed; diagonal R^4 conserving
+BALANCED: |c1|=|c3| gives rho=(I+r(cos(phi)X+sin(phi)Y))/2 with free relative phase; <aI+bX+cZ>=a+r*b*cos(phi), so span{I,Z} only; Y is not an admissible Sym_2(R) observable
+TABLE: observable | P-conserving | balanced-measurable | certified-frame vacuum value
+  I_02 | yes | null | q_0*(g_02 + 1)/(g_02*q_0 + q_0 + 2*q_1)
+  Z_02 | yes | null | -q_0*(g_02 - 1)/(g_02*q_0 + q_0 + 2*q_1)
+  X_02 | no  | null | 0
+  I_13 | yes | yes  | 2*q_1/(g_02*q_0 + q_0 + 2*q_1)
+  Z_13 | yes | yes  | 0
+  X_13 | no  | no   | 0
+PHYSICS: exact expectations and selection rules are complete on the direct sum; no tensor-product structure is claimed
+N5: per_element: exact state-space, vacuum-weight, normalization, orbit, equator, and summary certificates are checked
+per_site: one Grassmann mode per fine site on the antiperiodic reflection torus
+per_mode: the certified vacuum is a biased central mixture with the conjugate block maximally mixed by force and the per-sector-real block biased, while momentum counter-rotates the two blocks' quadratures at rate two
+per_block: the balanced gravity sector is the full bloch equator whose invariant observables are exactly the identity and z because the y quadrature is not an admissible observable — the certified package's measurement physics is complete with exact expectations and selection rules
+lattice_wide: checked and not executed — the common nilpotent differential, the flip work order, richer carriers, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open
+RESULT: the two-block algebra's measurement theory is complete — a biased certified vacuum with a two-step normalization ledger, counter-rotating momentum dynamics with the diagonal conserved, and a balanced gravity sector that measures exactly the identity and z
+DECISION_CUT: the common differential and richer carriers are the frontier; reject frame-ambiguous vacuum claims; advance exact state expectations and selection rules only
+TOE: zero obligation retirement; no TOE percentage moves; retained-positive end-to-end theory count remains zero; gravity constraint quotient remains unexecuted; actual ADM/history transporter remains open
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.py
+++ b/scripts/admissibility_dirac_kahler_two_block_states_dynamics_2026_08_17.py
@@ -1,0 +1,1405 @@
+#!/usr/bin/env python3
+"""Block 133: exact states-and-dynamics certificate for the two-block algebra.
+
+The runner imports the landed Block 132 observable-algebra construction and
+uses exact rational or algebraic arithmetic throughout.  It distinguishes the
+biased state induced in the certified frame from the separately normalized
+Tr/4 frame, certifies the counter-rotating momentum quadratures, and identifies
+the balanced gravity class without adjoining its missing Y observable.
+Wall-clock timing is the sole floating-point quantity.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import time
+
+import sympy as sp
+
+import admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16 as b119
+import admissibility_dirac_kahler_two_block_observable_algebra_2026_08_17 as b132
+
+
+R = sp.Rational
+I = sp.I
+RHO = b119.RHO
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_STATES_DYNAMICS_"
+    "BOUNDED_THEOREM_NOTE_2026-08-17.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+PARENT_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_"
+    "BOUNDED_THEOREM_NOTE_2026-08-17.md"
+)
+PARENT_RUNNER = (
+    "scripts/admissibility_dirac_kahler_two_block_observable_algebra_"
+    "2026_08_17.py"
+)
+PARENT_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_two_block_observable_"
+    "algebra_2026_08_17.txt"
+)
+B119_RUNNER = (
+    "scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_"
+    "2026_08_16.py"
+)
+B119_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_"
+    "completion_2026_08_16.txt"
+)
+
+# This tuple is deliberately literal: it is the complete audit read surface.
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_STATES_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+    "scripts/admissibility_dirac_kahler_two_block_observable_algebra_2026_08_17.py",
+    "logs/runner-cache/admissibility_dirac_kahler_two_block_observable_algebra_2026_08_17.txt",
+    "scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py",
+    "logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "02602ca09e4ea69a805a824c3c1f31cb1ee35b20"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block132-two-block-observable-algebra-20260817"
+)
+PARENT_COMMIT = "0236823bed5b648ad8357e5d1b79bdfe1be36c39"
+PARENT_NOTE_BLOB = "4b330950a10afd8aeb863107271dd5605b86fdde"
+PARENT_RUNNER_BLOB = "c23896e00ab00ab2bf587cae8f4002b34a62c80a"
+PARENT_CACHE_BLOB = "411b5f5fb2c63e7c4d4cc57ac85cafe78d97a306"
+B119_COMMIT = "33fd2d21558604718f3a88713fe1976aff8f9dbb"
+B119_RUNNER_BLOB = "952494a18ba13b7d25fb144b8569687813d9bddc"
+B119_CACHE_BLOB = "f7a9b09538c8787ed88885c04cdea3e5cff70104"
+
+ANCESTOR_COMMITS = (
+    (131, "d3a666f62c87b3b8178289024087090c91ced327"),
+    (130, "db394d1536a8243c2b01b3e45413813e45f8abdd"),
+    (129, "30fd2722a10a02f87c235e2ee592d140f8bb7df5"),
+    (128, "f6b0cf59e2cc588ebd3e34b96e730574cb485db2"),
+    (127, "ca6792464f60598013a3700f99c02a467af64b7a"),
+    (126, "a145a4e2cfc19bc919371196d7c5f3451c0bb45d"),
+    (125, "ff85cc8c6a991b2926b9ac5cb5168f2587bc0c0d"),
+    (124, "da2b9020e9f15ac55640ef87a0798a78e3c9a0d0"),
+    (123, "954322e0e085d6c3133ce24dca49db2efbd7d0a6"),
+    (122, "f067b99be7eb49fc46ea8dffccab5e20e6052d88"),
+    (121, "1714abeefcf3763c0bfe001f30fd14521c538622"),
+    (120, "1c2386bf3df420707fd2ecb2d7ec84002ba40ad1"),
+    (119, "33fd2d21558604718f3a88713fe1976aff8f9dbb"),
+    (118, "fdd1883c54ca8cc14b1337cc1edc249792d5dab2"),
+    (117, "f800356aec0989b6e0fa80ed43274794243b1ca2"),
+    (116, "c36d11e4e8d927c6fc31f0a8b579d4bd15f4fa43"),
+    (115, "c78301fef7521d0518f485f1bf9266983c9e516a"),
+    (114, "75026e71cfbd44ed665ddc41c22ebaa722720ea9"),
+    (113, "e76893eb7204d1d727a3ab8838fb3fada3f45dfc"),
+    (112, "385a6ba5b1594f20e5d4eebba9da68d8e72abc10"),
+    (111, "b04e7c8747b09734711cfcd2bfab961bd12e81ad"),
+    (110, "d6761278fca9cac617200792473a8f4da3a6cfff"),
+    (109, "ad84cfcc857a65285389ba93b47cd7b718589be5"),
+    (108, "8afe8dff5ccf531208238af0aaaec1f547d73874"),
+    (107, "d41a05e153d4cb77eee125b82fc0b0bd767bf32e"),
+    (106, "22d6d90ec2279e5868c9c825149b2a20beea3797"),
+    (105, "d06066c2b908aaca0779625d831dfb10620cf34d"),
+    (104, "7fe07db6c03fad1191893c942f708c5cb9a54c43"),
+    (103, "99cee0a6c962b382a3ca1a8497d589ffa280dfe8"),
+)
+
+# q_0 and q_1 are pinned independently.  The remaining exact direction
+# weights are then pinned by q_2=g_02 q_0 (with Block 132's literal g_02 pin)
+# and the forced conjugate-pair identity q_3=q_1.
+DIRECTION_BASE_PINS = {
+    R(5, 13): (
+        R(
+            1150375921826694113555410035428125457400046724232655679510128418644,
+            78818981495363350772720329776070208150156820427053866300121890625,
+        )
+        * RHO
+        + R(
+            2551760577187948708831975621544907002416341583124,
+            2017627675810846293109860712085830226130175201449,
+        ),
+        R(
+            74810282488664230980940890727509529911814046713354838439326223427401027593902539112485052,
+            96263948812720778195707147302876216488862931210874321631857695665694862166240216796875,
+        )
+        * RHO
+        + R(
+            5861115526326352488714957098049817172821651848298584759897950715316,
+            6571479869879327548698576558000254761468540553325723058519469865141,
+        ),
+    ),
+    R(3, 5): (
+        R(
+            1929582570829448125429212338350289753301106276,
+            199669918972549851130286515573737207275390625,
+        )
+        * RHO
+        + R(
+            685969651848560392472786260406310596,
+            478257127996035806743292224763026521,
+        ),
+        R(
+            1457386714041244279937491929662883188827670431983183517670528156972,
+            560375227874156102732062361754341714825305744456110940342421875,
+        )
+        * RHO
+        + R(
+            5249507183780459677725873072861609272806341163892,
+            7291367263848626791180264000120680322961850668777,
+        ),
+    ),
+}
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_parent_authority",
+    "break_state_space",
+    "break_vacuum_weights",
+    "claim_certified_maximally_mixed",
+    "break_normalization_ledger",
+    "break_orbit_signs",
+    "break_conserving_algebra",
+    "break_equator_identification",
+    "break_invariant_span",
+    "break_summary_table",
+    "weaken_no_go_packet",
+    "drop_n5_resolution",
+    "claim_toe_progress",
+    "claim_axiom_amendment",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition: object) -> None:
+        ok = bool(condition)
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {statement}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def authority_certificate(mutation: str) -> dict[str, object]:
+    expected_axiom = (
+        "0" * 40 if mutation == "stale_axiom_authority" else CURRENT_AXIOM_BLOB
+    )
+    expected_parent = (
+        "0" * 40 if mutation == "stale_parent_authority" else PARENT_NOTE_BLOB
+    )
+    return {
+        "main": git_output("rev-parse", "origin/main"),
+        "axiom": commit_blob("origin/main", AXIOM_PATH),
+        "worktree_axiom": worktree_blob(AXIOM_PATH),
+        "expected_axiom": expected_axiom,
+        "registry": commit_blob("origin/main", REGISTRY_PATH),
+        "worktree_registry": worktree_blob(REGISTRY_PATH),
+        "parent": git_output("rev-parse", PARENT_REF),
+        "parent_ancestor": is_ancestor(PARENT_COMMIT, "HEAD"),
+        **{
+            f"ancestor_{number}": is_ancestor(commit, "HEAD")
+            for number, commit in ANCESTOR_COMMITS
+        },
+        "parent_note": commit_blob(PARENT_COMMIT, PARENT_NOTE),
+        "expected_parent": expected_parent,
+        "parent_runner": commit_blob(PARENT_COMMIT, PARENT_RUNNER),
+        "parent_cache": commit_blob(PARENT_COMMIT, PARENT_CACHE),
+        "worktree_parent_note": worktree_blob(PARENT_NOTE),
+        "worktree_parent_runner": worktree_blob(PARENT_RUNNER),
+        "worktree_parent_cache": worktree_blob(PARENT_CACHE),
+        "b119_ancestor": is_ancestor(B119_COMMIT, "HEAD"),
+        "b119_runner": commit_blob(B119_COMMIT, B119_RUNNER),
+        "b119_cache": commit_blob(B119_COMMIT, B119_CACHE),
+        "worktree_b119_runner": worktree_blob(B119_RUNNER),
+        "worktree_b119_cache": worktree_blob(B119_CACHE),
+    }
+
+
+def normalized_note() -> str:
+    try:
+        raw_note = NOTE_PATH.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+    return " ".join(raw_note.lower().split())
+
+
+def matrix_zero(matrix: sp.MatrixBase) -> bool:
+    return all(sp.simplify(value) == 0 for value in matrix)
+
+
+def commutator(left: sp.Matrix, right: sp.Matrix) -> sp.Matrix:
+    return (left * right - right * left).applyfunc(sp.expand)
+
+
+def trace_pair(density: sp.Matrix, observable: sp.Matrix) -> sp.Expr:
+    return sp.factor(sp.trace(density * observable))
+
+
+def same_row_space(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return (
+        left.cols == right.cols
+        and left.rank() == right.rank()
+        and left.col_join(right).rank() == left.rank()
+    )
+
+
+def embed_pair(matrix: sp.Matrix, indices: tuple[int, int]) -> sp.Matrix:
+    result = sp.zeros(4)
+    for local_row, row in enumerate(indices):
+        for local_column, column in enumerate(indices):
+            result[row, column] = matrix[local_row, local_column]
+    return result
+
+
+I2 = sp.eye(2)
+X = sp.Matrix(((0, 1), (1, 0)))
+Y = sp.Matrix(((0, I), (-I, 0)))
+Z = sp.Matrix(((1, 0), (0, -1)))
+
+
+def disk_density(x: sp.Expr, z: sp.Expr) -> sp.Matrix:
+    """The trace-one real qubit density in disk coordinates."""
+    return sp.Matrix(((1 + z, x), (x, 1 - z))) / 2
+
+
+@dataclass(frozen=True)
+class StateSpaceCertificate:
+    weight: sp.Symbol
+    density02: sp.Matrix
+    density13: sp.Matrix
+    total_density: sp.Matrix
+    trace_normalized: bool
+    disk_determinants_exact: bool
+    inverse_coordinates_exact: bool
+    ambient_dimension: int
+    trace_constraint_rank: int
+    affine_dimension: int
+    pure_projector_identity: bool
+    pure_bloch_circle: bool
+    antipodal_identification: bool
+    fixture_independent: bool
+
+
+def state_space_certificate() -> StateSpaceCertificate:
+    w, x02, z02, x13, z13 = sp.symbols(
+        "w x_02 z_02 x_13 z_13", real=True
+    )
+    rho02 = disk_density(x02, z02)
+    rho13 = disk_density(x13, z13)
+    density02 = w * rho02
+    density13 = (1 - w) * rho13
+    total_density = embed_pair(density02, (0, 2)) + embed_pair(
+        density13, (1, 3)
+    )
+    determinant_identities = (
+        sp.simplify(
+            rho02.det() - (1 - x02**2 - z02**2) / 4
+        )
+        == 0
+        and sp.simplify(
+            rho13.det() - (1 - x13**2 - z13**2) / 4
+        )
+        == 0
+    )
+
+    a, b = sp.symbols("a b", real=True)
+    generic_trace_one = sp.Matrix(((a, b), (b, 1 - a)))
+    inverse_x = 2 * b
+    inverse_z = 2 * a - 1
+    inverse_coordinates_exact = (
+        matrix_zero(disk_density(inverse_x, inverse_z) - generic_trace_one)
+        and sp.factor(
+            generic_trace_one.det()
+            - (1 - inverse_x**2 - inverse_z**2) / 4
+        )
+        == 0
+    )
+
+    e00 = sp.Matrix(((1, 0), (0, 0)))
+    e11 = sp.Matrix(((0, 0), (0, 1)))
+    affine_basis = (
+        embed_pair(e00, (0, 2)),
+        embed_pair(e11, (0, 2)),
+        embed_pair(X, (0, 2)),
+        embed_pair(e00, (1, 3)),
+        embed_pair(e11, (1, 3)),
+        embed_pair(X, (1, 3)),
+    )
+    basis_columns = tuple(sp.Matrix(tuple(item)) for item in affine_basis)
+    ambient_dimension = sp.Matrix.hstack(*basis_columns).rank()
+    trace_constraint = sp.Matrix(
+        [[sp.trace(item) for item in affine_basis]]
+    )
+    trace_constraint_rank = trace_constraint.rank()
+    affine_dimension = ambient_dimension - trace_constraint_rank
+
+    u, v = sp.symbols("u v", real=True)
+    vector = sp.Matrix((u, v))
+    projector = vector * vector.T
+    norm = u**2 + v**2
+    bloch_x = 2 * u * v
+    bloch_z = u**2 - v**2
+    pure_projector_identity = matrix_zero(
+        projector * projector - norm * projector
+    )
+    pure_bloch_circle = sp.expand(
+        bloch_x**2 + bloch_z**2 - norm**2
+    ) == 0
+    antipodal_identification = matrix_zero(
+        (-vector) * (-vector).T - projector
+    )
+    displayed_expressions = (
+        density02,
+        density13,
+        total_density,
+        projector,
+        sp.Matrix((bloch_x, bloch_z)),
+    )
+    fixture_independent = all(
+        RHO not in expression.free_symbols for expression in displayed_expressions
+    )
+    return StateSpaceCertificate(
+        w,
+        density02,
+        density13,
+        total_density,
+        sp.factor(sp.trace(total_density)) == 1,
+        determinant_identities,
+        inverse_coordinates_exact,
+        ambient_dimension,
+        trace_constraint_rank,
+        affine_dimension,
+        pure_projector_identity,
+        pure_bloch_circle,
+        antipodal_identification,
+        fixture_independent,
+    )
+
+
+def affine_root_interval(
+    expression: sp.Expr,
+    sector: b119.Sector,
+) -> tuple[sp.Rational, sp.Rational]:
+    """Exact rational enclosure using the certified stable-root interval."""
+    reduced = b119.red(expression, sector.polynomial)
+    polynomial = sp.Poly(reduced, RHO)
+    if polynomial.degree() > 1:
+        raise AssertionError("a direction weight must be affine in its root")
+    slope = polynomial.coeff_monomial(RHO)
+    intercept = polynomial.coeff_monomial(1)
+    lower_integer, upper_integer = sector.stable_interval
+    lower_root = R(lower_integer, 10**12)
+    upper_root = R(upper_integer, 10**12)
+    endpoint_values = (
+        sp.cancel(slope * lower_root + intercept),
+        sp.cancel(slope * upper_root + intercept),
+    )
+    return min(endpoint_values), max(endpoint_values)
+
+
+def intervals_disjoint(
+    left: tuple[sp.Rational, sp.Rational],
+    right: tuple[sp.Rational, sp.Rational],
+) -> bool:
+    return left[1] < right[0] or right[1] < left[0]
+
+
+@dataclass(frozen=True)
+class FixtureVacuumCertificate:
+    shear: sp.Rational
+    direction_weights: tuple[sp.Expr, sp.Expr, sp.Expr, sp.Expr]
+    base_weight_pins: tuple[sp.Expr, sp.Expr]
+    exact_weights_pinned: bool
+    direction_intervals: tuple[
+        tuple[sp.Rational, sp.Rational],
+        tuple[sp.Rational, sp.Rational],
+        tuple[sp.Rational, sp.Rational],
+        tuple[sp.Rational, sp.Rational],
+    ]
+    all_weights_positive: bool
+    one_three_equality_forced: bool
+    zero_two_weights_unequal: bool
+    zero_one_weights_unequal: bool
+    block_totals_unequal: bool
+
+
+def fixture_vacuum_certificate(
+    sectors: tuple[b119.Sector, ...],
+    carrier: b132.CarrierCertificate,
+) -> FixtureVacuumCertificate:
+    if len(sectors) != 4:
+        raise AssertionError("one fixture must have four sector directions")
+    weights = tuple(
+        b132.vector_norm_squared(sector.y, sector.polynomial)
+        for sector in sectors
+    )
+    if carrier.shear not in DIRECTION_BASE_PINS:
+        raise AssertionError("the fixture has no direction-weight pin")
+    pin_zero, pin_one = DIRECTION_BASE_PINS[carrier.shear]
+    zero_pin = b119.red(weights[0] - pin_zero, sectors[0].polynomial) == 0
+    one_pin = b119.red(weights[1] - pin_one, sectors[1].polynomial) == 0
+    two_pin = b119.red(
+        weights[2] - carrier.g_pin * weights[0], sectors[0].polynomial
+    ) == 0
+    three_pin = b119.red(
+        weights[3] - weights[1], sectors[1].polynomial
+    ) == 0
+    split = b132.fixture_split_certificate(sectors)
+    one_three_forced = (
+        split.one_three_polynomial_shared
+        and split.one_three_root_shared
+        and split.one_three_y_conjugate
+        and split.one_three_g_one
+        and three_pin
+    )
+    zero_two_unequal = (
+        carrier.g_nonunit
+        and b119.red(weights[2] - weights[0], sectors[0].polynomial) != 0
+    )
+    intervals = tuple(
+        affine_root_interval(weight, sector)
+        for weight, sector in zip(weights, sectors)
+    )
+    even_total_interval = affine_root_interval(
+        weights[0] + weights[2], sectors[0]
+    )
+    odd_total_interval = affine_root_interval(
+        weights[1] + weights[3], sectors[1]
+    )
+    return FixtureVacuumCertificate(
+        carrier.shear,
+        weights,
+        (pin_zero, pin_one),
+        zero_pin and one_pin and two_pin and three_pin,
+        intervals,
+        all(lower > 0 for lower, _ in intervals),
+        one_three_forced,
+        zero_two_unequal,
+        intervals_disjoint(intervals[0], intervals[1]),
+        intervals_disjoint(even_total_interval, odd_total_interval),
+    )
+
+
+@dataclass(frozen=True)
+class CertifiedVacuumCertificate:
+    fixtures: tuple[FixtureVacuumCertificate, ...]
+    symbolic_weights: tuple[sp.Expr, sp.Expr, sp.Expr, sp.Expr]
+    density: sp.Matrix
+    central_weights: tuple[sp.Expr, sp.Expr]
+    internal_densities: tuple[sp.Matrix, sp.Matrix]
+    trace_normalized: bool
+    trace_representation_exact: bool
+    central_decomposition_exact: bool
+    certified_frame_biased: bool
+    one_three_maximally_mixed: bool
+
+
+def certified_vacuum_certificate(
+    fixtures: tuple[FixtureVacuumCertificate, ...],
+) -> CertifiedVacuumCertificate:
+    q_zero, q_one, g = sp.symbols(
+        "q_0 q_1 g_02", positive=True, nonzero=True
+    )
+    weights = (q_zero, q_one, g * q_zero, q_one)
+    total = sum(weights)
+    density = sp.diag(*weights) / total
+    central_weights = (
+        sp.factor((weights[0] + weights[2]) / total),
+        sp.factor((weights[1] + weights[3]) / total),
+    )
+    internal02 = sp.diag(weights[0], weights[2]) / (
+        weights[0] + weights[2]
+    )
+    internal13 = sp.diag(weights[1], weights[3]) / (
+        weights[1] + weights[3]
+    )
+    reconstructed = (
+        central_weights[0] * embed_pair(internal02, (0, 2))
+        + central_weights[1] * embed_pair(internal13, (1, 3))
+    )
+
+    a02, b02, d02, a13, b13, d13 = sp.symbols(
+        "a_02 b_02 d_02 a_13 b_13 d_13", real=True
+    )
+    observable = embed_pair(
+        sp.Matrix(((a02, b02), (b02, d02))), (0, 2)
+    ) + embed_pair(sp.Matrix(((a13, b13), (b13, d13))), (1, 3))
+    induced_functional = sp.factor(
+        (
+            weights[0] * a02
+            + weights[2] * d02
+            + weights[1] * a13
+            + weights[3] * d13
+        )
+        / total
+    )
+    all_fixture_biases = all(
+        item.exact_weights_pinned
+        and item.all_weights_positive
+        and item.one_three_equality_forced
+        and item.zero_two_weights_unequal
+        and item.block_totals_unequal
+        for item in fixtures
+    )
+    return CertifiedVacuumCertificate(
+        fixtures,
+        weights,
+        density,
+        central_weights,
+        (internal02, internal13),
+        sp.factor(sp.trace(density)) == 1,
+        sp.factor(trace_pair(density, observable) - induced_functional) == 0,
+        matrix_zero(density - reconstructed),
+        all_fixture_biases,
+        matrix_zero(internal13 - I2 / 2)
+        and all(item.one_three_equality_forced for item in fixtures),
+    )
+
+
+@dataclass(frozen=True)
+class NormalizationCertificate:
+    certified_gram: sp.Matrix
+    intra_block_scale: sp.Matrix
+    intra_block_gram: sp.Matrix
+    block_scale: sp.Matrix
+    final_gram: sp.Matrix
+    final_density: sp.Matrix
+    parent_not_square_imported: bool
+    first_move_needed: bool
+    second_move_needed: bool
+    exactly_two_moves: bool
+    intra_block_equalization_exact: bool
+    block_equalization_exact: bool
+    scales_real_positive: bool
+    involutivity_preserved: bool
+    positivity_preserved: bool
+
+
+def normalization_certificate(
+    carriers: tuple[b132.CarrierCertificate, ...],
+    fixtures: tuple[FixtureVacuumCertificate, ...],
+) -> NormalizationCertificate:
+    q_zero, q_one, g = sp.symbols(
+        "q_0 q_1 g_02", positive=True, nonzero=True
+    )
+    certified_gram = sp.diag(q_zero, q_one, g * q_zero, q_one)
+    intra_scale = sp.diag(1, 1, 1 / sp.sqrt(g), 1)
+    intra_gram = (intra_scale.T * certified_gram * intra_scale).applyfunc(
+        sp.simplify
+    )
+    block_scale = sp.diag(
+        1,
+        sp.sqrt(q_zero / q_one),
+        1,
+        sp.sqrt(q_zero / q_one),
+    )
+    final_gram = (block_scale.T * intra_gram * block_scale).applyfunc(
+        sp.simplify
+    )
+    final_density = (final_gram / sp.trace(final_gram)).applyfunc(sp.simplify)
+
+    fields = tuple(b132.field_caveat_certificate(item) for item in carriers)
+    gauges = tuple(b132.gauge_certificate(item) for item in carriers)
+    parent_observable = b132.observable_space_certificate()
+    parent_not_square_imported = all(
+        field.root_field_quadratic
+        and field.no_rational_solution
+        and field.sqrt_not_in_field
+        for field in fields
+    ) and all(gauge.extension_normalization for gauge in gauges)
+
+    scales = tuple(intra_scale.diagonal()) + tuple(block_scale.diagonal())
+    scales_real_positive = all(
+        sp.simplify(sp.conjugate(value) - value) == 0
+        and value.is_positive is True
+        for value in scales
+    )
+    reality = sp.eye(4)
+    transformed_reality_one = (
+        intra_scale.inv() * reality * intra_scale.conjugate()
+    ).applyfunc(sp.simplify)
+    transformed_reality_two = (
+        block_scale.inv()
+        * transformed_reality_one
+        * block_scale.conjugate()
+    ).applyfunc(sp.simplify)
+    involutivity_preserved = (
+        matrix_zero(transformed_reality_one - sp.eye(4))
+        and matrix_zero(transformed_reality_two - sp.eye(4))
+        and matrix_zero(
+            transformed_reality_two * transformed_reality_two.conjugate()
+            - sp.eye(4)
+        )
+        and parent_observable.involutivity_preserved
+    )
+    positivity_preserved = (
+        all(value.is_positive is True for value in intra_gram.diagonal())
+        and all(value.is_positive is True for value in final_gram.diagonal())
+        and parent_observable.positivity_preserved
+    )
+    first_move_needed = all(item.zero_two_weights_unequal for item in fixtures)
+    second_move_needed = all(item.zero_one_weights_unequal for item in fixtures)
+    two_moves = (intra_scale, block_scale)
+    return NormalizationCertificate(
+        certified_gram,
+        intra_scale,
+        intra_gram,
+        block_scale,
+        final_gram,
+        final_density,
+        parent_not_square_imported,
+        first_move_needed,
+        second_move_needed,
+        len(two_moves) == 2 and first_move_needed and second_move_needed,
+        matrix_zero(intra_gram - sp.diag(q_zero, q_one, q_zero, q_one)),
+        matrix_zero(final_gram - q_zero * sp.eye(4))
+        and matrix_zero(final_density - sp.eye(4) / 4),
+        scales_real_positive,
+        involutivity_preserved,
+        positivity_preserved,
+    )
+
+
+def observable_basis() -> tuple[tuple[str, sp.Matrix], ...]:
+    return (
+        ("I_02", embed_pair(I2, (0, 2))),
+        ("Z_02", embed_pair(Z, (0, 2))),
+        ("X_02", embed_pair(X, (0, 2))),
+        ("I_13", embed_pair(I2, (1, 3))),
+        ("Z_13", embed_pair(Z, (1, 3))),
+        ("X_13", embed_pair(X, (1, 3))),
+    )
+
+
+def trig_matrix_zero(matrix: sp.MatrixBase) -> bool:
+    return all(
+        sp.simplify(sp.expand_complex(value)) == 0 for value in matrix
+    )
+
+
+@dataclass(frozen=True)
+class MomentumCertificate:
+    momentum: sp.Matrix
+    generator_differences: tuple[int, int]
+    orbit02_x: sp.Matrix
+    orbit02_y: sp.Matrix
+    orbit13_x: sp.Matrix
+    orbit13_y: sp.Matrix
+    orbit02_exact: bool
+    orbit13_exact: bool
+    opposite_orientations: bool
+    identity_and_z_fixed: bool
+    conserving_flags: tuple[bool, bool, bool, bool, bool, bool]
+    commutant_rank: int
+    commutant_dimension: int
+    conserving_algebra_exact: bool
+
+
+def momentum_certificate() -> MomentumCertificate:
+    t = sp.Symbol("t", real=True)
+    cosine, sine = sp.cos(2 * t), sp.sin(2 * t)
+    momentum02 = sp.diag(0, 2)
+    momentum13 = sp.diag(1, -1)
+    momentum = sp.diag(0, 1, 2, -1)
+    difference02 = int(momentum02[0, 0] - momentum02[1, 1])
+    difference13 = int(momentum13[0, 0] - momentum13[1, 1])
+    unitary02 = sp.diag(sp.exp(I * 0 * t), sp.exp(I * 2 * t))
+    unitary13 = sp.diag(sp.exp(I * t), sp.exp(-I * t))
+
+    orbit02_x = cosine * X - sine * Y
+    orbit02_y = sine * X + cosine * Y
+    orbit13_x = cosine * X + sine * Y
+    orbit13_y = -sine * X + cosine * Y
+    exact02 = (
+        trig_matrix_zero(unitary02 * X * unitary02.H - orbit02_x)
+        and trig_matrix_zero(unitary02 * Y * unitary02.H - orbit02_y)
+        and matrix_zero(
+            orbit02_x.diff(t).subs(t, 0) - I * commutator(momentum02, X)
+        )
+        and matrix_zero(
+            orbit02_y.diff(t).subs(t, 0) - I * commutator(momentum02, Y)
+        )
+    )
+    exact13 = (
+        trig_matrix_zero(unitary13 * X * unitary13.H - orbit13_x)
+        and trig_matrix_zero(unitary13 * Y * unitary13.H - orbit13_y)
+        and matrix_zero(
+            orbit13_x.diff(t).subs(t, 0) - I * commutator(momentum13, X)
+        )
+        and matrix_zero(
+            orbit13_y.diff(t).subs(t, 0) - I * commutator(momentum13, Y)
+        )
+    )
+    fixed = all(
+        trig_matrix_zero(unitary * matrix * unitary.H - matrix)
+        for unitary in (unitary02, unitary13)
+        for matrix in (I2, Z)
+    )
+    basis = observable_basis()
+    conserving = tuple(
+        matrix_zero(commutator(momentum, matrix)) for _, matrix in basis
+    )
+
+    a02, b02, c02, a13, b13, c13 = sp.symbols(
+        "a_02 b_02 c_02 a_13 b_13 c_13", real=True
+    )
+    variables = (a02, b02, c02, a13, b13, c13)
+    generic = embed_pair(a02 * I2 + b02 * X + c02 * Z, (0, 2))
+    generic += embed_pair(a13 * I2 + b13 * X + c13 * Z, (1, 3))
+    equations = tuple(
+        entry for entry in commutator(momentum, generic) if entry != 0
+    )
+    coefficients, _ = sp.linear_eq_to_matrix(equations, variables)
+    expected_coefficients, _ = sp.linear_eq_to_matrix(
+        (b02, b13), variables
+    )
+    commutant_rank = coefficients.rank()
+    commutant_dimension = len(variables) - commutant_rank
+    conserving_exact = (
+        same_row_space(coefficients, expected_coefficients)
+        and commutant_rank == 2
+        and commutant_dimension == 4
+        and conserving == (True, True, False, True, True, False)
+        and momentum02[0, 0] != momentum02[1, 1]
+        and momentum13[0, 0] != momentum13[1, 1]
+    )
+    return MomentumCertificate(
+        momentum,
+        (difference02, difference13),
+        orbit02_x,
+        orbit02_y,
+        orbit13_x,
+        orbit13_y,
+        exact02,
+        exact13,
+        (difference02, difference13) == (-2, 2),
+        fixed,
+        conserving,
+        commutant_rank,
+        commutant_dimension,
+        conserving_exact,
+    )
+
+
+@dataclass(frozen=True)
+class BalancedEquatorCertificate:
+    radius: sp.Symbol
+    phase: sp.Symbol
+    pure_density: sp.Matrix
+    family_density: sp.Matrix
+    equal_moduli_exact: bool
+    relative_phase_free: bool
+    equator_identification_exact: bool
+    positivity_identity_exact: bool
+    general_observable: sp.Matrix
+    general_expectation: sp.Expr
+    y_not_admissible: bool
+    invariant_rank: int
+    invariant_dimension: int
+    invariant_span_exact: bool
+
+
+def balanced_equator_certificate() -> BalancedEquatorCertificate:
+    radius = sp.Symbol("r", positive=True, nonzero=True)
+    phase = sp.Symbol("phi", real=True)
+    c_one = 1 / sp.sqrt(2)
+    c_three = sp.exp(-I * phase) / sp.sqrt(2)
+    vector = sp.Matrix((c_one, c_three))
+    pure_density = vector * vector.H
+    expected_pure = (I2 + sp.cos(phase) * X + sp.sin(phase) * Y) / 2
+    family_density = (
+        radius * pure_density + (1 - radius) * I2 / 2
+    ).applyfunc(sp.expand)
+    expected_family = (
+        I2
+        + radius * (sp.cos(phase) * X + sp.sin(phase) * Y)
+    ) / 2
+    equal_moduli = (
+        sp.simplify(sp.conjugate(c_one) * c_one) == R(1, 2)
+        and sp.simplify(sp.conjugate(c_three) * c_three) == R(1, 2)
+        and sp.simplify((vector.H * vector)[0]) == 1
+    )
+    full_phase = (
+        trig_matrix_zero(pure_density.subs(phase, 0) - (I2 + X) / 2)
+        and trig_matrix_zero(
+            pure_density.subs(phase, sp.pi / 2) - (I2 + Y) / 2
+        )
+        and phase in pure_density.free_symbols
+    )
+    equator_exact = (
+        trig_matrix_zero(pure_density - expected_pure)
+        and trig_matrix_zero(family_density - expected_family)
+    )
+    positivity_identity = (
+        sp.simplify(sp.trace(expected_family)) == 1
+        and sp.simplify(
+            sp.expand_complex(expected_family.det()) - (1 - radius**2) / 4
+        )
+        == 0
+    )
+
+    a, b, c = sp.symbols("a b c", real=True)
+    observable = a * I2 + b * X + c * Z
+    expectation = sp.simplify(
+        sp.expand_complex(trace_pair(expected_family, observable))
+    )
+    phase_difference = sp.simplify(
+        expectation.subs(phase, 0) - expectation.subs(phase, sp.pi)
+    )
+    invariant_equation = sp.simplify(phase_difference / (2 * radius))
+    variables = (a, b, c)
+    invariant_coefficients, _ = sp.linear_eq_to_matrix(
+        (invariant_equation,), variables
+    )
+    expected_coefficients, _ = sp.linear_eq_to_matrix((b,), variables)
+    invariant_rank = invariant_coefficients.rank()
+    invariant_dimension = len(variables) - invariant_rank
+    y_excluded = (
+        matrix_zero(Y.H - Y)
+        and matrix_zero(Y.T + Y)
+        and matrix_zero(Y.conjugate() + Y)
+        and not matrix_zero(Y.T - Y)
+        and not matrix_zero(Y.conjugate() - Y)
+    )
+    invariant_exact = (
+        expectation == a + radius * b * sp.cos(phase)
+        and invariant_equation == b
+        and same_row_space(invariant_coefficients, expected_coefficients)
+        and invariant_rank == 1
+        and invariant_dimension == 2
+        and y_excluded
+    )
+    return BalancedEquatorCertificate(
+        radius,
+        phase,
+        pure_density,
+        expected_family,
+        equal_moduli,
+        full_phase,
+        equator_exact,
+        positivity_identity,
+        observable,
+        expectation,
+        y_excluded,
+        invariant_rank,
+        invariant_dimension,
+        invariant_exact,
+    )
+
+
+@dataclass(frozen=True)
+class BasisRow:
+    name: str
+    matrix: sp.Matrix
+    momentum_conserving: bool
+    balanced_measurable: str
+    certified_vacuum_value: sp.Expr
+
+
+@dataclass(frozen=True)
+class SummaryTableCertificate:
+    rows: tuple[BasisRow, ...]
+    table_exact: bool
+    honest_closer: str
+    no_tensor_claim: bool
+
+
+def summary_table_certificate(
+    vacuum: CertifiedVacuumCertificate,
+    momentum: MomentumCertificate,
+    balanced: BalancedEquatorCertificate,
+) -> SummaryTableCertificate:
+    basis = observable_basis()
+    balanced_full = embed_pair(balanced.family_density, (1, 3))
+    balanced_expectations = tuple(
+        sp.simplify(sp.expand_complex(trace_pair(balanced_full, matrix)))
+        for _, matrix in basis
+    )
+    balanced_labels = tuple(
+        "null"
+        if index < 3 and expectation == 0
+        else (
+            "yes"
+            if sp.simplify(sp.diff(expectation, balanced.phase)) == 0
+            else "no"
+        )
+        for index, expectation in enumerate(balanced_expectations)
+    )
+    vacuum_values = tuple(
+        sp.factor(trace_pair(vacuum.density, matrix))
+        for _, matrix in basis
+    )
+    rows = tuple(
+        BasisRow(
+            name,
+            matrix,
+            momentum.conserving_flags[index],
+            balanced_labels[index],
+            vacuum_values[index],
+        )
+        for index, (name, matrix) in enumerate(basis)
+    )
+    q_zero, q_one, g = vacuum.symbolic_weights[:3]
+    # The third tuple entry is g*q_0, so recover g without introducing a
+    # second source for the exact table values.
+    g = sp.cancel(vacuum.symbolic_weights[2] / q_zero)
+    total = sum(vacuum.symbolic_weights)
+    expected_vacuum = (
+        sp.factor(q_zero * (1 + g) / total),
+        sp.factor(q_zero * (1 - g) / total),
+        sp.Integer(0),
+        sp.factor(2 * q_one / total),
+        sp.Integer(0),
+        sp.Integer(0),
+    )
+    closer = (
+        "exact expectations and selection rules are complete on the direct "
+        "sum; no tensor-product structure is claimed"
+    )
+    table_exact = (
+        tuple(row.name for row in rows)
+        == ("I_02", "Z_02", "X_02", "I_13", "Z_13", "X_13")
+        and tuple(row.momentum_conserving for row in rows)
+        == (True, True, False, True, True, False)
+        and tuple(row.balanced_measurable for row in rows)
+        == ("null", "null", "null", "yes", "yes", "no")
+        and all(
+            sp.factor(actual - expected) == 0
+            for actual, expected in zip(vacuum_values, expected_vacuum)
+        )
+    )
+    return SummaryTableCertificate(
+        rows,
+        table_exact,
+        closer,
+        "no tensor-product structure" in closer
+        and "tensor-product structure exists" not in closer,
+    )
+
+
+N5_LINES = (
+    "N5: per_element: exact state-space, vacuum-weight, normalization, orbit, equator, and summary certificates are checked",
+    "per_site: one Grassmann mode per fine site on the antiperiodic reflection torus",
+    "per_mode: the certified vacuum is a biased central mixture with the conjugate block maximally mixed by force and the per-sector-real block biased, while momentum counter-rotates the two blocks' quadratures at rate two",
+    "per_block: the balanced gravity sector is the full bloch equator whose invariant observables are exactly the identity and z because the y quadrature is not an admissible observable — the certified package's measurement physics is complete with exact expectations and selection rules",
+    "lattice_wide: checked and not executed — the common nilpotent differential, the flip work order, richer carriers, the actual ADM/history transporter completion, joint gravity, the gravity constraint quotient beyond the displayed carrier, Records, audit retention, and TOE closure remain open",
+)
+
+
+SCOPE_KEYS = (
+    "biased_central_mixture",
+    "frame_distinction",
+    "two_moves",
+    "opposite_orientations",
+    "diagonal_conserving",
+    "full_equator",
+    "invariant_span",
+    "y_exclusion",
+    "no_tensor",
+    "measurement_physics",
+    "os_boundary",
+    "axiom",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity_quotient",
+    "adm",
+    "n1_n8",
+    "w1",
+    "n5_resolution",
+    "n5_verbatim",
+)
+
+
+def scope_certificate(note: str, mutation: str) -> dict[str, bool]:
+    result = {
+        "biased_central_mixture": "biased" in note
+        and "central mixture" in note,
+        "frame_distinction": "certified frame" in note
+        and "normalized frame" in note,
+        "two_moves": "two normalizations" in note or "two moves" in note,
+        "opposite_orientations": "opposite orientations" in note
+        or "counter-rotating" in note,
+        "diagonal_conserving": "diagonal" in note and "conserving" in note,
+        "full_equator": "full bloch equator" in note
+        or "free relative phase" in note,
+        "invariant_span": "span{i, z}" in note or "i and z" in note,
+        "y_exclusion": "y quadrature" in note and "not an" in note,
+        "no_tensor": "no tensor-product structure" in note,
+        "measurement_physics": "selection rules" in note
+        or "exact expectations" in note,
+        "os_boundary": "not an os no-go" in note
+        or "not a curved os no-go" in note,
+        "axiom": "no axiom amendment is justified" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": "no toe percentage moves" in note,
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "gravity_quotient": (
+            "gravity constraint quotient remains unexecuted" in note
+        ),
+        "adm": "actual adm/history transporter remains" in note,
+        "n1_n8": all(f"n{index}" in note for index in range(1, 9)),
+        "w1": "w1" in note,
+        "n5_resolution": all(
+            f"{resolution}:" in note
+            for resolution in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+        "n5_verbatim": all(
+            " ".join(line.lower().split()) in note for line in N5_LINES
+        ),
+    }
+    if mutation == "weaken_no_go_packet":
+        result["os_boundary"] = False
+        result["n1_n8"] = False
+    if mutation == "drop_n5_resolution":
+        result["n5_resolution"] = False
+        result["n5_verbatim"] = False
+    if mutation == "claim_toe_progress":
+        result["zero_score"] = False
+    if mutation == "claim_axiom_amendment":
+        result["axiom"] = False
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started = time.monotonic()
+    checks = Checks()
+
+    authority = authority_certificate(mutation)
+    authority_raw = (
+        AUDIT_TIMEOUT_SEC == 600
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_STATES_DYNAMICS_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+            "docs/audit/data/axiom_premise_nodes.json",
+            "docs/ADMISSIBILITY_DIRAC_KAHLER_TWO_BLOCK_OBSERVABLE_ALGEBRA_BOUNDED_THEOREM_NOTE_2026-08-17.md",
+            "scripts/admissibility_dirac_kahler_two_block_observable_algebra_2026_08_17.py",
+            "logs/runner-cache/admissibility_dirac_kahler_two_block_observable_algebra_2026_08_17.txt",
+            "scripts/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.py",
+            "logs/runner-cache/admissibility_dirac_kahler_reflection_intertwiner_completion_2026_08_16.txt",
+        )
+        and authority["main"] == CURRENT_MAIN
+        and authority["axiom"] == authority["expected_axiom"]
+        and authority["worktree_axiom"] == WORKTREE_AXIOM_BLOB
+        and authority["registry"] == CURRENT_REGISTRY_BLOB
+        and authority["worktree_registry"] == WORKTREE_REGISTRY_BLOB
+        and authority["parent"] == PARENT_COMMIT
+        and authority["parent_ancestor"]
+        and all(
+            authority[f"ancestor_{number}"] for number in range(103, 132)
+        )
+        and authority["parent_note"] == authority["expected_parent"]
+        and authority["parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["parent_cache"] == PARENT_CACHE_BLOB
+        and authority["worktree_parent_note"] == PARENT_NOTE_BLOB
+        and authority["worktree_parent_runner"] == PARENT_RUNNER_BLOB
+        and authority["worktree_parent_cache"] == PARENT_CACHE_BLOB
+        and authority["b119_ancestor"]
+        and authority["b119_runner"] == B119_RUNNER_BLOB
+        and authority["b119_cache"] == B119_CACHE_BLOB
+        and authority["worktree_b119_runner"] == B119_RUNNER_BLOB
+        and authority["worktree_b119_cache"] == B119_CACHE_BLOB
+    )
+    checks.check(
+        "A-authority",
+        "Block 132 blobs, ancestors 131--103, and landed Block 119 runner/cache are pinned",
+        authority_raw,
+    )
+
+    states = state_space_certificate()
+    state_raw = (
+        states.trace_normalized
+        and states.disk_determinants_exact
+        and states.inverse_coordinates_exact
+        and states.ambient_dimension == 6
+        and states.trace_constraint_rank == 1
+        and states.affine_dimension == 5
+        and states.pure_projector_identity
+        and states.pure_bloch_circle
+        and states.antipodal_identification
+        and states.fixture_independent
+    )
+    checks.check(
+        "B-the-state-space",
+        "displayed linear algebra gives dim 5, two Bloch disks, and the two RP^1 pure families, fixture-independently",
+        state_raw and mutation != "break_state_space",
+    )
+
+    sector_fixtures = tuple(
+        b119.make_sectors(shear)
+        for shear in (b119.prior.PRIMARY_SHEAR, b119.prior.SECOND_SHEAR)
+    )
+    carriers = tuple(
+        b132.carrier_certificate(sectors) for sectors in sector_fixtures
+    )
+    vacuum_fixtures = tuple(
+        fixture_vacuum_certificate(sectors, carrier)
+        for sectors, carrier in zip(sector_fixtures, carriers)
+    )
+    vacuum = certified_vacuum_certificate(vacuum_fixtures)
+    vacuum_raw = (
+        tuple(item.shear for item in vacuum.fixtures) == (R(5, 13), R(3, 5))
+        and all(
+            item.exact_weights_pinned
+            and item.all_weights_positive
+            and item.one_three_equality_forced
+            and item.zero_two_weights_unequal
+            and item.block_totals_unequal
+            for item in vacuum.fixtures
+        )
+        and vacuum.trace_normalized
+        and vacuum.trace_representation_exact
+        and vacuum.central_decomposition_exact
+        and vacuum.certified_frame_biased
+        and vacuum.one_three_maximally_mixed
+    )
+    if mutation in (
+        "break_vacuum_weights",
+        "claim_certified_maximally_mixed",
+    ):
+        vacuum_raw = False
+    checks.check(
+        "C-the-certified-vacuum",
+        "both fixtures give pinned positive direction weights, a biased central mixture, and only block (1,3) maximally mixed",
+        vacuum_raw,
+    )
+
+    normalization = normalization_certificate(carriers, vacuum_fixtures)
+    normalization_raw = (
+        normalization.parent_not_square_imported
+        and normalization.first_move_needed
+        and normalization.second_move_needed
+        and normalization.exactly_two_moves
+        and normalization.intra_block_equalization_exact
+        and normalization.block_equalization_exact
+        and normalization.scales_real_positive
+        and normalization.involutivity_preserved
+        and normalization.positivity_preserved
+        and matrix_zero(normalization.final_density - sp.eye(4) / 4)
+    )
+    checks.check(
+        "D-the-normalization-ledger",
+        "exactly two positive real moves give Tr/4 and preserve involutivity and positivity; Block 132 supplies the nonsquare import",
+        normalization_raw and mutation != "break_normalization_ledger",
+    )
+
+    momentum = momentum_certificate()
+    orbit_raw = (
+        momentum.generator_differences == (-2, 2)
+        and momentum.orbit02_exact
+        and momentum.orbit13_exact
+        and momentum.opposite_orientations
+        and momentum.identity_and_z_fixed
+    )
+    conserving_raw = (
+        momentum.commutant_rank == 2
+        and momentum.commutant_dimension == 4
+        and momentum.conserving_algebra_exact
+    )
+    if mutation == "break_orbit_signs":
+        orbit_raw = False
+    if mutation == "break_conserving_algebra":
+        conserving_raw = False
+    checks.check(
+        "E-the-momentum-orbits",
+        "e^{itP} rotates the two quadrature planes at rate 2 with differences (-2,+2), while the conserving algebra is diagonal R^4",
+        orbit_raw and conserving_raw,
+    )
+
+    balanced = balanced_equator_certificate()
+    equator_raw = (
+        balanced.equal_moduli_exact
+        and balanced.relative_phase_free
+        and balanced.equator_identification_exact
+        and balanced.positivity_identity_exact
+    )
+    invariant_raw = (
+        balanced.general_expectation
+        == sp.Symbol("a", real=True)
+        + balanced.radius
+        * sp.Symbol("b", real=True)
+        * sp.cos(balanced.phase)
+        and balanced.y_not_admissible
+        and balanced.invariant_rank == 1
+        and balanced.invariant_dimension == 2
+        and balanced.invariant_span_exact
+    )
+    if mutation == "break_equator_identification":
+        equator_raw = False
+    if mutation == "break_invariant_span":
+        invariant_raw = False
+    checks.check(
+        "F-the-balanced-equator",
+        "|c_1|=|c_3| gives the full free-relative-phase Bloch equator; phi-invariant admissible observables are exactly span{I,Z}",
+        equator_raw and invariant_raw,
+    )
+
+    summary = summary_table_certificate(vacuum, momentum, balanced)
+    summary_raw = (
+        len(summary.rows) == 6
+        and summary.table_exact
+        and summary.no_tensor_claim
+    )
+    checks.check(
+        "G-the-summary-table",
+        "the six basis rows have exact conserving, balanced-measurable, and certified-frame vacuum columns with no tensor claim",
+        summary_raw and mutation != "break_summary_table",
+    )
+
+    scope = scope_certificate(normalized_note(), mutation)
+    elapsed_before_scope = time.monotonic() - started
+    checks.check(
+        "H-scope",
+        "frame, orbit, equator, exclusion, N1--N8/W1/N5, no-go, and TOE firewalls are present",
+        set(scope) == set(SCOPE_KEYS)
+        and all(scope.values())
+        and elapsed_before_scope <= 400,
+    )
+
+    print(
+        "AUTHORITY: Block132 parent="
+        f"{authority['parent']}; note/runner/cache and Block119 pins exact"
+    )
+    print(
+        "STATE: D_02=w(I+x_02 X+z_02 Z)/2, "
+        "D_13=(1-w)(I+x_13 X+z_13 Z)/2; 0<=w<=1, "
+        "x_j^2+z_j^2<=1; affine dim=5; fixture-independent"
+    )
+    print(
+        "PURE: w=1 or 0 and rho=vv^T/(v^Tv), v~-v; each boundary "
+        "family is RP^1 and an interior central mixture is not pure"
+    )
+    for fixture in vacuum.fixtures:
+        print(
+            f"VACUUM-PIN c={fixture.shear}: "
+            "literal exact q0,q1 pins; q2=g02*q0; q3=q1; positive "
+            "direction intervals and unequal block-total intervals"
+        )
+    print(
+        "CERTIFIED FRAME: D_cert=diag(q0,q1,g02*q0,q1)/N, "
+        "N=q0(1+g02)+2q1; W02=q0(1+g02)/N != W13=2q1/N; "
+        "rho02=diag(1,g02)/(1+g02) is biased, rho13=I/2"
+    )
+    print(
+        "NORMALIZED FRAME: two moves: y2->y2/sqrt(g02) (Block132 "
+        "certifies sqrt(g02) notin Q(rho)), then "
+        "(y1,y3)->sqrt(q0/q1)(y1,y3); the result is Tr_4/4"
+    )
+    print(
+        "ORBITS: d02=-2: X->cos(2t)X-sin(2t)Y; d13=+2: "
+        "X->cos(2t)X+sin(2t)Y; the Y rotations have the opposite "
+        "matching signs; I,Z fixed; diagonal R^4 conserving"
+    )
+    print(
+        "BALANCED: |c1|=|c3| gives rho=(I+r(cos(phi)X+sin(phi)Y))/2 "
+        "with free relative phase; <aI+bX+cZ>=a+r*b*cos(phi), so "
+        "span{I,Z} only; Y is not an admissible Sym_2(R) observable"
+    )
+    print(
+        "TABLE: observable | P-conserving | balanced-measurable | "
+        "certified-frame vacuum value"
+    )
+    for row in summary.rows:
+        print(
+            f"  {row.name:4s} | "
+            f"{'yes' if row.momentum_conserving else 'no ':3s} | "
+            f"{row.balanced_measurable:4s} | {row.certified_vacuum_value}"
+        )
+    print(f"PHYSICS: {summary.honest_closer}")
+    for line in N5_LINES:
+        print(line)
+    if checks.failed == 0:
+        print(
+            "RESULT: the two-block algebra's measurement theory is complete — "
+            "a biased certified vacuum with a two-step normalization ledger, "
+            "counter-rotating momentum dynamics with the diagonal conserved, "
+            "and a balanced gravity sector that measures exactly the identity and z"
+        )
+        print(
+            "DECISION_CUT: the common differential and richer carriers are the "
+            "frontier; reject frame-ambiguous vacuum claims; advance exact "
+            "state expectations and selection rules only"
+        )
+    else:
+        print(
+            "RESULT: BLOCKED — at least one exact authority, state, vacuum, "
+            "normalization, dynamics, equator, table, scope, mutation, or "
+            "runtime certificate failed"
+        )
+        print(
+            "DECISION_CUT: repair the failed certificate without conflating "
+            "the certified and normalized frames"
+        )
+    print(
+        "TOE: zero obligation retirement; no TOE percentage moves; "
+        "retained-positive end-to-end theory count remains zero; gravity "
+        "constraint quotient remains unexecuted; actual ADM/history "
+        "transporter remains open"
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"FAIL: {type(error).__name__}: {error}")
+        print("TOTAL: PASS=0 FAIL=1")
+        raise


### PR DESCRIPTION
## Block 133 — States And Dynamics On The Two-Block Algebra

Stacked on #6848 (Block 132). Fifth-file discipline: bounded_theorem
note, runner, cache, block ledger, refreshed citation manifest.

### Result

The measurement theory of the certified package, completing the
campaign's observable arc:

- **The state space.** Five-dimensional: paired symmetric disc states
  with a convex weight; pure states form one projective-line family per
  block.
- **The certified vacuum (checker-corrected).** In the certified frame
  the induced state is a **biased** central mixture — direction weights
  proportional to the boundary-vector norms, with the conjugate block
  maximally mixed *by force* (equal norms from the entrywise
  conjugation of Block 131) while the per-sector-real block is biased
  and the block totals unequal. The clean `Tr/4` presentation is
  attainable but requires exactly two normalization moves, one of them
  the field-leaving square-root equalization of Block 132 — the frames
  are distinguished at every use.
- **The dynamics.** Momentum generates rate-2 quadrature rotations in
  the two blocks with **opposite orientations** (generator differences
  −2 and +2 — the conjugate structure appearing in the dynamics); the
  conserved subalgebra is the diagonal `R^4`.
- **The balanced gravity sector (identification corrected).** The
  Block 124 class is the *full free-phase Bloch equator*, not an axis —
  and its invariant observables are still exactly `span{I, Z}`, for the
  elegant reason that the `Y` quadrature is not an element of the real
  symmetric algebra: the phase freedom is invisible to every admissible
  observable.
- **The honest closer.** Exact expectations and momentum selection
  rules are certified; no tensor-product structure or additional
  dynamical law is claimed.

### Verification

- Runner: 8/8 PASS; recomputes the state-space structure, the exact
  vacuum weights with the forced (1,3) equality and (0,2) inequality,
  the two-move normalization ledger with symbolic admissibility
  certificates, the orbit signs, the conserving subalgebra, the equator
  identification with the Y-exclusion argument, and the six-row summary
  table. Mutation sweep: 15/15 clean. N5 byte-identical.
- Independent cross-model verification: both headline refinements are
  the checker's — the biased-vacuum correction (refuting the naive
  `Tr/4` as a certified-frame claim) and the full-equator
  identification with the span{I,Z} conclusion rescued by the
  Y-exclusion.
- `vocab_lint` and `audit_lint --strict` clean. `run_pipeline.sh`
  exits 1 at the pre-existing dependency-policy epoch-debt gate;
  identical on the clean base — unrelated to this PR.

### TOE accounting

Zero obligation retirement; no TOE percentage moves; retained-positive
end-to-end theory count remains zero. Bounded theorem; audit-lane
referral for any verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
