### PR TITLE
feat(ofkdbl): out-face doubled pairing holds k=1..4

### DIFF
--- a/docs/OUT_FACE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OUT_FACE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,283 @@
+---
+claim_id: out_face_doubled_pairing_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Doubled-axis versus body-diagonal reverse under the named out-face hop-cost on B_12(0) is reported for available k=1..4. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/out_face_doubled_pairing_b12_2026_08_15.py
+---
+
+# Named Out-Face Doubled Pairing On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the finite ball `B_12(0)`,
+scored only for the doubled pairing `((2k,0,0),(k,k,k))` at each
+available integer `k=1,2,3,4`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/out_face_doubled_pairing_b12_2026_08_15.py`](../scripts/out_face_doubled_pairing_b12_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named out-face hop-cost `ω` is the first
+display of doubled pairing under `ω`. The parent clauses `ν`, `μ`, and
+`ρ3` are those of the ridge-slide scoring on this ball:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `ω(v→w) = 3` if `ρ3` would be `3` or (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|`), else `1`.
+
+The extra clause is out-face growth: support stays at `2`, and the
+destination has larger max absolute coordinate than the source. It taxes
+growing the box on a face. The unit-height face hop `(1,1,0) → (2,1,0)`
+already costs `3` under `μ`, so `ρ3` already prices it. The new clause is
+the height-at-least-two case, such as `(2,2,0) → (3,2,0)`. Uniqueness is not claimed.
+
+The finite host is scored independently: one origin Dijkstra is run on this
+ball. The ball is not leftover of a larger-ball table.
+
+```text
+B_12(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 12 }.
+```
+
+It has 2625 sites (2624 nonzero). Edges are the cubic nearest-neighbor steps
+that remain inside `B_12(0)`. For each `k=1,2,3,4` both `(2k,0,0)` and
+`(k,k,k)` lie in `B_12(0)`, so no pair is omitted. One Dijkstra from the
+origin yields
+
+| `k` | site axis | `t(2k,0,0)` | site body | `t(k,k,k)` | `t(2k,0,0)^2/(4k^2)` | `t(k,k,k)^2/(3k^2)` | reverse |
+|---|---|---:|---|---:|---|---|---|
+| `1` | `(2,0,0)` | `6` | `(1,1,1)` | `5` | `36/4` | `25/3` | yes |
+| `2` | `(4,0,0)` | `12` | `(2,2,2)` | `10` | `144/16` | `100/12` | yes |
+| `3` | `(6,0,0)` | `18` | `(3,3,3)` | `13` | `324/36` | `169/27` | yes |
+| `4` | `(8,0,0)` | `24` | `(4,4,4)` | `16` | `576/64` | `256/48` | yes |
+
+Equivalently, `3 t(2k,0,0)^2 ? 4 t(k,k,k)^2` is `108 > 100`, `432 > 400`,
+`972 > 676`, and `1728 > 1024`. The inequality holds at every available
+`k=1..4`. Independently, the new axis site is `t(12,0,0) = 34`.
+
+The extra 2→2 clause is live on this host. The hop `(2,2,0) → (3,2,0)` has
+`ω=3` and `ρ3=1`, and both ends lie in `B_12(0)`. Therefore `ρ3` cannot price out-face. The displayed body last hop
+`(1,1,0) → (1,1,1)` raises support from `2` to `3`, so the extra clause
+does not fire and that hop keeps cost `1`. On the interior `3→3` hop
+`(2,2,2) → (3,2,2)` the destination has no unit coordinate, so both `ρ3`
+and `ω` cost `1`. On `(1,-2,0) → (2,-2,0)` the max absolute coordinate
+stays `2`, so both `ρ3` and `ω` cost `1`. The pair is not leftover of
+`ρ3` as a rule: at `k=4` the axis arrivals under `ω` and `ρ3` are
+`24` versus `20`, because a cheapest `ρ3` axis witness uses height-two
+face growth. The same walk that scores `20` under `ρ3` — seed-exit onto
+`(0,-1,0)`, unit-cube leave, corridor-slide to height two, six height-two
+slides to `(8,-2,0)`, corridor return, and support-drop — scores `32`
+under `ω`, because six of those height-two slides grow the max
+coordinate. Independently, `t(3,2,0) = 11`. The new clause is live. The
+site `(4,4,4)` has coordinate-sum `12`, so it is absent from `B_11(0)`.
+The `B_12(0)` table is therefore not leftover of a smaller-ball table.
+
+The rule is displayed, not adopted. Do not write `ω` into Admissibility.
+Do not write ω into Admissibility. Do not attach L1.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_12(0) reports t(2k,0,0) and t(k,k,k) under the named out-face hop-cost at available k=1..4 and scores the doubled pairing comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: out_face_doubled_pairing_b12
+target_blocker_text: "whether doubled-axis versus body-diagonal reverse at available k=1..4 holds after 2-to-2 hops that grow max abs coord are priced at 3"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_12(0) under the named hop-cost at available k=1..4 on ((2k,0,0),(k,k,k)); displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `ω` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_12(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`, and
+  `ω` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `ω` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_12(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`ω` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`ω`, using one Dijkstra on `B_12(0)`.
+
+The pairing is not the same-`k` axis / body pair `(k,0,0)` versus
+`(k,k,k)`. It is the doubled pairing `((2k,0,0),(k,k,k))`.
+
+On the out-face hop `(2,2,0) → (3,2,0)` one has `|σ_v|=2`, `|σ_w|=2`, and
+`max_i |w_i| = 3 > max_i |v_i| = 2`, and the least nonzero destination
+coordinate is `2`, so `ρ3 = 1` while `ω = 3`. Therefore `ρ3` cannot price out-face. On the unit-height face hop `(1,1,0) → (2,1,0)` the destination
+still has a unit coordinate, so both `μ` and `ω` price the hop at `3`.
+On the body hop `(1,0,0) → (1,1,0)` both `ρ3` and `ω` cost `1`. On the
+interior `3→3` hop `(2,2,2) → (3,2,2)` the destination has no unit
+coordinate, so both `ρ3` and `ω` cost `1`.
+
+## Theorem 1 — Arrivals For Each Available `k=1..4`
+
+Under `ω` on `B_12(0)`, one origin Dijkstra returns the integer arrivals
+
+| site | `t` |
+|---|---:|
+| `(2,0,0)` | `6` |
+| `(1,1,1)` | `5` |
+| `(4,0,0)` | `12` |
+| `(2,2,2)` | `10` |
+| `(6,0,0)` | `18` |
+| `(3,3,3)` | `13` |
+| `(8,0,0)` | `24` |
+| `(4,4,4)` | `16` |
+
+Every listed site lies in `B_12(0)`. The site `(4,4,4)` has coordinate-sum
+`12`, so it is absent from `B_11(0)`. The pair is computed on `B_12(0)`, not
+copied from a smaller-ball table and not copied from a `ρ3` table. These
+values are Dijkstra outputs, not fitted scalars.
+
+A witness walk of cost `6` from `0` to `(2,0,0)` is seed-exit `3` onto
+`(1,0,0)` and both-weights-`1` cost `3` onto `(2,0,0)`, summing to `6`.
+A witness walk of cost `5` from `0` to `(1,1,1)` is seed-exit `3` onto
+`(0,0,1)`, leave-axis `1` onto `(0,1,1)`, and enter-body `1` onto
+`(1,1,1)`, summing to `5`. A witness walk of cost `12` from `0` to
+`(4,0,0)` is four both-weights-`1` axis hops
+`0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0)` of costs `3,3,3,3`, summing
+to `12`. A witness walk of cost `10` from `0` to `(2,2,2)` is seed-exit
+`3` onto `(0,0,1)`, leave-axis `1` onto `(0,1,1)`, corridor-slide `3` onto
+`(0,1,2)`, non-growing `2→2` of cost `1` onto `(0,2,2)`, enter-body `1`
+onto `(1,2,2)`, and support-preserving cost-`1` body hop onto `(2,2,2)`,
+summing to `10`. A witness walk of cost `18` from `0` to `(6,0,0)` is
+six both-weights-`1` axis hops
+`0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0) → (5,0,0) → (6,0,0)` of
+costs `3,3,3,3,3,3`, summing to `18`. A witness walk of cost `13` from
+`0` to `(3,3,3)` is seed-exit `3` onto `(0,0,1)`, leave-axis `1` onto
+`(0,1,1)`, corridor-slide `3` onto `(0,1,2)`, non-growing `2→2` of cost
+`1` onto `(0,2,2)`, enter-body `1` onto `(1,2,2)`, support-preserving
+cost-`1` onto `(1,2,3)`, cost-`1` onto `(1,3,3)`, and two
+support-preserving cost-`1` body hops to `(3,3,3)`, summing to `13`.
+A witness walk of cost `24` from `0` to `(8,0,0)` is eight both-weights-`1`
+axis hops `0 → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0) → (5,0,0) →
+(6,0,0) → (7,0,0) → (8,0,0)` of costs `3,3,3,3,3,3,3,3`, summing to
+`24`. A witness walk of cost `16` from `0` to `(4,4,4)` is seed-exit `3`
+onto `(0,0,1)`, leave-axis `1` onto `(0,1,1)`, corridor-slide `3` onto
+`(0,1,2)`, non-growing `2→2` of cost `1` onto `(0,2,2)`, enter-body `1`
+onto `(1,2,2)`, two support-preserving cost-`1` hops onto `(1,2,4)`, two
+cost-`1` hops onto `(1,4,4)`, and three support-preserving cost-`1` body
+hops to `(4,4,4)`, summing to `16`. Those walks are witnesses of the
+listed costs, not uniqueness claims.
+
+A witness that the out-face clause is live is the walk seed-exit `3`
+onto `(1,0,0)`, unit-cube leave `1` onto `(1,1,0)`, corridor-slide `3`
+onto `(1,2,0)`, support-preserving `1` onto `(2,2,0)`, and out-face `3`
+onto `(3,2,0)`, summing to `11`. Replacing only the last hop by its
+`ρ3` price `1` yields `9`. Independently, `t(3,2,0) = 11`.
+
+## Theorem 2 — Reverse At Each Available Doubled Pair
+
+For each available `k=1,2,3,4` the Euclidean-normalized comparison is
+whether
+
+```text
+t(2k,0,0)^2 / (4k^2) > t(k,k,k)^2 / (3k^2).
+```
+
+Equivalently `3 t(2k,0,0)^2 ? 4 t(k,k,k)^2`. Substituting the computed
+times gives
+
+| `k` | `3 t(2k,0,0)^2` | `4 t(k,k,k)^2` | reverse |
+|---|---:|---:|---|
+| `1` | `108` | `100` | `108 > 100` |
+| `2` | `432` | `400` | `432 > 400` |
+| `3` | `972` | `676` | `972 > 676` |
+| `4` | `1728` | `1024` | `1728 > 1024` |
+
+Arrival per Euclidean length is larger at `(2k,0,0)` than at `(k,k,k)` for
+every available `k=1..4`. Doubled pairing reverse under `ω` is yes at each
+of those four scales. The comparison is displayed, not adopted. The
+inequality holds.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write ω into Admissibility. Do not attach L1.
+
+Do not write `ω` into Admissibility.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `ω`, `ρ3`, `μ`, or `ν`. This note
+proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at two sites; it is not an attachment of a
+coordinate-sum hop-cost. It is not a replacement for first arrival under
+a constant hop-cost. Uniqueness is not claimed.
+
+## What This Does Not Claim
+
+- No uniqueness claim is made for this named hop-cost at any available `k`.
+- The live 2→2 out-face clause on `B_12(0)` is not a statement about larger hosts.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+- Any statement off `B_12(0)`.
+- Any score for a pair that is not `((2k,0,0),(k,k,k))`.
+- Any omitted pair among `k=1..4`: both sites of each pair lie in `B_12(0)`.
+- Any reuse of the `ρ3` arrival table as a substitute for the `ω` Dijkstra.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_12(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(2k,0,0)` and `t(k,k,k)`
+for each available `k=1..4`, checks the integer form of Theorem 2, checks
+that the extra 2→2 out-face clause is live on in-host hops at cost `3` and
+does not tax the displayed body last hop, checks that the live Admissibility
+wording does not name `ω`, and records the import boundary. Declared review
+inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13561,6 +13561,10 @@
   "osterwalder_schrader_from_framework_narrow_theorem_note_2026-05-27": {
    "deps_hash": "37b34cf3d5e2",
    "out_degree": 3
+  },
+  "out_face_doubled_pairing_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "overlapping_edge_instrument_order_and_time_rate_nonselection_bounded_theorem_note_2026-07-11": {
    "deps_hash": "0533a016df20",

