### PR TITLE
feat(i2k19): c2d4-plus-interior same-k fails at k=19: t=35 vs t=79

### DIFF
--- a/docs/C2D4_INTERIOR_COST2_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_INTERIOR_COST2_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,240 @@
+---
+claim_id: c2d4_interior_cost2_samek_k19_b57_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=19 under the named c2d4-plus-interior hop-cost on B_57(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py
+---
+
+# Named Cost-2 Interior `3→3` Same-`k` Reverse At `k=19` On `B_57(0)`
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_57(0)`,
+scored only for the same-`k` pair `t(19,0,0)` versus `t(19,19,19)`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py`](../scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_57(0)`, the stacked
+rules `ν`, `μ`, and `ρ3` are
+
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+`|w_i|` equals `1)`, else `1`;
+
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`.
+
+The parent cost-2 max≥4 out-face rule `c2d4` is `ρ3` plus cost `2` on a
+`2→2` hop whose destination has a larger max absolute coordinate than the
+source and whose source max is at least `4`:
+
+`c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4)`, else `1`.
+
+The displayed c2d4-plus-interior hop-cost `i2` keeps those clauses and adds
+cost `2` on a `3→3` hop whose destination min absolute coordinate is at
+least `2`:
+
+`i2(v→w) = 3` if `ρ3` would be `3`, else `2` if `c2d4` would be `2` or
+`(|σ_v|=|σ_w|=3` and `min_i |w_i| ≥ 2)`, else `1`.
+
+Those clauses are the whole rule. Uniqueness is not claimed. This note is
+the first display of same-`k` reverse at `k=19` under `i2`.
+
+The interior addendum fires, for example, `(2,2,1) → (2,2,2)` and
+`(2,2,2) → (3,2,2)`. On both hops one has `|σ|=3→3` and
+`min_i |w_i| ≥ 2`, so `i2=2` while `c2d4=1` and `ρ3=1`. The same addendum
+skips `(2,2,1) → (3,2,1)`, whose destination min absolute coordinate is
+`1`, so `i2=1`. Ridge-slide `(1,1,1) → (2,1,1)` remains `ρ3=3`. The
+source-max floor of `c2d4` still skips `(3,2,0) → (4,2,0)` (`i2=1`) and
+still fires `(4,2,0) → (5,2,0)` (`i2=2`). The unit-out-face hop
+`(1,1,0) → (2,1,0)` is already `ρ3=3` by corridor-slide (`μ`).
+
+One Dijkstra from the origin on `B_57(0)` (253575 sites; 253574 nonzero)
+returns
+
+| site | `t_{i2}` |
+|---|---:|
+| `(19,0,0)` | `35` |
+| `(19,19,19)` | `79` |
+
+The same-`k` comparison at `k=19` is
+
+`t(19,0,0)^2 / 361  ?  t(19,19,19)^2 / 1083`,
+
+which is `1225/361` versus `6241/1083`, or equivalently `3 t(19,0,0)^2 ?
+t(19,19,19)^2`. Substituting the computed times gives `3 · 35^2 = 3675`
+and `79^2 = 6241`, so `3675 < 6241`. The inequality does not hold.
+Same-`k` reverse at `k=19` is no.
+
+Independently, `t(2,2,1) = 9`, `t(2,2,2) = 11`, `t(19,19,1) = 43`,
+`t(3,2,0) = 9`, `t(4,2,0) = 10`, and `t(5,2,0) = 12`. The new axis site
+is `t(57,0,0) = 78`. The shared axis site `t(54,0,0) = 70` is an `i2`
+score on this ball. The site `(19,19,19)` has ℓ¹ norm `57`, so it is
+absent from `B_54(0)`. The `B_57(0)` table is therefore not leftover of
+the `B_54(0)` times.
+
+A cheapest body walk keeps one coordinate at absolute value `1` until
+`(19,19,1)`, then pays cost `2` on each remaining interior grow. A named
+`c2d4` body walk that grows in the interior from `(2,2,1)` has `c2d4`
+hop-sum `61` and `i2` hop-sum `113`. The Dijkstra arrival `79` is
+therefore not leftover of `c2d4`. On `(2,2,1) → (2,2,2)` one has
+`i2=2` while `c2d4=1`, so `c2d4` cannot price interior 3→3 dest-min≥2.
+
+The extra interior clause is live: the cheapest walk to `(2,2,2)` uses
+`(2,2,1) → (2,2,2)` at cost `2`. Pricing that hop at `2` rather than `1`
+does not restore reverse at `k=19`. The axis arrival stays `35` because
+the axis witness never uses a `3→3` destination with min absolute
+coordinate at least `2`.
+
+The rule is displayed, not adopted. Do not write `i2` into Admissibility.
+Do not write i2 into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3`, `2`, and `1`, the support-size,
+max-coordinate, and dest-min clauses, and the arrival function `t` are
+separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_57(0) = { v ∈ Z^3 : |v|_1 ≤ 57 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_57(0)`,
+`t(v)` is the least sum of `i2` along a directed path from `0` to `v` in
+that graph.
+
+The first `ν` clause is seed-exit. The second is both weights `1`. The third
+is support drop. The `μ` addendum taxes a `2→2` hop whose destination still
+touches a unit coordinate. The `ρ3` addendum taxes a `3→3` hop whose
+destination has exactly two unit coordinates. The `c2d4` addendum taxes a
+`2→2` hop that grows the coordinate box on a face only after source max
+at least `4`, and prices that hop at `2`. The `i2` addendum taxes a `3→3`
+hop whose destination min absolute coordinate is at least `2`, and prices
+that hop at `2`.
+
+The comparator `c2d4` uses only the first six clauses. On
+`(2,2,1) → (2,2,2)` one has `|σ| : 3 → 3` and dest-min at least two, so
+`c2d4 = 1` while `i2 = 2`. Therefore `c2d4` cannot price interior 3→3
+dest-min≥2, and the `i2` scores below are not leftover of `c2d4`.
+Independently, `t(2,2,2) = 11`. Replacing only that last hop by its
+`c2d4` price `1` would yield `10`, which is not the `i2` arrival.
+
+The site `(19,0,0)` has ℓ¹ norm `19` and therefore also lies in `B_54(0)`.
+The site `(19,19,19)` has ℓ¹ norm `57`, so it is absent from `B_54(0)`. The
+`B_57(0)` table is therefore not leftover of the `B_54(0)` times.
+
+## Theorem 1 — Arrivals At `k=19` Under `i2`
+
+One origin Dijkstra on `B_57(0)` returns
+
+```text
+t(19,0,0) = 35
+t(19,19,19) = 79
+```
+
+Both sites lie in `B_57(0)`. The site `(19,19,19)` has ℓ¹ norm `57`, so it
+is absent from `B_54(0)`. The pair is computed on `B_57(0)`, not copied
+from a smaller-ball table. These values are Dijkstra outputs, not fitted
+scalars.
+
+A witness axis walk of cost `35` is seed-exit `3` onto `(1,0,0)`, leave-axis
+`1` onto `(1,1,0)`, enter-body `1` onto `(1,1,1)`, ridge-slide `3` onto
+`(1,2,1)`, eighteen support-preserving cost-`1` body hops to `(19,2,1)`,
+support-drop `3` onto `(19,2,0)`, corridor-slide `3` onto `(19,1,0)`, and
+support-drop `3` onto `(19,0,0)`, summing to `35`. Every body hop on that
+walk has destination min absolute coordinate `1`, so the interior addendum
+is idle. That walk is a witness of cost `35`, not a uniqueness claim.
+
+A witness body walk of cost `79` is seed-exit `3` onto `(1,0,0)`, leave-axis
+`1` onto `(1,1,0)`, enter-body `1` onto `(1,1,1)`, ridge-slide `3` onto
+`(2,1,1)`, leave-ridge `1` onto `(2,2,1)`, seventeen cost-`1` hugging body
+hops to `(19,2,1)`, seventeen cost-`1` hugging body hops to `(19,19,1)`,
+and eighteen interior cost-`2` body hops to `(19,19,19)`, summing to `79`.
+Independently, `t(19,19,1) = 43`. That walk is a witness of cost `79`, not
+a uniqueness claim.
+
+A witness that the interior hop is live is seed-exit `3` onto `(1,0,0)`,
+leave-axis `1` onto `(1,1,0)`, enter-body `1` onto `(1,1,1)`, ridge-slide
+`3` onto `(2,1,1)`, leave-ridge `1` onto `(2,2,1)`, and interior grow `2`
+onto `(2,2,2)`, summing to `11`. Independently, `t(2,2,1) = 9`.
+Independently, `t(2,2,2) = 11`. Replacing only that last hop by its
+`c2d4` price `1` would yield `10`, which is not the `i2` arrival.
+
+A witness that the skipped out-face hop is cheap is seed-exit `3` onto
+`(1,0,0)`, leave-axis `1` onto `(1,1,0)`, corridor-slide `3` onto
+`(1,2,0)`, non-hugging face hop `1` onto `(2,2,0)`, grow `1` onto
+`(3,2,0)`, and the skipped grow `1` onto `(4,2,0)`, summing to `10`.
+Independently, `t(4,2,0) = 10`. Independently, `t(3,2,0) = 9`. Continuing
+by max≥4 out-face `2` onto `(5,2,0)` sums to `12`. Independently,
+`t(5,2,0) = 12`.
+
+## Theorem 2 — Reverse At The Same-`k` Pair `k=19`
+
+The Euclidean-normalized comparison at `k=19` is
+
+`t(19,0,0)^2 / 361  ?  t(19,19,19)^2 / 1083`.
+
+The computed integers give `3 · 35^2 = 3675` and `79^2 = 6241`, so
+`3675 < 6241`. Arrival per Euclidean length is larger at `(19,19,19)` than
+at `(19,0,0)`. Same-`k` reverse at `k=19` under `i2` is no. The comparison
+is displayed, not adopted.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `i2` is a displayed scoring device on `B_57(0)`. Do not write
+`i2` into Admissibility. Do not write i2 into Admissibility. Do not
+attach L1. It is not a replacement for unit-cost first arrival, and it is
+not offered as the unique hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_57(0) for one named hop-cost. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_57(0) for the displayed rule i2 at k=19; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `i2` among hop-costs that reverse any same-`k` pair.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_57(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=19`.
+- Any reuse of a smaller-ball arrival table as a substitute for the
+  radius-`57` Dijkstra.
+- Any adoption of `i2` as an admissibility rule.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_interior_cost2_samek_k19_b57_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_interior_cost2_samek_k19_b57_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_interior_cost2_samek_k19_b57_2026_08_15.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py
+runner_sha256: 212e08ecf803955d6dda58d929a9da2b9cb9b324ad02e1244638ee254e7161d7
+input_fingerprint_sha256: 4330e09f49f1ec3e5e8f20b6133b49bb188d7f226737d94e74e8db3d8b799a6f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 4.01
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/C2D4_INTERIOR_COST2_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=19 under the named c2d4-plus-interior hop-cost on B_57(0) is reported. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_57(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+claim_boundary: same-k reverse at k=19 is displayed, not adopted
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility i2 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+PASS: cache-false the note records cache_write false
+n_sites 253575
+t(19,0,0) 35
+t(19,19,19) 79
+t(19,0,0)^2/361 1225/361
+t(19,19,19)^2/1083 6241/1083
+3 t(19,0,0)^2 3675
+t(19,19,19)^2 6241
+reverse False
+t(57,0,0) 78
+t(54,0,0) 70
+t(3,2,0) 9
+t(4,2,0) 10
+t(5,2,0) 12
+t(2,2,1) 9
+t(2,2,2) 11
+t(19,19,1) 43
+dijkstra_calls 1
+PASS: theorem-1 t(19,0,0)=35 and t(19,19,19)=79 match named witnesses
+PASS: reverse-k19 t(19,0,0)^2 / 361 > t(19,19,19)^2 / 1083 is false
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: ball-b57 B_57(0) has 253575 sites and 253574 nonzero sites
+PASS: reachable every site of B_57(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-product note records the integer reverse comparison
+PASS: interior-fires i2 prices interior 3-to-3 dest-min>=2 hops at 2
+PASS: interior-skips-hugging i2 extra skips 3-to-3 hops whose destination min abs is 1
+PASS: skips-early-out-face i2 keeps (3,2,0)->(4,2,0) at cost 1
+PASS: fires-max4-out-face-at-2 i2 keeps (4,2,0)->(5,2,0) at cost 2 from c2d4
+PASS: unit-out-face-by-mu unit-out-face (1,1,0)->(2,1,0) is already ρ3=3 by corridor-slide
+PASS: not-leftover-of-c2d4 interior 3-to-3 dest-min>=2 is i2=2 and c2d4=1
+PASS: not-leftover-of-b54 (19,19,19) lies outside B_54(0) and the note says so
+PASS: witness-arrivals named axis and body walks realize the computed arrivals
+PASS: seed-and-axis-clauses seed-exit and both-weights-1 cost 3; support increase costs 1
+PASS: i2-clauses seed-exit, axis, drop, corridor-slide, and ridge-slide cost 3; interior dest-min>=2 costs 2; hugging 3-to-3 and small 2-to-3 cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.
+per_site: arrival times are reported at (19,0,0) and (19,19,19).
+lattice_wide: checked and not executed — the search stays inside B_57(0).
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py
+++ b/scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=19 under i2 on B_57(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/C2D4_INTERIOR_COST2_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_INTERIOR_COST2_SAMEK_K19_B57_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=19 under the named c2d4-plus-interior "
+    "hop-cost on B_57(0) is reported. Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def coord_sum(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        nonzero = [abs(coord) for coord in w if coord != 0]
+        if nonzero and min(nonzero) == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3:
+        if sum(abs(coord) == 1 for coord in w) == 2:
+            return 3
+    return 1
+
+
+def c2d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2:
+        if (
+            max(abs(coord) for coord in w) > max(abs(coord) for coord in v)
+            and max(abs(coord) for coord in v) >= 4
+        ):
+            return 2
+    return 1
+
+
+def i2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if c2d4_cost(v, w) == 2:
+        return 2
+    if support_size(v) == 3 and support_size(w) == 3:
+        if min(abs(coord) for coord in w) >= 2:
+            return 2
+    return 1
+
+
+def path_cost(path: list[tuple[int, int, int]]) -> int:
+    return sum(i2_cost(a, b) for a, b in zip(path, path[1:]))
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(
+        self, sites: list[tuple[int, int, int]]
+    ) -> dict[tuple[int, int, int], int]:
+        self.calls += 1
+        site_set = set(sites)
+        dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+        heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+        seen: set[tuple[int, int, int]] = set()
+        while heap:
+            d, v = heapq.heappop(heap)
+            if v in seen:
+                continue
+            seen.add(v)
+            vx, vy, vz = v
+            for dx, dy, dz in NEIGH:
+                w = (vx + dx, vy + dy, vz + dz)
+                if w not in site_set:
+                    continue
+                nd = d + i2_cost(v, w)
+                if nd < dist.get(w, 10**9):
+                    dist[w] = nd
+                    heapq.heappush(heap, (nd, w))
+        return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_57(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+    print(
+        "claim_boundary: same-k reverse at k=19 is displayed, not adopted"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " ") and CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "i2 is not written into Admissibility",
+        "Do not write i2 into Admissibility." in note
+        and "Do not write `i2` into Admissibility." in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1." in note and "Do not attach L1." not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+    checks.check(
+        "cache-false",
+        "the note records cache_write false",
+        "cache_write: false" in note,
+    )
+
+    sites = ball(57)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    counter = DijkstraCounter()
+    dist = counter.distances(sites)
+    t1900 = dist[(19, 0, 0)]
+    t191919 = dist[(19, 19, 19)]
+    t5700 = dist[(57, 0, 0)]
+    t5400 = dist[(54, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    t420 = dist[(4, 2, 0)]
+    t520 = dist[(5, 2, 0)]
+    t221 = dist[(2, 2, 1)]
+    t222 = dist[(2, 2, 2)]
+    t19191 = dist[(19, 19, 1)]
+    reverse = 3 * t1900 * t1900 > t191919 * t191919
+    axis_sq = t1900 * t1900
+    body_sq = t191919 * t191919
+    axis_prod = 3 * axis_sq
+
+    axis_witness = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 2, 1)]
+    axis_witness.extend((x, 2, 1) for x in range(2, 20))
+    axis_witness.extend([(19, 2, 0), (19, 1, 0), (19, 0, 0)])
+    body_witness = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1), (2, 1, 1), (2, 2, 1)]
+    body_witness.extend((x, 2, 1) for x in range(3, 20))
+    body_witness.extend((19, y, 1) for y in range(3, 20))
+    body_witness.extend((19, 19, z) for z in range(2, 20))
+    c2d4_body_walk = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 2, 0), (2, 2, 0), (2, 2, 1)]
+    c2d4_body_walk.extend((2, 2, z) for z in range(2, 20))
+    c2d4_body_walk.extend((2, y, 19) for y in range(3, 20))
+    c2d4_body_walk.extend((x, 19, 19) for x in range(3, 20))
+    interior_fire = ((2, 2, 1), (2, 2, 2))
+    interior_grow = ((2, 2, 2), (3, 2, 2))
+    interior_skip = ((2, 2, 1), (3, 2, 1))
+    skip_hop = ((3, 2, 0), (4, 2, 0))
+    fire_hop = ((4, 2, 0), (5, 2, 0))
+    unit_out_face = ((1, 1, 0), (2, 1, 0))
+    fire_witness = [
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (3, 2, 0),
+        (4, 2, 0),
+        (5, 2, 0),
+    ]
+    interior_witness = [
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        (2, 2, 2),
+    ]
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(19,0,0) {t1900}")
+    print(f"t(19,19,19) {t191919}")
+    print(f"t(19,0,0)^2/361 {axis_sq}/361")
+    print(f"t(19,19,19)^2/1083 {body_sq}/1083")
+    print(f"3 t(19,0,0)^2 {axis_prod}")
+    print(f"t(19,19,19)^2 {body_sq}")
+    print(f"reverse {reverse}")
+    print(f"t(57,0,0) {t5700}")
+    print(f"t(54,0,0) {t5400}")
+    print(f"t(3,2,0) {t320}")
+    print(f"t(4,2,0) {t420}")
+    print(f"t(5,2,0) {t520}")
+    print(f"t(2,2,1) {t221}")
+    print(f"t(2,2,2) {t222}")
+    print(f"t(19,19,1) {t19191}")
+    print(f"dijkstra_calls {counter.calls}")
+
+    checks.check(
+        "theorem-1",
+        f"t(19,0,0)={t1900} and t(19,19,19)={t191919} match named witnesses",
+        t1900 == path_cost(axis_witness)
+        and t191919 == path_cost(body_witness)
+        and t1900 > 0
+        and t191919 > 0,
+    )
+    checks.check(
+        "reverse-k19",
+        "t(19,0,0)^2 / 361 > t(19,19,19)^2 / 1083 is false",
+        (not reverse)
+        and axis_prod < body_sq
+        and f"{axis_prod} < {body_sq}" in note
+        and "inequality does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1 and "DijkstraCounter" in source,
+    )
+    checks.check(
+        "ball-b57",
+        "B_57(0) has 253575 sites and 253574 nonzero sites",
+        len(sites) == 253575
+        and len(nonzero) == 253574
+        and all(coord_sum(v) <= 57 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_57(0) is reached",
+        len(dist) == 253575,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        f"t(19,0,0) = {t1900}" in note
+        and f"t(19,19,19) = {t191919}" in note
+        and "`(19,0,0)`" in note
+        and "`(19,19,19)`" in note,
+    )
+    checks.check(
+        "note-records-reverse-product",
+        "note records the integer reverse comparison",
+        f"{axis_prod} < {body_sq}" in note
+        and f"{axis_sq}/361" in note
+        and f"{body_sq}/1083" in note,
+    )
+    checks.check(
+        "interior-fires",
+        "i2 prices interior 3-to-3 dest-min>=2 hops at 2",
+        i2_cost(*interior_fire) == 2
+        and i2_cost(*interior_grow) == 2
+        and c2d4_cost(*interior_fire) == 1
+        and c2d4_cost(*interior_grow) == 1
+        and rho3_cost(*interior_fire) == 1
+        and rho3_cost(*interior_grow) == 1
+        and min(abs(c) for c in interior_fire[1]) >= 2
+        and min(abs(c) for c in interior_grow[1]) >= 2
+        and t221 == 9
+        and t222 == 11
+        and path_cost(interior_witness) == 11
+        and "(2,2,1) → (2,2,2)" in note
+        and "(2,2,2) → (3,2,2)" in note
+        and "`t(2,2,1) = 9`" in note
+        and "`t(2,2,2) = 11`" in note,
+    )
+    checks.check(
+        "interior-skips-hugging",
+        "i2 extra skips 3-to-3 hops whose destination min abs is 1",
+        i2_cost(*interior_skip) == 1
+        and c2d4_cost(*interior_skip) == 1
+        and rho3_cost(*interior_skip) == 1
+        and min(abs(c) for c in interior_skip[1]) == 1
+        and "(2,2,1) → (3,2,1)" in note,
+    )
+    checks.check(
+        "skips-early-out-face",
+        "i2 keeps (3,2,0)->(4,2,0) at cost 1",
+        i2_cost(*skip_hop) == 1
+        and c2d4_cost(*skip_hop) == 1
+        and rho3_cost(*skip_hop) == 1
+        and t320 == 9
+        and t420 == 10
+        and "(3,2,0) → (4,2,0)" in note
+        and "`t(3,2,0) = 9`" in note
+        and "`t(4,2,0) = 10`" in note,
+    )
+    checks.check(
+        "fires-max4-out-face-at-2",
+        "i2 keeps (4,2,0)->(5,2,0) at cost 2 from c2d4",
+        i2_cost(*fire_hop) == 2
+        and c2d4_cost(*fire_hop) == 2
+        and rho3_cost(*fire_hop) == 1
+        and t520 == path_cost(fire_witness)
+        and path_cost(fire_witness) == 12
+        and "(4,2,0) → (5,2,0)" in note
+        and "`t(5,2,0) = 12`" in note,
+    )
+    checks.check(
+        "unit-out-face-by-mu",
+        "unit-out-face (1,1,0)->(2,1,0) is already ρ3=3 by corridor-slide",
+        i2_cost(*unit_out_face) == 3
+        and rho3_cost(*unit_out_face) == 3
+        and mu_cost(*unit_out_face) == 3
+        and "(1,1,0) → (2,1,0)" in note,
+    )
+    checks.check(
+        "not-leftover-of-c2d4",
+        "interior 3-to-3 dest-min>=2 is i2=2 and c2d4=1",
+        i2_cost(*interior_fire) == 2
+        and c2d4_cost(*interior_fire) == 1
+        and t222 == 11
+        and sum(c2d4_cost(a, b) for a, b in zip(c2d4_body_walk, c2d4_body_walk[1:]))
+        == 61
+        and path_cost(c2d4_body_walk) == 113
+        and "cannot price interior 3→3 dest-min≥2" in note
+        and "not leftover of `c2d4`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b54",
+        "(19,19,19) lies outside B_54(0) and the note says so",
+        coord_sum((19, 19, 19)) == 57
+        and (19, 19, 19) in dist
+        and t5700 == dist[(57, 0, 0)]
+        and t5400 == dist[(54, 0, 0)]
+        and f"t(57,0,0) = {t5700}" in note
+        and f"t(54,0,0) = {t5400}" in note
+        and "absent from `B_54(0)`" in note
+        and "not leftover of the `B_54(0)` times" in note,
+    )
+    checks.check(
+        "witness-arrivals",
+        "named axis and body walks realize the computed arrivals",
+        path_cost(axis_witness) == t1900
+        and path_cost(body_witness) == t191919
+        and axis_witness[-1] == (19, 0, 0)
+        and body_witness[-1] == (19, 19, 19)
+        and all(coord_sum(v) <= 57 for v in axis_witness)
+        and all(coord_sum(v) <= 57 for v in body_witness)
+        and t19191 == 43
+        and "`t(19,19,1) = 43`" in note,
+    )
+    checks.check(
+        "seed-and-axis-clauses",
+        "seed-exit and both-weights-1 cost 3; support increase costs 1",
+        i2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and i2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and i2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and i2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 1, 1), (2, 1, 1)) == 3,
+    )
+    checks.check(
+        "i2-clauses",
+        "seed-exit, axis, drop, corridor-slide, and ridge-slide cost 3; interior dest-min>=2 costs 2; hugging 3-to-3 and small 2-to-3 cost 1",
+        i2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and i2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 1, 0), (2, 1, 0)) == 3
+        and i2_cost((1, 1, 1), (2, 1, 1)) == 3
+        and i2_cost((4, 2, 0), (5, 2, 0)) == 2
+        and i2_cost((2, 2, 2), (3, 2, 2)) == 2
+        and i2_cost((2, 2, 1), (2, 2, 2)) == 2
+        and i2_cost((19, 19, 1), (19, 19, 2)) == 2
+        and i2_cost((2, 2, 1), (3, 2, 1)) == 1
+        and i2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and i2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and i2_cost((3, 2, 0), (4, 2, 0)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "i2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported at (19,0,0) and (19,19,19).")
+    print("lattice_wide: checked and not executed — the search stays inside B_57(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named i2 hop-cost fails at k=19 on B_57(0): t(19,0,0)=35 vs t(19,19,19)=79 (3675<6241). Body slower than c2d4's 61; wall not restored. Displayed, not adopted. Do not spec i2k20 (test 19). Do not write i2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_interior_cost2_samek_k19_b57_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.