### PR TITLE
feat(renkiso): ridge-enter isochrones t(2,2,2)=10 t(4,4,4)=16

### DIFF
--- a/docs/RIDGE_ENTER_ISOCHRONE_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/RIDGE_ENTER_ISOCHRONE_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,294 @@
+---
+claim_id: ridge_enter_isochrone_types_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Isochrone type counts of the t(2,2,2) and t(4,4,4) shells under the named ridge-enter hop-cost on B_12(0) are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/ridge_enter_isochrone_types_b12_2026_08_15.py
+---
+
+# Isochrone Type Counts Of The t(2,2,2) And t(4,4,4) Shells On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_12(0)`,
+scored only for G+ type counts and distinct `|v|_2^2` on the arrivals
+`t(2,2,2)` and `t(4,4,4)` under ridge-enter.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/ridge_enter_isochrone_types_b12_2026_08_15.py`](../scripts/ridge_enter_isochrone_types_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+The residual here is the first display of the isochrone type counts of
+the `t(2,2,2)` and `t(4,4,4)` shells under the named ridge-enter hop-cost
+`κ` on `B_12(0)`.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_12(0)`, the displayed
+comparator `ν` is
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The displayed comparator `μ` is
+
+`μ(v→w) = 3` if `ν(v→w)` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`.
+
+The displayed comparator `ρ3` is
+
+`ρ3(v→w) = 3` if `μ(v→w)` would be `3` or `(|σ_v|=|σ_w|=3` and exactly
+two `|w_i|` equal `1)`, else `1`.
+
+The displayed rule `κ` is
+
+`κ(v→w) = 3` if `ρ3(v→w)` would be `3` or `(|σ_v|=2` and `|σ_w|=3` and
+exactly two `|w_i|` equal `1)`, else `1`.
+
+The extra clause is a ridge enter: support rises `2 → 3`, and the
+destination has exactly two unit coordinates. It is not the displayed
+body last hop into `(1,1,1)`, whose destination has three unit
+coordinates. Those clauses are the whole rule. Uniqueness is not claimed.
+
+The proper cubic group `G+` is the 24 signed-permutation rotations of
+determinant `+1`. A G+ type is one `G+` orbit. The representative of an
+orbit is its lexicographically maximal first-octant triple (the
+lex-sorted list of those abs-sorted 3-tuples is the type list).
+
+One Dijkstra from the origin on `B_12(0)` (2625 sites; 2624 nonzero) gives
+
+`t(2,2,2) = 10`, `t(4,4,4) = 16`.
+
+| `t` | site count | G+ types | distinct `|v|_2^2` |
+|---:|---:|---:|---:|
+| `10` | `116` | `6` | `5` |
+| `16` | `572` | `25` | `13` |
+
+So the `t(2,2,2)` and `t(4,4,4)` shells remain mixed.
+
+The body diagonal `(2,2,2)` sits in the `t=10` shell. The doubled body
+diagonal `(4,4,4)` sits in the `t=16` shell.
+
+The pair is not leftover of `ρ3`: on the ridge-enter hop
+`(2,1,0) → (2,1,1)` one has `|σ| : 2 → 3` and exactly two `|w_i| = 1`,
+so `ρ3 = 1` while `κ = 3`. On the displayed body last hop
+`(1,1,0) → (1,1,1)` the destination has three unit coordinates, so both
+`ρ3` and `κ` cost `1`. On the ridge slide `(1,1,1) → (2,1,1)` both
+already cost `3`. On the interior `3→3` hop `(2,2,2) → (3,2,2)` the
+destination has no unit coordinate, so both cost `1`. Therefore `ρ3`
+cannot price the ridge enter, and the `κ` type table is not a leftover
+of a `ρ3` hop-cost identity.
+
+The census is displayed, not adopted. Do not write κ into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the unit-coordinate test, and the arrival function `t` are separately
+displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule And Type Convention
+
+Let `B_12(0) = { v ∈ Z^3 : |v|_1 ≤ 12 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_12(0)`,
+`t(v)` is the least sum of `κ` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses the support-drop clauses, the axis-hugging
+`2→2` slide, and the ridge `3→3` slide. On the ridge-enter hop
+`(2,1,0) → (2,1,1)` one has `|σ_v|=2`, `|σ_w|=3` and exactly two
+`|w_i|=1`, so `ρ3 = 1` while `κ = 3`. Therefore `ρ3` cannot price the
+ridge enter. On the displayed body last hop `(1,1,0) → (1,1,1)` the
+destination has three unit coordinates, so the extra clause does not
+fire and both costs stay `1`.
+
+A G+ type is represented by the lexicographically maximal first-octant
+member of its orbit. The type list of a shell is those representatives
+sorted in lexicographic order. Absolute-coordinate first-octant form
+does not merge chiral pairs: `(3,1,2)` and `(3,2,1)` remain distinct `G+`
+orbits, as do the chiral pairs on the `t=16` shell.
+
+## Theorem 1 — Type Counts On The `t(2,2,2)` And `t(4,4,4)` Shells
+
+Let `t2 = t(2,2,2)` and `t4 = t(4,4,4)` under `κ`. One origin Dijkstra
+on `B_12(0)` reaches every site and returns `t2 = 10` and `t4 = 16`. The
+`t=10` shell has 116 sites, 6 G+ types, and 5 distinct values of
+`|v|_2^2`. The `t=16` shell has 572 sites, 25 G+ types, and 13 distinct
+values of `|v|_2^2`.
+
+The lex-sorted abs-sorted G+ representatives at `t=10`, each with
+`|v|_2^2` and orbit size, are
+
+| representative | `|v|_2^2` | orbit size |
+|---|---:|---:|
+| `(2,2,2)` | 12 | 8 |
+| `(3,1,0)` | 10 | 24 |
+| `(3,1,2)` | 14 | 24 |
+| `(3,2,1)` | 14 | 24 |
+| `(3,3,0)` | 18 | 12 |
+| `(4,2,0)` | 20 | 24 |
+
+Those six orbits partition the 116 sites. The five squared radii are
+`{10,12,14,18,20}`.
+
+The lex-sorted abs-sorted G+ representatives at `t=16` are
+
+| representative | `|v|_2^2` | orbit size |
+|---|---:|---:|
+| `(4,4,4)` | 48 | 8 |
+| `(5,3,4)` | 50 | 24 |
+| `(5,4,3)` | 50 | 24 |
+| `(5,5,2)` | 54 | 24 |
+| `(6,1,1)` | 38 | 24 |
+| `(6,1,5)` | 62 | 24 |
+| `(6,2,4)` | 56 | 24 |
+| `(6,3,3)` | 54 | 24 |
+| `(6,4,2)` | 56 | 24 |
+| `(6,5,1)` | 62 | 24 |
+| `(6,6,0)` | 72 | 12 |
+| `(7,1,0)` | 50 | 24 |
+| `(7,1,4)` | 66 | 24 |
+| `(7,2,3)` | 62 | 24 |
+| `(7,3,2)` | 62 | 24 |
+| `(7,4,1)` | 66 | 24 |
+| `(7,5,0)` | 74 | 24 |
+| `(8,1,3)` | 74 | 24 |
+| `(8,2,2)` | 72 | 24 |
+| `(8,3,1)` | 74 | 24 |
+| `(8,4,0)` | 80 | 24 |
+| `(9,1,2)` | 86 | 24 |
+| `(9,2,1)` | 86 | 24 |
+| `(9,3,0)` | 90 | 24 |
+| `(10,2,0)` | 104 | 24 |
+
+Those twenty-five orbits partition the 572 sites. The thirteen squared
+radii are `{38,48,50,54,56,62,66,72,74,80,86,90,104}`.
+
+B_12(0) only. The type counts are displayed, not adopted.
+
+## Theorem 2 — Body-Diagonal Membership Of `(2,2,2)`
+
+The same Dijkstra gives `t(2,2,2) = 10` and `t(4,4,4) = 16`. So
+`(2,2,2)` is in the `t=10` type list and `(4,4,4)` is in the `t=16`
+type list.
+
+A body-diagonal site is a nonzero site with `|x|=|y|=|z|`. The `t=10`
+shell contains exactly the eight signed copies of `(2,2,2)` as
+body-diagonal sites. No other body-diagonal type appears: `(1,1,1)`
+arrives at `5` and `(3,3,3)` arrives at `13`. So `(2,2,2)` is the unique
+body-diagonal G+ type in its shell.
+
+That uniqueness is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `κ` is a displayed scoring device on `B_12(0)`. Do not write κ
+into Admissibility. Do not attach L1. The isochrone type counts are not
+offered as a unique hop-cost property and are not a replacement for
+unit-cost first arrival.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact G+ type counts on the t(2,2,2) and t(4,4,4) shells of B_12(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_12(0) for the displayed rule κ; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `κ` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_12(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`, and
+  `κ` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `κ` into Admissibility, selecting it as
+  a physical cost, or lifting the census off `B_12(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`κ` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`κ`, using one Dijkstra on `B_12(0)`.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## What This Note Does Not Claim
+
+- Uniqueness of `κ` among hop-costs with these type counts.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_12(0)`.
+- Any reuse of a `ρ3` type table as a substitute for the `κ` Dijkstra.
+- Adoption of body-diagonal uniqueness in the `t=10` shell as a hop-cost
+  selector.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Runner Contract
+
+The companion runner builds `B_12(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports site count, G+ type count,
+and the number of distinct `|v|_2^2` on the `t(2,2,2)` and `t(4,4,4)`
+shells, checks that `(2,2,2)` is the unique body-diagonal type in its
+shell, checks that the extra `2→3` clause is live on in-host hops and
+does not tax the displayed body last hop, checks that the live
+Admissibility wording does not name `κ`, and records the import
+boundary. Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16377,6 +16377,10 @@
   "rh_sector_anomaly_cancellation_identities_note_2026-05-02": {
    "deps_hash": "785ba75e68d8",
    "out_degree": 5
+  },
+  "ridge_enter_isochrone_types_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "ring_family_uniformity_cycle737_bounded_theorem_note_2026-07-28": {
    "deps_hash": "f38aec7a66e3",

--- a/logs/runner-cache/ridge_enter_isochrone_types_b12_2026_08_15.txt
+++ b/logs/runner-cache/ridge_enter_isochrone_types_b12_2026_08_15.txt
@@ -1,0 +1,68 @@
+===== runner cache v1 =====
+runner: scripts/ridge_enter_isochrone_types_b12_2026_08_15.py
+runner_sha256: 91e5ab71425bbc572b722900d3ddca72c7a2f9ba9bfe6beef6240639c03013b2
+input_fingerprint_sha256: 6f41828e6aaf471442e176b5484895651f9a9972e7f19616771a28d48bd77c4a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/RIDGE_ENTER_ISOCHRONE_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Isochrone type counts of the t(2,2,2) and t(4,4,4) shells under the named ridge-enter hop-cost on B_12(0) are reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the isochrone type-count statement
+PASS: displayed-not-adopted the census is displayed, not adopted
+PASS: not-in-admissibility κ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 2625
+t2 10 t4 16
+t10_sites 116 t10_types 6 t10_n_r2 5
+t16_sites 572 t16_types 25 t16_n_r2 13
+t10_radii [10, 12, 14, 18, 20]
+t16_radii [38, 48, 50, 54, 56, 62, 66, 72, 74, 80, 86, 90, 104]
+t(2,2,2) 10
+t(4,4,4) 16
+t(1,1,1) 5
+t(3,3,3) 13
+has_222_in_t10 True
+has_444_in_t16 True
+body_t10 8 body_types_t10 [(2, 2, 2)]
+t10_mixed True
+t16_mixed True
+dijkstra_calls 1
+kappa_enter 3
+rho3_enter 1
+kappa_body_last 1
+rho3_body_last 1
+kappa_ridge 3
+rho3_ridge 3
+kappa_interior 1
+rho3_interior 1
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b12 B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: reachable every site of B_12(0) is reached
+PASS: rotation-group the proper cubic group used for types has 24 elements
+PASS: t10-counts t=10 has 116 sites, 6 G+ types, and 5 distinct |v|_2^2
+PASS: t16-counts t=16 has 572 sites, 25 G+ types, and 13 distinct |v|_2^2
+PASS: t-222-in-t10 (2,2,2) sits in the t=10 shell
+PASS: t-444-in-t16 (4,4,4) sits in the t=16 shell
+PASS: unique-body-diagonal (2,2,2) is the unique body-diagonal type in its shell
+PASS: shells-mixed the t(2,2,2) and t(4,4,4) shells remain mixed
+PASS: not-leftover-of-rho3 κ prices the ridge-enter 2→3 hop at 3 while ρ3 prices it at 1
+PASS: note-records-counts note records site, type, and radius counts for both shells
+PASS: note-records-memberships note records (2,2,2) in t=10 and (4,4,4) in t=16
+PASS: chiral-pairs-split abs-sorted first-octant form still splits G+ chiral pairs
+PASS: seed-and-ridge-enter-clauses ν clauses, corridor-slide, ridge 3→3, and ridge-enter 2→3 cost 3; body last and non-ridge 3→3 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: b12-only every named type stays inside B_12(0)
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/ridge_enter_isochrone_types_b12_2026_08_15.py
+++ b/scripts/ridge_enter_isochrone_types_b12_2026_08_15.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Count G+ types on the t(2,2,2) and t(4,4,4) shells of the ridge-enter hop-cost.
+
+One origin Dijkstra on B_12(0). No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/RIDGE_ENTER_ISOCHRONE_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/RIDGE_ENTER_ISOCHRONE_TYPES_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Isochrone type counts of the t(2,2,2) and t(4,4,4) shells under "
+    "the named ridge-enter hop-cost on B_12(0) are reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T10_EXPECTED = (
+    ((2, 2, 2), 12, 8),
+    ((3, 1, 0), 10, 24),
+    ((3, 1, 2), 14, 24),
+    ((3, 2, 1), 14, 24),
+    ((3, 3, 0), 18, 12),
+    ((4, 2, 0), 20, 24),
+)
+T16_EXPECTED = (
+    ((4, 4, 4), 48, 8),
+    ((5, 3, 4), 50, 24),
+    ((5, 4, 3), 50, 24),
+    ((5, 5, 2), 54, 24),
+    ((6, 1, 1), 38, 24),
+    ((6, 1, 5), 62, 24),
+    ((6, 2, 4), 56, 24),
+    ((6, 3, 3), 54, 24),
+    ((6, 4, 2), 56, 24),
+    ((6, 5, 1), 62, 24),
+    ((6, 6, 0), 72, 12),
+    ((7, 1, 0), 50, 24),
+    ((7, 1, 4), 66, 24),
+    ((7, 2, 3), 62, 24),
+    ((7, 3, 2), 62, 24),
+    ((7, 4, 1), 66, 24),
+    ((7, 5, 0), 74, 24),
+    ((8, 1, 3), 74, 24),
+    ((8, 2, 2), 72, 24),
+    ((8, 3, 1), 74, 24),
+    ((8, 4, 0), 80, 24),
+    ((9, 1, 2), 86, 24),
+    ((9, 2, 1), 86, 24),
+    ((9, 3, 0), 90, 24),
+    ((10, 2, 0), 104, 24),
+)
+DIJKSTRA_CALLS = 0
+Point = tuple[int, int, int]
+Rotation = tuple[tuple[int, int, int], tuple[int, int, int]]
+
+
+def permutation_sign(permutation: tuple[int, int, int]) -> int:
+    inversions = sum(
+        permutation[i] > permutation[j]
+        for i in range(3)
+        for j in range(i + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+ROTATIONS: tuple[Rotation, ...] = tuple(
+    (permutation, signs)
+    for permutation in permutations((0, 1, 2))
+    for signs in product((-1, 1), repeat=3)
+    if permutation_sign(permutation) * signs[0] * signs[1] * signs[2] == 1
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def rotate_vector(rotation: Rotation, vector: Point) -> Point:
+    permutation, signs = rotation
+    result = [0, 0, 0]
+    for source_axis in range(3):
+        result[permutation[source_axis]] = signs[source_axis] * vector[source_axis]
+    return (result[0], result[1], result[2])
+
+
+def l1(v: Point) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: Point) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: Point) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_coord_count(v: Point) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def r2(v: Point) -> int:
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def is_body_diagonal(v: Point) -> bool:
+    return v != (0, 0, 0) and abs(v[0]) == abs(v[1]) == abs(v[2])
+
+
+def ball(radius: int) -> list[Point]:
+    sites: list[Point] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: Point, w: Point) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: Point, w: Point) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: Point, w: Point) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def kappa_cost(v: Point, w: Point) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 3 and unit_coord_count(w) == 2:
+        return 3
+    return 1
+
+
+def dijkstra_kappa(sites: list[Point]) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[Point, int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, Point]] = [(0, (0, 0, 0))]
+    seen: set[Point] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + kappa_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def gplus_orbit(point: Point) -> frozenset[Point]:
+    return frozenset(rotate_vector(rotation, point) for rotation in ROTATIONS)
+
+
+def representative(orbit: frozenset[Point]) -> Point:
+    octant = tuple(point for point in orbit if point[0] >= 0 and point[1] >= 0 and point[2] >= 0)
+    if not octant:
+        raise ValueError("G+ orbit has no first-octant representative")
+    return max(octant)
+
+
+def shell_types(
+    dist: dict[Point, int],
+    site_set: set[Point],
+    arrival: int,
+) -> tuple[list[Point], list[tuple[Point, int, int]], tuple[int, ...]]:
+    pts = [v for v, t in dist.items() if t == arrival and v != (0, 0, 0)]
+    consumed: set[Point] = set()
+    rows: list[tuple[Point, int, int]] = []
+    for site in pts:
+        if site in consumed:
+            continue
+        orbit = gplus_orbit(site)
+        if not orbit.issubset(site_set):
+            raise AssertionError(f"orbit of {site} leaves B_12(0)")
+        times = {dist[point] for point in orbit}
+        if times != {arrival}:
+            raise AssertionError(f"arrival not constant on orbit of {site}: {times}")
+        consumed.update(orbit)
+        rep = representative(orbit)
+        rows.append((rep, r2(rep), len(orbit)))
+    rows.sort()
+    if consumed != set(pts):
+        raise AssertionError("G+ orbits do not partition the shell")
+    radii = tuple(sorted({radius for _, radius, _ in rows}))
+    return pts, rows, radii
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the isochrone type-count statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the census is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "κ is not written into Admissibility",
+        "Do not write κ into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(12)
+    site_set = set(sites)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_kappa(sites)
+    t2 = dist[(2, 2, 2)]
+    t4 = dist[(4, 4, 4)]
+    t111 = dist[(1, 1, 1)]
+    t333 = dist[(3, 3, 3)]
+    t10_sites, t10_rows, t10_radii = shell_types(dist, site_set, t2)
+    t16_sites, t16_rows, t16_radii = shell_types(dist, site_set, t4)
+    t10_reps = {rep for rep, _, _ in t10_rows}
+    t16_reps = {rep for rep, _, _ in t16_rows}
+    ridge_enter = ((2, 1, 0), (2, 1, 1))
+    body_last = ((1, 1, 0), (1, 1, 1))
+    ridge_slide = ((1, 1, 1), (2, 1, 1))
+    interior_hop = ((2, 2, 2), (3, 2, 2))
+    body_t10 = [v for v in t10_sites if is_body_diagonal(v)]
+    body_types_t10 = {tuple(sorted(abs(c) for c in v)) for v in body_t10}
+    t10_mixed = len(t10_radii) > 1
+    t16_mixed = len(t16_radii) > 1
+
+    print(f"n_sites {len(sites)}")
+    print(f"t2 {t2} t4 {t4}")
+    print(f"t10_sites {len(t10_sites)} t10_types {len(t10_rows)} t10_n_r2 {len(t10_radii)}")
+    print(f"t16_sites {len(t16_sites)} t16_types {len(t16_rows)} t16_n_r2 {len(t16_radii)}")
+    print(f"t10_radii {list(t10_radii)}")
+    print(f"t16_radii {list(t16_radii)}")
+    print(f"t(2,2,2) {t2}")
+    print(f"t(4,4,4) {t4}")
+    print(f"t(1,1,1) {t111}")
+    print(f"t(3,3,3) {t333}")
+    print(f"has_222_in_t10 {(2, 2, 2) in t10_reps}")
+    print(f"has_444_in_t16 {(4, 4, 4) in t16_reps}")
+    print(f"body_t10 {len(body_t10)} body_types_t10 {sorted(body_types_t10)}")
+    print(f"t10_mixed {t10_mixed}")
+    print(f"t16_mixed {t16_mixed}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"kappa_enter {kappa_cost(*ridge_enter)}")
+    print(f"rho3_enter {rho3_cost(*ridge_enter)}")
+    print(f"kappa_body_last {kappa_cost(*body_last)}")
+    print(f"rho3_body_last {rho3_cost(*body_last)}")
+    print(f"kappa_ridge {kappa_cost(*ridge_slide)}")
+    print(f"rho3_ridge {rho3_cost(*ridge_slide)}")
+    print(f"kappa_interior {kappa_cost(*interior_hop)}")
+    print(f"rho3_interior {rho3_cost(*interior_hop)}")
+
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b12",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == 2625 and len(nonzero) == 2624 and all(l1(v) <= 12 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_12(0) is reached",
+        len(dist) == 2625,
+    )
+    checks.check(
+        "rotation-group",
+        "the proper cubic group used for types has 24 elements",
+        len(ROTATIONS) == 24 and len(set(ROTATIONS)) == 24,
+    )
+    checks.check(
+        "t10-counts",
+        "t=10 has 116 sites, 6 G+ types, and 5 distinct |v|_2^2",
+        t2 == 10
+        and len(t10_sites) == 116
+        and len(t10_rows) == 6
+        and len(t10_radii) == 5
+        and tuple(t10_rows) == T10_EXPECTED
+        and t10_radii == (10, 12, 14, 18, 20),
+    )
+    checks.check(
+        "t16-counts",
+        "t=16 has 572 sites, 25 G+ types, and 13 distinct |v|_2^2",
+        t4 == 16
+        and len(t16_sites) == 572
+        and len(t16_rows) == 25
+        and len(t16_radii) == 13
+        and tuple(t16_rows) == T16_EXPECTED
+        and t16_radii == (38, 48, 50, 54, 56, 62, 66, 72, 74, 80, 86, 90, 104),
+    )
+    checks.check(
+        "t-222-in-t10",
+        "(2,2,2) sits in the t=10 shell",
+        t2 == 10 and (2, 2, 2) in t10_reps and r2((2, 2, 2)) == 12,
+    )
+    checks.check(
+        "t-444-in-t16",
+        "(4,4,4) sits in the t=16 shell",
+        t4 == 16 and (4, 4, 4) in t16_reps and r2((4, 4, 4)) == 48,
+    )
+    checks.check(
+        "unique-body-diagonal",
+        "(2,2,2) is the unique body-diagonal type in its shell",
+        len(body_t10) == 8
+        and body_types_t10 == {(2, 2, 2)}
+        and (2, 2, 2) in t10_reps
+        and (1, 1, 1) not in t10_reps
+        and (3, 3, 3) not in t10_reps
+        and t111 == 5
+        and t333 == 13
+        and "unique" in note
+        and "body-diagonal" in note,
+    )
+    checks.check(
+        "shells-mixed",
+        "the t(2,2,2) and t(4,4,4) shells remain mixed",
+        t10_mixed and t16_mixed and "remain mixed" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "κ prices the ridge-enter 2→3 hop at 3 while ρ3 prices it at 1",
+        kappa_cost(*ridge_enter) == 3
+        and rho3_cost(*ridge_enter) == 1
+        and kappa_cost(*body_last) == 1
+        and rho3_cost(*body_last) == 1
+        and kappa_cost(*ridge_slide) == 3
+        and rho3_cost(*ridge_slide) == 3
+        and kappa_cost(*interior_hop) == 1
+        and rho3_cost(*interior_hop) == 1
+        and "cannot price the ridge enter" in note,
+    )
+    checks.check(
+        "note-records-counts",
+        "note records site, type, and radius counts for both shells",
+        "| `10` | `116` | `6` | `5` |" in note
+        and "| `16` | `572` | `25` | `13` |" in note,
+    )
+    checks.check(
+        "note-records-memberships",
+        "note records (2,2,2) in t=10 and (4,4,4) in t=16",
+        "t(2,2,2) = 10" in note
+        and "t(4,4,4) = 16" in note
+        and "(2,2,2)` is in" in note
+        and "(4,4,4)` is in" in note,
+    )
+    checks.check(
+        "chiral-pairs-split",
+        "abs-sorted first-octant form still splits G+ chiral pairs",
+        gplus_orbit((3, 1, 2)).isdisjoint(gplus_orbit((3, 2, 1)))
+        and gplus_orbit((5, 3, 4)).isdisjoint(gplus_orbit((5, 4, 3)))
+        and ((3, 1, 2), 14, 24) in t10_rows
+        and ((3, 2, 1), 14, 24) in t10_rows
+        and ((5, 3, 4), 50, 24) in t16_rows
+        and ((5, 4, 3), 50, 24) in t16_rows,
+    )
+    checks.check(
+        "seed-and-ridge-enter-clauses",
+        "ν clauses, corridor-slide, ridge 3→3, and ridge-enter 2→3 cost 3; body last and non-ridge 3→3 cost 1",
+        kappa_cost((0, 0, 0), (1, 0, 0)) == 3
+        and kappa_cost((1, 0, 0), (2, 0, 0)) == 3
+        and kappa_cost((1, 1, 0), (1, 0, 0)) == 3
+        and kappa_cost((1, 1, 0), (2, 1, 0)) == 3
+        and kappa_cost((1, 1, 1), (2, 1, 1)) == 3
+        and kappa_cost((2, 1, 0), (2, 1, 1)) == 3
+        and kappa_cost((1, 0, 0), (1, 1, 0)) == 1
+        and kappa_cost((1, 1, 0), (1, 1, 1)) == 1
+        and kappa_cost((2, 2, 0), (3, 2, 0)) == 1
+        and kappa_cost((2, 2, 2), (3, 2, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "κ(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+    checks.check(
+        "b12-only",
+        "every named type stays inside B_12(0)",
+        all(l1(rep) <= 12 for rep, _, _ in t10_rows)
+        and all(l1(rep) <= 12 for rep, _, _ in t16_rows)
+        and l1((4, 4, 4)) == 12
+        and "B_12(0) only" in note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Isochrone type counts of the t(2,2,2)=10 and t(4,4,4)=16 shells under named ridge-enter hop-cost κ on B_12(0). First display. Displayed, not adopted. Do not write κ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/ridge_enter_isochrone_types_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.