### PR TITLE
feat(ufk14): unit-out-face same-k fails at k=14: t=26 vs t=46

### DIFF
--- a/docs/UNIT_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNIT_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,223 @@
+---
+claim_id: unit_out_face_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named unit-out-face hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unit_out_face_samek_k14_b42_2026_08_15.py
+---
+
+# Named Unit-Out-Face Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unit_out_face_samek_k14_b42_2026_08_15.py`](../scripts/unit_out_face_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+This is the first display of the named unit-out-face hop-cost `uf` at the
+`k=14` residual where ridge-slide `ρ3` fails same-`k` reverse. The named
+rule `uf` is `ρ3` plus cost `3` on a `2→2` hop whose destination max
+absolute coordinate grows and whose source max equals `1`. That extra
+clause names the unit-out-face hop `(1,1,0) → (2,1,0)` and skips every
+later face grow, including `(2,2,0) → (3,2,0)`. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rule `uf` is
+
+`uf(v→w) = 3` if `ρ3` would be `3` or `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| = 1)`, else `1`,
+
+where `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly
+two `|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equal `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is the unit-height ridge slide. The sixth clause is unit-out-face:
+grow the box on a face only from source max `1`. Those six clauses are
+the whole rule.
+
+On the six-neighbor graph the sixth clause does not change any hop cost.
+The unit-out-face hop `(1,1,0) → (2,1,0)` has `|σ| : 2 → 2`, dest max
+strictly larger, and source max `1`, so the sixth predicate holds, but
+the least nonzero dest coordinate is `1`, so corridor-slide already
+prices the hop at `3`. Independently, the deep-out-face hop
+`(2,2,0) → (3,2,0)` has source max `2`, so it is not unit-out-face;
+`uf = 1` there while a deep-out-face grow would be `3`. Therefore `uf`
+agrees with `ρ3` on every six-neighbor hop, and unit-out-face alone does
+not restore the `ρ3` same-`k` failure at `k=14`.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+gives
+
+`t(14,0,0) = 26`, `t(14,14,14) = 46`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `676/196` versus `2116/588`, or equivalently `2028 > 2116`. The
+inequality does not hold. Same-`k` reverse at `k=14` under `uf` is no.
+Independently, the new axis site is `t(42,0,0) = 58`. The shared axis
+site `t(39,0,0) = 51` is a `uf` score on this ball.
+
+The pair agrees with the `ρ3` pair `26` versus `46` because the extra
+unit-out-face clause is already priced by corridor-slide. That agreement
+is a hop-cost identity on the six-neighbor graph, not a copied `ρ3`
+table: the `uf` scores below are Dijkstra outputs under `uf`. On
+`(1,1,0) → (2,1,0)` both `ρ3` and `uf` cost `3`, and the sixth predicate
+is already priced. On `(2,2,0) → (3,2,0)` both `ρ3` and `uf` cost `1`,
+so `uf` cannot price deep out-face. Independently, `t(3,2,0) = 9` under
+`uf`. A cheapest `uf` walk to `(14,14,14)` uses no unit-out-face grow
+beyond the corridor hop already in `ρ3`, so the body arrival stays `46`.
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`.
+The `B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The rule is displayed, not adopted. Do not write `uf` into Admissibility.
+Do not write uf into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3` and `1`, the support-size clauses,
+the least-nonzero-coordinate clause, the two-unit-height ridge clause, the
+unit-out-face source-max clause, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `uf` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses only the first five clauses of `uf`. On the
+unit-out-face hop `(1,1,0) → (2,1,0)` the sixth predicate holds and
+corridor-slide already returns `3`, so `ρ3 = uf = 3`. On the deep-out-face
+hop `(2,2,0) → (3,2,0)` the sixth predicate fails and `ρ3 = uf = 1`.
+Therefore the extra named clause does not change any six-neighbor cost
+relative to `ρ3`, and unit-out-face alone does not restore reverse at
+`k=14`.
+
+The deep-out-face comparator `df` uses the grow test with source max at
+least `2`. On `(2,2,0) → (3,2,0)` one has `df = 3` while `uf = 1`. On
+`(1,1,0) → (2,1,0)` the `uf` grow predicate holds and the `df` grow
+predicate fails, while both final costs stay `3` by corridor-slide.
+Those hop-cost comparisons use the named rules only; they are not a
+second Dijkstra.
+
+On the interior body hop `(14,14,1) → (14,14,2)` the hop is `3→3` with
+only one absolute coordinate equal to `1`, so both `ρ3` and `uf` cost
+`1`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_uf` |
+|---|---:|
+| `(14,0,0)` | `26` |
+| `(14,14,14)` | `46` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table. These values are Dijkstra outputs, not
+fitted scalars.
+
+A witness axis walk of cost `26` is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, unit-out-face / corridor-slide `3` onto
+`(2,1,0)`, non-hugging face hop `1` onto `(2,2,0)`, twelve
+support-preserving cost-`1` face hops to `(14,2,0)`, hugging slide `3`
+onto `(14,1,0)`, and support-drop `3` onto `(14,0,0)`, summing to `26`.
+That walk is a witness of cost `26`, not a uniqueness claim. The pure
+axis 1-skeleton walk costs `42` and is not cheapest.
+
+A witness body walk of cost `46` is the same prefix of cost `8` to
+`(2,2,0)`, twelve cost-`1` face hops to `(14,2,0)`, twelve cost-`1` face
+hops to `(14,14,0)`, enter-body `1` onto `(14,14,1)`, and thirteen
+support-preserving cost-`1` body hops to `(14,14,14)`, summing to `46`.
+Those last hops have dest with only one absolute coordinate equal to `1`,
+or with all three coordinates large, so they are not unit-height ridges
+and are not unit-out-face `2→2` grows. That walk is a witness of cost
+`46`, not a uniqueness claim.
+
+A witness that deep out-face is not taxed by `uf` is the walk seed-exit
+`3` onto `(1,0,0)`, leave-axis `1` onto `(1,1,0)`, corridor-slide `3`
+onto `(1,2,0)`, support-preserving `1` onto `(2,2,0)`, and dest-max grow
+`1` onto `(3,2,0)`, summing to `9`. Independently, `t(3,2,0) = 9`.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 26^2 = 2028` and `46^2 = 2116`, so
+
+`2028 > 2116` is false; `2028 < 2116`.
+
+Arrival per Euclidean length is larger at `(14,14,14)` than at `(14,0,0)`.
+Same-`k` reverse at `k=14` under `uf` is no. Unit-out-face alone does not
+restore the `ρ3` failure at `k=14`. The comparison is displayed, not
+adopted. The inequality does not hold.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `uf` is a displayed scoring device on `B_42(0)`. Do not write `uf`
+into Admissibility. Do not write uf into Admissibility. Do not attach L1.
+It is not a replacement for unit-cost first arrival, and it is not offered
+as the unique hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule uf at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `uf` among hop-costs that score the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of a `ρ3` arrival table as a substitute for the `uf` Dijkstra.
+- That the extra unit-out-face clause changes a six-neighbor hop cost
+  relative to `ρ3`. It does not; the named hop is already priced.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18729,6 +18729,10 @@
   "unit_conversion_is_the_accepted_non_bounding_ruler_reconciliation_note_2026-06-08": {
    "deps_hash": "d292eab310f2",
    "out_degree": 2
+  },
+  "unit_out_face_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "unit_singlet_overlap_narrow_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/unit_out_face_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/unit_out_face_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/unit_out_face_samek_k14_b42_2026_08_15.py
+runner_sha256: 3aba94868385d6644e4ab3a443998163d9f0b877b6f248bc8cea85378370ba36
+input_fingerprint_sha256: 5e5489fdd58d8b4ab7610b37b03a9cce18204f3c3c0aafa3e05bb3128e53a9b6
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.83
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/UNIT_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named unit-out-face hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility uf is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 26
+t(14,14,14) 46
+t(14,0,0)^2/196 676/196
+t(14,14,14)^2/588 2116/588
+3t_axis^2 2028
+t_body^2 2116
+reverse False
+t(42,0,0) 58
+t(39,0,0) 51
+t(3,2,0) 9
+dijkstra_calls 1
+witness_uf_axis_sum 26
+witness_uf_body_sum 46
+uf_unit_out_face 3
+rho3_unit_out_face 3
+uf_grow_unit True
+df_grow_unit False
+uf_deep_out_face 1
+rho3_deep_out_face 1
+df_deep_out_face 3
+uf_grow_deep False
+df_grow_deep True
+PASS: t-14000-141414 t(14,0,0)=26 and t(14,14,14)=46
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: unit-out-face-already-in-rho3 the named unit-out-face hop is already ρ3 cost 3, and uf leaves deep out-face at 1
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: seed-and-unit-out-face-clauses seed-exit, both-weights-1, support-drop, corridor/unit-out-face, and ridge-slide cost 3; deep out-face and other hops cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unit_out_face_samek_k14_b42_2026_08_15.py
+++ b/scripts/unit_out_face_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under uf on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/UNIT_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/UNIT_OUT_FACE_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named unit-out-face "
+    "hop-cost on B_42(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 26
+T_BODY_REP = 46
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def unit_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def max_abs(v: tuple[int, int, int]) -> int:
+    return max(abs(v[0]), abs(v[1]), abs(v[2]))
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_count(w) == 2:
+        return 3
+    return 1
+
+
+def uf_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max_abs(w) > max_abs(v)
+        and max_abs(v) == 1
+    )
+
+
+def df_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max_abs(w) > max_abs(v)
+        and max_abs(v) >= 2
+    )
+
+
+def uf_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if uf_grow(v, w):
+        return 3
+    return 1
+
+
+def df_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if df_grow(v, w):
+        return 3
+    return 1
+
+
+def dijkstra_uf(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + uf_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(
+    walk: tuple[tuple[int, int, int], ...],
+    cost_fn,
+) -> int:
+    return sum(cost_fn(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "uf is not written into Admissibility",
+        "Do not write uf into Admissibility" in note
+        and "Do not write `uf` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_uf(sites)
+    t14000 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    reverse = 3 * t14000 * t14000 > t141414 * t141414
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+        *[(x, 2, 0) for x in range(3, 15)],
+        (14, 1, 0),
+        (14, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+        *[(x, 2, 0) for x in range(3, 15)],
+        *[(14, y, 0) for y in range(3, 15)],
+        (14, 14, 1),
+        *[(14, 14, z) for z in range(2, 15)],
+    )
+    unit_out_face = ((1, 1, 0), (2, 1, 0))
+    deep_out_face = ((2, 2, 0), (3, 2, 0))
+    later_out_face = ((7, 2, 0), (8, 2, 0))
+    ridge_hop = ((1, 1, 1), (2, 1, 1))
+    interior_body_hop = ((14, 14, 1), (14, 14, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t14000}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {t14000 * t14000}/196")
+    print(f"t(14,14,14)^2/588 {t141414 * t141414}/588")
+    print(f"3t_axis^2 {3 * t14000 * t14000}")
+    print(f"t_body^2 {t141414 * t141414}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(3,2,0) {t320}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_uf_axis_sum {path_cost(witness_axis, uf_cost)}")
+    print(f"witness_uf_body_sum {path_cost(witness_body, uf_cost)}")
+    print(f"uf_unit_out_face {uf_cost(*unit_out_face)}")
+    print(f"rho3_unit_out_face {rho3_cost(*unit_out_face)}")
+    print(f"uf_grow_unit {uf_grow(*unit_out_face)}")
+    print(f"df_grow_unit {df_grow(*unit_out_face)}")
+    print(f"uf_deep_out_face {uf_cost(*deep_out_face)}")
+    print(f"rho3_deep_out_face {rho3_cost(*deep_out_face)}")
+    print(f"df_deep_out_face {df_cost(*deep_out_face)}")
+    print(f"uf_grow_deep {uf_grow(*deep_out_face)}")
+    print(f"df_grow_deep {df_grow(*deep_out_face)}")
+
+    checks.check(
+        "t-14000-141414",
+        f"t(14,0,0)={T_AXIS_REP} and t(14,14,14)={T_BODY_REP}",
+        t14000 == T_AXIS_REP
+        and t141414 == T_BODY_REP
+        and t14000 == path_cost(witness_axis, uf_cost)
+        and t141414 == path_cost(witness_body, uf_cost),
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold",
+        (not reverse)
+        and 3 * t14000 * t14000 == 2028
+        and t141414 * t141414 == 2116
+        and "2028 < 2116" in note
+        and "does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`26`" in note
+        and "`46`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note
+        and "t(14,0,0) = 26" in note
+        and "t(14,14,14) = 46" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2028 < 2116" in note and "676/196" in note and "2116/588" in note,
+    )
+    checks.check(
+        "unit-out-face-already-in-rho3",
+        "the named unit-out-face hop is already ρ3 cost 3, and uf leaves deep out-face at 1",
+        uf_grow(*unit_out_face)
+        and not df_grow(*unit_out_face)
+        and uf_cost(*unit_out_face) == 3
+        and rho3_cost(*unit_out_face) == 3
+        and mu_cost(*unit_out_face) == 3
+        and not uf_grow(*deep_out_face)
+        and df_grow(*deep_out_face)
+        and uf_cost(*deep_out_face) == 1
+        and rho3_cost(*deep_out_face) == 1
+        and df_cost(*deep_out_face) == 3
+        and uf_cost(*later_out_face) == 1
+        and rho3_cost(*later_out_face) == 1
+        and t14000 == 26
+        and t141414 == 46
+        and t320 == 9
+        and "already priced" in note
+        and "`t(3,2,0) = 9`" in note
+        and "does not restore" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 58
+        and t3900 == 51
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "seed-and-unit-out-face-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor/unit-out-face, and ridge-slide cost 3; deep out-face and other hops cost 1",
+        uf_cost((0, 0, 0), (1, 0, 0)) == 3
+        and uf_cost((1, 0, 0), (2, 0, 0)) == 3
+        and uf_cost((1, 1, 0), (1, 0, 0)) == 3
+        and uf_cost((1, 1, 0), (2, 1, 0)) == 3
+        and uf_cost((1, 1, 1), (2, 1, 1)) == 3
+        and uf_cost((2, 2, 0), (3, 2, 0)) == 1
+        and uf_cost((1, 0, 0), (1, 1, 0)) == 1
+        and uf_cost((1, 1, 0), (1, 1, 1)) == 1
+        and uf_cost((2, 2, 1), (3, 2, 1)) == 1
+        and uf_cost(*interior_body_hop) == 1
+        and uf_cost((14, 14, 13), (14, 14, 14)) == 1
+        and uf_cost(*ridge_hop) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "uf(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom
+        and "μ(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named unit-out-face hop-cost uf fails at k=14 on B_42(0): t(14,0,0)=26 vs t(14,14,14)=46. Unit hop alone does not restore. Displayed, not adopted. Do not write uf into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/unit_out_face_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.