### PR TITLE
feat(rendbl): ridge-enter doubled pairing holds k=1..4

### DIFF
--- a/docs/RIDGE_ENTER_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/RIDGE_ENTER_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,260 @@
+---
+claim_id: ridge_enter_doubled_pairing_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Doubled-axis versus body-diagonal reverse under the named ridge-enter hop-cost on B_12(0) is reported for available k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py
+---
+
+# Doubled Pairing Under The Named Ridge-Enter Hop-Cost On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival comparison of the doubled pairing
+`((2k,0,0),(k,k,k))` at each available integer `k=1,2,3,4` on the finite
+nearest-neighbor graph `B_12(0)`, under a named hop-cost displayed for
+this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py`](../scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named ridge-enter hop-cost `κ` is
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `κ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and exactly
+  two `|w_i|` equal `1)`, else `1`.
+
+The extra clause is a ridge enter: support rises from `2` to `3`, and the
+destination has exactly two unit coordinates. It is not the displayed
+body last hop `(1,1,0) → (1,1,1)`, whose destination has three unit
+coordinates. Uniqueness is not claimed.
+
+The finite host is
+
+```text
+B_12(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 12 }.
+```
+
+It has 2625 sites (2624 nonzero). Edges are the cubic nearest-neighbor
+steps that remain inside `B_12(0)`. For each `k=1,2,3,4` both `(2k,0,0)`
+and `(k,k,k)` lie in `B_12(0)`, so no pair is omitted. One Dijkstra from
+the origin yields
+
+```text
+t(2,0,0) = 6
+t(1,1,1) = 5
+t(4,0,0) = 12
+t(2,2,2) = 10
+t(6,0,0) = 18
+t(3,3,3) = 13
+t(8,0,0) = 20
+t(4,4,4) = 16
+```
+
+Independently, `t(12,0,0) = 28`.
+
+| `k` | site axis | `t(2k,0,0)` | site body | `t(k,k,k)` | `t(2k,0,0)^2/(4k^2)` | `t(k,k,k)^2/(3k^2)` | reverse |
+|---|---|---:|---|---:|---|---|---|
+| `1` | `(2,0,0)` | `6` | `(1,1,1)` | `5` | `36/4` | `25/3` | yes |
+| `2` | `(4,0,0)` | `12` | `(2,2,2)` | `10` | `144/16` | `100/12` | yes |
+| `3` | `(6,0,0)` | `18` | `(3,3,3)` | `13` | `324/36` | `169/27` | yes |
+| `4` | `(8,0,0)` | `20` | `(4,4,4)` | `16` | `400/64` | `256/48` | yes |
+
+Equivalently, `3 t(2k,0,0)^2 ? 4 t(k,k,k)^2` is `108 > 100`, `432 > 400`,
+`972 > 676`, and `1200 > 1024`. The inequality holds at every available
+`k=1..4`. Displayed, not adopted.
+
+The extra 2→3 clause is live on this host. The hop `(2,1,0) → (2,1,1)` has
+`κ=3` and `ρ3=1`, and both ends lie in `B_12(0)`. The displayed pairing
+witness walks below never fire that extra clause: each of their hops is
+already priced `3` or `1` by `ρ3`. That does not identify `κ` with `ρ3`.
+The pairing comparison is a score of `κ` against itself at the named
+sites.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_12(0) reports t(2k,0,0) and t(k,k,k) under the named ridge-enter hop-cost for available k=1..4 and scores the doubled-pairing comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: ridge_enter_doubled_pairing_b12
+target_blocker_text: "whether doubled-axis versus body-diagonal reverse still holds at available k=1..4 after the ridge-enter clause is added to the ridge-slide hop-cost"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_12(0) under the named hop-cost at available k=1..4 on ((2k,0,0),(k,k,k)); displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `κ` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_12(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`, and
+  `κ` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `κ` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_12(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`κ` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`κ`, using one Dijkstra on `B_12(0)`.
+
+The pairing is not the same-`k` axis / body pair `(k,0,0)` versus
+`(k,k,k)`. It is the doubled pairing `((2k,0,0),(k,k,k))`.
+
+## Theorem 1 — Arrival times at available k=1..4
+
+Under `κ` on `B_12(0)`,
+
+```text
+t(2,0,0) = 6
+t(1,1,1) = 5
+t(4,0,0) = 12
+t(2,2,2) = 10
+t(6,0,0) = 18
+t(3,3,3) = 13
+t(8,0,0) = 20
+t(4,4,4) = 16
+```
+
+Every listed site lies in `B_12(0)`. The site `(4,4,4)` has coordinate-sum
+`12`, so it is absent from `B_11(0)`. These values are Dijkstra outputs, not
+fitted scalars.
+
+A witness walk of cost `6` from `0` to `(2,0,0)` is seed-exit `3` onto
+`(1,0,0)` and both-weights-`1` cost `3` onto `(2,0,0)`, summing to `6`.
+A witness walk of cost `5` from `0` to `(1,1,1)` is seed-exit `3` onto
+`(0,0,1)`, leave-axis `1` onto `(0,1,1)`, and enter-body `1` onto
+`(1,1,1)`, summing to `5`. The last hop of that walk has destination
+coordinates all of absolute value `1`, so the extra ridge-enter clause
+does not fire. A witness walk of cost `12` from `0` to `(4,0,0)` is four
+both-weights-`1` axis hops
+`0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0)` of costs `3,3,3,3`, summing
+to `12`. A witness walk of cost `10` from `0` to `(2,2,2)` is seed-exit
+`3` onto `(0,0,1)`, leave-axis `1` onto `(0,1,1)`, corridor-slide `3` onto
+`(0,1,2)`, non-hugging `2→2` of cost `1` onto `(0,2,2)`, enter-body `1`
+onto `(1,2,2)`, and support-preserving cost-`1` body hop onto `(2,2,2)`,
+summing to `10`. A witness walk of cost `18` from `0` to `(6,0,0)` is
+six both-weights-`1` axis hops
+`0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0) → (5,0,0) → (6,0,0)` of
+costs `3,3,3,3,3,3`, summing to `18`. A witness walk of cost `13` from
+`0` to `(3,3,3)` is seed-exit `3` onto `(0,0,1)`, leave-axis `1` onto
+`(0,1,1)`, corridor-slide `3` onto `(0,1,2)`, three non-hugging `2→2`
+hops of cost `1` to `(0,3,3)`, enter-body `1` onto `(1,3,3)`, and two
+support-preserving cost-`1` body hops to `(3,3,3)`, summing to `13`.
+A witness walk of cost `20` from `0` to `(8,0,0)` is seed-exit `3` onto
+`(0,-1,0)`, leave-axis `1` onto `(1,-1,0)`, corridor-slide `3` onto
+`(1,-2,0)`, seven non-hugging `2→2` hops of cost `1` to `(8,-2,0)`,
+corridor-slide `3` onto `(8,-1,0)`, and support-drop `3` onto `(8,0,0)`,
+summing to `20`. A witness walk of cost `16` from `0` to `(4,4,4)` is
+seed-exit `3` onto `(0,0,1)`, leave-axis `1` onto `(0,1,1)`,
+corridor-slide `3` onto `(0,1,2)`, five non-hugging `2→2` hops of cost
+`1` to `(0,4,4)`, enter-body `1` onto `(1,4,4)`, and three
+support-preserving cost-`1` body hops to `(4,4,4)`, summing to `16`.
+Those walks are witnesses of the listed costs, not uniqueness claims.
+
+## Theorem 2 — Doubled-pairing comparison at available k=1..4
+
+For each available `k=1,2,3,4` the displayed comparison is whether
+
+```text
+t(2k,0,0)^2 / (4k^2)  >  t(k,k,k)^2 / (3k^2).
+```
+
+Equivalently `3 t(2k,0,0)^2 > 4 t(k,k,k)^2`. Substituting the computed
+times gives
+
+| `k` | `3 t(2k,0,0)^2` | `4 t(k,k,k)^2` | reverse |
+|---|---:|---:|---|
+| `1` | `108` | `100` | `108 > 100` |
+| `2` | `432` | `400` | `432 > 400` |
+| `3` | `972` | `676` | `972 > 676` |
+| `4` | `1200` | `1024` | `1200 > 1024` |
+
+Arrival per Euclidean length is larger at `(2k,0,0)` than at `(k,k,k)` for
+every available `k=1..4`. The inequality holds. Displayed, not adopted.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write κ into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `κ`, `ρ3`, `μ`, or `ν`. This note
+proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at the doubled pairing sites; it is not an
+attachment of a coordinate-sum hop-cost.
+
+## What This Does Not Claim
+
+- Uniqueness is not claimed for this named hop-cost at any available `k`.
+- The live 2→3 clause on `B_12(0)` is not a statement about larger hosts.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+- `κ` is not identified with `ρ3`: the extra clause is live on
+  `(2,1,0) → (2,1,1)` even though it does not fire on the displayed
+  pairing witness walks.
+- Any omitted pair among `k=1..4`: both sites of each pair lie in `B_12(0)`.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_12(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(2k,0,0)` and `t(k,k,k)`
+for available `k=1..4`, checks the integer form of Theorem 2, checks that
+the extra 2→3 clause is live on in-host hops and does not tax the
+displayed pairing witness walks, checks that the live Admissibility
+wording does not name `κ`, and records the import boundary. Declared
+review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16377,6 +16377,10 @@
   "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
    "deps_hash": "785ba75e68d8",
    "out_degree": 5
