### PR TITLE
feat(klk13): kappa-plus-late-leave same-k holds at k=13: t=25 vs t=43

### DIFF
--- a/docs/KAPPA_LATE_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/KAPPA_LATE_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,179 @@
+---
+claim_id: kappa_late_leave_samek_k13_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=13 under the named kappa-plus-late-leave hop-cost on B_39(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py
+---
+
+# Named Kappa-Plus-Late-Leave Same-k Reverse At k=13 On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_39(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=13`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py`](../scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of same-`k` reverse at `k=13` under the named
+kappa-plus-late-leave hop-cost `κλ`. The pair is computed by one origin
+Dijkstra on `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39` and therefore
+lies on the boundary of this ball.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_39(0)`, the displayed
+rules are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+`κλ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and
+exactly two `|w_i|` equal `1)` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i| ≥ 2)`, else `1`.
+
+The last two clauses stack the ridge-enter tax and the late leave-axis tax
+on `ρ3`. The late-leave clause spares the unit-cube `1→2` hop, whose
+destination has `max_i |w_i| = 1`. The ridge-enter clause spares the
+unit-cube `2→3` hop into `(1,1,1)`, whose destination has three unit
+coordinates. Those clauses are the whole rule. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_39(0)` (82239 sites; 82238 nonzero) gives
+
+`t(13,0,0) = 25`, `t(13,13,13) = 43`.
+
+The displayed same-`k` comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+which is `625/169` versus `1849/507`, or equivalently `1875 > 1849`. The
+inequality holds.
+
+The rule is displayed, not adopted. Do not write κλ into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the stacked ridge-enter and late leave-axis clauses, and the arrival
+function `t` are separately displayed mathematical inputs. No axiom text is
+edited.
+
+## Named Rule
+
+Let `B_39(0) = { v ∈ Z^3 : |v|_1 ≤ 39 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_39(0)`,
+`t(v)` is the least sum of `κλ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses every clause of `κλ` except the ridge-enter tax
+and the late leave-axis tax. On the ridge-enter hop `(2,1,0) → (2,1,1)` one
+has `|σ| : 2 → 3` and exactly two destination coordinates of absolute
+value `1`, so `ρ3 = 1` while `κλ = 3`. Therefore `ρ3` cannot price the ridge-enter hop. On the late-leave hop `(2,0,0) → (2,1,0)` one has
+`|σ| : 1 → 2` and destination maximum absolute coordinate `2 ≥ 2`, so
+`ρ3 = 1` while `κλ = 3`. Therefore `ρ3` cannot price the late-leave hop.
+The `κλ` scores below are a distinct displayed rule. The unit-cube hops
+`(1,0,0) → (1,1,0)` and `(1,1,0) → (1,1,1)` remain cost `1`.
+
+A witness axis walk of cost `25` is seed-exit `3` onto `(1,0,0)`, leave-axis
+`1` onto `(1,1,0)`, corridor-slide `3` onto `(2,1,0)`, non-hugging face hop
+`1` onto `(2,2,0)`, eleven support-preserving cost-`1` face hops to
+`(13,2,0)`, corridor-slide `3` onto `(13,1,0)`, and support-drop `3` onto
+`(13,0,0)`. That walk is a witness of cost `25`, not a uniqueness claim.
+
+A witness body walk of cost `43` is the same prefix of cost `8` to
+`(2,2,0)`, eleven cost-`1` face hops to `(13,2,0)`, eleven cost-`1` face
+hops to `(13,13,0)`, enter-body `1` onto `(13,13,1)`, and twelve
+support-preserving cost-`1` body hops to `(13,13,13)`. The enter-body hop
+has only one unit destination coordinate, so the extra ridge-enter clause
+does not fire. That walk is a witness of cost `43`, not a uniqueness claim.
+
+## Theorem 1 — Arrivals `t(13,0,0)` And `t(13,13,13)` On `B_39(0)`
+
+One origin Dijkstra on `B_39(0)` returns the integer arrivals
+
+| site | `t_κλ` |
+|---|---:|
+| `(13,0,0)` | `25` |
+| `(13,13,13)` | `43` |
+
+Every listed site lies in `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39`
+and sits on the boundary of this ball. These values are Dijkstra outputs,
+not fitted scalars.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=13`
+
+The Euclidean-normalized comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+equivalently `3 t(13,0,0)^2 ? t(13,13,13)^2`. Substituting the computed times
+gives `3 · 25^2 = 1875` and `43^2 = 1849`, so
+
+`1875 > 1849`.
+
+Arrival per Euclidean length is larger at `(13,0,0)` than at `(13,13,13)`.
+Same-`k` reverse at `k=13` holds under `κλ`. The comparison is displayed,
+not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `κλ` is a displayed scoring device on `B_39(0)`. Do not write κλ
+into Admissibility. Do not attach L1. It is not a replacement for
+first arrival under equal hop weights, and it is not offered as the unique
+hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_39(0) for one named hop-cost at k=13. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_39(0) for the displayed rule κλ at k=13; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `κλ` among hop-costs that score the same-`k` pair at `k=13`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_39(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=13`.
+- Any write of `κλ` into Admissibility.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10397,6 +10397,10 @@
   "k_dependence_review_safe_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "kappa_late_leave_samek_k13_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "kcpt_ambient_lattice_symmetry_kernel_isolation_averaged_complex_structure_bounded_theorem_note_2026-07-19": {
    "deps_hash": "dafb468bb9c4",

--- a/logs/runner-cache/kappa_late_leave_samek_k13_b39_2026_08_15.txt
+++ b/logs/runner-cache/kappa_late_leave_samek_k13_b39_2026_08_15.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py
+runner_sha256: f3632eb75b3fba4b3e2db2186405af8acbe15507ecdfcfefbd8df146a312a2c1
+input_fingerprint_sha256: 7e14c75807ca10ce846e0a3ac42bc3166dc55bc1165c0d78b9b484def01e9c9b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.73
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/KAPPA_LATE_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=13 under the named kappa-plus-late-leave hop-cost on B_39(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility κλ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 82239
+t(13,0,0) 25
+t(13,13,13) 43
+t(13,0,0)^2/169 625/169
+t(13,13,13)^2/507 1849/507
+3t_axis^2 1875
+t_body^2 1849
+reverse True
+dijkstra_calls 1
+PASS: t-1300-131313 t(13,0,0) and t(13,13,13) match the witness walks
+PASS: reverse-k13 t(13,0,0)^2/169 > t(13,13,13)^2/507 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b39 B_39(0) has 82239 sites and contains the same-k pair
+PASS: reachable every site of B_39(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-rho3-ridge-enter ρ3 cannot price the ridge-enter hop (2,1,0)→(2,1,1)
+PASS: not-leftover-of-rho3-late-leave ρ3 cannot price the late-leave hop (2,0,0)→(2,1,0)
+PASS: unit-cube-spared the unit-cube 1→2 hop and the unit-cube 2→3 hop stay cost 1
+PASS: seed-and-stacked-clauses seed-exit, both-weights-1, ridge-enter, and late leave-axis cost 3
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py
+++ b/scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=13 under κλ on B_39(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/KAPPA_LATE_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/KAPPA_LATE_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=13 under the named kappa-plus-late-leave "
+    "hop-cost on B_39(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero_abs = [abs(coord) for coord in w if coord != 0]
+        if nonzero_abs and min(nonzero_abs) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        abs_w = (abs(w[0]), abs(w[1]), abs(w[2]))
+        if sum(1 for value in abs_w if value == 1) == 2:
+            return 3
+    return 1
+
+
+def kappa_lambda_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 3:
+        abs_w = (abs(w[0]), abs(w[1]), abs(w[2]))
+        if sum(1 for value in abs_w if value == 1) == 2:
+            return 3
+    if support_size(v) == 1 and support_size(w) == 2:
+        if max(abs(coord) for coord in w) >= 2:
+            return 3
+    return 1
+
+
+def path_cost(path: list[tuple[int, int, int]]) -> int:
+    return sum(kappa_lambda_cost(path[i], path[i + 1]) for i in range(len(path) - 1))
+
+
+def dijkstra_kappa_lambda(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + kappa_lambda_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "κλ is not written into Admissibility",
+        "Do not write κλ into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "Do not attach L1." not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(39)
+    dist = dijkstra_kappa_lambda(sites)
+    t1300 = dist[(13, 0, 0)]
+    t131313 = dist[(13, 13, 13)]
+    reverse = 3 * t1300 * t1300 > t131313 * t131313
+    axis_witness = (
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (2, 1, 0), (2, 2, 0)]
+        + [(x, 2, 0) for x in range(3, 14)]
+        + [(13, 1, 0), (13, 0, 0)]
+    )
+    body_witness = (
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (2, 1, 0), (2, 2, 0)]
+        + [(x, 2, 0) for x in range(3, 14)]
+        + [(13, y, 0) for y in range(3, 14)]
+        + [(13, 13, z) for z in range(1, 14)]
+    )
+    print(f"n_sites {len(sites)}")
+    print(f"t(13,0,0) {t1300}")
+    print(f"t(13,13,13) {t131313}")
+    print(f"t(13,0,0)^2/169 {t1300 * t1300}/169")
+    print(f"t(13,13,13)^2/507 {t131313 * t131313}/507")
+    print(f"3t_axis^2 {3 * t1300 * t1300}")
+    print(f"t_body^2 {t131313 * t131313}")
+    print(f"reverse {reverse}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "t-1300-131313",
+        "t(13,0,0) and t(13,13,13) match the witness walks",
+        t1300 == path_cost(axis_witness) == 25
+        and t131313 == path_cost(body_witness) == 43,
+    )
+    checks.check(
+        "reverse-k13",
+        "t(13,0,0)^2/169 > t(13,13,13)^2/507 holds",
+        reverse
+        and 3 * t1300 * t1300 == 1875
+        and t131313 * t131313 == 1849
+        and "1875 > 1849" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b39",
+        "B_39(0) has 82239 sites and contains the same-k pair",
+        len(sites) == 82239
+        and (13, 0, 0) in dist
+        and (13, 13, 13) in dist
+        and abs(13) + abs(13) + abs(13) == 39,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_39(0) is reached",
+        len(dist) == 82239,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "t(13,0,0) = 25" in note and "t(13,13,13) = 43" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1875 > 1849" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3-ridge-enter",
+        "ρ3 cannot price the ridge-enter hop (2,1,0)→(2,1,1)",
+        kappa_lambda_cost((2, 1, 0), (2, 1, 1)) == 3
+        and rho3_cost((2, 1, 0), (2, 1, 1)) == 1
+        and "cannot price the ridge-enter hop" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3-late-leave",
+        "ρ3 cannot price the late-leave hop (2,0,0)→(2,1,0)",
+        kappa_lambda_cost((2, 0, 0), (2, 1, 0)) == 3
+        and rho3_cost((2, 0, 0), (2, 1, 0)) == 1
+        and "cannot price the late-leave hop" in note,
+    )
+    checks.check(
+        "unit-cube-spared",
+        "the unit-cube 1→2 hop and the unit-cube 2→3 hop stay cost 1",
+        kappa_lambda_cost((1, 0, 0), (1, 1, 0)) == 1
+        and kappa_lambda_cost((1, 1, 0), (1, 1, 1)) == 1
+        and "spares the unit-cube" in note,
+    )
+    checks.check(
+        "seed-and-stacked-clauses",
+        "seed-exit, both-weights-1, ridge-enter, and late leave-axis cost 3",
+        kappa_lambda_cost((0, 0, 0), (1, 0, 0)) == 3
+        and kappa_lambda_cost((1, 0, 0), (2, 0, 0)) == 3
+        and kappa_lambda_cost((1, 1, 0), (1, 0, 0)) == 3
+        and kappa_lambda_cost((1, 1, 1), (2, 1, 1)) == 3
+        and kappa_lambda_cost((2, 1, 0), (2, 1, 1)) == 3
+        and kappa_lambda_cost((2, 0, 0), (2, 1, 0)) == 3
+        and kappa_lambda_cost((13, 13, 0), (13, 13, 1)) == 1
+        and kappa_lambda_cost((2, 2, 2), (3, 2, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "κλ(v→w)" not in axiom
+        and "kappa-plus-late-leave" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named kappa-plus-late-leave hop-cost κλ holds at k=13 on B_39(0): t(13,0,0)=25 vs t(13,13,13)=43. First display. Displayed, not adopted. Do not write κλ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/kappa_late_leave_samek_k13_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.