### PR TITLE
feat(j2k14): c2d4-plus-deep-interior same-k fails at k=14: t=30 vs t=58

### DIFF
--- a/docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,328 @@
+---
+claim_id: c2d4_deep_interior_cost2_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named c2d4-plus-deep-interior hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py
+---
+
+# Named C2d4-Plus-Deep-Interior Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py`](../scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named c2d4-plus-deep-interior hop-cost `j2` is the already scored
+cost-2 max≥4 out-face rule `c2d4` plus cost `2` on a `3→3` hop whose
+destination has least absolute coordinate at least `3`. That extra clause
+taxes deeper interior body hops only. The interior rule `i2` killed the
+`k=14` restore. This is the first display of whether same-`k` reverse
+still restores at `k=14` under the dest-min≥3 tax. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rule `j2` is
+
+`j2(v→w) = 3` if `ρ3` would be `3`, else `2` if `c2d4` would be `2` or
+`(|σ_v|=|σ_w|=3` and `min_i |w_i| ≥ 3)`, else `1`,
+
+where
+`c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4)`, else `1`,
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. The fifth
+clause is the ridge slide. Those five clauses stay at cost `3`. The sixth
+clause is max≥4 out-face priced at `2`: grow the box on a face only after
+height four. The seventh clause is dest-min≥3 interior `3→3` priced at
+`2`. Those seven clauses are the whole rule. The hop `(3,2,0) → (4,2,0)`
+has source max `3`, so it is not in the sixth clause; it stays at cost
+`1`. The hop `(4,2,0) → (5,2,0)` has source max `4` and a growing dest
+max, so it is cost `2`. The hop `(3,3,2) → (3,3,3)` is fully supported
+with dest min `3`, so it is cost `2`. The hop `(4,2,2) → (5,2,2)` is a
+height-`2` ridge with dest min `2`, so it is not dest-min≥3 interior and
+stays at cost `1`. The hop `(5,3,3) → (6,3,3)` is a height-`3` ridge with
+dest min `3`, so it is cost `2`. The hop `(4,3,1) → (5,3,1)` has dest min
+`1`, so it is not interior and stays at cost `1`. The hop
+`(14,14,1) → (14,14,2)` has dest min `2`, so it is not dest-min≥3
+interior and stays at cost `1`.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+gives
+
+`t(14,0,0) = 30`, `t(14,14,14) = 58`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `900/196` versus `3364/588`, or equivalently `2700 < 3364`. The
+inequality does not hold. Same-`k` reverse at `k=14` under `j2` is no.
+Reverse does not restore at the `ρ3`/`κ` wall under dest-min≥3 interior
+tax. Independently, the new axis site is `t(42,0,0) = 63`. The shared
+axis site `t(39,0,0) = 55` is a `j2` score on this ball, not a
+smaller-ball leftover.
+
+The same-`k` pair under `c2d4` is `30` versus `46`. The integers `58`
+versus `46` coincide with a raised body relative to that pair. That
+mismatch on the body is not a leftover of a `c2d4` table: the extra
+dest-min≥3 interior `3→3` clause is live on the ball. On the last body
+hop `(13,14,14) → (14,14,14)` one has `|σ| : 3 → 3` and dest min `14`, so
+`c2d4 = 1` while `j2 = 2`. Therefore `c2d4` cannot price dest-min≥3 interior 3→3.
+Independently, `t(14,14,14) = 58` and `t(14,14,2) = 34`. A
+cheapest `c2d4` walk to `(14,14,14)` of cost `46` becomes cost `58` once
+those twelve late dest-min≥3 hops are priced at `2`. Independently,
+`t(14,14,1) = 33` and `t(14,14,3) = 36`.
+
+The same-`k` pair under `i2` is `30` versus `59`. The integers `58`
+versus `59` coincide with a lowered body relative to that pair. That
+mismatch on the body is not a leftover of an `i2` table: `j2` skips
+dest-min=2 interior. On `(14,14,1) → (14,14,2)` one has `|σ| : 3 → 3` and
+dest min `2`, so `i2 = 2` while `j2 = 1`. Therefore `i2` cannot price
+dest-min=2 interior as idle. Independently, `t(2,2,2) = 10` and
+`t(5,2,2) = 13`. On `(2,2,1) → (2,2,2)` and on `(4,2,2) → (5,2,2)` one
+has dest min `2`, so those hops stay `j2 = 1`.
+
+The same-`k` pair under `ρ3` is `26` versus `46`. The integers `30` versus
+`26` coincide with a raised axis relative to that wall pair. That mismatch
+on the axis is not a leftover of a `ρ3` table: the extra max≥4 out-face
+clause is live on the ball. On the later out-face hop `(4,2,0) → (5,2,0)`
+one has `|σ| : 2 → 2`, `max |w_i| = 5 > max |v_i| = 4`, and source max
+`4`, while the least nonzero `|w_i|` is `2`, so `ρ3 = 1` while `j2 = 2`.
+Therefore `ρ3` cannot price max≥4 out-face. Independently,
+`t(5,2,0) = 12` under `j2`. The skipped hop `(3,2,0) → (4,2,0)` also grows
+the max absolute coordinate, but its source max is `3`, so it is not
+max≥4 out-face; it stays `j2 = 1` while `d3 = 3`. Independently,
+`t(4,2,0) = 10` under `j2`. The hop `(2,2,0) → (3,2,0)` also grows the
+max absolute coordinate, but its source max is `2`, so it is not max≥4
+out-face; it stays `j2 = 1` while `df = 3`. Independently,
+`t(3,2,0) = 9` under `j2`. The corridor hop `(1,1,0) → (2,1,0)` also
+grows the max absolute coordinate, but its source max is `1`, so it is not
+max≥4 out-face; it is already `ρ3 = 3` by the hugging clause.
+
+The interior-slide comparator `ι` taxes a non-ridge `3 → 3` hop whose
+destination has `min |w_i| ≥ 2` at cost `3`, and it leaves a height-`m`
+ridge at cost `1`. On `(3,3,2) → (3,3,3)` one has `j2 = 2` while `ι = 3`.
+On `(4,2,2) → (5,2,2)` one has `j2 = 1` while `ι = 1`. On
+`(5,3,3) → (6,3,3)` one has `j2 = 2` while `ι = 1`. Therefore the `j2`
+scores are not leftover of `ι`. Independently, `t(5,2,2) = 13`,
+`t(2,2,2) = 10`, and `t(3,3,3) = 14`. The `ι` pair `26` versus `72` is
+not the `j2` pair.
+
+The cost-3 max≥4 out-face comparator `d4` uses the same out-face clause
+but prices it at `3`. On `(4,2,0) → (5,2,0)` one has `j2 = 2` while
+`d4 = 3`. Independently, `t(5,2,0) = 12` under `j2` and `t(42,0,0) = 63`
+under `j2`. Therefore the `j2` scores are not leftover of `d4`.
+
+The same-`k` pair `30` versus `58` does not coincide with the `d3` pair,
+the `df` pair, or the `ω` pair. The named extra clauses are still not leftover of `d3`: that rule prices `(3,2,0) → (4,2,0)` at `3`, and `j2`
+prices it at `1`. Independently it is not leftover of `df` or of `ω`:
+those rules price `(2,2,0) → (3,2,0)` at `3`, and `j2` prices it at `1`.
+
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`.
+The `B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The rule is displayed, not adopted. Do not write `j2` into Admissibility.
+Do not write j2 into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3`, `2`, and `1`, the support-size
+clauses, the least-nonzero-coordinate clause, the two-unit-height ridge
+clause, the max≥4 out-face source-max clause, the dest-min≥3 interior
+clause, and the arrival function `t` are separately displayed mathematical
+inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `j2` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `c2d4` uses only the first six clauses of `j2`. On the
+interior hop `(13,14,14) → (14,14,14)` one has `|σ| : 3 → 3` and dest min
+at least three, so `c2d4 = 1` while `j2 = 2`. Therefore `c2d4` cannot
+price dest-min≥3 interior `3→3`, and the `j2` scores below are not a
+leftover of `c2d4`.
+
+The comparator `i2` taxes dest-min≥2 interior `3→3` at cost `2`. On
+`(14,14,1) → (14,14,2)` one has dest min `2`, so `i2 = 2` while `j2 = 1`.
+Therefore `i2` cannot price dest-min=2 interior as idle, and the `j2`
+scores are not leftover of `i2`.
+
+The comparator `ρ3` uses only the first five clauses. On
+`(4,2,0) → (5,2,0)` one has `|σ| : 2 → 2` and a growing max at source
+height at least four, so `ρ3 = 1` while `j2 = 2`. Therefore `ρ3` cannot
+price max≥4 out-face. On `(3,3,2) → (3,3,3)` one has `ρ3 = 1` while
+`j2 = 2`. Therefore `ρ3` cannot price dest-min≥3 interior `3→3`.
+
+The parent cost-3 comparator `d4` uses the same grow test with cost `3`.
+On `(4,2,0) → (5,2,0)` both grow predicates hold and the hop costs
+disagree. Therefore the `j2` scores are not leftover of `d4`.
+
+The max≥3 out-face comparator `d3` uses the same grow test with source-max
+floor three. On `(3,2,0) → (4,2,0)` the `d3` grow predicate holds and the
+`j2` grow predicate fails. The rule skips the height-three out-face hop.
+
+The deep-out-face comparator `df` uses the same grow test with source-max
+floor two. On `(2,2,0) → (3,2,0)` the `df` grow predicate holds and the
+`j2` grow predicate fails.
+
+The cost-3 out-face comparator `ω` uses the same grow test without a
+source-max floor. On `(3,2,0) → (4,2,0)` the `ω` grow predicate holds and
+the `j2` grow predicate fails.
+
+The cost-3 ridge-enter comparator `κ` prices `(2,1,0) → (2,1,1)` at `3`
+while `j2` leaves it at `1`. Therefore the `j2` scores are not leftover of `κ`.
+
+The interior-slide comparator `ι` taxes a non-ridge interior `3 → 3` hop
+at cost `3` and leaves a height-`m` ridge at cost `1`. On
+`(3,3,2) → (3,3,3)` one has `j2 = 2` while `ι = 3`. On
+`(4,2,2) → (5,2,2)` one has `j2 = 1` while `ι = 1`. On
+`(5,3,3) → (6,3,3)` one has `j2 = 2` while `ι = 1`. Therefore the `j2`
+scores are not leftover of `ι`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_j2` |
+|---|---:|
+| `(14,0,0)` | `30` |
+| `(14,14,14)` | `58` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table and not copied from the `c2d4` pair
+`30` versus `46` or from the `i2` pair `30` versus `59` or from the `ρ3`
+pair `26` versus `46`. These values are Dijkstra outputs, not fitted
+scalars.
+
+A witness axis walk of cost `30` is seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, unit-cube enter `1` onto `(1,1,1)`,
+ridge-slide `3` onto `(2,1,1)`, support-preserving `1` onto `(2,2,1)`,
+twelve support-preserving cost-`1` body hops to `(14,2,1)`, ridge-slide
+`3` onto `(14,1,1)`, support-drop `3` onto `(14,1,0)`, and support-drop
+`3` onto `(14,0,0)`, summing to `30`. Those twelve body hops have dest min
+`1`, so they are not dest-min≥3 interior. That walk never uses a `2→2`
+dest whose max grows at source height at least four. That walk is a
+witness of cost `30`, not a uniqueness claim.
+
+A witness body walk of cost `58` is the same prefix of cost `9` to
+`(2,2,1)`, twelve cost-`1` hops to `(14,2,1)`, twelve cost-`1` hops to
+`(14,14,1)`, one dest-min-`2` cost-`1` hop to `(14,14,2)`, and twelve
+dest-min≥3 cost-`2` body hops to `(14,14,14)`, summing to `58`. Those last
+twelve hops have dest min at least `3`, so they are dest-min≥3 interior
+`3→3`. They have dest with only one absolute coordinate equal to `1` or
+none, so they are not ridge slides. That walk is a witness of cost `58`,
+not a uniqueness claim.
+
+A witness that the skip is live is the walk seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, corridor-slide `3` onto `(1,2,0)`,
+support-preserving `1` onto `(2,2,0)`, support-preserving `1` onto
+`(3,2,0)`, and skipped height-three out-face `1` onto `(4,2,0)`, summing
+to `10`. Replacing only the last hop by its `d3` price `3` yields `12`.
+Independently, `t(4,2,0) = 10`.
+
+A witness that the max≥4 out-face clause is live is that same prefix of
+cost `10` to `(4,2,0)` followed by max≥4 out-face `2` onto `(5,2,0)`,
+summing to `12`. Replacing only the last hop by its `ρ3` price `1` yields
+`11`. Replacing only the last hop by its `d4` price `3` yields `13`.
+Independently, `t(5,2,0) = 12`.
+
+A witness that dest-min=2 interior is idle is the body prefix of cost `33`
+to `(14,14,1)` followed by dest-min-`2` cost `1` onto `(14,14,2)`, summing
+to `34`. Replacing only that last hop by its `i2` price `2` yields `35`.
+Independently, `t(14,14,1) = 33` and `t(14,14,2) = 34`.
+
+A witness that the dest-min≥3 interior clause is live is that prefix of
+cost `34` to `(14,14,2)` followed by dest-min≥3 interior `2` onto
+`(14,14,3)`, summing to `36`. Replacing only that last hop by its `c2d4`
+price `1` yields `35`. Independently, `t(14,14,3) = 36`.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 30^2 = 2700` and `58^2 = 3364`, so
+
+`2700 < 3364`.
+
+Arrival per Euclidean length is larger at `(14,14,14)` than at `(14,0,0)`.
+Same-`k` reverse at `k=14` under `j2` is no. Reverse does not restore at
+the `ρ3`/`κ` wall under dest-min≥3 interior tax. The comparison is
+displayed, not adopted. The inequality does not hold.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `j2` is a displayed scoring device on `B_42(0)`. Do not write `j2`
+into Admissibility. Do not write j2 into Admissibility. Do not attach L1.
+It is not a replacement for first arrival, and it is not offered as the
+only hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule j2 at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `j2` among hop-costs that reverse or fail to reverse the
+  same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of the `c2d4` arrival table as a substitute for the `j2` Dijkstra.
+- Any reuse of the `i2` arrival table as a substitute for the `j2` Dijkstra.
+- Any reuse of the `ρ3` arrival table as a substitute for the `j2` Dijkstra.
+- Any reuse of the `ι`, `d4`, `d3`, `df`, or `ω` arrival table as a
+  substitute for the `j2` Dijkstra.
+- Membership of `j2` as a physical hop-cost. Reverse at `k=14` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_deep_interior_cost2_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,83 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py
+runner_sha256: 56232336ac58d1368c28367b09aad0994c0c289db1a98c012b3a89e4c6f98bae
+input_fingerprint_sha256: 6f37823022877ce4c50fb9151c110bb33214d9681883ab2b6d155bdcc1b43dea
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.65
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named c2d4-plus-deep-interior hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility j2 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 30
+t(14,14,14) 58
+t(14,0,0)^2/196 900/196
+t(14,14,14)^2/588 3364/588
+3t_axis^2 2700
+t_body^2 3364
+reverse False
+t(42,0,0) 63
+t(39,0,0) 55
+t(3,2,0) 9
+t(4,2,0) 10
+t(5,2,0) 12
+t(5,2,2) 13
+t(2,2,2) 10
+t(3,3,3) 14
+t(14,14,1) 33
+t(14,14,2) 34
+t(14,14,3) 36
+dijkstra_calls 1
+witness_axis_sum 30
+witness_body_sum 58
+witness_body_c2d4 46
+witness_body_i2 59
+j2_deep 2
+i2_deep 2
+c2d4_deep 1
+iota_deep 3
+j2_ridge2 1
+i2_ridge2 2
+iota_ridge2 1
+j2_ridge3 2
+iota_ridge3 1
+j2_last 2
+c2d4_last 1
+j2_min2 1
+i2_min2 2
+j2_min3 2
+c2d4_min3 1
+PASS: t-1400-141414 t(14,0,0)=30 and t(14,14,14)=58
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-c2d4 j2 prices dest-min>=3 interior 3→3 at 2 while c2d4 prices it at 1
+PASS: not-leftover-of-i2 j2 leaves dest-min=2 interior at 1 while i2 prices it at 2
+PASS: not-leftover-of-rho3 j2 prices max≥4 out-face at 2 and dest-min≥3 interior at 2 while ρ3 prices both at 1
+PASS: not-leftover-of-iota ι prices non-ridge dest-min≥2 3→3 at 3 and height-m ridge at 1; j2 prices dest-min≥3 at 2 including height-3 ridge
+PASS: not-leftover-of-d4 d4 prices max≥4 out-face at 3 while j2 prices it at 2
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: skips-height-three-out-face c2d4 extra clause skips (3,2,0)→(4,2,0); d3, df, and ω extra clauses include it
+PASS: not-leftover-of-kappa κ prices ridge-enter at 3 while j2 leaves it at 1
+PASS: seed-max4-and-deep-interior-clauses seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide cost 3; max≥4 out-face and dest-min≥3 interior cost 2; dest-min=2, skipped grow, unit-cube, min-1 body, and body enter cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py
+++ b/scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under j2 on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named c2d4-plus-deep-interior "
+    "hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_height_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_height_count(w) == 2:
+        return 3
+    return 1
+
+
+def kappa_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 2
+        and support_size(w) == 3
+        and unit_height_count(w) == 2
+    ):
+        return 3
+    return 1
+
+
+def iota_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 3 and sigma_w == 3:
+        m = min(abs(c) for c in w)
+        if m >= 2 and sum(1 for c in w if abs(c) == m) != 2:
+            return 3
+    return 1
+
+
+def omega_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max(abs(c) for c in w) > max(abs(c) for c in v)
+    )
+
+
+def df_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 2
+
+
+def d3_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 3
+
+
+def d4_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 4
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if omega_grow(v, w):
+        return 3
+    return 1
+
+
+def df_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if df_grow(v, w):
+        return 3
+    return 1
+
+
+def d3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d3_grow(v, w):
+        return 3
+    return 1
+
+
+def d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d4_grow(v, w):
+        return 3
+    return 1
+
+
+def c2d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d4_grow(v, w):
+        return 2
+    return 1
+
+
+def interior_min2(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 3
+        and support_size(w) == 3
+        and min(abs(c) for c in w) >= 2
+    )
+
+
+def deep_interior(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 3
+        and support_size(w) == 3
+        and min(abs(c) for c in w) >= 3
+    )
+
+
+def i2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if c2d4_cost(v, w) == 2 or interior_min2(v, w):
+        return 2
+    return 1
+
+
+def j2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if c2d4_cost(v, w) == 2 or deep_interior(v, w):
+        return 2
+    return 1
+
+
+def dijkstra_j2(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + j2_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(
+    walk: tuple[tuple[int, int, int], ...],
+    cost_fn,
+) -> int:
+    return sum(cost_fn(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "j2 is not written into Admissibility",
+        "Do not write j2 into Admissibility" in note
+        and "Do not write `j2` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_j2(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    t420 = dist[(4, 2, 0)]
+    t520 = dist[(5, 2, 0)]
+    t522 = dist[(5, 2, 2)]
+    t222 = dist[(2, 2, 2)]
+    t333 = dist[(3, 3, 3)]
+    t14141 = dist[(14, 14, 1)]
+    t14142 = dist[(14, 14, 2)]
+    t14143 = dist[(14, 14, 3)]
+    axis_sq = t1400 * t1400
+    body_sq = t141414 * t141414
+    triple_axis_sq = 3 * axis_sq
+    reverse = triple_axis_sq > body_sq
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        (14, 1, 1),
+        (14, 1, 0),
+        (14, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        *[(14, y, 1) for y in range(3, 15)],
+        *[(14, 14, z) for z in range(2, 15)],
+    )
+    witness_skip = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (3, 2, 0),
+        (4, 2, 0),
+    )
+    witness_later = witness_skip + ((5, 2, 0),)
+    witness_min2 = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        *[(14, y, 1) for y in range(3, 15)],
+        (14, 14, 2),
+    )
+    witness_deep = witness_min2 + ((14, 14, 3),)
+    skip_hop = ((3, 2, 0), (4, 2, 0))
+    later_hop = ((4, 2, 0), (5, 2, 0))
+    height_two = ((2, 2, 0), (3, 2, 0))
+    unit_out_face = ((1, 1, 0), (2, 1, 0))
+    later_out_face = ((7, 2, 0), (8, 2, 0))
+    height2_nongrow = ((1, -2, 0), (2, -2, 0))
+    ridge_enter = ((2, 1, 0), (2, 1, 1))
+    height2_ridge = ((4, 2, 2), (5, 2, 2))
+    height3_ridge = ((5, 3, 3), (6, 3, 3))
+    interior_cube = ((3, 3, 2), (3, 3, 3))
+    interior_last = ((13, 14, 14), (14, 14, 14))
+    min1_body = ((4, 3, 1), (5, 3, 1))
+    min2_body = ((14, 14, 1), (14, 14, 2))
+    min3_body = ((14, 14, 2), (14, 14, 3))
+    min2_cube = ((2, 2, 1), (2, 2, 2))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {axis_sq}/196")
+    print(f"t(14,14,14)^2/588 {body_sq}/588")
+    print(f"3t_axis^2 {triple_axis_sq}")
+    print(f"t_body^2 {body_sq}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(3,2,0) {t320}")
+    print(f"t(4,2,0) {t420}")
+    print(f"t(5,2,0) {t520}")
+    print(f"t(5,2,2) {t522}")
+    print(f"t(2,2,2) {t222}")
+    print(f"t(3,3,3) {t333}")
+    print(f"t(14,14,1) {t14141}")
+    print(f"t(14,14,2) {t14142}")
+    print(f"t(14,14,3) {t14143}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_axis_sum {path_cost(witness_axis, j2_cost)}")
+    print(f"witness_body_sum {path_cost(witness_body, j2_cost)}")
+    print(f"witness_body_c2d4 {path_cost(witness_body, c2d4_cost)}")
+    print(f"witness_body_i2 {path_cost(witness_body, i2_cost)}")
+    print(f"j2_deep {j2_cost(*interior_cube)}")
+    print(f"i2_deep {i2_cost(*interior_cube)}")
+    print(f"c2d4_deep {c2d4_cost(*interior_cube)}")
+    print(f"iota_deep {iota_cost(*interior_cube)}")
+    print(f"j2_ridge2 {j2_cost(*height2_ridge)}")
+    print(f"i2_ridge2 {i2_cost(*height2_ridge)}")
+    print(f"iota_ridge2 {iota_cost(*height2_ridge)}")
+    print(f"j2_ridge3 {j2_cost(*height3_ridge)}")
+    print(f"iota_ridge3 {iota_cost(*height3_ridge)}")
+    print(f"j2_last {j2_cost(*interior_last)}")
+    print(f"c2d4_last {c2d4_cost(*interior_last)}")
+    print(f"j2_min2 {j2_cost(*min2_body)}")
+    print(f"i2_min2 {i2_cost(*min2_body)}")
+    print(f"j2_min3 {j2_cost(*min3_body)}")
+    print(f"c2d4_min3 {c2d4_cost(*min3_body)}")
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={t1400} and t(14,14,14)={t141414}",
+        t1400 == path_cost(witness_axis, j2_cost)
+        and t141414 == path_cost(witness_body, j2_cost)
+        and t1400 == 30
+        and t141414 == 58,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 does not hold",
+        (not reverse)
+        and triple_axis_sq == 2700
+        and body_sq == 3364
+        and "2700 < 3364" in note
+        and "inequality does not hold" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`30`" in note
+        and "`58`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note
+        and "t(14,0,0) = 30" in note
+        and "t(14,14,14) = 58" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2700 < 3364" in note and "900/196" in note and "3364/588" in note,
+    )
+    checks.check(
+        "not-leftover-of-c2d4",
+        "j2 prices dest-min>=3 interior 3→3 at 2 while c2d4 prices it at 1",
+        j2_cost(*interior_cube) == 2
+        and c2d4_cost(*interior_cube) == 1
+        and j2_cost(*interior_last) == 2
+        and c2d4_cost(*interior_last) == 1
+        and j2_cost(*min3_body) == 2
+        and c2d4_cost(*min3_body) == 1
+        and path_cost(witness_body, j2_cost) == 58
+        and path_cost(witness_body, c2d4_cost) == 46
+        and t141414 == 58
+        and t14141 == 33
+        and t14142 == 34
+        and t14143 == 36
+        and path_cost(witness_min2, j2_cost) == 34
+        and path_cost(witness_deep, j2_cost) == 36
+        and path_cost(witness_deep, c2d4_cost) == 35
+        and "cannot price dest-min≥3 interior 3→3" in note
+        and "`t(14,14,14) = 58`" in note
+        and "30` versus `46" in note,
+    )
+    checks.check(
+        "not-leftover-of-i2",
+        "j2 leaves dest-min=2 interior at 1 while i2 prices it at 2",
+        j2_cost(*min2_body) == 1
+        and i2_cost(*min2_body) == 2
+        and j2_cost(*min2_cube) == 1
+        and i2_cost(*min2_cube) == 2
+        and j2_cost(*height2_ridge) == 1
+        and i2_cost(*height2_ridge) == 2
+        and j2_cost(*interior_cube) == 2
+        and i2_cost(*interior_cube) == 2
+        and path_cost(witness_body, j2_cost) == 58
+        and path_cost(witness_body, i2_cost) == 59
+        and t141414 == 58
+        and t222 == 10
+        and t522 == 13
+        and t14142 == 34
+        and path_cost(witness_min2, j2_cost) == 34
+        and path_cost(witness_min2, i2_cost) == 35
+        and "cannot price dest-min=2 interior" in note
+        and "not leftover of `i2`" in note
+        and "`t(14,14,2) = 34`" in note
+        and "30` versus `59" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "j2 prices max≥4 out-face at 2 and dest-min≥3 interior at 2 while ρ3 prices both at 1",
+        j2_cost(*later_hop) == 2
+        and rho3_cost(*later_hop) == 1
+        and mu_cost(*later_hop) == 1
+        and j2_cost(*later_out_face) == 2
+        and rho3_cost(*later_out_face) == 1
+        and j2_cost(*interior_cube) == 2
+        and rho3_cost(*interior_cube) == 1
+        and j2_cost(*height2_nongrow) == 1
+        and t1400 == 30
+        and t141414 == 58
+        and t520 == 12
+        and path_cost(witness_later, j2_cost) == 12
+        and path_cost(witness_later, rho3_cost) == 11
+        and "cannot price max≥4 out-face" in note
+        and "`t(5,2,0) = 12`" in note
+        and "26` versus `46" in note,
+    )
+    checks.check(
+        "not-leftover-of-iota",
+        "ι prices non-ridge dest-min≥2 3→3 at 3 and height-m ridge at 1; j2 prices dest-min≥3 at 2 including height-3 ridge",
+        j2_cost(*interior_cube) == 2
+        and iota_cost(*interior_cube) == 3
+        and j2_cost(*height2_ridge) == 1
+        and iota_cost(*height2_ridge) == 1
+        and j2_cost(*height3_ridge) == 2
+        and iota_cost(*height3_ridge) == 1
+        and j2_cost(*interior_last) == 2
+        and iota_cost(*interior_last) == 3
+        and t1400 == 30
+        and t141414 == 58
+        and t141414 != 72
+        and t222 == 10
+        and t333 == 14
+        and t522 == 13
+        and "not leftover of `ι`" in note
+        and "`t(5,2,2) = 13`" in note
+        and "`t(2,2,2) = 10`" in note
+        and "`t(3,3,3) = 14`" in note,
+    )
+    checks.check(
+        "not-leftover-of-d4",
+        "d4 prices max≥4 out-face at 3 while j2 prices it at 2",
+        j2_cost(*later_hop) == 2
+        and d4_cost(*later_hop) == 3
+        and path_cost(witness_later, d4_cost) == 13
+        and path_cost(witness_later, j2_cost) == 12
+        and t520 == 12
+        and t4200 == 63
+        and "not leftover of `d4`" in note
+        and "`t(42,0,0) = 63`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 63
+        and t3900 == 55
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "skips-height-three-out-face",
+        "c2d4 extra clause skips (3,2,0)→(4,2,0); d3, df, and ω extra clauses include it",
+        (not d4_grow(*skip_hop))
+        and d3_grow(*skip_hop)
+        and df_grow(*skip_hop)
+        and omega_grow(*skip_hop)
+        and d4_grow(*later_hop)
+        and j2_cost(*skip_hop) == 1
+        and d3_cost(*skip_hop) == 3
+        and df_cost(*skip_hop) == 3
+        and omega_cost(*skip_hop) == 3
+        and rho3_cost(*skip_hop) == 1
+        and j2_cost(*later_hop) == 2
+        and j2_cost(*unit_out_face) == 3
+        and j2_cost(*height_two) == 1
+        and df_cost(*height_two) == 3
+        and t420 == 10
+        and t320 == 9
+        and path_cost(witness_skip, j2_cost) == 10
+        and path_cost(witness_skip, d3_cost) == 12
+        and "skips the height-three out-face" in note
+        and "not leftover of `d3`" in note
+        and "not leftover of `df`" in note,
+    )
+    checks.check(
+        "not-leftover-of-kappa",
+        "κ prices ridge-enter at 3 while j2 leaves it at 1",
+        j2_cost(*ridge_enter) == 1
+        and kappa_cost(*ridge_enter) == 3
+        and rho3_cost(*ridge_enter) == 1
+        and "not leftover of `κ`" in note,
+    )
+    checks.check(
+        "seed-max4-and-deep-interior-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide, ridge-slide cost 3; max≥4 out-face and dest-min≥3 interior cost 2; dest-min=2, skipped grow, unit-cube, min-1 body, and body enter cost 1",
+        j2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and j2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and j2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and j2_cost(*unit_out_face) == 3
+        and j2_cost((1, 1, 1), (2, 1, 1)) == 3
+        and j2_cost((2, 2, 0), (3, 2, 0)) == 1
+        and j2_cost((3, 2, 0), (4, 2, 0)) == 1
+        and j2_cost((4, 2, 0), (5, 2, 0)) == 2
+        and j2_cost((3, 2, 0), (3, 3, 0)) == 1
+        and j2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and j2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and j2_cost((2, 1, 0), (2, 1, 1)) == 1
+        and j2_cost((2, 2, 0), (2, 2, 1)) == 1
+        and j2_cost((2, 2, 1), (3, 2, 1)) == 1
+        and j2_cost(*min1_body) == 1
+        and j2_cost(*min2_cube) == 1
+        and j2_cost((2, 2, 2), (3, 2, 2)) == 1
+        and j2_cost((3, 3, 2), (3, 3, 3)) == 2
+        and j2_cost((4, 2, 2), (5, 2, 2)) == 1
+        and j2_cost((5, 3, 3), (6, 3, 3)) == 2
+        and j2_cost((13, 14, 14), (14, 14, 14)) == 2
+        and j2_cost((14, 14, 1), (14, 14, 2)) == 1
+        and j2_cost((14, 14, 2), (14, 14, 3)) == 2,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "j2(v→w)" not in axiom
+        and "i2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named j2 hop-cost fails at k=14 on B_42(0): t(14,0,0)=30 vs t(14,14,14)=58. Dest-min≥3 interior still kills the c2d4 restore. Displayed, not adopted. Do not write j2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_deep_interior_cost2_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.