### PR TITLE
feat(ofk19): out-face same-k first-fails at k=19: t=35 vs t=61

### DIFF
--- a/docs/OUT_FACE_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OUT_FACE_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,179 @@
+---
+claim_id: out_face_samek_k19_b57_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=19 under the named out-face hop-cost on B_57(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/out_face_samek_k19_b57_2026_08_15.py
+---
+
+# Named Out-Face Same-`k` Reverse At `k=19` On `B_57(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_57(0)`,
+scored only for the same-`k` pair `t(19,0,0)` versus `t(19,19,19)`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/out_face_samek_k19_b57_2026_08_15.py`](../scripts/out_face_samek_k19_b57_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_57(0)`, the stacked
+rules `ν`, `μ`, and `ρ3` are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+`|w_i|` equals `1)`, else `1`;
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The displayed out-face rule `ω` is `ρ3` plus cost `3` on a `2→2` hop whose
+destination has a larger max absolute coordinate than the source:
+
+`ω(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|)`, else `1`.
+
+Those clauses are the whole rule. Uniqueness is not claimed. This note is
+the first display of same-`k` reverse at `k=19` under `ω`.
+
+A mid-leave clause that would cost `3` on a `1→2` hop with destination max
+absolute coordinate `1` and source max at least `2` cannot fire on the
+six-neighbor graph: a cubic step never realizes both of those max conditions
+together with `|σ_v|=1` and `|σ_w|=2`. The out-face hop
+`(1,1,0) → (2,1,0)` does fire: `|σ|=2→2` and `max |w_i|=2 > max |v_i|=1`,
+so `ω=3`. Independently, `ω` is not leftover of `ρ3`: the interior
+face-growth hop `(2,2,0) → (3,2,0)` has `ρ3=1` and `ω=3`.
+
+One Dijkstra from the origin on `B_57(0)` (253575 sites; 253574 nonzero)
+returns
+
+| site | `t_ω` |
+|---|---:|
+| `(19,0,0)` | `35` |
+| `(19,19,19)` | `61` |
+
+The same-`k` comparison at `k=19` is
+
+`t(19,0,0)^2 / 361  ?  t(19,19,19)^2 / 1083`,
+
+equivalently `3 t(19,0,0)^2 ? t(19,19,19)^2`. Substituting the computed times
+gives `3675 < 3721`. Same-`k` reverse at `k=19` is no.
+
+The site `(19,19,19)` has ℓ¹ norm `57`, so it is absent from `B_54(0)`.
+The `B_57(0)` table is therefore not leftover of the `B_54(0)` times.
+Independently, the new axis site is `t(57,0,0) = 79`. The shared axis site
+`t(54,0,0) = 70` is an `ω` score on this ball.
+
+The rule is displayed, not adopted. Do not write `ω` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size and
+max-coordinate clauses, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_57(0) = { v ∈ Z^3 : |v|_1 ≤ 57 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_57(0)`,
+`t(v)` is the least sum of `ω` along a directed path from `0` to `v` in
+that graph.
+
+The first `ν` clause is seed-exit. The second is both weights `1`. The third
+is support drop. The `μ` addendum taxes a `2→2` hop whose destination still
+touches a unit coordinate. The `ρ3` addendum taxes a `3→3` hop whose
+destination has exactly two unit coordinates. The `ω` addendum taxes a
+`2→2` hop that grows the coordinate box on a face.
+
+The site `(19,0,0)` has ℓ¹ norm `19` and therefore also lies in `B_54(0)`.
+The site `(19,19,19)` has ℓ¹ norm `57`, so it is absent from `B_54(0)`. The
+`B_57(0)` table is therefore not leftover of the `B_54(0)` times.
+
+## Theorem 1 — Arrivals At `k=19` Under `ω`
+
+One origin Dijkstra on `B_57(0)` returns `t(19,0,0) = 35` and
+`t(19,19,19) = 61`. Both sites lie in `B_57(0)`. The site `(19,19,19)` has
+ℓ¹ norm `57`, so it is absent from `B_54(0)`. The pair is computed on
+`B_57(0)`, not copied from a smaller-ball table. These values are Dijkstra
+outputs, not fitted scalars.
+
+A witness axis walk of cost `35` is seed-exit `3` onto `(1,0,0)`, leave-axis
+`1` onto `(1,1,0)`, enter-body `1` onto `(1,1,1)`, ridge-slide `3` onto
+`(1,2,1)`, eighteen support-preserving cost-`1` body hops to `(19,2,1)`,
+support-drop `3` onto `(19,2,0)`, corridor-slide `3` onto `(19,1,0)`, and
+support-drop `3` onto `(19,0,0)`, summing to `35`. That walk is a witness of
+cost `35`, not a uniqueness claim.
+
+A witness body walk of cost `61` is seed-exit `3` onto `(1,0,0)`, leave-axis
+`1` onto `(1,1,0)`, corridor-slide `3` onto `(1,2,0)`, non-hugging face hop
+`1` onto `(2,2,0)`, enter-body `1` onto `(2,2,1)`, eighteen support-preserving
+cost-`1` body hops to `(2,2,19)`, seventeen cost-`1` body hops to `(2,19,19)`,
+and seventeen cost-`1` body hops to `(19,19,19)`, summing to `61`. That walk
+is a witness of cost `61`, not a uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Pair `k=19`
+
+The Euclidean-normalized comparison at `k=19` is
+
+`t(19,0,0)^2 / 361  ?  t(19,19,19)^2 / 1083`.
+
+The computed integers give `3 · 35^2 = 3675` and `61^2 = 3721`, so
+`3675 < 3721`. Arrival per Euclidean length is larger at `(19,19,19)` than at
+`(19,0,0)`. Same-`k` reverse at `k=19` under `ω` is no. The comparison
+is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ω` is a displayed scoring device on `B_57(0)`. Do not write `ω`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_57(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_57(0) for the displayed rule ω at k=19; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ω` among hop-costs that reverse any same-`k` pair.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_57(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=19`.
+- Any reuse of a smaller-ball arrival table as a substitute for the
+  radius-`57` Dijkstra.
+- Any adoption of `ω` as an admissibility rule.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13561,6 +13561,10 @@
   "osterwalder_schrader_from_framework_narrow_theorem_note_2026-05-27": {
    "deps_hash": "37b34cf3d5e2",
    "out_degree": 3
+  },
+  "out_face_samek_k19_b57_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "overlapping_edge_instrument_order_and_time_rate_nonselection_bounded_theorem_note_2026-07-11": {
    "deps_hash": "0533a016df20",

--- a/logs/runner-cache/out_face_samek_k19_b57_2026_08_15.txt
+++ b/logs/runner-cache/out_face_samek_k19_b57_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/out_face_samek_k19_b57_2026_08_15.py
+runner_sha256: 8eefd92a9c2821230008ee0a12dcd45f5c6d90bd433e0da4a351095bcc6dd3be
+input_fingerprint_sha256: fa516da69023324ddb0defc30dcfd608fd0141b97962d941976843cabc4ccf09
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 2.64
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/OUT_FACE_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=19 under the named out-face hop-cost on B_57(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ω is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+PASS: cache-false the note records cache_write false
+n_sites 253575
+t(19,0,0) 35
+t(19,19,19) 61
+t(19,0,0)^2/361 1225/361
+t(19,19,19)^2/1083 3721/1083
+3 t(19,0,0)^2 3675
+t(19,19,19)^2 3721
+reverse False
+t(57,0,0) 79
+t(54,0,0) 70
+dijkstra_calls 1
+PASS: theorem-1 t(19,0,0)=35 and t(19,19,19)=61
+PASS: reverse-k19 t(19,0,0)^2 / 361 > t(19,19,19)^2 / 1083 is false
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b57 B_57(0) has 253575 sites and 253574 nonzero sites
+PASS: reachable every site of B_57(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-product note records the integer reverse comparison
+PASS: out-face-hop the named out-face hop (1,1,0)->(2,1,0) has ω=3
+PASS: mid-leave-cannot-fire mid-leave dest-max=1 and source-max>=2 never both hold on 6-NN
+PASS: omega-not-leftover-of-rho3 face-growth (2,2,0)->(3,2,0) is ω=3 and ρ3=1
+PASS: not-leftover-of-b54 (19,19,19) lies outside B_54(0) and the note says so
+PASS: witness-arrivals named axis and body walks realize costs 35 and 61
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/out_face_samek_k19_b57_2026_08_15.py
+++ b/scripts/out_face_samek_k19_b57_2026_08_15.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=19 under ω on B_57(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/OUT_FACE_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/OUT_FACE_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=19 under the named out-face hop-cost "
+    "on B_57(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero = [abs(coord) for coord in w if coord != 0]
+        if nonzero and min(nonzero) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        if sum(abs(coord) == 1 for coord in w) == 2:
+            return 3
+    return 1
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        if max(abs(coord) for coord in w) > max(abs(coord) for coord in v):
+            return 3
+    return 1
+
+
+def mid_leave_would_fire(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 1
+        and support_size(w) == 2
+        and max(abs(coord) for coord in w) == 1
+        and max(abs(coord) for coord in v) >= 2
+    )
+
+
+def path_cost(path: list[tuple[int, int, int]]) -> int:
+    return sum(omega_cost(a, b) for a, b in zip(path, path[1:]))
+
+
+def dijkstra_omega(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + omega_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ω is not written into Admissibility",
+        "Do not write `ω` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "cache-false",
+        "the note records cache_write false",
+        "cache_write: false" in note,
+    )
+
+    sites = ball(57)
+    site_set = set(sites)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_omega(sites)
+    t1900 = dist[(19, 0, 0)]
+    t191919 = dist[(19, 19, 19)]
+    t5700 = dist[(57, 0, 0)]
+    t5400 = dist[(54, 0, 0)]
+    reverse = 3 * t1900 * t1900 > t191919 * t191919
+    print(f"n_sites {len(sites)}")
+    print(f"t(19,0,0) {t1900}")
+    print(f"t(19,19,19) {t191919}")
+    print(f"t(19,0,0)^2/361 {t1900 * t1900}/361")
+    print(f"t(19,19,19)^2/1083 {t191919 * t191919}/1083")
+    print(f"3 t(19,0,0)^2 {3 * t1900 * t1900}")
+    print(f"t(19,19,19)^2 {t191919 * t191919}")
+    print(f"reverse {reverse}")
+    print(f"t(57,0,0) {t5700}")
+    print(f"t(54,0,0) {t5400}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    mid_leave_hits = 0
+    for v in sites:
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w in site_set and mid_leave_would_fire(v, w):
+                mid_leave_hits += 1
+
+    axis_witness = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 2, 1)]
+    axis_witness.extend((x, 2, 1) for x in range(2, 20))
+    axis_witness.extend([(19, 2, 0), (19, 1, 0), (19, 0, 0)])
+    body_witness = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 2, 0), (2, 2, 0), (2, 2, 1)]
+    body_witness.extend((2, 2, z) for z in range(2, 20))
+    body_witness.extend((2, y, 19) for y in range(3, 20))
+    body_witness.extend((x, 19, 19) for x in range(3, 20))
+
+    checks.check(
+        "theorem-1",
+        f"t(19,0,0)={t1900} and t(19,19,19)={t191919}",
+        t1900 == 35 and t191919 == 61,
+    )
+    checks.check(
+        "reverse-k19",
+        "t(19,0,0)^2 / 361 > t(19,19,19)^2 / 1083 is false",
+        (not reverse)
+        and 3 * t1900 * t1900 == 3675
+        and t191919 * t191919 == 3721
+        and "3675 < 3721" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b57",
+        "B_57(0) has 253575 sites and 253574 nonzero sites",
+        len(sites) == 253575 and len(nonzero) == 253574 and all(l1(v) <= 57 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_57(0) is reached",
+        len(dist) == 253575,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`(19,0,0)`" in note and "`(19,19,19)`" in note and "`35`" in note and "`61`" in note,
+    )
+    checks.check(
+        "note-records-reverse-product",
+        "note records the integer reverse comparison",
+        "3675 < 3721" in note,
+    )
+    checks.check(
+        "out-face-hop",
+        "the named out-face hop (1,1,0)->(2,1,0) has ω=3",
+        omega_cost((1, 1, 0), (2, 1, 0)) == 3
+        and support_size((1, 1, 0)) == 2
+        and support_size((2, 1, 0)) == 2
+        and max(abs(c) for c in (2, 1, 0)) > max(abs(c) for c in (1, 1, 0))
+        and "(1,1,0) → (2,1,0)" in note,
+    )
+    checks.check(
+        "mid-leave-cannot-fire",
+        "mid-leave dest-max=1 and source-max>=2 never both hold on 6-NN",
+        mid_leave_hits == 0 and "cannot fire" in note,
+    )
+    checks.check(
+        "omega-not-leftover-of-rho3",
+        "face-growth (2,2,0)->(3,2,0) is ω=3 and ρ3=1",
+        omega_cost((2, 2, 0), (3, 2, 0)) == 3
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and "(2,2,0) → (3,2,0)" in note,
+    )
+    checks.check(
+        "not-leftover-of-b54",
+        "(19,19,19) lies outside B_54(0) and the note says so",
+        l1((19, 19, 19)) == 57
+        and (19, 19, 19) in dist
+        and t5700 == 79
+        and t5400 == 70
+        and "absent from `B_54(0)`" in note
+        and "not leftover of the `B_54(0)` times" in note,
+    )
+    checks.check(
+        "witness-arrivals",
+        "named axis and body walks realize costs 35 and 61",
+        path_cost(axis_witness) == 35
+        and path_cost(body_witness) == 61
+        and axis_witness[-1] == (19, 0, 0)
+        and body_witness[-1] == (19, 19, 19)
+        and all(l1(v) <= 57 for v in axis_witness)
+        and all(l1(v) <= 57 for v in body_witness),
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        omega_cost((0, 0, 0), (1, 0, 0)) == 3
+        and omega_cost((1, 0, 0), (2, 0, 0)) == 3
+        and omega_cost((1, 0, 0), (1, 1, 0)) == 1
+        and omega_cost((1, 1, 0), (1, 1, 1)) == 1
+        and omega_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ω(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named out-face hop-cost ω first-fails at k=19 on B_57(0): t(19,0,0)=35 vs t(19,19,19)=61 (3675<3721). Held through k=18. Displayed, not adopted. Do not spec ofk20 (test 19). Do not write ω into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/out_face_samek_k19_b57_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.