### PR TITLE
feat(mlk14): mid-leave same-k fails at k=14: t=26 vs t=46

### DIFF
--- a/docs/MID_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/MID_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,198 @@
+---
+claim_id: mid_leave_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named mid-leave hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/mid_leave_samek_k14_b42_2026_08_15.py
+---
+
+# Named Mid-Leave Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/mid_leave_samek_k14_b42_2026_08_15.py`](../scripts/mid_leave_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of the named mid-leave hop-cost `μλ` at the
+`k=14` wall. Every extra scored so far has left `t(14,0,0) = 26`. The
+question here is whether same-`k` reverse restores at `k=14` after the
+new clause taxes a `1→2` hop whose destination has `max_i |w_i| = 1` and
+whose source already has a coordinate of absolute value at least `2`.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rules are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+`μλ(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=1` and `|σ_w|=2` and
+`max_i |w_i|=1` and `max_i |v_i| ≥ 2)`, else `1`.
+
+The last clause is the mid-leave tax. Those clauses are the whole rule.
+
+On the six-neighbor graph there is no nearest-neighbor hop for which the
+extra clause fires. A destination with support `2` and `max_i |w_i|=1` is
+a signed permutation of `(1,1,0)`. Any nearest-neighbor predecessor of
+support `1` is then a signed axis unit, so `max_i |v_i|=1`, and the source
+threshold `max_i |v_i| ≥ 2` fails. The unit-cube hop `(1,0,0) → (1,1,0)`
+has destination maximum `1` but source maximum `1`, so it stays cost `1`.
+The late-leave hop `(2,0,0) → (2,1,0)` has destination maximum `2`, so it
+is not this clause. Therefore `μλ` agrees with `ρ3` on every directed
+nearest-neighbor hop in `B_42(0)`.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+gives
+
+`t(14,0,0) = 26`, `t(14,14,14) = 46`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `676/196` versus `2116/588`, or equivalently `2028 > 2116`. The
+inequality does not hold. Same-`k` reverse does not restore at `k=14`
+under `μλ`. Independently, the new axis site is `t(42,0,0) = 58`. The
+shared axis site `t(39,0,0) = 51` is a `μλ` score on this ball.
+
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`.
+The `B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The rule is displayed, not adopted. Do not write `μλ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the mid-leave clause, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `μλ` along a directed path from `0` to `v` in
+that graph.
+
+The site `(14,0,0)` has ℓ¹ norm `14` and therefore also lies in `B_39(0)`.
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`. The
+`B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The comparator `ρ3` is every clause of `μλ` except the extra mid-leave
+tax. Because that extra clause has no nearest-neighbor hop in the ball,
+`ρ3` and `μλ` assign the same integer to every scored edge. The first
+display of `μλ` at the wall is nevertheless an independent origin Dijkstra
+under the named six-clause rule, not a copy of a `ρ3` table.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_μλ` |
+|---|---:|
+| `(14,0,0)` | `26` |
+| `(14,14,14)` | `46` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+A witness axis walk of cost `26` is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, hugging corridor-slide `3` onto `(2,1,0)`,
+non-hugging face hop `1` onto `(2,2,0)`, twelve support-preserving
+cost-`1` face hops to `(14,2,0)`, hugging slide `3` onto `(14,1,0)`, and
+support-drop `3` onto `(14,0,0)`, summing to `26`. That walk is a witness
+of cost `26`, not a uniqueness claim.
+
+A witness body walk of cost `46` is the same prefix of cost `8` to
+`(2,2,0)`, twelve cost-`1` face hops to `(14,2,0)`, twelve cost-`1` face
+hops to `(14,14,0)`, enter-body `1` onto `(14,14,1)`, and thirteen
+support-preserving cost-`1` body hops to `(14,14,14)`, summing to `46`.
+That walk is a witness of cost `46`, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 26^2 = 2028` and `46^2 = 2116`, so
+
+`2028 > 2116` is false; `2028 < 2116`.
+
+Arrival per Euclidean length is larger at `(14,14,14)` than at `(14,0,0)`.
+Same-`k` reverse at `k=14` under `μλ` is no. Reverse does not restore at
+`k=14`. The comparison is displayed, not adopted. The inequality does not
+hold.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `μλ` is a displayed scoring device on `B_42(0)`. Do not write `μλ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule μλ at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `μλ` among hop-costs that score the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of a smaller-ball arrival table as a substitute for the
+  radius-`42` Dijkstra.
+- Any write of `μλ` into Admissibility.
+- Membership of `μλ` as a physical hop-cost. Reverse at `k=14` on this ball
+  is a displayed comparison, not an adoption.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12525,6 +12525,10 @@
   "microcausality_weighted_quasilocal_class_walk_expansion_lieb_robinson_bounded_theorem_note_2026-07-18": {
    "deps_hash": "4a576dba9306",
    "out_degree": 6
+  },
+  "mid_leave_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "min_time_step_is_the_planck_time_from_the_single_scale_reference_primitive_narrow_theorem_note_2026-06-08": {
    "deps_hash": "3c3e26353fe0",

