### PR TITLE
feat(klk14): kappa-plus-late-leave same-k fails at k=14: t=26 vs t=46

### DIFF
--- a/docs/KAPPA_LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/KAPPA_LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,189 @@
+---
+claim_id: kappa_late_leave_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named kappa-plus-late-leave hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py
+---
+
+# Named Kappa-Plus-Late-Leave Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`. First display of the named kappa-plus-late-leave hop-cost at the
+wall.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py`](../scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named kappa-plus-late-leave hop-cost `κλ` stacks both extras on the
+ridge-slide rule `ρ3`: ridge-enter from `κ` and late-leave from `λ2`.
+The ball is not leftover of a smaller-ball table: one origin Dijkstra is
+run on `B_42(0)`, and the site `(14,14,14)` is absent from `B_39(0)`.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+ancestors of `κλ` are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`;
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`;
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The displayed extras are
+
+`κ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and
+exactly two `|w_i|` equal `1)`, else `1`;
+
+`λ2(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i| ≥ 2)`, else `1`.
+
+The displayed rule `κλ` is
+
+`κλ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and
+exactly two `|w_i|` equal `1)` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i| ≥ 2)`, else `1`.
+
+The first extra is ridge-enter. The second extra is late-leave: a
+leave-axis hop whose destination has some absolute coordinate at least
+`2`. The unit-cube leave `(1,0,0) → (1,1,0)` stays cost `1`. The body
+last hop `(1,1,0) → (1,1,1)` stays cost `1`.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+gives the first display of `κλ` at the wall
+
+`t(14,0,0) = 26`, `t(14,14,14) = 46`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `676/196` versus `2116/588`, or equivalently `2028 > 2116`. The
+inequality does not hold. Same-`k` reverse does not restore at `k=14`.
+Independently, the new axis site is `t(42,0,0) = 58`. The shared axis site
+`t(39,0,0) = 51` is an independent readout on this ball.
+
+The integers `26` and `46` coincide with the named `ρ3` wall pair. They
+are not leftover of `ρ3`. They are not leftover of `κ`. They are not leftover of `λ2`.
+On `(2,1,0) → (2,1,1)` one has `|σ| : 2 → 3` and exactly two `|w_i|`
+equal `1`, so `κλ = 3` while `ρ3 = 1` and `λ2 = 1`. On
+`(2,0,0) → (2,1,0)` one has `|σ| : 1 → 2` and `max |w_i| = 2`, so
+`κλ = 3` while `ρ3 = 1` and `κ = 1`. Stacking both extras therefore
+prices hops that neither ancestor prices alone.
+
+The rule is displayed, not adopted. Do not write κλ into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `κλ` along a directed path from `0` to `v` in
+that graph.
+
+The site `(14,0,0)` has ℓ¹ norm `14` and therefore also lies in `B_39(0)`.
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`. The
+`B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The ridge-slide comparator `ρ3` uses every clause of `κλ` except the two
+stacked extras. The ridge-enter comparator `κ` omits late-leave. The
+late-leave comparator `λ2` omits ridge-enter. Therefore none of those
+three comparators can price both extras, and the `κλ` scores below are
+not a leftover of `ρ3`, of `κ`, or of `λ2`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_κλ` |
+|---|---:|
+| `(14,0,0)` | `26` |
+| `(14,14,14)` | `46` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 26^2 = 2028` and `46^2 = 2116`, so
+
+`2028 > 2116` is false; `2028 < 2116`.
+
+Arrival per Euclidean length is smaller at `(14,0,0)` than at `(14,14,14)`.
+Same-`k` reverse at `k=14` is no. Reverse does not restore at the wall. The
+comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `κλ` is a displayed scoring device on `B_42(0)`. Do not write κλ
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule κλ at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `κλ` among hop-costs that score the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of a smaller-ball arrival table as a substitute for the
+  radius-`42` Dijkstra.
+- Membership of `κλ` as a physical hop-cost. Reverse at `k=14` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10397,6 +10397,10 @@
   "k_dependence_review_safe_note": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "kappa_late_leave_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "kcpt_ambient_lattice_symmetry_kernel_isolation_averaged_complex_structure_bounded_theorem_note_2026-07-19": {
    "deps_hash": "dafb468bb9c4",