+  },
+  "ridge_enter_doubled_pairing_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ring_family_uniformity_cycle737_bounded_theorem_note_2026-07-28": {
    "deps_hash": "f38aec7a66e3",

--- a/logs/runner-cache/ridge_enter_doubled_pairing_b12_2026_08_15.txt
+++ b/logs/runner-cache/ridge_enter_doubled_pairing_b12_2026_08_15.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py
+runner_sha256: df08b0d17c38185ae9d6b7951350e70fa8fd60c4eb4eaebeb77fce9660670772
+input_fingerprint_sha256: f4ceb06462b555995f48c814200b5df87aa1605f7edd0e7851b682a0df8d8e14
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_12(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+claim_scope: Doubled-axis versus body-diagonal reverse under the named ridge-enter hop-cost on B_12(0) is reported for available k=1..4. Displayed, not adopted.
+cache_write: false
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+n_sites 2625
+dijkstra_calls 1
+t(12,0,0) = 28
+k 1 t(2,0,0) = 6 t(1,1,1) = 5 t_axis^2/(4k^2) = 36/4 t_body^2/(3k^2) = 25/3 3 t_axis^2 = 108 4 t_body^2 = 100 reverse=True
+k 2 t(4,0,0) = 12 t(2,2,2) = 10 t_axis^2/(4k^2) = 144/16 t_body^2/(3k^2) = 100/12 3 t_axis^2 = 432 4 t_body^2 = 400 reverse=True
+k 3 t(6,0,0) = 18 t(3,3,3) = 13 t_axis^2/(4k^2) = 324/36 t_body^2/(3k^2) = 169/27 3 t_axis^2 = 972 4 t_body^2 = 676 reverse=True
+k 4 t(8,0,0) = 20 t(4,4,4) = 16 t_axis^2/(4k^2) = 400/64 t_body^2/(3k^2) = 256/48 3 t_axis^2 = 1200 4 t_body^2 = 1024 reverse=True
+ridge_enter_live_hops 432
+PASS: ball-cardinality B_12(0) is the 2625-site integer set with coordinate-sum at most 12
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: reachable every site of B_12(0) is reached
+PASS: pairs-available both sites of each k=1..4 pair lie in B_12(0)
+PASS: hop-origin the unique origin hop has named cost 3
+PASS: hop-axis-axis a same-support axis hop has named cost 3
+PASS: hop-body-last-untaxed the 2-to-3 hop into (1,1,1) is not priced by the extra clause
+PASS: hop-ridge-enter-clause the named 2-to-3 two-unit dest clause prices (2,1,0) to (2,1,1) at 3
+PASS: ridge-enter-live-on-ball nearest-neighbor hops inside B_12(0) trigger the extra 2-to-3 clause
+PASS: hop-rho3-ridge a 3-to-3 hop whose dest has exactly two unit coordinates has cost 3
+PASS: thm1-witness-walks each displayed pairing site has a walk whose cost matches Dijkstra
+PASS: extra-clause-off-pairing-walks the extra 2-to-3 clause does not fire on the displayed pairing walks
+PASS: thm1-k1 t(2,0,0) and t(1,1,1) are computed and reported
+PASS: thm2-k1 t(2,0,0)^2/(4k^2) > t(1,1,1)^2/(3k^2) is True
+PASS: thm1-k2 t(4,0,0) and t(2,2,2) are computed and reported
+PASS: thm2-k2 t(4,0,0)^2/(4k^2) > t(2,2,2)^2/(3k^2) is True
+PASS: thm1-k3 t(6,0,0) and t(3,3,3) are computed and reported
+PASS: thm2-k3 t(6,0,0)^2/(4k^2) > t(3,3,3)^2/(3k^2) is True
+PASS: thm1-k4 t(8,0,0) and t(4,4,4) are computed and reported
+PASS: thm2-k4 t(8,0,0)^2/(4k^2) > t(4,4,4)^2/(3k^2) is True
+PASS: thm1-note-reports-times the note reports all eight computed pairing arrivals
+PASS: thm2-reverse-holds the doubled-pairing inequality holds at every available k=1..4
+PASS: thm2-note-reports-comparison the note reports the integer comparisons and does not adopt them
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name kappa
+PASS: thm3-no-l1-attachment the note refuses to attach L1 and does not score a unit hop-cost
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-claimed the note does not claim uniqueness of the named hop-cost
+PASS: scope-boundary the theorem stays on B_12(0) and proposes no axiom edit
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.
+per_site: arrival times are reported at the doubled pairing sites and at (12,0,0).
+lattice_wide: checked and not executed — the search stays inside B_12(0).
+TOTAL: PASS=32 FAIL=0
+
+----- stderr -----
+

--- a/scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py
+++ b/scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Doubled pairing reverse under the named ridge-enter hop-cost on B_12(0).
+
+One Dijkstra from the origin on the finite nearest-neighbor graph. The
+ridge-enter hop-cost is displayed, not adopted, and is not written into
+Admissibility. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/RIDGE_ENTER_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/RIDGE_ENTER_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Doubled-axis versus body-diagonal reverse under the named "
+    "ridge-enter hop-cost on B_12(0) is reported for available "
+    "k=1..4. Displayed, not adopted."
+)
+
+RADIUS = 12
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+RIDGE_ENTER_SRC = (2, 1, 0)
+RIDGE_ENTER_DST = (2, 1, 1)
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+Site = tuple[int, int, int]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, sites: frozenset[Site], origin: Site) -> dict[Site, int]:
+        self.calls += 1
+        infinity = 10**9
+        dist = {site: infinity for site in sites}
+        dist[origin] = 0
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if cost != dist[site]:
+                continue
+            for step in STEPS:
+                neighbor = add(site, step)
+                if neighbor not in dist:
+                    continue
+                candidate = cost + kappa_cost(site, neighbor)
+                if candidate < dist[neighbor]:
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def coordinate_sum(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def support_size(site: Site) -> int:
+    return int(site[0] != 0) + int(site[1] != 0) + int(site[2] != 0)
+
+
+def least_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(site: Site) -> int:
+    return (
+        int(abs(site[0]) == 1)
+        + int(abs(site[1]) == 1)
+        + int(abs(site[2]) == 1)
+    )
+
+
+def ball_sites(radius: int) -> frozenset[Site]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and least_nonzero_abs(dest) == 1
+    ):
+        return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if (
+        support_size(source) == 3
+        and support_size(dest) == 3
+        and unit_coord_count(dest) == 2
+    ):
+        return 3
+    return 1
+
+
+def kappa_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if (
+        support_size(source) == 2
+        and support_size(dest) == 3
+        and unit_coord_count(dest) == 2
+    ):
+        return 3
+    return 1
+
+
+def walk_cost(path: tuple[Site, ...]) -> int:
+    total = 0
+    for source, dest in zip(path, path[1:]):
+        total += kappa_cost(source, dest)
+    return total
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_12(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+    print("claim_scope: " + CLAIM_SCOPE)
+    print("cache_write: false")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+
+    sites = ball_sites(RADIUS)
+    origin = (0, 0, 0)
+    counter = DijkstraCounter()
+    dist = counter.distances(sites, origin)
+    t_far_axis = dist[(12, 0, 0)]
+
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {counter.calls}")
+    print(f"t(12,0,0) = {t_far_axis}")
+
+    pairing: list[tuple[int, int, int, bool, str]] = []
+    all_in_ball = True
+    all_reverse = True
+    for k in range(1, 5):
+        axis = (2 * k, 0, 0)
+        body = (k, k, k)
+        in_ball = axis in sites and body in sites
+        all_in_ball = all_in_ball and in_ball
+        t_axis = dist[axis]
+        t_body = dist[body]
+        lhs = 3 * t_axis * t_axis
+        rhs = 4 * t_body * t_body
+        reverse = lhs > rhs
+        all_reverse = all_reverse and reverse
+        product = f"{lhs} > {rhs}"
+        pairing.append((k, t_axis, t_body, reverse, product))
+        print(
+            f"k {k} t({2 * k},0,0) = {t_axis} t({k},{k},{k}) = {t_body} "
+            f"t_axis^2/(4k^2) = {t_axis * t_axis}/{4 * k * k} "
+            f"t_body^2/(3k^2) = {t_body * t_body}/{3 * k * k} "
+            f"3 t_axis^2 = {lhs} 4 t_body^2 = {rhs} reverse={reverse}"
+        )
+
+    in_ball_new = 0
+    for site in sites:
+        for step in STEPS:
+            neighbor = add(site, step)
+            if neighbor not in sites:
+                continue
+            if kappa_cost(site, neighbor) == 3 and rho3_cost(site, neighbor) == 1:
+                in_ball_new += 1
+    print(f"ridge_enter_live_hops {in_ball_new}")
+
+    checks.check(
+        "ball-cardinality",
+        "B_12(0) is the 2625-site integer set with coordinate-sum at most 12",
+        len(sites) == 2625
+        and origin in sites
+        and (8, 0, 0) in sites
+        and (4, 4, 4) in sites,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1 and "DijkstraCounter" in self_source,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        all(dist[site] < 10**9 for site in sites) and len(dist) == 2625,
+    )
+    checks.check(
+        "pairs-available",
+        "both sites of each k=1..4 pair lie in B_12(0)",
+        all_in_ball
+        and coordinate_sum((8, 0, 0)) == 8
+        and coordinate_sum((4, 4, 4)) == 12
+        and "no pair is omitted" in note,
+    )
+    checks.check(
+        "hop-origin",
+        "the unique origin hop has named cost 3",
+        kappa_cost(origin, (1, 0, 0)) == 3 and nu_cost(origin, (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "hop-axis-axis",
+        "a same-support axis hop has named cost 3",
+        kappa_cost((1, 0, 0), (2, 0, 0)) == 3,
+    )
+    checks.check(
+        "hop-body-last-untaxed",
+        "the 2-to-3 hop into (1,1,1) is not priced by the extra clause",
+        kappa_cost((1, 1, 0), (1, 1, 1)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and unit_coord_count((1, 1, 1)) == 3,
+    )
+    checks.check(
+        "hop-ridge-enter-clause",
+        "the named 2-to-3 two-unit dest clause prices (2,1,0) to (2,1,1) at 3",
+        kappa_cost(RIDGE_ENTER_SRC, RIDGE_ENTER_DST) == 3
+        and rho3_cost(RIDGE_ENTER_SRC, RIDGE_ENTER_DST) == 1
+        and RIDGE_ENTER_SRC in sites
+        and RIDGE_ENTER_DST in sites,
+    )
+    checks.check(
+        "ridge-enter-live-on-ball",
+        "nearest-neighbor hops inside B_12(0) trigger the extra 2-to-3 clause",
+        in_ball_new > 0,
+    )
+    checks.check(
+        "hop-rho3-ridge",
+        "a 3-to-3 hop whose dest has exactly two unit coordinates has cost 3",
+        kappa_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3,
+    )
+    witness = {
+        (2, 0, 0): ((0, 0, 0), (1, 0, 0), (2, 0, 0)),
+        (1, 1, 1): ((0, 0, 0), (0, 0, 1), (0, 1, 1), (1, 1, 1)),
+        (4, 0, 0): ((0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0), (4, 0, 0)),
+        (2, 2, 2): (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 1),
+            (0, 1, 2),
+            (0, 2, 2),
+            (1, 2, 2),
+            (2, 2, 2),
+        ),
+        (6, 0, 0): (
+            (0, 0, 0),
+            (1, 0, 0),
+            (2, 0, 0),
+            (3, 0, 0),
+            (4, 0, 0),
+            (5, 0, 0),
+            (6, 0, 0),
+        ),
+        (3, 3, 3): (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 1),
+            (0, 1, 2),
+            (0, 2, 2),
+            (0, 3, 2),
+            (0, 3, 3),
+            (1, 3, 3),
+            (2, 3, 3),
+            (3, 3, 3),
+        ),
+        (8, 0, 0): (
+            (0, 0, 0),
+            (0, -1, 0),
+            (1, -1, 0),
+            (1, -2, 0),
+            (2, -2, 0),
+            (3, -2, 0),
+            (4, -2, 0),
+            (5, -2, 0),
+            (6, -2, 0),
+            (7, -2, 0),
+            (8, -2, 0),
+            (8, -1, 0),
+            (8, 0, 0),
+        ),
+        (4, 4, 4): (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 1),
+            (0, 1, 2),
+            (0, 2, 2),
+            (0, 3, 2),
+            (0, 4, 2),
+            (0, 4, 3),
+            (0, 4, 4),
+            (1, 4, 4),
+            (2, 4, 4),
+            (3, 4, 4),
+            (4, 4, 4),
+        ),
+    }
+    witness_ok = True
+    extra_off_witness = True
+    for target, path in witness.items():
+        if walk_cost(path) != dist[target]:
+            witness_ok = False
+        for source, dest in zip(path, path[1:]):
+            if kappa_cost(source, dest) == 3 and rho3_cost(source, dest) == 1:
+                extra_off_witness = False
+    checks.check(
+        "thm1-witness-walks",
+        "each displayed pairing site has a walk whose cost matches Dijkstra",
+        witness_ok and all(dist[target] > 0 for target in witness),
+    )
+    checks.check(
+        "extra-clause-off-pairing-walks",
+        "the extra 2-to-3 clause does not fire on the displayed pairing walks",
+        extra_off_witness,
+    )
+
+    times_in_note = True
+    products_in_note = True
+    for k, t_axis, t_body, reverse, product in pairing:
+        axis_line = f"t({2 * k},0,0) = {t_axis}"
+        body_line = f"t({k},{k},{k}) = {t_body}"
+        times_in_note = times_in_note and axis_line in note and body_line in note
+        products_in_note = products_in_note and product in note
+        checks.check(
+            f"thm1-k{k}",
+            f"t({2 * k},0,0) and t({k},{k},{k}) are computed and reported",
+            t_axis > 0 and t_body > 0 and axis_line in note and body_line in note,
+        )
+        checks.check(
+            f"thm2-k{k}",
+            f"t({2 * k},0,0)^2/(4k^2) > t({k},{k},{k})^2/(3k^2) is {reverse}",
+            reverse and product in note,
+        )
+
+    checks.check(
+        "thm1-note-reports-times",
+        "the note reports all eight computed pairing arrivals",
+        times_in_note and f"t(12,0,0) = {t_far_axis}" in note,
+    )
+    checks.check(
+        "thm2-reverse-holds",
+        "the doubled-pairing inequality holds at every available k=1..4",
+        all_reverse and products_in_note,
+    )
+    checks.check(
+        "thm2-note-reports-comparison",
+        "the note reports the integer comparisons and does not adopt them",
+        products_in_note and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name kappa",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "kappa" not in axiom
+        and "κ" not in axiom
+        and "Do not write κ into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1 and does not score a unit hop-cost",
+        "Do not attach L1." in note
+        and "attach L1" in note
+        and "unit hop-cost" not in note.lower(),
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "the note does not claim uniqueness of the named hop-cost",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_12(0) and proposes no axiom edit",
+        "B_12(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "one Dijkstra" in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "κ(v→w)" not in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.")
+    print(
+        "per_site: arrival times are reported at the doubled pairing sites "
+        "and at (12,0,0)."
+    )
+    print("lattice_wide: checked and not executed — the search stays inside B_12(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Doubled pairing reverse under named ridge-enter hop-cost κ holds at every available k=1..4 on B_12(0). First display. Displayed, not adopted. Do not write κ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/ridge_enter_doubled_pairing_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.