### PR TITLE
feat(dek1): deep-enter same-k holds at k=1: t=3 vs t=5

### DIFF
--- a/docs/DEEP_ENTER_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/DEEP_ENTER_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,192 @@
+---
+claim_id: deep_enter_samek_k1_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=1 under the named deep-enter hop-cost on B_6(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/deep_enter_samek_k1_b6_2026_08_15.py
+---
+
+# Named Deep-Enter Same-k Reverse At k=1 On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_6(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=1`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/deep_enter_samek_k1_b6_2026_08_15.py`](../scripts/deep_enter_samek_k1_b6_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named deep-enter hop-cost `δε` is scored independently on `B_6(0)`.
+The ball is not leftover of a larger-ball table: one origin Dijkstra is run
+on this ball.
+
+The late-enter-body rule `ε2` prices a `2→3` hop when `max_i |w_i| ≥ 2`
+and scores the same `k=1` pair as the corridor-slide rule `μ`. The residual
+scored here is whether `δε`, which is `ρ3` plus cost `3` on a `2→3` hop
+whose dest has `min_i |w_i| ≥ 2` among coordinates already nonzero at the
+source, still reverses at `k=1`. That extra clause enters the deep body and
+spares the unit cube and the unit plane.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_6(0)`, let `ν` be the
+support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. Let `μ` be the corridor-slide rule
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The ridge-slide rule `ρ3` is
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The displayed rule `δε` is
+
+`δε(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and
+`min_{i : v_i ≠ 0} |w_i| ≥ 2)`, else `1`.
+
+On a nearest-neighbor `2→3` hop the destination always carries a newly
+created unit coordinate, so the min over all dest coordinates would be
+`1` and the extra clause would be idle. The displayed min is therefore
+the min over dest coordinates already nonzero at the source. Equivalently,
+the dest has exactly one unit coordinate and the other two of absolute
+value at least `2`. Uniqueness is not claimed.
+
+One Dijkstra from the origin on `B_6(0)` (377 sites; 376 nonzero) gives
+
+`t(1,0,0) = 3`, `t(1,1,1) = 5`.
+
+The displayed same-`k` comparison at `k=1` is
+
+`t(1,0,0)^2 / 1  ?  t(1,1,1)^2 / 3`,
+
+which is `9/1` versus `25/3`, or equivalently `27 > 25`. The
+inequality holds. Same-`k` reverse holds at `k=1`. The
+displayed rule is not adopted. Independently, the axis
+endpoint of this ball is `t(6,0,0) = 18`.
+
+The `k=1` pair is `3` versus `5`. A least-cost walk to `(1,0,0)` or
+`(1,1,1)` never needs a deep-enter `2→3` hop. The extra clause is live
+on the ball: on `(2,2,0) → (2,2,1)` one has `|σ| : 2 → 3` and
+`min_{i : v_i ≠ 0} |w_i| = 2`, so `ρ3 = 1` while `δε = 3`. Therefore
+`ρ3` cannot price the deep-enter hop. The scores are therefore not leftover
+of a larger-ball table.
+
+The unit-cube hop `(1,1,0) → (1,1,1)` and the unit-plane hop
+`(2,1,0) → (2,1,1)` both have continuing min `1`, so both keep cost `1`.
+
+The rule is displayed, not adopted. Do not write `δε` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+and the arrival function `t` are separately displayed mathematical inputs.
+No axiom text is edited.
+
+## Named Rule
+
+Let `B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_6(0)`,
+`t(v)` is the least sum of `δε` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses the three support-drop clauses, the axis-hugging
+`2→2` slide, and the ridge `3→3` slide. On the deep-enter hop
+`(2,2,0) → (2,2,1)` one has `|σ| : 2 → 3` and continuing dest min `2`,
+so `ρ3 = 1` while `δε = 3`. Therefore `ρ3` cannot price the deep-enter
+hop. On the unit-cube hop `(1,1,0) → (1,1,1)` the continuing dest min is
+`1`, so both `ρ3` and `δε` cost `1`. On the unit-plane hop
+`(2,1,0) → (2,1,1)` the continuing dest min is `1`, so both cost `1`.
+On the ridge slide `(1,1,1) → (2,1,1)` both cost `3`. On the interior
+`3→3` hop `(2,2,2) → (3,2,2)` both cost `1`.
+
+## Theorem 1 — Arrivals `t(1,0,0)` And `t(1,1,1)` On `B_6(0)`
+
+One origin Dijkstra on `B_6(0)` returns the integer arrivals
+
+| site | `t_δε` |
+|---|---:|
+| `(1,0,0)` | `3` |
+| `(1,1,1)` | `5` |
+
+Every listed site lies in `B_6(0)`. The pair is computed on `B_6(0)`, not
+copied from a larger-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+A witness walk to `(1,0,0)` is seed-exit of cost `3` onto `(1,0,0)`,
+summing to `3`. A witness walk to `(1,1,1)` is seed-exit `3` onto
+`(1,0,0)`, body `1→2` of cost `1` onto `(1,1,0)`, and unit-cube `2→3`
+of cost `1` onto `(1,1,1)`, summing to `5`. Those walks are witnesses, not a
+uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=1`
+
+The Euclidean-normalized comparison at `k=1` is
+
+`t(1,0,0)^2 / 1  ?  t(1,1,1)^2 / 3`,
+
+equivalently `3 t(1,0,0)^2 ? t(1,1,1)^2`. Substituting the computed times
+gives `3 · 3^2 = 27` and `5^2 = 25`, so
+
+`27 > 25` is true; `27 > 25` holds.
+
+Arrival per Euclidean length is larger at `(1,0,0)` than at `(1,1,1)`.
+Same-`k` reverse at `k=1` is yes. The comparison is
+displayed, not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `δε` is a displayed scoring device on `B_6(0)`. Do not write `δε`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_6(0) for one named hop-cost at k=1. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_6(0) for the displayed rule δε at k=1; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `δε` among hop-costs that score the same-`k` pair at `k=1`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_6(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=1`.
+- Any reuse of a larger-ball arrival table as a substitute for the
+  radius-`6` Dijkstra.
+- Membership of `δε` as a physical hop-cost. Reverse at `k=1` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3069,6 +3069,10 @@
   "decoherence_failure_analysis": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "deep_enter_samek_k1_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "delta_magnitude_reduces_to_massless_gravity_scale_narrow_theorem_note_2026-06-06": {
    "deps_hash": "a38ede67de87",

--- a/logs/runner-cache/deep_enter_samek_k1_b6_2026_08_15.txt
+++ b/logs/runner-cache/deep_enter_samek_k1_b6_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/deep_enter_samek_k1_b6_2026_08_15.py
+runner_sha256: 8e5f5b3fdf1d4bafc274c3b27453ec9890490389adcf425802fc58bb760bf017
+input_fingerprint_sha256: 84716344914d81625b9118d6157cb0e749433a769444b69b0ec1a67955ee0bdb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/DEEP_ENTER_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=1 under the named deep-enter hop-cost on B_6(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility δε is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 377
+t(1,0,0) 3
+t(1,1,1) 5
+t(1,0,0)^2/1 9/1
+t(1,1,1)^2/3 25/3
+3t_axis^2 27
+t_body^2 25
+reverse True
+t(6,0,0) 18
+dijkstra_calls 1
+delta_eps_deep 3
+rho3_deep 1
+delta_eps_cube 1
+delta_eps_plane 1
+min_all_deep 1
+min_cont_deep 2
+PASS: t-100-111 t(1,0,0)=3 and t(1,1,1)=5
+PASS: reverse-k1 t(1,0,0)^2/1 > t(1,1,1)^2/3 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b6 B_6(0) has 377 sites and 376 nonzero sites
+PASS: reachable every site of B_6(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: independent-b6-dijkstra axis endpoint t(6,0,0)=18 and the note scores B_6 independently
+PASS: k1-pair-kept the k=1 pair remains 3 versus 5 on this ball
+PASS: deep-enter-clause δε prices (2,2,0)→(2,2,1) at 3 while ρ3 prices it at 1
+PASS: spare-unit-cube-and-plane δε leaves unit-cube and unit-plane 2→3 hops at cost 1
+PASS: seed-and-deep-enter-clauses ν clauses, corridor-slide, ridge 3→3, and deep 2→3 cost 3; 1→2, unit-cube 2→3, unit-plane 2→3, and non-ridge 3→3 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/deep_enter_samek_k1_b6_2026_08_15.py
+++ b/scripts/deep_enter_samek_k1_b6_2026_08_15.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=1 under δε on B_6(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/DEEP_ENTER_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/DEEP_ENTER_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=1 under the named "
+    "deep-enter hop-cost on B_6(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 3
+T_BODY_REP = 5
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def min_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def min_continuing_abs(
+    v: tuple[int, int, int], w: tuple[int, int, int]
+) -> int | None:
+    continuing = [abs(w[i]) for i in range(3) if v[i] != 0]
+    if not continuing:
+        return None
+    return min(continuing)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and min_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def delta_eps_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 2
+        and support_size(w) == 3
+        and min_continuing_abs(v, w) is not None
+        and min_continuing_abs(v, w) >= 2
+    ):
+        return 3
+    return 1
+
+
+def dijkstra_delta_eps(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + delta_eps_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "δε is not written into Admissibility",
+        "Do not write `δε` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(6)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_delta_eps(sites)
+    t100 = dist[(1, 0, 0)]
+    t111 = dist[(1, 1, 1)]
+    t600 = dist[(6, 0, 0)]
+    reverse = 3 * t100 * t100 > t111 * t111
+    deep_enter = ((2, 2, 0), (2, 2, 1))
+    unit_cube = ((1, 1, 0), (1, 1, 1))
+    unit_plane = ((2, 1, 0), (2, 1, 1))
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    interior_hop = ((2, 2, 2), (3, 2, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(1,0,0) {t100}")
+    print(f"t(1,1,1) {t111}")
+    print(f"t(1,0,0)^2/1 {t100 * t100}/1")
+    print(f"t(1,1,1)^2/3 {t111 * t111}/3")
+    print(f"3t_axis^2 {3 * t100 * t100}")
+    print(f"t_body^2 {t111 * t111}")
+    print(f"reverse {reverse}")
+    print(f"t(6,0,0) {t600}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"delta_eps_deep {delta_eps_cost(*deep_enter)}")
+    print(f"rho3_deep {rho3_cost(*deep_enter)}")
+    print(f"delta_eps_cube {delta_eps_cost(*unit_cube)}")
+    print(f"delta_eps_plane {delta_eps_cost(*unit_plane)}")
+    print(f"min_all_deep {min(abs(c) for c in deep_enter[1])}")
+    print(f"min_cont_deep {min_continuing_abs(*deep_enter)}")
+
+    checks.check(
+        "t-100-111",
+        f"t(1,0,0)={T_AXIS_REP} and t(1,1,1)={T_BODY_REP}",
+        t100 == T_AXIS_REP and t111 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k1",
+        "t(1,0,0)^2/1 > t(1,1,1)^2/3 holds",
+        reverse
+        and 3 * t100 * t100 == 27
+        and t111 * t111 == 25
+        and "27 > 25" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b6",
+        "B_6(0) has 377 sites and 376 nonzero sites",
+        len(sites) == 377 and len(nonzero) == 376 and all(l1(v) <= 6 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        len(dist) == 377,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`3`" in note
+        and "`5`" in note
+        and "`(1,0,0)`" in note
+        and "`(1,1,1)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "27 > 25" in note,
+    )
+    checks.check(
+        "independent-b6-dijkstra",
+        "axis endpoint t(6,0,0)=18 and the note scores B_6 independently",
+        t600 == 18
+        and l1((1, 1, 1)) == 3
+        and (1, 1, 1) in dist
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "k1-pair-kept",
+        "the k=1 pair remains 3 versus 5 on this ball",
+        t100 == 3
+        and t111 == 5
+        and "3` versus `5" in note,
+    )
+    checks.check(
+        "deep-enter-clause",
+        "δε prices (2,2,0)→(2,2,1) at 3 while ρ3 prices it at 1",
+        delta_eps_cost(*deep_enter) == 3
+        and rho3_cost(*deep_enter) == 1
+        and mu_cost(*deep_enter) == 1
+        and min_continuing_abs(*deep_enter) == 2
+        and unit_coord_count(deep_enter[1]) == 1
+        and min(abs(c) for c in deep_enter[1]) == 1
+        and "cannot price the deep-enter hop" in note,
+    )
+    checks.check(
+        "spare-unit-cube-and-plane",
+        "δε leaves unit-cube and unit-plane 2→3 hops at cost 1",
+        delta_eps_cost(*unit_cube) == 1
+        and rho3_cost(*unit_cube) == 1
+        and delta_eps_cost(*unit_plane) == 1
+        and rho3_cost(*unit_plane) == 1
+        and min_continuing_abs(*unit_cube) == 1
+        and min_continuing_abs(*unit_plane) == 1
+        and "unit cube" in note
+        and "unit plane" in note,
+    )
+    checks.check(
+        "seed-and-deep-enter-clauses",
+        "ν clauses, corridor-slide, ridge 3→3, and deep 2→3 cost 3; 1→2, unit-cube 2→3, unit-plane 2→3, and non-ridge 3→3 cost 1",
+        delta_eps_cost((0, 0, 0), (1, 0, 0)) == 3
+        and delta_eps_cost((1, 0, 0), (2, 0, 0)) == 3
+        and delta_eps_cost((1, 1, 0), (1, 0, 0)) == 3
+        and delta_eps_cost((1, 1, 0), (2, 1, 0)) == 3
+        and delta_eps_cost((1, 1, 1), (2, 1, 1)) == 3
+        and delta_eps_cost(*deep_enter) == 3
+        and delta_eps_cost((1, 0, 0), (1, 1, 0)) == 1
+        and delta_eps_cost(*unit_cube) == 1
+        and delta_eps_cost(*unit_plane) == 1
+        and delta_eps_cost((2, 2, 0), (3, 2, 0)) == 1
+        and delta_eps_cost(*interior_hop) == 1
+        and rho3_cost(*ridge_hop) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "δε(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named deep-enter hop-cost δε holds at k=1 on B_6(0): t(1,0,0)=3 vs t(1,1,1)=5. First display. Displayed, not adopted. Do not write δε into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/deep_enter_samek_k1_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.