### PR TITLE
feat(i2k13): c2d4-plus-interior same-k fails at k=13: t=29 vs t=55

### DIFF
--- a/docs/C2D4_INTERIOR_COST2_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_INTERIOR_COST2_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,402 @@
+---
+claim_id: c2d4_interior_cost2_samek_k13_b39_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=13 under the named c2d4-plus-interior hop-cost on B_39(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py
+---
+
+# Same-k Reverse At k=13 Under The Named C2d4-Plus-Interior Hop-Cost On B_39(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival comparison at k=13 on the finite nearest-neighbor
+graph `B_39(0)`, under the named c2d4-plus-interior hop-cost `i2` displayed
+for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py`](../scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named c2d4-plus-interior hop-cost `i2` is
+the first display of `i2` at `k=13`. The parent clauses `ν`, `μ`, `ρ3`, and
+`c2d4` are those of the cost-2 max≥4 out-face scoring:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4`), else `1`;
+- `i2(v→w) = 3` if `ρ3` would be `3`, else `2` if `c2d4` would be `2` or
+  (`|σ_v|=|σ_w|=3` and `min_i |w_i| ≥ 2`), else `1`.
+
+The extra interior clause prices a fully supported `3→3` hop whose
+destination least absolute coordinate is at least `2`, including
+height-`m` ridges. It fires on `(2,2,2) → (3,2,2)` at cost `2`. It also
+fires on the height-`2` ridge `(4,2,2) → (5,2,2)` at cost `2`. It does not
+fire on `(4,3,1) → (5,3,1)`, whose destination least absolute coordinate is
+`1`. The parent `c2d4` extra remains: `(4,2,0) → (5,2,0)` stays at cost
+`2`. The skipped max≥3 out hop `(3,2,0) → (4,2,0)` stays at cost `1`. The
+interior-slide comparator `ι` prices non-ridge interior `3→3` hops at `3`
+and leaves height-`m` ridges at `1`; `i2` is not that clause. Uniqueness is not claimed.
+
+The finite host is scored independently: one origin Dijkstra is run on this
+ball. The ball is not leftover of a larger-ball table.
+
+```text
+B_39(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 39 }.
+```
+
+It has 82239 sites. Edges are the cubic nearest-neighbor steps that remain
+inside `B_39(0)`. One Dijkstra from the origin yields
+
+```text
+t(13,0,0) = 29
+t(13,13,13) = 55
+```
+
+The same-k comparison at k=13 is
+
+```text
+t(13,0,0)^2 / 169 = 841/169 = 2523/507
+t(13,13,13)^2 / 507 = 3025/507
+2523/507 < 3025/507
+```
+
+Equivalently `2523 < 3025`. The inequality `t(13,0,0)^2 / 169 > t(13,13,13)^2 / 507`
+does not hold. Same-k reverse at k=13 under `i2` is reported no. Displayed,
+not adopted.
+
+A witness axis walk of cost `29` is seed-exit `3` onto `(1,0,0)`, unit-cube
+leave `1` onto `(1,1,0)`, unit-cube enter `1` onto `(1,1,1)`, ridge-slide
+`3` onto `(2,1,1)`, support-preserving `1` onto `(2,2,1)`, eleven
+support-preserving cost-`1` hops to `(13,2,1)`, ridge-slide `3` onto
+`(13,1,1)`, support-drop `3` onto `(13,1,0)`, and support-drop `3` onto
+`(13,0,0)`. That walk is a witness of cost `29`, not a uniqueness claim.
+
+A witness body walk of cost `55` is the same prefix of cost `9` to
+`(2,2,1)`, eleven cost-`1` hops to `(13,2,1)`, eleven cost-`1` hops to
+`(13,13,1)`, and twelve interior `3→3` hops of cost `2` to `(13,13,13)`,
+summing to `55`. Independently, `t(13,13,1) = 31`. Those last twelve hops
+have destination least absolute coordinate at least `2`, so the interior
+clause is live on the body walk. That walk is a witness of cost `55`, not
+a uniqueness claim.
+
+On the max≥4 out hop `(4,2,0) → (5,2,0)` one has `|σ_v|=|σ_w|=2`, dest max
+`5` greater than source max `4`, and source max already `4`, so `ρ3 = 1`
+while `c2d4 = 2` and `i2 = 2`. Independently, `t(4,2,0) = 10` and
+`t(5,2,0) = 12`. On the skipped max≥3 out hop `(3,2,0) → (4,2,0)` the
+`c2d4` extra is idle because the source max is `3`; both `c2d4` and `i2`
+cost `1`. Independently, `t(3,2,0) = 9`. On the interior hop
+`(2,2,2) → (3,2,2)` one has `|σ|=3→3` and dest min `2`, so `c2d4 = 1`
+while `i2 = 2`. Therefore `c2d4` cannot price the interior clause, and the
+body arrival `55` is not leftover of `c2d4`.
+
+The displayed body last hop `(12,13,13) → (13,13,13)` has dest min `13`,
+so `i2 = 2`. The displayed interior hop is not a leftover of `ι`: on
+`(4,2,2) → (5,2,2)` one has `ι = 1` (height-`2` ridge) while `i2 = 2`, and
+on `(3,3,2) → (4,3,2)` one has `ι = 3` while `i2 = 2`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_39(0) reports t(13,0,0) and t(13,13,13) under the named c2d4-plus-interior hop-cost and scores the k=13 same-k comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: c2d4_interior_cost2_samek_k13_b39
+target_blocker_text: "whether same-k reverse at k=13 still holds after interior 3-to-3 hops with dest min abs coord at least 2 are priced at 2 on top of c2d4"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_39(0) under the named hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `i2` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_39(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`,
+  `c2d4`, and `i2` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `i2` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_39(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`i2` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`i2`, using one Dijkstra on `B_39(0)`.
+
+Representative values:
+
+| hop | class | `i2` |
+|---|---|---|
+| `(0,0,0)→(1,0,0)` | leave origin | `3` |
+| `(1,0,0)→(2,0,0)` | `1→1` | `3` |
+| `(1,0,0)→(1,1,0)` | `1→2` | `1` |
+| `(1,1,0)→(1,1,1)` | `2→3` unit cube | `1` |
+| `(1,1,0)→(2,1,0)` | corridor `2→2` | `3` |
+| `(2,2,0)→(3,2,0)` | plane `2→2` with min nonzero `2` | `1` |
+| `(3,2,0)→(4,2,0)` | skipped max≥3 out-face | `1` |
+| `(4,2,0)→(5,2,0)` | max≥4 out-face | `2` |
+| `(4,1,0)→(5,1,0)` | corridor already in `ρ3` | `3` |
+| `(2,2,2)→(3,2,2)` | interior `3→3` dest min `2` | `2` |
+| `(3,3,2)→(4,3,2)` | interior non-ridge `3→3` | `2` |
+| `(4,2,2)→(5,2,2)` | height-`2` ridge `3→3` | `2` |
+| `(1,2,2)→(2,2,2)` | equal-coordinate interior `3→3` | `2` |
+| `(4,3,1)→(5,3,1)` | min-`1` non-ridge `3→3` | `1` |
+| `(4,1,1)→(5,1,1)` | unit ridge `3→3` | `3` |
+| `(12,13,13)→(13,13,13)` | last hop onto `(13,13,13)` | `2` |
+
+## Theorem 1 — Arrival times at k=13
+
+Under `i2` on `B_39(0)`,
+
+```text
+t(13,0,0) = 29
+t(13,13,13) = 55
+```
+
+Both sites lie in the ball: `13 ≤ 39` and `13+13+13 = 39`. The search
+visits `82239` sites, which is the exact census of `B_39(0)`. The runner
+computes both values from the single origin Dijkstra and checks them
+against the explicit walks above. These values are Dijkstra outputs, not
+fitted scalars.
+
+The word "unique" here names the single Dijkstra run required by the
+theorem, not uniqueness of a realizing hop sequence.
+
+## Theorem 2 — Same-k comparison at k=13
+
+The displayed comparison is whether
+
+```text
+t(13,0,0)^2 / 169 > t(13,13,13)^2 / 507.
+```
+
+Substituting the computed times gives the integer statement `841/169 > 3025/507`,
+or equivalently `2523 > 3025`. Cross-multiplication is exact:
+
+```text
+29^2 · 507 = 426387
+55^2 · 169 = 511225
+426387 < 511225
+```
+
+Therefore `t(13,0,0)^2 / 169 > t(13,13,13)^2 / 507` is false, so
+the displayed inequality does not hold. Displayed, not adopted.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write i2 into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `i2`, `c2d4`, `ρ3`, `μ`, or `ν`. This
+note proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at two sites; it is not an attachment of a
+coordinate-sum hop-cost. The coordinate-sum that names `B_39(0)` is not
+attached as an arrival law.
+
+## What This Does Not Claim
+
+- No uniqueness claim is made for this named hop-cost at k=13.
+- The live interior `3→3` clause on `B_39(0)` is not a statement about
+  larger hosts.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Current Premise Boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+When present, a record locks exactly one admissible local possibility.
+
+A site with no record cannot be read.
+
+Lattice supplies the cubic graph used to name nearest-neighbor hops. Qubit
+and Record are unused beyond vocabulary and the unread-absence boundary.
+Admissibility is quoted and is not edited. `i2` is a declared scoring on that
+already-named graph.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| `B_39(0)` | finite search domain | declared as sites with coordinate-sum at most `39` |
+| six nearest-neighbor shifts | hop graph | Lattice adjacency, restricted to the ball |
+| `ν`, `μ`, `ρ3`, `c2d4`, `i2` | named hop-costs | declared integer scoring; not axiom content |
+| `t(13,0,0)`, `t(13,13,13)` | arrivals | one Dijkstra from the origin |
+| `169`, `507` | displayed denominators | `13^2` and `3·13^2`; comparison only |
+| Record unread sentence | absence boundary | live axiom memo, quoted |
+
+There are no measured, fitted, literature, or observational inputs. No second
+search is run. No hop-cost is written into Admissibility.
+
+## No-Go Discipline
+
+The negative report is only that the displayed same-k inequality is false
+for this named scoring on this named ball. It is not a universal obstruction
+against other declared scorings.
+
+No-Go Discipline disposition: **PASS** for the displayed comparison and the
+refusal to adopt `i2` or attach a coordinate-sum arrival.
+
+### N1 — materially distinct route scan
+
+| route | marker | outcome relative to the narrow target |
+|---|---|---|
+| attach the coordinate-sum itself as arrival | **ATTEMPTED** | the ball predicate is not the scored arrival; `t(13,0,0)=29 ≠ 13` |
+| write `i2` into Admissibility | **ATTEMPTED** | Theorem 3 refuses the edit; the live sentences are unchanged |
+| claim a unique cheapest path | **ATTEMPTED** | uniqueness of a realizing sequence is outside the target |
+| adopt the same-k reverse as a law | **ATTEMPTED** | Theorem 2 is displayed, not adopted, and the inequality is false |
+| run a second search from the body site | **ATTEMPTED** | one origin Dijkstra already returns both arrivals |
+| enlarge the ball or add non-neighbor hops | **ATTEMPTED** | the theorem is only `B_39(0)` with the six in-ball shifts |
+
+### N2 — wall independence
+
+One comparison is reported: the displayed `k=13` same-k inequality under
+`i2`. Failure of that inequality is not a second impossibility wall and is
+not promoted to a no-go against later named scorings.
+
+### N3 — hidden-wall scan
+
+The ball, the six shifts, and the integer costs are declared. No clock,
+boost, continuum limit, occupancy growth, or Record readout of `t` is
+imported.
+
+### N4 — residual matching
+
+The residual that remains after this report is the same one named in the
+claim scope: a same-k reverse at `k=13` under this hop-cost is not obtained.
+The residual is not enlarged. Closing it would require a different declared
+scoring or a different theorem, not an axiom edit.
+
+### N5 — certificate granularity
+
+```text
+per-element: executed — i2 samples and both k=13 targets
+per-site: executed — origin, (13,0,0), and (13,13,13)
+per-mode: executed — the single named c2d4-plus-interior hop-cost
+per-block: executed — the displayed k=13 comparison only
+lattice-wide: not executed — no axiom edit and no attached arrival law
+```
+
+### N6 — partial-closure paths
+
+A later named scoring on the same graph could be compared in the same
+displayed way. Any such scoring remains a declaration until independently
+supported. Admissibility need not change.
+
+### N7 — steelman
+
+The strongest objection is that a cheaper path to `(13,13,13)` might exist
+outside `B_39(0)` or along a non-neighbor step. Correct: those graphs are
+different theorems. Inside the declared ball and six-shift graph, the
+origin Dijkstra is exhaustive.
+
+### N8 — cross-cycle echo
+
+Earlier hop-cost scores at other `k` or under `c2d4` or `ι` are not consumed
+as premises. This note is the first display of `i2` at `k=13` on `B_39(0)`
+and stands on one Dijkstra plus exact rational arithmetic.
+
+## Boundaries and explicit non-claims
+
+- `i2` is displayed hop-cost data. It is not an axiom, primitive, or adopted
+  law.
+- The same-k comparison is displayed, not adopted.
+- Uniqueness of a cheapest path is not claimed.
+- The coordinate-sum that names `B_39(0)` is not attached as an arrival law.
+- No Record readout of `t`, no clock, and no continuum identification is
+  asserted.
+- No axiom, primitive, registry, citation manifest, or audit verdict is
+  edited.
+
+## Runner Contract
+
+The companion runner builds `B_39(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(13,0,0)` and `t(13,13,13)`,
+checks the integer form of Theorem 2, checks that the interior `3→3` clause
+adds a cost-`2` tax that `c2d4` does not, keeps the max≥4 out-face tax at
+`2`, skips `(3,2,0) → (4,2,0)` as a new tax, checks that the live
+Admissibility wording does not name `i2`, and records the import boundary.
+Declared review inputs are this note and the axiom memo only.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py
+```
+
+The runner evaluates one origin Dijkstra on `B_39(0)`, checks the named
+hop-cost samples, the two arrivals, the exact reverse comparison, the live
+axiom quotes, and the N1–N8 packet. Expected summary:
+
+```text
+TOTAL: PASS>=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_interior_cost2_samek_k13_b39_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_interior_cost2_samek_k13_b39_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_interior_cost2_samek_k13_b39_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py
+runner_sha256: 2be42c22da5255c6347576fc3fd15744a680d8199cce685d922213b57963d2fd
+input_fingerprint_sha256: b90fc816f3084881308518be759cf226f0026974fea79147bfe208354bd181d0
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.10
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/C2D4_INTERIOR_COST2_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=13 under the named c2d4-plus-interior hop-cost on B_39(0) is reported. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_39(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+claim_boundary: same-k reverse at k=13 is displayed, not adopted
+n_sites 82239
+t(13,0,0) = 29
+t(13,13,13) = 55
+same-k comparison: 29^2 / 169 = 841/169 versus 55^2 / 507 = 3025/507; reverse=False
+3 t(13,0,0)^2 = 2523
+t(13,13,13)^2 = 3025
+cross 426387 vs 511225
+t(13,13,0) = 34
+t(13,13,1) = 31
+t(3,2,0) = 9
+t(4,2,0) = 10
+t(5,2,0) = 12
+dijkstra_calls 1
+witness_axis_sum 29
+witness_body_sum 55
+i2_max4_out 2 c2d4_max4_out 2 rho3_max4_out 1
+i2_interior 2 c2d4_interior 1 iota_interior 1
+i2_ridge_interior 2 iota_ridge_interior 1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_39(0) is the 82239-site integer set with coordinate-sum at most 39
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: reachable every site of B_39(0) is reached
+PASS: i2-samples named c2d4-plus-interior hop-cost matches the displayed samples
+PASS: i2-clauses rho3-cost-3 hops stay 3; max>=4 out-face and interior 3-to-3 dest min>=2 cost 2
+PASS: thm1-axis-time t(13,0,0) equals the computed origin-to-axis arrival time 29
+PASS: thm1-body-time t(13,13,13) equals the computed origin-to-body arrival time 55
+PASS: thm2-reverse-false t(13,0,0)^2 / 169 > t(13,13,13)^2 / 507 is false on the computed times
+PASS: thm2-exact-cross 29^2 * 507 = 426387 < 511225 = 55^2 * 169
+PASS: live-arrivals the same Dijkstra records skipped max>=3 out at cost 1 and max>=4 out at cost 2
+PASS: thm1-note-reports-times the note reports the computed arrival times
+PASS: thm2-note-reports-comparison the note reports the integer same-k comparison and does not adopt it
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name i2
+PASS: thm3-no-l1-attachment the note refuses to attach L1 and does not score a unit hop-cost
+PASS: forbidden-tokens forbidden tokens are absent from the note and runner
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-claimed the note does not claim uniqueness of the named hop-cost
+PASS: scope-boundary the theorem stays on B_39(0) and proposes no axiom edit
+PASS: live-quotes live Lattice, Admissibility, and Record sentences are quoted without rewrite
+PASS: nogo-packet claim_scope, machine status, and N1-N8 gate are source-visible
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.
+per_site: arrival times are reported only at (13,0,0) and (13,13,13).
+lattice_wide: checked and not executed — the search stays inside B_39(0).
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py
+++ b/scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""Same-k reverse at k=13 under the named c2d4-plus-interior hop-cost on B_39(0).
+
+One Dijkstra from the origin on the finite nearest-neighbor graph. The
+hop-cost i2 is displayed, not adopted, and is not written into
+Admissibility. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/C2D4_INTERIOR_COST2_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_INTERIOR_COST2_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Same-k reverse at k=13 under the named c2d4-plus-interior "
+    "hop-cost on B_39(0) is reported. Displayed, not adopted."
+)
+
+RADIUS = 39
+ORIGIN = (0, 0, 0)
+AXIS = (13, 0, 0)
+BODY = (13, 13, 13)
+FACE = (13, 13, 0)
+AXIS_R2 = 169
+BODY_R2 = 507
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+INF = 10**9
+N_SITES = 82239
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def coord_sum(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def in_ball(site: Site) -> bool:
+    return coord_sum(site) <= RADIUS
+
+
+def support_size(site: Site) -> int:
+    return (site[0] != 0) + (site[1] != 0) + (site[2] != 0)
+
+
+def unit_coord_count(site: Site) -> int:
+    return (abs(site[0]) == 1) + (abs(site[1]) == 1) + (abs(site[2]) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def min_abs(site: Site) -> int:
+    return min(abs(coordinate) for coordinate in site)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def omega_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+    )
+
+
+def d3_extra(source: Site, dest: Site) -> bool:
+    return omega_extra(source, dest) and max_abs(source) >= 3
+
+
+def d4_extra(source: Site, dest: Site) -> bool:
+    return omega_extra(source, dest) and max_abs(source) >= 4
+
+
+def interior_extra(source: Site, dest: Site) -> bool:
+    if support_size(source) != 3 or support_size(dest) != 3:
+        return False
+    return min_abs(dest) >= 2
+
+
+def is_height_ridge(dest: Site) -> bool:
+    height = min_abs(dest)
+    return sum(1 for coordinate in dest if abs(coordinate) == height) == 2
+
+
+def c2d4_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if d4_extra(source, dest):
+        return 2
+    return 1
+
+
+def iota_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if interior_extra(source, dest) and not is_height_ridge(dest):
+        return 3
+    return 1
+
+
+def i2_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if c2d4_cost(source, dest) == 2 or interior_extra(source, dest):
+        return 2
+    return 1
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self) -> dict[Site, int]:
+        self.calls += 1
+        dist = {ORIGIN: 0}
+        queue: list[tuple[int, Site]] = [(0, ORIGIN)]
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if cost != dist[site]:
+                continue
+            for step in STEPS:
+                neighbor = add(site, step)
+                if not in_ball(neighbor):
+                    continue
+                candidate = cost + i2_cost(site, neighbor)
+                if candidate < dist.get(neighbor, INF):
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(walk: tuple[Site, ...]) -> int:
+    return sum(i2_cost(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_39(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+    print(
+        "claim_boundary: same-k reverse at k=13 is displayed, not adopted"
+    )
+
+    hop_samples = (
+        ((0, 0, 0), (1, 0, 0), 3),
+        ((1, 0, 0), (2, 0, 0), 3),
+        ((1, 0, 0), (1, 1, 0), 1),
+        ((1, 1, 0), (1, 1, 1), 1),
+        ((1, 1, 0), (2, 1, 0), 3),
+        ((2, 2, 0), (3, 2, 0), 1),
+        ((3, 2, 0), (4, 2, 0), 1),
+        ((4, 2, 0), (5, 2, 0), 2),
+        ((4, 1, 0), (5, 1, 0), 3),
+        ((2, 2, 2), (3, 2, 2), 2),
+        ((3, 3, 2), (4, 3, 2), 2),
+        ((4, 2, 2), (5, 2, 2), 2),
+        ((1, 2, 2), (2, 2, 2), 2),
+        ((4, 3, 1), (5, 3, 1), 1),
+        ((4, 1, 1), (5, 1, 1), 3),
+        ((12, 13, 13), (13, 13, 13), 2),
+        ((12, 0, 0), (13, 0, 0), 3),
+        ((13, 12, 13), (13, 13, 13), 2),
+    )
+
+    counter = DijkstraCounter()
+    dist = counter.distances()
+    t_axis = dist[AXIS]
+    t_body = dist[BODY]
+    t320 = dist[(3, 2, 0)]
+    t420 = dist[(4, 2, 0)]
+    t520 = dist[(5, 2, 0)]
+    t_face = dist[FACE]
+    t13131 = dist[(13, 13, 1)]
+    axis_sq = t_axis * t_axis
+    body_sq = t_body * t_body
+    reverse = axis_sq * BODY_R2 > body_sq * AXIS_R2
+
+    witness_axis = (
+        ORIGIN,
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 14)],
+        (13, 1, 1),
+        (13, 1, 0),
+        AXIS,
+    )
+    witness_body = (
+        ORIGIN,
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 14)],
+        *[(13, y, 1) for y in range(3, 14)],
+        *[(13, 13, z) for z in range(2, 14)],
+    )
+
+    print(f"n_sites {len(dist)}")
+    print(f"t(13,0,0) = {t_axis}")
+    print(f"t(13,13,13) = {t_body}")
+    print(
+        f"same-k comparison: {t_axis}^2 / {AXIS_R2} = {axis_sq}/{AXIS_R2} versus "
+        f"{t_body}^2 / {BODY_R2} = {body_sq}/{BODY_R2}; reverse={reverse}"
+    )
+    print(f"3 t(13,0,0)^2 = {3 * axis_sq}")
+    print(f"t(13,13,13)^2 = {body_sq}")
+    print(f"cross {axis_sq * BODY_R2} vs {body_sq * AXIS_R2}")
+    print(f"t(13,13,0) = {t_face}")
+    print(f"t(13,13,1) = {t13131}")
+    print(f"t(3,2,0) = {t320}")
+    print(f"t(4,2,0) = {t420}")
+    print(f"t(5,2,0) = {t520}")
+    print(f"dijkstra_calls {counter.calls}")
+    print(f"witness_axis_sum {path_cost(witness_axis)}")
+    print(f"witness_body_sum {path_cost(witness_body)}")
+    print(
+        f"i2_max4_out {i2_cost((4, 2, 0), (5, 2, 0))} "
+        f"c2d4_max4_out {c2d4_cost((4, 2, 0), (5, 2, 0))} "
+        f"rho3_max4_out {rho3_cost((4, 2, 0), (5, 2, 0))}"
+    )
+    print(
+        f"i2_interior {i2_cost((2, 2, 2), (3, 2, 2))} "
+        f"c2d4_interior {c2d4_cost((2, 2, 2), (3, 2, 2))} "
+        f"iota_interior {iota_cost((2, 2, 2), (3, 2, 2))}"
+    )
+    print(
+        f"i2_ridge_interior {i2_cost((4, 2, 2), (5, 2, 2))} "
+        f"iota_ridge_interior {iota_cost((4, 2, 2), (5, 2, 2))}"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/C2D4_INTERIOR_COST2_SAMEK_K13_B39_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file()
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_39(0) is the 82239-site integer set with coordinate-sum at most 39",
+        len(dist) == N_SITES
+        and ORIGIN in dist
+        and AXIS in dist
+        and BODY in dist
+        and coord_sum(AXIS) == 13
+        and coord_sum(BODY) == 39
+        and not in_ball((14, 13, 13))
+        and all(in_ball(site) for site in dist),
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1
+        and dist[ORIGIN] == 0
+        and "DijkstraCounter" in self_source,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_39(0) is reached",
+        all(cost < INF for cost in dist.values()) and len(dist) == N_SITES,
+    )
+    checks.check(
+        "i2-samples",
+        "named c2d4-plus-interior hop-cost matches the displayed samples",
+        all(i2_cost(src, dest) == cost for src, dest, cost in hop_samples),
+    )
+    checks.check(
+        "i2-clauses",
+        "rho3-cost-3 hops stay 3; max>=4 out-face and interior 3-to-3 dest min>=2 cost 2",
+        i2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and i2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 1, 0), (2, 1, 0)) == 3
+        and i2_cost((4, 1, 1), (5, 1, 1)) == 3
+        and i2_cost((4, 2, 0), (5, 2, 0)) == 2
+        and i2_cost((2, 2, 2), (3, 2, 2)) == 2
+        and i2_cost((3, 3, 2), (4, 3, 2)) == 2
+        and i2_cost((4, 2, 2), (5, 2, 2)) == 2
+        and i2_cost((1, 2, 2), (2, 2, 2)) == 2
+        and i2_cost((12, 13, 13), (13, 13, 13)) == 2
+        and i2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and i2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and i2_cost((2, 2, 0), (3, 2, 0)) == 1
+        and i2_cost((3, 2, 0), (4, 2, 0)) == 1
+        and i2_cost((4, 3, 1), (5, 3, 1)) == 1
+        and c2d4_cost((4, 2, 0), (5, 2, 0)) == 2
+        and c2d4_cost((2, 2, 2), (3, 2, 2)) == 1
+        and interior_extra((2, 2, 2), (3, 2, 2))
+        and interior_extra((4, 2, 2), (5, 2, 2))
+        and is_height_ridge((5, 2, 2))
+        and not is_height_ridge((4, 3, 2))
+        and iota_cost((4, 2, 2), (5, 2, 2)) == 1
+        and iota_cost((3, 3, 2), (4, 3, 2)) == 3
+        and not d4_extra((3, 2, 0), (4, 2, 0))
+        and d3_extra((3, 2, 0), (4, 2, 0))
+        and d4_extra((4, 2, 0), (5, 2, 0)),
+    )
+    checks.check(
+        "thm1-axis-time",
+        "t(13,0,0) equals the computed origin-to-axis arrival time 29",
+        t_axis == 29 and t_axis == path_cost(witness_axis) and t_axis > 0,
+    )
+    checks.check(
+        "thm1-body-time",
+        "t(13,13,13) equals the computed origin-to-body arrival time 55",
+        t_body == 55 and t_body == path_cost(witness_body) and t_body > 0,
+    )
+    checks.check(
+        "thm2-reverse-false",
+        "t(13,0,0)^2 / 169 > t(13,13,13)^2 / 507 is false on the computed times",
+        reverse is False
+        and 3 * t_axis * t_axis == 2523
+        and t_body * t_body == 3025
+        and 2523 < 3025,
+    )
+    checks.check(
+        "thm2-exact-cross",
+        "29^2 * 507 = 426387 < 511225 = 55^2 * 169",
+        axis_sq * BODY_R2 == 426387
+        and body_sq * AXIS_R2 == 511225
+        and AXIS_R2 * 3 == BODY_R2
+        and 841 * 3 == 2523,
+    )
+    checks.check(
+        "live-arrivals",
+        "the same Dijkstra records skipped max>=3 out at cost 1 and max>=4 out at cost 2",
+        t320 == 9
+        and t420 == 10
+        and t520 == 12
+        and t320 + i2_cost((3, 2, 0), (4, 2, 0)) == t420
+        and t420 + i2_cost((4, 2, 0), (5, 2, 0)) == t520
+        and t13131 == 31
+        and t13131 + 12 * 2 == t_body,
+    )
+    checks.check(
+        "thm1-note-reports-times",
+        "the note reports the computed arrival times",
+        f"t(13,0,0) = {t_axis}" in note and f"t(13,13,13) = {t_body}" in note,
+    )
+    checks.check(
+        "thm2-note-reports-comparison",
+        "the note reports the integer same-k comparison and does not adopt it",
+        "841/169" in note
+        and "3025/507" in note
+        and "2523/507" in note
+        and "426387" in note
+        and "511225" in note
+        and "the displayed inequality does not hold" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name i2",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "i2(v→w)" not in axiom
+        and "Do not write i2 into Admissibility." in note
+        and "c2d4-plus-interior" in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1 and does not score a unit hop-cost",
+        "Do not attach L1." in note
+        and "attach L1" in note
+        and "unit hop-cost" not in note.lower()
+        and "not attached as an arrival law" in note,
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note and runner",
+        all(token not in note and token not in self_source for token in forbidden)
+        and ("runner-" + "cache") not in note,
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " ")
+        and CLAIM_SCOPE in note
+        and 'claim_scope: "Same-k reverse at k=13 under the named c2d4-plus-interior hop-cost on B_39(0) is reported. Displayed, not adopted."'
+        in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "the note does not claim uniqueness of the named hop-cost",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_39(0) and proposes no axiom edit",
+        "B_39(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "one Dijkstra" in note
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "live-quotes",
+        "live Lattice, Admissibility, and Record sentences are quoted without rewrite",
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+        in note
+        and "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in axiom
+        and "There is one fixed nearest-neighbor admissibility rule, covariant under lattice"
+        in note
+        and "A site with no record cannot be read." in axiom
+        and "A site with no record cannot be read." in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in note,
+    )
+    checks.check(
+        "nogo-packet",
+        "claim_scope, machine status, and N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and "actual_current_surface_status: bounded-support" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and "FAIL / DO NOT SHIP" not in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "i2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported only at (13,0,0) and (13,13,13).")
+    print("lattice_wide: checked and not executed — the search stays inside B_39(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named i2 hop-cost fails at k=13 on B_39(0): t(13,0,0)=29 vs t(13,13,13)=55 (2523<3025). Milder than ι but still kills k=13. Displayed, not adopted. Do not write i2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_interior_cost2_samek_k13_b39_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.