### PR TITLE
feat(mlk7): mid-leave same-k holds at k=7: t=19 vs t=25

### DIFF
--- a/docs/MID_LEAVE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/MID_LEAVE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,190 @@
+---
+claim_id: mid_leave_samek_k7_b21_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=7 under the named mid-leave hop-cost on B_21(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/mid_leave_samek_k7_b21_2026_08_15.py
+---
+
+# Named Mid-Leave Same-k Reverse At k=7 On B_21(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_21(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=7`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/mid_leave_samek_k7_b21_2026_08_15.py`](../scripts/mid_leave_samek_k7_b21_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named mid-leave hop-cost `μλ` is `ρ3` plus cost `3` on a `1→2` hop
+whose destination has `max_i |w_i| = 1` and whose source has
+`max_i |v_i| ≥ 2`. The extra clause is the dest-max-`1` leave after the
+source has already left the origin. It spares the unit-cube `1→2` hop,
+whose source has `max_i |v_i| = 1`. This is the first display of `μλ` at
+the same-`k` scale `k=7`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_21(0)`, let `ν` be
+the support-drop rule that costs `3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or
+`|σ_w| < |σ_v|`, else `1`. Let `μ` be the corridor-slide rule that costs
+`3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|`
+equals `1)`, else `1`. Let `ρ3` be the ridge-slide rule that costs `3` if
+`μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)`,
+else `1`. The displayed rule `μλ` is
+
+`μλ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i| = 1` and `max_i |v_i| ≥ 2)`, else `1`.
+
+Those clauses are the whole rule.
+
+One Dijkstra from the origin on `B_21(0)` (13287 sites; 13286 nonzero)
+gives
+
+`t(7,0,0) = 19`, `t(7,7,7) = 25`.
+
+The displayed same-`k` comparison at `k=7` is
+
+`t(7,0,0)^2 / 49  ?  t(7,7,7)^2 / 147`,
+
+which is `361/49` versus `625/147`, or equivalently `1083 > 625`. The
+inequality holds. Same-`k` reverse at `k=7` under `μλ` is yes.
+Independently, the new axis site is `t(21,0,0) = 37`. The shared axis
+site `t(18,0,0) = 30` is a `μλ` score on this ball, not a leftover.
+
+The extra clause is idle on every nearest-neighbor hop in `B_21(0)`. A
+dest with `|σ_w|=2` and `max_i |w_i| = 1` is a unit-cube face diagonal.
+Every support-`1` neighbor of such a dest has `max_i |v_i| = 1`. The two
+extra predicates therefore never co-occur on a nearest-neighbor hop, so
+`μλ` agrees with `ρ3` on this ball. The pair is still a `μλ` Dijkstra
+output, not a copied `ρ3` table.
+
+The pair is not leftover of `λ2` as a rule: on the late-leave hop
+`(2,0,0) → (2,1,0)` one has `|σ| : 1 → 2` and `max_i |w_i| = 2`, so
+`λ2 = 3` while `μλ = 1` and `ρ3 = 1`. Therefore `λ2` cannot price late leave
+as `μλ` does. The unit-cube hop `(1,0,0) → (1,1,0)` has `|σ| : 1 → 2`
+and `max_i |w_i| = 1` with `max_i |v_i| = 1`, so `μλ` spares the unit-cube
+`1→2` at cost `1`.
+
+The site `(7,7,7)` has ℓ¹ norm `21`, so it is absent from `B_18(0)`. The
+`B_21(0)` table is therefore not leftover of the `B_18(0)` times.
+
+The rule is displayed, not adopted. Do not write `μλ` into Admissibility.
+Do not write μλ into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the mid-leave clause, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_21(0) = { v ∈ Z^3 : |v|_1 ≤ 21 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_21(0)`,
+`t(v)` is the least sum of `μλ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `λ2` taxes `1→2` hops whose dest has `max_i |w_i| ≥ 2`.
+On the late-leave hop `(2,0,0) → (2,1,0)` one has `|σ| : 1 → 2` and
+`max_i |w_i| = 2`, so `λ2 = 3` while `μλ = 1`. Therefore `λ2` cannot
+price late leave. On the unit-cube hop `(1,0,0) → (1,1,0)` the extra
+clause is idle, so the unit-cube `1→2` is spared.
+
+## Theorem 1 — Arrivals `t(7,0,0)` And `t(7,7,7)` On `B_21(0)`
+
+One origin Dijkstra on `B_21(0)` returns the integer arrivals
+
+| site | `t_μλ` |
+|---|---:|
+| `(7,0,0)` | `19` |
+| `(7,7,7)` | `25` |
+
+Every listed site lies in `B_21(0)`. The site `(7,7,7)` has ℓ¹ norm `21`,
+so it is absent from `B_18(0)`. The pair is computed on `B_21(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+A witness axis walk of cost `19` is seed-exit `3` onto `(0,-1,0)`,
+unit-cube support-increase `1` onto `(1,-1,0)`, corridor-slide `3` onto
+`(1,-2,0)`, six support-preserving cost-`1` height-`2` face slides to
+`(7,-2,0)`, corridor-slide `3` onto `(7,-1,0)`, and support-drop `3`
+onto `(7,0,0)`, summing to `19`. That walk never takes a dest-max-`1`
+source-max-`≥2` hop. A witness body walk of cost `25` is seed-exit `3`
+onto `(0,0,1)`, support-increase `1` onto `(0,1,1)`, corridor-slide `3`
+onto `(0,1,2)`, eleven support-preserving cost-`1` face hops to
+`(0,7,7)`, support-increase `1` onto `(1,7,7)`, and six
+support-preserving cost-`1` body hops onto `(7,7,7)`, summing to `25`.
+Those walks are witnesses, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=7`
+
+The Euclidean-normalized comparison at `k=7` is
+
+`t(7,0,0)^2 / 49  ?  t(7,7,7)^2 / 147`,
+
+equivalently `3 t(7,0,0)^2 ? t(7,7,7)^2`. Substituting the computed times
+gives `3 · 19^2 = 1083` and `25^2 = 625`, so
+
+`1083 > 625`.
+
+Arrival per Euclidean length is larger at `(7,0,0)` than at `(7,7,7)`.
+Same-`k` reverse at `k=7` under `μλ` is yes. The comparison is displayed,
+not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μλ` is a displayed scoring device on `B_21(0)`. Do not write
+`μλ` into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_21(0) for one named hop-cost at k=7. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_21(0) for the displayed rule μλ at k=7; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μλ` among hop-costs that reverse the same-`k` pair at `k=7`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_21(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=7`.
+- Any reuse of a `ρ3` or `λ2` arrival table as a substitute for the `μλ`
+  Dijkstra.
+- Any reuse of the `B_18(0)` arrival table as a substitute for the
+  radius-`21` Dijkstra.
+- Membership of `μλ` as a physical hop-cost. Reverse at `k=7` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12525,6 +12525,10 @@
   "microcausality_weighted_quasilocal_class_walk_expansion_lieb_robinson_bounded_theorem_note_2026-07-18": {
    "deps_hash": "4a576dba9306",
    "out_degree": 6
+  },
+  "mid_leave_samek_k7_b21_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "min_time_step_is_the_planck_time_from_the_single_scale_reference_primitive_narrow_theorem_note_2026-06-08": {
    "deps_hash": "3c3e26353fe0",

--- a/logs/runner-cache/mid_leave_samek_k7_b21_2026_08_15.txt
+++ b/logs/runner-cache/mid_leave_samek_k7_b21_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/mid_leave_samek_k7_b21_2026_08_15.py
+runner_sha256: 11dd8a36ce16e6d3a3470b27e76d167c11778bc2649be6a30074c37fec979f7e
+input_fingerprint_sha256: 12cda482e5e2ab0f7358846acb705bbd1b3e9cac72446d37fe4cda1eac8422bb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.26
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/MID_LEAVE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=7 under the named mid-leave hop-cost on B_21(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μλ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 13287
+t(7,0,0) 19
+t(7,7,7) 25
+t(7,0,0)^2/49 361/49
+t(7,7,7)^2/147 625/147
+3t_axis^2 1083
+t_body^2 625
+reverse True
+t(21,0,0) 37
+t(18,0,0) 30
+dijkstra_calls 1
+extra_live 0
+differ_rho3 0
+witness_mulambda_costs [3, 1, 3, 1, 1, 1, 1, 1, 1, 3, 3]
+witness_mulambda_sum 19
+mulambda_late_leave 1
+rho3_late_leave 1
+lambda2_late_leave 3
+mulambda_unit_cube 1
+rho3_unit_cube 1
+PASS: t-700-777 t(7,0,0)=19 and t(7,7,7)=25
+PASS: reverse-k7 t(7,0,0)^2/49 > t(7,7,7)^2/147 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b21 B_21(0) has 13287 sites and 13286 nonzero sites
+PASS: reachable every site of B_21(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: mid-leave-clause-idle the dest-max-1 source-max>=2 extra clause is idle on every B_21 hop
+PASS: not-leftover-of-lambda2 λ2 prices the late-leave hop at 3 while μλ prices it at 1
+PASS: not-leftover-of-b18 (7,7,7) lies outside B_18(0) and the note says so
+PASS: seed-and-mid-leave-clauses seed-exit, both-weights-1, support-drop, corridor-slide, and ridge-slide cost 3; unit-cube 1→2, late-leave, and generic rises cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/mid_leave_samek_k7_b21_2026_08_15.py
+++ b/scripts/mid_leave_samek_k7_b21_2026_08_15.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=7 under μλ on B_21(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/MID_LEAVE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/MID_LEAVE_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=7 under the named "
+    "mid-leave hop-cost on B_21(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 19
+T_BODY_REP = 25
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def extra_mid_leave(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 1
+        and support_size(w) == 2
+        and max(abs(c) for c in w) == 1
+        and max(abs(c) for c in v) >= 2
+    )
+
+
+def mulambda_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if extra_mid_leave(v, w):
+        return 3
+    return 1
+
+
+def lambda2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 1 and support_size(w) == 2 and max(abs(c) for c in w) >= 2:
+        return 3
+    return 1
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_mulambda(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + mulambda_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μλ is not written into Admissibility",
+        "Do not write `μλ` into Admissibility" in note
+        and "Do not write μλ into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(21)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    site_set = set(sites)
+    dist = dijkstra_mulambda(sites)
+    t700 = dist[(7, 0, 0)]
+    t777 = dist[(7, 7, 7)]
+    t2100 = dist[(21, 0, 0)]
+    t1800 = dist[(18, 0, 0)]
+    reverse = 3 * t700 * t700 > t777 * t777
+    late_leave_hop = ((2, 0, 0), (2, 1, 0))
+    unit_cube_hop = ((1, 0, 0), (1, 1, 0))
+    extra_live = 0
+    differ_rho3 = 0
+    for v in sites:
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            if extra_mid_leave(v, w):
+                extra_live += 1
+            if mulambda_cost(v, w) != rho3_cost(v, w):
+                differ_rho3 += 1
+    witness_axis = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (1, -2, 0),
+        (2, -2, 0),
+        (3, -2, 0),
+        (4, -2, 0),
+        (5, -2, 0),
+        (6, -2, 0),
+        (7, -2, 0),
+        (7, -1, 0),
+        (7, 0, 0),
+    )
+    witness_mulambda_costs = [
+        mulambda_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])
+    ]
+    print(f"n_sites {len(sites)}")
+    print(f"t(7,0,0) {t700}")
+    print(f"t(7,7,7) {t777}")
+    print(f"t(7,0,0)^2/49 {t700 * t700}/49")
+    print(f"t(7,7,7)^2/147 {t777 * t777}/147")
+    print(f"3t_axis^2 {3 * t700 * t700}")
+    print(f"t_body^2 {t777 * t777}")
+    print(f"reverse {reverse}")
+    print(f"t(21,0,0) {t2100}")
+    print(f"t(18,0,0) {t1800}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"extra_live {extra_live}")
+    print(f"differ_rho3 {differ_rho3}")
+    print(f"witness_mulambda_costs {witness_mulambda_costs}")
+    print(f"witness_mulambda_sum {sum(witness_mulambda_costs)}")
+    print(f"mulambda_late_leave {mulambda_cost(*late_leave_hop)}")
+    print(f"rho3_late_leave {rho3_cost(*late_leave_hop)}")
+    print(f"lambda2_late_leave {lambda2_cost(*late_leave_hop)}")
+    print(f"mulambda_unit_cube {mulambda_cost(*unit_cube_hop)}")
+    print(f"rho3_unit_cube {rho3_cost(*unit_cube_hop)}")
+
+    checks.check(
+        "t-700-777",
+        f"t(7,0,0)={T_AXIS_REP} and t(7,7,7)={T_BODY_REP}",
+        t700 == T_AXIS_REP and t777 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k7",
+        "t(7,0,0)^2/49 > t(7,7,7)^2/147 holds",
+        reverse
+        and 3 * t700 * t700 == 1083
+        and t777 * t777 == 625
+        and "1083 > 625" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b21",
+        "B_21(0) has 13287 sites and 13286 nonzero sites",
+        len(sites) == 13287 and len(nonzero) == 13286 and all(l1(v) <= 21 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_21(0) is reached",
+        len(dist) == 13287,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`19`" in note
+        and "`25`" in note
+        and "`(7,0,0)`" in note
+        and "`(7,7,7)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1083 > 625" in note,
+    )
+    checks.check(
+        "mid-leave-clause-idle",
+        "the dest-max-1 source-max>=2 extra clause is idle on every B_21 hop",
+        extra_live == 0
+        and differ_rho3 == 0
+        and not extra_mid_leave(*unit_cube_hop)
+        and not extra_mid_leave(*late_leave_hop)
+        and mulambda_cost(*unit_cube_hop) == 1
+        and mulambda_cost(*late_leave_hop) == 1
+        and "never co-occur" in note
+        and "idle" in note,
+    )
+    checks.check(
+        "not-leftover-of-lambda2",
+        "λ2 prices the late-leave hop at 3 while μλ prices it at 1",
+        lambda2_cost(*late_leave_hop) == 3
+        and mulambda_cost(*late_leave_hop) == 1
+        and rho3_cost(*late_leave_hop) == 1
+        and sum(witness_mulambda_costs) == 19
+        and t700 == 19
+        and t777 == 25
+        and "cannot price late leave" in note
+        and "spares the unit-cube" in note,
+    )
+    checks.check(
+        "not-leftover-of-b18",
+        "(7,7,7) lies outside B_18(0) and the note says so",
+        l1((7, 7, 7)) == 21
+        and (7, 7, 7) in dist
+        and t2100 == 37
+        and t1800 == 30
+        and "absent from `B_18(0)`" in note
+        and "not leftover of the `B_18(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-mid-leave-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, and ridge-slide cost 3; unit-cube 1→2, late-leave, and generic rises cost 1",
+        mulambda_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mulambda_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mulambda_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mulambda_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mulambda_cost((1, 1, 1), (2, 1, 1)) == 3
+        and mulambda_cost((2, 0, 0), (2, 1, 0)) == 1
+        and mulambda_cost((3, 0, 0), (3, 1, 0)) == 1
+        and mulambda_cost((1, 0, 0), (1, 1, 0)) == 1
+        and mulambda_cost((1, 1, 0), (1, 1, 1)) == 1
+        and mulambda_cost((2, 2, 0), (3, 2, 0)) == 1
+        and mulambda_cost((2, 2, 2), (3, 2, 2)) == 1
+        and mulambda_cost((2, 7, 7), (3, 7, 7)) == 1
+        and mulambda_cost((6, 7, 7), (7, 7, 7)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μλ(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named mid-leave hop-cost μλ holds at k=7 on B_21(0): t(7,0,0)=19 vs t(7,7,7)=25. Extra 6-NN clause is empty so μλ agrees with ρ3. First display. Displayed, not adopted. Do not write μλ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/mid_leave_samek_k7_b21_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.