--- a/logs/runner-cache/mid_leave_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/mid_leave_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/mid_leave_samek_k14_b42_2026_08_15.py
+runner_sha256: ae21298f6994d88f710360af6e2e91ebe508711cb85a7580aaddc96482df4f42
+input_fingerprint_sha256: 4e85568ea37239f9642a8ba47cf354d980e4d8576c6142a51571550d3573aa69
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.89
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/MID_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named mid-leave hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility μλ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 26
+t(14,14,14) 46
+t(14,0,0)^2/196 676/196
+t(14,14,14)^2/588 2116/588
+3t_axis^2 2028
+t_body^2 2116
+reverse False
+t(42,0,0) 58
+t(39,0,0) 51
+dijkstra_calls 1
+extra_nn 0
+mulambda_unit_cube 1
+mulambda_late_leave 1
+rho3_late_leave 1
+mulambda_ridge 3
+PASS: t-1400-141414 t(14,0,0)=26 and t(14,14,14)=46
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: extra-clause-empty-nn the extra 1→2 dest-max-1 source-max-≥2 clause never fires on a nearest-neighbor hop
+PASS: unit-cube-1to2-spared the unit-cube 1→2 hop stays cost 1 because source max is 1
+PASS: late-leave-not-taxed μλ does not tax the late-leave hop (2,0,0)→(2,1,0)
+PASS: seed-and-mid-leave-clauses seed-exit, both-weights-1, support-drop, corridor-slide, and ridge-slide cost 3; unit-cube and late-leave 1→2 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/mid_leave_samek_k14_b42_2026_08_15.py
+++ b/scripts/mid_leave_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under μλ on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/MID_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/MID_LEAVE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named "
+    "mid-leave hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 26
+T_BODY_REP = 46
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_height_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_height_count(w) == 2:
+        return 3
+    return 1
+
+
+def extra_mid_leave(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 1
+        and support_size(w) == 2
+        and max(abs(c) for c in w) == 1
+        and max(abs(c) for c in v) >= 2
+    )
+
+
+def mulambda_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if extra_mid_leave(v, w):
+        return 3
+    return 1
+
+
+def dijkstra_mulambda(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + mulambda_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def extra_clause_nn_count(sites: list[tuple[int, int, int]]) -> int:
+    site_set = set(sites)
+    count = 0
+    for v in sites:
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w in site_set and extra_mid_leave(v, w):
+                count += 1
+    return count
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "μλ is not written into Admissibility",
+        "Do not write `μλ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_mulambda(sites)
+    extra_nn = extra_clause_nn_count(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    reverse = 3 * t1400 * t1400 > t141414 * t141414
+    unit_cube = ((1, 0, 0), (1, 1, 0))
+    late_leave = ((2, 0, 0), (2, 1, 0))
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t1400 * t1400}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t1400 * t1400}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"extra_nn {extra_nn}")
+    print(f"mulambda_unit_cube {mulambda_cost(*unit_cube)}")
+    print(f"mulambda_late_leave {mulambda_cost(*late_leave)}")
+    print(f"rho3_late_leave {rho3_cost(*late_leave)}")
+    print(f"mulambda_ridge {mulambda_cost(*ridge_hop)}")
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t1400 == T_AXIS_REP and t141414 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold",
+        (not reverse)
+        and 3 * t1400 * t1400 == 2028
+        and t141414 * t141414 == 2116
+        and "2028 > 2116" in note
+        and "2028 < 2116" in note
+        and "does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`26`" in note
+        and "`46`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2028 > 2116" in note and "2028 < 2116" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 58
+        and t3900 == 51
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "extra-clause-empty-nn",
+        "the extra 1→2 dest-max-1 source-max-≥2 clause never fires on a nearest-neighbor hop",
+        extra_nn == 0
+        and extra_mid_leave((1, 0, 0), (1, 1, 0)) is False
+        and extra_mid_leave((2, 0, 0), (2, 1, 0)) is False
+        and "no nearest-neighbor hop" in note,
+    )
+    checks.check(
+        "unit-cube-1to2-spared",
+        "the unit-cube 1→2 hop stays cost 1 because source max is 1",
+        mulambda_cost(*unit_cube) == 1
+        and rho3_cost(*unit_cube) == 1
+        and max(abs(c) for c in unit_cube[0]) == 1
+        and max(abs(c) for c in unit_cube[1]) == 1
+        and "unit-cube" in note,
+    )
+    checks.check(
+        "late-leave-not-taxed",
+        "μλ does not tax the late-leave hop (2,0,0)→(2,1,0)",
+        mulambda_cost(*late_leave) == 1
+        and rho3_cost(*late_leave) == 1
+        and max(abs(c) for c in late_leave[1]) == 2
+        and "late-leave hop" in note,
+    )
+    checks.check(
+        "seed-and-mid-leave-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, and ridge-slide cost 3; unit-cube and late-leave 1→2 cost 1",
+        mulambda_cost((0, 0, 0), (1, 0, 0)) == 3
+        and mulambda_cost((1, 0, 0), (2, 0, 0)) == 3
+        and mulambda_cost((1, 1, 0), (1, 0, 0)) == 3
+        and mulambda_cost((1, 1, 0), (2, 1, 0)) == 3
+        and mulambda_cost((1, 1, 1), (2, 1, 1)) == 3
+        and mulambda_cost((1, 0, 0), (1, 1, 0)) == 1
+        and mulambda_cost((2, 0, 0), (2, 1, 0)) == 1
+        and mulambda_cost((1, 1, 0), (1, 1, 1)) == 1
+        and mulambda_cost((2, 2, 0), (3, 2, 0)) == 1
+        and mulambda_cost((2, 2, 2), (3, 2, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "μλ(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named mid-leave hop-cost μλ fails at k=14 on B_42(0): t(14,0,0)=26 vs t(14,14,14)=46. Extra 6-NN clause is empty. First display. Displayed, not adopted. Do not write μλ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/mid_leave_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.