### PR TITLE
feat(c2d4k16): cost-2 max≥4 out-face same-k holds at k=16: t=32 vs t=52

### DIFF
--- a/docs/COST2_MAX4_OUT_FACE_SAMEK_K16_B48_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/COST2_MAX4_OUT_FACE_SAMEK_K16_B48_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,265 @@
+---
+claim_id: cost2_max4_out_face_samek_k16_b48_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=16 under the named cost-2 max≥4 out-face hop-cost on B_48(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py
+---
+
+# Named Cost-2 Max≥4 Out-Face Same-k Reverse At k=16 On B_48(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_48(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=16`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py`](../scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named cost-2 max≥4 out-face hop-cost `c2d4` is the already scored
+ridge-slide rule `ρ3` plus cost `2` on a `2→2` hop whose destination max
+absolute coordinate grows and whose source max is at least `4`. That extra
+clause cheapens the corresponding max≥4 out-face hops of the cost-3 rule
+`d4` from `3` to `2`. The extra clause skips the height-three out-face hop
+`(3,2,0) → (4,2,0)` that the max≥3 out-face rule `d3` writes into its grow
+clause, and it fires on later hops such as `(4,2,0) → (5,2,0)`. This is
+the first display of whether same-`k` reverse still holds at `k=16` under
+that cheapened later tax. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_48(0)`, the displayed
+rule `c2d4` is
+
+`c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4)`, else `1`,
+
+where `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly
+two `|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is the ridge slide. Those five clauses stay at cost `3`. The sixth
+clause is max≥4 out-face priced at `2`: grow the box on a face only after
+height four. Those six clauses are the whole rule. The hop `(3,2,0) →
+(4,2,0)` has source max `3`, so it is not in the sixth clause; its least
+nonzero destination coordinate is `2`, so it is also not a corridor slide,
+and it stays at cost `1`. The hop `(4,2,0) → (5,2,0)` has source max `4`
+and a growing dest max, so it is cost `2`.
+
+One Dijkstra from the origin on `B_48(0)` (152193 sites; 152192 nonzero)
+gives
+
+`t(16,0,0) = 32`, `t(16,16,16) = 52`.
+
+The displayed same-`k` comparison at `k=16` is
+
+`t(16,0,0)^2 / 256  ?  t(16,16,16)^2 / 768`,
+
+which is `1024/256` versus `2704/768`, or equivalently `3072 > 2704`. The
+inequality holds. Same-`k` reverse at `k=16` under `c2d4` is yes. Independently, the new axis site is
+`t(48,0,0) = 69`. The shared axis site `t(45,0,0) = 61` is a `c2d4` score
+on this ball, not a smaller-ball leftover.
+
+The same-`k` pair under `ρ3` is `28` versus `52`. The integers `32` versus
+`28` coincide with a raised axis relative to that wall pair. That mismatch
+on the axis is not a leftover of a `ρ3` table: the extra max≥4 out-face
+clause is live on the ball. On the later out-face hop `(4,2,0) → (5,2,0)`
+one has `|σ| : 2 → 2`, `max |w_i| = 5 > max |v_i| = 4`, and source max
+`4`, while the least nonzero `|w_i|` is `2`, so `ρ3 = 1` while `c2d4 = 2`.
+Therefore `ρ3` cannot price max≥4 out-face. Independently, `t(5,2,0) = 12`
+under `c2d4`. The skipped hop `(3,2,0) → (4,2,0)` also grows the max
+absolute coordinate, but its source max is `3`, so it is not max≥4
+out-face; it stays `c2d4 = 1` while `d3 = 3`. Independently,
+`t(4,2,0) = 10` under `c2d4`. The hop `(2,2,0) → (3,2,0)` also grows the
+max absolute coordinate, but its source max is `2`, so it is not max≥4
+out-face; it stays `c2d4 = 1` while `df = 3`. Independently,
+`t(3,2,0) = 9` under `c2d4`. The corridor hop `(1,1,0) → (2,1,0)` also
+grows the max absolute coordinate, but its source max is `1`, so it is not
+max≥4 out-face; it is already `ρ3 = 3` by the hugging clause. A cheapest
+`c2d4` walk to `(16,16,16)` uses no max≥4 out-face `2→2` grow, so the body
+arrival stays `52`. The site `(16,16,16)` has ℓ¹ norm `48`, so it is
+absent from `B_45(0)`. The `B_48(0)` table is therefore not leftover of the `B_45(0)` times.
+
+The cost-3 max≥4 out-face comparator `d4` uses the same extra clause but
+prices it at `3`. On `(4,2,0) → (5,2,0)` one has `c2d4 = 2` while
+`d4 = 3`. Independently, `t(5,2,0) = 13` under `d4` and `t(48,0,0) = 70`
+under `d4`. Therefore the `c2d4` scores are not leftover of `d4`. The
+integers `32` versus `52` happen to match that `d4` pair; the live hop
+still differs.
+
+The same-`k` pair `32` versus `52` also coincides with the `d3` pair, with
+the `df` pair, and with the `ω` pair. The named extra clause is still
+not leftover of `d3`: that rule prices `(3,2,0) → (4,2,0)` at `3`, and
+`c2d4` prices it at `1`. Independently it is not leftover of `df` or of `ω`:
+those rules price `(2,2,0) → (3,2,0)` at `3`, and `c2d4` prices it at `1`.
+
+The rule is displayed, not adopted. Do not write `c2d4` into Admissibility.
+Do not write c2d4 into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3`, `2`, and `1`, the support-size
+clauses, the least-nonzero-coordinate clause, the two-unit-height ridge
+clause, the max≥4 out-face source-max clause, and the arrival function `t`
+are separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_48(0) = { v ∈ Z^3 : |v|_1 ≤ 48 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_48(0)`,
+`t(v)` is the least sum of `c2d4` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses only the first five clauses of `c2d4`. On the
+max≥4 out-face hop `(4,2,0) → (5,2,0)` one has `|σ| : 2 → 2` and a growing
+max at source height at least four, so `ρ3 = 1` while `c2d4 = 2`. Therefore
+`ρ3` cannot price max≥4 out-face, and the `c2d4` scores below are not a
+leftover of `ρ3`.
+
+The parent cost-3 comparator `d4` uses the same grow test with cost `3`.
+On `(4,2,0) → (5,2,0)` both grow predicates hold and the hop costs
+disagree. Therefore the `c2d4` scores are not leftover of `d4`.
+
+The max≥3 out-face comparator `d3` uses the same grow test with source-max
+floor three. On `(3,2,0) → (4,2,0)` the `d3` grow predicate holds and the
+`c2d4` grow predicate fails. On `(4,2,0) → (5,2,0)` both grow predicates
+hold. Final six-neighbor costs therefore disagree on the skipped hop.
+
+The deep-out-face comparator `df` uses the same grow test with source-max
+floor two. On `(2,2,0) → (3,2,0)` the `df` grow predicate holds and the
+`c2d4` grow predicate fails. On `(4,2,0) → (5,2,0)` both grow predicates
+hold.
+
+The cost-3 out-face comparator `ω` uses the same grow test without a
+source-max floor. On `(3,2,0) → (4,2,0)` the `ω` grow predicate holds and
+the `c2d4` grow predicate fails.
+
+The cost-3 ridge-enter comparator `κ` prices `(2,1,0) → (2,1,1)` at `3`
+while `c2d4` leaves it at `1`. Therefore the `c2d4` scores are not leftover of `κ`.
+
+The interior-slide comparator `ι` taxes a `3 → 3` hop whose destination
+has `min |w_i| ≥ 2` and is not a height-`m` ridge. On `(3,3,2) → (3,3,3)`
+one has `c2d4 = 1` while `ι = 3`. Therefore the `c2d4` body arrival `52` is
+not leftover of `ι`.
+
+## Theorem 1 — Arrivals `t(16,0,0)` And `t(16,16,16)` On `B_48(0)`
+
+One origin Dijkstra on `B_48(0)` returns the integer arrivals
+
+| site | `t_c2d4` |
+|---|---:|
+| `(16,0,0)` | `32` |
+| `(16,16,16)` | `52` |
+
+Every listed site lies in `B_48(0)`. The site `(16,16,16)` has ℓ¹ norm `48`,
+so it is absent from `B_45(0)`. The pair is computed on `B_48(0)`, not
+copied from a smaller-ball table and not copied from the `ρ3` pair
+`28` versus `52`. These values are Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `32` is seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, unit-cube enter `1` onto `(1,1,1)`,
+ridge-slide `3` onto `(2,1,1)`, support-preserving `1` onto `(2,2,1)`,
+fourteen support-preserving cost-`1` body hops to `(16,2,1)`, ridge-slide
+`3` onto `(16,1,1)`, support-drop `3` onto `(16,1,0)`, and support-drop
+`3` onto `(16,0,0)`, summing to `32`. That walk never uses a `2→2` dest
+whose max grows at source height at least four. That walk is a witness of
+cost `32`, not a uniqueness claim.
+
+A witness body walk of cost `52` is the same prefix of cost `9` to
+`(2,2,1)`, fourteen cost-`1` hops to `(16,2,1)`, fourteen cost-`1` hops to
+`(16,16,1)`, and fifteen support-preserving cost-`1` body hops to
+`(16,16,16)`, summing to `52`. Those last hops have dest with only one
+absolute coordinate equal to `1` or none, so they are not ridge slides.
+That walk is a witness of cost `52`, not a uniqueness claim.
+
+A witness that the skip is live is the walk seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, corridor-slide `3` onto `(1,2,0)`,
+support-preserving `1` onto `(2,2,0)`, support-preserving `1` onto
+`(3,2,0)`, and skipped height-three out-face `1` onto `(4,2,0)`, summing
+to `10`. Replacing only the last hop by its `d3` price `3` yields `12`.
+Independently, `t(4,2,0) = 10`.
+
+A witness that the max≥4 out-face clause is live is that same prefix of
+cost `10` to `(4,2,0)` followed by max≥4 out-face `2` onto `(5,2,0)`,
+summing to `12`. Replacing only the last hop by its `ρ3` price `1` yields
+`11`. Replacing only the last hop by its `d4` price `3` yields `13`.
+Independently, `t(5,2,0) = 12`.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=16`
+
+The Euclidean-normalized comparison at `k=16` is
+
+`t(16,0,0)^2 / 256  ?  t(16,16,16)^2 / 768`,
+
+equivalently `3 t(16,0,0)^2 ? t(16,16,16)^2`. Substituting the computed times
+gives `3 · 32^2 = 3072` and `52^2 = 2704`, so
+
+`3072 > 2704`.
+
+Arrival per Euclidean length is larger at `(16,0,0)` than at `(16,16,16)`.
+Same-`k` reverse at `k=16` under `c2d4` is yes. The comparison is
+displayed, not adopted. The inequality holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `c2d4` is a displayed scoring device on `B_48(0)`. Do not write `c2d4`
+into Admissibility. Do not write c2d4 into Admissibility. Do not attach L1.
+It is not a replacement for unit-cost first arrival, and it is not offered
+as the unique hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_48(0) for one named hop-cost at k=16. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_48(0) for the displayed rule c2d4 at k=16; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `c2d4` among hop-costs that reverse the same-`k` pair at `k=16`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_48(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=16`.
+- Any reuse of the `ρ3` arrival table as a substitute for the `c2d4` Dijkstra.
+- Any reuse of the `d4` arrival table as a substitute for the `c2d4` Dijkstra.
+- Any reuse of the `d3`, `df`, or `ω` arrival table as a substitute for the
+  `c2d4` Dijkstra.
+- Membership of `c2d4` as a physical hop-cost. Reverse at `k=16` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -2737,6 +2737,10 @@
   "cosmology_single_ratio_inverse_reconstruction_theorem_note_2026-04-25": {
    "deps_hash": "14400756f044",
    "out_degree": 4
+  },
+  "cost2_max4_out_face_samek_k16_b48_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "coulomb_stability_upper_bound_support_note_2026-05-20": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/cost2_max4_out_face_samek_k16_b48_2026_08_15.txt
+++ b/logs/runner-cache/cost2_max4_out_face_samek_k16_b48_2026_08_15.txt
@@ -1,0 +1,75 @@
+===== runner cache v1 =====
+runner: scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py
+runner_sha256: 60a66d53d385516345247bb7c5ae020ea31dd721296ca34ee194e5d85351e221
+input_fingerprint_sha256: 3bf8e0ef38f52b7eec6f9fcbfd10e1d7925a649685f0ce892f00b54384d68a95
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.21
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/COST2_MAX4_OUT_FACE_SAMEK_K16_B48_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=16 under the named cost-2 max≥4 out-face hop-cost on B_48(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility c2d4 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 152193
+t(16,0,0) 32
+t(16,16,16) 52
+t(16,0,0)^2/256 1024/256
+t(16,16,16)^2/768 2704/768
+3t_axis^2 3072
+t_body^2 2704
+reverse True
+t(48,0,0) 69
+t(45,0,0) 61
+t(3,2,0) 9
+t(4,2,0) 10
+t(5,2,0) 12
+dijkstra_calls 1
+witness_axis_sum 32
+witness_body_sum 52
+c2d4_skip 1
+d4_skip 1
+d3_skip 3
+df_skip 3
+omega_skip 3
+rho3_skip 1
+c2d4_later 2
+d4_later 3
+rho3_later 1
+d4_grow_skip False
+d3_grow_skip True
+d4_grow_later True
+witness_skip_c2d4 10
+witness_skip_d3 12
+witness_later_c2d4 12
+witness_later_d4 13
+witness_later_rho3 11
+PASS: t-1600-161616 t(16,0,0)=32 and t(16,16,16)=52
+PASS: reverse-k16 t(16,0,0)^2/256 > t(16,16,16)^2/768 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b48 B_48(0) has 152193 sites and 152192 nonzero sites
+PASS: reachable every site of B_48(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-rho3 c2d4 prices max≥4 out-face at 2 while ρ3 prices it at 1
+PASS: not-leftover-of-d4 d4 prices max≥4 out-face at 3 while c2d4 prices it at 2
+PASS: not-leftover-of-b45 (16,16,16) lies outside B_45(0) and the note says so
+PASS: skips-height-three-out-face c2d4 extra clause skips (3,2,0)→(4,2,0); d3, df, and ω extra clauses include it
+PASS: not-leftover-of-kappa κ prices ridge-enter at 3 while c2d4 leaves it at 1
+PASS: not-leftover-of-iota c2d4 does not tax the interior 3→3 hop that ι taxes
+PASS: seed-and-max4-out-face-clauses seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide cost 3; max≥4 out-face costs 2; skipped height-two and height-three grow, unit-cube, and body enter cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py
+++ b/scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=16 under c2d4 on B_48(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/COST2_MAX4_OUT_FACE_SAMEK_K16_B48_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/COST2_MAX4_OUT_FACE_SAMEK_K16_B48_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=16 under the named cost-2 max≥4 "
+    "out-face hop-cost on B_48(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+T_AXIS_REP = 32
+T_BODY_REP = 52
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_height_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_height_count(w) == 2:
+        return 3
+    return 1
+
+
+def kappa_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 2
+        and support_size(w) == 3
+        and unit_height_count(w) == 2
+    ):
+        return 3
+    return 1
+
+
+def iota_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 3 and sigma_w == 3:
+        m = min(abs(c) for c in w)
+        if m >= 2 and sum(1 for c in w if abs(c) == m) != 2:
+            return 3
+    return 1
+
+
+def omega_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max(abs(c) for c in w) > max(abs(c) for c in v)
+    )
+
+
+def df_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 2
+
+
+def d3_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 3
+
+
+def d4_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 4
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if omega_grow(v, w):
+        return 3
+    return 1
+
+
+def df_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if df_grow(v, w):
+        return 3
+    return 1
+
+
+def d3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d3_grow(v, w):
+        return 3
+    return 1
+
+
+def d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d4_grow(v, w):
+        return 3
+    return 1
+
+
+def c2d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d4_grow(v, w):
+        return 2
+    return 1
+
+
+def dijkstra_c2d4(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + c2d4_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(
+    walk: tuple[tuple[int, int, int], ...],
+    cost_fn,
+) -> int:
+    return sum(cost_fn(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "c2d4 is not written into Admissibility",
+        "Do not write c2d4 into Admissibility" in note
+        and "Do not write `c2d4` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(48)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_c2d4(sites)
+    t1600 = dist[(16, 0, 0)]
+    t161616 = dist[(16, 16, 16)]
+    t4800 = dist[(48, 0, 0)]
+    t4500 = dist[(45, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    t420 = dist[(4, 2, 0)]
+    t520 = dist[(5, 2, 0)]
+    reverse = 3 * t1600 * t1600 > t161616 * t161616
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 17)],
+        (16, 1, 1),
+        (16, 1, 0),
+        (16, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 17)],
+        *[(16, y, 1) for y in range(3, 17)],
+        *[(16, 16, z) for z in range(2, 17)],
+    )
+    witness_skip = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (3, 2, 0),
+        (4, 2, 0),
+    )
+    witness_later = witness_skip + ((5, 2, 0),)
+    skip_hop = ((3, 2, 0), (4, 2, 0))
+    later_hop = ((4, 2, 0), (5, 2, 0))
+    height_two = ((2, 2, 0), (3, 2, 0))
+    unit_out_face = ((1, 1, 0), (2, 1, 0))
+    later_out_face = ((7, 2, 0), (8, 2, 0))
+    height2_nongrow = ((1, -2, 0), (2, -2, 0))
+    ridge_enter = ((2, 1, 0), (2, 1, 1))
+    print(f"n_sites {len(sites)}")
+    print(f"t(16,0,0) {t1600}")
+    print(f"t(16,16,16) {t161616}")
+    print(f"t(16,0,0)^2/256 {t1600 * t1600}/256")
+    print(f"t(16,16,16)^2/768 {t161616 * t161616}/768")
+    print(f"3t_axis^2 {3 * t1600 * t1600}")
+    print(f"t_body^2 {t161616 * t161616}")
+    print(f"reverse {reverse}")
+    print(f"t(48,0,0) {t4800}")
+    print(f"t(45,0,0) {t4500}")
+    print(f"t(3,2,0) {t320}")
+    print(f"t(4,2,0) {t420}")
+    print(f"t(5,2,0) {t520}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_axis_sum {path_cost(witness_axis, c2d4_cost)}")
+    print(f"witness_body_sum {path_cost(witness_body, c2d4_cost)}")
+    print(f"c2d4_skip {c2d4_cost(*skip_hop)}")
+    print(f"d4_skip {d4_cost(*skip_hop)}")
+    print(f"d3_skip {d3_cost(*skip_hop)}")
+    print(f"df_skip {df_cost(*skip_hop)}")
+    print(f"omega_skip {omega_cost(*skip_hop)}")
+    print(f"rho3_skip {rho3_cost(*skip_hop)}")
+    print(f"c2d4_later {c2d4_cost(*later_hop)}")
+    print(f"d4_later {d4_cost(*later_hop)}")
+    print(f"rho3_later {rho3_cost(*later_hop)}")
+    print(f"d4_grow_skip {d4_grow(*skip_hop)}")
+    print(f"d3_grow_skip {d3_grow(*skip_hop)}")
+    print(f"d4_grow_later {d4_grow(*later_hop)}")
+    print(f"witness_skip_c2d4 {path_cost(witness_skip, c2d4_cost)}")
+    print(f"witness_skip_d3 {path_cost(witness_skip, d3_cost)}")
+    print(f"witness_later_c2d4 {path_cost(witness_later, c2d4_cost)}")
+    print(f"witness_later_d4 {path_cost(witness_later, d4_cost)}")
+    print(f"witness_later_rho3 {path_cost(witness_later, rho3_cost)}")
+
+    checks.check(
+        "t-1600-161616",
+        f"t(16,0,0)={T_AXIS_REP} and t(16,16,16)={T_BODY_REP}",
+        t1600 == T_AXIS_REP
+        and t161616 == T_BODY_REP
+        and t1600 == path_cost(witness_axis, c2d4_cost)
+        and t161616 == path_cost(witness_body, c2d4_cost),
+    )
+    checks.check(
+        "reverse-k16",
+        "t(16,0,0)^2/256 > t(16,16,16)^2/768 holds",
+        reverse
+        and 3 * t1600 * t1600 == 3072
+        and t161616 * t161616 == 2704
+        and "3072 > 2704" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b48",
+        "B_48(0) has 152193 sites and 152192 nonzero sites",
+        len(sites) == 152193 and len(nonzero) == 152192 and all(l1(v) <= 48 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_48(0) is reached",
+        len(dist) == 152193,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`32`" in note
+        and "`52`" in note
+        and "`(16,0,0)`" in note
+        and "`(16,16,16)`" in note
+        and "t(16,0,0) = 32" in note
+        and "t(16,16,16) = 52" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "3072 > 2704" in note and "1024/256" in note and "2704/768" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "c2d4 prices max≥4 out-face at 2 while ρ3 prices it at 1",
+        c2d4_cost(*later_hop) == 2
+        and rho3_cost(*later_hop) == 1
+        and mu_cost(*later_hop) == 1
+        and c2d4_cost(*later_out_face) == 2
+        and rho3_cost(*later_out_face) == 1
+        and c2d4_cost(*height2_nongrow) == 1
+        and t1600 == 32
+        and t161616 == 52
+        and t520 == 12
+        and path_cost(witness_later, c2d4_cost) == 12
+        and path_cost(witness_later, rho3_cost) == 11
+        and "cannot price max≥4 out-face" in note
+        and "`t(5,2,0) = 12`" in note
+        and "28` versus `52" in note,
+    )
+    checks.check(
+        "not-leftover-of-d4",
+        "d4 prices max≥4 out-face at 3 while c2d4 prices it at 2",
+        c2d4_cost(*later_hop) == 2
+        and d4_cost(*later_hop) == 3
+        and path_cost(witness_later, d4_cost) == 13
+        and path_cost(witness_later, c2d4_cost) == 12
+        and t520 == 12
+        and t4800 == 69
+        and "not leftover of `d4`" in note
+        and "`t(48,0,0) = 69`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b45",
+        "(16,16,16) lies outside B_45(0) and the note says so",
+        l1((16, 16, 16)) == 48
+        and (16, 16, 16) in dist
+        and t4800 == 69
+        and t4500 == 61
+        and "absent from `B_45(0)`" in note
+        and "not leftover of the `B_45(0)` times" in note,
+    )
+    checks.check(
+        "skips-height-three-out-face",
+        "c2d4 extra clause skips (3,2,0)→(4,2,0); d3, df, and ω extra clauses include it",
+        (not d4_grow(*skip_hop))
+        and d3_grow(*skip_hop)
+        and df_grow(*skip_hop)
+        and omega_grow(*skip_hop)
+        and d4_grow(*later_hop)
+        and d3_grow(*later_hop)
+        and df_grow(*later_hop)
+        and omega_grow(*later_hop)
+        and c2d4_cost(*skip_hop) == 1
+        and d3_cost(*skip_hop) == 3
+        and df_cost(*skip_hop) == 3
+        and omega_cost(*skip_hop) == 3
+        and rho3_cost(*skip_hop) == 1
+        and c2d4_cost(*later_hop) == 2
+        and c2d4_cost(*unit_out_face) == 3
+        and c2d4_cost(*height_two) == 1
+        and df_cost(*height_two) == 3
+        and t420 == 10
+        and t320 == 9
+        and path_cost(witness_skip, c2d4_cost) == 10
+        and path_cost(witness_skip, d3_cost) == 12
+        and "skips the height-three out-face" in note
+        and "not leftover of `d3`" in note
+        and "not leftover of `df`" in note,
+    )
+    checks.check(
+        "not-leftover-of-kappa",
+        "κ prices ridge-enter at 3 while c2d4 leaves it at 1",
+        c2d4_cost(*ridge_enter) == 1
+        and kappa_cost(*ridge_enter) == 3
+        and rho3_cost(*ridge_enter) == 1
+        and "not leftover of `κ`" in note,
+    )
+    checks.check(
+        "not-leftover-of-iota",
+        "c2d4 does not tax the interior 3→3 hop that ι taxes",
+        c2d4_cost((3, 3, 2), (3, 3, 3)) == 1
+        and iota_cost((3, 3, 2), (3, 3, 3)) == 3
+        and t161616 == 52
+        and t161616 != 72
+        and "not leftover of `ι`" in note,
+    )
+    checks.check(
+        "seed-and-max4-out-face-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide cost 3; max≥4 out-face costs 2; skipped height-two and height-three grow, unit-cube, and body enter cost 1",
+        c2d4_cost((0, 0, 0), (1, 0, 0)) == 3
+        and c2d4_cost((1, 0, 0), (2, 0, 0)) == 3
+        and c2d4_cost((1, 1, 0), (1, 0, 0)) == 3
+        and c2d4_cost(*unit_out_face) == 3
+        and c2d4_cost((1, 1, 1), (2, 1, 1)) == 3
+        and c2d4_cost((2, 2, 0), (3, 2, 0)) == 1
+        and c2d4_cost((3, 2, 0), (4, 2, 0)) == 1
+        and c2d4_cost((4, 2, 0), (5, 2, 0)) == 2
+        and c2d4_cost((3, 2, 0), (3, 3, 0)) == 1
+        and c2d4_cost((3, 3, 0), (4, 3, 0)) == 1
+        and c2d4_cost((4, 3, 0), (5, 3, 0)) == 2
+        and c2d4_cost((1, 0, 0), (1, 1, 0)) == 1
+        and c2d4_cost((1, 1, 0), (1, 1, 1)) == 1
+        and c2d4_cost((2, 1, 0), (2, 1, 1)) == 1
+        and c2d4_cost((2, 2, 0), (2, 2, 1)) == 1
+        and c2d4_cost((1, -2, 0), (2, -2, 0)) == 1
+        and c2d4_cost((2, 2, 2), (3, 2, 2)) == 1
+        and c2d4_cost((2, 7, 7), (3, 7, 7)) == 1
+        and c2d4_cost((15, 16, 16), (16, 16, 16)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named cost-2 max≥4 out-face hop-cost c2d4 holds at k=16 on B_48(0): t(16,0,0)=32 vs t(16,16,16)=52. First display. Displayed, not adopted. Do not write c2d4 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/cost2_max4_out_face_samek_k16_b48_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.