--- a/logs/runner-cache/out_face_doubled_pairing_b12_2026_08_15.txt
+++ b/logs/runner-cache/out_face_doubled_pairing_b12_2026_08_15.txt
@@ -1,0 +1,73 @@
+===== runner cache v1 =====
+runner: scripts/out_face_doubled_pairing_b12_2026_08_15.py
+runner_sha256: 86b9059af93ffab6c776f8d0a9d78722bf6fa605aac85cd25949b02585a75448
+input_fingerprint_sha256: 20b128b1c6b7e2cf8402ad58e74908e75b53fa70af5c7250e896b5b65d5f1054
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/OUT_FACE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Doubled-axis versus body-diagonal reverse under the named out-face hop-cost on B_12(0) is reported for available k=1..4. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_12(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+claim_boundary: doubled pairing reverse at k=1..4 is displayed, not adopted
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ω is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+dijkstra_calls 1
+t(12,0,0) 34
+t(3,2,0) 11
+omega_out_face 3 rho3_out_face 1 mu_out_face 1
+omega_unit_face_grow 3
+omega_body_last 1
+out_face_live_hops 480
+witness_rho3_axis8_omega 32
+witness_rho3_axis8_rho3 20
+witness_out_face_omega 11
+witness_out_face_rho3 9
+k 1 t(2,0,0) 6 t(1,1,1) 5 t_axis^2/(4k^2) 36/4 t_body^2/(3k^2) 25/3 3t_axis^2 108 4t_body^2 100 reverse True
+PASS: t-k1 t(2,0,0)=6 and t(1,1,1)=5
+PASS: reverse-k1 t(2,0,0)^2/(4k^2) > t(1,1,1)^2/(3k^2) is True
+k 2 t(4,0,0) 12 t(2,2,2) 10 t_axis^2/(4k^2) 144/16 t_body^2/(3k^2) 100/12 3t_axis^2 432 4t_body^2 400 reverse True
+PASS: t-k2 t(4,0,0)=12 and t(2,2,2)=10
+PASS: reverse-k2 t(4,0,0)^2/(4k^2) > t(2,2,2)^2/(3k^2) is True
+k 3 t(6,0,0) 18 t(3,3,3) 13 t_axis^2/(4k^2) 324/36 t_body^2/(3k^2) 169/27 3t_axis^2 972 4t_body^2 676 reverse True
+PASS: t-k3 t(6,0,0)=18 and t(3,3,3)=13
+PASS: reverse-k3 t(6,0,0)^2/(4k^2) > t(3,3,3)^2/(3k^2) is True
+k 4 t(8,0,0) 24 t(4,4,4) 16 t_axis^2/(4k^2) 576/64 t_body^2/(3k^2) 256/48 3t_axis^2 1728 4t_body^2 1024 reverse True
+PASS: t-k4 t(8,0,0)=24 and t(4,4,4)=16
+PASS: reverse-k4 t(8,0,0)^2/(4k^2) > t(4,4,4)^2/(3k^2) is True
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: ball-b12 B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: reachable every site of B_12(0) is reached
+PASS: pairs-available both sites of each k=1..4 pair lie in B_12(0)
+PASS: reverse-bits-match computed reverse bits match the four-scale census
+PASS: note-records-times note records the eight computed arrivals
+PASS: note-records-reverse-products note records the four integer reverse products
+PASS: out-face-clause the named 2-to-2 growing-max clause prices (2,2,0) to (3,2,0) at 3
+PASS: out-face-live-on-ball nearest-neighbor hops inside B_12(0) trigger the extra out-face clause
+PASS: hop-body-last-untaxed the 2-to-3 hop into (1,1,1) is not priced by the extra clause
+PASS: not-leftover-of-rho3 ω prices height-2 out-face growth at 3 while ρ3 prices it at 1, and t(8,0,0) differs
+PASS: not-leftover-of-b11 (4,4,4) lies outside B_11(0) and the note says so
+PASS: omega-clauses seed-exit, axis, drop, corridor-slide, ridge-slide, and out-face growth cost 3; 1-to-2, small 2-to-3, non-growing height-2, and interior 3-to-3 cost 1
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name ω
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.
+per_site: arrival times are reported at the doubled pairing sites and (12,0,0).
+lattice_wide: checked and not executed — the search stays inside B_12(0).
+TOTAL: PASS=32 FAIL=0
+
+----- stderr -----
+

--- a/scripts/out_face_doubled_pairing_b12_2026_08_15.py
+++ b/scripts/out_face_doubled_pairing_b12_2026_08_15.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Score doubled pairing reverse under ω on B_12(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/OUT_FACE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/OUT_FACE_DOUBLED_PAIRING_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Doubled-axis versus body-diagonal reverse under the named "
+    "out-face hop-cost on B_12(0) is reported for available "
+    "k=1..4. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+# (k, t(2k,0,0), t(k,k,k), reverse)
+REPORTED = ((1, 6, 5, True), (2, 12, 10, True), (3, 18, 13, True), (4, 24, 16, True))
+REVERSE_PRODUCTS = ("108 > 100", "432 > 400", "972 > 676", "1728 > 1024")
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max(abs(c) for c in w) > max(abs(c) for c in v)
+    ):
+        return 3
+    return 1
+
+
+def dijkstra_omega(
+    sites: list[tuple[int, int, int]],
+) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + omega_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(
+    walk: tuple[tuple[int, int, int], ...],
+    cost_fn,
+) -> int:
+    return sum(cost_fn(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_12(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+    print(
+        "claim_boundary: doubled pairing reverse at k=1..4 is displayed, "
+        "not adopted"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ω is not written into Admissibility",
+        "Do not write ω into Admissibility." in note
+        and "Do not write `ω` into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "Do not attach L1." not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_omega(sites)
+    unit_face_grow = ((1, 1, 0), (2, 1, 0))
+    out_face_hop = ((2, 2, 0), (3, 2, 0))
+    body_last = ((1, 1, 0), (1, 1, 1))
+    interior_hop = ((2, 2, 2), (3, 2, 2))
+    ridge_slide = ((1, 1, 1), (2, 1, 1))
+    height2_nongrow = ((1, -2, 0), (2, -2, 0))
+    later_out_face = ((7, 2, 0), (8, 2, 0))
+    t1200 = dist[(12, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    witness_rho3_axis8 = (
+        (0, 0, 0),
+        (0, -1, 0),
+        (1, -1, 0),
+        (1, -2, 0),
+        (2, -2, 0),
+        (3, -2, 0),
+        (4, -2, 0),
+        (5, -2, 0),
+        (6, -2, 0),
+        (7, -2, 0),
+        (8, -2, 0),
+        (8, -1, 0),
+        (8, 0, 0),
+    )
+    witness_out_face = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (3, 2, 0),
+    )
+    in_ball_new = 0
+    for site in sites:
+        sx, sy, sz = site
+        for dx, dy, dz in NEIGH:
+            neighbor = (sx + dx, sy + dy, sz + dz)
+            if neighbor not in dist:
+                continue
+            if omega_cost(site, neighbor) == 3 and rho3_cost(site, neighbor) == 1:
+                in_ball_new += 1
+    print(f"n_sites {len(sites)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"t(12,0,0) {t1200}")
+    print(f"t(3,2,0) {t320}")
+    print(
+        f"omega_out_face {omega_cost(*out_face_hop)} "
+        f"rho3_out_face {rho3_cost(*out_face_hop)} "
+        f"mu_out_face {mu_cost(*out_face_hop)}"
+    )
+    print(f"omega_unit_face_grow {omega_cost(*unit_face_grow)}")
+    print(f"omega_body_last {omega_cost(*body_last)}")
+    print(f"out_face_live_hops {in_ball_new}")
+    print(f"witness_rho3_axis8_omega {path_cost(witness_rho3_axis8, omega_cost)}")
+    print(f"witness_rho3_axis8_rho3 {path_cost(witness_rho3_axis8, rho3_cost)}")
+    print(f"witness_out_face_omega {path_cost(witness_out_face, omega_cost)}")
+    print(f"witness_out_face_rho3 {path_cost(witness_out_face, rho3_cost)}")
+
+    all_match = True
+    available = True
+    for k, t_axis_rep, t_body_rep, reverse_rep in REPORTED:
+        axis = (2 * k, 0, 0)
+        body = (k, k, k)
+        in_ball = l1(axis) <= 12 and l1(body) <= 12
+        available = available and in_ball
+        t_axis = dist[axis]
+        t_body = dist[body]
+        lhs = 3 * t_axis * t_axis
+        rhs = 4 * t_body * t_body
+        reverse = lhs > rhs
+        all_match = all_match and reverse == reverse_rep
+        print(
+            f"k {k} t({2 * k},0,0) {t_axis} t({k},{k},{k}) {t_body} "
+            f"t_axis^2/(4k^2) {t_axis * t_axis}/{4 * k * k} "
+            f"t_body^2/(3k^2) {t_body * t_body}/{3 * k * k} "
+            f"3t_axis^2 {lhs} 4t_body^2 {rhs} reverse {reverse}"
+        )
+        checks.check(
+            f"t-k{k}",
+            f"t({2 * k},0,0)={t_axis_rep} and t({k},{k},{k})={t_body_rep}",
+            in_ball and t_axis == t_axis_rep and t_body == t_body_rep,
+        )
+        checks.check(
+            f"reverse-k{k}",
+            f"t({2 * k},0,0)^2/(4k^2) > t({k},{k},{k})^2/(3k^2) is {reverse_rep}",
+            reverse == reverse_rep and (lhs > rhs) == reverse,
+        )
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        DIJKSTRA_CALLS == 1 and "dijkstra_omega" in source,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == 2625 and len(nonzero) == 2624 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625 and all(dist[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "pairs-available",
+        "both sites of each k=1..4 pair lie in B_12(0)",
+        available
+        and l1((8, 0, 0)) == 8
+        and l1((4, 4, 4)) == 12
+        and "no pair is omitted" in note,
+    )
+    checks.check(
+        "reverse-bits-match",
+        "computed reverse bits match the four-scale census",
+        all_match,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the eight computed arrivals",
+        all(
+            f"`{t_axis}`" in note and f"`{t_body}`" in note
+            for _k, t_axis, t_body, _rev in REPORTED
+        )
+        and "`(2,0,0)`" in note
+        and "`(6,0,0)`" in note
+        and "`(8,0,0)`" in note
+        and "`(4,4,4)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the four integer reverse products",
+        all(product in note for product in REVERSE_PRODUCTS),
+    )
+    checks.check(
+        "out-face-clause",
+        "the named 2-to-2 growing-max clause prices (2,2,0) to (3,2,0) at 3",
+        omega_cost(*out_face_hop) == 3
+        and rho3_cost(*out_face_hop) == 1
+        and mu_cost(*out_face_hop) == 1
+        and omega_cost(*later_out_face) == 3
+        and rho3_cost(*later_out_face) == 1
+        and omega_cost(*height2_nongrow) == 1
+        and out_face_hop[0] in dist
+        and out_face_hop[1] in dist
+        and "cannot price out-face" in note,
+    )
+    checks.check(
+        "out-face-live-on-ball",
+        "nearest-neighbor hops inside B_12(0) trigger the extra out-face clause",
+        in_ball_new > 0 and "new clause is live" in note,
+    )
+    checks.check(
+        "hop-body-last-untaxed",
+        "the 2-to-3 hop into (1,1,1) is not priced by the extra clause",
+        omega_cost(*body_last) == 1
+        and rho3_cost(*body_last) == 1
+        and unit_coord_count((1, 1, 1)) == 3,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "ω prices height-2 out-face growth at 3 while ρ3 prices it at 1, and t(8,0,0) differs",
+        omega_cost(*out_face_hop) == 3
+        and rho3_cost(*out_face_hop) == 1
+        and dist[(8, 0, 0)] == 24
+        and path_cost(witness_rho3_axis8, rho3_cost) == 20
+        and path_cost(witness_rho3_axis8, omega_cost) == 32
+        and t320 == 11
+        and path_cost(witness_out_face, omega_cost) == 11
+        and path_cost(witness_out_face, rho3_cost) == 9
+        and "24` versus `20" in note
+        and "cannot price out-face" in note,
+    )
+    checks.check(
+        "not-leftover-of-b11",
+        "(4,4,4) lies outside B_11(0) and the note says so",
+        l1((4, 4, 4)) == 12
+        and (4, 4, 4) in dist
+        and t1200 == 34
+        and "absent from `B_11(0)`" in note,
+    )
+    checks.check(
+        "omega-clauses",
+        "seed-exit, axis, drop, corridor-slide, ridge-slide, and out-face growth cost 3; 1-to-2, small 2-to-3, non-growing height-2, and interior 3-to-3 cost 1",
+        omega_cost((0, 0, 0), (1, 0, 0)) == 3
+        and omega_cost((1, 0, 0), (2, 0, 0)) == 3
+        and omega_cost((1, 1, 0), (1, 0, 0)) == 3
+        and omega_cost((1, 1, 0), (2, 1, 0)) == 3
+        and omega_cost(*ridge_slide) == 3
+        and omega_cost(*out_face_hop) == 3
+        and omega_cost((2, 2, 0), (2, 3, 0)) == 3
+        and omega_cost((1, 0, 0), (1, 1, 0)) == 1
+        and omega_cost((1, 1, 0), (1, 1, 1)) == 1
+        and omega_cost((2, 1, 0), (2, 1, 1)) == 1
+        and omega_cost(*height2_nongrow) == 1
+        and omega_cost((2, 2, 0), (2, 2, 1)) == 1
+        and omega_cost(*interior_hop) == 1,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name ω",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "ω(v→w)" not in axiom
+        and "Do not write ω into Admissibility." in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ω(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported at the doubled pairing sites and (12,0,0).")
+    print("lattice_wide: checked and not executed — the search stays inside B_12(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Doubled pairing reverse under named out-face hop-cost ω holds at every available k=1..4 on B_12(0). First display. Displayed, not adopted. Do not write ω into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/out_face_doubled_pairing_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.