### PR TITLE
feat(dfk1): deep-out-face same-k holds at k=1: t=3 vs t=5

### DIFF
--- a/docs/DEEP_OUT_FACE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/DEEP_OUT_FACE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,213 @@
+---
+claim_id: deep_out_face_samek_k1_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=1 under the named deep-out-face hop-cost on B_6(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/deep_out_face_samek_k1_b6_2026_08_15.py
+---
+
+# Same-k Reverse At k=1 Under The Named Deep-Out-Face Hop-Cost On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival comparison at k=1 on the finite nearest-neighbor
+graph `B_6(0)`, under a named hop-cost displayed for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/deep_out_face_samek_k1_b6_2026_08_15.py`](../scripts/deep_out_face_samek_k1_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named deep-out-face hop-cost `df` is the
+first display of `df`. The parent clauses `ν`, `μ`, and `ρ3` are those of
+the ridge-slide same-k scoring on this ball:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `df(v→w) = 3` if `ρ3` would be `3` or (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 2`), else `1`.
+
+The extra clause is a deep-out-face hop: support stays `2`, the destination
+max absolute coordinate grows, and the source max is already at least `2`.
+It fires on `(2,2,0) → (3,2,0)`. It does not fire on the unit-out-face hop
+`(1,1,0) → (2,1,0)`, whose source max is `1`. That unit-out hop remains
+priced at `3` by corridor-slide `μ`, which is already inside `ρ3`. The
+out-face rule that prices every growing-max `2→2` hop, including the unit
+source, is not the displayed rule. Uniqueness is not claimed.
+
+The finite host is scored independently: one origin Dijkstra is run on this
+ball. The ball is not leftover of a larger-ball table.
+
+```text
+B_6(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 6 }.
+```
+
+It has 377 sites. Edges are the cubic nearest-neighbor steps that remain
+inside `B_6(0)`. One Dijkstra from the origin yields
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+```
+
+The same-k comparison at k=1 is
+
+```text
+t(1,0,0)^2 / 1 = 9 > 25/3 = t(1,1,1)^2 / 3.
+```
+
+Equivalently `27 > 25`. The inequality holds. Same-k reverse holds at k=1.
+Displayed, not adopted.
+
+The extra `2→2` clause is live on this host. The hop `(2,2,0) → (3,2,0)` has
+`df=3` and `ρ3=1`, and both ends lie in `B_6(0)`. Therefore `ρ3` cannot
+price the deep-out-face hop. The displayed body last hop `(1,1,0) → (1,1,1)`
+keeps cost `1`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_6(0) reports t(1,0,0) and t(1,1,1) under the named deep-out-face hop-cost and scores the k=1 same-k comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: deep_out_face_samek_k1_b6
+target_blocker_text: "whether same-k reverse at k=1 still holds after deep-out-face 2-to-2 hops are priced at 3"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_6(0) under the named hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `df` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_6(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`, and
+  `df` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `df` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_6(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`df` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`df`, using one Dijkstra on `B_6(0)`.
+
+An explicit axis path is the single hop `(0,0,0) → (1,0,0)` of cost `3`.
+An explicit body path is
+
+```text
+(0,0,0) → (1,0,0) → (1,1,0) → (1,1,1)
+```
+
+with costs `3+1+1=5`. Every path has first hop cost `3`, and every hop costs
+at least `1`, so these paths are optimal once Dijkstra matches them.
+
+On the deep-out hop `(2,2,0) → (3,2,0)` one has `|σ_v|=|σ_w|=2`, dest max
+`3` greater than source max `2`, and source max already `2`, so `ρ3 = 1`
+while `df = 3`. On the unit-out hop `(1,1,0) → (2,1,0)` the extra clause is
+idle because the source max is `1`; corridor-slide already prices that hop
+at `3`. On the body hop `(1,0,0) → (1,1,0)` both `ρ3` and `df` cost `1`.
+On the interior `3→3` hop `(2,2,2) → (3,2,2)` the destination has no unit
+coordinate, so both `ρ3` and `df` cost `1`.
+
+## Theorem 1 — Arrival times at k=1
+
+Under `df` on `B_6(0)`,
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+```
+
+The runner computes both values from the single origin Dijkstra and checks
+them against the explicit paths above. These values are Dijkstra outputs,
+not fitted scalars.
+
+## Theorem 2 — Same-k comparison at k=1
+
+The displayed comparison is whether
+
+```text
+t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3.
+```
+
+Substituting the computed times gives the integer statement `9 > 25/3`, or
+equivalently `27 > 25`. The inequality holds. Displayed, not adopted.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write df into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `df`, `ρ3`, `μ`, or `ν`. This note
+proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at two sites; it is not an attachment of a
+coordinate-sum hop-cost.
+
+## What This Does Not Claim
+
+- No uniqueness claim is made for this named hop-cost at k=1.
+- The live `2→2` clause on `B_6(0)` is not a statement about larger hosts.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_6(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(1,0,0)` and `t(1,1,1)`,
+checks the integer form of Theorem 2, checks that the extra `2→2` clause is
+live on in-host hops at cost `3` and skips the unit-out hop as a new tax,
+checks that the live Admissibility wording does not name `df`, and
+records the import boundary. Declared review inputs are this note and the
+axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3069,6 +3069,10 @@
   "decoherence_failure_analysis": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "deep_out_face_samek_k1_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "delta_magnitude_reduces_to_massless_gravity_scale_narrow_theorem_note_2026-06-06": {
    "deps_hash": "a38ede67de87",

--- a/logs/runner-cache/deep_out_face_samek_k1_b6_2026_08_15.txt
+++ b/logs/runner-cache/deep_out_face_samek_k1_b6_2026_08_15.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/deep_out_face_samek_k1_b6_2026_08_15.py
+runner_sha256: b4bbfaae037d2550eb0cde04e32ebca69e6752a78c34c9e29b19211c339e1d55
+input_fingerprint_sha256: c985ad2ca681c8669ecab1ae94022ac9bf22124ac3c1f330074896dd43def6a5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/DEEP_OUT_FACE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=1 under the named deep-out-face hop-cost on B_6(0) is reported. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_6(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+claim_boundary: same-k reverse at k=1 is displayed, not adopted
+n_sites 377
+t(1,0,0) = 3
+t(1,1,1) = 5
+same-k comparison: 3^2 / 1 = 9 versus 5^2 / 3 = 25/3; reverse=True
+3 t(1,0,0)^2 = 27
+t(1,1,1)^2 = 25
+dijkstra_calls 1
+df_unit_out 3 rho3_unit_out 3 df_extra_unit_out 0 omega_extra_unit_out 1
+df_deep_out 3 rho3_deep_out 1 df_extra_deep_out 1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_6(0) is the 377-site integer set with coordinate-sum at most 6
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: reachable every site of B_6(0) is reached
+PASS: hop-origin the unique origin hop has named cost 3
+PASS: hop-axis-axis a same-support axis hop has named cost 3
+PASS: hop-support-rise the displayed body path keeps cost 1 on the 1-to-2 and 2-to-3 hops
+PASS: hop-unit-out-skipped the extra clause skips (1,1,0) to (2,1,0); rho3 already prices that hop
+PASS: hop-deep-out-clause the named 2-to-2 growing-max clause with source max at least 2 prices (2,2,0) to (3,2,0)
+PASS: deep-out-live-on-ball nearest-neighbor hops inside B_6(0) trigger the extra 2-to-2 clause
+PASS: df-clauses seed-exit, axis, drop, corridor-slide, ridge-slide, and deep-out cost 3; unit-out extra is idle; 1-to-2 and small 2-to-3 cost 1
+PASS: thm1-axis-time t(1,0,0) equals the computed origin-to-axis arrival time
+PASS: thm1-body-time t(1,1,1) equals the computed origin-to-body arrival time
+PASS: thm2-reverse-holds t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3 holds on the computed times
+PASS: thm1-note-reports-times the note reports the computed arrival times
+PASS: thm2-note-reports-comparison the note reports the integer same-k comparison and does not adopt it
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name df
+PASS: thm3-no-l1-attachment the note refuses to attach L1 and does not score a unit hop-cost
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-claimed the note does not claim uniqueness of the named hop-cost
+PASS: scope-boundary the theorem stays on B_6(0) and proposes no axiom edit
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.
+per_site: arrival times are reported only at (1,0,0) and (1,1,1).
+lattice_wide: checked and not executed — the search stays inside B_6(0).
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/deep_out_face_samek_k1_b6_2026_08_15.py
+++ b/scripts/deep_out_face_samek_k1_b6_2026_08_15.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Same-k reverse at k=1 under the named deep-out-face hop-cost on B_6(0).
+
+One Dijkstra from the origin on the finite nearest-neighbor graph. The
+deep-out-face hop-cost is displayed, not adopted, and is not written into
+Admissibility. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "DEEP_OUT_FACE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/DEEP_OUT_FACE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Same-k reverse at k=1 under the named deep-out-face "
+    "hop-cost on B_6(0) is reported. Displayed, not adopted."
+)
+
+RADIUS = 6
+AXIS = (1, 0, 0)
+BODY = (1, 1, 1)
+FACE = (1, 1, 0)
+UNIT_OUT = (2, 1, 0)
+DEEP_OUT_SRC = (2, 2, 0)
+DEEP_OUT_DST = (3, 2, 0)
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def support_size(site: Site) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def unit_coord_count(site: Site) -> int:
+    return sum(1 for coordinate in site if abs(coordinate) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball_sites(radius: int) -> frozenset[Site]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def omega_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+    )
+
+
+def df_extra(source: Site, dest: Site) -> bool:
+    return omega_extra(source, dest) and max_abs(source) >= 2
+
+
+def df_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3 or df_extra(source, dest):
+        return 3
+    return 1
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, sites: frozenset[Site], origin: Site) -> dict[Site, int]:
+        self.calls += 1
+        infinity = 10**9
+        dist = {site: infinity for site in sites}
+        dist[origin] = 0
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if cost != dist[site]:
+                continue
+            for step in STEPS:
+                neighbor = add(site, step)
+                if neighbor not in dist:
+                    continue
+                candidate = cost + df_cost(site, neighbor)
+                if candidate < dist[neighbor]:
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_6(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+    print(
+        "claim_boundary: same-k reverse at k=1 is displayed, not adopted"
+    )
+
+    sites = ball_sites(RADIUS)
+    origin = (0, 0, 0)
+    counter = DijkstraCounter()
+    dist = counter.distances(sites, origin)
+    t_axis = dist[AXIS]
+    t_body = dist[BODY]
+    reverse = 3 * t_axis * t_axis > t_body * t_body
+    axis_sq = t_axis * t_axis
+    body_sq = t_body * t_body
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(1,0,0) = {t_axis}")
+    print(f"t(1,1,1) = {t_body}")
+    print(
+        f"same-k comparison: {t_axis}^2 / 1 = {axis_sq} versus "
+        f"{t_body}^2 / 3 = {body_sq}/3; reverse={reverse}"
+    )
+    print(f"3 t(1,0,0)^2 = {3 * axis_sq}")
+    print(f"t(1,1,1)^2 = {body_sq}")
+    print(f"dijkstra_calls {counter.calls}")
+    print(
+        f"df_unit_out {df_cost(FACE, UNIT_OUT)} "
+        f"rho3_unit_out {rho3_cost(FACE, UNIT_OUT)} "
+        f"df_extra_unit_out {int(df_extra(FACE, UNIT_OUT))} "
+        f"omega_extra_unit_out {int(omega_extra(FACE, UNIT_OUT))}"
+    )
+    print(
+        f"df_deep_out {df_cost(DEEP_OUT_SRC, DEEP_OUT_DST)} "
+        f"rho3_deep_out {rho3_cost(DEEP_OUT_SRC, DEEP_OUT_DST)} "
+        f"df_extra_deep_out {int(df_extra(DEEP_OUT_SRC, DEEP_OUT_DST))}"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/DEEP_OUT_FACE_SAMEK_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_6(0) is the 377-site integer set with coordinate-sum at most 6",
+        len(sites) == 377 and origin in sites and AXIS in sites and BODY in sites,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1 and "DijkstraCounter" in self_source,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached",
+        all(dist[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "hop-origin",
+        "the unique origin hop has named cost 3",
+        df_cost(origin, AXIS) == 3 and nu_cost(origin, AXIS) == 3,
+    )
+    checks.check(
+        "hop-axis-axis",
+        "a same-support axis hop has named cost 3",
+        df_cost(AXIS, (2, 0, 0)) == 3,
+    )
+    checks.check(
+        "hop-support-rise",
+        "the displayed body path keeps cost 1 on the 1-to-2 and 2-to-3 hops",
+        df_cost(AXIS, FACE) == 1 and df_cost(FACE, BODY) == 1,
+    )
+    checks.check(
+        "hop-unit-out-skipped",
+        "the extra clause skips (1,1,0) to (2,1,0); rho3 already prices that hop",
+        not df_extra(FACE, UNIT_OUT)
+        and omega_extra(FACE, UNIT_OUT)
+        and max_abs(FACE) == 1
+        and rho3_cost(FACE, UNIT_OUT) == 3
+        and df_cost(FACE, UNIT_OUT) == 3
+        and FACE in sites
+        and UNIT_OUT in sites,
+    )
+    checks.check(
+        "hop-deep-out-clause",
+        "the named 2-to-2 growing-max clause with source max at least 2 prices (2,2,0) to (3,2,0)",
+        df_extra(DEEP_OUT_SRC, DEEP_OUT_DST)
+        and rho3_cost(DEEP_OUT_SRC, DEEP_OUT_DST) == 1
+        and df_cost(DEEP_OUT_SRC, DEEP_OUT_DST) == 3
+        and max_abs(DEEP_OUT_SRC) >= 2
+        and max_abs(DEEP_OUT_DST) > max_abs(DEEP_OUT_SRC)
+        and DEEP_OUT_SRC in sites
+        and DEEP_OUT_DST in sites,
+    )
+    in_ball_new = 0
+    for site in sites:
+        for step in STEPS:
+            neighbor = add(site, step)
+            if neighbor not in sites:
+                continue
+            if df_extra(site, neighbor) and rho3_cost(site, neighbor) == 1:
+                in_ball_new += 1
+    checks.check(
+        "deep-out-live-on-ball",
+        "nearest-neighbor hops inside B_6(0) trigger the extra 2-to-2 clause",
+        in_ball_new > 0,
+    )
+    checks.check(
+        "df-clauses",
+        "seed-exit, axis, drop, corridor-slide, ridge-slide, and deep-out cost 3; unit-out extra is idle; 1-to-2 and small 2-to-3 cost 1",
+        df_cost((0, 0, 0), (1, 0, 0)) == 3
+        and df_cost((1, 0, 0), (2, 0, 0)) == 3
+        and df_cost((1, 1, 0), (1, 0, 0)) == 3
+        and df_cost((1, 1, 0), (2, 1, 0)) == 3
+        and df_cost((1, 1, 1), (2, 1, 1)) == 3
+        and df_cost((2, 2, 0), (3, 2, 0)) == 3
+        and df_cost((1, 0, 0), (1, 1, 0)) == 1
+        and df_cost((1, 1, 0), (1, 1, 1)) == 1
+        and df_cost((2, 2, 2), (3, 2, 2)) == 1
+        and not df_extra((1, 1, 0), (2, 1, 0)),
+    )
+    axis_path_cost = df_cost(origin, AXIS)
+    body_path_cost = (
+        df_cost(origin, AXIS)
+        + df_cost(AXIS, FACE)
+        + df_cost(FACE, BODY)
+    )
+    checks.check(
+        "thm1-axis-time",
+        "t(1,0,0) equals the computed origin-to-axis arrival time",
+        t_axis == axis_path_cost and t_axis > 0,
+    )
+    checks.check(
+        "thm1-body-time",
+        "t(1,1,1) equals the computed origin-to-body arrival time",
+        t_body == body_path_cost and t_body > 0,
+    )
+    checks.check(
+        "thm2-reverse-holds",
+        "t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3 holds on the computed times",
+        reverse and 3 * t_axis * t_axis > t_body * t_body,
+    )
+    checks.check(
+        "thm1-note-reports-times",
+        "the note reports the computed arrival times",
+        f"t(1,0,0) = {t_axis}" in note and f"t(1,1,1) = {t_body}" in note,
+    )
+    checks.check(
+        "thm2-note-reports-comparison",
+        "the note reports the integer same-k comparison and does not adopt it",
+        f"{axis_sq} > {body_sq}/3" in note
+        and f"{3 * axis_sq} > {body_sq}" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name df",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "df(v→w)" not in axiom
+        and "Do not write df into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1 and does not score a unit hop-cost",
+        "Do not attach L1." in note
+        and "attach L1" in note
+        and "unit hop-cost" not in note.lower(),
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " ")
+        and CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "the note does not claim uniqueness of the named hop-cost",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_6(0) and proposes no axiom edit",
+        "B_6(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "one Dijkstra" in note
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "df(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1 or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported only at (1,0,0) and (1,1,1).")
+    print("lattice_wide: checked and not executed — the search stays inside B_6(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named deep-out-face hop-cost df holds at k=1 on B_6(0): t(1,0,0)=3 vs t(1,1,1)=5. First display. Displayed, not adopted. Do not write df into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/deep_out_face_samek_k1_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.