### PR TITLE
feat(ofk15): out-face same-k holds at k=15: t=31 vs t=49

### DIFF
--- a/docs/OUT_FACE_SAMEK_K15_B45_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OUT_FACE_SAMEK_K15_B45_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,198 @@
+---
+claim_id: out_face_samek_k15_b45_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=15 under the named out-face hop-cost on B_45(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/out_face_samek_k15_b45_2026_08_15.py
+---
+
+# Named Out-Face Same-k Reverse At k=15 On B_45(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_45(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=15`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/out_face_samek_k15_b45_2026_08_15.py`](../scripts/out_face_samek_k15_b45_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of same-`k` at `k=15` under the named out-face
+hop-cost `ω`. Mid-leave is empty on six-neighbor hops, so it agrees with
+the ridge-slide rule `ρ3` on that graph. The named rule `ω` is `ρ3` plus
+cost `3` on a `2→2` hop whose destination has strictly larger max
+absolute coordinate than the source (growing the box on a face). The same
+origin Dijkstra on `B_45(0)` keeps reverse at `k=1` and restores reverse
+at `k=14` (`30` versus `46`). The residual scored here is whether reverse
+still holds at `k=15` on `B_45(0)`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_45(0)`, the displayed
+rule `ω` is
+
+`ω(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|)`, else `1`,
+
+where `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly
+two `|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is the unit-height ridge slide. The sixth clause is the out-face
+`2→2` that grows the max absolute coordinate. Those six clauses are the
+whole rule.
+
+One Dijkstra from the origin on `B_45(0)` (125671 sites; 125670 nonzero) gives
+
+`t(15,0,0) = 31`, `t(15,15,15) = 49`.
+
+The displayed same-`k` comparison at `k=15` is
+
+`t(15,0,0)^2 / 225  ?  t(15,15,15)^2 / 675`,
+
+which is `961/225` versus `2401/675`, or equivalently `2883 > 2401`. The
+inequality holds. Same-`k` reverse at `k=15` under `ω` is yes.
+Independently, the new axis site is `t(45,0,0) = 67`. The shared axis
+site `t(42,0,0) = 58` is a `ω` score on this ball. The same table keeps
+`t(1,0,0) = 3` and `t(1,1,1) = 5`, and restores `t(14,0,0) = 30` versus
+`t(14,14,14) = 46`.
+
+The same-`k` pair under `ρ3` is not reused as a substitute for this table.
+The extra out-face clause is live on the ball. On the out-face hop
+`(2,2,0) → (3,2,0)` one has `|σ| : 2 → 2` and `max |w_i| = 3 > max |v_i| = 2`,
+while the least nonzero `|w_i|` is `2`, so `ρ3 = 1` while `ω = 3`.
+Therefore `ρ3` cannot price the out-face grow. The same hop is a `ω`
+cost-`3` step, and `t(3,2,0) = 11` under `ω`. The corridor hop
+`(1,1,0) → (2,1,0)` also grows the max absolute coordinate, but it is
+already `ρ3 = 3` by the hugging clause. A cheapest `ω` walk to
+`(15,15,15)` uses no out-face `2→2` grow, so the body arrival stays `49`.
+The site `(15,15,15)` has ℓ¹ norm `45`, so it is absent from `B_42(0)`.
+The `B_45(0)` table is therefore not leftover of the `B_42(0)` times.
+
+The rule is displayed, not adopted. Do not write `ω` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the unit-height ridge clause, the
+out-face grow clause, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_45(0) = { v ∈ Z^3 : |v|_1 ≤ 45 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_45(0)`,
+`t(v)` is the least sum of `ω` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses only the first five clauses of `ω`. On the
+out-face hop `(2,2,0) → (3,2,0)` one has `|σ| : 2 → 2` and a strictly
+larger dest max absolute coordinate, so `ρ3 = 1` while `ω = 3`. Therefore
+`ρ3` cannot price the out-face grow, and the `ω` scores below are not a
+leftover of `ρ3`. On the corridor hop `(1,1,0) → (2,1,0)` both `ρ3` and
+`ω` cost `3`. On the interior body hop `(15,15,1) → (15,15,2)` the hop
+is `3→3` with only one absolute coordinate equal to `1`, so both `ρ3`
+and `ω` cost `1`.
+
+## Theorem 1 — Arrivals `t(15,0,0)` And `t(15,15,15)` On `B_45(0)`
+
+One origin Dijkstra on `B_45(0)` returns the integer arrivals
+
+| site | `t_ω` |
+|---|---:|
+| `(15,0,0)` | `31` |
+| `(15,15,15)` | `49` |
+
+Every listed site lies in `B_45(0)`. The site `(15,15,15)` has ℓ¹ norm `45`,
+so it is absent from `B_42(0)`. The pair is computed on `B_45(0)`, not
+copied from a smaller-ball table and not copied from a `ρ3` table. These
+values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `31` is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, enter-body `1` onto `(1,1,1)`, ridge-slide
+`3` onto `(2,1,1)`, support-preserving cost-`1` hop onto `(2,2,1)`, thirteen
+support-preserving cost-`1` body hops to `(15,2,1)`, ridge-slide `3` onto
+`(15,1,1)`, support-drop `3` onto `(15,1,0)`, and support-drop `3` onto
+`(15,0,0)`, summing to `31`. That walk is a witness of cost `31`, not a
+uniqueness claim. The pure axis 1-skeleton walk costs `45` and is not
+cheapest.
+
+A witness body walk of cost `49` is the same prefix of cost `9` to
+`(2,2,1)`, thirteen cost-`1` body hops to `(15,2,1)`, thirteen cost-`1` body
+hops to `(15,15,1)`, and fourteen support-preserving cost-`1` body hops to
+`(15,15,15)`, summing to `49`. Those last hops have dest with only one
+absolute coordinate equal to `1`, or with all three coordinates large, so
+they are not unit-height ridges and are not out-face `2→2` grows. That
+walk is a witness of cost `49`, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=15`
+
+The Euclidean-normalized comparison at `k=15` is
+
+`t(15,0,0)^2 / 225  ?  t(15,15,15)^2 / 675`,
+
+equivalently `3 t(15,0,0)^2 ? t(15,15,15)^2`. Substituting the computed times
+gives `3 · 31^2 = 2883` and `49^2 = 2401`, so
+
+`2883 > 2401` is true; `2883 > 2401` holds.
+
+Arrival per Euclidean length is larger at `(15,0,0)` than at
+`(15,15,15)`. Same-`k` reverse at `k=15` under `ω` is yes. The comparison
+is displayed, not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ω` is a displayed scoring device on `B_45(0)`. Do not write `ω`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_45(0) for one named hop-cost at k=15. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_45(0) for the displayed rule ω at k=15; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ω` among hop-costs that reverse the same-`k` pair at `k=15`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_45(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=15`.
+- Any reuse of a `ρ3` arrival table as a substitute for the `ω` Dijkstra.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13561,6 +13561,10 @@
   "osterwalder_schrader_from_framework_narrow_theorem_note_2026-05-27": {
    "deps_hash": "37b34cf3d5e2",
    "out_degree": 3
+  },
+  "out_face_samek_k15_b45_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "overlapping_edge_instrument_order_and_time_rate_nonselection_bounded_theorem_note_2026-07-11": {
    "deps_hash": "0533a016df20",

--- a/logs/runner-cache/out_face_samek_k15_b45_2026_08_15.txt
+++ b/logs/runner-cache/out_face_samek_k15_b45_2026_08_15.txt
@@ -1,0 +1,68 @@
+===== runner cache v1 =====
+runner: scripts/out_face_samek_k15_b45_2026_08_15.py
+runner_sha256: 21d20f0719f75faa602f1f699027b7a570a143e0fa757053806ca0e680d57fbc
+input_fingerprint_sha256: 79eb0e865f502d933a00ae27bbf13a71eea3f61b66f3004e01d988a6b006c5a1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.02
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/OUT_FACE_SAMEK_K15_B45_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=15 under the named out-face hop-cost on B_45(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ω is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 125671
+t(15,0,0) 31
+t(15,15,15) 49
+t(15,0,0)^2/225 961/225
+t(15,15,15)^2/675 2401/675
+3t_axis^2 2883
+t_body^2 2401
+reverse True
+t(1,0,0) 3
+t(1,1,1) 5
+reverse_k1 True
+t(14,0,0) 30
+t(14,14,14) 46
+reverse_k14 True
+t(45,0,0) 67
+t(42,0,0) 58
+t(3,2,0) 11
+dijkstra_calls 1
+witness_omega_axis [3, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3]
+witness_omega_axis_sum 31
+witness_omega_body_sum 49
+omega_out_face 3
+rho3_out_face 1
+omega_corridor 3
+rho3_corridor 3
+omega_ridge 3
+rho3_ridge 3
+omega_interior_body 1
+rho3_interior_body 1
+PASS: t-15000-151515 t(15,0,0)=31 and t(15,15,15)=49
+PASS: reverse-k15 t(15,0,0)^2/225 > t(15,15,15)^2/675 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b45 B_45(0) has 125671 sites and 125670 nonzero sites
+PASS: reachable every site of B_45(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-rho3 ω prices the out-face hop at 3 while ρ3 prices it at 1
+PASS: not-leftover-of-b42 (15,15,15) lies outside B_42(0) and the note says so
+PASS: keeps-k1-and-restores-k14 the same Dijkstra keeps k=1 reverse and restores k=14 as 30 vs 46
+PASS: seed-and-out-face-clauses seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide, and out-face grow cost 3; other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/out_face_samek_k15_b45_2026_08_15.py
+++ b/scripts/out_face_samek_k15_b45_2026_08_15.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=15 under ω on B_45(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/OUT_FACE_SAMEK_K15_B45_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/OUT_FACE_SAMEK_K15_B45_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=15 under the named out-face hop-cost "
+    "on B_45(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 31
+T_BODY_REP = 49
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def unit_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def max_abs(v: tuple[int, int, int]) -> int:
+    return max(abs(v[0]), abs(v[1]), abs(v[2]))
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_count(w) == 2:
+        return 3
+    return 1
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and max_abs(w) > max_abs(v):
+        return 3
+    return 1
+
+
+def dijkstra_omega(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + omega_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ω is not written into Admissibility",
+        "Do not write `ω` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(45)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_omega(sites)
+    t15000 = dist[(15, 0, 0)]
+    t151515 = dist[(15, 15, 15)]
+    t4500 = dist[(45, 0, 0)]
+    t4200 = dist[(42, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    t100 = dist[(1, 0, 0)]
+    t111 = dist[(1, 1, 1)]
+    t14000 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    reverse = 3 * t15000 * t15000 > t151515 * t151515
+    reverse_k1 = 3 * t100 * t100 > t111 * t111
+    reverse_k14 = 3 * t14000 * t14000 > t141414 * t141414
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 16)],
+        (15, 1, 1),
+        (15, 1, 0),
+        (15, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 16)],
+        *[(15, y, 1) for y in range(3, 16)],
+        *[(15, 15, z) for z in range(2, 16)],
+    )
+    witness_omega_axis = [omega_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    witness_omega_body = [omega_cost(a, b) for a, b in zip(witness_body, witness_body[1:])]
+    out_face_hop = ((2, 2, 0), (3, 2, 0))
+    corridor_hop = ((1, 1, 0), (2, 1, 0))
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    interior_body_hop = ((15, 15, 1), (15, 15, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(15,0,0) {t15000}")
+    print(f"t(15,15,15) {t151515}")
+    print(f"t(15,0,0)^2/225 {t15000 * t15000}/225")
+    print(f"t(15,15,15)^2/675 {t151515 * t151515}/675")
+    print(f"3t_axis^2 {3 * t15000 * t15000}")
+    print(f"t_body^2 {t151515 * t151515}")
+    print(f"reverse {reverse}")
+    print(f"t(1,0,0) {t100}")
+    print(f"t(1,1,1) {t111}")
+    print(f"reverse_k1 {reverse_k1}")
+    print(f"t(14,0,0) {t14000}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"reverse_k14 {reverse_k14}")
+    print(f"t(45,0,0) {t4500}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(3,2,0) {t320}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_omega_axis {witness_omega_axis}")
+    print(f"witness_omega_axis_sum {sum(witness_omega_axis)}")
+    print(f"witness_omega_body_sum {sum(witness_omega_body)}")
+    print(f"omega_out_face {omega_cost(*out_face_hop)}")
+    print(f"rho3_out_face {rho3_cost(*out_face_hop)}")
+    print(f"omega_corridor {omega_cost(*corridor_hop)}")
+    print(f"rho3_corridor {rho3_cost(*corridor_hop)}")
+    print(f"omega_ridge {omega_cost(*ridge_hop)}")
+    print(f"rho3_ridge {rho3_cost(*ridge_hop)}")
+    print(f"omega_interior_body {omega_cost(*interior_body_hop)}")
+    print(f"rho3_interior_body {rho3_cost(*interior_body_hop)}")
+
+    checks.check(
+        "t-15000-151515",
+        f"t(15,0,0)={T_AXIS_REP} and t(15,15,15)={T_BODY_REP}",
+        t15000 == T_AXIS_REP and t151515 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k15",
+        "t(15,0,0)^2/225 > t(15,15,15)^2/675 holds",
+        reverse
+        and 3 * t15000 * t15000 == 2883
+        and t151515 * t151515 == 2401
+        and "2883 > 2401" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b45",
+        "B_45(0) has 125671 sites and 125670 nonzero sites",
+        len(sites) == 125671 and len(nonzero) == 125670 and all(l1(v) <= 45 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_45(0) is reached",
+        len(dist) == 125671,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`31`" in note
+        and "`49`" in note
+        and "`(15,0,0)`" in note
+        and "`(15,15,15)`" in note
+        and "t(15,0,0) = 31" in note
+        and "t(15,15,15) = 49" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2883 > 2401" in note and "961/225" in note and "2401/675" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "ω prices the out-face hop at 3 while ρ3 prices it at 1",
+        omega_cost(*out_face_hop) == 3
+        and rho3_cost(*out_face_hop) == 1
+        and omega_cost(*corridor_hop) == 3
+        and rho3_cost(*corridor_hop) == 3
+        and sum(witness_omega_axis) == 31
+        and sum(witness_omega_body) == 49
+        and t15000 == 31
+        and t151515 == 49
+        and t320 == 11
+        and "cannot price the out-face" in note
+        and "`t(3,2,0) = 11`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b42",
+        "(15,15,15) lies outside B_42(0) and the note says so",
+        l1((15, 15, 15)) == 45
+        and (15, 15, 15) in dist
+        and t4500 == 67
+        and t4200 == 58
+        and "absent from `B_42(0)`" in note
+        and "not leftover of the `B_42(0)` times" in note,
+    )
+    checks.check(
+        "keeps-k1-and-restores-k14",
+        "the same Dijkstra keeps k=1 reverse and restores k=14 as 30 vs 46",
+        t100 == 3
+        and t111 == 5
+        and reverse_k1
+        and t14000 == 30
+        and t141414 == 46
+        and reverse_k14
+        and "keeps reverse at `k=1`" in note
+        and "`30` versus `46`" in note,
+    )
+    checks.check(
+        "seed-and-out-face-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide, and out-face grow cost 3; other hops cost 1",
+        omega_cost((0, 0, 0), (1, 0, 0)) == 3
+        and omega_cost((1, 0, 0), (2, 0, 0)) == 3
+        and omega_cost((1, 1, 0), (1, 0, 0)) == 3
+        and omega_cost((1, 1, 0), (2, 1, 0)) == 3
+        and omega_cost((1, 1, 1), (2, 1, 1)) == 3
+        and omega_cost((2, 2, 0), (3, 2, 0)) == 3
+        and omega_cost((1, 0, 0), (1, 1, 0)) == 1
+        and omega_cost((1, 1, 0), (1, 1, 1)) == 1
+        and omega_cost((2, 2, 1), (3, 2, 1)) == 1
+        and omega_cost(*interior_body_hop) == 1
+        and omega_cost((15, 15, 14), (15, 15, 15)) == 1
+        and omega_cost((15, 2, 0), (15, 3, 0)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ω(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named out-face hop-cost ω holds at k=15 on B_45(0): t(15,0,0)=31 vs t(15,15,15)=49 (2883>2401). First display. Displayed, not adopted. Do not write ω into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/out_face_samek_k15_b45_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.