### PR TITLE
feat(psk14): same-max face-slide same-k restores k=14: t=30 vs t=46

### DIFF
--- a/docs/SAME_MAX_FACE_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/SAME_MAX_FACE_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,184 @@
+---
+claim_id: same_max_face_slide_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named same-max face-slide hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py
+---
+
+# Named Same-Max Face-Slide Same-`k` Reverse At `k=14` On `B_42(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` pair `t(14,0,0)` versus `t(14,14,14)`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py`](../scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the stacked
+rules `ν`, `μ`, `ρ3`, and `ω` are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+`|w_i|` equals `1)`, else `1`;
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`;
+
+`ω(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|)`, else `1`.
+
+The displayed same-max face-slide rule `ψ` is `ω` plus cost `3` on a
+`2→2` hop whose destination max absolute coordinate equals the source max
+(same-max face slide, not box-growth):
+
+`ψ(v→w) = 3` if `ω` would be `3` or `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| = max_i |v_i|)`, else `1`.
+
+Those clauses are the whole rule. Uniqueness is not claimed. This note is
+the first display of same-`k` reverse under `ψ` at the `k=14` wall, the
+body site of ℓ¹-norm `42`.
+
+The same-max face-slide hop `(2,1,0) → (2,2,0)` does fire: `|σ|=2→2` and
+`max |w_i|=2 = max |v_i|=2`, so `ψ=3`. Independently that hop is not
+leftover of `ω`: `ω((2,1,0)→(2,2,0))=1`. The out-face box-growth hop
+`(1,1,0) → (2,1,0)` already has `ω=3` and therefore `ψ=3`. The same-max
+clause is live in the arrival table: `t(2,2,0) = 10`.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+returns
+
+| site | `t_ψ` |
+|---|---:|
+| `(14,0,0)` | `30` |
+| `(14,14,14)` | `46` |
+
+The same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 30^2 = 2700` and `46^2 = 2116`, so `2700 > 2116`. Same-`k`
+reverse at `k=14` is yes. Independently the same table has `t(1,0,0) = 3`
+and `t(1,1,1) = 5`.
+
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`.
+The `B_42(0)` table is therefore not leftover of a radius-`39` table.
+
+A cheapest `ψ` walk to `(14,14,14)` uses no same-max `2→2` face-slide hop,
+so the body arrival stays `46`. A cheapest `ψ` walk to `(14,0,0)` likewise
+uses none, so the axis arrival stays `30`. The named rule is still not a
+leftover of `ω`, because the same-max hop is live on the ball.
+
+The rule is displayed, not adopted. Do not write `ψ` into Admissibility.
+Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size and
+max-coordinate clauses, and the arrival function `t` are separately displayed
+mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `ψ` along a directed path from `0` to `v` in
+that graph.
+
+The first `ν` clause is seed-exit. The second is both weights `1`. The third
+is support drop. The `μ` addendum taxes a `2→2` hop whose destination still
+touches a unit coordinate. The `ρ3` addendum taxes a `3→3` hop whose
+destination has exactly two unit coordinates. The `ω` addendum taxes a
+`2→2` hop that grows the coordinate box on a face. The `ψ` addendum taxes
+a `2→2` hop that slides on a face at constant max absolute coordinate.
+
+## Theorem 1 — Arrivals At `k=14` Under `ψ`
+
+One origin Dijkstra on `B_42(0)` returns `t(14,0,0) = 30` and
+`t(14,14,14) = 46`. Both sites lie in `B_42(0)`. These values are Dijkstra
+outputs, not fitted scalars.
+
+A witness axis walk of cost `30` is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, enter-body `1` onto `(1,1,1)`, ridge-slide
+`3` onto `(2,1,1)`, support-preserving cost-`1` hop onto `(2,2,1)`, twelve
+support-preserving cost-`1` body hops to `(14,2,1)`, ridge-slide `3` onto
+`(14,1,1)`, support-drop `3` onto `(14,1,0)`, and support-drop `3` onto
+`(14,0,0)`, summing to `30`. That walk uses no same-max `2→2` face-slide
+hop. It is a witness of cost `30`, not a uniqueness claim. The pure axis
+1-skeleton walk costs `42` and is not cheapest.
+
+A witness body walk of cost `46` is the same prefix of cost `9` to
+`(2,2,1)`, twelve cost-`1` body hops to `(14,2,1)`, twelve cost-`1` body
+hops to `(14,14,1)`, and thirteen support-preserving cost-`1` body hops to
+`(14,14,14)`, summing to `46`. Those last hops have dest with only one
+absolute coordinate equal to `1`, or with all three coordinates large, so
+they are not unit-height ridges, not out-face `2→2` grows, and not
+same-max `2→2` slides. That walk is a witness of cost `46`, not a
+uniqueness claim.
+
+## Theorem 2 — Reverse At The Same-`k` Pair `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`.
+
+The computed integers give `2700 > 2116`. Arrival per Euclidean length is
+larger at `(14,0,0)` than at `(14,14,14)`. Same-`k` reverse at `k=14`
+under `ψ` is yes. The comparison is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `ψ` is a displayed scoring device on `B_42(0)`. Do not write `ψ`
+into Admissibility. Do not attach L1. It is not a replacement for
+unit-cost first arrival, and it is not offered as the unique hop-cost with
+same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule ψ at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `ψ` among hop-costs that reverse any same-`k` pair.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any adoption of `ψ` as an admissibility rule.
+- Any face-reverse score.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -16609,6 +16609,10 @@
   "same_family_3d_closure_note": {
    "deps_hash": "473ab73403e7",
    "out_degree": 3
+  },
+  "same_max_face_slide_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "scalar_3plus1_temporal_ratio_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/same_max_face_slide_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/same_max_face_slide_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py
+runner_sha256: fa69e278916e500ca7e713209078edc61d5d3ee308a3eef8daed480c2eec58d8
+input_fingerprint_sha256: c0fc8b5593eeb909fb09e15402cf39443e86bf1127babce4bb501932dc54b962
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.97
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/SAME_MAX_FACE_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named same-max face-slide hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility ψ is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+PASS: cache-false the note records cache_write false
+n_sites 102425
+t(14,0,0) 30
+t(14,14,14) 46
+t(14,0,0)^2/196 900/196
+t(14,14,14)^2/588 2116/588
+3t_axis^2 2700
+t_body^2 2116
+reverse True
+t(1,0,0) 3
+t(1,1,1) 5
+t(2,2,0) 10
+dijkstra_calls 1
+witness_psi_axis [3, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3]
+witness_psi_axis_sum 30
+witness_psi_body_sum 46
+psi_same_max 3
+omega_same_max 1
+psi_box_growth 3
+omega_box_growth 3
+PASS: theorem-1 t(14,0,0)=30 and t(14,14,14)=46
+PASS: reverse-k14 t(14,0,0)^2 / 196 > t(14,14,14)^2 / 588
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-product note records the integer reverse comparison
+PASS: same-max-face-slide-hop the named same-max hop (2,1,0)->(2,2,0) has ψ=3 and ω=1
+PASS: psi-not-leftover-of-omega same-max slide is new over ω; box-growth remains ψ=3
+PASS: k14-geodesic-costs the k=14 axis and body witnesses use no same-max 2→2 hop
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py
+++ b/scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under ψ on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/SAME_MAX_FACE_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/SAME_MAX_FACE_SLIDE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named same-max face-slide hop-cost "
+    "on B_42(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 30
+T_BODY_REP = 46
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero = [abs(coord) for coord in w if coord != 0]
+        if nonzero and min(nonzero) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        if sum(abs(coord) == 1 for coord in w) == 2:
+            return 3
+    return 1
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        if max(abs(coord) for coord in w) > max(abs(coord) for coord in v):
+            return 3
+    return 1
+
+
+def psi_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if omega_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        if max(abs(coord) for coord in w) == max(abs(coord) for coord in v):
+            return 3
+    return 1
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def dijkstra_psi(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + psi_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "ψ is not written into Admissibility",
+        "Do not write `ψ` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "cache-false",
+        "the note records cache_write false",
+        "cache_write: false" in note,
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_psi(sites)
+    t14000 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t100 = dist[(1, 0, 0)]
+    t111 = dist[(1, 1, 1)]
+    t220 = dist[(2, 2, 0)]
+    reverse = 3 * t14000 * t14000 > t141414 * t141414
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        (14, 1, 1),
+        (14, 1, 0),
+        (14, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        *[(14, y, 1) for y in range(3, 15)],
+        *[(14, 14, z) for z in range(2, 15)],
+    )
+    witness_psi_axis = [psi_cost(a, b) for a, b in zip(witness_axis, witness_axis[1:])]
+    witness_psi_body = [psi_cost(a, b) for a, b in zip(witness_body, witness_body[1:])]
+    same_max_hop = ((2, 1, 0), (2, 2, 0))
+    box_growth_hop = ((1, 1, 0), (2, 1, 0))
+    interior_body_hop = ((14, 14, 1), (14, 14, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t14000}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t14000 * t14000}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t14000 * t14000}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(1,0,0) {t100}")
+    print(f"t(1,1,1) {t111}")
+    print(f"t(2,2,0) {t220}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_psi_axis {witness_psi_axis}")
+    print(f"witness_psi_axis_sum {sum(witness_psi_axis)}")
+    print(f"witness_psi_body_sum {sum(witness_psi_body)}")
+    print(f"psi_same_max {psi_cost(*same_max_hop)}")
+    print(f"omega_same_max {omega_cost(*same_max_hop)}")
+    print(f"psi_box_growth {psi_cost(*box_growth_hop)}")
+    print(f"omega_box_growth {omega_cost(*box_growth_hop)}")
+
+    checks.check(
+        "theorem-1",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t14000 == T_AXIS_REP and t141414 == T_BODY_REP,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2 / 196 > t(14,14,14)^2 / 588",
+        reverse
+        and 3 * t14000 * t14000 == 2700
+        and t141414 * t141414 == 2116
+        and "2700 > 2116" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note
+        and "`30`" in note
+        and "`46`" in note,
+    )
+    checks.check(
+        "note-records-reverse-product",
+        "note records the integer reverse comparison",
+        "2700 > 2116" in note,
+    )
+    checks.check(
+        "same-max-face-slide-hop",
+        "the named same-max hop (2,1,0)->(2,2,0) has ψ=3 and ω=1",
+        psi_cost(*same_max_hop) == 3
+        and omega_cost(*same_max_hop) == 1
+        and support_size((2, 1, 0)) == 2
+        and support_size((2, 2, 0)) == 2
+        and max(abs(c) for c in (2, 2, 0)) == max(abs(c) for c in (2, 1, 0))
+        and "(2,1,0) → (2,2,0)" in note
+        and t220 == 10
+        and "`t(2,2,0) = 10`" in note,
+    )
+    checks.check(
+        "psi-not-leftover-of-omega",
+        "same-max slide is new over ω; box-growth remains ψ=3",
+        psi_cost(*same_max_hop) == 3
+        and omega_cost(*same_max_hop) == 1
+        and omega_cost(*box_growth_hop) == 3
+        and psi_cost(*box_growth_hop) == 3
+        and "(1,1,0) → (2,1,0)" in note
+        and sum(witness_psi_axis) == 30
+        and sum(witness_psi_body) == 46,
+    )
+    checks.check(
+        "k14-geodesic-costs",
+        "the k=14 axis and body witnesses use no same-max 2→2 hop",
+        all(psi_cost(a, b) in (1, 3) for a, b in zip(witness_axis, witness_axis[1:]))
+        and all(
+            not (
+                support_size(a) == 2
+                and support_size(b) == 2
+                and max(abs(c) for c in b) == max(abs(c) for c in a)
+            )
+            for a, b in zip(witness_axis, witness_axis[1:])
+        )
+        and all(
+            not (
+                support_size(a) == 2
+                and support_size(b) == 2
+                and max(abs(c) for c in b) == max(abs(c) for c in a)
+            )
+            for a, b in zip(witness_body, witness_body[1:])
+        )
+        and t100 == 3
+        and t111 == 5
+        and psi_cost(*interior_body_hop) == 1,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        psi_cost((0, 0, 0), (1, 0, 0)) == 3
+        and psi_cost((1, 0, 0), (2, 0, 0)) == 3
+        and psi_cost((1, 0, 0), (1, 1, 0)) == 1
+        and psi_cost((1, 1, 0), (1, 1, 1)) == 1
+        and psi_cost((1, 1, 0), (1, 0, 0)) == 3
+        and l1((14, 14, 14)) == 42
+        and "absent from `B_39(0)`" in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "ψ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named same-max face-slide hop-cost ψ holds at k=14 on B_42(0): t(14,0,0)=30 vs t(14,14,14)=46. Displayed, not adopted. Do not write ψ into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/same_max_face_slide_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.