--- a/logs/runner-cache/kappa_late_leave_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/kappa_late_leave_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py
+runner_sha256: 0b88eed3daa016566cd80eaa43ab72970f100f47bbef2b7bb7d012bd81630411
+input_fingerprint_sha256: d11368d9b632b4bb818367b5a155ccf4ee809f15c7eb62dd6639b0f4ee7f0fc7
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.97
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/KAPPA_LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named kappa-plus-late-leave hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility κλ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 26
+t(14,14,14) 46
+t(14,0,0)^2/196 676/196
+t(14,14,14)^2/588 2116/588
+3t_axis^2 2028
+t_body^2 2116
+reverse False
+t(42,0,0) 58
+t(39,0,0) 51
+dijkstra_calls 1
+ridge_enter kl=3 rho3=1 lam2=1
+late_leave kl=3 rho3=1 kap=1
+PASS: t-1400-141414 t(14,0,0)=26 and t(14,14,14)=46
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: not-leftover-of-rho3 ρ3 cannot price either stacked extra hop
+PASS: not-leftover-of-kappa κ cannot price the late-leave hop (2,0,0)→(2,1,0)
+PASS: not-leftover-of-lambda2 λ2 cannot price the ridge-enter hop (2,1,0)→(2,1,1)
+PASS: stacked-extra-clauses seed-exit and both-weights-1 cost 3; both extras fire; unit-cube leave stays 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py
+++ b/scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under κλ on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/KAPPA_LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/KAPPA_LATE_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named "
+    "kappa-plus-late-leave hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 26
+T_BODY_REP = 46
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def abs_coords(v: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (abs(v[0]), abs(v[1]), abs(v[2]))
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 2 and sigma_w == 2:
+        nonzero = [c for c in abs_coords(w) if c != 0]
+        if nonzero and min(nonzero) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 3 and sigma_w == 3:
+        if sum(1 for c in abs_coords(w) if c == 1) == 2:
+            return 3
+    return 1
+
+
+def kappa_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 2 and sigma_w == 3:
+        if sum(1 for c in abs_coords(w) if c == 1) == 2:
+            return 3
+    return 1
+
+
+def lambda2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 1 and sigma_w == 2 and max(abs_coords(w)) >= 2:
+        return 3
+    return 1
+
+
+def kappalambda_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 2 and sigma_w == 3:
+        if sum(1 for c in abs_coords(w) if c == 1) == 2:
+            return 3
+    if sigma_v == 1 and sigma_w == 2 and max(abs_coords(w)) >= 2:
+        return 3
+    return 1
+
+
+def dijkstra_kappalambda(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + kappalambda_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "κλ is not written into Admissibility",
+        "Do not write κλ into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_kappalambda(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    reverse = 3 * t1400 * t1400 > t141414 * t141414
+    ridge_enter = ((2, 1, 0), (2, 1, 1))
+    late_leave = ((2, 0, 0), (2, 1, 0))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t1400 * t1400}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t1400 * t1400}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(
+        "ridge_enter "
+        f"kl={kappalambda_cost(*ridge_enter)} "
+        f"rho3={rho3_cost(*ridge_enter)} "
+        f"lam2={lambda2_cost(*ridge_enter)}"
+    )
+    print(
+        "late_leave "
+        f"kl={kappalambda_cost(*late_leave)} "
+        f"rho3={rho3_cost(*late_leave)} "
+        f"kap={kappa_cost(*late_leave)}"
+    )
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t1400 == T_AXIS_REP and t141414 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold",
+        (not reverse)
+        and 3 * t1400 * t1400 == 2028
+        and t141414 * t141414 == 2116
+        and "2028 > 2116" in note
+        and "does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`26`" in note
+        and "`46`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2028 > 2116" in note and "2028 < 2116" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 58
+        and t3900 == 51
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "ρ3 cannot price either stacked extra hop",
+        kappalambda_cost(*ridge_enter) == 3
+        and rho3_cost(*ridge_enter) == 1
+        and kappalambda_cost(*late_leave) == 3
+        and rho3_cost(*late_leave) == 1
+        and "not leftover of `ρ3`" in note,
+    )
+    checks.check(
+        "not-leftover-of-kappa",
+        "κ cannot price the late-leave hop (2,0,0)→(2,1,0)",
+        kappalambda_cost(*late_leave) == 3
+        and kappa_cost(*late_leave) == 1
+        and "not leftover of `κ`" in note,
+    )
+    checks.check(
+        "not-leftover-of-lambda2",
+        "λ2 cannot price the ridge-enter hop (2,1,0)→(2,1,1)",
+        kappalambda_cost(*ridge_enter) == 3
+        and lambda2_cost(*ridge_enter) == 1
+        and "not leftover of `λ2`" in note,
+    )
+    checks.check(
+        "stacked-extra-clauses",
+        "seed-exit and both-weights-1 cost 3; both extras fire; unit-cube leave stays 1",
+        kappalambda_cost((0, 0, 0), (1, 0, 0)) == 3
+        and kappalambda_cost((1, 0, 0), (2, 0, 0)) == 3
+        and kappalambda_cost((1, 0, 0), (1, 1, 0)) == 1
+        and kappalambda_cost((1, 1, 0), (1, 1, 1)) == 1
+        and kappalambda_cost((2, 1, 0), (2, 1, 1)) == 3
+        and kappalambda_cost((2, 0, 0), (2, 1, 0)) == 3
+        and kappalambda_cost((2, 1, 1), (3, 1, 1)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "κλ(v→w)" not in axiom
+        and "kappa-plus-late-leave" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named kappa-plus-late-leave hop-cost κλ fails at k=14 on B_42(0): t(14,0,0)=26 vs t(14,14,14)=46, same wall as ρ3. Stacked extras are live. First display. Displayed, not adopted. Do not write κλ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/kappa_late_leave_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.