### PR TITLE
feat(j2k18): c2d4-plus-deep-interior same-k fails at k=18: t=34 vs t=74

### DIFF
--- a/docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K18_B54_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K18_B54_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,264 @@
+---
+claim_id: c2d4_deep_interior_cost2_samek_k18_b54_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=18 under the named c2d4-plus-deep-interior hop-cost on B_54(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py
+---
+
+# Same-k Reverse At k=18 Under The Named C2d4-Plus-Deep-Interior Hop-Cost On B_54(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one Dijkstra arrival comparison at k=18 on the finite nearest-neighbor
+graph `B_54(0)`, under a named hop-cost displayed for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py`](../scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Same-k reverse at k=18 under the named c2d4-plus-deep-interior hop-cost on B_54(0) is reported. Displayed, not adopted.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+nearest-neighbor hop `v → w` the named c2d4-plus-deep-interior hop-cost `j2`
+is the first display of `j2` at k=18. The parent clauses `ν`, `μ`, `ρ3`, and
+`c2d4` are those of the ridge-slide and cost-2 max≥4 out-face same-k scoring
+on this ball:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4`), else `1`;
+- `j2(v→w) = 3` if `ρ3` would be `3`, else `2` if `c2d4` would be `2` or
+  (`|σ_v|=|σ_w|=3` and `min_i |w_i| ≥ 3`), else `1`.
+
+So `j2` equals `3` if `ρ3` would be `3`. Otherwise it prices at `2` the
+parent max≥4 out-face hops already priced at `2` by `c2d4`, and also the
+deeper interior body hops: support stays `3` and every absolute destination
+coordinate is at least `3`. It fires on `(3,3,2) → (3,3,3)` at cost `2`.
+It does not fire on the dest-min-abs=`2` hop `(2,2,1) → (2,2,2)`, whose
+destination min absolute coordinate is `2`. It does not fire on the body
+last hop `(1,1,0) → (1,1,1)`, which is not a `3→3` hop, nor on
+`(3,3,3) → (2,3,3)`, whose destination min absolute coordinate is `2`.
+Those hops remain priced at `1`. The parent `c2d4` prices
+`(3,3,2) → (3,3,3)` at `1`. Uniqueness is not claimed.
+
+The finite host is scored independently: one Dijkstra from the origin is run
+on this ball. The ball is not leftover of a larger-ball table.
+
+```text
+B_54(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 54 }.
+```
+
+It has 215929 sites (215928 nonzero). Edges are the cubic nearest-neighbor
+steps that remain inside `B_54(0)`. One Dijkstra from the origin yields
+
+```text
+t(18,0,0) = 34
+t(18,18,18) = 74
+```
+
+The same-k comparison at k=18 is
+
+```text
+t(18,0,0)^2 / 324 = 1156/324  versus  5476/972 = t(18,18,18)^2 / 972.
+```
+
+Equivalently whether `3468 > 5476`. The inequality does not hold. Same-k
+reverse at k=18 under `j2` is no. Displayed, not adopted.
+
+The extra deep-interior clause is live on this host. The hop
+`(3,3,2) → (3,3,3)` has `|σ_v|=|σ_w|=3` and destination min absolute
+coordinate `3`, so `ρ3 = 1` and `c2d4 = 1` while `j2 = 2`. Both sites lie
+in `B_54(0)`. Independently, `t(3,3,2) = 12` and `t(3,3,3) = 14`, matching
+that extra hop of cost `2`. The skipped dest-min-abs=`2` hop
+`(2,2,1) → (2,2,2)` has `j2=1`. The same Dijkstra gives `t(2,2,2) = 10`.
+The displayed body last hop `(1,1,0) → (1,1,1)` keeps cost `1`. The skipped
+hop `(3,2,0) → (4,2,0)` has `j2=1`. The same Dijkstra gives `t(3,2,0) = 9`
+and `t(4,2,0) = 10`, matching that skipped extra hop of cost `1`. The
+max≥4 out-face hop `(4,2,0) → (5,2,0)` has `c2d4=2` and therefore `j2=2`;
+both ends lie in `B_54(0)`. Independently, `t(5,2,0) = 12`.
+
+A cheapest body walk stays on the dest-min-abs=`1` surface until
+`(18,18,1)`, takes one dest-min-abs=`2` hop to `(18,18,2)`, and only then
+pays the deeper interior extra. Independently, `t(18,18,1) = 41` and
+`t(18,18,2) = 42`. The remaining sixteen hops to `(18,18,18)` each cost
+`2`, matching `t(18,18,18) = 74`.
+
+The site `(18,18,18)` has coordinate-sum `54`, so it is absent from
+`B_51(0)`. The new axis site is `t(54,0,0) = 75`. The shared axis site
+`t(51,0,0) = 67` is a `j2` score on this ball. The `B_54(0)` table is
+therefore not leftover of the `B_51(0)` times. The body site `(19,19,19)`
+has coordinate-sum `57` and is absent from `B_54(0)`.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "One Dijkstra on B_54(0) reports t(18,0,0) and t(18,18,18) under the named c2d4-plus-deep-interior hop-cost and scores the k=18 same-k comparison. The hop-cost is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: c2d4_deep_interior_cost2_samek_k18_b54
+target_blocker_text: "whether same-k reverse at k=18 still holds after 3-to-3 hops with dest min abs at least 3 are priced at 2"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded arrival comparison"
+conditional_surface_status: "exact on B_54(0) under the named hop-cost; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. The hop-cost `j2` is not
+  Lattice content.
+- **Explicit theorem-domain condition:** the finite set `B_54(0)`, its
+  nearest-neighbor edges, and the named directed costs `ν`, `μ`, `ρ3`,
+  `c2d4`, and `j2` are supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing `j2` into Admissibility, selecting it as
+  a physical cost, or lifting the comparison off `B_54(0)` remain separate
+  obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+`j2` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under
+`j2`, using one Dijkstra on `B_54(0)`.
+
+An explicit axis path of cost `34` is seed-exit `(0,0,0) → (1,0,0)` of
+cost `3`, leave-axis `(1,0,0) → (1,1,0)` of cost `1`, enter-body
+`(1,1,0) → (1,1,1)` of cost `1`, ridge-slide `(1,1,1) → (1,2,1)` of cost
+`3`, seventeen support-preserving cost-`1` hops to `(18,2,1)`,
+support-drop `(18,2,1) → (18,2,0)` of cost `3`, corridor-slide
+`(18,2,0) → (18,1,0)` of cost `3`, and support-drop `(18,1,0) → (18,0,0)`
+of cost `3`, summing to `34`. Every path has first hop cost `3`. That walk
+is a witness of cost `34`, not a uniqueness claim.
+
+An explicit body path of cost `74` is seed-exit `(0,0,0) → (1,0,0)` of
+cost `3`, leave-axis `(1,0,0) → (1,1,0)` of cost `1`, corridor-slide
+`(1,1,0) → (1,2,0)` of cost `3`, non-hugging face hop `(1,2,0) → (2,2,0)`
+of cost `1`, enter-body `(2,2,0) → (2,2,1)` of cost `1`, sixteen
+support-preserving cost-`1` hops to `(18,2,1)`, sixteen cost-`1` hops to
+`(18,18,1)`, one dest-min-abs=`2` hop of cost `1` to `(18,18,2)`, and
+sixteen deeper interior extra hops of cost `2` to `(18,18,18)`, summing
+to `74`. That walk is a witness of cost `74`, not a uniqueness claim.
+
+On the deep-interior hop `(3,3,2) → (3,3,3)` one has `|σ_v|=|σ_w|=3` and
+dest min absolute coordinate `3`, so `ρ3 = 1` and `c2d4 = 1` while `j2 = 2`;
+both sites lie in `B_54(0)`. On the reverse hop `(3,3,3) → (2,3,3)` the extra
+clause is idle because the dest min absolute coordinate is `2`; `j2` costs
+`1`. On the dest-min-abs=`2` hop `(2,2,1) → (2,2,2)` the extra clause is idle
+because the dest min absolute coordinate is `2`; `ρ3`, `c2d4`, and `j2` all
+cost `1`. On the max≥4 out hop `(4,2,0) → (5,2,0)` one has `|σ_v|=|σ_w|=2`,
+dest max `5` greater than source max `4`, and source max already `4`, so
+`ρ3 = 1` while `c2d4 = 2` and `j2 = 2`; both ends lie in `B_54(0)`. On the
+in-ball hop `(4,1,0) → (5,1,0)` the `c2d4` extra clause fires, but the
+destination least nonzero absolute coordinate is `1`, so `ρ3`, `c2d4`, and
+`j2` all cost `3`. On the max≥3 out hop `(3,2,0) → (4,2,0)` the `c2d4`
+extra clause is idle because the source max is `3`; `ρ3`, `c2d4`, and `j2`
+all cost `1`. On the unit-out hop `(1,1,0) → (2,1,0)` corridor-slide already
+prices that hop at `3`. On the body hop `(1,0,0) → (1,1,0)` both `ρ3` and
+`j2` cost `1`. Independently, `t(1,0,0) = 3` and `t(1,1,1) = 5`.
+
+## Theorem 1 — Arrival times at k=18
+
+Under `j2` on `B_54(0)`,
+
+```text
+t(18,0,0) = 34
+t(18,18,18) = 74
+```
+
+The runner computes both values from the single origin Dijkstra and checks
+them against the explicit paths above. These values are Dijkstra outputs,
+not fitted scalars. Both sites lie in `B_54(0)`. The site `(18,18,18)` has
+coordinate-sum `54`, so it is absent from `B_51(0)`. The pair is computed
+on `B_54(0)`, not copied from a smaller-ball table.
+
+## Theorem 2 — Same-k comparison at k=18
+
+The displayed comparison is whether
+
+```text
+t(18,0,0)^2 / 324 > t(18,18,18)^2 / 972.
+```
+
+Substituting the computed times gives the integer statement `1156/324`
+versus `5476/972`, or equivalently `3468 > 5476`. The inequality does not
+hold. Displayed, not adopted.
+
+## Theorem 3 — No axiom write and no L1 attachment
+
+Do not write j2 into Admissibility. Do not attach L1.
+
+Do not write `j2` into Admissibility.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `j2`, `c2d4`, `ρ3`, `μ`, or `ν`. This
+note proposes no axiom edit. The comparison above is a score of the named
+hop-cost against itself at two sites; it is not an attachment of a
+coordinate-sum hop-cost.
+
+## What This Does Not Claim
+
+- No uniqueness claim is made for this named hop-cost at k=18.
+- The live dest-min-abs≥`3` `3→3` clause on `B_54(0)` is not a statement
+  about larger hosts.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_54(0)`, evaluates the named hop-cost, and
+runs one Dijkstra from the origin. It reports `t(18,0,0)` and `t(18,18,18)`,
+checks the integer form of Theorem 2, checks that the deep-interior extra
+clause prices `(3,3,2) → (3,3,3)` at `2` on this host, skips
+`(2,2,1) → (2,2,2)` and `(3,3,3) → (2,3,3)` as a new tax, and fires
+`(4,2,0) → (5,2,0)` at cost `2` with both ends inside the ball, checks that
+the live Admissibility wording does not name `j2`, and records the import
+boundary. Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_deep_interior_cost2_samek_k18_b54_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.txt
@@ -1,0 +1,78 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py
+runner_sha256: ba4c99cbe4d40675bb731fa85b4468b66f545ad726728118f77ba3245b5361eb
+input_fingerprint_sha256: 651a56411298689651f6d88467eed49dacd18942abdf91fe989824ab3ef583e1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 12.04
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K18_B54_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=18 under the named c2d4-plus-deep-interior hop-cost on B_54(0) is reported. Displayed, not adopted.
+external_scientific_inputs: none; named hop-cost on the finite nearest-neighbor graph B_54(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and one Dijkstra; no fit and no second graph search
+claim_boundary: same-k reverse at k=18 is displayed, not adopted
+n_sites 215929
+t(18,0,0) = 34
+t(18,18,18) = 74
+same-k comparison: 34^2 / 324 = 1156/324 versus 74^2 / 972 = 5476/972; reverse=False
+3 t(18,0,0)^2 = 3468
+t(18,18,18)^2 = 5476
+t(1,0,0) = 3
+t(1,1,1) = 5
+t(3,2,0) = 9
+t(4,2,0) = 10
+t(5,2,0) = 12
+t(2,2,2) = 10
+t(3,3,2) = 12
+t(3,3,3) = 14
+t(18,18,1) = 41
+t(18,18,2) = 42
+t(54,0,0) = 75
+t(51,0,0) = 67
+dijkstra_calls 1
+j2_deep 2 c2d4_deep 1 rho3_deep 1
+j2_shallow 1 c2d4_shallow 1
+j2_max4_out 2 c2d4_max4_out 2
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_54(0) is the 215929-site integer set with coordinate-sum at most 54
+PASS: one-dijkstra exactly one Dijkstra from the origin is executed
+PASS: reachable every site of B_54(0) is reached
+PASS: hop-origin the unique origin hop has named cost 3
+PASS: hop-deep-interior-clause the named 3-to-3 dest min-abs>=3 clause prices (3,3,2) to (3,3,3) at 2
+PASS: hop-deep-interior-exit-idle the named deep-interior clause skips (3,3,3) to (2,3,3) because dest min abs is 2
+PASS: hop-shallow-interior-idle the named deep-interior clause skips (2,2,1) to (2,2,2) because dest min abs is 2
+PASS: hop-max4-out-clause c2d4 still prices (4,2,0) to (5,2,0) at 2, so j2 does as well
+PASS: in-ball-cost2-split in-ball j2=2 hops are dest-min-abs>=3 3-to-3 hops plus c2d4 max>=4 out-face hops
+PASS: j2-clauses seed-exit, axis, drop, corridor-slide, and ridge-slide cost 3; dest-min-abs>=3 3-to-3 and max>=4 out-face cost 2; dest-min-abs=2 body hops cost 1
+PASS: thm1-axis-time t(18,0,0) equals the computed origin-to-axis arrival time
+PASS: thm1-body-time t(18,18,18) equals the computed origin-to-body arrival time
+PASS: thm2-reverse-reported the integer same-k comparison is computed from the two arrivals
+PASS: thm1-note-reports-times the note reports the computed arrival times
+PASS: thm2-note-reports-comparison the note reports the integer same-k comparison and does not adopt it
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name j2
+PASS: thm3-no-l1-attachment the note refuses to attach L1 and does not score a unit hop-cost
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-claimed the note does not claim uniqueness of the named hop-cost
+PASS: scope-boundary the theorem stays on B_54(0) and proposes no axiom edit
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: deep-interior-arrival the same Dijkstra records t(3,3,3) matching the dest-min-abs>=3 extra hop of cost 2
+PASS: shallow-interior-arrival the same Dijkstra records t(2,2,2) matching the skipped dest-min-abs=2 hop of cost 1
+PASS: skipped-max3-arrival the same Dijkstra records t(3,2,0)=9 and t(4,2,0)=10 matching the skipped extra hop of cost 1
+PASS: hug-then-deep-interior the same Dijkstra records t(18,18,2) and the remaining deep-interior hops of cost 2
+PASS: not-leftover-of-b51 (18,18,18) lies outside B_51(0) and the note says so
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.
+per_site: arrival times are reported only at (18,0,0) and (18,18,18).
+lattice_wide: checked and not executed — the search stays inside B_54(0).
+TOTAL: PASS=31 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py
+++ b/scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""Same-k reverse at k=18 under the named c2d4-plus-deep-interior hop-cost on B_54(0).
+
+One Dijkstra from the origin on the finite nearest-neighbor graph. The
+c2d4-plus-deep-interior hop-cost is displayed, not adopted, and is not
+written into Admissibility. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "C2D4_DEEP_INTERIOR_COST2_SAMEK_K18_B54_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K18_B54_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Same-k reverse at k=18 under the named c2d4-plus-deep-interior "
+    "hop-cost on B_54(0) is reported. Displayed, not adopted."
+)
+
+RADIUS = 54
+K = 18
+AXIS = (18, 0, 0)
+BODY = (18, 18, 18)
+MAX3_OUT_SRC = (3, 2, 0)
+MAX3_OUT_DST = (4, 2, 0)
+MAX4_OUT_SRC = (4, 2, 0)
+MAX4_OUT_DST = (5, 2, 0)
+SHALLOW_SRC = (2, 2, 1)
+SHALLOW_DST = (2, 2, 2)
+DEEP_SRC = (3, 3, 2)
+DEEP_DST = (3, 3, 3)
+DEEP_EXIT = (2, 3, 3)
+HUG = (18, 18, 2)
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def l1(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def support_size(site: Site) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def unit_coord_count(site: Site) -> int:
+    return sum(1 for coordinate in site if abs(coordinate) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def min_abs(site: Site) -> int:
+    return min(abs(coordinate) for coordinate in site)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball_sites(radius: int) -> list[Site]:
+    sites: list[Site] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def omega_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+    )
+
+
+def d4_extra(source: Site, dest: Site) -> bool:
+    return omega_extra(source, dest) and max_abs(source) >= 4
+
+
+def c2d4_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if d4_extra(source, dest):
+        return 2
+    return 1
+
+
+def deep_interior_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 3
+        and support_size(dest) == 3
+        and min_abs(dest) >= 3
+    )
+
+
+def j2_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if c2d4_cost(source, dest) == 2 or deep_interior_extra(source, dest):
+        return 2
+    return 1
+
+
+def path_cost(path: list[Site]) -> int:
+    return sum(j2_cost(a, b) for a, b in zip(path, path[1:]))
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, sites: list[Site], origin: Site) -> dict[Site, int]:
+        self.calls += 1
+        site_set = set(sites)
+        dist: dict[Site, int] = {origin: 0}
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        seen: set[Site] = set()
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if site in seen:
+                continue
+            seen.add(site)
+            sx, sy, sz = site
+            for dx, dy, dz in STEPS:
+                neighbor = (sx + dx, sy + dy, sz + dz)
+                if neighbor not in site_set:
+                    continue
+                candidate = cost + j2_cost(site, neighbor)
+                if candidate < dist.get(neighbor, 10**9):
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def axis_witness() -> list[Site]:
+    path: list[Site] = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 2, 1)]
+    path.extend((x, 2, 1) for x in range(2, K + 1))
+    path.extend([(K, 2, 0), (K, 1, 0), (K, 0, 0)])
+    return path
+
+
+def body_witness() -> list[Site]:
+    path: list[Site] = [
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (2, 2, 1),
+    ]
+    path.extend((x, 2, 1) for x in range(3, K + 1))
+    path.extend((K, y, 1) for y in range(3, K + 1))
+    path.extend((K, K, z) for z in range(2, K + 1))
+    return path
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named hop-cost on the finite "
+        "nearest-neighbor graph B_54(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and one Dijkstra; no fit and "
+        "no second graph search"
+    )
+    print(
+        "claim_boundary: same-k reverse at k=18 is displayed, not adopted"
+    )
+
+    sites = ball_sites(RADIUS)
+    origin = (0, 0, 0)
+    counter = DijkstraCounter()
+    dist = counter.distances(sites, origin)
+    t_axis = dist[AXIS]
+    t_body = dist[BODY]
+    t100 = dist[(1, 0, 0)]
+    t111 = dist[(1, 1, 1)]
+    t320 = dist[MAX3_OUT_SRC]
+    t420 = dist[MAX3_OUT_DST]
+    t520 = dist[MAX4_OUT_DST]
+    t222 = dist[SHALLOW_DST]
+    t332 = dist[DEEP_SRC]
+    t333 = dist[DEEP_DST]
+    t_hug = dist[HUG]
+    t18181 = dist[(18, 18, 1)]
+    t5400 = dist[(54, 0, 0)]
+    t5100 = dist[(51, 0, 0)]
+    reverse = 3 * t_axis * t_axis > t_body * t_body
+    axis_sq = t_axis * t_axis
+    body_sq = t_body * t_body
+    axis_prod = 3 * axis_sq
+    axis_path = axis_witness()
+    body_path = body_witness()
+    axis_path_cost = path_cost(axis_path)
+    body_path_cost = path_cost(body_path)
+
+    print(f"n_sites {len(sites)}")
+    print(f"t(18,0,0) = {t_axis}")
+    print(f"t(18,18,18) = {t_body}")
+    print(
+        f"same-k comparison: {t_axis}^2 / 324 = {axis_sq}/324 versus "
+        f"{t_body}^2 / 972 = {body_sq}/972; reverse={reverse}"
+    )
+    print(f"3 t(18,0,0)^2 = {axis_prod}")
+    print(f"t(18,18,18)^2 = {body_sq}")
+    print(f"t(1,0,0) = {t100}")
+    print(f"t(1,1,1) = {t111}")
+    print(f"t(3,2,0) = {t320}")
+    print(f"t(4,2,0) = {t420}")
+    print(f"t(5,2,0) = {t520}")
+    print(f"t(2,2,2) = {t222}")
+    print(f"t(3,3,2) = {t332}")
+    print(f"t(3,3,3) = {t333}")
+    print(f"t(18,18,1) = {t18181}")
+    print(f"t(18,18,2) = {t_hug}")
+    print(f"t(54,0,0) = {t5400}")
+    print(f"t(51,0,0) = {t5100}")
+    print(f"dijkstra_calls {counter.calls}")
+    print(
+        f"j2_deep {j2_cost(DEEP_SRC, DEEP_DST)} "
+        f"c2d4_deep {c2d4_cost(DEEP_SRC, DEEP_DST)} "
+        f"rho3_deep {rho3_cost(DEEP_SRC, DEEP_DST)}"
+    )
+    print(
+        f"j2_shallow {j2_cost(SHALLOW_SRC, SHALLOW_DST)} "
+        f"c2d4_shallow {c2d4_cost(SHALLOW_SRC, SHALLOW_DST)}"
+    )
+    print(
+        f"j2_max4_out {j2_cost(MAX4_OUT_SRC, MAX4_OUT_DST)} "
+        f"c2d4_max4_out {c2d4_cost(MAX4_OUT_SRC, MAX4_OUT_DST)}"
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/C2D4_DEEP_INTERIOR_COST2_SAMEK_K18_B54_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_54(0) is the 215929-site integer set with coordinate-sum at most 54",
+        len(sites) == 215929 and origin in dist and AXIS in dist and BODY in dist,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra from the origin is executed",
+        counter.calls == 1 and "DijkstraCounter" in self_source,
+    )
+    checks.check(
+        "reachable",
+        "every site of B_54(0) is reached",
+        len(dist) == 215929 and all(dist[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "hop-origin",
+        "the unique origin hop has named cost 3",
+        j2_cost(origin, (1, 0, 0)) == 3 and nu_cost(origin, (1, 0, 0)) == 3,
+    )
+    checks.check(
+        "hop-deep-interior-clause",
+        "the named 3-to-3 dest min-abs>=3 clause prices (3,3,2) to (3,3,3) at 2",
+        deep_interior_extra(DEEP_SRC, DEEP_DST)
+        and rho3_cost(DEEP_SRC, DEEP_DST) == 1
+        and c2d4_cost(DEEP_SRC, DEEP_DST) == 1
+        and j2_cost(DEEP_SRC, DEEP_DST) == 2
+        and min_abs(DEEP_DST) >= 3
+        and DEEP_SRC in dist
+        and DEEP_DST in dist,
+    )
+    checks.check(
+        "hop-deep-interior-exit-idle",
+        "the named deep-interior clause skips (3,3,3) to (2,3,3) because dest min abs is 2",
+        not deep_interior_extra(DEEP_DST, DEEP_EXIT)
+        and min_abs(DEEP_EXIT) == 2
+        and rho3_cost(DEEP_DST, DEEP_EXIT) == 1
+        and j2_cost(DEEP_DST, DEEP_EXIT) == 1
+        and DEEP_EXIT in dist,
+    )
+    checks.check(
+        "hop-shallow-interior-idle",
+        "the named deep-interior clause skips (2,2,1) to (2,2,2) because dest min abs is 2",
+        not deep_interior_extra(SHALLOW_SRC, SHALLOW_DST)
+        and min_abs(SHALLOW_DST) == 2
+        and rho3_cost(SHALLOW_SRC, SHALLOW_DST) == 1
+        and c2d4_cost(SHALLOW_SRC, SHALLOW_DST) == 1
+        and j2_cost(SHALLOW_SRC, SHALLOW_DST) == 1
+        and SHALLOW_SRC in dist
+        and SHALLOW_DST in dist,
+    )
+    checks.check(
+        "hop-max4-out-clause",
+        "c2d4 still prices (4,2,0) to (5,2,0) at 2, so j2 does as well",
+        d4_extra(MAX4_OUT_SRC, MAX4_OUT_DST)
+        and rho3_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 1
+        and c2d4_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and j2_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and not deep_interior_extra(MAX4_OUT_SRC, MAX4_OUT_DST)
+        and MAX4_OUT_SRC in dist
+        and MAX4_OUT_DST in dist,
+    )
+    in_ball_deep = 0
+    in_ball_cost2 = 0
+    in_ball_c2d4_new = 0
+    site_set = set(sites)
+    for site in sites:
+        for step in STEPS:
+            neighbor = add(site, step)
+            if neighbor not in site_set:
+                continue
+            if j2_cost(site, neighbor) == 2:
+                in_ball_cost2 += 1
+            if deep_interior_extra(site, neighbor):
+                in_ball_deep += 1
+            if d4_extra(site, neighbor) and rho3_cost(site, neighbor) == 1:
+                in_ball_c2d4_new += 1
+    checks.check(
+        "in-ball-cost2-split",
+        "in-ball j2=2 hops are dest-min-abs>=3 3-to-3 hops plus c2d4 max>=4 out-face hops",
+        in_ball_cost2 == in_ball_deep + in_ball_c2d4_new
+        and in_ball_deep > 0
+        and in_ball_c2d4_new > 0,
+    )
+    checks.check(
+        "j2-clauses",
+        "seed-exit, axis, drop, corridor-slide, and ridge-slide cost 3; dest-min-abs>=3 3-to-3 and max>=4 out-face cost 2; dest-min-abs=2 body hops cost 1",
+        j2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and j2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and j2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and j2_cost((1, 1, 0), (2, 1, 0)) == 3
+        and j2_cost((1, 1, 1), (2, 1, 1)) == 3
+        and j2_cost((2, 2, 1), (2, 2, 2)) == 1
+        and j2_cost((3, 3, 2), (3, 3, 3)) == 2
+        and j2_cost((4, 2, 0), (5, 2, 0)) == 2
+        and j2_cost((4, 1, 0), (5, 1, 0)) == 3
+        and j2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and j2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and j2_cost((2, 2, 0), (3, 2, 0)) == 1
+        and j2_cost((3, 2, 0), (4, 2, 0)) == 1
+        and j2_cost((3, 3, 3), (2, 3, 3)) == 1
+        and j2_cost((18, 18, 1), (18, 18, 2)) == 1
+        and j2_cost((18, 18, 2), (18, 18, 3)) == 2
+        and j2_cost((18, 18, 17), (18, 18, 18)) == 2
+        and not deep_interior_extra((1, 1, 0), (1, 1, 1))
+        and not deep_interior_extra((2, 2, 1), (2, 2, 2))
+        and not deep_interior_extra((3, 3, 3), (2, 3, 3)),
+    )
+    checks.check(
+        "thm1-axis-time",
+        "t(18,0,0) equals the computed origin-to-axis arrival time",
+        t_axis == axis_path_cost and t_axis == 34 and axis_path[-1] == AXIS,
+    )
+    checks.check(
+        "thm1-body-time",
+        "t(18,18,18) equals the computed origin-to-body arrival time",
+        t_body == body_path_cost and t_body == 74 and body_path[-1] == BODY,
+    )
+    checks.check(
+        "thm2-reverse-reported",
+        "the integer same-k comparison is computed from the two arrivals",
+        reverse == (axis_prod > body_sq)
+        and reverse is False
+        and axis_sq == 1156
+        and body_sq == 5476
+        and axis_prod == 3468
+        and (K * K) == 324
+        and (3 * K * K) == 972,
+    )
+    checks.check(
+        "thm1-note-reports-times",
+        "the note reports the computed arrival times",
+        f"t(18,0,0) = {t_axis}" in note and f"t(18,18,18) = {t_body}" in note,
+    )
+    checks.check(
+        "thm2-note-reports-comparison",
+        "the note reports the integer same-k comparison and does not adopt it",
+        f"{axis_sq}/324" in note
+        and f"{body_sq}/972" in note
+        and f"{axis_prod} > {body_sq}" in note
+        and "Displayed, not adopted" in note
+        and ("does not hold" in note or "inequality does not hold" in note),
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name j2",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "j2(v→w)" not in axiom
+        and "Do not write j2 into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1 and does not score a unit hop-cost",
+        "Do not attach L1." in note
+        and "attach L1" in note
+        and "unit hop-cost" not in note.lower(),
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " ")
+        and CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "the note does not claim uniqueness of the named hop-cost",
+        "Uniqueness is not claimed" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_54(0) and proposes no axiom edit",
+        "B_54(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "one Dijkstra" in note
+        and "not leftover of a larger-ball table" in note,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "interior body hops" in note
+        and "j2` equals `3` if `ρ3" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "deep-interior-arrival",
+        "the same Dijkstra records t(3,3,3) matching the dest-min-abs>=3 extra hop of cost 2",
+        t332 == 12
+        and t333 == 14
+        and t332 + j2_cost(DEEP_SRC, DEEP_DST) == t333
+        and f"t(3,3,2) = {t332}" in note
+        and f"t(3,3,3) = {t333}" in note,
+    )
+    checks.check(
+        "shallow-interior-arrival",
+        "the same Dijkstra records t(2,2,2) matching the skipped dest-min-abs=2 hop of cost 1",
+        t222 == 10
+        and j2_cost(SHALLOW_SRC, SHALLOW_DST) == 1
+        and f"t(2,2,2) = {t222}" in note,
+    )
+    checks.check(
+        "skipped-max3-arrival",
+        "the same Dijkstra records t(3,2,0)=9 and t(4,2,0)=10 matching the skipped extra hop of cost 1",
+        t320 == 9
+        and t420 == 10
+        and t320 + j2_cost(MAX3_OUT_SRC, MAX3_OUT_DST) == t420
+        and "t(3,2,0) = 9" in note
+        and "t(4,2,0) = 10" in note,
+    )
+    checks.check(
+        "hug-then-deep-interior",
+        "the same Dijkstra records t(18,18,2) and the remaining deep-interior hops of cost 2",
+        t_hug == t_body - 2 * 16
+        and j2_cost(HUG, (18, 18, 3)) == 2
+        and t_hug + 2 * 16 == t_body
+        and t18181 == 41
+        and f"t(18,18,2) = {t_hug}" in note
+        and f"t(18,18,1) = {t18181}" in note,
+    )
+    checks.check(
+        "not-leftover-of-b51",
+        "(18,18,18) lies outside B_51(0) and the note says so",
+        l1(BODY) == 54
+        and t5400 == dist[(54, 0, 0)]
+        and t5100 == dist[(51, 0, 0)]
+        and t5400 == 75
+        and t5100 == 67
+        and f"t(54,0,0) = {t5400}" in note
+        and f"t(51,0,0) = {t5100}" in note
+        and "absent from `B_51(0)`" in note
+        and "not leftover of the `B_51(0)` times" in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "j2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.")
+    print("per_site: arrival times are reported only at (18,0,0) and (18,18,18).")
+    print("lattice_wide: checked and not executed — the search stays inside B_54(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named j2 hop-cost fails at k=18 on B_54(0): t(18,0,0)=34 vs t(18,18,18)=74 (3468<5476). Displayed, not adopted. Do not write j2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_deep_interior_cost2_samek_k18_b54_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.