### PR TITLE
feat(llk14): late-leave same-k fails at k=14: t=26 vs t=46

### DIFF
--- a/docs/LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,168 @@
+---
+claim_id: late_leave_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named late-leave hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/late_leave_samek_k14_b42_2026_08_15.py
+---
+
+# Named Late-Leave Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/late_leave_samek_k14_b42_2026_08_15.py`](../scripts/late_leave_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of the named late-leave hop-cost `λ2` at `k=14`.
+The ball is not leftover of the `B_39(0)` times: one origin Dijkstra is run
+on this ball, and the site `(14,14,14)` is absent from `B_39(0)`.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rules are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+`λ2(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i| ≥ 2)`, else `1`.
+
+The last clause is the late leave-axis tax. It spares the unit-cube `1→2`
+hop, whose destination has `max_i |w_i| = 1`. Those clauses are the whole
+rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero) gives
+
+`t(14,0,0) = 26`, `t(14,14,14) = 46`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `676/196` versus `2116/588`, or equivalently `2028 > 2116`. The
+inequality does not hold. Same-`k` reverse does not restore at `k=14` under
+`λ2`. Independently, the new axis site is `t(42,0,0) = 58`.
+
+The rule is displayed, not adopted. Do not write λ2 into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the late leave-axis clause, and the arrival function `t` are separately
+displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `λ2` along a directed path from `0` to `v` in
+that graph.
+
+The site `(14,0,0)` has ℓ¹ norm `14` and therefore also lies in `B_39(0)`.
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`. The
+`B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The comparator `ρ3` uses every clause of `λ2` except the late leave-axis
+tax. On the late-leave hop `(2,0,0) → (2,1,0)` one has `|σ| : 1 → 2` and
+destination maximum absolute coordinate `2 ≥ 2`, so `ρ3 = 1` while
+`λ2 = 3`. Therefore `ρ3` cannot price the late-leave hop, and the `λ2`
+scores below are a distinct displayed rule even though the same-`k` pair at
+`k=14` is the pair `26` versus `46`. The unit-cube hop
+`(1,0,0) → (1,1,0)` remains cost `1`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_λ2` |
+|---|---:|
+| `(14,0,0)` | `26` |
+| `(14,14,14)` | `46` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 26^2 = 2028` and `46^2 = 2116`, so
+
+`2028 > 2116` is false; `2028 < 2116`.
+
+Arrival per Euclidean length is smaller at `(14,0,0)` than at `(14,14,14)`.
+Same-`k` reverse at `k=14` is no. Reverse does not restore at `k=14` under
+`λ2`. The comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `λ2` is a displayed scoring device on `B_42(0)`. Do not write λ2
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule λ2 at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `λ2` among hop-costs that score the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of a smaller-ball arrival table as a substitute for the
+  radius-`42` Dijkstra.
+- Any write of `λ2` into Admissibility.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15747,
- "node_count": 5549,
+ "edge_count": 15748,
+ "node_count": 5550,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11817,6 +11817,10 @@
   "lanes_open_science_03_quark_mass_retention_open_lane_2026-04-26_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "late_leave_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "lattice_3d_dense_refinement_reconciliation_note": {
    "deps_hash": "bc5f8211bba0",

--- a/logs/runner-cache/late_leave_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/late_leave_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,49 @@
+===== runner cache v1 =====
+runner: scripts/late_leave_samek_k14_b42_2026_08_15.py
+runner_sha256: b65932449928d49d53d974643d4ed00eb72d509a692813f82cfe48438b5a5c43
+input_fingerprint_sha256: 3b10d699c94c1d1cd4e01d2a8a9e75e571b6cff1fd26ad90175d8e89877f46d7
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.80
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named late-leave hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility λ2 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 26
+t(14,14,14) 46
+t(14,0,0)^2/196 676/196
+t(14,14,14)^2/588 2116/588
+3t_axis^2 2028
+t_body^2 2116
+reverse False
+t(42,0,0) 58
+dijkstra_calls 1
+PASS: t-1400-141414 t(14,0,0)=26 and t(14,14,14)=46
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 is false
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: not-leftover-of-rho3-clause ρ3 cannot price the late-leave hop (2,0,0)→(2,1,0)
+PASS: unit-cube-1to2-spared the unit-cube 1→2 hop is cost 1 under λ2
+PASS: seed-and-late-leave-clauses seed-exit, both-weights-1, and late leave-axis cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/late_leave_samek_k14_b42_2026_08_15.py
+++ b/scripts/late_leave_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under λ2 on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named "
+    "late-leave hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 26
+T_BODY_REP = 46
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero_abs = [abs(coord) for coord in w if coord != 0]
+        if nonzero_abs and min(nonzero_abs) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        abs_w = (abs(w[0]), abs(w[1]), abs(w[2]))
+        if sum(1 for value in abs_w if value == 1) == 2:
+            return 3
+    return 1
+
+
+def lambda2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 1 and support_size(w) == 2:
+        if max(abs(coord) for coord in w) >= 2:
+            return 3
+    return 1
+
+
+def dijkstra_lambda2(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + lambda2_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "λ2 is not written into Admissibility",
+        "Do not write λ2 into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "Do not attach L1." not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_lambda2(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    reverse = 3 * t1400 * t1400 > t141414 * t141414
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t1400 * t1400}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t1400 * t1400}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t1400 == T_AXIS_REP and t141414 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 is false",
+        (not reverse)
+        and 3 * t1400 * t1400 == 2028
+        and t141414 * t141414 == 2116
+        and "2028 > 2116" in note
+        and "does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`26`" in note
+        and "`46`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2028 > 2116" in note and "2028 < 2116" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 58
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3-clause",
+        "ρ3 cannot price the late-leave hop (2,0,0)→(2,1,0)",
+        lambda2_cost((2, 0, 0), (2, 1, 0)) == 3
+        and rho3_cost((2, 0, 0), (2, 1, 0)) == 1
+        and "cannot price the late-leave hop" in note,
+    )
+    checks.check(
+        "unit-cube-1to2-spared",
+        "the unit-cube 1→2 hop is cost 1 under λ2",
+        lambda2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and "spares the unit-cube" in note,
+    )
+    checks.check(
+        "seed-and-late-leave-clauses",
+        "seed-exit, both-weights-1, and late leave-axis cost 3; support increase costs 1",
+        lambda2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and lambda2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and lambda2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and lambda2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and lambda2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and lambda2_cost((1, 1, 1), (2, 1, 1)) == 3
+        and lambda2_cost((2, 0, 0), (2, 1, 0)) == 3
+        and lambda2_cost((2, 2, 2), (3, 2, 2)) == 1
+        and lambda2_cost((2, 2, 2), (2, 2, 1)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "λ2(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named late-leave hop-cost λ2 fails at k=14 on B_42(0): t(14,0,0)=26 vs t(14,14,14)=46, same wall as ρ3. First display. Displayed, not adopted. Do not write λ2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/late_leave_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.