### PR TITLE
feat(mlk13): mid-leave same-k holds at k=13: t=25 vs t=43

### DIFF
--- a/docs/MID_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/MID_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,181 @@
+---
+claim_id: mid_leave_samek_k13_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=13 under the named mid-leave hop-cost on B_39(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/mid_leave_samek_k13_b39_2026_08_15.py
+---
+
+# Named Mid-Leave Same-k Reverse At k=13 On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_39(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=13`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/mid_leave_samek_k13_b39_2026_08_15.py`](../scripts/mid_leave_samek_k13_b39_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of same-`k` reverse at `k=13` under the named
+mid-leave hop-cost `μλ`. The pair is computed by one origin Dijkstra on
+`B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39` and therefore lies on
+the boundary of this ball.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_39(0)`, the displayed
+rules are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+`μλ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i|=1` and `max_i |v_i| ≥ 2)`, else `1`.
+
+The last clause is the mid-leave tax: a `1→2` hop whose destination has
+maximum absolute coordinate `1` after the source already has maximum
+absolute coordinate at least `2`. The same clause spares the unit-cube
+`1→2` hop, whose source has `max_i |v_i| = 1`. Those clauses are the whole
+rule. Uniqueness is not claimed.
+
+The extra mid-leave clause does not fire on nearest-neighbor hops. A hop
+with `|σ_v|=1` and `|σ_w|=2` must keep the unique source axis coordinate
+and add a unit perpendicular coordinate, so the destination maximum is at
+least the source maximum. The source-maximum condition `≥ 2` then forbids
+destination maximum `1`. The displayed `μλ` scores on this graph therefore
+coincide with the `ρ3` scores. That identity is a property of the
+six-neighbor graph, not a uniqueness claim among hop-costs.
+
+One Dijkstra from the origin on `B_39(0)` (82239 sites; 82238 nonzero) gives
+
+`t(13,0,0) = 25`, `t(13,13,13) = 43`.
+
+The displayed same-`k` comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+which is `625/169` versus `1849/507`, or equivalently `1875 > 1849`. The
+inequality holds.
+
+The rule is displayed, not adopted. Do not write μλ into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the mid-leave clause, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_39(0) = { v ∈ Z^3 : |v|_1 ≤ 39 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_39(0)`,
+`t(v)` is the least sum of `μλ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses every clause of `μλ` except the extra mid-leave
+tax. On this six-neighbor graph that extra clause does not fire, so
+`μλ = ρ3` as functions on the directed edges of `B_39(0)`. The `μλ`
+scores below are still a named displayed rule, scored independently by
+one origin Dijkstra.
+
+A witness axis walk of cost `25` is seed-exit `3` onto `(1,0,0)`, leave-axis
+`1` onto `(1,1,0)`, corridor-slide `3` onto `(2,1,0)`, non-hugging face hop
+`1` onto `(2,2,0)`, eleven support-preserving cost-`1` face hops to
+`(13,2,0)`, corridor-slide `3` onto `(13,1,0)`, and support-drop `3` onto
+`(13,0,0)`. That walk is a witness of cost `25`, not a uniqueness claim.
+
+A witness body walk of cost `43` is the same prefix of cost `8` to
+`(2,2,0)`, eleven cost-`1` face hops to `(13,2,0)`, eleven cost-`1` face
+hops to `(13,13,0)`, enter-body `1` onto `(13,13,1)`, and twelve
+support-preserving cost-`1` body hops to `(13,13,13)`. That walk is a
+witness of cost `43`, not a uniqueness claim.
+
+## Theorem 1 — Arrivals `t(13,0,0)` And `t(13,13,13)` On `B_39(0)`
+
+One origin Dijkstra on `B_39(0)` returns the integer arrivals
+
+| site | `t_μλ` |
+|---|---:|
+| `(13,0,0)` | `25` |
+| `(13,13,13)` | `43` |
+
+Every listed site lies in `B_39(0)`. The site `(13,13,13)` has ℓ¹ norm `39`
+and sits on the boundary of this ball. These values are Dijkstra outputs,
+not fitted scalars.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=13`
+
+The Euclidean-normalized comparison at `k=13` is
+
+`t(13,0,0)^2 / 169  ?  t(13,13,13)^2 / 507`,
+
+equivalently `3 t(13,0,0)^2 ? t(13,13,13)^2`. Substituting the computed times
+gives `3 · 25^2 = 1875` and `43^2 = 1849`, so
+
+`1875 > 1849`.
+
+Arrival per Euclidean length is larger at `(13,0,0)` than at `(13,13,13)`.
+Same-`k` reverse at `k=13` holds under `μλ`. The comparison is displayed,
+not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μλ` is a displayed scoring device on `B_39(0)`. Do not write μλ
+into Admissibility. Do not attach L1. It is not a replacement for
+first arrival under equal hop weights, and it is not offered as the unique
+hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_39(0) for one named hop-cost at k=13. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_39(0) for the displayed rule μλ at k=13; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μλ` among hop-costs that score the same-`k` pair at `k=13`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_39(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=13`.
+- Any write of `μλ` into Admissibility.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12525,6 +12525,10 @@
   "microcausality_weighted_quasilocal_class_walk_expansion_lieb_robinson_bounded_theorem_note_2026-07-18": {
    "deps_hash": "4a576dba9306",
    "out_degree": 6
+  },
+  "mid_leave_samek_k13_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "min_time_step_is_the_planck_time_from_the_single_scale_reference_primitive_narrow_theorem_note_2026-06-08": {
    "deps_hash": "3c3e26353fe0",

--- a/logs/runner-cache/mid_leave_samek_k13_b39_2026_08_15.txt
+++ b/logs/runner-cache/mid_leave_samek_k13_b39_2026_08_15.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/mid_leave_samek_k13_b39_2026_08_15.py
+runner_sha256: 733aee8e8b9e90a83fe51060eff005074ac965331c3eb582bb7f990af917ad45
+input_fingerprint_sha256: cec04aa3d6f49ba3b4a24505f772f970129eb965b5e2448f14017c458c3e72be
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.79
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/MID_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=13 under the named mid-leave hop-cost on B_39(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μλ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 82239
+t(13,0,0) 25
+t(13,13,13) 43
+t(13,0,0)^2/169 625/169
+t(13,13,13)^2/507 1849/507
+3t_axis^2 1875
+t_body^2 1849
+reverse True
+extra_clause_nn False
+dijkstra_calls 1
+PASS: t-1300-131313 t(13,0,0) and t(13,13,13) match the witness walks
+PASS: reverse-k13 t(13,0,0)^2/169 > t(13,13,13)^2/507 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b39 B_39(0) has 82239 sites and contains the same-k pair
+PASS: reachable every site of B_39(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: extra-clause-vacant-on-nn the extra mid-leave clause does not fire on nearest-neighbor hops
+PASS: unit-cube-spared the unit-cube 1→2 hop stays cost 1 because source max is 1
+PASS: seed-and-stacked-clauses seed-exit, both-weights-1, corridor-slide, and ridge-slide cost 3
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/mid_leave_samek_k13_b39_2026_08_15.py
+++ b/scripts/mid_leave_samek_k13_b39_2026_08_15.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=13 under μλ on B_39(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/MID_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/MID_LEAVE_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=13 under the named mid-leave "
+    "hop-cost on B_39(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero_abs = [abs(coord) for coord in w if coord != 0]
+        if nonzero_abs and min(nonzero_abs) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        abs_w = (abs(w[0]), abs(w[1]), abs(w[2]))
+        if sum(1 for value in abs_w if value == 1) == 2:
+            return 3
+    return 1
+
+
+def mu_lambda_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 1
+        and support_size(w) == 2
+        and max(abs(coord) for coord in w) == 1
+        and max(abs(coord) for coord in v) >= 2
+    ):
+        return 3
+    return 1
+
+
+def path_cost(path: list[tuple[int, int, int]]) -> int:
+    return sum(mu_lambda_cost(path[i], path[i + 1]) for i in range(len(path) - 1))
+
+
+def dijkstra_mu_lambda(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + mu_lambda_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def extra_clause_fires(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 1
+        and support_size(w) == 2
+        and max(abs(coord) for coord in w) == 1
+        and max(abs(coord) for coord in v) >= 2
+    )
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μλ is not written into Admissibility",
+        "Do not write μλ into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "Do not attach L1." not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(39)
+    dist = dijkstra_mu_lambda(sites)
+    t1300 = dist[(13, 0, 0)]
+    t131313 = dist[(13, 13, 13)]
+    reverse = 3 * t1300 * t1300 > t131313 * t131313
+    axis_witness = (
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (2, 1, 0), (2, 2, 0)]
+        + [(x, 2, 0) for x in range(3, 14)]
+        + [(13, 1, 0), (13, 0, 0)]
+    )
+    body_witness = (
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (2, 1, 0), (2, 2, 0)]
+        + [(x, 2, 0) for x in range(3, 14)]
+        + [(13, y, 0) for y in range(3, 14)]
+        + [(13, 13, z) for z in range(1, 14)]
+    )
+    extra_live = False
+    for v in sites:
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if extra_clause_fires(v, w):
+                extra_live = True
+                break
+        if extra_live:
+            break
+    print(f"n_sites {len(sites)}")
+    print(f"t(13,0,0) {t1300}")
+    print(f"t(13,13,13) {t131313}")
+    print(f"t(13,0,0)^2/169 {t1300 * t1300}/169")
+    print(f"t(13,13,13)^2/507 {t131313 * t131313}/507")
+    print(f"3t_axis^2 {3 * t1300 * t1300}")
+    print(f"t_body^2 {t131313 * t131313}")
+    print(f"reverse {reverse}")
+    print(f"extra_clause_nn {extra_live}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "t-1300-131313",
+        "t(13,0,0) and t(13,13,13) match the witness walks",
+        t1300 == path_cost(axis_witness) == 25
+        and t131313 == path_cost(body_witness) == 43,
+    )
+    checks.check(
+        "reverse-k13",
+        "t(13,0,0)^2/169 > t(13,13,13)^2/507 holds",
+        reverse
+        and 3 * t1300 * t1300 == 1875
+        and t131313 * t131313 == 1849
+        and "1875 > 1849" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b39",
+        "B_39(0) has 82239 sites and contains the same-k pair",
+        len(sites) == 82239
+        and (13, 0, 0) in dist
+        and (13, 13, 13) in dist
+        and abs(13) + abs(13) + abs(13) == 39,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_39(0) is reached",
+        len(dist) == 82239,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "t(13,0,0) = 25" in note and "t(13,13,13) = 43" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "1875 > 1849" in note,
+    )
+    checks.check(
+        "extra-clause-vacant-on-nn",
+        "the extra mid-leave clause does not fire on nearest-neighbor hops",
+        extra_live is False
+        and mu_lambda_cost((2, 0, 0), (2, 1, 0)) == 1
+        and rho3_cost((2, 0, 0), (2, 1, 0)) == 1
+        and "does not fire on nearest-neighbor hops" in note,
+    )
+    checks.check(
+        "unit-cube-spared",
+        "the unit-cube 1→2 hop stays cost 1 because source max is 1",
+        mu_lambda_cost((1, 0, 0), (1, 1, 0)) == 1
+        and extra_clause_fires((1, 0, 0), (1, 1, 0)) is False
+        and "spares the unit-cube" in note,
+    )
+    checks.check(
+        "seed-and-stacked-clauses",
+        "seed-exit, both-weights-1, corridor-slide, and ridge-slide cost 3",
+        mu_lambda_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mu_lambda_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mu_lambda_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mu_lambda_cost((1, 1, 1), (2, 1, 1)) == 3
+        and mu_lambda_cost((2, 1, 0), (2, 2, 0)) == 1
+        and mu_lambda_cost((13, 13, 0), (13, 13, 1)) == 1
+        and mu_lambda_cost((2, 2, 2), (3, 2, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μλ(v→w)" not in axiom
+        and "mid-leave" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named mid-leave hop-cost μλ holds at k=13 on B_39(0): t(13,0,0)=25 vs t(13,13,13)=43. First display. Displayed, not adopted. Do not write μλ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/mid_leave_samek_k13_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.