### PR TITLE
physics: complete the ledger at the third size and find the isospectral mechanism (block 139)

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block139-z8-ledger-completion-20260819/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block139-z8-ledger-completion-20260819/NO_GO_LEDGER.md
@@ -1,0 +1,40 @@
+# Block 139 No-Go Ledger
+
+Scope: the Z8 ledger completion — Block 138's named next executed,
+with two discoveries and one named negative. THE POSITIVE: the Z8
+fixture is the same-family extension (supervisor-audited: the
+committed Block 136 builders consumed unchanged; only the spatial
+extent, its root field Q(i, sqrt(2)), and the projector set change);
+rho_0 = rho_4 at both shears with identical monodromy trace AND
+determinant (det = 1 exactly on every even momentum, independently
+confirmed at N=4 by the checker's own companion construction); the
+trace classes are (0,4),(1,5),(2,6),(3,7) under the two rules (k ->
+k+4 exact equality, k -> 8-k exact conjugation;
+supervisor-verified independently from the printed exact values) —
+so Block 138's verification ledger completes at three sizes, all on
+the 3m branch: Sym_2(R)^4, dimension 12, center 4 on the displayed
+Z8 fixture. THE DISCOVERIES: (1) the cross-size law — the k=0
+monodromy trace is EXACTLY size-independent, digit-for-digit
+identical at Z4, Z6, and Z8 at both displayed shears (the Z4 point
+computed independently of the solve); (2) the isospectral mechanism —
+the k=0 and k=N/2 momentum blocks have identical characteristic
+polynomials (all coefficients, both shears), which forces the
+degeneracy; verified at N=4 by the checker and at Z6/Z8 by the
+runner. THE NAMED NEGATIVE: the plain one-slice time shift is NOT
+the similarity (exact inequality both shears) — the intertwiner
+witnessing the isospectrality is unidentified. `W1`: the
+family-theorem upgrade is NOT claimed; the transfer-degeneracy rider
+stays a per-size checkable fact (the family upgrade is gated on
+exhibiting the general-even-N similarity, the named next).
+
+| tempting upgrade | honesty | exact disposition | live repair |
+|---|---|---|---|
+| the degeneracy holds for all even N | `ATTEMPTED` | not proven: three sizes, two shears; the similarity is unidentified | the similarity hunt |
+| the one-slice time shift is the intertwiner | `ATTEMPTED` | refuted exactly at both shears | the similarity hunt |
+| the cross-size law is a theorem | `ATTEMPTED` | exact at the checked fixtures only; no general proof | the similarity hunt |
+| the isospectrality is mere trace equality | `ATTEMPTED` | stronger: all characteristic-polynomial coefficients agree | none needed |
+| the Z8 fixture is a new model | `ATTEMPTED` | false: committed builders unchanged; the same-family audit | none needed |
+| the 3m branch is now unconditional | `ATTEMPTED` | false: per-size checkable fact; Block 138's rider unchanged | the similarity hunt |
+| axiom/TOE movement | `ATTEMPTED` | false | zero retirement, no movement |
+
+The source note is the landing N1-N8 artifact; the completion ships with both discoveries and the named negative displayed.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_Z8_LEDGER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-19.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_Z8_LEDGER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-19.md
@@ -1,0 +1,1163 @@
+---
+claim_id: admissibility_dirac_kahler_z8_ledger_completion_bounded_theorem_note_2026-08-19
+final_path: docs/ADMISSIBILITY_DIRAC_KAHLER_Z8_LEDGER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-19.md
+claim_type: bounded_theorem
+claim_scope: "for the same committed Block 136 flat cyclic-shear family at spatial Z8 and the two displayed shears 5/13 and 3/5, the exact transfer construction gives rho_0=rho_4 through identical monodromy trace and determinant, completing the N=4,6,8 verification ledger on the 3m branch and giving Sym_2(R)^4 with dimension 12 and center 4 at Z8; the Z8 trace classes are exactly (0,4),(1,5),(2,6),(3,7), with k->k+4 exact trace equality and k->8-k exact conjugation, the k=0 trace is exactly size-independent across N=4,6,8 at both shears, and the N=4 checker identifies full characteristic-polynomial equality of the two real-character momentum blocks while exactly refuting the plain one-slice time shift as their similarity (the refuted intertwiner: it does not conjugate the k=0 block into the k=N/2 block) — but no family theorem is claimed because the witnessing similarity remains unidentified and no general-even-N isospectral proof, parity-mixing dressing classification, joint-lane completion, completed ADM/history transporter, joint gravity, gravity constraint quotient beyond the displayed carriers, Records result, retention, axiom amendment, obligation retirement, or TOE percentage movement is established."
+depends_on:
+  - admissibility_dirac_kahler_general_zn_charge_kinematic_theorem_bounded_theorem_note_2026-08-19
+  - admissibility_dirac_kahler_observable_scaling_law_bounded_theorem_note_2026-08-18
+runner: scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_dirac_kahler_general_zn_charge_kinematic_theorem_bounded_theorem_note_2026-08-19
+target_blocker_text: "The N=8 dynamical degeneracy; parity-mixing dressing classes; the joint-lane program."
+source_of_blocker_text: next_trace_action
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "The isospectral similarity for general even N; parity-mixing dressing classes; the joint-lane program."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-138 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the exact same-family Z8 construction verifies rho_0=rho_4 at both displayed shears by identical monodromy trace and determinant, completes the three-size transfer-degeneracy ledger on the 3m branch, determines the Z8 trace and determinant classes, and records an exact three-size k=0 trace law; the checker additionally establishes full characteristic-polynomial equality of the two real-character momentum blocks at N=4 and refutes the plain one-slice time shift as the similarity, but the similarity itself is unidentified and no general-even-N isospectral theorem, parity-mixing classification, or joint-lane completion is supplied, so bounded"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# The Z8 Ledger Completion
+
+**Date:** 2026-08-19
+
+**Campaign block:** 139
+
+**Type:** `bounded_theorem`
+
+**Audit authority:** none. Independent audit alone may assign a verdict.
+
+**Constitutional effect:** none. No action is adopted and no axiom is edited.
+
+**TOE accounting:** zero obligation retirement. No TOE percentage moves. The
+retained-positive end-to-end theory count remains zero.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py`](../scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py)
+
+## 1. Result Up Front
+
+[Block 138](ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md)
+closed onto the following `next_trace_action`:
+
+> The N=8 dynamical degeneracy; parity-mixing dressing classes; the joint-lane program.
+
+**THE Z8 LEDGER COMPLETION.** On the same flat cyclic-shear family used by
+the committed Block 136 builders, set only the spatial extent to eight,
+replace the cyclic root carrier by its exact field
+(\mathbb Q(i,\sqrt2)), and use the eight exact character projectors.
+At each of the two displayed shears,
+
+\[
+ c\in\left\{\frac5{13},\frac35\right\},
+\]
+
+the self-charge transfer data obey
+
+\[
+ \boxed{\rho_0=\rho_4.}                                  \tag{1}
+\]
+
+The certificate is not trace-only: the charge-zero and charge-four
+monodromies have identical exact trace and identical exact determinant at
+both shears. Their determinant is one. More generally on the displayed Z8
+fixture,
+
+\[
+ \boxed{\det\mathcal M_k=1\qquad(k=0,2,4,6)}.            \tag{2}
+\]
+
+The checker independently obtained the unit determinant from its own N=4
+companion construction, so (2) is not a formatting or printing artifact.
+Together with the already verified N=4 and N=6 entries, (1) completes the
+transfer-degeneracy ledger at three even sizes and two shears. All three
+checked sizes occupy Block 138's (3m), center-(m) branch. In particular, the
+displayed N=8 fixture has
+
+\[
+ \boxed{
+  \mathcal A_8^{\rm obs}
+   =\operatorname{Sym}_2(\mathbb R)^4,\qquad
+  \dim_{\mathbb R}\mathcal A_8^{\rm obs}=12,\qquad
+  \dim_{\mathbb R}Z(\mathcal A_8^{\rm obs})=4.}          \tag{3}
+\]
+
+This is a same-family extension, not a new model. The Z8 fixture calls the
+committed builders
+
+\[
+ \boxed{
+  \texttt{fixture_data_spatial}(c,8),\qquad
+  \texttt{momentum_block},\qquad
+  \texttt{transfer_from_action}}
+                                                               \tag{4}
+\]
+
+unchanged. Only the spatial extent, the exact root field, and the projector
+set change.
+
+At either shear the exact Z8 monodromy-trace classes are
+
+\[
+ \boxed{(0,4),\qquad(1,5),\qquad(2,6),\qquad(3,7),}      \tag{5}
+\]
+
+and the four displayed classes are mutually distinct. They are governed by
+the two exact rules
+
+\[
+ \boxed{
+  \tau_{k+4}^{(8)}=\tau_k^{(8)},\qquad
+  \tau_{8-k}^{(8)}=\overline{\tau_k^{(8)}}.}             \tag{6}
+\]
+
+The determinant classes are
+
+\[
+ \boxed{(0,2,4,6),\qquad(1,5),\qquad(3,7).}             \tag{7}
+\]
+
+The equality rule in (6) is the same half-period rule seen at Z4 and Z6,
+while the second rule is charge conjugation. Equality classes and
+charge-conjugation orbits are not thereby identified: at Z6 the equal
+non-self pairs are ((1,4),(2,5)), whereas the conjugate pairs are
+((1,5),(2,4)).
+
+There is also an exact checked-size law. The charge-zero monodromy trace is
+digit-for-digit independent of spatial size at N=4,6,8:
+
+\[
+ \boxed{
+ \tau_0^{(4)}\!\left(\frac5{13}\right)
+ =\tau_0^{(6)}\!\left(\frac5{13}\right)
+ =\tau_0^{(8)}\!\left(\frac5{13}\right)
+ =-\frac{
+ 3962371610825721602827025599106
+ }{
+ 127417091906251505055019140625
+ }.}                                                     \tag{8}
+\]
+
+At the second shear,
+
+\[
+ \boxed{
+ \tau_0^{(4)}\!\left(\frac35\right)
+ =\tau_0^{(6)}\!\left(\frac35\right)
+ =\tau_0^{(8)}\!\left(\frac35\right)
+ =-\frac{
+ 234369399320455883852546
+ }{
+ 8465566947515869140625
+ }.}                                                     \tag{9}
+\]
+
+For (8), the N=4 value comes from the checker's independent companion
+construction and the N=6 and N=8 values agree exactly. For (9), the
+supervisor verified the N=6--N=8 identity and the checker independently
+verified the N=4 equality. Equations (8)--(9) are an exact three-size,
+two-shear statement; they are not an all-size theorem.
+
+The round also exposes a mechanism stronger than trace equality. In the
+checker's N=4 companion construction, the two real-character momentum
+blocks, at charges (0) and (N/2=2), have identical characteristic
+polynomials coefficient by coefficient at both shears:
+
+\[
+ \boxed{
+  \chi_{\operatorname{mom}(Q,0)}(\lambda)
+  =\chi_{\operatorname{mom}(Q,N/2)}(\lambda)
+  \quad\text{coefficient by coefficient at }N=4.}       \tag{10}
+\]
+
+Thus those two blocks are isospectral. This forces their equal trace and
+determinant and hence the ledger equality
+(\rho_0=\rho_{N/2}) at that checked size. Full characteristic-polynomial
+equality is strictly stronger than the equality of one displayed trace.
+
+The simplest proposed intertwiner is exactly refuted. If (T_t) is the plain
+one-slice time shift, then at N=4
+
+\[
+ \boxed{
+  \operatorname{mom}(Q,N/2)
+  \ne
+  T_t\,\operatorname{mom}(Q,0)\,T_t^{-1}}
+ \qquad
+ \left(c=\frac5{13},\frac35\right).                     \tag{11}
+\]
+
+The inequality is exact at both shears. The similarity that witnesses the
+checked isospectrality remains unidentified.
+
+The ledger completion therefore does not upgrade Block 138's
+transfer-degeneracy rider into a family theorem. It records three exact
+sizes at two exact shears and selects the (3m) branch on each displayed
+fixture. A general-even-(N) theorem is gated on exhibiting the similarity
+that makes the two real-character momentum blocks isospectral. The
+parity-mixing dressing classes and the joint-lane program remain live.
+
+The completed ADM/history transporter, joint gravity, the gravity constraint
+quotient beyond the displayed carriers, Records, effective audit retention,
+axiom amendment, obligation retirement, and TOE percentage movement remain
+outside this theorem.
+
+## 2. Authority And Executed Contract
+
+Current axiom authority is
+[MINIMAL_AXIOMS_2026-06-29.md](MINIMAL_AXIOMS_2026-06-29.md), inherited
+content-bound through the certified chain. No newer authority claim is made
+here, and no audit verdict is imported.
+
+The exact handoff parent is
+[Block 138](ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md).
+Its next action names the N=8 dynamical degeneracy, parity-mixing dressing
+classes, and the joint-lane program. The present note completes the first
+item on the displayed same-family Z8 fixtures only. It does not complete the
+other two items and does not promote the checked-size evidence to all even
+orders.
+
+[Block 136](ADMISSIBILITY_DIRAC_KAHLER_OBSERVABLE_SCALING_LAW_BOUNDED_THEOREM_NOTE_2026-08-18.md)
+is the second explicit dependency because its committed fixture and transfer
+builders are consumed unchanged. Its Z6 model family is extended by the
+existing spatial-extent seam; no action, boundary condition, mass,
+time extent, shear profile, momentum-block algorithm, or transfer algorithm
+is replaced.
+
+The executed contract is:
+
+1. the two exact rational shears (5/13) and (3/5);
+2. the same committed Block 136 family with spatial extent changed to eight;
+3. the exact Z8 root carrier in (\mathbb Q(i,\sqrt2));
+4. the eight exact cyclic projectors, with no floating-point spectral fit;
+5. unchanged use of `fixture_data_spatial(shear, 8)`,
+   `momentum_block`, and `transfer_from_action`;
+6. exact charge-zero/charge-four equality of monodromy trace and determinant
+   at both shears;
+7. exact unit determinant on every even Z8 momentum and the independent N=4
+   checker companion check;
+8. completion of the N=4,6,8 degeneracy ledger, with each checked size on
+   Block 138's (3m), center-(m) branch;
+9. the displayed Z8 algebra
+   (\operatorname{Sym}_2(\mathbb R)^4), dimension twelve, center four;
+10. the exact Z8 trace classes and determinant classes in (5) and (7);
+11. both trace rules in (6), kept distinct from charge-conjugation orbit
+    bookkeeping;
+12. the exact three-size charge-zero traces (8)--(9), with their separate
+    checker and supervisor provenance;
+13. the N=4 coefficient-by-coefficient characteristic-polynomial identity
+    for the two real-character momentum blocks;
+14. the exact N=4 refutation of the plain one-slice time-shift intertwiner at
+    both shears; and
+15. one narrow wall W1, leaving the general-even-(N) isospectral similarity,
+    parity-mixing dressing classes, and the joint-lane program live.
+
+The assigned primary runner is the path recorded in the front matter. This
+note does not invent a replay footer or a `TOTAL` line. The eight fixed N5
+resolution lines are reproduced in Section 9 as the textual contract
+specified for that runner.
+
+The scope is the displayed exact N=4,6,8 evidence in one inherited
+cyclic-shear family at two rational shears. No arbitrary-shear result,
+all-even transfer-degeneracy theorem, general similarity, parity-mixing
+classification, twisted completion, curved observable theorem, or
+joint-gravity result follows.
+
+## 3. The Same-Family Z8 Extension
+
+Let (c) be either displayed shear. The Z8 construction begins at exactly the
+Block 136 fixture seam:
+
+\[
+ (\mathcal G_8(c),\mathcal C_8(c))
+ :=\texttt{fixture_data_spatial}(c,8),                  \tag{12}
+\]
+
+where (\mathcal G_8) is the inherited propagator data and
+(\mathcal C_8) records the inherited call. The exact action is obtained
+by the same inversion step as in the supplied solve. No replacement action
+is introduced.
+
+The only Fourier data that must change with spatial order are the root field
+and the projector set. With
+
+\[
+ \omega_8=\frac{\sqrt2}{2}(1+i),\qquad
+ \omega_8^8=1,\qquad
+ \mathbb F_8=\mathbb Q(i,\sqrt2),                       \tag{13}
+\]
+
+the exact projectors are
+
+\[
+ P_k^{(8)}
+ =\frac18\sum_{r=0}^{7}\omega_8^{-kr}S_8^r,
+ \qquad k\in\mathbb Z_8.                                \tag{14}
+\]
+
+These replace the size-six root carrier and projectors because the spatial
+extent has changed. They do not alter the model. The same real cyclic shift
+formula, same action builder, and same charge-projection algorithm are used.
+
+For each momentum, the solve passes the inherited action to the committed
+momentum-block routine,
+
+\[
+ B_k^{(8)}(c)
+ :=\texttt{momentum_block}
+       (A_8(c),k,\texttt{TIME_SIZE},8),                 \tag{15}
+\]
+
+then passes that exact block to the committed transfer routine,
+
+\[
+ \mathcal M_k^{(8)}(c)
+ :=\texttt{transfer_from_action}\!\left(B_k^{(8)}(c)\right).
+                                                               \tag{16}
+\]
+
+The field used internally by the unchanged transfer arithmetic is switched
+from the Z6 root field to (\mathbb F_8) only for these calls and then
+restored. The projector adapter similarly supplies (14) to the unchanged
+`momentum_block` code. Those are carrier adaptations forced by
+(L_x=8), not changes to the transfer or action algorithms.
+
+Therefore the family relation is exact:
+
+\[
+ \boxed{
+ \text{same fixture family}
+ +\text{ spatial extent }8
+ +\mathbb Q(i,\sqrt2)
+ +\{P_k^{(8)}\}_{k=0}^{7}.}                             \tag{17}
+\]
+
+Calling this construction a new model would erase the explicit builder
+reuse in (12), (15), and (16). The scientific comparison across N=4,6,8
+uses the same family precisely because the spatial-extent seam was supplied
+for that purpose.
+
+## 4. The Transfer Ledger Completion
+
+Write the exact monodromy invariants as
+
+\[
+ \tau_k^{(N)}(c):=\operatorname{tr}\mathcal M_k^{(N)}(c),
+ \qquad
+ \delta_k^{(N)}(c):=\det\mathcal M_k^{(N)}(c).           \tag{18}
+\]
+
+For a two-by-two monodromy, trace and determinant fix its characteristic
+polynomial:
+
+\[
+ \chi_{\mathcal M_k}(\lambda)
+ =\lambda^2-\tau_k\lambda+\delta_k.                     \tag{19}
+\]
+
+The transfer-degeneracy ledger therefore requires both invariants rather
+than a decimal agreement between printed traces. At Z8 the exact result is
+
+\[
+ \boxed{
+ \begin{aligned}
+ \tau_0^{(8)}\!\left(\frac5{13}\right)
+   &=\tau_4^{(8)}\!\left(\frac5{13}\right),&
+ \delta_0^{(8)}\!\left(\frac5{13}\right)
+   &=\delta_4^{(8)}\!\left(\frac5{13}\right)=1,\\
+ \tau_0^{(8)}\!\left(\frac35\right)
+   &=\tau_4^{(8)}\!\left(\frac35\right),&
+ \delta_0^{(8)}\!\left(\frac35\right)
+   &=\delta_4^{(8)}\!\left(\frac35\right)=1.
+ \end{aligned}}                                         \tag{20}
+\]
+
+There are no numerical tolerances in (20). The equalities hold in the exact
+root field. In the terminology of Block 138, (19)--(20) give
+
+\[
+ \boxed{
+  \rho_0^{(8)}\!\left(\frac5{13}\right)
+   =\rho_4^{(8)}\!\left(\frac5{13}\right),\qquad
+  \rho_0^{(8)}\!\left(\frac35\right)
+   =\rho_4^{(8)}\!\left(\frac35\right).}                \tag{21}
+\]
+
+The unit-determinant result extends across every even Z8 momentum:
+
+\[
+ \boxed{
+  \delta_0^{(8)}=\delta_2^{(8)}
+  =\delta_4^{(8)}=\delta_6^{(8)}=1}
+ \quad\text{at each displayed shear}.                  \tag{22}
+\]
+
+The checker's own N=4 companion construction independently returns the
+corresponding exact unit determinant. This companion did not parse or reuse
+a displayed Z8 value. It rules out the possibility that the determinant-one
+statement is merely a print-path artifact.
+
+### Completed Degeneracy Verification Ledger
+
+| even order | self charges | displayed shears | exact ledger status | realized Block 138 branch |
+|---|---|---|---|---|
+| (N=4) | (0,2) | (5/13), (3/5) | **VERIFIED:** equal real-character transfer data; checker companion independently confirms the characteristic-polynomial and determinant facts | (\operatorname{Sym}_2(\mathbb R)^2), dimension 6, center 2 |
+| (N=6) | (0,3) | (5/13), (3/5) | **VERIFIED:** identical monodromy trace and determinant, with determinant one | (\operatorname{Sym}_2(\mathbb R)^3), dimension 9, center 3 |
+| (N=8) | (0,4) | (5/13), (3/5) | **VERIFIED BY (20):** identical monodromy trace and determinant, with determinant one | (\operatorname{Sym}_2(\mathbb R)^4), dimension 12, center 4 |
+
+The ledger now contains three checked sizes rather than Block 138's two
+checked sizes plus one unchecked dynamical item. At each row, the exact
+self-charge degeneracy permits the self-charge mixer and selects
+
+\[
+ \boxed{
+  \mathcal A_{2m}^{\rm obs}
+  =\operatorname{Sym}_2(\mathbb R)^m,\qquad
+  (\dim_{\mathbb R}\mathcal A_{2m}^{\rm obs},
+   \dim_{\mathbb R}Z(\mathcal A_{2m}^{\rm obs}))
+  =(3m,m)}
+                                                               \tag{23}
+\]
+
+for that displayed fixture. Equation (23) is applied row by row. The table
+does not quantify over an uncomputed fourth size and does not turn
+(\rho_0=\rho_m) into a consequence of charge kinematics.
+
+## 5. The Z8 Trace Classes And The Cross-Size Law
+
+At both shears the exact trace partition is
+
+\[
+ \mathcal T_8
+ =\bigl\{(0,4),(1,5),(2,6),(3,7)\bigr\}.                \tag{24}
+\]
+
+Each tuple in (24) is an equality class, and no two tuples share a common
+trace. Equivalently,
+
+\[
+ \tau_k^{(8)}(c)=\tau_{k+4}^{(8)}(c)
+ \quad(k\in\mathbb Z_8),                                \tag{25}
+\]
+
+while the real action gives
+
+\[
+ \tau_{8-k}^{(8)}(c)=\overline{\tau_k^{(8)}(c)}
+ \quad(k\in\mathbb Z_8).                                \tag{26}
+\]
+
+Equations (25) and (26) are distinct rules. The first is half-period
+equality; the second is conjugation. Together they explain why
+(\tau_1=\tau_5) and (\tau_3=\tau_7), while the two classes are
+exact conjugates rather than one larger equality class. The four trace
+classes in (24) remain distinct at each shear.
+
+The exact determinant partition is
+
+\[
+ \mathcal D_8
+ =\bigl\{(0,2,4,6),(1,5),(3,7)\bigr\}.                  \tag{27}
+\]
+
+The first class in (27) is the unit class (22). The determinant classes do
+not merge the distinct trace classes, and they do not redefine the
+charge-conjugation orbits.
+
+The same two-rule structure is visible at the two smaller checked sizes:
+
+| order | half-period trace-equality structure | exact conjugation structure |
+|---|---|---|
+| Z4 | ({0,2}), ({1,3}) | (k\mapsto4-k), with ({0}) and ({2}) fixed and ({1,3}) conjugate |
+| Z6 | ((0,3)), ((1,4)), ((2,5)) | (k\mapsto6-k), with ((1,5)) and ((2,4)) the non-self conjugate pairs |
+| Z8 | ((0,4)), ((1,5)), ((2,6)), ((3,7)) | (k\mapsto8-k), with ((1,7)), ((2,6)), and ((3,5)) the non-self conjugate pairs |
+
+This table prevents a category error already exposed at Z6. Raw
+trace-equality pairs ((1,4),(2,5)) are not the same as conjugation pairs
+((1,5),(2,4)). At Z8, likewise, ((1,5)) and ((3,7)) are equality
+classes, whereas ((1,7)) and ((3,5)) are the corresponding non-self
+conjugation orbits. Only ((2,6)) happens to be both.
+
+The charge-zero class has an additional exact cross-size property. For the
+primary shear,
+
+\[
+ \tau_0^{(N)}\!\left(\frac5{13}\right)
+ =-\frac{
+ 3962371610825721602827025599106
+ }{
+ 127417091906251505055019140625
+ },
+ \qquad N\in\{4,6,8\}.                                  \tag{28}
+\]
+
+For the secondary shear,
+
+\[
+ \tau_0^{(N)}\!\left(\frac35\right)
+ =-\frac{
+ 234369399320455883852546
+ }{
+ 8465566947515869140625
+ },
+ \qquad N\in\{4,6,8\}.                                  \tag{29}
+\]
+
+The fractions are not rounded summaries. They are digit-for-digit identical
+across the three sizes. The provenance is deliberately split:
+
+1. at (c=5/13), the N=4 checker companion value agrees exactly with the N=6
+   and N=8 values;
+2. at (c=3/5), the supervisor independently verified the N=6--N=8 identity;
+   and
+3. the checker independently verified the N=4 equality at (c=3/5).
+
+Thus the strongest justified formulation is an **exact three-size,
+two-shear cross-size law**. No recurrence in (N), similarity valid for all
+even (N), or induction step has yet been exhibited.
+
+## 6. The Isospectral Mechanism
+
+The checker's N=4 companion construction probes the two real characters
+directly. Write
+
+\[
+ M_k(c):=\operatorname{mom}(Q,k)                        \tag{30}
+\]
+
+for its exact momentum block. At each displayed shear the checker compares
+the entire characteristic-polynomial coefficient vectors and obtains
+
+\[
+ \boxed{
+  \operatorname{coeff}\chi_{M_0(c)}
+  =\operatorname{coeff}\chi_{M_{N/2}(c)}
+  \quad(N=4,\ c=5/13,3/5).}                             \tag{31}
+\]
+
+Equivalently,
+
+\[
+ \boxed{\chi_{M_0(c)}(\lambda)
+       =\chi_{M_{N/2}(c)}(\lambda)}
+ \quad(N=4,\ c=5/13,3/5).                               \tag{32}
+\]
+
+This is the round's mechanism discovery: the two real-character momentum
+blocks are isospectral at the checked companion size. Equality of all
+characteristic-polynomial coefficients contains, in particular, equality
+of trace and determinant. It therefore forces the corresponding checked
+transfer-degeneracy conclusion
+
+\[
+ \rho_0=\rho_{N/2}.                                     \tag{33}
+\]
+
+Equation (32) is stronger than observing
+(\tau_0=\tau_{N/2}) in runner output. It rules out a coincidence in only
+one spectral invariant. It also gives a concrete target for the family
+upgrade: explain the coefficient identity by an explicit similarity between
+the two real-character blocks.
+
+The quantifier is load-bearing. The checker establishes (31)--(32) at N=4
+and both displayed shears. The N=6 and N=8 transfer ledgers provide exact
+further spectral evidence, including equal monodromy trace and determinant,
+but this note does not claim that the checker has constructed a common
+block-level similarity at those sizes or at symbolic even (N).
+
+## 7. The Observable-Algebra Consequence
+
+At N=8, charge negation gives the two self-conjugate singleton charges (0)
+and (4), together with the three non-self pairs
+
+\[
+ (1,7),\qquad(2,6),\qquad(3,5).                         \tag{34}
+\]
+
+Block 138's transfer-commuting criterion permits the off-diagonal
+(0\leftrightarrow4) mixer exactly when (\rho_0=\rho_4). Equation
+(21) verifies that rider at both displayed Z8 shears. The admitted
+two-carrier blocks are therefore
+
+\[
+ \boxed{(0,4),\qquad(1,7),\qquad(2,6),\qquad(3,5).}     \tag{35}
+\]
+
+With the inherited symmetric Jordan discipline, each block contributes one
+(\operatorname{Sym}_2(\mathbb R)) factor, real dimension three, and
+one-dimensional center. Four such factors give exactly (3).
+
+The trace table (24) does not replace (35). Its pairs ((1,5)) and ((3,7))
+come from the half-period spectral equality rule, while the observable
+pairs ((1,7)) and ((3,5)) come from charge negation. The ((0,4)) block is
+also not a conjugation orbit: it is the permitted mixer of two distinct
+self-conjugate singleton sectors, admitted here because the transfer
+degeneracy is now checked.
+
+No associative enlargement is made. The antisymmetric commutator direction
+remains derived and excluded exactly as in Block 138. Consequently neither
+the completed ledger nor the additional trace coincidences add observable
+directions beyond the four symmetric Jordan factors.
+
+## 8. The Refuted Intertwiner And The Family Boundary
+
+The natural first guess for the similarity in Section 6 is a translation by
+one time slice. Let (T_t) denote that plain one-slice time shift. The checker
+evaluates the proposed identity itself, rather than inferring it from the
+equal characteristic polynomials, and finds
+
+\[
+ \boxed{
+  M_{N/2}(c)\ne T_tM_0(c)T_t^{-1}}
+ \quad(N=4,\ c=5/13,3/5).                               \tag{36}
+\]
+
+The residual is exactly nonzero at each shear. Therefore:
+
+\[
+ \boxed{\text{the plain one-slice time shift is not the similarity}.}
+                                                               \tag{37}
+\]
+
+This named negative result is useful because it prevents the checked
+isospectrality from being narrated as an already understood translation
+symmetry. The sought witnessing similarity remains unidentified.
+
+The boundary is correspondingly sharp. The completed fixture ledger says
+
+\[
+ \rho_0^{(N)}=\rho_{N/2}^{(N)}
+ \quad
+ \text{for }N=4,6,8
+ \text{ at }c=5/13,3/5.                                \tag{38}
+\]
+
+It does not say
+
+\[
+ \rho_0^{(N)}=\rho_{N/2}^{(N)}
+ \quad\text{for every even }N.                          \tag{39}
+\]
+
+An upgrade from (38) to (39) is gated on an explicit similarity making the
+two real-character momentum blocks isospectral for general even (N), or an
+equally strong exact proof of that family identity. Neither three data
+points nor the size-independent charge-zero trace supplies that missing
+proof.
+
+This is not an OS no-go and not a curved OS no-go. It is a bounded statement
+about one inherited flat cyclic-shear family, two rational shear fixtures,
+and the still-unidentified isospectral similarity.
+
+## 9. No-Go Discipline Gate
+
+There is exactly one bounded checked-size wall.
+
+- W1 — **Z8 LEDGER-COMPLETION / GENERAL-EVEN ISOSPECTRAL-SIMILARITY
+  WALL:** in the inherited Block 136 family, at the displayed shears
+  (5/13) and (3/5), the exact N=8 transfer data satisfy
+  (\rho_0=\rho_4) through identical monodromy trace and determinant,
+  completing the N=4,6,8 ledger on the (3m), center-(m) branch. The
+  checker identifies coefficient-by-coefficient characteristic-polynomial
+  equality of the two real-character momentum blocks at N=4 and refutes the
+  plain one-slice time shift as their similarity. A general-even family
+  theorem is not claimed because the witnessing similarity is unidentified.
+
+W1 is narrow. It concerns the displayed N=4,6,8 fixtures in one inherited
+flat cyclic-shear family, the exact Z8 trace and determinant partitions, the
+two-shear charge-zero cross-size law, the N=4 checker isospectrality, and the
+named failed time-shift intertwiner. It does not quantify over arbitrary
+even size, arbitrary shear, another action family, parity-mixing dressing
+classes, or joint constructions.
+
+The positive content remains exact inside W1. The Z8 ledger entry is fully
+checked at both shears, not conditional on an unrun dynamic calculation.
+The Z8 algebra is
+(\operatorname{Sym}_2(\mathbb R)^4), dimension twelve, center four.
+The trace rules, determinant classes, rational charge-zero traces, and N=4
+characteristic-polynomial equality are exact.
+
+W1 is not a refutation of a general similarity. It records that the simplest
+candidate, the plain one-slice time shift, fails exactly and that no
+replacement similarity has yet been exhibited.
+
+W1 is not an OS no-go and not a curved OS no-go.
+
+There is zero axiom retirement and zero TOE movement. The standard Records,
+retention, constitutional, obligation, and end-to-end accounting firewalls
+remain in force, and no axiom amendment is justified.
+
+### N1 — Alternative Route Enumeration
+
+Routes are normalized by (object, mechanism, terminal). The family
+extension, fixture ledger, spectral classes, cross-size trace, checker
+mechanism, failed intertwiner, and forward program remain distinct.
+
+1. **(a) SAME-FAMILY VERIFIED — Z8 fixture / set the committed Block 136
+   spatial-extent seam to eight and supply
+   (\mathbb Q(i,\sqrt2)) plus the eight projectors / reuse
+   `fixture_data_spatial`, `momentum_block`, and
+   `transfer_from_action` unchanged.** The result is a third size in the
+   same model family, not a replacement model.
+2. **(b) LEDGER COMPLETED — Z8 self charges / compare exact monodromy trace
+   and determinant at (k=0,4) / obtain (\rho_0=\rho_4) at both shears
+   and realize (\operatorname{Sym}_2(\mathbb R)^4), dimension twelve,
+   center four.** The exact unit determinant on every even Z8 momentum is
+   independently companion-checked at N=4.
+3. **(c) SPECTRAL CLASSES VERIFIED — all Z8 momenta / calculate exact trace
+   and determinant equality classes / obtain trace classes
+   ((0,4),(1,5),(2,6),(3,7)), determinant classes
+   ((0,2,4,6),(1,5),(3,7)), half-period equality, and charge
+   conjugation.** Equality classes remain distinct from observable
+   charge-negation blocks.
+4. **(d) THREE-SIZE LAW VERIFIED — charge-zero monodromy / compare exact
+   rational traces across N=4,6,8 / obtain the same fraction at each size
+   for each displayed shear.** This is exact checked-size evidence, not an
+   all-size recurrence.
+5. **(e) ISOSPECTRAL MECHANISM CHECKED AT N=4 — the two real-character
+   momentum blocks / compare every characteristic-polynomial coefficient /
+   obtain exact isospectrality at both shears, forcing equal trace and
+   determinant and hence the checked transfer degeneracy.** No general-even
+   similarity is supplied.
+6. **(f) NAMED INTERTWINER REFUTED — the plain one-slice time shift / test
+   (M_{N/2}=T_tM_0T_t^{-1}) exactly / obtain strict inequality at both
+   shears.** This rejects one proposed mechanism without rejecting
+   isospectrality.
+7. **(g) UNTESTED-LIVE — family mechanism and downstream program / exhibit
+   the real-character similarity for general even (N), classify
+   parity-mixing dressing classes, and execute the joint-lane program /
+   decide whether the checked pattern has a theorem-level extension and how
+   it couples beyond this carrier.** None of those terminals is imported.
+
+The completed ADM/history transporter, joint gravity, and the gravity
+constraint quotient beyond the displayed carriers remain downstream of row
+(g). W1 consumes none of those routes.
+
+### N2 — Wall-Independence Audit
+
+W1 is logically distinct from Block 136's displayed-Z6 scaling wall and
+Block 138's conditional general-even kinematic wall, although both are
+explicit dependencies.
+
+Block 136 supplies one of the checked sizes and, more importantly, the
+committed family builders. Its object is the displayed flat Z6 observable
+fixture; its mechanisms include the fixture construction, momentum blocks,
+transfer construction, and bounded algebra count; its terminal is the
+displayed Z6 result and the request for a general charge theorem.
+
+Block 138 supplies the conditional general-even charge kinematics and the
+two-branch transfer count. Its object is symbolic even (N); its mechanisms
+are cyclic character conjugation, the shared-pivot convention, transfer
+commutation, and Jordan counting; its terminal leaves the N=8 dynamical
+degeneracy explicitly unchecked.
+
+Block 139 returns to the inherited fixture family. Its object is the missing
+Z8 dynamical entry plus the new checked-size spectral pattern; its mechanisms
+are exact builder reuse, exact monodromy invariants, the trace-class rules,
+the cross-size charge-zero identity, and the N=4 checker
+characteristic-polynomial comparison; its terminal completes the three-size
+ledger while exposing the unidentified family similarity.
+
+The walls have distinct objects, mechanisms, and terminals:
+
+\[
+ \begin{array}{c|c|c|c}
+ \text{block} & \text{object} & \text{mechanism} & \text{terminal}\\\hline
+ 136 & \text{displayed flat Z6 observable fixture} &
+       \text{committed family and transfer builders} &
+       (\dim,\dim Z)=(9,3)\ \text{on its fixtures}\\
+ 138 & \text{symbolic even-N charge and transfer branches} &
+       \text{characters, shared pivot, transfer commutation} &
+       \text{conditional }(3m,m)\text{ or }(3m-1,m+1)\\
+ 139 & \text{same-family Z8 dynamics and checked-size spectrum} &
+       \text{exact monodromy invariants and N4 isospectral check} &
+       \text{three-size ledger complete; family similarity live}
+ \end{array}.                                            \tag{40}
+\]
+
+There is an intentional chain dependency but no proof substitution. Block
+136's code reuse establishes same-family continuity; it does not by itself
+establish the Z8 degeneracy. Block 138 supplies the branch criterion; it does
+not choose the Z8 branch. Block 139 chooses that displayed branch through
+the exact calculation, but does not prove Block 138's rider for every even
+(N).
+
+The new trace-equality classes are also independent of the earlier
+charge-orbit theorem. Half-period equality pairs momenta that charge
+conjugation may pair differently. The two structures coexist; neither is
+silently substituted for the other.
+
+### N3 — Hidden-Wall And Phrase Scan
+
+The required H-gate scope-certificate phrase scan is classified explicitly.
+Every hit in the left column is lowercase as required.
+
+| lowercase hit | classification |
+|---|---|
+| the z8 ledger completion | the title's bounded same-family fixture result, not an all-even theorem |
+| same committed block 136 flat cyclic-shear family | the inherited model-family identity |
+| fixture_data_spatial(shear, 8) | the existing spatial-extent seam with extent eight |
+| momentum_block | the committed momentum-block builder, reused unchanged |
+| transfer_from_action | the committed transfer builder, reused unchanged |
+| only the spatial extent, root field, and projector set change | the exact same-family boundary |
+| not a new model | the supervisor-audited (the same-family audit) builder-continuity conclusion |
+| q(i,sqrt(2)) | the exact Z8 root field, replacing the Z6 root carrier only because the extent changes |
+| rho_0=rho_4 | the exact Z8 transfer-degeneracy result at both displayed shears |
+| identical monodromy trace and determinant | the two-invariant certificate for the ledger equality |
+| determinant one on every even momentum | the exact Z8 determinant class (0,2,4,6) |
+| independently at n=4 | the checker's own companion construction, excluding a print artifact |
+| three sizes | exactly N=4,6,8, not an induction base plus theorem |
+| two shears | exactly 5/13 and 3/5 |
+| all on the 3m branch | row-by-row selection of Block 138's degenerate branch |
+| sym_2(r)^4 | the displayed Z8 observable algebra |
+| dimension 12, center 4 | the Z8 specialization of the checked branch |
+| trace classes (0,4),(1,5),(2,6),(3,7) | the four exact and mutually distinct Z8 trace-equality classes |
+| k -> k+4 gives exact trace equality | the Z8 half-period spectral rule |
+| k -> 8-k gives exact conjugation | the real-action charge-conjugation rule |
+| determinant classes (0,2,4,6),(1,5),(3,7) | the exact Z8 determinant partition |
+| the four classes are distinct | pairwise distinctness of the four trace classes, not a claim about four determinant classes |
+| same two-rule structure as z4 | the checked half-period and conjugation pattern at size four |
+| same two-rule structure as z6 | the checked half-period and conjugation pattern at size six |
+| equal pairs (1,4),(2,5) | the non-self Z6 half-period trace-equality pairs |
+| conjugate pairs (1,5),(2,4) | the distinct non-self Z6 charge-conjugation pairs |
+| the k=0 monodromy trace is exactly size-independent | the exact N=4,6,8 equality at a fixed displayed shear |
+| digit-for-digit identical | rational equality, not a decimal tolerance |
+| -3962371610825721602827025599106/127417091906251505055019140625 | the exact common charge-zero trace at shear 5/13 |
+| -234369399320455883852546/8465566947515869140625 | the exact common charge-zero trace at shear 3/5 |
+| z4 checker-independent computation | the provenance of the N=4 cross-size comparison |
+| z6 = z8 supervisor-verified | the independent provenance of the second-shear larger-size equality |
+| the two real-character momentum blocks are isospectral | coefficient-by-coefficient characteristic-polynomial equality in the N=4 checker |
+| all characteristic-polynomial coefficients identical | the certificate stronger than trace equality |
+| forces equal trace and determinant | the immediate spectral consequence of the full polynomial identity |
+| stronger than trace equality | the distinction between one invariant and the complete characteristic polynomial |
+| the plain one-slice time shift is not the similarity | the exact named negative at N=4 and both shears |
+| exact inequality at both shears | the checker's direct intertwiner refutation |
+| the similarity is unidentified | the missing mechanism, not a denial of checked isospectrality |
+| the family-theorem upgrade is not claimed | the primary W1 boundary |
+| a per-size checkable fact (the family upgrade is gated) | Block 138's transfer-degeneracy rider as applied at each displayed size |
+| exhibiting the similarity for general even n | the gate for promoting the ledger pattern to a family theorem |
+| parity-mixing dressing classes | the named next classification, not a completed result |
+| joint-lane program | future execution, not a consequence of the fixture ledger |
+| the completed adm/history transporter | downstream construction firewall |
+| joint gravity | explicitly not completed |
+| gravity constraint quotient beyond the displayed carriers | outside the present carrier scope |
+| records | no Records claim |
+| retention | independent-audit firewall |
+| axiom amendment | explicitly not justified |
+| obligation retirement | TOE accounting firewall |
+| toe percentage movement | TOE accounting firewall |
+| are not claimed | applies to every downstream item in the scope sentence |
+| no axiom amendment is justified | constitutional firewall |
+| zero obligation retirement | TOE accounting statement |
+| no toe percentage moves | TOE accounting statement |
+| retained-positive end-to-end theory count remains zero | audit accounting |
+| n1 n2 n3 n4 n5 n6 n7 n8 | every discipline gate is present |
+| w1 | the wall set has exactly one member |
+| per_element per_site per_mode per_block lattice_wide | the first five N5 keys |
+| result decision_cut toe | the final three N5 keys |
+| no-go discipline verdict | the adjudication at the end of N8 |
+| pass only for narrow w1 | no broader positive or negative terminal |
+| three checked sizes prove all even sizes | forbidden family-theorem upgrade |
+| the time shift is the intertwiner | explicitly refuted mechanism |
+| trace equality alone proves rho equality | forbidden deletion of the determinant check |
+| trace classes are conjugation orbits | forbidden merger of two distinct structures |
+
+No phrase turns the existing spatial-extent seam into a new model. No phrase
+turns exact equality at three sizes into induction. Nothing converts the
+charge-zero cross-size trace into an all-mode or all-size theorem, or the N=4
+characteristic-polynomial identity into a symbolic-even similarity.
+
+Nothing says the plain one-slice time shift is the intertwiner. Nothing says
+trace equality alone proves the transfer degeneracy. Nothing says trace
+classes are charge-conjugation or observable blocks. Nothing asserts
+completion of parity-mixing dressing classes, the joint-lane program, the
+actual transporter, joint gravity, or a gravity constraint quotient beyond
+the displayed carriers. Nothing asserts axiom amendment, effective audit
+retention, obligation retirement, or TOE percentage movement.
+
+### N4 — Residual Matching
+
+The Block 138 `next_trace_action`, quoted exactly, is:
+
+> The N=8 dynamical degeneracy; parity-mixing dressing classes; the joint-lane program.
+
+| source anchor | exact inherited residual | current match |
+|---|---|---|
+| [Block 138 next action](ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md) | “The N=8 dynamical degeneracy; parity-mixing dressing classes; the joint-lane program.” | **PARTIALLY DISCHARGED:** the first item is completed at both displayed Z8 shears; the other two items remain live |
+| [Block 138](ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md) | the transfer-degeneracy rider and its N=4,6 verified / N=8 unchecked ledger | **LEDGER COMPLETED WITHOUT FAMILY UPGRADE:** N=8 joins N=4,6 on the (3m), center-(m) branch |
+| [Block 136](ADMISSIBILITY_DIRAC_KAHLER_OBSERVABLE_SCALING_LAW_BOUNDED_THEOREM_NOTE_2026-08-18.md) | the committed family builders and exact Z6 transfer construction | **CONSUMED UNCHANGED:** only extent, root field, and projector set are adapted for Z8 |
+| solve plus checker and supervisor round | exact Z8 classes, cross-size traces, N=4 isospectrality, and the proposed time-shift similarity | **INCORPORATED WITH NAMED BOUNDARY:** exact positives are recorded, the time shift is refuted, and the actual similarity remains unidentified |
+
+The N=8 dynamical-degeneracy item — **CLOSED ON THE DISPLAYED SAME-FAMILY
+FIXTURES.** At both shears, identical exact monodromy trace and determinant
+give (\rho_0=\rho_4). The displayed Z8 algebra therefore realizes
+(\operatorname{Sym}_2(\mathbb R)^4), dimension twelve, center four.
+
+The parent action as a whole is only partially closed because its
+parity-mixing dressing and joint-lane clauses remain unexecuted. In
+addition, the new mechanism question exposed by the checker remains live:
+the checked two-real-character isospectrality has no identified similarity
+that extends to general even (N).
+
+The exact replacement residual is:
+
+> The isospectral similarity for general even N; parity-mixing dressing classes; the joint-lane program.
+
+### N5 — Rhetoric And Granularity Audit
+
+The strongest permitted sentence is: “In the same committed Block 136
+family at spatial Z8 and shears (5/13) and (3/5), the exact charge-zero and
+charge-four monodromies have identical trace and determinant, so
+(\rho_0=\rho_4) and the displayed algebra is
+(\operatorname{Sym}_2(\mathbb R)^4), dimension twelve, center four;
+this completes the N=4,6,8 ledger on the (3m), center-(m) branch, while the
+exact Z8 trace classes, the two half-period/conjugation rules, the
+three-size charge-zero trace, and the N=4 coefficient-by-coefficient
+isospectrality are recorded as checked-size results; the plain one-slice
+time shift is not the similarity, the similarity remains unidentified, and
+no general-even family theorem follows.”
+
+Forbidden upgrades include:
+
+- “three checked sizes prove (\rho_0=\rho_{N/2}) for every even
+  (N)”;
+- “the charge-zero cross-size trace is independent of every spatial size”;
+- “trace equality alone proves the transfer degeneracy”;
+- “the Z8 trace classes are the charge-conjugation or observable blocks”;
+- “the plain one-slice time shift is the isospectral similarity”; and
+- “the N=4 characteristic-polynomial identity exhibits the general-even
+  similarity”.
+
+The first two turn finite exact evidence into an induction-free family law.
+The third deletes the determinant certificate. The fourth conflates
+half-period spectral equality with charge negation. The fifth contradicts
+the exact checker inequality. The sixth replaces an unidentified mechanism
+with a theorem that has not been supplied.
+
+Also forbidden are “the Z8 extension is a new model,” “the determinant-one
+result is a print artifact,” “parity-mixing dressing classes are
+classified,” “the joint-lane program is complete,” “the gravity constraint
+quotient is complete beyond the displayed carriers,” “an axiom amendment is
+required,” and any claim of effective audit retention, obligation
+retirement, or TOE movement. None is established here.
+
+The runner's eight N5 resolution lines are reproduced verbatim:
+
+```text
+N5: per_element: exact Z8 roots and projectors plus the committed Block 136 action and transfer builders are checked in Q(i,sqrt(2))
+per_site: one spatial Z8 extension in the same family; only the extent, root field, and projector set change
+per_mode: at both shears k->k+4 gives exact trace equality and k->8-k gives exact conjugation; the four trace classes remain distinct
+per_block: rho_0=rho_4 gives Sym_2(R)^4, dimension 12, center 4; the N=4 checker finds all characteristic-polynomial coefficients equal for the two real-character momentum blocks
+lattice_wide: exact evidence is N=4,6,8 at shears 5/13 and 3/5; no general-even-N similarity theorem is claimed
+RESULT: the Z8 ledger completes and all three checked sizes occupy the 3m branch; the exact k=0 trace is size-independent on those fixtures
+DECISION_CUT: exhibit the general-even-N isospectral similarity; classify parity-mixing dressing classes; execute the joint-lane program
+TOE: zero obligation retirement; no TOE percentage movement; retained-positive end-to-end theory count remains zero
+```
+
+### N6 — Partial-Closure Path Scan
+
+No registered primitive is needed. The note uses the inherited cyclic
+carrier, exact root fields, momentum blocks, transfer construction,
+observable admissibility, and exact scalar arithmetic. No all-even
+transfer-degeneracy axiom, trace-class pairing axiom, canonical time-shift
+intertwiner, or population axiom is adopted.
+
+| route | present status | remaining terminal |
+|---|---|---|
+| same-family Z8 construction | `fixture_data_spatial(shear, 8)`, `momentum_block`, and `transfer_from_action` are consumed unchanged | no new-model interpretation is allowed |
+| Z8 root carrier | exact (\mathbb Q(i,\sqrt2)) roots and eight projectors | other extents require their own exact root data |
+| Z8 self-charge trace | (\tau_0=\tau_4) at both displayed shears | trace alone is not used as the full degeneracy certificate |
+| Z8 self-charge determinant | (\delta_0=\delta_4=1) at both displayed shears | no determinant identity for arbitrary even order is claimed |
+| even Z8 momenta | exact determinant-one class ((0,2,4,6)) | odd determinant classes remain separate |
+| N=4 determinant companion | independent exact unit-determinant construction | companion provenance does not prove a symbolic-N law |
+| three-size transfer ledger | N=4,6,8 all realize the (3m), center-(m) branch at both shears | a fourth size and symbolic even (N) remain unproved |
+| Z8 observable algebra | (\operatorname{Sym}_2(\mathbb R)^4), dimension twelve, center four | no additional observable direction follows from trace coincidences |
+| Z8 trace half-period | (\tau_{k+4}=\tau_k) with four distinct equality classes | the source of the rule is not yet a family theorem |
+| Z8 trace conjugation | (\tau_{8-k}=\overline{\tau_k}) | conjugation orbits remain distinct from half-period equality classes |
+| Z8 determinant classes | ((0,2,4,6),(1,5),(3,7)) | no all-size determinant partition is claimed |
+| charge-zero cross-size trace at 5/13 | exact common fraction for N=4,6,8 | no recurrence or all-size result follows |
+| charge-zero cross-size trace at 3/5 | exact common fraction for N=4,6,8 | no recurrence or all-size result follows |
+| N=4 real-character blocks | full characteristic-polynomial coefficient equality at both shears | exhibit a witnessing similarity |
+| plain time-shift proposal | exactly refuted at both shears | search for a different intertwiner |
+| general-even real-character similarity | **UNIDENTIFIED-LIVE** | construct and verify the similarity for symbolic even (N) |
+| parity-mixing dressing classes | **UNTESTED-LIVE** | classify without importing the checked-size degeneracy as an axiom |
+| joint-lane program | **UNTESTED-LIVE** | execute without importing transporter or gravity completion |
+| actual ADM/history transporter | not executed | complete beyond the displayed packages |
+| gravity constraint quotient | displayed carriers only | execute beyond those carriers |
+
+The source handoff is therefore partially closed. Its N=8 dynamic clause has
+an exact positive answer on both displayed fixtures. Its parity-mixing and
+joint-lane clauses remain open, and the checker discovery sharpens the next
+theorem gate to the general-even isospectral similarity.
+
+### N7 — Steelman
+
+**Hostile steelman: changing Z6 to Z8 creates a new model, so the third
+ledger point is not comparable.** The root field and projector matrices are
+different.
+
+Rejected by the audited call path. The committed
+`fixture_data_spatial(shear, spatial_extent)` seam is called with extent
+eight, and the committed `momentum_block` and
+`transfer_from_action` algorithms are reused unchanged. A cyclic carrier
+of a different extent necessarily has a different exact root field and
+projectors. Those are the only swaps, so the result is a same-family
+extension.
+
+**Hostile steelman: equal printed traces do not establish
+(\rho_0=\rho_4).** The displayed equality could hide different
+determinants or a formatting artifact.
+
+Rejected by (20)--(22). The monodromy trace and determinant are both exactly
+identical at each shear, and the even-momentum determinant is exactly one.
+The checker independently reproduces the unit determinant in its own N=4
+companion construction.
+
+**Hostile steelman: the four trace classes are already the four observable
+blocks.** Both lists begin with ((0,4)) and include ((2,6)).
+
+Rejected by the other two pairs. Half-period trace equality gives ((1,5))
+and ((3,7)); charge negation gives observable pairs ((1,7)) and ((3,5)).
+Coincidence of ((0,4)) and ((2,6)) does not identify the two partitions.
+
+**Hostile steelman: the exact charge-zero trace at three sizes proves spatial
+size independence.** The same two large rational numbers recur
+digit-for-digit.
+
+Agreed as exact evidence, not as an all-size proof. Equations (28)--(29)
+quantify only over ({4,6,8}). No recurrence, structural cancellation proof,
+or symbolic similarity has been supplied.
+
+**Hostile steelman: full characteristic-polynomial equality means the
+one-slice time shift must be the similarity.** A temporal translation is the
+most economical explanation of the two real characters.
+
+Rejected by direct substitution. Equation (36) is an exact inequality at
+both shears. Isospectrality survives; this particular proposed intertwiner
+does not.
+
+**Hostile steelman: three positive ledger rows are enough to state the
+general-even transfer theorem.** They cover consecutive tested even sizes
+and the N=4 checker gives a stronger mechanism.
+
+Rejected by the quantifiers. The N=4 checker identifies isospectrality but
+not its witnessing similarity, and the N=6 and N=8 rows are further exact
+fixture facts. Without the general-even similarity or an equivalent exact
+argument, Block 138's rider remains per-size checkable.
+
+These steelmen preserve narrow W1. They strengthen the exact same-family and
+checked-size conclusions while keeping the missing general mechanism
+visible.
+
+### N8 — Cross-Cycle Echo
+
+The flat observable chain now moves from the landed Z4 companion behavior
+through Block 136's Z6 scaling fixture and Block 138's conditional symbolic
+classification to a dynamically completed Z8 ledger. The checker discovery
+then turns the former “compute N=8” request into a sharper mechanism request:
+identify the real-character similarity for general even order.
+
+| source | narrowing that leads to W1 and the live similarity decision |
+|---|---|
+| N=4 checker companion | independently confirms determinant one, the charge-zero cross-size values, full real-character characteristic-polynomial equality, and failure of the plain time shift |
+| [Block 136](ADMISSIBILITY_DIRAC_KAHLER_OBSERVABLE_SCALING_LAW_BOUNDED_THEOREM_NOTE_2026-08-18.md) | supplies the committed same-family builders and the exact N=6 ledger row |
+| [Block 138](ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md) | supplies the exact transfer-degeneracy rider, both Jordan count branches, and the N=8 dynamical residual |
+| Block 139 exact Z8 solve | supplies the same-family N=8 monodromy traces, determinants, trace rules, and determinant classes |
+| supervisor verification | confirms the Z8 exact classes, the N=6--N=8 second-shear equality, and the three-size ledger interpretation |
+| isospectral mechanism | strengthens the N=4 equality from one trace to the complete characteristic polynomial |
+| refuted time-shift intertwiner | removes the simplest false explanation while leaving the actual similarity unidentified |
+
+The echo is bounded but positive. The previously unchecked Z8 dynamical
+item now realizes the degenerate transfer branch at both shears, and the
+three checked sizes share an exact charge-zero trace. What remains
+unexplained is why the two real-character momentum blocks are isospectral in
+a form that survives symbolic even (N).
+
+**No-Go Discipline verdict:** **PASS** only for narrow W1. **SAME-FAMILY
+VERIFIED** for the unchanged Block 136 builders with only extent, exact root
+field, and projector set adapted. **LEDGER COMPLETED** for
+(\rho_0=\rho_4) at both Z8 shears through identical exact monodromy trace
+and determinant, placing N=4,6,8 on the (3m), center-(m) branch.
+**POSITIVE** for the displayed
+(\operatorname{Sym}_2(\mathbb R)^4), dimension twelve, center four.
+**SUPERVISOR-VERIFIED** for the Z8 trace and determinant classes and the
+two-rule structure. **EXACT CHECKED-SIZE LAW** for the charge-zero trace at
+N=4,6,8 and both shears. **CHECKER-VERIFIED** for the N=4
+coefficient-by-coefficient isospectrality and **REFUTED** for the plain
+one-slice time-shift similarity at both shears. **BOUNDARY** for the three
+sizes, two shears, inherited flat family, and per-size transfer rider.
+**LIVE** for the general-even isospectral similarity, parity-mixing dressing
+classes, and the joint-lane program. **FAIL** for an all-even degeneracy
+theorem, all-size charge-zero trace theorem, trace-only transfer certificate,
+identification of trace classes with charge-conjugation blocks, the plain
+time shift as intertwiner, completed parity-mixing classification, a
+completed joint lane or transporter, joint gravity, a gravity constraint
+quotient beyond the displayed carriers, axiom necessity, effective audit
+retention, obligation retirement, or TOE movement.
+
+## 10. Axiom And TOE Disposition
+
+No axiom amendment is justified. The flat cyclic-shear action family,
+spatial-extent seam, exact root fields, charge projectors, momentum blocks,
+transfer construction, observable admissibility, and exact scalar structure
+are inherited data. Evaluating the existing seam at extent eight does not
+introduce a new action axiom.
+
+Nor is the transfer degeneracy elevated into an axiom. The identities
+(\rho_0=\rho_{N/2}) at N=4,6,8 are verified fixture facts at the two
+displayed shears. Three exact ledger entries make the pattern sharper; they
+do not license imposing it at every even size.
+
+The exact cross-size charge-zero trace is likewise not adopted as an axiom.
+Its current quantifier is N in ({4,6,8}) at (c=5/13) or (c=3/5). A
+general size-independence result would require an exact family mechanism.
+
+The N=4 characteristic-polynomial identity and the failed time-shift test
+require no constitutional change. They refine the proof obligation: retain
+the exact isospectrality, discard the false plain-shift explanation, and
+search for the actual similarity. No axiom encodes that unidentified map.
+
+This is bounded route closure, not an audit-grade assignment. It retires no
+end-to-end obligation. TOE accounting remains:
+
+- zero obligation retirement;
+- no TOE percentage moves; and
+- retained-positive end-to-end theory count remains zero.
+
+Axiom retirement is zero, TOE movement is zero, the standard firewalls are
+unchanged, and no axiom amendment is justified.
+
+## 11. Next Decision
+
+The shortest high-value sequence is:
+
+1. exhibit and verify the similarity that makes the charge-zero and
+   charge-(N/2) momentum blocks isospectral for general even (N), explicitly
+   excluding the already refuted plain one-slice time shift;
+2. classify the parity-mixing dressing classes without converting the
+   three-size degeneracy ledger into an axiom or conflating half-period trace
+   classes with charge-negation orbits; and
+3. execute the joint-lane program without assuming transporter completion,
+   a gravity quotient, joint gravity, or an arbitrary-shear extension.
+
+The exact next gate is: “The isospectral similarity for general even N;
+parity-mixing dressing classes; the joint-lane program.”
+
+The N=8 dynamical-degeneracy item from Block 138 is closed at both displayed
+same-family shears. The three-size ledger, exact Z8 class structure, and
+charge-zero cross-size evidence are recorded without promoting them to a
+family theorem. The witnessing similarity remains the missing mechanism.
+
+The actual ADM/history transporter remains unexecuted beyond the displayed
+flat half-space positive package, the curved finite carrier with its bounded
+residual-invariance result, and the displayed flat observable sizes.
+
+The gravity constraint quotient remains unexecuted beyond the displayed
+carriers.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16044,
- "node_count": 5567,
+ "edge_count": 16047,
+ "node_count": 5568,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -561,6 +561,10 @@
   "admissibility_dirac_kahler_wick_phase_fine_site_staggered_os_lorentz_boundary_bounded_theorem_note_2026-08-14": {
    "deps_hash": "825cb5c969e8",
    "out_degree": 6
+  },
+  "admissibility_dirac_kahler_z8_ledger_completion_bounded_theorem_note_2026-08-19": {
+   "deps_hash": "c1148cdd32f2",
+   "out_degree": 3
   },
   "admissibility_dirac_signature_gravity_replacement_shortest_route_gate_boundary_bounded_theorem_note_2026-08-14": {
    "deps_hash": "0f2a2c502553",

--- a/logs/runner-cache/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.txt
@@ -1,0 +1,30 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py
+runner_sha256: 53b8ea39b9ba8fd4d73f7fff16afe5daae72eb52e6067b320ad7baa54f0bab98
+input_fingerprint_sha256: fad5f58b61e88baf03bf31629427c3ea6a4049518f42d9c52cbde7624a3e3e20
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 18.98
+status: ok
+----- stdout -----
+[PASS] A-authority: main, Block 138 parent artifacts, and committed Block 136 artifacts are content-bound
+[PASS] B-same-family: only spatial extent, exact root field, and cyclic projectors change in the exact Z8 rebuild
+[PASS] C-ledger-completion: rho_0=rho_4 and every even-momentum determinant is one at both committed shears
+[PASS] D-two-rule-classes: the exact trace and determinant classes obey shift-four equality and momentum conjugation
+[PASS] E-cross-size-law: the pinned k=0 trace is exactly equal at Z6 and Z8 for both committed shears
+[PASS] F-isospectrality: k=0 and k=N/2 blocks have identical characteristic-polynomial coefficients at Z6 and Z8
+[PASS] G-refuted-intertwiner: the exact one-slice-shift conjugacy residual is nonzero at both Z8 shears
+[PASS] H-note-scope: the bounded upgrade, negative mechanism, firewalls, pinned rationals, and exact N5 fence are present
+GATES A-authority=PASS B-same-family=PASS C-ledger-completion=PASS D-two-rule-classes=PASS E-cross-size-law=PASS F-isospectrality=PASS G-refuted-intertwiner=PASS H-note-scope=PASS
+N5: per_element: exact Z8 roots and projectors plus the committed Block 136 action and transfer builders are checked in Q(i,sqrt(2))
+per_site: one spatial Z8 extension in the same family; only the extent, root field, and projector set change
+per_mode: at both shears k->k+4 gives exact trace equality and k->8-k gives exact conjugation; the four trace classes remain distinct
+per_block: rho_0=rho_4 gives Sym_2(R)^4, dimension 12, center 4; the N=4 checker finds all characteristic-polynomial coefficients equal for the two real-character momentum blocks
+lattice_wide: exact evidence is N=4,6,8 at shears 5/13 and 3/5; no general-even-N similarity theorem is claimed
+RESULT: the Z8 ledger completes and all three checked sizes occupy the 3m branch; the exact k=0 trace is size-independent on those fixtures
+DECISION_CUT: exhibit the general-even-N isospectral similarity; classify parity-mixing dressing classes; execute the joint-lane program
+TOE: zero obligation retirement; no TOE percentage movement; retained-positive end-to-end theory count remains zero
+TOTAL: PASS=8 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py
+++ b/scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py
@@ -1,0 +1,1293 @@
+#!/usr/bin/env python3
+# Final path: scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py
+"""Block 139: exact Z8 ledger-completion bounded theorem.
+
+The committed Block 136 fixture is extended from spatial size six to eight
+through its public spatial-fixture seam.  Only the cyclic root field and
+projectors are adapted; the committed momentum-block and transfer machinery
+is reused.  All scientific comparisons use exact SymPy arithmetic.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+
+import sympy as sp
+
+
+R = sp.Rational
+I = sp.I
+SQRT2 = sp.sqrt(2)
+_FINAL_LOCATION_ROOT = Path(__file__).resolve().parents[1]
+# The cwd fallback keeps this staged scratchpad draft executable before the
+# supervisor moves it to scripts/, where the final-location branch is used.
+ROOT = (
+    _FINAL_LOCATION_ROOT
+    if (_FINAL_LOCATION_ROOT / ".git").exists()
+    else Path.cwd()
+)
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import admissibility_dirac_kahler_observable_scaling_law_2026_08_18 as b136
+
+
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_Z8_LEDGER_COMPLETION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-19.md"
+)
+AXIOM_PATH = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+REGISTRY_PATH = "docs/audit/data/axiom_premise_nodes.json"
+BLOCK138_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_"
+    "BOUNDED_THEOREM_NOTE_2026-08-19.md"
+)
+BLOCK138_RUNNER = (
+    "scripts/admissibility_dirac_kahler_general_zn_charge_kinematic_"
+    "theorem_2026_08_19.py"
+)
+BLOCK138_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_general_zn_charge_"
+    "kinematic_theorem_2026_08_19.txt"
+)
+BLOCK136_NOTE = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_OBSERVABLE_SCALING_LAW_"
+    "BOUNDED_THEOREM_NOTE_2026-08-18.md"
+)
+BLOCK136_RUNNER = (
+    "scripts/admissibility_dirac_kahler_observable_scaling_law_"
+    "2026_08_18.py"
+)
+BLOCK136_CACHE = (
+    "logs/runner-cache/admissibility_dirac_kahler_observable_scaling_"
+    "law_2026_08_18.txt"
+)
+
+# Deliberately literal: this is the complete audit read surface.
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_Z8_LEDGER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-19.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md",
+    "scripts/admissibility_dirac_kahler_general_zn_charge_kinematic_theorem_2026_08_19.py",
+    "logs/runner-cache/admissibility_dirac_kahler_general_zn_charge_kinematic_theorem_2026_08_19.txt",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_OBSERVABLE_SCALING_LAW_BOUNDED_THEOREM_NOTE_2026-08-18.md",
+    "scripts/admissibility_dirac_kahler_observable_scaling_law_2026_08_18.py",
+    "logs/runner-cache/admissibility_dirac_kahler_observable_scaling_law_2026_08_18.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 600
+CURRENT_MAIN = "29d17653c9c043a74041f070e311f03fce114c0a"
+CURRENT_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+CURRENT_REGISTRY_BLOB = "b93959cca4f7e26c673cdccbe601e50c3cb93daa"
+WORKTREE_AXIOM_BLOB = "bc23300becfe4e4db57153c0e94cfcdf2338da71"
+WORKTREE_REGISTRY_BLOB = "f01d3be864f682584d50eede8b3abe6671bb4719"
+PARENT_REF = (
+    "origin/physics-loop/"
+    "toe-axiom-closure-block138-general-zn-theorem-20260819"
+)
+# Landing supervisor: replace this placeholder with the Block 138 branch tip.
+PARENT_COMMIT = "a177384ff4710a8ef1c7f7f244fe2a946df85757"
+BLOCK136_COMMIT = "a9e0725db114298d9885e86b34d3c99bfe051444"
+BLOCK136_NOTE_BLOB = "5c7e8b724e90320f3ceea332cc3abd4ce5128723"
+BLOCK136_RUNNER_BLOB = "f86976787595c0f183ca8ce15456c8f857c2b6a6"
+BLOCK136_CACHE_BLOB = "34f29c9a23d97732e864cfc85ba51304d298f8bc"
+
+SPACE_SIZE = 8
+TIME_SIZE = b136.TIME_SIZE
+Z8_EXTENSION = (I, SQRT2)
+Z8_FIELD = sp.QQ.algebraic_field(*Z8_EXTENSION)
+PRIMARY_K0_TRACE = R(
+    -3962371610825721602827025599106,
+    127417091906251505055019140625,
+)
+SECONDARY_K0_TRACE = R(
+    -234369399320455883852546,
+    8465566947515869140625,
+)
+PRIMARY_K0_TRACE_TEXT = (
+    "-3962371610825721602827025599106/"
+    "127417091906251505055019140625"
+)
+SECONDARY_K0_TRACE_TEXT = (
+    "-234369399320455883852546/"
+    "8465566947515869140625"
+)
+
+MUTATIONS = (
+    "stale_axiom_authority",
+    "stale_block138_authority",
+    "break_spatial_extension",
+    "break_root_projectors",
+    "break_rho_completion",
+    "break_even_determinants",
+    "break_trace_shift_rule",
+    "break_class_ledger",
+    "break_cross_size_primary",
+    "break_cross_size_secondary",
+    "break_z8_isospectrality",
+    "break_z6_isospectrality",
+    "assert_time_shift_intertwiner",
+    "weaken_scope_firewalls",
+    "drop_n5_fence",
+)
+
+MUTATION_GATE = {
+    "stale_axiom_authority": "A",
+    "stale_block138_authority": "A",
+    "break_spatial_extension": "B",
+    "break_root_projectors": "B",
+    "break_rho_completion": "C",
+    "break_even_determinants": "C",
+    "break_trace_shift_rule": "D",
+    "break_class_ledger": "D",
+    "break_cross_size_primary": "E",
+    "break_cross_size_secondary": "E",
+    "break_z8_isospectrality": "F",
+    "break_z6_isospectrality": "F",
+    "assert_time_shift_intertwiner": "G",
+    "weaken_scope_firewalls": "H",
+    "drop_n5_fence": "H",
+}
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.results: list[tuple[str, str, bool]] = []
+
+    def check(self, key: str, statement: str, condition: object) -> None:
+        self.results.append((key, statement, bool(condition)))
+
+    def report(self) -> None:
+        for key, statement, value in self.results:
+            print(f"[{'PASS' if value else 'FAIL'}] {key}: {statement}")
+        print(
+            "GATES "
+            + " ".join(
+                f"{key}={'PASS' if value else 'FAIL'}"
+                for key, _, value in self.results
+            )
+        )
+
+    def finish(self) -> int:
+        passed = sum(value for _, _, value in self.results)
+        failed = len(self.results) - passed
+        print(f"TOTAL: PASS={passed} FAIL={failed}")
+        return failed
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(
+        ("git",) + args,
+        cwd=ROOT,
+        text=True,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).strip()
+
+
+def worktree_blob(path: str) -> str:
+    return git_output("hash-object", path)
+
+
+def commit_blob(commit: str, path: str) -> str:
+    return git_output("rev-parse", f"{commit}:{path}")
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    return subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=ROOT,
+        check=False,
+        timeout=AUDIT_TIMEOUT_SEC,
+    ).returncode == 0
+
+
+def is_hash(value: str) -> bool:
+    return re.fullmatch(r"[0-9a-f]{40}", value) is not None
+
+
+@dataclass(frozen=True)
+class AuthorityCertificate:
+    fixed_authority: bool
+    block138_authority: bool
+    block136_authority: bool
+
+
+def authority_certificate() -> AuthorityCertificate:
+    fixed_authority = bool(
+        AUDIT_TIMEOUT_SEC == 600
+        and git_output("rev-parse", "origin/main") == CURRENT_MAIN
+        and commit_blob("origin/main", AXIOM_PATH) == CURRENT_AXIOM_BLOB
+        and commit_blob("origin/main", REGISTRY_PATH) == CURRENT_REGISTRY_BLOB
+        and worktree_blob(AXIOM_PATH) == WORKTREE_AXIOM_BLOB
+        and worktree_blob(REGISTRY_PATH) == WORKTREE_REGISTRY_BLOB
+    )
+
+    parent_ready = is_hash(PARENT_COMMIT)
+    block138_authority = False
+    if parent_ready:
+        parent_blobs = tuple(
+            commit_blob(PARENT_COMMIT, path)
+            for path in (BLOCK138_NOTE, BLOCK138_RUNNER, BLOCK138_CACHE)
+        )
+        block138_authority = bool(
+            git_output("rev-parse", PARENT_REF) == PARENT_COMMIT
+            and is_ancestor(PARENT_COMMIT, "HEAD")
+            and all(is_hash(value) for value in parent_blobs)
+            and parent_blobs
+            == tuple(
+                worktree_blob(path)
+                for path in (BLOCK138_NOTE, BLOCK138_RUNNER, BLOCK138_CACHE)
+            )
+        )
+
+    block136_authority = bool(
+        is_ancestor(BLOCK136_COMMIT, "HEAD")
+        and commit_blob(BLOCK136_COMMIT, BLOCK136_NOTE) == BLOCK136_NOTE_BLOB
+        and commit_blob(BLOCK136_COMMIT, BLOCK136_RUNNER)
+        == BLOCK136_RUNNER_BLOB
+        and commit_blob(BLOCK136_COMMIT, BLOCK136_CACHE) == BLOCK136_CACHE_BLOB
+        and worktree_blob(BLOCK136_NOTE) == BLOCK136_NOTE_BLOB
+        and worktree_blob(BLOCK136_RUNNER) == BLOCK136_RUNNER_BLOB
+        and worktree_blob(BLOCK136_CACHE) == BLOCK136_CACHE_BLOB
+        and b136.AUDIT_TIMEOUT_SEC == AUDIT_TIMEOUT_SEC
+    )
+    return AuthorityCertificate(
+        fixed_authority,
+        block138_authority,
+        block136_authority,
+    )
+
+
+def raw_note() -> str:
+    try:
+        return NOTE_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def normalized_note(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def no_float(value: object) -> bool:
+    if isinstance(value, sp.MatrixBase):
+        return not value.has(sp.Float)
+    if isinstance(value, (tuple, list)):
+        return all(no_float(item) for item in value)
+    if isinstance(value, dict):
+        return all(no_float(key) and no_float(item) for key, item in value.items())
+    return not sp.sympify(value).has(sp.Float)
+
+
+def canonical8(value: sp.Expr) -> sp.Expr:
+    return Z8_FIELD.to_sympy(Z8_FIELD.from_sympy(sp.expand(value)))
+
+
+def exact_equal8(left: sp.Expr, right: sp.Expr) -> bool:
+    return Z8_FIELD.from_sympy(sp.expand(left - right)) == Z8_FIELD.zero
+
+
+def matrix_equal8(left: sp.MatrixBase, right: sp.MatrixBase) -> bool:
+    return left.shape == right.shape and all(
+        exact_equal8(left[row, column], right[row, column])
+        for row in range(left.rows)
+        for column in range(left.cols)
+    )
+
+
+def conjugate8(value: sp.Expr) -> sp.Expr:
+    return canonical8(sp.conjugate(value))
+
+
+# omega_8 = exp(+2*pi*i/8), in the committed Block 136 sign convention.
+ROOTS8 = (
+    sp.S.One,
+    SQRT2 * (1 + I) / 2,
+    I,
+    SQRT2 * (-1 + I) / 2,
+    -sp.S.One,
+    SQRT2 * (-1 - I) / 2,
+    -I,
+    SQRT2 * (1 - I) / 2,
+)
+
+
+def root_power8(power: int) -> sp.Expr:
+    return ROOTS8[power % SPACE_SIZE]
+
+
+@lru_cache(maxsize=1)
+def projectors8() -> tuple[sp.Matrix, ...]:
+    cyclic = b136.shift(SPACE_SIZE)
+    return tuple(
+        (
+            sum(
+                (
+                    root_power8(-momentum * power) * cyclic**power
+                    for power in range(SPACE_SIZE)
+                ),
+                sp.zeros(SPACE_SIZE),
+            )
+            / SPACE_SIZE
+        ).applyfunc(sp.expand)
+        for momentum in range(SPACE_SIZE)
+    )
+
+
+def projectors8_adapter(spatial_size: int) -> tuple[sp.Matrix, ...]:
+    if spatial_size != SPACE_SIZE:
+        raise ValueError(f"Z8 adapter received spatial size {spatial_size}")
+    return projectors8()
+
+
+@dataclass(frozen=True)
+class Z8Solve:
+    shear: sp.Rational
+    raw: object
+    torus_calls: tuple[b136.TorusCall, ...]
+    action: sp.Matrix
+    blocks: tuple[sp.Matrix, ...]
+    transfers: tuple[b136.Transfer, ...]
+    momentum_call_count: int
+    transfer_call_count: int
+    projectors_restored: bool
+    field_restored: bool
+
+
+def build_z8(shear: sp.Rational) -> Z8Solve:
+    """Change L_x from six to eight and reuse the committed algorithms."""
+    raw, calls = b136.fixture_data_spatial(shear, SPACE_SIZE)
+    action = raw.propagator.inv(method="DM").applyfunc(sp.expand)
+
+    committed_projectors = b136.projectors
+    momentum_call_count = 0
+    try:
+        b136.projectors = projectors8_adapter
+        block_list = []
+        for momentum in range(SPACE_SIZE):
+            block_list.append(
+                b136.momentum_block(
+                    action,
+                    momentum,
+                    TIME_SIZE,
+                    SPACE_SIZE,
+                )
+            )
+            momentum_call_count += 1
+        blocks = tuple(block_list)
+    finally:
+        b136.projectors = committed_projectors
+    projectors_restored = b136.projectors is committed_projectors
+
+    committed_extension = b136.ALGEBRAIC_EXTENSION
+    committed_field = b136.NUMBER_FIELD
+    transfer_call_count = 0
+    try:
+        b136.ALGEBRAIC_EXTENSION = Z8_EXTENSION
+        b136.NUMBER_FIELD = Z8_FIELD
+        transfer_list = []
+        for block in blocks:
+            transfer_list.append(b136.transfer_from_action(block))
+            transfer_call_count += 1
+        transfers = tuple(transfer_list)
+    finally:
+        b136.ALGEBRAIC_EXTENSION = committed_extension
+        b136.NUMBER_FIELD = committed_field
+    field_restored = bool(
+        b136.ALGEBRAIC_EXTENSION == committed_extension
+        and b136.NUMBER_FIELD is committed_field
+    )
+
+    return Z8Solve(
+        shear,
+        raw,
+        calls,
+        action,
+        blocks,
+        transfers,
+        momentum_call_count,
+        transfer_call_count,
+        projectors_restored,
+        field_restored,
+    )
+
+
+def fourier_reconstruction_exact(solve: Z8Solve) -> bool:
+    projectors = projectors8()
+    for time_row in range(TIME_SIZE):
+        for time_column in range(TIME_SIZE):
+            original = solve.action[
+                SPACE_SIZE * time_row : SPACE_SIZE * (time_row + 1),
+                SPACE_SIZE * time_column : SPACE_SIZE * (time_column + 1),
+            ]
+            reconstructed = sum(
+                (
+                    solve.blocks[momentum][time_row, time_column]
+                    * projectors[momentum]
+                    for momentum in range(SPACE_SIZE)
+                ),
+                sp.zeros(SPACE_SIZE),
+            )
+            if not matrix_equal8(original, reconstructed):
+                return False
+    return True
+
+
+def root_projector_certificate() -> bool:
+    omega = ROOTS8[1]
+    projectors = projectors8()
+    cyclic = b136.shift(SPACE_SIZE)
+    return bool(
+        Z8_EXTENSION == (I, sp.sqrt(2))
+        and no_float(ROOTS8)
+        and all(exact_equal8(omega**power, ROOTS8[power]) for power in range(8))
+        and exact_equal8(omega**8, 1)
+        and exact_equal8(omega**4, -1)
+        and exact_equal8(omega**2, I)
+        and len(projectors) == SPACE_SIZE
+        and matrix_equal8(
+            sum(projectors, sp.zeros(SPACE_SIZE)),
+            sp.eye(SPACE_SIZE),
+        )
+        and all(projector.rank() == 1 for projector in projectors)
+        and all(
+            matrix_equal8(
+                projectors[left] * projectors[right],
+                (
+                    projectors[left]
+                    if left == right
+                    else sp.zeros(SPACE_SIZE)
+                ),
+            )
+            for left in range(SPACE_SIZE)
+            for right in range(SPACE_SIZE)
+        )
+        and all(
+            matrix_equal8(
+                cyclic * projectors[momentum],
+                root_power8(momentum) * projectors[momentum],
+            )
+            for momentum in range(SPACE_SIZE)
+        )
+    )
+
+
+@dataclass(frozen=True)
+class SameFamilyCertificate:
+    both_committed_shears: bool
+    mass_equal_committed_expectation: bool
+    shear_profiles_equal_committed_expectations: bool
+    only_spatial_input_changed: bool
+    root_field_and_projectors_only_adapters: bool
+    action_and_momentum_reconstruction_exact: bool
+    transfer_machinery_reused: bool
+    exact_no_float: bool
+
+
+def same_family_certificate(
+    z8_fixtures: tuple[Z8Solve, ...],
+    z6_fixtures: tuple[object, ...],
+) -> SameFamilyCertificate:
+    shears = (b136.PRIMARY_SHEAR, b136.SECOND_SHEAR)
+    calls8 = tuple(item.torus_calls[0] for item in z8_fixtures)
+    calls6 = tuple(item.torus_calls[0] for item in z6_fixtures)
+    mass_equal = all(
+        call8.mass == call6.mass == b136.EXPECTED_MASS
+        for call8, call6 in zip(calls8, calls6, strict=True)
+    )
+    shear_equal = all(
+        call8.shear
+        == call6.shear
+        == b136.expected_shear_profile(shear)
+        for shear, call8, call6 in zip(
+            shears,
+            calls8,
+            calls6,
+            strict=True,
+        )
+    )
+    only_spatial = all(
+        len(z8.torus_calls) == len(z6.torus_calls) == 1
+        and call8.half_time == call6.half_time
+        and call8.half_time * 2 == TIME_SIZE
+        and call8.boundary_sign == call6.boundary_sign == -1
+        and call8.spatial_extent == SPACE_SIZE
+        and call6.spatial_extent == 6
+        and z8.raw.propagator.shape
+        == z8.action.shape
+        == (TIME_SIZE * SPACE_SIZE, TIME_SIZE * SPACE_SIZE)
+        and z6.raw.propagator.shape
+        == z6.action.shape
+        == (TIME_SIZE * 6, TIME_SIZE * 6)
+        for z8, z6, call8, call6 in zip(
+            z8_fixtures,
+            z6_fixtures,
+            calls8,
+            calls6,
+            strict=True,
+        )
+    )
+    reconstruction = all(
+        matrix_equal8(
+            z8.action * z8.raw.propagator,
+            sp.eye(TIME_SIZE * SPACE_SIZE),
+        )
+        and matrix_equal8(
+            z8.raw.propagator * z8.action,
+            sp.eye(TIME_SIZE * SPACE_SIZE),
+        )
+        and z8.momentum_call_count == SPACE_SIZE
+        and len(z8.blocks) == SPACE_SIZE
+        and all(block.shape == (TIME_SIZE, TIME_SIZE) for block in z8.blocks)
+        and fourier_reconstruction_exact(z8)
+        for z8 in z8_fixtures
+    )
+    transfers_reused = all(
+        z8.transfer_call_count == SPACE_SIZE
+        and len(z8.transfers) == SPACE_SIZE
+        and all(
+            transfer.fine_band
+            and transfer.construction_valid
+            and transfer.characteristic_valid
+            and len(transfer.slices) == TIME_SIZE // 2
+            and len(transfer.local_transfers) == TIME_SIZE // 2
+            and transfer.monodromy.shape == (2, 2)
+            for transfer in z8.transfers
+        )
+        for z8 in z8_fixtures
+    )
+    exactness = all(
+        no_float(z8.raw.propagator)
+        and no_float(z8.action)
+        and no_float(z8.blocks)
+        and no_float(
+            tuple(
+                transfer.monodromy_trace
+                for transfer in z8.transfers
+            )
+        )
+        and no_float(
+            tuple(
+                transfer.monodromy_determinant
+                for transfer in z8.transfers
+            )
+        )
+        and all(
+            no_float(transfer.local_transfers)
+            and no_float(transfer.monodromy)
+            for transfer in z8.transfers
+        )
+        for z8 in z8_fixtures
+    )
+    adapters_only = bool(
+        root_projector_certificate()
+        and b136.ALGEBRAIC_EXTENSION == (I, sp.sqrt(3))
+        and Z8_EXTENSION != b136.ALGEBRAIC_EXTENSION
+        and all(
+            z8.projectors_restored and z8.field_restored
+            for z8 in z8_fixtures
+        )
+    )
+    return SameFamilyCertificate(
+        tuple(item.shear for item in z8_fixtures)
+        == tuple(item.shear for item in z6_fixtures)
+        == shears
+        and shears[0] != shears[1],
+        mass_equal,
+        shear_equal,
+        only_spatial,
+        adapters_only,
+        reconstruction,
+        transfers_reused,
+        exactness,
+    )
+
+
+def equality_classes8(
+    values: tuple[sp.Expr, ...],
+) -> tuple[tuple[int, ...], ...]:
+    classes: list[tuple[int, ...]] = []
+    consumed: set[int] = set()
+    for index, value in enumerate(values):
+        if index in consumed:
+            continue
+        current = tuple(
+            candidate
+            for candidate, other in enumerate(values)
+            if exact_equal8(value, other)
+        )
+        classes.append(current)
+        consumed.update(current)
+    return tuple(classes)
+
+
+@dataclass(frozen=True)
+class Spectrum8:
+    traces: tuple[sp.Expr, ...]
+    determinants: tuple[sp.Expr, ...]
+    trace_classes: tuple[tuple[int, ...], ...]
+    determinant_classes: tuple[tuple[int, ...], ...]
+
+
+def spectrum8(solve: Z8Solve) -> Spectrum8:
+    traces = tuple(
+        canonical8(transfer.monodromy_trace)
+        for transfer in solve.transfers
+    )
+    determinants = tuple(
+        canonical8(transfer.monodromy_determinant)
+        for transfer in solve.transfers
+    )
+    return Spectrum8(
+        traces,
+        determinants,
+        equality_classes8(traces),
+        equality_classes8(determinants),
+    )
+
+
+@dataclass(frozen=True)
+class LedgerCompletionCertificate:
+    both_committed_shears: bool
+    zero_four_trace_equal: bool
+    zero_four_determinant_equal: bool
+    rho_zero_equals_rho_four: bool
+    every_even_determinant_one: bool
+    exact_no_float: bool
+
+
+def ledger_completion_certificate(
+    spectra: tuple[Spectrum8, ...],
+) -> LedgerCompletionCertificate:
+    trace_equal = tuple(
+        exact_equal8(item.traces[0], item.traces[4])
+        for item in spectra
+    )
+    determinant_equal = tuple(
+        exact_equal8(item.determinants[0], item.determinants[4])
+        for item in spectra
+    )
+    rho_equal = tuple(
+        trace_ok and determinant_ok
+        for trace_ok, determinant_ok in zip(
+            trace_equal,
+            determinant_equal,
+            strict=True,
+        )
+    )
+    even_determinants_one = tuple(
+        all(
+            exact_equal8(item.determinants[momentum], 1)
+            for momentum in (0, 2, 4, 6)
+        )
+        for item in spectra
+    )
+    return LedgerCompletionCertificate(
+        len(spectra) == 2,
+        all(trace_equal),
+        all(determinant_equal),
+        all(rho_equal),
+        all(even_determinants_one),
+        no_float(
+            tuple(
+                value
+                for item in spectra
+                for value in item.traces + item.determinants
+            )
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class ClassRulesCertificate:
+    trace_classes_exact: bool
+    determinant_classes_exact: bool
+    trace_shift_four_rule: bool
+    trace_conjugation_rule: bool
+    four_distinct_trace_classes: bool
+    both_committed_shears: bool
+
+
+def class_rules_certificate(
+    spectra: tuple[Spectrum8, ...],
+) -> ClassRulesCertificate:
+    expected_traces = ((0, 4), (1, 5), (2, 6), (3, 7))
+    expected_determinants = ((0, 2, 4, 6), (1, 5), (3, 7))
+    trace_classes_exact = all(
+        item.trace_classes == expected_traces for item in spectra
+    )
+    determinant_classes_exact = all(
+        item.determinant_classes == expected_determinants
+        for item in spectra
+    )
+    shift_rule = all(
+        all(
+            exact_equal8(
+                item.traces[momentum],
+                item.traces[(momentum + 4) % SPACE_SIZE],
+            )
+            for momentum in range(SPACE_SIZE)
+        )
+        for item in spectra
+    )
+    conjugation_rule = all(
+        all(
+            exact_equal8(
+                item.traces[(-momentum) % SPACE_SIZE],
+                conjugate8(item.traces[momentum]),
+            )
+            for momentum in range(SPACE_SIZE)
+        )
+        for item in spectra
+    )
+    four_distinct = all(
+        len(item.trace_classes) == 4
+        and all(
+            not exact_equal8(
+                item.traces[left[0]],
+                item.traces[right[0]],
+            )
+            for left_index, left in enumerate(item.trace_classes)
+            for right in item.trace_classes[left_index + 1 :]
+        )
+        for item in spectra
+    )
+    return ClassRulesCertificate(
+        trace_classes_exact,
+        determinant_classes_exact,
+        shift_rule,
+        conjugation_rule,
+        four_distinct,
+        len(spectra) == 2,
+    )
+
+
+def exact_equal6(left: sp.Expr, right: sp.Expr) -> bool:
+    return (
+        b136.field_element(sp.expand(left - right))
+        == b136.NUMBER_FIELD.zero
+    )
+
+
+@dataclass(frozen=True)
+class CrossSizeCertificate:
+    both_committed_shears: bool
+    primary_z6_equals_z8: bool
+    secondary_z6_equals_z8: bool
+    primary_pinned_rational: bool
+    secondary_pinned_rational: bool
+    displayed_pins_exact: bool
+    exact_no_float: bool
+
+
+def cross_size_certificate(
+    z8_spectra: tuple[Spectrum8, ...],
+    z6_fixtures: tuple[object, ...],
+) -> CrossSizeCertificate:
+    pinned = (PRIMARY_K0_TRACE, SECONDARY_K0_TRACE)
+    z8_traces = tuple(item.traces[0] for item in z8_spectra)
+    z6_traces = tuple(
+        item.transfers[0].monodromy_trace
+        for item in z6_fixtures
+    )
+    cross_equal = tuple(
+        exact_equal8(z8_trace, z6_trace)
+        for z8_trace, z6_trace in zip(
+            z8_traces,
+            z6_traces,
+            strict=True,
+        )
+    )
+    pins_equal = tuple(
+        exact_equal8(z8_trace, expected)
+        and exact_equal6(z6_trace, expected)
+        for z8_trace, z6_trace, expected in zip(
+            z8_traces,
+            z6_traces,
+            pinned,
+            strict=True,
+        )
+    )
+    return CrossSizeCertificate(
+        tuple(item.shear for item in z6_fixtures)
+        == (b136.PRIMARY_SHEAR, b136.SECOND_SHEAR),
+        cross_equal[0],
+        cross_equal[1],
+        pins_equal[0],
+        pins_equal[1],
+        str(PRIMARY_K0_TRACE) == PRIMARY_K0_TRACE_TEXT
+        and str(SECONDARY_K0_TRACE) == SECONDARY_K0_TRACE_TEXT,
+        no_float(z8_traces + z6_traces + pinned),
+    )
+
+
+def characteristic_coefficients(
+    matrix: sp.Matrix,
+) -> tuple[sp.Expr, ...]:
+    return tuple(sp.expand(value) for value in matrix.charpoly().all_coeffs())
+
+
+def coefficients_equal8(
+    left: tuple[sp.Expr, ...],
+    right: tuple[sp.Expr, ...],
+) -> bool:
+    return len(left) == len(right) and all(
+        exact_equal8(a, b)
+        for a, b in zip(left, right, strict=True)
+    )
+
+
+def coefficients_equal6(
+    left: tuple[sp.Expr, ...],
+    right: tuple[sp.Expr, ...],
+) -> bool:
+    return len(left) == len(right) and all(
+        exact_equal6(a, b)
+        for a, b in zip(left, right, strict=True)
+    )
+
+
+@dataclass(frozen=True)
+class IsospectralCertificate:
+    z8_primary_all_coefficients: bool
+    z8_secondary_all_coefficients: bool
+    z6_primary_all_coefficients: bool
+    z6_secondary_all_coefficients: bool
+    monic_degree_eight: bool
+    exact_no_float: bool
+
+
+def isospectral_certificate(
+    z8_fixtures: tuple[Z8Solve, ...],
+    z6_fixtures: tuple[object, ...],
+) -> IsospectralCertificate:
+    z8_pairs = tuple(
+        (
+            characteristic_coefficients(item.blocks[0]),
+            characteristic_coefficients(item.blocks[SPACE_SIZE // 2]),
+        )
+        for item in z8_fixtures
+    )
+    z6_pairs = tuple(
+        (
+            characteristic_coefficients(item.blocks[0]),
+            characteristic_coefficients(item.blocks[3]),
+        )
+        for item in z6_fixtures
+    )
+    z8_equal = tuple(
+        coefficients_equal8(left, right) for left, right in z8_pairs
+    )
+    z6_equal = tuple(
+        coefficients_equal6(left, right) for left, right in z6_pairs
+    )
+    all_pairs = z8_pairs + z6_pairs
+    monic_degree_eight = all(
+        len(left) == len(right) == TIME_SIZE + 1
+        and left[0] == right[0] == 1
+        for left, right in all_pairs
+    )
+    return IsospectralCertificate(
+        z8_equal[0],
+        z8_equal[1],
+        z6_equal[0],
+        z6_equal[1],
+        monic_degree_eight,
+        no_float(all_pairs),
+    )
+
+
+@dataclass(frozen=True)
+class RefutedIntertwinerCertificate:
+    one_slice_shift_exact: bool
+    primary_conjugacy_residual_nonzero: bool
+    secondary_conjugacy_residual_nonzero: bool
+    exact_no_float: bool
+
+
+def refuted_intertwiner_certificate(
+    z8_fixtures: tuple[Z8Solve, ...],
+) -> RefutedIntertwinerCertificate:
+    time_shift = b136.shift(TIME_SIZE)
+    shift_exact = bool(
+        time_shift.shape == (TIME_SIZE, TIME_SIZE)
+        and matrix_equal8(time_shift * time_shift.T, sp.eye(TIME_SIZE))
+        and time_shift != sp.eye(TIME_SIZE)
+        and all(
+            time_shift[(column + 1) % TIME_SIZE, column] == 1
+            for column in range(TIME_SIZE)
+        )
+        and sum(time_shift) == TIME_SIZE
+    )
+    residuals = tuple(
+        (
+            time_shift * item.blocks[0] * time_shift.T
+            - item.blocks[SPACE_SIZE // 2]
+        ).applyfunc(sp.expand)
+        for item in z8_fixtures
+    )
+    residual_nonzero = tuple(
+        not matrix_equal8(residual, sp.zeros(TIME_SIZE))
+        and any(not exact_equal8(entry, 0) for entry in residual)
+        for residual in residuals
+    )
+    return RefutedIntertwinerCertificate(
+        shift_exact,
+        residual_nonzero[0],
+        residual_nonzero[1],
+        no_float(residuals),
+    )
+
+
+N5_FENCE = 'N5: per_element: exact Z8 roots and projectors plus the committed Block 136 action and transfer builders are checked in Q(i,sqrt(2))\nper_site: one spatial Z8 extension in the same family; only the extent, root field, and projector set change\nper_mode: at both shears k->k+4 gives exact trace equality and k->8-k gives exact conjugation; the four trace classes remain distinct\nper_block: rho_0=rho_4 gives Sym_2(R)^4, dimension 12, center 4; the N=4 checker finds all characteristic-polynomial coefficients equal for the two real-character momentum blocks\nlattice_wide: exact evidence is N=4,6,8 at shears 5/13 and 3/5; no general-even-N similarity theorem is claimed\nRESULT: the Z8 ledger completes and all three checked sizes occupy the 3m branch; the exact k=0 trace is size-independent on those fixtures\nDECISION_CUT: exhibit the general-even-N isospectral similarity; classify parity-mixing dressing classes; execute the joint-lane program\nTOE: zero obligation retirement; no TOE percentage movement; retained-positive end-to-end theory count remains zero'
+
+
+SCOPE_KEYS = (
+    "same_family_audit",
+    "ledger_completion",
+    "two_rule_classes",
+    "trace_classes",
+    "determinant_classes",
+    "cross_size_law",
+    "primary_pinned_rational",
+    "secondary_pinned_rational",
+    "isospectrality",
+    "refuted_intertwiner",
+    "gated_family_upgrade",
+    "os_no_go",
+    "curved_os_no_go",
+    "axiom",
+    "firewalls",
+    "zero_retirement",
+    "zero_score",
+    "zero_e2e",
+    "gravity_quotient",
+    "adm",
+    "records",
+    "audit_retention",
+    "n1_n8",
+    "w1",
+    "n5_fence_keys",
+    "n5_verbatim",
+)
+
+
+def scope_certificate(note_text: str) -> dict[str, bool]:
+    note = normalized_note(note_text)
+    compact = note.replace(" ", "")
+    shift_rule = bool(
+        "k->k+4" in compact
+        or "k→k+4" in compact
+        or "k↦k+4" in compact
+    )
+    conjugation_rule = bool(
+        "k->8-k" in compact
+        or "k→8-k" in compact
+        or "k↦8-k" in compact
+    )
+    return {
+        "same_family_audit": (
+            "same-family audit" in note
+            or "same family audit" in note
+        ),
+        "ledger_completion": (
+            "ledger completion" in note
+            and ("rho_0=rho_4" in compact or "ρ_0=ρ_4" in compact)
+        ),
+        "two_rule_classes": bool(
+            shift_rule
+            and conjugation_rule
+            and (
+                "two-rule classes" in note
+                or "two rule classes" in note
+                or "trace classes" in note
+            )
+        ),
+        "trace_classes": all(
+            pair in compact
+            for pair in ("(0,4)", "(1,5)", "(2,6)", "(3,7)")
+        ),
+        "determinant_classes": (
+            "(0,2,4,6)" in compact
+            and "(1,5)" in compact
+            and "(3,7)" in compact
+            and (
+                "determinant classes" in note
+                or "det classes" in note
+            )
+        ),
+        "cross_size_law": (
+            (
+                "cross-size law" in note
+                or "cross size law" in note
+            )
+            and "z6" in compact
+            and "z8" in compact
+            and "k=0" in compact
+        ),
+        "primary_pinned_rational": PRIMARY_K0_TRACE_TEXT in compact,
+        "secondary_pinned_rational": SECONDARY_K0_TRACE_TEXT in compact,
+        "isospectrality": (
+            "isospectral" in note
+            and "characteristic polynomial" in note
+            and "z6" in compact
+            and "z8" in compact
+        ),
+        "refuted_intertwiner": (
+            "refuted intertwiner" in note
+            and "one-slice time shift" in note
+            and (
+                "does not conjugate" in note
+                or "not conjugate" in note
+                or "nonzero residual" in note
+            )
+        ),
+        "gated_family_upgrade": (
+            "per-size checkable fact" in note
+            and (
+                "gated family upgrade" in note
+                or "family upgrade is gated" in note
+            )
+        ),
+        "os_no_go": "not an os no-go" in note,
+        "curved_os_no_go": "not a curved os no-go" in note,
+        "axiom": "no axiom amendment is justified" in note,
+        "firewalls": "firewall" in note,
+        "zero_retirement": "zero obligation retirement" in note,
+        "zero_score": bool(
+            "no toe percentage moves" in note
+            or "no toe percentage movement" in note
+        ),
+        "zero_e2e": (
+            "retained-positive end-to-end theory count remains zero" in note
+        ),
+        "gravity_quotient": (
+            "gravity constraint quotient remains unexecuted" in note
+            or "gravity-constraint quotient is promoted" in note
+        ),
+        "adm": (
+            "actual adm/history transporter remains" in note
+            or "actual adm/history transporter" in note
+        ),
+        "records": "records" in note and "remain" in note,
+        "audit_retention": "audit retention" in note,
+        "n1_n8": all(
+            re.search(rf"\bn{index}\b", note) is not None
+            for index in range(1, 9)
+        ),
+        "w1": re.search(r"\bw1\b", note) is not None,
+        "n5_fence_keys": all(
+            f"{category}:" in note
+            for category in (
+                "per_element",
+                "per_site",
+                "per_mode",
+                "per_block",
+                "lattice_wide",
+            )
+        ),
+        # Raw substring membership, not normalized membership, makes the
+        # printed eight-line fence byte-identical to its note occurrence.
+        "n5_verbatim": N5_FENCE in note_text,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS, default="")
+    mutation = parser.parse_args().mutation
+    started_ns = time.monotonic_ns()
+
+    authority = authority_certificate()
+    shears = (b136.PRIMARY_SHEAR, b136.SECOND_SHEAR)
+    z8_fixtures = tuple(build_z8(shear) for shear in shears)
+    z6_fixtures = tuple(b136.build_z6(shear) for shear in shears)
+    spectra = tuple(spectrum8(item) for item in z8_fixtures)
+    same_family = same_family_certificate(z8_fixtures, z6_fixtures)
+    ledger = ledger_completion_certificate(spectra)
+    classes = class_rules_certificate(spectra)
+    cross_size = cross_size_certificate(spectra, z6_fixtures)
+    isospectral = isospectral_certificate(z8_fixtures, z6_fixtures)
+    refuted = refuted_intertwiner_certificate(z8_fixtures)
+    scope = scope_certificate(raw_note())
+
+    audit_surface_raw = AUDIT_INPUT_PATHS == (
+        "docs/ADMISSIBILITY_DIRAC_KAHLER_Z8_LEDGER_COMPLETION_BOUNDED_THEOREM_NOTE_2026-08-19.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        "docs/audit/data/axiom_premise_nodes.json",
+        "docs/ADMISSIBILITY_DIRAC_KAHLER_GENERAL_ZN_CHARGE_KINEMATIC_THEOREM_BOUNDED_THEOREM_NOTE_2026-08-19.md",
+        "scripts/admissibility_dirac_kahler_general_zn_charge_kinematic_theorem_2026_08_19.py",
+        "logs/runner-cache/admissibility_dirac_kahler_general_zn_charge_kinematic_theorem_2026_08_19.txt",
+        "docs/ADMISSIBILITY_DIRAC_KAHLER_OBSERVABLE_SCALING_LAW_BOUNDED_THEOREM_NOTE_2026-08-18.md",
+        "scripts/admissibility_dirac_kahler_observable_scaling_law_2026_08_18.py",
+        "logs/runner-cache/admissibility_dirac_kahler_observable_scaling_law_2026_08_18.txt",
+    )
+    authority_raw = all(
+        (
+            audit_surface_raw,
+            authority.fixed_authority,
+            authority.block138_authority,
+            authority.block136_authority,
+        )
+    )
+    same_family_raw = all(
+        (
+            same_family.both_committed_shears,
+            same_family.mass_equal_committed_expectation,
+            same_family.shear_profiles_equal_committed_expectations,
+            same_family.only_spatial_input_changed,
+            same_family.root_field_and_projectors_only_adapters,
+            same_family.action_and_momentum_reconstruction_exact,
+            same_family.transfer_machinery_reused,
+            same_family.exact_no_float,
+        )
+    )
+    ledger_raw = all(
+        (
+            ledger.both_committed_shears,
+            ledger.zero_four_trace_equal,
+            ledger.zero_four_determinant_equal,
+            ledger.rho_zero_equals_rho_four,
+            ledger.every_even_determinant_one,
+            ledger.exact_no_float,
+        )
+    )
+    classes_raw = all(
+        (
+            classes.trace_classes_exact,
+            classes.determinant_classes_exact,
+            classes.trace_shift_four_rule,
+            classes.trace_conjugation_rule,
+            classes.four_distinct_trace_classes,
+            classes.both_committed_shears,
+        )
+    )
+    cross_size_raw = all(
+        (
+            cross_size.both_committed_shears,
+            cross_size.primary_z6_equals_z8,
+            cross_size.secondary_z6_equals_z8,
+            cross_size.primary_pinned_rational,
+            cross_size.secondary_pinned_rational,
+            cross_size.displayed_pins_exact,
+            cross_size.exact_no_float,
+        )
+    )
+    isospectral_raw = all(
+        (
+            isospectral.z8_primary_all_coefficients,
+            isospectral.z8_secondary_all_coefficients,
+            isospectral.z6_primary_all_coefficients,
+            isospectral.z6_secondary_all_coefficients,
+            isospectral.monic_degree_eight,
+            isospectral.exact_no_float,
+        )
+    )
+    refuted_raw = all(
+        (
+            refuted.one_slice_shift_exact,
+            refuted.primary_conjugacy_residual_nonzero,
+            refuted.secondary_conjugacy_residual_nonzero,
+            refuted.exact_no_float,
+        )
+    )
+    elapsed_ns = time.monotonic_ns() - started_ns
+    scope_raw = bool(
+        set(scope) == set(SCOPE_KEYS)
+        and all(scope.values())
+        and len(MUTATIONS) == 15
+        and set(MUTATION_GATE) == set(MUTATIONS)
+        and set(MUTATION_GATE.values()) == set("ABCDEFGH")
+        and N5_FENCE.count("\n") == 7
+        and elapsed_ns <= 500 * 1_000_000_000
+    )
+
+    # Every certificate and raw gate is captured before a mutation flag can
+    # act.  A mutation negates exactly one copied gate value, so no dependent
+    # certificate or neighboring gate can cascade.
+    raw_gates = {
+        "A": authority_raw,
+        "B": same_family_raw,
+        "C": ledger_raw,
+        "D": classes_raw,
+        "E": cross_size_raw,
+        "F": isospectral_raw,
+        "G": refuted_raw,
+        "H": scope_raw,
+    }
+    gate_values = dict(raw_gates)
+    if mutation:
+        target = MUTATION_GATE[mutation]
+        gate_values[target] = not gate_values[target]
+        changed = tuple(
+            key
+            for key in raw_gates
+            if raw_gates[key] != gate_values[key]
+        )
+        if changed != (target,):
+            raise AssertionError("mutation did not flip exactly one gate")
+
+    checks = Checks()
+    checks.check(
+        "A-authority",
+        "main, Block 138 parent artifacts, and committed Block 136 artifacts are content-bound",
+        gate_values["A"],
+    )
+    checks.check(
+        "B-same-family",
+        "only spatial extent, exact root field, and cyclic projectors change in the exact Z8 rebuild",
+        gate_values["B"],
+    )
+    checks.check(
+        "C-ledger-completion",
+        "rho_0=rho_4 and every even-momentum determinant is one at both committed shears",
+        gate_values["C"],
+    )
+    checks.check(
+        "D-two-rule-classes",
+        "the exact trace and determinant classes obey shift-four equality and momentum conjugation",
+        gate_values["D"],
+    )
+    checks.check(
+        "E-cross-size-law",
+        "the pinned k=0 trace is exactly equal at Z6 and Z8 for both committed shears",
+        gate_values["E"],
+    )
+    checks.check(
+        "F-isospectrality",
+        "k=0 and k=N/2 blocks have identical characteristic-polynomial coefficients at Z6 and Z8",
+        gate_values["F"],
+    )
+    checks.check(
+        "G-refuted-intertwiner",
+        "the exact one-slice-shift conjugacy residual is nonzero at both Z8 shears",
+        gate_values["G"],
+    )
+    checks.check(
+        "H-note-scope",
+        "the bounded upgrade, negative mechanism, firewalls, pinned rationals, and exact N5 fence are present",
+        gate_values["H"],
+    )
+    checks.report()
+    print(N5_FENCE)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"[FAIL] INTERNAL-EXCEPTION: {type(error).__name__}: {error}")
+        print("TOTAL: PASS=0 FAIL=1")
+        raise


### PR DESCRIPTION
## Block 139 — The Z8 Ledger Completion (three sizes on the 3m branch, the isospectral mechanism, and the cross-size law)

Stacked on Block 138 (#6854). Block 138's conditional theorem left one named next: check the transfer degeneracy ρ₀ = ρ_{N/2} dynamically at N=8. This block executes it — and the round produced two discoveries and one named negative along the way.

### The ledger completion

On the same-family Z8 extension (supervisor-audited: the committed Block 136 builders — `fixture_data_spatial`, `momentum_block`, `transfer_from_action` — consumed unchanged; only the spatial extent, its root field ℚ(i,√2), and the projector set change):

- **ρ₀ = ρ₄ at both shears** (5/13 and 3/5): identical monodromy trace AND determinant, with det = 1 exactly on every even momentum (independently confirmed at N=4 by the checker's own companion construction — not a printing artifact).
- **Trace classes** (0,4),(1,5),(2,6),(3,7) under the two rules — k↦k+4 exact trace equality, k↦8−k exact conjugation (supervisor-verified independently from the printed exact rationals). Same two-rule structure as Z4 and Z6.
- Block 138's verification ledger completes at **three sizes, all on the 3m branch**: the displayed Z8 fixture carries Sym₂(ℝ)⁴ — dimension 12, center 4.

### The discoveries

1. **The cross-size law.** The k=0 monodromy trace is *exactly* size-independent — digit-for-digit identical at Z4, Z6, and Z8, at both displayed shears. The Z4 point was computed by the checker independently of the solve; the Z6 = Z8 identity at the second shear is supervisor-verified.
2. **The isospectral mechanism.** The k=0 and k=N/2 momentum blocks are *isospectral* — all characteristic-polynomial coefficients identical at both shears (checker at N=4; runner at Z6 and Z8). This is stronger than trace equality and is what forces the degeneracy.

### The named negative

The plain one-slice time shift is **not** the similarity: mom(Q, N/2) ≠ T_t · mom(Q, 0) · T_t⁻¹, exact inequality at both shears. The intertwiner witnessing the isospectrality is unidentified.

### The boundary W1

The family-theorem upgrade is **not claimed**: Block 138's transfer-degeneracy rider stays a per-size checkable fact with the cross-size evidence recorded (three sizes, two shears). The upgrade is gated on exhibiting the similarity that makes the two real-character momentum blocks isospectral for general even N — the named next. Not an OS no-go, not a curved OS no-go.

### Verification

- Runner: `scripts/admissibility_dirac_kahler_z8_ledger_completion_2026_08_19.py` — baseline 8/8 PASS, N5 fence byte-identical, mutation sweep 15/15 clean.
- Worker split disclosed: codex `gpt-5.6-sol` (max effort) solve + drafts; cross-model Opus checker spec'd to refute (the N=4 independent confirmation, the isospectrality discovery, and the intertwiner refutation are checker products; the checker honestly flagged the same-family audit and Z8 partition as outside its verification, and the supervisor closed both by direct audit and independent recomputation from the printed exact values).

### Status discipline

No axiom retirement, no TOE movement. NO_GO_LEDGER.md records dispositions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
