### PR TITLE
feat(s2k14): c2d4-plus-soft-ridge same-k holds at k=14: t=28 vs t=45

### DIFF
--- a/docs/C2D4_SOFT_RIDGE_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_SOFT_RIDGE_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,298 @@
+---
+claim_id: c2d4_soft_ridge_cost2_samek_k14_b42_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse at k=14 under the named c2d4-plus-soft-ridge hop-cost on B_42(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py
+---
+
+# Named C2d4-Plus-Soft-Ridge Same-k Reverse At k=14 On B_42(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** one named nearest-neighbor hop-cost on the ℓ¹ ball `B_42(0)`,
+scored only for the same-`k` axis versus body-diagonal arrival ratio at
+`k=14`.
+**Audit-status authority:** independent audit lane only. This note authors
+no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py`](../scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named c2d4-plus-soft-ridge hop-cost `s2` is the already scored cost-2
+max≥4 out-face rule `c2d4` except that `ρ3`'s `3→3` ridge-stay (exactly
+two destination absolute coordinates equal to `1`) is priced at `2` rather
+than `3`. That extra cheapening is the opposite of an interior tax. This
+is the first display of whether same-`k` reverse still holds at the
+`ρ3`/`κ` wall under that cheapened ridge-stay. Uniqueness is not claimed.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. On a
+directed nearest-neighbor hop `v → w` still inside `B_42(0)`, the displayed
+rule `s2` is
+
+`s2(v→w) = 3` if `μ` would be `3`, else `2` if `(|σ_v|=|σ_w|=3` and
+exactly two `|w_i|` equal `1)` or (`c2d4` would be `2`), else `1`,
+
+where
+`c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if `(|σ_v|=|σ_w|=2` and
+`max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4)`, else `1`,
+`ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+`|w_i|` equal `1)`, else `1`,
+`μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least
+nonzero `|w_i|` equals `1)`, else `1`, and
+`ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`,
+else `1`.
+
+The first three clauses are seed-exit, both weights `1`, and support drop.
+The fourth clause is the axis-hugging `2→2` corridor slide. Those four
+clauses stay at cost `3`. The fifth clause is the ridge-stay priced at
+`2`: a fully supported hop whose destination has exactly two unit-height
+coordinates. The sixth clause is max≥4 out-face priced at `2`: grow the
+box on a face only after height four. Those six clauses are the whole
+rule. The hop `(1,1,1) → (2,1,1)` is a ridge-stay, so it is cost `2`. The
+hop `(3,2,0) → (4,2,0)` has source max `3`, so it is not in the sixth
+clause; it stays at cost `1`. The hop `(4,2,0) → (5,2,0)` has source max
+`4` and a growing dest max, so it is cost `2`. The hop `(3,3,2) → (3,3,3)`
+is fully supported with dest min `3`, so it is not a ridge-stay and stays
+at cost `1`.
+
+One Dijkstra from the origin on `B_42(0)` (102425 sites; 102424 nonzero)
+gives
+
+`t(14,0,0) = 28`, `t(14,14,14) = 45`.
+
+The displayed same-`k` comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+which is `784/196` versus `2025/588`, or equivalently `2352 > 2025`. The
+inequality holds. Same-`k` reverse at `k=14` under `s2` is yes. Reverse
+still holds at the `ρ3`/`κ` wall. Independently, the new axis site is
+`t(42,0,0) = 61`. The shared axis site `t(39,0,0) = 53` is an `s2` score
+on this ball, not a smaller-ball leftover.
+
+The same-`k` pair under `c2d4` is `30` versus `46`. The integers `28`
+versus `30` coincide with a lowered axis relative to that pair, and `45`
+versus `46` coincide with a lowered body. That mismatch is not a leftover
+of a `c2d4` table: the cheapened ridge-stay is live on the ball. On the
+ridge-stay hop `(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and exactly two
+`|w_i|` equal to `1`, so `c2d4 = 3` while `s2 = 2`. Therefore `c2d4`
+cannot price ridge-stay at cost 2. Independently, `t(1,1,1) = 5` and
+`t(2,1,1) = 7`. A cheapest `c2d4` walk to `(14,0,0)` of cost `30` becomes
+cost `28` once those two ridge-stays are priced at `2`. Independently,
+`t(2,2,1) = 8`.
+
+The same-`k` pair under `ρ3` is `26` versus `46`. The integers `28` versus
+`26` coincide with a raised axis relative to that wall pair. That mismatch
+on the axis is not a leftover of a `ρ3` table: the extra max≥4 out-face
+clause is live on the ball, and the cheapened ridge-stay also disagrees
+with `ρ3`. On the later out-face hop `(4,2,0) → (5,2,0)` one has
+`|σ| : 2 → 2`, `max |w_i| = 5 > max |v_i| = 4`, and source max `4`, while
+the least nonzero `|w_i|` is `2`, so `ρ3 = 1` while `s2 = 2`. Therefore
+`ρ3` cannot price max≥4 out-face. On `(1,1,1) → (2,1,1)` one has
+`ρ3 = 3` while `s2 = 2`, so `ρ3` also cannot price ridge-stay at cost 2.
+Independently, `t(5,2,0) = 12` under `s2`. The skipped hop
+`(3,2,0) → (4,2,0)` also grows the max absolute coordinate, but its source
+max is `3`, so it is not max≥4 out-face; it stays `s2 = 1` while `d3 = 3`.
+Independently, `t(4,2,0) = 10` under `s2`. The hop `(2,2,0) → (3,2,0)` also
+grows the max absolute coordinate, but its source max is `2`, so it is not
+max≥4 out-face; it stays `s2 = 1` while `df = 3`. Independently,
+`t(3,2,0) = 9` under `s2`. The corridor hop `(1,1,0) → (2,1,0)` also
+grows the max absolute coordinate, but its source max is `1`, so it is not
+max≥4 out-face; it is already `μ = 3` by the hugging clause.
+
+The cost-3 max≥4 out-face comparator `d4` uses the same grow test but
+prices it at `3`. On `(4,2,0) → (5,2,0)` one has `s2 = 2` while
+`d4 = 3`. Independently, `t(5,2,0) = 12` under `s2` and `t(42,0,0) = 61`
+under `s2`. Therefore the `s2` scores are not leftover of `d4`.
+
+The same-`k` pair `28` versus `45` does not coincide with the `d3` pair,
+the `df` pair, or the `ω` pair. The named extra clauses are still not leftover of `d3`: that rule prices `(3,2,0) → (4,2,0)` at `3`, and `s2`
+prices it at `1`. Independently it is not leftover of `df` or of `ω`:
+those rules price `(2,2,0) → (3,2,0)` at `3`, and `s2` prices it at `1`.
+
+The site `(14,14,14)` has ℓ¹ norm `42`, so it is absent from `B_39(0)`.
+The `B_42(0)` table is therefore not leftover of the `B_39(0)` times.
+
+The interior-slide comparator `ι` taxes a non-ridge `3 → 3` hop whose
+destination has `min |w_i| ≥ 2` at cost `3`. On `(3,3,2) → (3,3,3)` one
+has `s2 = 1` while `ι = 3`. Therefore the `s2` body arrival `45` is not
+leftover of `ι`. Independently, `t(5,2,2) = 12`, `t(2,2,2) = 9`,
+`t(3,3,3) = 12`, and `t(14,14,1) = 32`.
+
+The cost-3 ridge-enter comparator `κ` prices `(2,1,0) → (2,1,1)` at `3`
+while `s2` leaves it at `1`. Therefore the `s2` scores are not leftover of `κ`.
+
+The rule is displayed, not adopted. Do not write `s2` into Admissibility.
+Do not write s2 into Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+Lattice supplies the six-neighbor graph and the ball. Admissibility supplies
+none of the hop costs. The integers `3`, `2`, and `1`, the support-size
+clauses, the least-nonzero-coordinate clause, the two-unit-height ridge
+clause, the max≥4 out-face source-max clause, and the arrival function `t`
+are separately displayed mathematical inputs. No axiom text is edited.
+
+## Named Rule
+
+Let `B_42(0) = { v ∈ Z^3 : |v|_1 ≤ 42 }`. Directed edges are the six
+nearest-neighbor steps whose both ends lie in the ball. For `v ∈ B_42(0)`,
+`t(v)` is the least sum of `s2` along a directed path from `0` to `v` in
+that graph.
+
+The comparator `c2d4` uses cost `3` on the ridge-stay that `s2` prices at
+`2`. On `(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and exactly two unit
+heights at the destination, so `c2d4 = 3` while `s2 = 2`. Therefore
+`c2d4` cannot price ridge-stay at cost 2, and the `s2` scores below are
+not a leftover of `c2d4`.
+
+The comparator `ρ3` uses cost `3` on that same ridge-stay and cost `1` on
+max≥4 out-face. On `(1,1,1) → (2,1,1)` one has `ρ3 = 3` while `s2 = 2`.
+On `(4,2,0) → (5,2,0)` one has `|σ| : 2 → 2` and a growing max at source
+height at least four, so `ρ3 = 1` while `s2 = 2`. Therefore `ρ3` cannot
+price ridge-stay at cost 2 and cannot price max≥4 out-face.
+
+The parent cost-3 comparator `d4` uses the same grow test with cost `3`.
+On `(4,2,0) → (5,2,0)` both grow predicates hold and the hop costs
+disagree. Therefore the `s2` scores are not leftover of `d4`.
+
+The max≥3 out-face comparator `d3` uses the same grow test with source-max
+floor three. On `(3,2,0) → (4,2,0)` the `d3` grow predicate holds and the
+`s2` grow predicate fails. The rule skips the height-three out-face hop.
+
+The deep-out-face comparator `df` uses the same grow test with source-max
+floor two. On `(2,2,0) → (3,2,0)` the `df` grow predicate holds and the
+`s2` grow predicate fails.
+
+The cost-3 out-face comparator `ω` uses the same grow test without a
+source-max floor. On `(3,2,0) → (4,2,0)` the `ω` grow predicate holds and
+the `s2` grow predicate fails.
+
+The cost-3 ridge-enter comparator `κ` prices `(2,1,0) → (2,1,1)` at `3`
+while `s2` leaves it at `1`. Therefore the `s2` scores are not leftover of `κ`.
+
+The interior-slide comparator `ι` taxes a non-ridge interior `3 → 3` hop
+at cost `3`. On `(3,3,2) → (3,3,3)` one has `s2 = 1` while `ι = 3`.
+Therefore the `s2` scores are not leftover of `ι`.
+
+## Theorem 1 — Arrivals `t(14,0,0)` And `t(14,14,14)` On `B_42(0)`
+
+One origin Dijkstra on `B_42(0)` returns the integer arrivals
+
+| site | `t_s2` |
+|---|---:|
+| `(14,0,0)` | `28` |
+| `(14,14,14)` | `45` |
+
+Every listed site lies in `B_42(0)`. The site `(14,14,14)` has ℓ¹ norm `42`,
+so it is absent from `B_39(0)`. The pair is computed on `B_42(0)`, not
+copied from a smaller-ball table and not copied from the `c2d4` pair
+`30` versus `46` or from the `ρ3` pair `26` versus `46`. These values are
+Dijkstra outputs, not fitted scalars.
+
+A witness axis walk of cost `28` is seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, unit-cube enter `1` onto `(1,1,1)`,
+ridge-stay `2` onto `(2,1,1)`, support-preserving `1` onto `(2,2,1)`,
+twelve support-preserving cost-`1` body hops to `(14,2,1)`, ridge-stay
+`2` onto `(14,1,1)`, support-drop `3` onto `(14,1,0)`, and support-drop
+`3` onto `(14,0,0)`, summing to `28`. Those twelve body hops have dest min
+`1`, so they are not interior. That walk never uses a `2→2` dest whose
+max grows at source height at least four. That walk is a witness of cost
+`28`, not a uniqueness claim.
+
+A witness body walk of cost `45` is the same prefix of cost `8` to
+`(2,2,1)`, twelve cost-`1` hops to `(14,2,1)`, twelve cost-`1` hops to
+`(14,14,1)`, and thirteen support-preserving cost-`1` body hops to
+`(14,14,14)`, summing to `45`. Those last hops have dest with only one
+absolute coordinate equal to `1` or none, so they are not ridge-stays.
+That walk is a witness of cost `45`, not a uniqueness claim.
+
+A witness that the skip is live is the walk seed-exit `3` onto `(1,0,0)`,
+unit-cube leave `1` onto `(1,1,0)`, corridor-slide `3` onto `(1,2,0)`,
+support-preserving `1` onto `(2,2,0)`, support-preserving `1` onto
+`(3,2,0)`, and skipped height-three out-face `1` onto `(4,2,0)`, summing
+to `10`. Replacing only the last hop by its `d3` price `3` yields `12`.
+Independently, `t(4,2,0) = 10`.
+
+A witness that the max≥4 out-face clause is live is that same prefix of
+cost `10` to `(4,2,0)` followed by max≥4 out-face `2` onto `(5,2,0)`,
+summing to `12`. Replacing only the last hop by its `ρ3` price `1` yields
+`11`. Replacing only the last hop by its `d4` price `3` yields `13`.
+Independently, `t(5,2,0) = 12`.
+
+A witness that the cheapened ridge-stay is live is the walk seed-exit `3`
+onto `(1,0,0)`, unit-cube leave `1` onto `(1,1,0)`, unit-cube enter `1`
+onto `(1,1,1)`, and ridge-stay `2` onto `(2,1,1)`, summing to `7`.
+Replacing only the last hop by its `c2d4` price `3` yields `8`.
+Independently, `t(1,1,1) = 5` and `t(2,1,1) = 7`.
+
+## Theorem 2 — Reverse At The Same-`k` Scale `k=14`
+
+The Euclidean-normalized comparison at `k=14` is
+
+`t(14,0,0)^2 / 196  ?  t(14,14,14)^2 / 588`,
+
+equivalently `3 t(14,0,0)^2 ? t(14,14,14)^2`. Substituting the computed times
+gives `3 · 28^2 = 2352` and `45^2 = 2025`, so
+
+`2352 > 2025`.
+
+Arrival per Euclidean length is larger at `(14,0,0)` than at `(14,14,14)`.
+Same-`k` reverse at `k=14` under `s2` is yes. Reverse still holds at the
+`ρ3`/`κ` wall. The comparison is displayed, not adopted. The inequality
+holds.
+
+## Theorem 3 — Displayed, Not Adopted
+
+The rule `s2` is a displayed scoring device on `B_42(0)`. Do not write `s2`
+into Admissibility. Do not write s2 into Admissibility. Do not attach L1.
+It is not a replacement for unit-cost first arrival, and it is not offered
+as the unique hop-cost with same-`k` reverse.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact integer same-k arrivals and reverse comparison on the finite ball B_42(0) for one named hop-cost at k=14. The rule is displayed, not adopted."
+trace_class: frontier_discovery
+artifact_role: theorem
+conditional_surface_status: "exact on B_42(0) for the displayed rule s2 at k=14; no Admissibility edit; not attached to L1"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## What This Note Does Not Claim
+
+- Uniqueness of `s2` among hop-costs that reverse the same-`k` pair at `k=14`.
+- Any edit of Lattice, Qubit, Admissibility, or Record.
+- Any attachment to L1.
+- Any continuum potential, any inverse-power kernel, and any gravitational
+  identification.
+- Any statement off `B_42(0)`.
+- Any score for a pair that is not the same-`k` axis / body-diagonal pair
+  at `k=14`.
+- Any reuse of the `c2d4` arrival table as a substitute for the `s2` Dijkstra.
+- Any reuse of the `ρ3` arrival table as a substitute for the `s2` Dijkstra.
+- Any reuse of the `ι`, `d4`, `d3`, `df`, or `ω` arrival table as a
+  substitute for the `s2` Dijkstra.
+- Membership of `s2` as a physical hop-cost. Reverse at `k=14` on this ball
+  is a displayed comparison, not an adoption.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_soft_ridge_cost2_samek_k14_b42_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.txt
@@ -1,0 +1,71 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py
+runner_sha256: 6842359a1985f703195bd25456617f4ffdcc0fbf1ed20b26df8e0ab89d4279e0
+input_fingerprint_sha256: e6d6d8a1f9059116e0fffc7e30b08aa1263685456a07f107ace89e1b66a16d7f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.28
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/C2D4_SOFT_RIDGE_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse at k=14 under the named c2d4-plus-soft-ridge hop-cost on B_42(0) is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are the source note and the current axiom memo
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: claim-scope note claim_scope matches the displayed scoring statement
+PASS: displayed-not-adopted the rule is displayed, not adopted
+PASS: not-in-admissibility s2 is not written into Admissibility
+PASS: not-attach-l1 the displayed rule is not attached to L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: forbidden-absent forbidden phrases are absent from the source note
+n_sites 102425
+t(14,0,0) 28
+t(14,14,14) 45
+t(14,0,0)^2/196 784/196
+t(14,14,14)^2/588 2025/588
+3t_axis^2 2352
+t_body^2 2025
+reverse True
+t(42,0,0) 61
+t(39,0,0) 53
+t(3,2,0) 9
+t(4,2,0) 10
+t(5,2,0) 12
+t(1,1,1) 5
+t(2,1,1) 7
+t(2,2,1) 8
+t(14,14,1) 32
+dijkstra_calls 1
+witness_axis_sum 28
+witness_body_sum 45
+witness_axis_c2d4 30
+witness_body_c2d4 46
+s2_ridge 2
+c2d4_ridge 3
+rho3_ridge 3
+s2_later 2
+c2d4_later 2
+rho3_later 1
+PASS: t-1400-141414 t(14,0,0)=28 and t(14,14,14)=45
+PASS: reverse-k14 t(14,0,0)^2/196 > t(14,14,14)^2/588 holds
+PASS: one-dijkstra exactly one Dijkstra ran
+PASS: ball-b42 B_42(0) has 102425 sites and 102424 nonzero sites
+PASS: reachable every site of B_42(0) is reached
+PASS: note-records-times note records the two computed arrivals
+PASS: note-records-reverse-products note records the integer reverse products
+PASS: not-leftover-of-c2d4 s2 prices ridge-stay at 2 while c2d4 prices it at 3
+PASS: not-leftover-of-rho3 s2 prices ridge-stay at 2 and max≥4 out-face at 2 while ρ3 prices those at 3 and 1
+PASS: not-leftover-of-d4 d4 prices max≥4 out-face at 3 while s2 prices it at 2
+PASS: not-leftover-of-b39 (14,14,14) lies outside B_39(0) and the note says so
+PASS: skips-height-three-out-face c2d4 extra clause skips (3,2,0)→(4,2,0); d3, df, and ω extra clauses include it
+PASS: not-leftover-of-kappa κ prices ridge-enter at 3 while s2 leaves it at 1
+PASS: not-leftover-of-iota s2 does not tax the interior 3→3 hop that ι taxes
+PASS: seed-max4-and-soft-ridge-clauses seed-exit, both-weights-1, support-drop, corridor-slide cost 3; ridge-stay and max≥4 out-face cost 2; skipped grow, unit-cube, ridge-enter, interior, and body enter cost 1
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py
+++ b/scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Score same-k reverse at k=14 under s2 on B_42(0).
+
+One origin Dijkstra. No cache write. No axiom edit.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/C2D4_SOFT_RIDGE_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_SOFT_RIDGE_COST2_SAMEK_K14_B42_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+CLAIM_SCOPE = (
+    "Same-k reverse at k=14 under the named c2d4-plus-soft-ridge "
+    "hop-cost on B_42(0) is reported. "
+    "Displayed, not adopted."
+)
+NEIGH = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+FORBIDDEN_PARTS = (
+    ("G_", "N"),
+    ("1/", "r"),
+    ("1/", "r^2"),
+    ("Lattice-", "named"),
+    ("not a ", "TOE"),
+)
+DIJKSTRA_CALLS = 0
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def l1(v: tuple[int, int, int]) -> int:
+    return abs(v[0]) + abs(v[1]) + abs(v[2])
+
+
+def support_size(v: tuple[int, int, int]) -> int:
+    return int(v[0] != 0) + int(v[1] != 0) + int(v[2] != 0)
+
+
+def least_nonzero_abs(v: tuple[int, int, int]) -> int | None:
+    nonzero = [abs(c) for c in v if c != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_height_count(v: tuple[int, int, int]) -> int:
+    return int(abs(v[0]) == 1) + int(abs(v[1]) == 1) + int(abs(v[2]) == 1)
+
+
+def ball(radius: int) -> list[tuple[int, int, int]]:
+    sites: list[tuple[int, int, int]] = []
+    for x in range(-radius, radius + 1):
+        for y in range(-radius, radius + 1):
+            rem = radius - abs(x) - abs(y)
+            for z in range(-rem, rem + 1):
+                sites.append((x, y, z))
+    return sites
+
+
+def nu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if nu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 2 and support_size(w) == 2 and least_nonzero_abs(w) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if support_size(v) == 3 and support_size(w) == 3 and unit_height_count(w) == 2:
+        return 3
+    return 1
+
+
+def kappa_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if (
+        support_size(v) == 2
+        and support_size(w) == 3
+        and unit_height_count(w) == 2
+    ):
+        return 3
+    return 1
+
+
+def iota_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    sigma_v = support_size(v)
+    sigma_w = support_size(w)
+    if sigma_v == 3 and sigma_w == 3:
+        m = min(abs(c) for c in w)
+        if m >= 2 and sum(1 for c in w if abs(c) == m) != 2:
+            return 3
+    return 1
+
+
+def omega_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 2
+        and support_size(w) == 2
+        and max(abs(c) for c in w) > max(abs(c) for c in v)
+    )
+
+
+def df_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 2
+
+
+def d3_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 3
+
+
+def d4_grow(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return omega_grow(v, w) and max(abs(c) for c in v) >= 4
+
+
+def omega_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if omega_grow(v, w):
+        return 3
+    return 1
+
+
+def df_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if df_grow(v, w):
+        return 3
+    return 1
+
+
+def d3_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d3_grow(v, w):
+        return 3
+    return 1
+
+
+def d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d4_grow(v, w):
+        return 3
+    return 1
+
+
+def c2d4_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if rho3_cost(v, w) == 3:
+        return 3
+    if d4_grow(v, w):
+        return 2
+    return 1
+
+
+def ridge_stay(v: tuple[int, int, int], w: tuple[int, int, int]) -> bool:
+    return (
+        support_size(v) == 3
+        and support_size(w) == 3
+        and unit_height_count(w) == 2
+    )
+
+
+def s2_cost(v: tuple[int, int, int], w: tuple[int, int, int]) -> int:
+    if mu_cost(v, w) == 3:
+        return 3
+    if ridge_stay(v, w) or c2d4_cost(v, w) == 2:
+        return 2
+    return 1
+
+
+def dijkstra_s2(sites: list[tuple[int, int, int]]) -> dict[tuple[int, int, int], int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist: dict[tuple[int, int, int], int] = {(0, 0, 0): 0}
+    heap: list[tuple[int, tuple[int, int, int]]] = [(0, (0, 0, 0))]
+    seen: set[tuple[int, int, int]] = set()
+    while heap:
+        d, v = heapq.heappop(heap)
+        if v in seen:
+            continue
+        seen.add(v)
+        vx, vy, vz = v
+        for dx, dy, dz in NEIGH:
+            w = (vx + dx, vy + dy, vz + dz)
+            if w not in site_set:
+                continue
+            nd = d + s2_cost(v, w)
+            if nd < dist.get(w, 10**9):
+                dist[w] = nd
+                heapq.heappush(heap, (nd, w))
+    return dist
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "AUDIT_INPUT_PATHS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def path_cost(
+    walk: tuple[tuple[int, int, int], ...],
+    cost_fn,
+) -> int:
+    return sum(cost_fn(a, b) for a, b in zip(walk, walk[1:]))
+
+
+def main() -> int:
+    checks = Checks()
+    note_path = ROOT / NOTE_REL
+    axiom_path = ROOT / AXIOM_REL
+    note = note_path.read_text(encoding="utf-8")
+    axiom = axiom_path.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are the source note and the current axiom memo",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "note claim_scope matches the displayed scoring statement",
+        CLAIM_SCOPE in note.replace("\n", " "),
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the rule is displayed, not adopted",
+        "Displayed, not adopted" in note or "displayed, not adopted" in note,
+    )
+    checks.check(
+        "not-in-admissibility",
+        "s2 is not written into Admissibility",
+        "Do not write s2 into Admissibility" in note
+        and "Do not write `s2` into Admissibility" in note,
+    )
+    checks.check(
+        "not-attach-l1",
+        "the displayed rule is not attached to L1",
+        "Do not attach L1" in note and "Do not attach L1" not in axiom,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note or "no uniqueness" in note.lower(),
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    forbidden = tuple("".join(parts) for parts in FORBIDDEN_PARTS)
+    forbidden_hits = [token for token in forbidden if token in note]
+    checks.check(
+        "forbidden-absent",
+        "forbidden phrases are absent from the source note",
+        forbidden_hits == [],
+    )
+
+    sites = ball(42)
+    nonzero = [v for v in sites if v != (0, 0, 0)]
+    dist = dijkstra_s2(sites)
+    t1400 = dist[(14, 0, 0)]
+    t141414 = dist[(14, 14, 14)]
+    t4200 = dist[(42, 0, 0)]
+    t3900 = dist[(39, 0, 0)]
+    t320 = dist[(3, 2, 0)]
+    t420 = dist[(4, 2, 0)]
+    t520 = dist[(5, 2, 0)]
+    t111 = dist[(1, 1, 1)]
+    t211 = dist[(2, 1, 1)]
+    t221 = dist[(2, 2, 1)]
+    t14141 = dist[(14, 14, 1)]
+    t522 = dist[(5, 2, 2)]
+    t222 = dist[(2, 2, 2)]
+    t333 = dist[(3, 3, 3)]
+    axis_sq = t1400 * t1400
+    body_sq = t141414 * t141414
+    triple_axis_sq = 3 * axis_sq
+    reverse = triple_axis_sq > body_sq
+    witness_axis = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        (14, 1, 1),
+        (14, 1, 0),
+        (14, 0, 0),
+    )
+    witness_body = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (2, 2, 1),
+        *[(x, 2, 1) for x in range(3, 15)],
+        *[(14, y, 1) for y in range(3, 15)],
+        *[(14, 14, z) for z in range(2, 15)],
+    )
+    witness_skip = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 2, 0),
+        (2, 2, 0),
+        (3, 2, 0),
+        (4, 2, 0),
+    )
+    witness_later = witness_skip + ((5, 2, 0),)
+    witness_ridge = (
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+    )
+    skip_hop = ((3, 2, 0), (4, 2, 0))
+    later_hop = ((4, 2, 0), (5, 2, 0))
+    height_two = ((2, 2, 0), (3, 2, 0))
+    unit_out_face = ((1, 1, 0), (2, 1, 0))
+    later_out_face = ((7, 2, 0), (8, 2, 0))
+    height2_nongrow = ((1, -2, 0), (2, -2, 0))
+    ridge_enter = ((2, 1, 0), (2, 1, 1))
+    ridge_stay_hop = ((1, 1, 1), (2, 1, 1))
+    ridge_stay_late = ((14, 2, 1), (14, 1, 1))
+    height2_ridge = ((4, 2, 2), (5, 2, 2))
+    interior_cube = ((3, 3, 2), (3, 3, 3))
+    interior_last = ((13, 14, 14), (14, 14, 14))
+    print(f"n_sites {len(sites)}")
+    print(f"t(14,0,0) {t1400}")
+    print(f"t(14,14,14) {t141414}")
+    print(f"t(14,0,0)^2/196 {axis_sq}/196")
+    print(f"t(14,14,14)^2/588 {body_sq}/588")
+    print(f"3t_axis^2 {triple_axis_sq}")
+    print(f"t_body^2 {body_sq}")
+    print(f"reverse {reverse}")
+    print(f"t(42,0,0) {t4200}")
+    print(f"t(39,0,0) {t3900}")
+    print(f"t(3,2,0) {t320}")
+    print(f"t(4,2,0) {t420}")
+    print(f"t(5,2,0) {t520}")
+    print(f"t(1,1,1) {t111}")
+    print(f"t(2,1,1) {t211}")
+    print(f"t(2,2,1) {t221}")
+    print(f"t(14,14,1) {t14141}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(f"witness_axis_sum {path_cost(witness_axis, s2_cost)}")
+    print(f"witness_body_sum {path_cost(witness_body, s2_cost)}")
+    print(f"witness_axis_c2d4 {path_cost(witness_axis, c2d4_cost)}")
+    print(f"witness_body_c2d4 {path_cost(witness_body, c2d4_cost)}")
+    print(f"s2_ridge {s2_cost(*ridge_stay_hop)}")
+    print(f"c2d4_ridge {c2d4_cost(*ridge_stay_hop)}")
+    print(f"rho3_ridge {rho3_cost(*ridge_stay_hop)}")
+    print(f"s2_later {s2_cost(*later_hop)}")
+    print(f"c2d4_later {c2d4_cost(*later_hop)}")
+    print(f"rho3_later {rho3_cost(*later_hop)}")
+
+    checks.check(
+        "t-1400-141414",
+        f"t(14,0,0)={t1400} and t(14,14,14)={t141414}",
+        t1400 == path_cost(witness_axis, s2_cost)
+        and t141414 == path_cost(witness_body, s2_cost)
+        and t1400 == 28
+        and t141414 == 45,
+    )
+    checks.check(
+        "reverse-k14",
+        "t(14,0,0)^2/196 > t(14,14,14)^2/588 holds",
+        reverse
+        and triple_axis_sq == 2352
+        and body_sq == 2025
+        and "2352 > 2025" in note
+        and "inequality holds" in note,
+    )
+    checks.check(
+        "one-dijkstra",
+        "exactly one Dijkstra ran",
+        DIJKSTRA_CALLS == 1,
+    )
+    checks.check(
+        "ball-b42",
+        "B_42(0) has 102425 sites and 102424 nonzero sites",
+        len(sites) == 102425 and len(nonzero) == 102424 and all(l1(v) <= 42 for v in sites),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_42(0) is reached",
+        len(dist) == 102425,
+    )
+    checks.check(
+        "note-records-times",
+        "note records the two computed arrivals",
+        "`28`" in note
+        and "`45`" in note
+        and "`(14,0,0)`" in note
+        and "`(14,14,14)`" in note
+        and "t(14,0,0) = 28" in note
+        and "t(14,14,14) = 45" in note,
+    )
+    checks.check(
+        "note-records-reverse-products",
+        "note records the integer reverse products",
+        "2352 > 2025" in note and "784/196" in note and "2025/588" in note,
+    )
+    checks.check(
+        "not-leftover-of-c2d4",
+        "s2 prices ridge-stay at 2 while c2d4 prices it at 3",
+        s2_cost(*ridge_stay_hop) == 2
+        and c2d4_cost(*ridge_stay_hop) == 3
+        and rho3_cost(*ridge_stay_hop) == 3
+        and mu_cost(*ridge_stay_hop) == 1
+        and s2_cost(*ridge_stay_late) == 2
+        and c2d4_cost(*ridge_stay_late) == 3
+        and path_cost(witness_ridge, s2_cost) == 7
+        and path_cost(witness_ridge, c2d4_cost) == 8
+        and path_cost(witness_axis, s2_cost) == 28
+        and path_cost(witness_axis, c2d4_cost) == 30
+        and path_cost(witness_body, s2_cost) == 45
+        and path_cost(witness_body, c2d4_cost) == 46
+        and t1400 == 28
+        and t141414 == 45
+        and t111 == 5
+        and t211 == 7
+        and "cannot price ridge-stay at cost 2" in note
+        and "30` versus `46" in note,
+    )
+    checks.check(
+        "not-leftover-of-rho3",
+        "s2 prices ridge-stay at 2 and max≥4 out-face at 2 while ρ3 prices those at 3 and 1",
+        s2_cost(*ridge_stay_hop) == 2
+        and rho3_cost(*ridge_stay_hop) == 3
+        and s2_cost(*later_hop) == 2
+        and rho3_cost(*later_hop) == 1
+        and mu_cost(*later_hop) == 1
+        and s2_cost(*later_out_face) == 2
+        and rho3_cost(*later_out_face) == 1
+        and s2_cost(*height2_nongrow) == 1
+        and t1400 == 28
+        and t141414 == 45
+        and t520 == 12
+        and path_cost(witness_later, s2_cost) == 12
+        and path_cost(witness_later, rho3_cost) == 11
+        and "cannot price max≥4 out-face" in note
+        and "cannot price ridge-stay at cost 2" in note
+        and "`t(5,2,0) = 12`" in note
+        and "26` versus `46" in note,
+    )
+    checks.check(
+        "not-leftover-of-d4",
+        "d4 prices max≥4 out-face at 3 while s2 prices it at 2",
+        s2_cost(*later_hop) == 2
+        and d4_cost(*later_hop) == 3
+        and path_cost(witness_later, d4_cost) == 13
+        and path_cost(witness_later, s2_cost) == 12
+        and t520 == 12
+        and t4200 == 61
+        and "not leftover of `d4`" in note
+        and "`t(42,0,0) = 61`" in note,
+    )
+    checks.check(
+        "not-leftover-of-b39",
+        "(14,14,14) lies outside B_39(0) and the note says so",
+        l1((14, 14, 14)) == 42
+        and (14, 14, 14) in dist
+        and t4200 == 61
+        and t3900 == 53
+        and "absent from `B_39(0)`" in note
+        and "not leftover of the `B_39(0)` times" in note,
+    )
+    checks.check(
+        "skips-height-three-out-face",
+        "c2d4 extra clause skips (3,2,0)→(4,2,0); d3, df, and ω extra clauses include it",
+        (not d4_grow(*skip_hop))
+        and d3_grow(*skip_hop)
+        and df_grow(*skip_hop)
+        and omega_grow(*skip_hop)
+        and d4_grow(*later_hop)
+        and s2_cost(*skip_hop) == 1
+        and d3_cost(*skip_hop) == 3
+        and df_cost(*skip_hop) == 3
+        and omega_cost(*skip_hop) == 3
+        and rho3_cost(*skip_hop) == 1
+        and s2_cost(*later_hop) == 2
+        and s2_cost(*unit_out_face) == 3
+        and s2_cost(*height_two) == 1
+        and df_cost(*height_two) == 3
+        and t420 == 10
+        and t320 == 9
+        and path_cost(witness_skip, s2_cost) == 10
+        and path_cost(witness_skip, d3_cost) == 12
+        and "skips the height-three out-face" in note
+        and "not leftover of `d3`" in note
+        and "not leftover of `df`" in note,
+    )
+    checks.check(
+        "not-leftover-of-kappa",
+        "κ prices ridge-enter at 3 while s2 leaves it at 1",
+        s2_cost(*ridge_enter) == 1
+        and kappa_cost(*ridge_enter) == 3
+        and rho3_cost(*ridge_enter) == 1
+        and "not leftover of `κ`" in note,
+    )
+    checks.check(
+        "not-leftover-of-iota",
+        "s2 does not tax the interior 3→3 hop that ι taxes",
+        s2_cost(*interior_cube) == 1
+        and iota_cost(*interior_cube) == 3
+        and s2_cost(*height2_ridge) == 1
+        and iota_cost(*height2_ridge) == 1
+        and s2_cost(*interior_last) == 1
+        and iota_cost(*interior_last) == 3
+        and t141414 == 45
+        and t141414 != 72
+        and t221 == 8
+        and t222 == 9
+        and t333 == 12
+        and t522 == 12
+        and t14141 == 32
+        and "not leftover of `ι`" in note,
+    )
+    checks.check(
+        "seed-max4-and-soft-ridge-clauses",
+        "seed-exit, both-weights-1, support-drop, corridor-slide cost 3; ridge-stay and max≥4 out-face cost 2; skipped grow, unit-cube, ridge-enter, interior, and body enter cost 1",
+        s2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and s2_cost((1, 0, 0), (2, 0, 0)) == 3
+        and s2_cost((1, 1, 0), (1, 0, 0)) == 3
+        and s2_cost(*unit_out_face) == 3
+        and s2_cost((1, 1, 1), (2, 1, 1)) == 2
+        and s2_cost((14, 2, 1), (14, 1, 1)) == 2
+        and s2_cost((2, 2, 0), (3, 2, 0)) == 1
+        and s2_cost((3, 2, 0), (4, 2, 0)) == 1
+        and s2_cost((4, 2, 0), (5, 2, 0)) == 2
+        and s2_cost((3, 2, 0), (3, 3, 0)) == 1
+        and s2_cost((4, 3, 0), (5, 3, 0)) == 2
+        and s2_cost((1, 0, 0), (1, 1, 0)) == 1
+        and s2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and s2_cost((2, 1, 0), (2, 1, 1)) == 1
+        and s2_cost((2, 2, 0), (2, 2, 1)) == 1
+        and s2_cost((2, 2, 1), (3, 2, 1)) == 1
+        and s2_cost((1, -2, 0), (2, -2, 0)) == 1
+        and s2_cost((2, 2, 2), (3, 2, 2)) == 1
+        and s2_cost((3, 3, 2), (3, 3, 3)) == 1
+        and s2_cost((4, 2, 2), (5, 2, 2)) == 1
+        and s2_cost((13, 14, 14), (14, 14, 14)) == 1
+        and s2_cost((14, 14, 1), (14, 14, 2)) == 1,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "s2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-k reverse under named s2 hop-cost holds at k=14 on B_42(0): t(14,0,0)=28 vs t(14,14,14)=45. Restore kept; intercepts moved vs c2d4 30 vs 46. Displayed, not adopted. Do not write s2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_soft_ridge_cost2_samek_k14_b42_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.