### PR TITLE
feat(dfface): deep-out-face face reverse holds k=1..5,7,8 fails k=6

### DIFF
--- a/docs/DEEP_OUT_FACE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/DEEP_OUT_FACE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,231 @@
+---
+claim_id: deep_out_face_face_reverse_vs_k_b16_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face reverse under the named deep-out-face hop-cost on B_16(0) at k=1..8 is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py
+---
+
+# Named Deep-Out-Face Face Reverse Versus Integer Scale `k` On `B_16(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_16(0)`,
+scored only for the face-diagonal reverse comparison at every available
+integer scale `k=1..8`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py`](../scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_16(0)`, the stacked
+rules `ν`, `μ`, and `ρ3` are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+`|w_i|` equals `1)`, else `1`;
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The displayed deep-out-face rule `df` is `ρ3` plus cost `3` on a `2→2`
+hop whose destination max grows and whose source max is already at least
+`2`:
+
+`df(v→w) = 3` if `ρ3` would be `3` or (`|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 2`), else `1`.
+
+Those clauses are the whole rule. Uniqueness is not claimed. This note is
+the first display of face reverse under `df` at `k=1..8` on `B_16(0)`.
+
+The extra clause skips the unit-out-face hop `(1,1,0) → (2,1,0)`: that hop
+has `|σ|=2→2` and dest max `2` greater than source max `1`, but the source
+max is `1`, so the extra clause is idle. Corridor-slide `μ` already prices
+that hop at `3`, so `df=3` there as well. The extra clause is not leftover
+of `ρ3`: the interior face-growth hop `(2,2,0) → (3,2,0)` has `ρ3=1` and
+`df=3`.
+
+A pair `((2k,0,0),(k,k,0))` is available when both sites lie in `B_16(0)`.
+That is `| (2k,0,0) |_1 = 2k ≤ 16` and `| (k,k,0) |_1 = 2k ≤ 16`, so every
+`k=1..8` is available. No scale is omitted.
+
+One Dijkstra from the origin on `B_16(0)` (6017 sites; 6016 nonzero) gives
+
+`t(2,0,0) = 6`, `t(4,0,0) = 12`, `t(6,0,0) = 18`, `t(8,0,0) = 24`,
+`t(10,0,0) = 26`, `t(12,0,0) = 28`, `t(14,0,0) = 32`, `t(16,0,0) = 38`,
+
+`t(1,1,0) = 4`, `t(2,2,0) = 8`, `t(3,3,0) = 12`, `t(4,4,0) = 16`,
+`t(5,5,0) = 18`, `t(6,6,0) = 20`, `t(7,7,0) = 22`, `t(8,8,0) = 24`.
+
+For each available `k`, the displayed face-diagonal comparison is whether
+
+`t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2)`,
+
+equivalently `t(2k,0,0)^2 > 2 t(k,k,0)^2`. The bits are
+
+| `k` | pair | axis `t^2/|v|_2^2` | face `t^2/|v|_2^2` | reverse |
+|---|---|---|---|---|
+| `1` | `((2,0,0),(1,1,0))` | `36/4=9` | `16/2=8` | yes |
+| `2` | `((4,0,0),(2,2,0))` | `144/16=9` | `64/8=8` | yes |
+| `3` | `((6,0,0),(3,3,0))` | `324/36=9` | `144/18=8` | yes |
+| `4` | `((8,0,0),(4,4,0))` | `576/64=9` | `256/32=8` | yes |
+| `5` | `((10,0,0),(5,5,0))` | `676/100=169/25` | `324/50=162/25` | yes |
+| `6` | `((12,0,0),(6,6,0))` | `784/144=49/9` | `400/72=50/9` | no |
+| `7` | `((14,0,0),(7,7,0))` | `1024/196=256/49` | `484/98=242/49` | yes |
+| `8` | `((16,0,0),(8,8,0))` | `1444/256=361/64` | `576/128=9/2` | yes |
+
+Exact integer comparisons `t(2k,0,0)^2 ? 2 t(k,k,0)^2`:
+
+- `k=1`: `36 > 32` holds
+- `k=2`: `144 > 128` holds
+- `k=3`: `324 > 288` holds
+- `k=4`: `576 > 512` holds
+- `k=5`: `676 > 648` holds
+- `k=6`: `784 > 800` fails
+- `k=7`: `1024 > 968` holds
+- `k=8`: `1444 > 1152` holds
+
+The hold/fail pattern of the eight bits is yes, yes, yes, yes, yes, no, yes, yes.
+Face reverse holds at `k=1..5`, `k=7`, and `k=8`, and fails at `k=6`.
+The `k=6` fail is the only fail.
+
+A pure both-weights-`1` axis walk to `(2k,0,0)` costs `6k`. That walk
+matches the Dijkstra arrival through `k=4`. From `k=5` the computed axis
+arrival is strictly cheaper than `6k`. Those walks are witnesses, not a
+uniqueness claim.
+
+The sixteen arrivals are computed on `B_16(0)` under `df`, not copied from
+a smaller-ball table and not copied from a `ρ3` pair table. The extra
+deep-out-face clause is live on this host: `(2,2,0) → (3,2,0)` lies in
+`B_16(0)` and has `df = 3` while `ρ3 = 1`.
+
+The rule is displayed, not adopted. Do not write `df` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size, max-coordinate,
+and source-max clauses, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_16(0) = { v ∈ Z^3 : |v|_1 ≤ 16 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_16(0)`,
+`t(v)` is the least sum of `df` along a directed path from `0` to `v` in
+that graph.
+
+The first `ν` clause is seed-exit. The second is both weights `1`. The third
+is support drop. The `μ` addendum taxes a `2→2` hop whose destination still
+touches a unit coordinate. The `ρ3` addendum taxes a `3→3` hop whose
+destination has exactly two unit coordinates. The `df` addendum taxes a
+`2→2` hop that grows the coordinate box on a face whose source max is
+already at least `2`. It skips the unit-out-face hop.
+
+## Theorem 1 — Arrivals `t(2k,0,0)` And `t(k,k,0)` On `B_16(0)`
+
+One origin Dijkstra on `B_16(0)` returns the integer arrivals
+
+| site | `t_{df}` |
+|---|---:|
+| `(2,0,0)` | `6` |
+| `(1,1,0)` | `4` |
+| `(4,0,0)` | `12` |
+| `(2,2,0)` | `8` |
+| `(6,0,0)` | `18` |
+| `(3,3,0)` | `12` |
+| `(8,0,0)` | `24` |
+| `(4,4,0)` | `16` |
+| `(10,0,0)` | `26` |
+| `(5,5,0)` | `18` |
+| `(12,0,0)` | `28` |
+| `(6,6,0)` | `20` |
+| `(14,0,0)` | `32` |
+| `(7,7,0)` | `22` |
+| `(16,0,0)` | `38` |
+| `(8,8,0)` | `24` |
+
+Every listed site lies in `B_16(0)`. No `k=1..8` pair is omitted. The
+sixteen values are computed on `B_16(0)`, not copied from a larger-ball
+table. These values are Dijkstra outputs, not fitted scalars.
+
+A witness walk to `(2,0,0)` is seed-exit `3` onto `(1,0,0)` and both-weights-`1`
+axis hop `3` onto `(2,0,0)`, summing to `6`. A witness walk to `(1,1,0)` is
+seed-exit `3` onto `(0,1,0)` and support-increase `1` onto `(1,1,0)`,
+summing to `4`. A witness walk to `(8,0,0)` is eight both-weights-`1` axis
+hops of cost `3`, summing to `24`. Those walks are witnesses, not a
+uniqueness claim.
+
+For each `k=1..8` the note also records whether
+
+`t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2)`.
+
+## Theorem 2 — Hold/Fail Pattern Of The Eight Bits
+
+The Euclidean-normalized comparison at each available `k` is
+
+`t(2k,0,0)^2 / (4k^2) > t(k,k,0)^2 / (2k^2)`,
+
+equivalently `t(2k,0,0)^2 > 2 t(k,k,0)^2`. Substituting the computed times
+gives the eight bits of Result Up Front. The hold/fail pattern is
+yes, yes, yes, yes, yes, no, yes, yes. Reverse holds at `k=1..5`, `k=7`, and
+`k=8`, and fails at `k=6`. The comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `df` is a displayed scoring device on `B_16(0)`. Do not write `df`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+face reverse at any `k`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer face-versus-axis arrivals and reverse bits versus available integer scale k on the finite ball B_16(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_16(0) for the displayed rule df at available k=1..8; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `df` among hop-costs that score the face-versus-axis bits
+  at any `k`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_16(0)`.
+- Any score for a pair that is not an available face-versus-axis pair
+  `((2k,0,0),(k,k,0))` at `k=1..8`.
+- Any reuse of a `ρ3` arrival table as a substitute for the `df`
+  Dijkstra.
+- Any reuse of a larger-ball arrival table as a substitute for the
+  radius-`16` Dijkstra.
+- Any adoption of `df` as an admissibility rule. Face reverse versus `k`
+  on this ball is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3069,6 +3069,10 @@
   "decoherence_failure_analysis": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "deep_out_face_face_reverse_vs_k_b16_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "delta_magnitude_reduces_to_massless_gravity_scale_narrow_theorem_note_2026-06-06": {
    "deps_hash": "a38ede67de87",

