### PR TITLE
feat(i2k7): c2d4-plus-interior same-k holds at k=7: t=21 vs t=31

### DIFF
--- a/docs/C2D4_INTERIOR_COST2_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_INTERIOR_COST2_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,286 @@
+---
+claim_id: c2d4_interior_cost2_samek_k7_b21_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=7 under the named c2d4-plus-interior hop-cost on B_21(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py
+---
+
+# Same-k Reverse At k=7 Under The Named C2d4-Plus-Interior Hop-Cost On B_21(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival comparison at k=7 on the finite nearest-neighbor
+graph `B_21(0)`, under a named hop-cost displayed for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py`](../scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named c2d4-plus-interior hop-cost `i2` is
+the first display of `i2` at `k=7`. The parent clauses `ν`, `μ`, `ρ3`, and
+`c2d4` are those of the ridge-slide and cost-2 max≥4 out-face scorings:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4`), else `1`;
+- `i2(v→w) = 3` if `ρ3` would be `3`, else `2` if `c2d4` would be `2` or
+  (`|σ_v|=|σ_w|=3` and `min_i |w_i| ≥ 2`), else `1`.
+
+The extra interior clause is a `3→3` hop whose destination minimum absolute
+coordinate is at least `2`. It taxes body hops more than axis hops. It
+fires on `(2,2,2) → (3,2,2)` at cost `2`. It does not fire on the ridge-slide
+hop `(1,1,1) → (2,1,1)`, whose destination minimum absolute coordinate is
+`1` and which is already priced at `3` by `ρ3`. The cost-3 interior-slide
+parent `ι` prices some of those interior hops at `3` and skips height-`m`
+ridges; `i2` prices the interior clause at `2` and also taxes height-`m`
+ridges such as `(3,2,2) → (4,2,2)`. Uniqueness is not claimed.
+
+The finite host is scored independently: one origin Dijkstra is run on this
+ball. The ball is not leftover of a larger-ball table.
+
+```text
+B_21(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 21 }.
+```
+
+It has 13287 sites. Edges are the cubic nearest-neighbor steps that remain
+inside `B_21(0)`. One Dijkstra from the origin yields
+
+```text
+t(7,0,0) = 21
+t(7,7,7) = 31
+```
+
+The same-k comparison at k=7 is
+
+```text
+t(7,0,0)^2 / 49 = 441/49 > 961/147 = t(7,7,7)^2 / 147.
+```
+
+Equivalently `1323 > 961`. The inequality holds. Same-k reverse holds at k=7.
+Displayed, not adopted.
+
+Independently, the new axis site is `t(21,0,0) = 42`. The shared axis site
+`t(18,0,0) = 34` is an `i2` score on this ball, not a `ρ3` leftover. The
+site `(7,7,7)` has coordinate-sum `21`, so it is absent from `B_18(0)`. The
+`B_21(0)` table is therefore not leftover of the `B_18(0)` times.
+
+The pair is not leftover of `ρ3`: the same sites under `ρ3` are `19` versus
+`25`. On the interior hop `(2,2,2) → (3,2,2)` one has `|σ| : 3 → 3` and
+destination min abs `2`, so `ρ3 = 1` while `i2 = 2`. Therefore `ρ3`
+cannot price interior body hops. On the max≥4 out-face hop `(4,2,0) → (5,2,0)` one
+has `|σ| : 2 → 2`, destination max `5` greater than source max `4`, and
+source max already `4`, so `ρ3 = 1` while `c2d4 = 2` and `i2 = 2`.
+Therefore `ρ3` cannot price max≥4 out-face. Independently, `t(5,2,0) = 12`
+and `t(3,2,2) = 12` under `i2`. The skipped hop `(3,2,0) → (4,2,0)` grows
+the max absolute coordinate, but its source max is `3`, so it is not max≥4
+out-face; it stays `i2 = 1`. Independently, `t(3,2,0) = 9` and
+`t(4,2,0) = 10`.
+
+The pair is not leftover of `c2d4`: that parent already prices max≥4
+out-face at `2`, but it leaves interior body hops at `1`. On
+`(2,2,2) → (3,2,2)` one has `c2d4 = 1` while `i2 = 2`.
+
+The pair is not leftover of `ι`. That cost-3 interior-slide parent taxes a
+`3→3` hop whose destination has `min |w_i| ≥ 2` and is not a height-`m`
+ridge, and it killed reverse at `k=7`. On `(2,2,1) → (2,2,2)` and on
+`(3,3,2) → (3,3,3)` one has `ι = 3` while `i2 = 2`, so `ι`
+cannot price the cost-2 interior clause. On the height-`m` ridge `(3,2,2) → (4,2,2)` one has
+`ι = 1` while `i2 = 2`.
+
+A cheapest `i2` walk to `(7,0,0)` is seven axis hops of cost `3`, summing
+to `21`. A cheapest `i2` walk to `(7,7,7)` uses two cost-`3` hops, thirteen
+cost-`1` hops, and six interior cost-`2` hops, summing to `31`. Those walks
+are witnesses, not a uniqueness claim. The displayed body last hop
+`(1,1,0) → (1,1,1)` keeps cost `1`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_21(0) reports t(7,0,0) and t(7,7,7) under the named c2d4-plus-interior hop-cost and scores the k=7 same-k comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: c2d4_interior_cost2_samek_k7_b21
+target_blocker_text: "whether same-k reverse at k=7 still holds after interior 3-to-3 hops are priced at 2 on top of c2d4"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_21(0) under the named hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `i2` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_21(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`,
+  `c2d4`, and `i2` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `i2` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_21(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`i2` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`i2`, using one Dijkstra on `B_21(0)`.
+
+An explicit axis path is
+
+```text
+(0,0,0) → (1,0,0) → (2,0,0) → (3,0,0) → (4,0,0) → (5,0,0) → (6,0,0) → (7,0,0)
+```
+
+with costs `3+3+3+3+3+3+3=21`. An explicit body path is
+
+```text
+(0,0,0) → (0,0,1) → (0,1,1) → (0,1,2) → (0,2,2) → (0,2,3) → (0,2,4)
+→ (1,2,4) → (1,2,5) → (1,2,6) → (1,2,7) → (1,3,7) → (1,4,7) → (1,5,7)
+→ (1,6,7) → (1,7,7) → (2,7,7) → (3,7,7) → (4,7,7) → (5,7,7) → (6,7,7)
+→ (7,7,7)
+```
+
+with costs `3+1+3+1+1+1+1+1+1+1+1+1+1+1+1+2+2+2+2+2+2=31`. Every path has
+first hop cost `3`, and every hop costs at least `1`, so these paths are
+optimal once Dijkstra matches them.
+
+On the interior hop `(2,2,2) → (3,2,2)` one has `|σ_v|=|σ_w|=3` and dest
+min abs `2`, so `ρ3 = 1` and `c2d4 = 1` while `i2 = 2`. Independently,
+`t(2,2,2) = 11`. On the height-`m` ridge `(3,2,2) → (4,2,2)` the
+destination has min abs `2` and exactly two coordinates equal to that min,
+so `ι = 1` while `i2 = 2`. On `(3,3,2) → (3,3,3)` one has `ι = 3` while
+`i2 = 2`. On the max≥4 out hop `(4,2,0) → (5,2,0)` one has `c2d4 = 2` and
+`i2 = 2` while `ρ3 = 1`. On the max≥3 out hop `(3,2,0) → (4,2,0)` the
+max≥4 extra is idle; `i2 = 1`. On the deep-out hop `(2,2,0) → (3,2,0)` the
+max≥4 extra is idle; `i2 = 1`. On the unit-out hop `(1,1,0) → (2,1,0)`
+corridor-slide already prices the hop at `3`. On the body hop
+`(1,0,0) → (1,1,0)` one has `i2 = 1`. On `(2,1,1) → (2,1,2)` the
+destination min abs is `1`, so the interior clause is idle and `i2 = 1`.
+
+## Theorem 1 — Arrival times at k=7
+
+Under `i2` on `B_21(0)`,
+
+```text
+t(7,0,0) = 21
+t(7,7,7) = 31
+```
+
+The runner computes both values from the single origin Dijkstra and checks
+them against the explicit paths above. These values are Dijkstra outputs,
+not fitted scalars.
+
+## Theorem 2 — Same-k comparison at k=7
+
+The displayed comparison is whether
+
+```text
+t(7,0,0)^2 / 49 > t(7,7,7)^2 / 147.
+```
+
+Substituting the computed times gives the integer statement `441/49 > 961/147`,
+or equivalently `1323 > 961`. The inequality holds. Displayed, not adopted.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write i2 into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `i2`, `c2d4`, `ρ3`, `μ`, or `ν`. This
+note proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at two sites; it is not an attachment of a
+coordinate-sum hop-cost.
+
+## What This Does Not Claim
+
+- No uniqueness claim is made for this named hop-cost at k=7.
+- The live interior and max≥4 out-face clauses on `B_21(0)` are not a
+  statement about larger hosts.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md). Lattice
+supplies the six-neighbor graph and the ball. Admissibility supplies none
+of the hop costs. The integers `3`, `2`, and `1`, the support-size
+clauses, the least-nonzero-coordinate clause, the two-unit-height ridge
+clause, the max≥4 out-face source-max clause, the interior dest-min
+clause, and the arrival function `t` are separately displayed mathematical
+inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_21(0) = { v ∈ Z^3 : |v|_1 ≤ 21 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_21(0)`,
+`t(v)` is the least sum of `i2` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `ρ3` uses only the first five clauses. On
+`(2,2,2) → (3,2,2)` and on `(4,2,0) → (5,2,0)` the extra `i2` predicates
+hold and `ρ3` stays at `1`. The comparator `c2d4` uses the max≥4 out-face
+clause but not the interior clause. On `(2,2,2) → (3,2,2)` one has
+`c2d4 = 1` while `i2 = 2`. The comparator `ι` uses a cost-3 interior
+non-ridge test. On `(3,3,2) → (3,3,3)` one has `ι = 3` while `i2 = 2`.
+On `(3,2,2) → (4,2,2)` one has `ι = 1` while `i2 = 2`.
+
+## Runner Contract
+
+The companion runner builds `B_21(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(7,0,0)` and `t(7,7,7)`,
+checks the integer form of Theorem 2, checks that the extra interior and
+max≥4 out-face clauses fire in-ball, skips `(3,2,0) → (4,2,0)` as a new
+max≥4 tax, checks that the live Admissibility wording does not name `i2`,
+and records the import boundary. Declared review inputs are this note and
+the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_interior_cost2_samek_k7_b21_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_interior_cost2_samek_k7_b21_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_interior_cost2_samek_k7_b21_2026_08_15.txt
@@ -1,0 +1,66 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py
+runner_sha256: c80e0c61db819537432cb8a6c4ef55b0e9485405da1592ba45e0bb60033795a4
+input_fingerprint_sha256: ba5f8152c504a82822869371b24d99a4e792fe6131c56e28b6d7d7b83e47b447
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.50
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/C2D4_INTERIOR_COST2_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=7 under the named c2d4-plus-interior hop-cost on B_21(0) is reported. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_21(0) only
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+n_sites 13287
+t(7,0,0) = 21
+t(7,7,7) = 31
+same-k comparison: 21^2 / 49 = 441/49 versus 31^2 / 147 = 961/147; reverse=True
+3 t(7,0,0)^2 = 1323
+t(7,7,7)^2 = 961
+t(21,0,0) = 42
+t(18,0,0) = 34
+t(3,2,0) = 9
+t(4,2,0) = 10
+t(5,2,0) = 12
+t(2,2,2) = 11
+t(3,2,2) = 12
+dijkstra_calls 1
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_21(0) is the 13287-site integer set with coordinate-sum at most 21
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: reachable every site of B_21(0) is reached
+PASS: hop-origin the unique origin hop has named cost 3
+PASS: hop-max4-out-clause c2d4 would be 2 on (4,2,0) to (5,2,0), so i2 prices that hop at 2
+PASS: hop-interior-clause a 3-to-3 hop whose dest min abs coord is at least 2 is priced at 2
+PASS: hop-max3-out-skipped the max>=4 out-face clause skips (3,2,0) to (4,2,0)
+PASS: i2-clauses seed-exit, axis, drop, corridor, and ridge cost 3; max>=4 out-face and interior 3-to-3 cost 2; other displayed hops cost 1
+PASS: extras-live-on-ball both extra i2 clauses fire on in-ball hops
+PASS: thm1-axis-time t(7,0,0) equals the computed origin-to-axis arrival time
+PASS: thm1-body-time t(7,7,7) equals the computed origin-to-body arrival time
+PASS: thm2-reverse-holds t(7,0,0)^2 / 49 > t(7,7,7)^2 / 147 holds on the computed times
+PASS: thm1-note-reports-times the note reports the computed arrival times
+PASS: thm2-note-reports-comparison the note reports the integer same-k comparison and does not adopt it
+PASS: not-leftover-of-rho3-or-c2d4 i2 disagrees with rho3 and with c2d4 on in-ball hops, and the arrivals are not the rho3 pair
+PASS: not-leftover-of-iota i2 cheapens interior non-ridge 3-to-3 hops relative to iota and taxes height-m ridges that iota skips
+PASS: not-leftover-of-b18 (7,7,7) lies outside B_18(0) and the note says so
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name i2
+PASS: thm3-no-l1-attachment the note refuses to attach L1
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-claimed the note does not claim uniqueness of the named hop-cost
+PASS: scope-boundary the theorem stays on B_21(0) and proposes no axiom edit
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: independent-sites the same Dijkstra records the skipped max>=3 hop and the live interior and max>=4 arrivals
+per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.
+per_site: arrival times are reported at (7,0,0) and (7,7,7).
+lattice_wide: checked and not executed — the search stays inside B_21(0).
+TOTAL: PASS=29 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py
+++ b/scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""Same-k reverse at k=7 under the named c2d4-plus-interior hop-cost on B_21(0).
+
+One Dijkstra from the origin on the finite nearest-neighbor graph. The
+named hop-cost i2 is displayed, not adopted, and is not written into
+Admissibility. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/C2D4_INTERIOR_COST2_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_INTERIOR_COST2_SAMEK_K7_B21_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Same-k reverse at k=7 under the named c2d4-plus-interior "
+    "hop-cost on B_21(0) is reported. Displayed, not adopted."
+)
+
+RADIUS = 21
+AXIS = (7, 0, 0)
+BODY = (7, 7, 7)
+ORIGIN = (0, 0, 0)
+FACE = (1, 1, 0)
+UNIT_OUT = (2, 1, 0)
+DF_OUT_SRC = (2, 2, 0)
+DF_OUT_DST = (3, 2, 0)
+MAX3_OUT_SRC = (3, 2, 0)
+MAX3_OUT_DST = (4, 2, 0)
+MAX4_OUT_SRC = (4, 2, 0)
+MAX4_OUT_DST = (5, 2, 0)
+MAX4_LIVE_SRC = (4, 1, 0)
+MAX4_LIVE_DST = (5, 1, 0)
+RIDGE_SRC = (1, 1, 1)
+RIDGE_DST = (2, 1, 1)
+INT_SRC = (2, 2, 2)
+INT_DST = (3, 2, 2)
+IOTA_INT_SRC = (2, 2, 1)
+IOTA_INT_DST = (2, 2, 2)
+HEIGHT_M_SRC = (3, 2, 2)
+HEIGHT_M_DST = (4, 2, 2)
+CUBE_SRC = (3, 3, 2)
+CUBE_DST = (3, 3, 3)
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def l1(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def support_size(site: Site) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def unit_coord_count(site: Site) -> int:
+    return sum(1 for coordinate in site if abs(coordinate) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def min_abs(site: Site) -> int:
+    return min(abs(coordinate) for coordinate in site)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball_sites(radius: int) -> list[Site]:
+    sites: list[Site] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def d4_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+        and max_abs(source) >= 4
+    )
+
+
+def d3_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+        and max_abs(source) >= 3
+    )
+
+
+def c2d4_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if d4_extra(source, dest):
+        return 2
+    return 1
+
+
+def interior_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 3
+        and support_size(dest) == 3
+        and min_abs(dest) >= 2
+    )
+
+
+def iota_extra(source: Site, dest: Site) -> bool:
+    if support_size(source) != 3 or support_size(dest) != 3:
+        return False
+    least = min_abs(dest)
+    if least < 2:
+        return False
+    equal_min = sum(1 for coordinate in dest if abs(coordinate) == least)
+    return equal_min != 2
+
+
+def iota_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if iota_extra(source, dest):
+        return 3
+    return 1
+
+
+def i2_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if c2d4_cost(source, dest) == 2 or interior_extra(source, dest):
+        return 2
+    return 1
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, sites: list[Site], origin: Site) -> dict[Site, int]:
+        self.calls += 1
+        site_set = set(sites)
+        dist: dict[Site, int] = {origin: 0}
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        seen: set[Site] = set()
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if site in seen:
+                continue
+            seen.add(site)
+            for step in STEPS:
+                neighbor = add(site, step)
+                if neighbor not in site_set:
+                    continue
+                candidate = cost + i2_cost(site, neighbor)
+                if candidate < dist.get(neighbor, 10**9):
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_21(0) only"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+
+    sites = ball_sites(RADIUS)
+    site_set = set(sites)
+    counter = DijkstraCounter()
+    dist = counter.distances(sites, ORIGIN)
+    t_axis = dist[AXIS]
+    t_body = dist[BODY]
+    t2100 = dist[(21, 0, 0)]
+    t1800 = dist[(18, 0, 0)]
+    t320 = dist[MAX3_OUT_SRC]
+    t420 = dist[MAX3_OUT_DST]
+    t520 = dist[MAX4_OUT_DST]
+    t222 = dist[INT_SRC]
+    t322 = dist[INT_DST]
+    reverse = 3 * t_axis * t_axis > t_body * t_body
+    axis_sq = t_axis * t_axis
+    body_sq = t_body * t_body
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(7,0,0) = {t_axis}")
+    print(f"t(7,7,7) = {t_body}")
+    print(
+        f"same-k comparison: {t_axis}^2 / 49 = {axis_sq}/49 versus "
+        f"{t_body}^2 / 147 = {body_sq}/147; reverse={reverse}"
+    )
+    print(f"3 t(7,0,0)^2 = {3 * axis_sq}")
+    print(f"t(7,7,7)^2 = {body_sq}")
+    print(f"t(21,0,0) = {t2100}")
+    print(f"t(18,0,0) = {t1800}")
+    print(f"t(3,2,0) = {t320}")
+    print(f"t(4,2,0) = {t420}")
+    print(f"t(5,2,0) = {t520}")
+    print(f"t(2,2,2) = {t222}")
+    print(f"t(3,2,2) = {t322}")
+    print(f"dijkstra_calls {counter.calls}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_21(0) is the 13287-site integer set with coordinate-sum at most 21",
+        len(sites) == 13287
+        and ORIGIN in site_set
+        and AXIS in site_set
+        and BODY in site_set
+        and all(l1(site) <= RADIUS for site in sites),
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1 and "DijkstraCounter" in self_source,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_21(0) is reached",
+        len(dist) == 13287 and all(dist[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "hop-origin",
+        "the unique origin hop has named cost 3",
+        i2_cost(ORIGIN, (1, 0, 0)) == 3 and nu_cost(ORIGIN, (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "hop-max4-out-clause",
+        "c2d4 would be 2 on (4,2,0) to (5,2,0), so i2 prices that hop at 2",
+        d4_extra(MAX4_OUT_SRC, MAX4_OUT_DST)
+        and rho3_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 1
+        and c2d4_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and i2_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and MAX4_OUT_SRC in site_set
+        and MAX4_OUT_DST in site_set,
+    )
+    checks.check(
+        "hop-interior-clause",
+        "a 3-to-3 hop whose dest min abs coord is at least 2 is priced at 2",
+        interior_extra(INT_SRC, INT_DST)
+        and rho3_cost(INT_SRC, INT_DST) == 1
+        and c2d4_cost(INT_SRC, INT_DST) == 1
+        and i2_cost(INT_SRC, INT_DST) == 2
+        and min_abs(INT_DST) >= 2
+        and INT_SRC in site_set
+        and INT_DST in site_set,
+    )
+    checks.check(
+        "hop-max3-out-skipped",
+        "the max>=4 out-face clause skips (3,2,0) to (4,2,0)",
+        not d4_extra(MAX3_OUT_SRC, MAX3_OUT_DST)
+        and d3_extra(MAX3_OUT_SRC, MAX3_OUT_DST)
+        and rho3_cost(MAX3_OUT_SRC, MAX3_OUT_DST) == 1
+        and i2_cost(MAX3_OUT_SRC, MAX3_OUT_DST) == 1
+        and MAX3_OUT_SRC in site_set
+        and MAX3_OUT_DST in site_set,
+    )
+    checks.check(
+        "i2-clauses",
+        "seed-exit, axis, drop, corridor, and ridge cost 3; max>=4 out-face and interior 3-to-3 cost 2; other displayed hops cost 1",
+        i2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and i2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and i2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and i2_cost(FACE, UNIT_OUT) == 3
+        and i2_cost(RIDGE_SRC, RIDGE_DST) == 3
+        and i2_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and i2_cost(INT_SRC, INT_DST) == 2
+        and i2_cost(HEIGHT_M_SRC, HEIGHT_M_DST) == 2
+        and i2_cost(CUBE_SRC, CUBE_DST) == 2
+        and i2_cost((1, 0, 0), FACE) == 1
+        and i2_cost(FACE, (1, 1, 1)) == 1
+        and i2_cost(DF_OUT_SRC, DF_OUT_DST) == 1
+        and i2_cost(MAX3_OUT_SRC, MAX3_OUT_DST) == 1
+        and i2_cost((2, 1, 1), (2, 1, 2)) == 1,
+    )
+    in_ball_interior = 0
+    in_ball_max4 = 0
+    for site in sites:
+        for step in STEPS:
+            neighbor = add(site, step)
+            if neighbor not in site_set:
+                continue
+            if interior_extra(site, neighbor) and rho3_cost(site, neighbor) == 1:
+                in_ball_interior += 1
+            if d4_extra(site, neighbor) and rho3_cost(site, neighbor) == 1:
+                in_ball_max4 += 1
+    checks.check(
+        "extras-live-on-ball",
+        "both extra i2 clauses fire on in-ball hops",
+        in_ball_interior > 0 and in_ball_max4 > 0,
+    )
+    axis_path_cost = sum(
+        i2_cost((k, 0, 0), (k + 1, 0, 0)) for k in range(7)
+    )
+    body_path = (
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 1, 1),
+        (0, 1, 2),
+        (0, 2, 2),
+        (0, 2, 3),
+        (0, 2, 4),
+        (1, 2, 4),
+        (1, 2, 5),
+        (1, 2, 6),
+        (1, 2, 7),
+        (1, 3, 7),
+        (1, 4, 7),
+        (1, 5, 7),
+        (1, 6, 7),
+        (1, 7, 7),
+        (2, 7, 7),
+        (3, 7, 7),
+        (4, 7, 7),
+        (5, 7, 7),
+        (6, 7, 7),
+        (7, 7, 7),
+    )
+    body_path_cost = sum(
+        i2_cost(a, b) for a, b in zip(body_path, body_path[1:])
+    )
+    checks.check(
+        "thm1-axis-time",
+        "t(7,0,0) equals the computed origin-to-axis arrival time",
+        t_axis == axis_path_cost and t_axis > 0,
+    )
+    checks.check(
+        "thm1-body-time",
+        "t(7,7,7) equals the computed origin-to-body arrival time",
+        t_body == body_path_cost and t_body > 0,
+    )
+    checks.check(
+        "thm2-reverse-holds",
+        "t(7,0,0)^2 / 49 > t(7,7,7)^2 / 147 holds on the computed times",
+        reverse and 3 * t_axis * t_axis > t_body * t_body,
+    )
+    checks.check(
+        "thm1-note-reports-times",
+        "the note reports the computed arrival times",
+        f"t(7,0,0) = {t_axis}" in note and f"t(7,7,7) = {t_body}" in note,
+    )
+    checks.check(
+        "thm2-note-reports-comparison",
+        "the note reports the integer same-k comparison and does not adopt it",
+        f"{3 * axis_sq} > {body_sq}" in note
+        and "Displayed, not adopted" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3-or-c2d4",
+        "i2 disagrees with rho3 and with c2d4 on in-ball hops, and the arrivals are not the rho3 pair",
+        i2_cost(INT_SRC, INT_DST) == 2
+        and rho3_cost(INT_SRC, INT_DST) == 1
+        and c2d4_cost(INT_SRC, INT_DST) == 1
+        and i2_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and rho3_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 1
+        and t_axis != 19
+        and t_body != 25
+        and "cannot price interior body hops" in note
+        and "cannot price max≥4 out-face" in note,
+    )
+    checks.check(
+        "not-leftover-of-iota",
+        "i2 cheapens interior non-ridge 3-to-3 hops relative to iota and taxes height-m ridges that iota skips",
+        iota_cost(IOTA_INT_SRC, IOTA_INT_DST) == 3
+        and i2_cost(IOTA_INT_SRC, IOTA_INT_DST) == 2
+        and iota_cost(HEIGHT_M_SRC, HEIGHT_M_DST) == 1
+        and i2_cost(HEIGHT_M_SRC, HEIGHT_M_DST) == 2
+        and iota_cost(CUBE_SRC, CUBE_DST) == 3
+        and i2_cost(CUBE_SRC, CUBE_DST) == 2
+        and "cannot price the cost-2 interior clause" in note,
+    )
+    checks.check(
+        "not-leftover-of-b18",
+        "(7,7,7) lies outside B_18(0) and the note says so",
+        l1(BODY) == 21
+        and BODY in dist
+        and t2100 == 42
+        and t1800 == 34
+        and "absent from `B_18(0)`" in note
+        and "not leftover of the `B_18(0)` times" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name i2",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "i2(v→w)" not in axiom
+        and "Do not write i2 into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1",
+        "Do not attach L1." in note and "Do not attach L1." not in axiom,
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " ") and CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "the note does not claim uniqueness of the named hop-cost",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_21(0) and proposes no axiom edit",
+        "B_21(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "one Dijkstra" in note
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "i2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom,
+    )
+    checks.check(
+        "independent-sites",
+        "the same Dijkstra records the skipped max>=3 hop and the live interior and max>=4 arrivals",
+        t320 == 9
+        and t420 == 10
+        and t520 == 12
+        and t222 == 11
+        and t322 == 12
+        and "t(3,2,0) = 9" in note
+        and "t(4,2,0) = 10" in note
+        and "t(5,2,0) = 12" in note
+        and "t(3,2,2) = 12" in note,
+    )
+
+    print("per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported at (7,0,0) and (7,7,7).")
+    print("lattice_wide: checked and not executed — the search stays inside B_21(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named i2 hop-cost holds at k=7 on B_21(0): t(7,0,0)=21 vs t(7,7,7)=31. Unlike ι, cost-2 interior does not kill k=7. Displayed, not adopted. Do not write i2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_interior_cost2_samek_k7_b21_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.