### PR TITLE
feat(mlk1): mid-leave same-k holds at k=1: t=3 vs t=5

### DIFF
--- a/docs/MID_LEAVE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/MID_LEAVE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,220 @@
+---
+claim_id: mid_leave_samek_k1_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=1 under the named mid-leave hop-cost on B_6(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/mid_leave_samek_k1_b6_2026_08_15.py
+---
+
+# Same-k Reverse At k=1 Under The Named Mid-Leave Hop-Cost On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival comparison at k=1 on the finite nearest-neighbor
+graph `B_6(0)`, under a named hop-cost displayed for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/mid_leave_samek_k1_b6_2026_08_15.py`](../scripts/mid_leave_samek_k1_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of the named mid-leave hop-cost `μλ`. Write
+`|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named costs `ν`, `μ`, and `ρ3` are those
+of the ridge-slide display, and `μλ` is `ρ3` plus one extra 1→2 clause:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `μλ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=1` and `|σ_w|=2` and
+  `max_i |w_i|=1` and `max_i |v_i| ≥ 2)`, else `1`.
+
+The finite host is
+
+```text
+B_6(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 6 }.
+```
+
+It has 377 sites. Edges are the cubic nearest-neighbor steps that remain
+inside `B_6(0)`. The ball is not leftover of a larger-ball table: one
+Dijkstra from the origin is run on this ball.
+
+On a nearest-neighbor hop, a support-1 source with `max_i |v_i| ≥ 2` that
+gains a second coordinate keeps that large coordinate, so the destination
+cannot have `max_i |w_i|=1`. The extra clause is therefore empty on the
+graph of `B_6(0)`, and `μλ` agrees with `ρ3` on every remaining edge.
+The unit-cube leave `(1,0,0) → (1,1,0)` has source max `1`, so it stays
+cost `1`. The dest-max-at-least-two leave `(2,0,0) → (2,1,0)` is not the
+extra clause and also stays cost `1` under `μλ`.
+
+One Dijkstra from the origin yields
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+```
+
+The same-k comparison at k=1 is
+
+```text
+t(1,0,0)^2 / 1 = 9 > 25/3 = t(1,1,1)^2 / 3.
+```
+
+Equivalently `27 > 25`. The inequality holds. Same-k reverse holds at
+k=1. Displayed, not adopted. Independently, the axis endpoint of this
+ball is `t(6,0,0) = 18`. Uniqueness is not claimed.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_6(0) reports t(1,0,0) and t(1,1,1) under the named mid-leave hop-cost and scores the k=1 same-k comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: mid_leave_samek_k1_b6
+target_blocker_text: "whether same-k reverse at k=1 still holds after the mid-leave clause is added to the ridge-slide hop-cost"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_6(0) under the named hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `μλ` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_6(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`, and
+  `μλ` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `μλ` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_6(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`μλ` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`μλ`, using one Dijkstra on `B_6(0)`.
+
+An explicit axis path is the single hop `(0,0,0) → (1,0,0)` of cost `3`.
+An explicit body path is
+
+```text
+(0,0,0) → (1,0,0) → (1,1,0) → (1,1,1)
+```
+
+with costs `3+1+1=5`. Every path has first hop cost `3`, and every hop costs
+at least `1`, so these paths are optimal once Dijkstra matches them.
+
+## Named Rule
+
+Let `B_6(0) = { v ∈ Z^3 : |v|_1 ≤ 6 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_6(0)`,
+`t(v)` is the least sum of `μλ` along a directed path from `0` to `v` in
+that graph.
+
+The extra clause asks for a 1→2 hop whose destination has all coordinates
+of absolute value at most `1` and whose source already has some coordinate
+of absolute value at least `2`. No nearest-neighbor edge of `B_6(0)` meets
+both conditions at once. The displayed rule is therefore a first naming of
+that conjunction, not a change of any remaining nearest-neighbor price
+relative to `ρ3`.
+
+## Theorem 1 — Arrival times at k=1
+
+Under `μλ` on `B_6(0)`,
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+```
+
+The runner computes both values from the single origin Dijkstra and checks
+them against the explicit paths above. Every listed site lies in `B_6(0)`.
+These values are Dijkstra outputs, not fitted scalars.
+
+## Theorem 2 — Same-k comparison at k=1
+
+The displayed comparison is whether
+
+```text
+t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3.
+```
+
+Substituting the computed times gives the integer statement `9 > 25/3`, or
+equivalently `3 t(1,0,0)^2 ? t(1,1,1)^2`. That is `27 > 25`. The
+inequality holds. Arrival per Euclidean length is larger at `(1,0,0)` than
+at `(1,1,1)`. Same-k reverse at k=1 is yes. Displayed, not adopted.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write μλ into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `μλ`, `ρ3`, `μ`, or `ν`. This note
+proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at two sites; it is not an attachment of a
+coordinate-sum hop-cost.
+
+## What This Does Not Claim
+
+- Uniqueness is not claimed for this named hop-cost at k=1.
+- The empty extra clause on nearest-neighbor edges of `B_6(0)` is not a
+  statement about larger hosts or about non-nearest-neighbor steps.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_6(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(1,0,0)` and `t(1,1,1)`,
+checks the integer form of Theorem 2, checks that the extra mid-leave
+clause fires on no nearest-neighbor edge while sparing the unit-cube 1→2,
+checks that the live Admissibility wording does not name `μλ`, and records
+the import boundary. Declared review inputs are this note and the axiom
+memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12525,6 +12525,10 @@
   "microcausality_weighted_quasilocal_class_walk_expansion_lieb_robinson_bounded_theorem_note_2026-07-18": {
    "deps_hash": "4a576dba9306",
    "out_degree": 6
+  },
+  "mid_leave_samek_k1_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "min_time_step_is_the_planck_time_from_the_single_scale_reference_primitive_narrow_theorem_note_2026-06-08": {
    "deps_hash": "3c3e26353fe0",

--- a/logs/runner-cache/mid_leave_samek_k1_b6_2026_08_15.txt
+++ b/logs/runner-cache/mid_leave_samek_k1_b6_2026_08_15.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/mid_leave_samek_k1_b6_2026_08_15.py
+runner_sha256: d274a00134d8c9f2a9f0b30ce23e15ecc551787a46f2406bd24308b26b1a8f71
+input_fingerprint_sha256: 694b37682615de325c167afc30ff6028e55999e36025aab3e096f63ec97943f5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.11
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/MID_LEAVE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=1 under the named mid-leave hop-cost on B_6(0) is reported. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_6(0) only
+n_sites 377
+t(1,0,0) = 3
+t(1,1,1) = 5
+t(6,0,0) = 18
+same-k comparison: 3^2 / 1 = 9 versus 5^2 / 3 = 25/3; reverse=True
+3t_axis^2 27
+t_body^2 25
+dijkstra_calls 1
+nn_extra_clause_hops 0
+nn_disagree_with_rho3 0
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_6(0) is the 377-site integer set with coordinate-sum at most 6
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: hop-origin the unique origin hop has named cost 3
+PASS: hop-axis-axis a same-support axis hop has named cost 3
+PASS: hop-unit-cube-leave the unit-cube 1-to-2 hop is spared and has named cost 1
+PASS: hop-late-leave-untaxed the dest-max>=2 1-to-2 hop stays at rho3 cost 1 under mid-leave
+PASS: hop-mid-leave-empty-on-nn no nearest-neighbor hop fires the extra dest-max=1 source-max>=2 clause
+PASS: hop-rho3-ridge a 3-to-3 hop whose dest has exactly two unit coordinates has cost 3
+PASS: thm1-axis-time t(1,0,0) equals the computed origin-to-axis arrival time
+PASS: thm1-body-time t(1,1,1) equals the computed origin-to-body arrival time
+PASS: thm2-reverse-holds t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3 holds on the computed times
+PASS: thm1-note-reports-times the note reports the computed arrival times
+PASS: thm2-note-reports-comparison the note reports the integer same-k comparison and does not adopt it
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name mulambda
+PASS: thm3-no-l1-attachment the note refuses to attach L1 and does not score a unit hop-cost
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-claimed the note does not claim uniqueness of the named hop-cost
+PASS: scope-boundary the theorem stays on B_6(0) and proposes no axiom edit
+PASS: reachable every site of B_6(0) is reached
+PASS: independent-b6-dijkstra axis endpoint t(6,0,0) is computed on this ball and the note is independent
+per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.
+per_site: arrival times are reported only at (1,0,0) and (1,1,1).
+lattice_wide: checked and not executed — the search stays inside B_6(0).
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/mid_leave_samek_k1_b6_2026_08_15.py
+++ b/scripts/mid_leave_samek_k1_b6_2026_08_15.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Same-k reverse at k=1 under the named mid-leave hop-cost on B_6(0).
+
+One Dijkstra from the origin on the finite nearest-neighbor graph. The
+mid-leave hop-cost is displayed, not adopted, and is not written into
+Admissibility. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/MID_LEAVE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/MID_LEAVE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=1 under the named "
+    "mid-leave hop-cost on B_6(0) is reported. "
+    "Displayed, not adopted."
+)
+
+RADIUS = 6
+AXIS = (1, 0, 0)
+BODY = (1, 1, 1)
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def support_size(site: Site) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(site: Site) -> int:
+    return sum(1 for coordinate in site if abs(coordinate) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def ball_sites(radius: int) -> frozenset[Site]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def mulambda_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if (
+        support_size(source) == 1
+        and support_size(dest) == 2
+        and max_abs(dest) == 1
+        and max_abs(source) >= 2
+    ):
+        return 3
+    return 1
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, sites: frozenset[Site], origin: Site) -> dict[Site, int]:
+        self.calls += 1
+        infinity = 10**9
+        dist = {site: infinity for site in sites}
+        dist[origin] = 0
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if cost != dist[site]:
+                continue
+            for step in STEPS:
+                neighbor = add(site, step)
+                if neighbor not in dist:
+                    continue
+                candidate = cost + mulambda_cost(site, neighbor)
+                if candidate < dist[neighbor]:
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def nn_extra_clause_hops(sites: frozenset[Site]) -> list[tuple[Site, Site]]:
+    hits: list[tuple[Site, Site]] = []
+    for site in sites:
+        for step in STEPS:
+            neighbor = add(site, step)
+            if neighbor not in sites:
+                continue
+            if rho3_cost(site, neighbor) != 3 and mulambda_cost(site, neighbor) == 3:
+                hits.append((site, neighbor))
+    return hits
+
+
+def nn_disagrees_with_rho3(sites: frozenset[Site]) -> list[tuple[Site, Site]]:
+    hits: list[tuple[Site, Site]] = []
+    for site in sites:
+        for step in STEPS:
+            neighbor = add(site, step)
+            if neighbor not in sites:
+                continue
+            if mulambda_cost(site, neighbor) != rho3_cost(site, neighbor):
+                hits.append((site, neighbor))
+    return hits
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_6(0) only"
+    )
+
+    sites = ball_sites(RADIUS)
+    origin = (0, 0, 0)
+    counter = DijkstraCounter()
+    dist = counter.distances(sites, origin)
+    t_axis = dist[AXIS]
+    t_body = dist[BODY]
+    t_end = dist[(6, 0, 0)]
+    reverse = 3 * t_axis * t_axis > t_body * t_body
+    extra_hops = nn_extra_clause_hops(sites)
+    disagree = nn_disagrees_with_rho3(sites)
+    axis_path_cost = mulambda_cost(origin, AXIS)
+    body_path_cost = (
+        mulambda_cost(origin, AXIS)
+        + mulambda_cost(AXIS, (1, 1, 0))
+        + mulambda_cost((1, 1, 0), BODY)
+    )
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(1,0,0) = {t_axis}")
+    print(f"t(1,1,1) = {t_body}")
+    print(f"t(6,0,0) = {t_end}")
+    print(
+        f"same-k comparison: {t_axis}^2 / 1 = {t_axis * t_axis} versus "
+        f"{t_body}^2 / 3 = {t_body * t_body}/3; reverse={reverse}"
+    )
+    print(f"3t_axis^2 {3 * t_axis * t_axis}")
+    print(f"t_body^2 {t_body * t_body}")
+    print(f"dijkstra_calls {counter.calls}")
+    print(f"nn_extra_clause_hops {len(extra_hops)}")
+    print(f"nn_disagree_with_rho3 {len(disagree)}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/MID_LEAVE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and note_path.is_file()
+        and axiom_path.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_6(0) is the 377-site integer set with coordinate-sum at most 6",
+        len(sites) == 377 and origin in sites and AXIS in sites and BODY in sites,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1 and "DijkstraCounter" in self_source,
+    )
+    checks.check(
+        "hop-origin",
+        "the unique origin hop has named cost 3",
+        mulambda_cost(origin, AXIS) == 3 and nu_cost(origin, AXIS) == 3,
+    )
+    checks.check(
+        "hop-axis-axis",
+        "a same-support axis hop has named cost 3",
+        mulambda_cost(AXIS, (2, 0, 0)) == 3,
+    )
+    checks.check(
+        "hop-unit-cube-leave",
+        "the unit-cube 1-to-2 hop is spared and has named cost 1",
+        mulambda_cost(AXIS, (1, 1, 0)) == 1
+        and mulambda_cost((1, 1, 0), BODY) == 1
+        and rho3_cost(AXIS, (1, 1, 0)) == 1
+        and max_abs(AXIS) == 1,
+    )
+    checks.check(
+        "hop-late-leave-untaxed",
+        "the dest-max>=2 1-to-2 hop stays at rho3 cost 1 under mid-leave",
+        mulambda_cost((2, 0, 0), (2, 1, 0)) == 1
+        and rho3_cost((2, 0, 0), (2, 1, 0)) == 1
+        and max_abs((2, 1, 0)) >= 2
+        and (2, 0, 0) in sites
+        and (2, 1, 0) in sites,
+    )
+    checks.check(
+        "hop-mid-leave-empty-on-nn",
+        "no nearest-neighbor hop fires the extra dest-max=1 source-max>=2 clause",
+        extra_hops == [] and disagree == [],
+    )
+    checks.check(
+        "hop-rho3-ridge",
+        "a 3-to-3 hop whose dest has exactly two unit coordinates has cost 3",
+        mulambda_cost((2, 1, 1), (3, 1, 1)) == 3
+        and rho3_cost((2, 1, 1), (3, 1, 1)) == 3,
+    )
+    checks.check(
+        "thm1-axis-time",
+        "t(1,0,0) equals the computed origin-to-axis arrival time",
+        t_axis == axis_path_cost and t_axis > 0,
+    )
+    checks.check(
+        "thm1-body-time",
+        "t(1,1,1) equals the computed origin-to-body arrival time",
+        t_body == body_path_cost and t_body > 0,
+    )
+    checks.check(
+        "thm2-reverse-holds",
+        "t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3 holds on the computed times",
+        reverse and 3 * t_axis * t_axis > t_body * t_body,
+    )
+    checks.check(
+        "thm1-note-reports-times",
+        "the note reports the computed arrival times",
+        f"t(1,0,0) = {t_axis}" in note and f"t(1,1,1) = {t_body}" in note,
+    )
+    checks.check(
+        "thm2-note-reports-comparison",
+        "the note reports the integer same-k comparison and does not adopt it",
+        f"{3 * t_axis * t_axis} > {t_body * t_body}" in note
+        and "inequality holds" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name mulambda",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "μλ" not in axiom
+        and "mulambda" not in axiom
+        and "Do not write μλ into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1 and does not score a unit hop-cost",
+        "Do not attach L1." in note
+        and "attach L1" in note
+        and "unit hop-cost" not in note.lower(),
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "the note does not claim uniqueness of the named hop-cost",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_6(0) and proposes no axiom edit",
+        "B_6(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "one Dijkstra" in note,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        len(dist) == 377,
+    )
+    checks.check(
+        "independent-b6-dijkstra",
+        "axis endpoint t(6,0,0) is computed on this ball and the note is independent",
+        t_end == dist[(6, 0, 0)]
+        and (1, 1, 1) in dist
+        and "not leftover of a larger-ball table" in note,
+    )
+
+    print("per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported only at (1,0,0) and (1,1,1).")
+    print("lattice_wide: checked and not executed — the search stays inside B_6(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named mid-leave hop-cost μλ holds at k=1 on B_6(0): t(1,0,0)=3 vs t(1,1,1)=5. Extra 6-NN clause is empty. First display. Displayed, not adopted. Do not write μλ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/mid_leave_samek_k1_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.