### PR TITLE
feat(dfk14): deep-out-face same-k restores k=14: t=30 vs t=46

### DIFF
--- a/docs/DEEP_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/DEEP_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,225 @@
+---
+claim_id: deep_out_face_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named deep-out-face hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/deep_out_face_samek_k14_b42_2026_08_15.py
+---
+
+# Named Deep-Out-Face Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/deep_out_face_samek_k14_b42_2026_08_15.py`](../scripts/deep_out_face_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named deep-out-face hop-cost `df` is the already scored ridge-slide
+rule `ρ3` plus cost `3` on a `2→2` hop whose destination max absolute
+coordinate grows and whose source max is at least `2`. That extra clause
+skips the unit-out-face hop `(1,1,0) → (2,1,0)` that the cost-3 out-face
+rule `ω` writes into its grow clause. The unit-out-face hop is already
+priced `3` by the corridor-slide clause of `μ`, so on the six-neighbor
+graph the two extra predicates disagree while the hop-costs agree.
+Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rule `df` is
+
+`df(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 2)`, else `1`,
+
+where `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly
+two `|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is the ridge slide. The sixth clause is deep out-face: grow the
+box on a face only after height two. Those six clauses are the whole
+rule. The unit-out-face hop `(1,1,0) → (2,1,0)` has source max `1`, so it
+is not in the sixth clause; it stays at cost `3` by corridor-slide.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+gives
+
+`t(14,0,0) = 30`, `t(14,14,14) = 46`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `900/196` versus `2116/588`, or equivalently `2700 > 2116`. The
+inequality holds. Same-`k` reverse at `k=14` under `df` is yes. Reverse
+still holds at the `ρ3`/`κ` wall. Independently, the new axis site is
+`t(42,0,0) = 64`. The shared axis site `t(39,0,0) = 55` is a `df` score
+on this ball, not a smaller-ball leftover.
+
+The same-`k` pair under `ρ3` is `26` versus `46`. That mismatch on the
+axis is not a leftover of a `ρ3` table: the extra deep-out-face clause is
+live on the ball. On the deep-out-face hop `(2,2,0) → (3,2,0)` one has
+`|σ| : 2 → 2`, `max |w_i| = 3 > max |v_i| = 2`, and source max `2`, while
+the least nonzero `|w_i|` is `2`, so `ρ3 = 1` while `df = 3`. Therefore
+`ρ3` cannot price deep out-face. Independently, `t(3,2,0) = 11` under
+`df`. The corridor hop `(1,1,0) → (2,1,0)` also grows the max absolute
+coordinate, but its source max is `1`, so it is not deep out-face; it is
+already `ρ3 = 3` by the hugging clause. A cheapest `df` walk to
+`(14,14,14)` uses no deep-out-face `2→2` grow, so the body arrival stays
+`46`. The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from
+`B_39(0)`. The `B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+On every six-neighbor hop the cost `df` equals the cost `ω`, because the
+only grow hop that `ω` names and `df` skips is already priced `3` by `μ`.
+The pair `30` versus `46` therefore coincides with the `ω` pair. The
+named extra clause is still not leftover of `ω`: `ω` writes unit-out-face
+into its grow clause, and `df` does not.
+
+The rule is displayed, not adopted. Do not write `df` into Admissibility.
+Do not write df into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the two-unit-height ridge clause, the
+deep-out-face source-max clause, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `df` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses only the first five clauses of `df`. On the
+deep-out-face hop `(2,2,0) → (3,2,0)` one has `|σ| : 2 → 2` and a growing
+max at source height at least two, so `ρ3 = 1` while `df = 3`. Therefore
+`ρ3` cannot price deep out-face, and the `df` scores below are not a
+leftover of `ρ3`.
+
+The cost-3 out-face comparator `ω` uses the same grow test without the
+source-max floor. On `(1,1,0) → (2,1,0)` the `ω` grow predicate holds and
+the `df` grow predicate fails. On `(2,2,0) → (3,2,0)` both grow
+predicates hold. Final six-neighbor costs still agree.
+
+The cost-3 ridge-enter comparator `κ` prices `(2,1,0) → (2,1,1)` at `3`
+while `df` leaves it at `1`. Therefore the `df` scores are not leftover of `κ`.
+
+The interior-slide comparator `ι` taxes a `3 → 3` hop whose destination
+has `min |w_i| ≥ 2` and is not a height-`m` ridge. On `(3,3,2) → (3,3,3)`
+one has `df = 1` while `ι = 3`. Therefore the `df` body arrival `46` is
+not leftover of `ι`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_df` |
+|---|---:|
+| `(14,0,0)` | `30` |
+| `(14,14,14)` | `46` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table and not copied from the `ρ3` pair
+`26` versus `46`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `30` is seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, unit-cube enter `1` onto `(1,1,1)`,
+ridge-slide `3` onto `(2,1,1)`, support-preserving `1` onto `(2,2,1)`,
+twelve support-preserving cost-`1` body hops to `(14,2,1)`, ridge-slide
+`3` onto `(14,1,1)`, support-drop `3` onto `(14,1,0)`, and support-drop
+`3` onto `(14,0,0)`, summing to `30`. That walk never uses a `2→2` dest
+whose max grows at source height at least two. That walk is a witness of
+cost `30`, not a uniqueness claim.
+
+A witness body walk of cost `46` is the same prefix of cost `9` to
+`(2,2,1)`, twelve cost-`1` hops to `(14,2,1)`, twelve cost-`1` hops to
+`(14,14,1)`, and thirteen support-preserving cost-`1` body hops to
+`(14,14,14)`, summing to `46`. Those last hops have dest with only one
+absolute coordinate equal to `1` or none, so they are not ridge slides.
+That walk is a witness of cost `46`, not a uniqueness claim.
+
+A witness that the deep-out-face clause is live is the walk seed-exit `3`
+onto `(1,0,0)`, unit-cube leave `1` onto `(1,1,0)`, corridor-slide `3`
+onto `(1,2,0)`, support-preserving `1` onto `(2,2,0)`, and deep out-face
+`3` onto `(3,2,0)`, summing to `11`. Replacing only the last hop by its
+`ρ3` price `1` yields `9`. Independently, `t(3,2,0) = 11`.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 30^2 = 2700` and `46^2 = 2116`, so
+
+`2700 > 2116`.
+
+Arrival per Euclidean length is larger at `(14,0,0)` than at `(14,14,14)`.
+Same-`k` reverse at `k=14` under `df` is yes. Reverse still holds at the
+`ρ3`/`κ` wall. The comparison is displayed, not adopted. The inequality
+holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `df` is a displayed scoring device on `B_42(0)`. Do not write `df`
+into Admissibility. Do not write df into Admissibility. Do not attach L1.
+It is not a replacement for unit-cost first arrival, and it is not offered
+as the unique hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule df at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `df` among hop-costs that reverse the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of the `ρ3` arrival table as a substitute for the `df` Dijkstra.
+- Any reuse of the `ω` arrival table as a substitute for the `df` Dijkstra.
+- Membership of `df` as a physical hop-cost. Reverse at `k=14` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3069,6 +3069,10 @@
   "decoherence_failure_analysis": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "deep_out_face_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "delta_magnitude_reduces_to_massless_gravity_scale_narrow_theorem_note_2026-06-06": {
    "deps_hash": "a38ede67de87",

--- a/logs/runner-cache/deep_out_face_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/deep_out_face_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/deep_out_face_samek_k14_b42_2026_08_15.py
+runner_sha256: 039b9c0ffd6a72a8682c65920e5b3ee8406833fe496f0941d609c89eeb42cf16
+input_fingerprint_sha256: 3b68fe433a10df7df4b0149b431cce04c8db903da504bd55beb1a9f5b1332118
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.88
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/DEEP_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named deep-out-face hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility df is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 30
+t(14,14,14) 46
+t(14,0,0)^2/196 900/196
+t(14,14,14)^2/588 2116/588
+3t_axis^2 2700
+t_body^2 2116
+reverse True
+t(42,0,0) 64
+t(39,0,0) 55
+t(3,2,0) 11
+dijkstra_calls 1
+witness_axis_sum 30
+witness_body_sum 46
+df_out_face 3
+omega_out_face 3
+rho3_out_face 1
+df_unit_out_face 3
+omega_grow_unit True
+df_grow_unit False
+witness_out_face_df 11
+witness_out_face_rho3 9
+PASS: t-1400-141414 t(14,0,0)=30 and t(14,14,14)=46
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-rho3 df prices deep out-face at 3 while ρ3 prices it at 1
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: skips-unit-out-face df extra clause skips unit-out-face; ω extra clause includes it; both hop-costs are 3 by μ
+PASS: not-leftover-of-kappa κ prices ridge-enter at 3 while df leaves it at 1
+PASS: not-leftover-of-iota df does not tax the interior 3→3 hop that ι taxes
+PASS: seed-and-deep-out-face-clauses seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide, and deep out-face cost 3; unit-cube and body enter cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/deep_out_face_samek_k14_b42_2026_08_15.py
+++ b/scripts/deep_out_face_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under df on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/DEEP_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/DEEP_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named "
+    "deep-out-face hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 30
+T_BODY_REP = 46
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_height_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_height_count(w) == 2:
+        return 3
+    return 1
+
+
+def kappa_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 2
+        and support_size(w) == 3
+        and unit_height_count(w) == 2
+    ):
+        return 3
+    return 1
+
+
+def iota_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 3 and sigma_w == 3:
+        m = min(abs(c) for c in w)
+        if m >= 2 and sum(1 for c in w if abs(c) == m) != 2:
+            return 3
+    return 1
+
+
+def omega_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max(abs(c) for c in w) > max(abs(c) for c in v)
+    )
+
+
+def df_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 2
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if omega_grow(v, w):
+        return 3
+    return 1
+
+
+def df_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if df_grow(v, w):
+        return 3
+    return 1
+
+
+def dijkstra_df(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + df_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(
+    walk: tuple[tuple[int, int, int], ...],
+    cost_fn,
+) -> int:
+    return sum(cost_fn(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "df is not written into Admissibility",
+        "Do not write df into Admissibility" in note
+        and "Do not write `df` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_df(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    reverse = 3 * t1400 * t1400 > t141414 * t141414
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        (14, 1, 1),
+        (14, 1, 0),
+        (14, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        *[(14, y, 1) for y in range(3, 15)],
+        *[(14, 14, z) for z in range(2, 15)],
+    )
+    witness_out_face = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (3, 2, 0),
+    )
+    out_face_hop = ((2, 2, 0), (3, 2, 0))
+    unit_out_face = ((1, 1, 0), (2, 1, 0))
+    later_out_face = ((7, 2, 0), (8, 2, 0))
+    height2_nongrow = ((1, -2, 0), (2, -2, 0))
+    ridge_enter = ((2, 1, 0), (2, 1, 1))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t1400 * t1400}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t1400 * t1400}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(3,2,0) {t320}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_axis_sum {path_cost(witness_axis, df_cost)}")
+    print(f"witness_body_sum {path_cost(witness_body, df_cost)}")
+    print(f"df_out_face {df_cost(*out_face_hop)}")
+    print(f"omega_out_face {omega_cost(*out_face_hop)}")
+    print(f"rho3_out_face {rho3_cost(*out_face_hop)}")
+    print(f"df_unit_out_face {df_cost(*unit_out_face)}")
+    print(f"omega_grow_unit {omega_grow(*unit_out_face)}")
+    print(f"df_grow_unit {df_grow(*unit_out_face)}")
+    print(f"witness_out_face_df {path_cost(witness_out_face, df_cost)}")
+    print(f"witness_out_face_rho3 {path_cost(witness_out_face, rho3_cost)}")
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t1400 == T_AXIS_REP
+        and t141414 == T_BODY_REP
+        and t1400 == path_cost(witness_axis, df_cost)
+        and t141414 == path_cost(witness_body, df_cost),
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 holds",
+        reverse
+        and 3 * t1400 * t1400 == 2700
+        and t141414 * t141414 == 2116
+        and "2700 > 2116" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`30`" in note
+        and "`46`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note
+        and "t(14,0,0) = 30" in note
+        and "t(14,14,14) = 46" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2700 > 2116" in note and "900/196" in note and "2116/588" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "df prices deep out-face at 3 while ρ3 prices it at 1",
+        df_cost(*out_face_hop) == 3
+        and rho3_cost(*out_face_hop) == 1
+        and mu_cost(*out_face_hop) == 1
+        and df_cost(*later_out_face) == 3
+        and rho3_cost(*later_out_face) == 1
+        and df_cost(*height2_nongrow) == 1
+        and t1400 == 30
+        and t141414 == 46
+        and t320 == 11
+        and path_cost(witness_out_face, df_cost) == 11
+        and path_cost(witness_out_face, rho3_cost) == 9
+        and "cannot price deep out-face" in note
+        and "`t(3,2,0) = 11`" in note
+        and "26` versus `46" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 64
+        and t3900 == 55
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "skips-unit-out-face",
+        "df extra clause skips unit-out-face; ω extra clause includes it; both hop-costs are 3 by μ",
+        omega_grow(*unit_out_face)
+        and (not df_grow(*unit_out_face))
+        and df_grow(*out_face_hop)
+        and omega_grow(*out_face_hop)
+        and df_cost(*unit_out_face) == 3
+        and omega_cost(*unit_out_face) == 3
+        and rho3_cost(*unit_out_face) == 3
+        and df_cost(*out_face_hop) == omega_cost(*out_face_hop) == 3
+        and "skips the unit-out-face" in note
+        and "not leftover of `ω`" in note,
+    )
+    checks.check(
+        "not-leftover-of-kappa",
+        "κ prices ridge-enter at 3 while df leaves it at 1",
+        df_cost(*ridge_enter) == 1
+        and kappa_cost(*ridge_enter) == 3
+        and rho3_cost(*ridge_enter) == 1
+        and "not leftover of `κ`" in note,
+    )
+    checks.check(
+        "not-leftover-of-iota",
+        "df does not tax the interior 3→3 hop that ι taxes",
+        df_cost((3, 3, 2), (3, 3, 3)) == 1
+        and iota_cost((3, 3, 2), (3, 3, 3)) == 3
+        and t141414 == 46
+        and t141414 != 72
+        and "not leftover of `ι`" in note,
+    )
+    checks.check(
+        "seed-and-deep-out-face-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide, and deep out-face cost 3; unit-cube and body enter cost 1",
+        df_cost((0, 0, 0), (1, 0, 0)) == 3
+        and df_cost((1, 0, 0), (2, 0, 0)) == 3
+        and df_cost((1, 1, 0), (1, 0, 0)) == 3
+        and df_cost(*unit_out_face) == 3
+        and df_cost((1, 1, 1), (2, 1, 1)) == 3
+        and df_cost((2, 2, 0), (3, 2, 0)) == 3
+        and df_cost((2, 2, 0), (2, 3, 0)) == 3
+        and df_cost((3, 2, 0), (4, 2, 0)) == 3
+        and df_cost((1, 0, 0), (1, 1, 0)) == 1
+        and df_cost((1, 1, 0), (1, 1, 1)) == 1
+        and df_cost((2, 1, 0), (2, 1, 1)) == 1
+        and df_cost((2, 2, 0), (2, 2, 1)) == 1
+        and df_cost((1, -2, 0), (2, -2, 0)) == 1
+        and df_cost((2, 2, 2), (3, 2, 2)) == 1
+        and df_cost((2, 7, 7), (3, 7, 7)) == 1
+        and df_cost((13, 14, 14), (14, 14, 14)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "df(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named deep-out-face hop-cost df holds at k=14 on B_42(0): t(14,0,0)=30 vs t(14,14,14)=46. Unit-out-face is not required for the restore. Displayed, not adopted. Do not write df into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/deep_out_face_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.