### PR TITLE
feat(dekvar): deep-enter ties rho3 variance on B12

### DIFF
--- a/docs/DEEP_ENTER_VAR_VS_KAPPA_RHO3_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/DEEP_ENTER_VAR_VS_KAPPA_RHO3_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,301 @@
+---
+claim_id: deep_enter_var_vs_kappa_rho3_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Arrival-speed variance under deep-enter, ridge-enter, and ridge-slide on B_12(0) is compared. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py
+---
+
+# Named Deep-Enter Versus κ Versus ρ3 Arrival-Speed Variance On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** three named directed nearest-neighbor hop-costs on the finite
+ℓ¹-ball `B_12(0)`, their Dijkstra arrival times from the origin, and the
+population variance of `|v|_2/t` on the 2624 nonzero sites. No hop-cost is
+written into Admissibility. L1 is not attached.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py`](../scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named deep-enter hop-cost `δε` is the already scored ridge-slide rule
+`ρ3` plus cost `3` on those `2→3` hops whose dest coordinates already
+nonzero at the source have least absolute value at least `2`. That extra
+clause enters the deep body and spares the unit cube and the unit plane.
+The named ridge-enter hop-cost `κ` is `ρ3` plus cost `3` on those `2→3`
+hops whose destination has exactly two absolute coordinates equal to `1`.
+The named ridge-slide hop-cost `ρ3` is the corridor-slide rule `μ` plus
+cost `3` only on those `3→3` hops whose destination has exactly two
+absolute coordinates equal to `1`. The investment is that `δε` is the new
+deep-enter hop-cost. The residual here is the first display of
+arrival-speed variance versus `κ` and `ρ3` on `B_12(0)`.
+Uniqueness is not claimed.
+
+The executed order of arrival-speed variances on `B_12(0)` is
+
+`var_κ < var_δε = var_ρ3`.
+
+The two equal scores are the same exact second moment, not a truncated
+coincidence: the `δε` and `ρ3` arrival fields agree on every site of
+`B_12(0)`. So `κ` is strictly rounder than both `δε` and `ρ3` on
+`B_12(0)`, while the deep-enter extra clause is live as a hop-cost and
+idle as an arrival-time change. The lex-first minimizer among the three
+displayed names is `κ`. The scores are displayed, not adopted. Do not
+write `δε`, `κ`, or `ρ3` into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom does not supply hop-cost values. It does not
+supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+None of Record is used to select a hop-cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Three finite Dijkstra scores and their population arrival-speed variances on B_12(0) are exact; no hop-cost is adopted and L1 is not attached."
+trace_class: upstream_support
+target_claim_id: deep_enter_var_vs_kappa_rho3_b12
+target_blocker_text: "compare arrival-speed variance of δε, κ, and ρ3 on B_12(0)"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the three scores displayed. Do not write δε, κ, or ρ3 into Admissibility. Do not attach L1."
+conditional_surface_status: "exact for the three named hop-costs on the induced B_12(0) graph; no physical law is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0=(0,0,0)` and `B_12(0)={v∈Z^3 : |v|_1 ≤ 12}`. This set has 2625 sites.
+The executed graph is the induced nearest-neighbor graph on that set: a
+directed hop `v→w` exists when `w-v` is a signed axis unit and `w∈B_12(0)`.
+
+The coordinate support is `σ_v={i : v_i ≠ 0}`. Its cardinality is the
+weight. On a hop `v→w`:
+
+- seed-exit means `|σ_v|=0`,
+- both-weights-1 means `|σ_v|=|σ_w|=1`,
+- support-drop means `|σ_w| < |σ_v|`,
+- corridor-slide means `|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1`,
+- ridge-slide means `|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1`,
+- ridge-enter means `|σ_v|=2` and `|σ_w|=3` and exactly two `|w_i|` equal `1`,
+- deep-enter means `|σ_v|=2` and `|σ_w|=3` and
+  `min_{i : v_i ≠ 0} |w_i| ≥ 2`.
+
+On a nearest-neighbor `2→3` hop the destination always carries a newly
+created unit coordinate, so the min over all dest coordinates would be
+`1` and the deep-enter clause would be idle. The displayed min is
+therefore the min over dest coordinates already nonzero at the source, as
+in the scored `δε` same-`k` display. Equivalently, the dest has exactly
+one unit coordinate and the other two of absolute value at least `2`.
+
+The three named costs are:
+
+- `δε`: cost `3` if `ρ3` would be `3` or deep-enter, else `1`. Written
+  `δε(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|` or
+  `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1)` or
+  `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)` or
+  `(|σ_v|=2` and `|σ_w|=3` and `min_{i : v_i ≠ 0} |w_i| ≥ 2)`, else `1`.
+- `κ`: cost `3` if `ρ3` would be `3` or ridge-enter, else `1`. Written
+  `κ(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|` or
+  `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1)` or
+  `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)` or
+  `(|σ_v|=2` and `|σ_w|=3` and exactly two `|w_i|` equal `1)`, else `1`.
+- `ρ3`: cost `3` if `μ` would be `3` or ridge-slide, else `1`. Written
+  `ρ3(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|` or
+  `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1)` or
+  `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)`, else `1`.
+
+On the deep-enter hop `(2,2,0) → (2,2,1)` one has `|σ| : 2 → 3` and
+continuing dest min `2`, so `κ = ρ3 = 1` while `δε = 3`. On the
+ridge-enter hop `(2,1,0) → (2,1,1)` one has `|σ| : 2 → 3` and exactly
+two `|w_i| = 1`, so `δε = ρ3 = 1` while `κ = 3`. On the three-unit
+enter hop `(1,1,0) → (1,1,1)` one has `|σ| : 2 → 3` and three `|w_i| = 1`,
+so all three names stay at cost `1`. On the ridge hop
+`(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and exactly two `|w_i| = 1`,
+so all three names cost `3`. On the axis-hugging hop `(1,1,0) → (2,1,0)`
+one has `|σ| : 2 → 2` and least nonzero `|w_i| = 1`, so all three names
+cost `3`. The leave-axis hop `(0,-1,0) → (1,-1,0)` stays at cost `1`
+under all three names. Therefore neither `κ` nor `ρ3` prices the
+deep-enter clause, and the `δε` scores below are not a leftover of
+either comparator as a hop-cost.
+
+Arrival time `t(v)` is the Dijkstra cost from `0` under the named rule.
+The compared statistic on `B_12(0)\{0}` is the population variance
+
+`var(|v|_2/t) = (1/N) Σ_v (|v|_2/t(v) - mean)^2`,
+
+with `N=2624` and `mean=(1/N) Σ_v |v|_2/t(v)`. Equivalently,
+`var = Q - mean^2` where the second moment `Q=(1/N) Σ_v |v|_2^2 / t(v)^2` is
+rational. Three Dijkstras are run, one per cost.
+
+This note does not attach L1. The comparison uses only the three named
+clause families on the same directed graph.
+
+## Theorem 1 — Three Variances
+
+Every nonzero site is reached under each of the three costs. The exact
+second moments on the 2624 nonzero sites are
+
+`Q_δε = 8080835149812247289/37031456927424960000`,
+
+`Q_κ = 8065845471432407489/37031456927424960000`,
+
+`Q_ρ3 = 8080835149812247289/37031456927424960000`.
+
+The population variances, truncated to 18 decimal digits, are
+
+`var_δε = 0.005047718614862020`,
+
+`var_κ = 0.005030477616848010`,
+
+`var_ρ3 = 0.005047718614862020`.
+
+Thus all three variances are reported. The ridge-enter rule `κ` is
+strictly rounder than `δε` on `B_12(0)`, and `δε` is exactly as round as
+`ρ3`. The equality is an identity of arrival fields: `t_δε(v)=t_ρ3(v)`
+at every site of `B_12(0)`. The ball carries 864 directed deep-enter hops,
+each priced `3` under `δε` and `1` under `ρ3` and `κ`; none of
+those hops is used by a least-cost path from the origin.
+
+## Theorem 2 — Lex-First Minimizer
+
+Order the three names as the strings `delta_eps`, `kappa`, and `rho3`.
+The variance-minimizing score among those three is `κ`, and it is the
+unique minimum of the three displayed numbers. Therefore the lex-first
+minimizer among the three is `κ`. Uniqueness among hop-costs outside this
+triple is not required and is not claimed.
+
+The minimizer is displayed, not adopted.
+
+## Theorem 3 — No Admissibility Write, L1 Not Attached
+
+Do not write `δε`, `κ`, or `ρ3` into Admissibility. The current
+admissibility rule remains the quoted nearest-neighbor distribution
+constraint. The three clause families are scoring rules on `B_12(0)`, not
+a replacement of that axiom.
+
+Do not attach L1. No formation law, occupancy member, or locked-set filling
+rule is identified with any of the three hop-costs.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether δε is rounder or worse than κ and ρ3 on B_12(0). |
+| V2 | Current main has no landed δε/κ/ρ3 variance comparison on B_12(0). |
+| V3 | The three Dijkstras and the 2624-site population variances are finite and exact. |
+| V4 | The comparison is not an axiom rewrite: Admissibility is left unchanged. |
+| V5 | Displayed scores are not a physical hop-cost or formation law. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: these three scores are compared on `B_12(0)`
+and are not adopted. No uniqueness of a physical law is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| `δε` | all `ρ3` clauses plus deep-enter `2→3` hops expensive | executed; arrival field equals `ρ3` |
+| `κ` | all `ρ3` clauses plus ridge-enter `2→3` hops expensive | executed; lex-first variance minimizer |
+| `ρ3` | all `μ` clauses plus ridge `3→3` hops expensive | executed; ties `δε` as an arrival field |
+| other clause triples | tax every `2→3` or drop the continuing-min family | different named family; not this residual |
+| unrestricted `Z^3` paths | leave `B_12(0)` and return | outside the declared ball |
+| adopt a score | write `δε`, `κ`, or `ρ3` into Admissibility | forbidden; not executed |
+| attach L1 | identify a score with a formation member | forbidden; not executed |
+
+### N2 — wall independence
+
+Ball restriction, hop-cost clauses, the speed statistic, and axiom
+non-adoption are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball, the induced graph, the three cost clauses, population variance,
+and lex-first among the three names are declared. No continuum limit, no
+physical clock, and no formation rate are assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate and the
+distribution sentence. It does not name hop-cost clauses. The residual is
+a finite comparison on that substrate, not an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each nonzero site of `B_12(0)` | no other ball |
+| per site | one arrival time per named cost | no physical tick identification |
+| per mode | no spectral calculation | no mode exhaustion |
+| per block | three Dijkstras and one variance triple | no law selection |
+| lattice wide | checked and not executed | no `Z^3` or infinite-volume score |
+
+### N6 — live partial-closure paths
+
+Live routes are a derived hop-cost, a reason to adopt one of the three
+scores, a comparison on a larger ball, and a separately derived formation
+law. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `δε` taxes 864 deep-enter hops that `ρ3` leaves
+cheap, the extra `2→3` tax should stretch the arrival-speed field and
+make `δε` strictly different from `ρ3` on `B_12(0)`, either rounder or
+worse.
+
+**Answer:** Pricing the deep-enter clause changes the hop-cost and does
+not change the origin Dijkstra field on this ball. On `B_12(0)` the
+executed variances satisfy `var_κ < var_δε = var_ρ3`, and
+`t_δε = t_ρ3` sitewise. The extra deep-enter clause is idle as an
+arrival-time change, while `κ` remains strictly rounder than both.
+
+### N8 — cross-cycle echo
+
+The deep-enter same-`k` scores and the ridge-enter and ridge-slide
+variance scores are not reused as lemmas. The three scores are computed
+on `B_12(0)`. L1 remains unattached.
+
+**Gate disposition:** PASS for the three reported variances, the displayed
+lex-first minimizer `κ`, and the refusal to adopt a hop-cost or attach L1.
+FAIL / DO NOT SHIP for writing `δε`, `κ`, or `ρ3` into Admissibility,
+attaching L1, or claiming a unique physical law.
+
+## Primary Runner
+
+The primary runner rebuilds `B_12(0)`, runs the three Dijkstras, recomputes
+the second moments and population variances, checks the reported order and
+lex-first minimizer, and pins the current axiom wording together with the
+non-adoption sentences. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3069,6 +3069,10 @@
   "decoherence_failure_analysis": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "deep_enter_var_vs_kappa_rho3_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "delta_magnitude_reduces_to_massless_gravity_scale_narrow_theorem_note_2026-06-06": {
    "deps_hash": "a38ede67de87",

--- a/logs/runner-cache/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.txt
+++ b/logs/runner-cache/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py
+runner_sha256: eb92935bf15a0ca5900a2016c9d5354b12fe7c0daa00e5a8b8168a0625887d86
+input_fingerprint_sha256: b054a99cee0e0935292a4d9f0dcc11806d7022c10573c0d916386dba449bdf12
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.26
+status: ok
+----- stdout -----
+claim_scope: Arrival-speed variance under deep-enter, ridge-enter, and ridge-slide on B_12(0) is compared. Displayed, not adopted.
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: three directed Dijkstras on the induced B_12(0) graph
+negative_scope: displayed scores are not adopted and L1 is not attached
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: audit-tuple-literal AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-scope front matter uses the declared claim_scope
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: ball-cardinality B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: three-dijkstras exactly three Dijkstras run and each named cost reaches every ball site
+PASS: named-clauses ρ3 prices ridge 3→3; κ adds ridge-enter 2→3; δε adds deep-enter 2→3
+PASS: deep-enter-live-cost 864 directed deep-enter hops are priced only by δε
+Q_delta_eps = 8080835149812247289/37031456927424960000
+Q_kappa = 8065845471432407489/37031456927424960000
+Q_rho3 = 8080835149812247289/37031456927424960000
+var_delta_eps = 0.005047718614862020
+var_kappa = 0.005030477616848010
+var_rho3 = 0.005047718614862020
+dijkstra_calls 3
+PASS: second-moments the three exact second moments match the note
+PASS: reported-variances the note reports the three truncated population variances
+PASS: arrival-fields δε and ρ3 agree sitewise while κ differs on a nonempty set
+PASS: variance-order κ is strictly rounder than δε, which equals ρ3
+lex_first_minimizer = kappa
+PASS: lex-first-minimizer the lex-first minimizer among the three names is κ
+PASS: forbidden-phrases note and runner omit the forbidden phrases
+PASS: theorems-displayed three theorems are present and the scores are displayed, not adopted
+PASS: no-admissibility-write the note refuses to write δε, κ, or ρ3 into Admissibility
+PASS: no-l1-attach the note does not attach L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: mutation-idle-arrival the deep-enter extra clause is a live hop-cost that does not change any arrival time
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: checked exactly — each of the 2624 nonzero B_12(0) sites receives three arrival times
+per_site: checked exactly — population variance uses |v|_2/t at every nonzero site
+per_mode: checked exactly — three named hop-costs only; no other clause triple is scored
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py
+++ b/scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Exact B_12(0) arrival-speed variance comparison of δε, κ, and ρ3."""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from fractions import Fraction
+from heapq import heappop, heappush
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/DEEP_ENTER_VAR_VS_KAPPA_RHO3_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/DEEP_ENTER_VAR_VS_KAPPA_RHO3_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Arrival-speed variance under deep-enter, ridge-enter, and "
+    "ridge-slide on B_12(0) is compared. Displayed, not adopted."
+)
+
+RADIUS = 12
+ORIGIN = (0, 0, 0)
+SHIFTS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+NONZERO_COUNT = 2624
+SITE_COUNT = 2625
+DEEP_ENTER_HOPS = 864
+DIJKSTRA_CALLS = 0
+
+Q_DELTA_EPS = Fraction(8080835149812247289, 37031456927424960000)
+Q_KAPPA = Fraction(8065845471432407489, 37031456927424960000)
+Q_RHO3 = Fraction(8080835149812247289, 37031456927424960000)
+VAR_DIGITS = {
+    "delta_eps": "0.005047718614862020",
+    "kappa": "0.005030477616848010",
+    "rho3": "0.005047718614862020",
+}
+
+
+Point = tuple[int, int, int]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def l1_norm(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def radius_squared(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def support_size(point: Point) -> int:
+    return int(point[0] != 0) + int(point[1] != 0) + int(point[2] != 0)
+
+
+def least_nonzero_abs(point: Point) -> int | None:
+    nonzero = [abs(coord) for coord in point if coord != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_abs_count(point: Point) -> int:
+    return int(abs(point[0]) == 1) + int(abs(point[1]) == 1) + int(abs(point[2]) == 1)
+
+
+def min_continuing_abs(source: Point, target: Point) -> int | None:
+    continuing = [abs(target[index]) for index in range(3) if source[index] != 0]
+    if not continuing:
+        return None
+    return min(continuing)
+
+
+def ball_sites(radius: int) -> tuple[Point, ...]:
+    extent = range(-radius, radius + 1)
+    return tuple(point for point in product(extent, repeat=3) if l1_norm(point) <= radius)
+
+
+def split_square(value: int) -> tuple[int, int]:
+    square = 1
+    square_free = 1
+    remaining = value
+    prime = 2
+    while prime * prime <= remaining:
+        exponent = 0
+        while remaining % prime == 0:
+            remaining //= prime
+            exponent += 1
+        if exponent:
+            square *= prime ** (exponent // 2)
+            if exponent % 2:
+                square_free *= prime
+        prime += 1 if prime == 2 else 2
+    if remaining > 1:
+        square_free *= remaining
+    return square, square_free
+
+
+def nu_cost(source: Point, target: Point) -> int:
+    sigma_v = support_size(source)
+    sigma_w = support_size(target)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(source: Point, target: Point) -> int:
+    if nu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(target) == 2 and least_nonzero_abs(target) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(source: Point, target: Point) -> int:
+    if mu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(target) == 3 and unit_abs_count(target) == 2:
+        return 3
+    return 1
+
+
+def kappa_cost(source: Point, target: Point) -> int:
+    if rho3_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(target) == 3 and unit_abs_count(target) == 2:
+        return 3
+    return 1
+
+
+def delta_eps_cost(source: Point, target: Point) -> int:
+    if rho3_cost(source, target) == 3:
+        return 3
+    continuing = min_continuing_abs(source, target)
+    if (
+        support_size(source) == 2
+        and support_size(target) == 3
+        and continuing is not None
+        and continuing >= 2
+    ):
+        return 3
+    return 1
+
+
+def neighbors(site: Point, sites: set[Point]) -> tuple[Point, ...]:
+    out: list[Point] = []
+    for shift in SHIFTS:
+        candidate = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        if candidate in sites:
+            out.append(candidate)
+    return tuple(out)
+
+
+def dijkstra(sites: tuple[Point, ...], cost_fn) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist = {ORIGIN: 0}
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while heap:
+        current, site = heappop(heap)
+        if current != dist[site]:
+            continue
+        for nxt in neighbors(site, site_set):
+            trial = current + cost_fn(site, nxt)
+            prior = dist.get(nxt)
+            if prior is None or trial < prior:
+                dist[nxt] = trial
+                heappush(heap, (trial, nxt))
+    return dist
+
+
+def second_moment_and_var_coeff(
+    dist: dict[Point, int], sites: tuple[Point, ...]
+) -> tuple[Fraction, dict[int, Fraction]]:
+    nonzero = tuple(site for site in sites if site != ORIGIN)
+    count = len(nonzero)
+    moment = Fraction(0)
+    linear: dict[int, Fraction] = defaultdict(Fraction)
+    for site in nonzero:
+        arrival = dist[site]
+        squared = radius_squared(site)
+        moment += Fraction(squared, arrival * arrival)
+        square, square_free = split_square(squared)
+        linear[square_free] += Fraction(square, arrival)
+    moment /= count
+    square_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    keys = tuple(linear)
+    for left in keys:
+        for right in keys:
+            square, square_free = split_square(left * right)
+            square_coeff[square_free] += linear[left] * linear[right] * square
+    var_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    var_coeff[1] += moment
+    denom = count * count
+    for square_free, coeff in square_coeff.items():
+        var_coeff[square_free] -= coeff / denom
+    return moment, {key: value for key, value in var_coeff.items() if value != 0}
+
+
+def eval_coeff(coeff: dict[int, Fraction], precision: int = 50) -> Decimal:
+    getcontext().prec = precision
+    total = Decimal(0)
+    for square_free, value in coeff.items():
+        total += (Decimal(value.numerator) / Decimal(value.denominator)) * Decimal(square_free).sqrt()
+    return total
+
+
+def truncated_decimal(value: Decimal, places: int = 18) -> str:
+    quantized = value.quantize(Decimal(10) ** -places)
+    text = format(quantized, "f")
+    whole, frac = text.split(".")
+    return whole + "." + frac[:places]
+
+
+def parse_audit_tuple(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names and isinstance(node.value, ast.Tuple):
+                values: list[str] = []
+                for element in node.value.elts:
+                    if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                        return None
+                    values.append(element.value)
+                return tuple(values)
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: three directed Dijkstras on the induced B_12(0) graph")
+    print("negative_scope: displayed scores are not adopted and L1 is not attached")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-tuple-literal",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        parse_audit_tuple(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "front matter uses the declared claim_scope",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note.replace("\n", " ")
+        or f'claim_scope: "{CLAIM_SCOPE}"' in note,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalized_axiom and admissibility_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+
+    sites = ball_sites(RADIUS)
+    site_set = set(sites)
+    checks.check(
+        "ball-cardinality",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == SITE_COUNT and ORIGIN in site_set and len(sites) - 1 == NONZERO_COUNT,
+    )
+
+    dist_delta_eps = dijkstra(sites, delta_eps_cost)
+    dist_kappa = dijkstra(sites, kappa_cost)
+    dist_rho3 = dijkstra(sites, rho3_cost)
+    checks.check(
+        "three-dijkstras",
+        "exactly three Dijkstras run and each named cost reaches every ball site",
+        DIJKSTRA_CALLS == 3
+        and len(dist_delta_eps) == SITE_COUNT
+        and len(dist_kappa) == SITE_COUNT
+        and len(dist_rho3) == SITE_COUNT,
+        residual=(DIJKSTRA_CALLS, len(dist_delta_eps), len(dist_kappa), len(dist_rho3)),
+    )
+    checks.check(
+        "named-clauses",
+        "ρ3 prices ridge 3→3; κ adds ridge-enter 2→3; δε adds deep-enter 2→3",
+        mu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mu_cost((1, 0, 0), (1, 1, 0)) == 1
+        and mu_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mu_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mu_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((2, 2, 1), (3, 2, 1)) == 1
+        and rho3_cost((2, 1, 0), (2, 1, 1)) == 1
+        and rho3_cost((2, 2, 0), (2, 2, 1)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and kappa_cost((2, 1, 0), (2, 1, 1)) == 3
+        and kappa_cost((2, 2, 0), (2, 2, 1)) == 1
+        and kappa_cost((1, 1, 0), (1, 1, 1)) == 1
+        and delta_eps_cost((2, 2, 0), (2, 2, 1)) == 3
+        and delta_eps_cost((2, 1, 0), (2, 1, 1)) == 1
+        and delta_eps_cost((1, 1, 0), (1, 1, 1)) == 1
+        and delta_eps_cost((1, 1, 1), (2, 1, 1)) == 3
+        and delta_eps_cost((0, -1, 0), (1, -1, 0)) == 1,
+    )
+
+    live_deep_enter = 0
+    for site in sites:
+        for nxt in neighbors(site, site_set):
+            if delta_eps_cost(site, nxt) == 3 and rho3_cost(site, nxt) == 1:
+                live_deep_enter += 1
+    checks.check(
+        "deep-enter-live-cost",
+        "864 directed deep-enter hops are priced only by δε",
+        live_deep_enter == DEEP_ENTER_HOPS and "864 directed deep-enter hops" in note,
+        residual=live_deep_enter,
+    )
+
+    moment_delta_eps, var_delta_eps_coeff = second_moment_and_var_coeff(dist_delta_eps, sites)
+    moment_kappa, var_kappa_coeff = second_moment_and_var_coeff(dist_kappa, sites)
+    moment_rho3, var_rho3_coeff = second_moment_and_var_coeff(dist_rho3, sites)
+    var_delta_eps = eval_coeff(var_delta_eps_coeff)
+    var_kappa = eval_coeff(var_kappa_coeff)
+    var_rho3 = eval_coeff(var_rho3_coeff)
+
+    print(f"Q_delta_eps = {moment_delta_eps}")
+    print(f"Q_kappa = {moment_kappa}")
+    print(f"Q_rho3 = {moment_rho3}")
+    print(f"var_delta_eps = {truncated_decimal(var_delta_eps)}")
+    print(f"var_kappa = {truncated_decimal(var_kappa)}")
+    print(f"var_rho3 = {truncated_decimal(var_rho3)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "second-moments",
+        "the three exact second moments match the note",
+        moment_delta_eps == Q_DELTA_EPS
+        and moment_kappa == Q_KAPPA
+        and moment_rho3 == Q_RHO3
+        and moment_delta_eps == moment_rho3
+        and "8080835149812247289/37031456927424960000" in note
+        and "8065845471432407489/37031456927424960000" in note,
+    )
+    checks.check(
+        "reported-variances",
+        "the note reports the three truncated population variances",
+        VAR_DIGITS["delta_eps"] in note
+        and VAR_DIGITS["kappa"] in note
+        and VAR_DIGITS["rho3"] in note
+        and truncated_decimal(var_delta_eps) == VAR_DIGITS["delta_eps"]
+        and truncated_decimal(var_kappa) == VAR_DIGITS["kappa"]
+        and truncated_decimal(var_rho3) == VAR_DIGITS["rho3"],
+    )
+    checks.check(
+        "arrival-fields",
+        "δε and ρ3 agree sitewise while κ differs on a nonempty set",
+        all(dist_delta_eps[site] == dist_rho3[site] for site in sites)
+        and any(dist_delta_eps[site] != dist_kappa[site] for site in sites),
+    )
+    checks.check(
+        "variance-order",
+        "κ is strictly rounder than δε, which equals ρ3",
+        var_kappa < var_delta_eps and var_delta_eps == var_rho3,
+        residual=(str(var_delta_eps), str(var_kappa), str(var_rho3)),
+    )
+
+    named = {
+        "delta_eps": var_delta_eps,
+        "kappa": var_kappa,
+        "rho3": var_rho3,
+    }
+    lex_first = min(named, key=lambda name: (named[name], name))
+    print(f"lex_first_minimizer = {lex_first}")
+    checks.check(
+        "lex-first-minimizer",
+        "the lex-first minimizer among the three names is κ",
+        lex_first == "kappa",
+    )
+
+    forbidden = ("G_" "N", "1/" "r", "1/" "r^2", "Lattice-" "named", "not a " "TOE")
+    checks.check(
+        "forbidden-phrases",
+        "note and runner omit the forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "theorems-displayed",
+        "three theorems are present and the scores are displayed, not adopted",
+        "## Theorem 1 — Three Variances" in note
+        and "## Theorem 2 — Lex-First Minimizer" in note
+        and "## Theorem 3 — No Admissibility Write, L1 Not Attached" in note
+        and "Displayed, not adopted." in note
+        and "displayed, not adopted" in normalized_note,
+    )
+    checks.check(
+        "no-admissibility-write",
+        "the note refuses to write δε, κ, or ρ3 into Admissibility",
+        "Do not write `δε`, `κ`, or `ρ3` into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom
+        and "δε(v→w)" not in axiom
+        and "κ(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+    checks.check(
+        "no-l1-attach",
+        "the note does not attach L1",
+        "This note does not attach L1." in note
+        and "Do not attach L1." in note
+        and "Do not attach L1" not in axiom
+        and 'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note and "not claimed" in normalized_note,
+    )
+    checks.check(
+        "mutation-idle-arrival",
+        "the deep-enter extra clause is a live hop-cost that does not change any arrival time",
+        live_deep_enter == DEEP_ENTER_HOPS
+        and all(dist_delta_eps[site] == dist_rho3[site] for site in sites)
+        and delta_eps_cost((2, 2, 0), (2, 2, 1)) != rho3_cost((2, 2, 0), (2, 2, 1)),
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "δε(v→w)" not in axiom
+        and "κ(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    print("per_element: checked exactly — each of the 2624 nonzero B_12(0) sites receives three arrival times")
+    print("per_site: checked exactly — population variance uses |v|_2/t at every nonzero site")
+    print("per_mode: checked exactly — three named hop-costs only; no other clause triple is scored")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Arrival-speed variance on B_12(0) is var_κ=0.005030 < var_δε=var_ρ3=0.005048. Lex-first minimizer remains κ. First display. Displayed, not adopted. Do not write δε into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/deep_enter_var_vs_kappa_rho3_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.