--- a/logs/runner-cache/deep_out_face_face_reverse_vs_k_b16_2026_08_15.txt
+++ b/logs/runner-cache/deep_out_face_face_reverse_vs_k_b16_2026_08_15.txt
@@ -1,0 +1,56 @@
+===== runner cache v1 =====
+runner: scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py
+runner_sha256: 8830b76cc142a1e08742760ad91199889919a74801192f6f4d46d315569ff86e
+input_fingerprint_sha256: 1716f9d516a529c1599257396a6bbc480795bd24b842e76449fca5039ed38c44
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/DEEP_OUT_FACE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Face reverse under the named deep-out-face hop-cost on B_16(0) at k=1..8 is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility df is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+PASS: cache-false the note records cache_write false
+n_sites 6017
+available_k [1, 2, 3, 4, 5, 6, 7, 8]
+k=1 t(2, 0, 0)=6 t(1, 1, 0)=4 axis_dens 36/4 face_dens 16/2 cmp 36 ? 32 reverse True
+k=2 t(4, 0, 0)=12 t(2, 2, 0)=8 axis_dens 144/16 face_dens 64/8 cmp 144 ? 128 reverse True
+k=3 t(6, 0, 0)=18 t(3, 3, 0)=12 axis_dens 324/36 face_dens 144/18 cmp 324 ? 288 reverse True
+k=4 t(8, 0, 0)=24 t(4, 4, 0)=16 axis_dens 576/64 face_dens 256/32 cmp 576 ? 512 reverse True
+k=5 t(10, 0, 0)=26 t(5, 5, 0)=18 axis_dens 676/100 face_dens 324/50 cmp 676 ? 648 reverse True
+k=6 t(12, 0, 0)=28 t(6, 6, 0)=20 axis_dens 784/144 face_dens 400/72 cmp 784 ? 800 reverse False
+k=7 t(14, 0, 0)=32 t(7, 7, 0)=22 axis_dens 1024/196 face_dens 484/98 cmp 1024 ? 968 reverse True
+k=8 t(16, 0, 0)=38 t(8, 8, 0)=24 axis_dens 1444/256 face_dens 576/128 cmp 1444 ? 1152 reverse True
+hold_fail_pattern yes,yes,yes,yes,yes,no,yes,yes
+dijkstra_calls 1
+df_deep_out 3
+rho3_deep_out 1
+df_unit_out 3
+df_extra_unit_out False
+mu_unit_out 3
+PASS: theorem-1 computed arrivals match the displayed B_16(0) table
+PASS: reverse-bits displayed reverse bits match t(2k,0,0)^2 > 2 t(k,k,0)^2
+PASS: hold-fail-pattern the eight bits are yes,yes,yes,yes,yes,no,yes,yes
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b16 B_16(0) has 6017 sites and 6016 nonzero sites
+PASS: reachable every site of B_16(0) is reached
+PASS: available-k-1-8 every k=1..8 pair lies in B_16(0); none omitted
+PASS: deep-out-face-hop the named deep-out-face hop (2,2,0)->(3,2,0) has df=3 and rho3=1
+PASS: unit-out-face-skipped unit-out-face (1,1,0)->(2,1,0) is skipped by the extra clause
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py
+++ b/scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Score face reverse versus k under df on B_16(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/DEEP_OUT_FACE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/DEEP_OUT_FACE_FACE_REVERSE_VS_K_B16_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Face reverse under the named deep-out-face hop-cost on B_16(0) "
+    "at k=1..8 is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+SCALES = (1, 2, 3, 4, 5, 6, 7, 8)
+EXPECTED_AXIS = {
+    1: 6,
+    2: 12,
+    3: 18,
+    4: 24,
+    5: 26,
+    6: 28,
+    7: 32,
+    8: 38,
+}
+EXPECTED_FACE = {
+    1: 4,
+    2: 8,
+    3: 12,
+    4: 16,
+    5: 18,
+    6: 20,
+    7: 22,
+    8: 24,
+}
+EXPECTED_REVERSE = {
+    1: True,
+    2: True,
+    3: True,
+    4: True,
+    5: True,
+    6: False,
+    7: True,
+    8: True,
+}
+UNIT_OUT_SRC = (1, 1, 0)
+UNIT_OUT_DST = (2, 1, 0)
+DEEP_OUT_SRC = (2, 2, 0)
+DEEP_OUT_DST = (3, 2, 0)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero = [abs(coord) for coord in w if coord != 0]
+        if nonzero and min(nonzero) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        if sum(abs(coord) == 1 for coord in w) == 2:
+            return 3
+    return 1
+
+
+def df_extra(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    if support_size(v) != 2 or support_size(w) != 2:
+        return False
+    return max(abs(coord) for coord in w) > max(abs(coord) for coord in v) and max(
+        abs(coord) for coord in v
+    ) >= 2
+
+
+def df_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3 or df_extra(v, w):
+        return 3
+    return 1
+
+
+def dijkstra_df(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + df_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def axis_site(k: int) -> tuple[int, int, int]:
+    return (2 * k, 0, 0)
+
+
+def face_site(k: int) -> tuple[int, int, int]:
+    return (k, k, 0)
+
+
+def available(k: int, radius: int) -> bool:
+    return l1(axis_site(k)) <= radius and l1(face_site(k)) <= radius
+
+
+def is_reverse(t_axis: int, t_face: int) -> bool:
+    return t_axis * t_axis > 2 * t_face * t_face
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "df is not written into Admissibility",
+        "Do not write `df` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "cache-false",
+        "the note records cache_write false",
+        "cache_write: false" in note,
+    )
+
+    sites = ball(16)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    available_ks = [k for k in SCALES if available(k, 16)]
+    dist = dijkstra_df(sites)
+    print(f"n_sites {len(sites)}")
+    print(f"available_k {available_ks}")
+    bits: dict[int, bool] = {}
+    for k in available_ks:
+        axis = axis_site(k)
+        face = face_site(k)
+        t_axis = dist[axis]
+        t_face = dist[face]
+        bit = is_reverse(t_axis, t_face)
+        bits[k] = bit
+        print(
+            f"k={k} t{axis}={t_axis} t{face}={t_face} "
+            f"axis_dens {t_axis * t_axis}/{4 * k * k} "
+            f"face_dens {t_face * t_face}/{2 * k * k} "
+            f"cmp {t_axis * t_axis} ? {2 * t_face * t_face} reverse {bit}"
+        )
+    pattern = ",".join("yes" if bits[k] else "no" for k in available_ks)
+    print(f"hold_fail_pattern {pattern}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"df_deep_out {df_cost(DEEP_OUT_SRC, DEEP_OUT_DST)}")
+    print(f"rho3_deep_out {rho3_cost(DEEP_OUT_SRC, DEEP_OUT_DST)}")
+    print(f"df_unit_out {df_cost(UNIT_OUT_SRC, UNIT_OUT_DST)}")
+    print(f"df_extra_unit_out {df_extra(UNIT_OUT_SRC, UNIT_OUT_DST)}")
+    print(f"mu_unit_out {mu_cost(UNIT_OUT_SRC, UNIT_OUT_DST)}")
+
+    times_ok = all(
+        dist[axis_site(k)] == EXPECTED_AXIS[k] and dist[face_site(k)] == EXPECTED_FACE[k]
+        for k in available_ks
+    )
+    checks.check(
+        "theorem-1",
+        "computed arrivals match the displayed B_16(0) table",
+        times_ok
+        and all(f"`t({2 * k},0,0) = {EXPECTED_AXIS[k]}`" in note for k in SCALES)
+        and all(f"`t({k},{k},0) = {EXPECTED_FACE[k]}`" in note for k in SCALES),
+    )
+    checks.check(
+        "reverse-bits",
+        "displayed reverse bits match t(2k,0,0)^2 > 2 t(k,k,0)^2",
+        bits == {k: EXPECTED_REVERSE[k] for k in available_ks}
+        and "36 > 32" in note
+        and "144 > 128" in note
+        and "324 > 288" in note
+        and "576 > 512" in note
+        and "676 > 648" in note
+        and "784 > 800" in note
+        and "1024 > 968" in note
+        and "1444 > 1152" in note,
+    )
+    checks.check(
+        "hold-fail-pattern",
+        "the eight bits are yes,yes,yes,yes,yes,no,yes,yes",
+        bits == {k: EXPECTED_REVERSE[k] for k in available_ks}
+        and "yes, yes, yes, yes, yes, no, yes, yes" in note
+        and "fails at `k=6`" in note
+        and "holds at `k=1..5`, `k=7`, and `k=8`" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b16",
+        "B_16(0) has 6017 sites and 6016 nonzero sites",
+        len(sites) == 6017 and len(nonzero) == 6016 and all(l1(v) <= 16 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_16(0) is reached",
+        len(dist) == 6017,
+    )
+    checks.check(
+        "available-k-1-8",
+        "every k=1..8 pair lies in B_16(0); none omitted",
+        available_ks == list(SCALES)
+        and all(axis_site(k) in dist and face_site(k) in dist for k in SCALES)
+        and "No scale is omitted" in note,
+    )
+    site_set = set(sites)
+    extra_live = (
+        DEEP_OUT_SRC in site_set
+        and DEEP_OUT_DST in site_set
+        and df_cost(DEEP_OUT_SRC, DEEP_OUT_DST) == 3
+        and rho3_cost(DEEP_OUT_SRC, DEEP_OUT_DST) == 1
+        and df_extra(DEEP_OUT_SRC, DEEP_OUT_DST)
+        and support_size(DEEP_OUT_SRC) == 2
+        and support_size(DEEP_OUT_DST) == 2
+        and max(abs(c) for c in DEEP_OUT_DST) > max(abs(c) for c in DEEP_OUT_SRC)
+        and max(abs(c) for c in DEEP_OUT_SRC) >= 2
+    )
+    checks.check(
+        "deep-out-face-hop",
+        "the named deep-out-face hop (2,2,0)->(3,2,0) has df=3 and rho3=1",
+        extra_live and "(2,2,0) → (3,2,0)" in note,
+    )
+    unit_skip = (
+        UNIT_OUT_SRC in site_set
+        and UNIT_OUT_DST in site_set
+        and not df_extra(UNIT_OUT_SRC, UNIT_OUT_DST)
+        and mu_cost(UNIT_OUT_SRC, UNIT_OUT_DST) == 3
+        and rho3_cost(UNIT_OUT_SRC, UNIT_OUT_DST) == 3
+        and df_cost(UNIT_OUT_SRC, UNIT_OUT_DST) == 3
+        and max(abs(c) for c in UNIT_OUT_SRC) == 1
+        and max(abs(c) for c in UNIT_OUT_DST) > max(abs(c) for c in UNIT_OUT_SRC)
+    )
+    checks.check(
+        "unit-out-face-skipped",
+        "unit-out-face (1,1,0)->(2,1,0) is skipped by the extra clause",
+        unit_skip and "(1,1,0) → (2,1,0)" in note and "source max" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        df_cost((0, 0, 0), (1, 0, 0)) == 3
+        and df_cost((1, 0, 0), (2, 0, 0)) == 3
+        and df_cost((1, 0, 0), (1, 1, 0)) == 1
+        and df_cost((1, 1, 0), (1, 1, 1)) == 1
+        and df_cost((1, 1, 0), (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "df(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Face reverse under named deep-out-face hop-cost df holds at k=1..5,7,8 and fails only at k=6 on B_16(0), same pattern as ω. Displayed, not adopted. Do not write df into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/deep_out_face_face_reverse_vs_k_b16_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.