### PR TITLE
feat(s2var): c2d4-plus-soft-ridge is worse-round than c2d4 on B12

### DIFF
--- a/docs/C2D4_SOFT_RIDGE_COST2_VAR_VS_C2D4_OMEGA_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/C2D4_SOFT_RIDGE_COST2_VAR_VS_C2D4_OMEGA_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,300 @@
+---
+claim_id: c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Arrival-speed variance under c2d4-plus-soft-ridge, cost-2 max≥4 out-face, and out-face on B_12(0) is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py
+---
+
+# Named c2d4-Plus-Soft-Ridge Versus c2d4 Versus ω Arrival-Speed Variance On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** three named directed nearest-neighbor hop-costs on the finite
+ℓ¹-ball `B_12(0)`, their Dijkstra arrival times from the origin, and the
+population variance of `|v|_2/t` on the 2624 nonzero sites. No hop-cost is
+written into Admissibility. L1 is not attached.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py`](../scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py)
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+The named cost-2 max≥4 out-face hop-cost `c2d4` is the already scored
+ridge-slide rule `ρ3` except that those `2→2` hops whose destination has
+a strictly larger max absolute coordinate than the source, and whose
+source max is already at least `4`, cost `2` rather than `1`. The named
+c2d4-plus-soft-ridge hop-cost `s2` is `c2d4` except that `ρ3`'s `3→3`
+ridge-stay hops, those with exactly two `|w_i|=1`, cost `2` rather than
+`3`. The named out-face hop-cost `ω` is `ρ3` plus cost `3` on every `2→2`
+hop whose destination has a strictly larger max absolute coordinate than
+the source, with no source-max floor. The investment is that `c2d4` is
+the roundest displayed score at about `0.003575`, while a distinct
+deep-interior draft was worse-round. The residual here is the first
+display of arrival-speed variance of `s2` versus `c2d4` and `ω` on
+`B_12(0)`. Uniqueness is not claimed.
+
+The executed order of arrival-speed variances on `B_12(0)` is
+
+`var_c2d4 < var_s2 < var_ω`.
+
+So `c2d4` is strictly rounder than both `s2` and `ω` on `B_12(0)`, and
+`s2` is strictly rounder than `ω`. Cheapening the ridge-stay hop from
+`3` to `2` makes the arrival-speed field worse-round than `c2d4` on this
+ball, the opposite of a roundness gain. The lex-first minimizer among
+the three displayed names is `c2d4`. The scores are displayed, not
+adopted. Do not write `s2`, `c2d4`, or `ω` into Admissibility. Do not
+attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom does not supply hop-cost values. It does not
+supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+None of Record is used to select a hop-cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Three finite Dijkstra scores and their population arrival-speed variances on B_12(0) are exact; no hop-cost is adopted and L1 is not attached."
+trace_class: upstream_support
+target_claim_id: c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12
+target_blocker_text: "compare arrival-speed variance of s2, c2d4, and ω on B_12(0)"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the three scores displayed. Do not write s2, c2d4, or ω into Admissibility. Do not attach L1."
+conditional_surface_status: "exact for the three named hop-costs on the induced B_12(0) graph; no physical law is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0=(0,0,0)` and `B_12(0)={v∈Z^3 : |v|_1 ≤ 12}`. This set has 2625 sites.
+The executed graph is the induced nearest-neighbor graph on that set: a
+directed hop `v→w` exists when `w-v` is a signed axis unit and `w∈B_12(0)`.
+
+The coordinate support is `σ_v={i : v_i ≠ 0}`. Its cardinality is the
+weight. On a hop `v→w`:
+
+- seed-exit means `|σ_v|=0`,
+- both-weights-1 means `|σ_v|=|σ_w|=1`,
+- support-drop means `|σ_w| < |σ_v|`,
+- corridor-slide means `|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1`,
+- ridge-stay means `|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1`,
+- out-face means `|σ_v|=|σ_w|=2` and `max_i |w_i| > max_i |v_i|`,
+- max≥4 out-face means out-face and `max_i |v_i| ≥ 4`.
+
+The three named costs are:
+
+- `s2`: cost `3` if `μ` would be `3`, else `2` if ridge-stay or `c2d4`
+  would be `2`, else `1`. Written `s2(v→w) = 3` if `|σ_v|=0` or
+  `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|` or `(|σ_v|=|σ_w|=2` and the least
+  nonzero `|w_i|` equals `1)`, else `2` if `(|σ_v|=|σ_w|=3` and exactly
+  two `|w_i|` equal `1)` or `(|σ_v|=|σ_w|=2` and `max_i |w_i| > max_i |v_i|`
+  and `max_i |v_i| ≥ 4)`, else `1`.
+- `c2d4`: cost `3` if `ρ3` would be `3`, else `2` if max≥4 out-face,
+  else `1`. Written `c2d4(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)`
+  or `|σ_w| < |σ_v|` or `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|`
+  equals `1)` or `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)`,
+  else `2` if `|σ_v|=|σ_w|=2` and `max_i |w_i| > max_i |v_i|` and
+  `max_i |v_i| ≥ 4`, else `1`.
+- `ω`: cost `3` if `ρ3` would be `3` or out-face, else `1`. Written
+  `ω(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|` or
+  `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1)` or
+  `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)` or
+  `(|σ_v|=|σ_w|=2` and `max_i |w_i| > max_i |v_i|)`, else `1`.
+
+On the ridge-stay hop `(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and
+exactly two `|w_i| = 1`, so `s2 = 2` while `c2d4 = ω = 3`. On the
+max≥4 out-face hop `(4,2,0) → (5,2,0)` one has `|σ| : 2 → 2`,
+`max |w_i| = 5 > max |v_i| = 4`, and source max already `4`, so
+`ω = 3` and `s2 = c2d4 = 2`. On the source-max `3` out-face hop
+`(3,2,0) → (4,2,0)` one has `|σ| : 2 → 2` and a growing max, but source
+max `3`, so `ω = 3` while `s2 = c2d4 = 1`. On the deep-out hop
+`(2,2,0) → (3,2,0)` one has `|σ| : 2 → 2` and a growing max, but source
+max `2`, so `ω = 3` while `s2 = c2d4 = 1`. On the axis-hugging hop
+`(1,1,0) → (2,1,0)` one has `|σ| : 2 → 2`, least nonzero `|w_i| = 1`,
+and a growing max, so all three names cost `3` by corridor-slide. The
+three-unit enter hop `(1,1,0) → (1,1,1)` stays at cost `1` under all
+three names. The leave-axis hop `(0,-1,0) → (1,-1,0)` stays at cost `1`
+under all three names. Therefore neither `c2d4` nor `ω` is the
+c2d4-plus-soft-ridge clause, and the `s2` scores below are not a leftover
+of either comparator.
+
+Arrival time `t(v)` is the Dijkstra cost from `0` under the named rule.
+The compared statistic on `B_12(0)\{0}` is the population variance
+
+`var(|v|_2/t) = (1/N) Σ_v (|v|_2/t(v) - mean)^2`,
+
+with `N=2624` and `mean=(1/N) Σ_v |v|_2/t(v)`. Equivalently,
+`var = Q - mean^2` where the second moment `Q=(1/N) Σ_v |v|_2^2 / t(v)^2` is
+rational. Three Dijkstras are run, one per cost.
+
+This note does not attach L1. The comparison uses only the three named
+clause families on the same directed graph.
+
+## Theorem 1 — Three Variances
+
+Every nonzero site is reached under each of the three costs. The exact
+second moments on the 2624 nonzero sites are
+
+`Q_s2 = 16980526448118364437089867/75302578906952397960960000`,
+
+`Q_c2d4 = 12586016761121881939/63482497589871360000`,
+
+`Q_ω = 2697928722329275408991/14234892042902154624000`.
+
+The population variances, truncated to 18 decimal digits, are
+
+`var_s2 = 0.004122575340811453`,
+
+`var_c2d4 = 0.003574941366936777`,
+
+`var_ω = 0.004242786759120176`.
+
+Thus all three variances are reported. The cost-2 max≥4 out-face rule
+`c2d4` is strictly rounder than `s2` on `B_12(0)`, and `s2` remains
+strictly rounder than `ω`.
+
+## Theorem 2 — Lex-First Minimizer
+
+Order the three names as the strings `c2d4`, `omega`, and `s2`. The
+variance-minimizing score among those three is `c2d4`, and it is the
+unique minimum of the three displayed numbers. Therefore the lex-first minimizer among the three is `c2d4`. Uniqueness among hop-costs outside
+this triple is not required and is not claimed.
+
+The minimizer is displayed, not adopted.
+
+Displayed, not adopted.
+
+## Theorem 3 — No Admissibility Write, L1 Not Attached
+
+Do not write `s2`, `c2d4`, or `ω` into Admissibility. The current
+admissibility rule remains the quoted nearest-neighbor distribution
+constraint. The three clause families are scoring rules on `B_12(0)`, not
+a replacement of that axiom.
+
+Do not attach L1. No formation law, occupancy member, or locked-set filling
+rule is identified with any of the three hop-costs.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether s2 is rounder or worse than c2d4 and ω on B_12(0). |
+| V2 | Current main has no landed s2/c2d4/ω variance comparison on B_12(0). |
+| V3 | The three Dijkstras and the 2624-site population variances are finite and exact. |
+| V4 | The comparison is not an axiom rewrite: Admissibility is left unchanged. |
+| V5 | Displayed scores are not a physical hop-cost or formation law. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: these three scores are reported on `B_12(0)`
+and are not adopted. No uniqueness of a physical law is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| `s2` | all `c2d4` clauses except ridge-stay `3→3` hops at cost `2` | executed; between `c2d4` and `ω` |
+| `c2d4` | all `ρ3` clauses plus max≥4 out-face `2→2` hops at cost `2` | executed; lex-first variance minimizer |
+| `ω` | all `ρ3` clauses plus every out-face `2→2` hop at cost `3` | executed; largest variance |
+| other clause triples | tax ridge-stay at `3`, or tax every out-face at `3` only | different named family; not this residual |
+| unrestricted `Z^3` paths | leave `B_12(0)` and return | outside the declared ball |
+| adopt a score | write `s2`, `c2d4`, or `ω` into Admissibility | forbidden; not executed |
+| attach L1 | identify a score with a formation member | forbidden; not executed |
+
+### N2 — wall independence
+
+Ball restriction, hop-cost clauses, the speed statistic, and axiom
+non-adoption are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball, the induced graph, the three cost clauses, population variance,
+and lex-first among the three names are declared. No continuum limit, no
+physical clock, and no formation rate are assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate and the
+distribution sentence. It does not name hop-cost clauses. The residual is
+a finite comparison on that substrate, not an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each nonzero site of `B_12(0)` | no other ball |
+| per site | one arrival time per named cost | no physical tick identification |
+| per mode | no spectral calculation | no mode exhaustion |
+| per block | three Dijkstras and one variance triple | no law selection |
+| lattice wide | checked and not executed | no `Z^3` or infinite-volume score |
+
+### N6 — live partial-closure paths
+
+Live routes are a derived hop-cost, a reason to adopt one of the three
+scores, a comparison on a larger ball, and a separately derived formation
+law. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because `s2` cheapens every ridge-stay hop from cost `3` to
+cost `2`, the body is cheaper than under `c2d4`, so the arrival-speed
+field of `s2` should be at least as round as `c2d4` on `B_12(0)`, and
+the displayed minimum among the three names should be `s2` rather than
+`c2d4`.
+
+**Answer:** Pricing only the ridge-stay hop at `2`, and leaving every
+`ρ3` seed, axis, drop, and corridor clause at `3`, changes the whole
+arrival field. On `B_12(0)` the executed variances are strictly ordered
+`var_c2d4 < var_s2 < var_ω`. Cheapening the ridge-stay hop makes `s2`
+strictly worse-round than `c2d4` on this ball, while still strictly
+rounder than `ω`.
+
+### N8 — cross-cycle echo
+
+The c2d4-plus-soft-ridge same-`k` scores, the cost-2 max≥4 variance
+scores, and the out-face variance scores are not reused as lemmas. The
+three scores are computed on `B_12(0)`. L1 remains unattached.
+
+**Gate disposition:** PASS for the three reported variances, the displayed
+lex-first minimizer `c2d4`, and the refusal to adopt a hop-cost or attach L1.
+FAIL / DO NOT SHIP for writing `s2`, `c2d4`, or `ω` into Admissibility,
+attaching L1, or claiming a unique physical law.
+
+## Primary Runner
+
+The primary runner rebuilds `B_12(0)`, runs the three Dijkstras, recomputes
+the second moments and population variances, checks the reported order and
+lex-first minimizer, and pins the current axiom wording together with the
+non-adoption sentences. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -1657,6 +1657,10 @@
   "c2_weighting_normal_form_one_parameter_uniqueness_bounded_note_2026-07-02": {
    "deps_hash": "161b289f6620",
    "out_degree": 3
+  },
+  "c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "c3_bloch_orbit_is_three_menu_not_unital_m3_bounded_theorem_note_2026-08-13": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.txt
+++ b/logs/runner-cache/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py
+runner_sha256: 92dc6de4cec3953baedab278212c5f55bfb976c7ff97042dd0be48f7c46c84a4
+input_fingerprint_sha256: 8a30d5fbf6dc8a81073a7f8368bf32cb01a64fd891ec47a81f840f26064320b4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+claim_scope: Arrival-speed variance under c2d4-plus-soft-ridge, cost-2 max≥4 out-face, and out-face on B_12(0) is reported. Displayed, not adopted.
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: three directed Dijkstras on the induced B_12(0) graph
+negative_scope: displayed scores are not adopted and L1 is not attached
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: audit-tuple-literal AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-scope front matter uses the declared claim_scope
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: ball-cardinality B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: three-dijkstras exactly three Dijkstras run and each named cost reaches every ball site
+PASS: named-clauses s2 prices ridge-stay at 2; c2d4 prices max≥4 out-face at 2; ω prices all out-face at 3
+Q_s2 = 16980526448118364437089867/75302578906952397960960000
+Q_c2d4 = 12586016761121881939/63482497589871360000
+Q_omega = 2697928722329275408991/14234892042902154624000
+var_s2 = 0.004122575340811453
+var_c2d4 = 0.003574941366936777
+var_omega = 0.004242786759120176
+dijkstra_calls 3
+PASS: second-moments the three exact second moments match the note
+PASS: reported-variances the note reports the three truncated population variances
+PASS: variance-order c2d4 is strictly rounder than s2, which is strictly rounder than ω
+lex_first_minimizer = c2d4
+PASS: lex-first-minimizer the lex-first minimizer among the three names is c2d4
+PASS: forbidden-phrases note and runner omit the forbidden phrases
+PASS: theorems-displayed three theorems are present and the scores are displayed, not adopted
+PASS: no-admissibility-write the note refuses to write s2, c2d4, or ω into Admissibility
+PASS: no-l1-attach the note does not attach L1
+PASS: uniqueness-not-claimed uniqueness among hop-costs is not claimed
+PASS: mutation-s2-as-c2d4 pricing ridge-stay at 3 would identify s2 with c2d4 and erase the displayed split
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+per_element: checked exactly — each of the 2624 nonzero B_12(0) sites receives three arrival times
+per_site: checked exactly — population variance uses |v|_2/t at every nonzero site
+per_mode: checked exactly — three named hop-costs only; no other clause triple is scored
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py
+++ b/scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Exact B_12(0) arrival-speed variance comparison of s2, c2d4, and ω."""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from fractions import Fraction
+from heapq import heappop, heappush
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/C2D4_SOFT_RIDGE_COST2_VAR_VS_C2D4_OMEGA_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/C2D4_SOFT_RIDGE_COST2_VAR_VS_C2D4_OMEGA_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Arrival-speed variance under c2d4-plus-soft-ridge, cost-2 "
+    "max≥4 out-face, and out-face on B_12(0) is reported. Displayed, not adopted."
+)
+
+RADIUS = 12
+ORIGIN = (0, 0, 0)
+SHIFTS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+NONZERO_COUNT = 2624
+SITE_COUNT = 2625
+DIJKSTRA_CALLS = 0
+
+Q_S2 = Fraction(16980526448118364437089867, 75302578906952397960960000)
+Q_C2D4 = Fraction(12586016761121881939, 63482497589871360000)
+Q_OMEGA = Fraction(2697928722329275408991, 14234892042902154624000)
+VAR_DIGITS = {
+    "s2": "0.004122575340811453",
+    "c2d4": "0.003574941366936777",
+    "omega": "0.004242786759120176",
+}
+
+
+Point = tuple[int, int, int]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def l1_norm(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def radius_squared(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def support_size(point: Point) -> int:
+    return int(point[0] != 0) + int(point[1] != 0) + int(point[2] != 0)
+
+
+def least_nonzero_abs(point: Point) -> int | None:
+    nonzero = [abs(coord) for coord in point if coord != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_abs_count(point: Point) -> int:
+    return int(abs(point[0]) == 1) + int(abs(point[1]) == 1) + int(abs(point[2]) == 1)
+
+
+def max_abs_coord(point: Point) -> int:
+    return max(abs(point[0]), abs(point[1]), abs(point[2]))
+
+
+def ball_sites(radius: int) -> tuple[Point, ...]:
+    extent = range(-radius, radius + 1)
+    return tuple(point for point in product(extent, repeat=3) if l1_norm(point) <= radius)
+
+
+def split_square(value: int) -> tuple[int, int]:
+    square = 1
+    square_free = 1
+    remaining = value
+    prime = 2
+    while prime * prime <= remaining:
+        exponent = 0
+        while remaining % prime == 0:
+            remaining //= prime
+            exponent += 1
+        if exponent:
+            square *= prime ** (exponent // 2)
+            if exponent % 2:
+                square_free *= prime
+        prime += 1 if prime == 2 else 2
+    if remaining > 1:
+        square_free *= remaining
+    return square, square_free
+
+
+def nu_cost(source: Point, target: Point) -> int:
+    sigma_v = support_size(source)
+    sigma_w = support_size(target)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(source: Point, target: Point) -> int:
+    if nu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(target) == 2 and least_nonzero_abs(target) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(source: Point, target: Point) -> int:
+    if mu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(target) == 3 and unit_abs_count(target) == 2:
+        return 3
+    return 1
+
+
+def omega_cost(source: Point, target: Point) -> int:
+    if rho3_cost(source, target) == 3:
+        return 3
+    if (
+        support_size(source) == 2
+        and support_size(target) == 2
+        and max_abs_coord(target) > max_abs_coord(source)
+    ):
+        return 3
+    return 1
+
+
+def c2d4_cost(source: Point, target: Point) -> int:
+    if rho3_cost(source, target) == 3:
+        return 3
+    if (
+        support_size(source) == 2
+        and support_size(target) == 2
+        and max_abs_coord(target) > max_abs_coord(source)
+        and max_abs_coord(source) >= 4
+    ):
+        return 2
+    return 1
+
+
+def s2_cost(source: Point, target: Point) -> int:
+    if mu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(target) == 3 and unit_abs_count(target) == 2:
+        return 2
+    if c2d4_cost(source, target) == 2:
+        return 2
+    return 1
+
+
+def neighbors(site: Point, sites: set[Point]) -> tuple[Point, ...]:
+    out: list[Point] = []
+    for shift in SHIFTS:
+        candidate = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        if candidate in sites:
+            out.append(candidate)
+    return tuple(out)
+
+
+def dijkstra(sites: tuple[Point, ...], cost_fn) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist = {ORIGIN: 0}
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while heap:
+        current, site = heappop(heap)
+        if current != dist[site]:
+            continue
+        for nxt in neighbors(site, site_set):
+            trial = current + cost_fn(site, nxt)
+            prior = dist.get(nxt)
+            if prior is None or trial < prior:
+                dist[nxt] = trial
+                heappush(heap, (trial, nxt))
+    return dist
+
+
+def second_moment_and_var_coeff(
+    dist: dict[Point, int], sites: tuple[Point, ...]
+) -> tuple[Fraction, dict[int, Fraction]]:
+    nonzero = tuple(site for site in sites if site != ORIGIN)
+    count = len(nonzero)
+    moment = Fraction(0)
+    linear: dict[int, Fraction] = defaultdict(Fraction)
+    for site in nonzero:
+        arrival = dist[site]
+        squared = radius_squared(site)
+        moment += Fraction(squared, arrival * arrival)
+        square, square_free = split_square(squared)
+        linear[square_free] += Fraction(square, arrival)
+    moment /= count
+    square_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    keys = tuple(linear)
+    for left in keys:
+        for right in keys:
+            square, square_free = split_square(left * right)
+            square_coeff[square_free] += linear[left] * linear[right] * square
+    var_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    var_coeff[1] += moment
+    denom = count * count
+    for square_free, coeff in square_coeff.items():
+        var_coeff[square_free] -= coeff / denom
+    return moment, {key: value for key, value in var_coeff.items() if value != 0}
+
+
+def eval_coeff(coeff: dict[int, Fraction], precision: int = 50) -> Decimal:
+    getcontext().prec = precision
+    total = Decimal(0)
+    for square_free, value in coeff.items():
+        total += (Decimal(value.numerator) / Decimal(value.denominator)) * Decimal(square_free).sqrt()
+    return total
+
+
+def truncated_decimal(value: Decimal, places: int = 18) -> str:
+    quantized = value.quantize(Decimal(10) ** -places)
+    text = format(quantized, "f")
+    whole, frac = text.split(".")
+    return whole + "." + frac[:places]
+
+
+def parse_audit_tuple(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names and isinstance(node.value, ast.Tuple):
+                values: list[str] = []
+                for element in node.value.elts:
+                    if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                        return None
+                    values.append(element.value)
+                return tuple(values)
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: three directed Dijkstras on the induced B_12(0) graph")
+    print("negative_scope: displayed scores are not adopted and L1 is not attached")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-tuple-literal",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        parse_audit_tuple(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "front matter uses the declared claim_scope",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note.replace("\n", " ")
+        or f'claim_scope: "{CLAIM_SCOPE}"' in note,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalized_axiom and admissibility_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+
+    sites = ball_sites(RADIUS)
+    site_set = set(sites)
+    checks.check(
+        "ball-cardinality",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == SITE_COUNT and ORIGIN in site_set and len(sites) - 1 == NONZERO_COUNT,
+    )
+
+    dist_s2 = dijkstra(sites, s2_cost)
+    dist_c2d4 = dijkstra(sites, c2d4_cost)
+    dist_omega = dijkstra(sites, omega_cost)
+    checks.check(
+        "three-dijkstras",
+        "exactly three Dijkstras run and each named cost reaches every ball site",
+        DIJKSTRA_CALLS == 3
+        and len(dist_s2) == SITE_COUNT
+        and len(dist_c2d4) == SITE_COUNT
+        and len(dist_omega) == SITE_COUNT,
+        residual=(DIJKSTRA_CALLS, len(dist_s2), len(dist_c2d4), len(dist_omega)),
+    )
+    checks.check(
+        "named-clauses",
+        "s2 prices ridge-stay at 2; c2d4 prices max≥4 out-face at 2; ω prices all out-face at 3",
+        mu_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (2, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 1, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (2, 1, 0)) == 3
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((4, 2, 0), (5, 2, 0)) == 1
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((2, 2, 1), (3, 2, 1)) == 1
+        and rho3_cost((2, 1, 0), (2, 1, 1)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and s2_cost((1, 1, 1), (2, 1, 1)) == 2
+        and s2_cost((4, 2, 0), (5, 2, 0)) == 2
+        and s2_cost((3, 2, 0), (4, 2, 0)) == 1
+        and s2_cost((2, 2, 0), (3, 2, 0)) == 1
+        and s2_cost((1, 1, 0), (2, 1, 0)) == 3
+        and s2_cost((2, 1, 0), (2, 1, 1)) == 1
+        and s2_cost((1, 1, 0), (1, 1, 1)) == 1
+        and s2_cost((2, 2, 1), (3, 2, 1)) == 1
+        and s2_cost((0, -1, 0), (1, -1, 0)) == 1
+        and s2_cost((0, 0, 0), (1, 0, 0)) == 3
+        and c2d4_cost((1, 1, 1), (2, 1, 1)) == 3
+        and c2d4_cost((4, 2, 0), (5, 2, 0)) == 2
+        and c2d4_cost((3, 2, 0), (4, 2, 0)) == 1
+        and c2d4_cost((2, 2, 0), (3, 2, 0)) == 1
+        and c2d4_cost((1, 1, 0), (2, 1, 0)) == 3
+        and c2d4_cost((2, 1, 0), (2, 1, 1)) == 1
+        and c2d4_cost((1, 1, 0), (1, 1, 1)) == 1
+        and c2d4_cost((2, 2, 1), (3, 2, 1)) == 1
+        and c2d4_cost((0, -1, 0), (1, -1, 0)) == 1
+        and omega_cost((4, 2, 0), (5, 2, 0)) == 3
+        and omega_cost((3, 2, 0), (4, 2, 0)) == 3
+        and omega_cost((2, 2, 0), (3, 2, 0)) == 3
+        and omega_cost((1, 1, 0), (2, 1, 0)) == 3
+        and omega_cost((1, 1, 1), (2, 1, 1)) == 3
+        and omega_cost((2, 2, 1), (3, 2, 1)) == 1
+        and omega_cost((2, 1, 0), (2, 1, 1)) == 1
+        and omega_cost((1, 1, 0), (1, 1, 1)) == 1
+        and omega_cost((0, -1, 0), (1, -1, 0)) == 1,
+    )
+
+    moment_s2, var_s2_coeff = second_moment_and_var_coeff(dist_s2, sites)
+    moment_c2d4, var_c2d4_coeff = second_moment_and_var_coeff(dist_c2d4, sites)
+    moment_omega, var_omega_coeff = second_moment_and_var_coeff(dist_omega, sites)
+    var_s2 = eval_coeff(var_s2_coeff)
+    var_c2d4 = eval_coeff(var_c2d4_coeff)
+    var_omega = eval_coeff(var_omega_coeff)
+
+    print(f"Q_s2 = {moment_s2}")
+    print(f"Q_c2d4 = {moment_c2d4}")
+    print(f"Q_omega = {moment_omega}")
+    print(f"var_s2 = {truncated_decimal(var_s2)}")
+    print(f"var_c2d4 = {truncated_decimal(var_c2d4)}")
+    print(f"var_omega = {truncated_decimal(var_omega)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+
+    checks.check(
+        "second-moments",
+        "the three exact second moments match the note",
+        moment_s2 == Q_S2
+        and moment_c2d4 == Q_C2D4
+        and moment_omega == Q_OMEGA
+        and "16980526448118364437089867/75302578906952397960960000" in note
+        and "12586016761121881939/63482497589871360000" in note
+        and "2697928722329275408991/14234892042902154624000" in note,
+        residual=(str(moment_s2), str(moment_c2d4), str(moment_omega)),
+    )
+    checks.check(
+        "reported-variances",
+        "the note reports the three truncated population variances",
+        VAR_DIGITS["s2"] in note
+        and VAR_DIGITS["c2d4"] in note
+        and VAR_DIGITS["omega"] in note
+        and truncated_decimal(var_s2) == VAR_DIGITS["s2"]
+        and truncated_decimal(var_c2d4) == VAR_DIGITS["c2d4"]
+        and truncated_decimal(var_omega) == VAR_DIGITS["omega"],
+        residual=(truncated_decimal(var_s2), truncated_decimal(var_c2d4), truncated_decimal(var_omega)),
+    )
+    checks.check(
+        "variance-order",
+        "c2d4 is strictly rounder than s2, which is strictly rounder than ω",
+        var_c2d4 < var_s2 < var_omega,
+        residual=(str(var_s2), str(var_c2d4), str(var_omega)),
+    )
+
+    named = {
+        "c2d4": var_c2d4,
+        "omega": var_omega,
+        "s2": var_s2,
+    }
+    lex_first = min(named, key=lambda name: (named[name], name))
+    print(f"lex_first_minimizer = {lex_first}")
+    checks.check(
+        "lex-first-minimizer",
+        "the lex-first minimizer among the three names is c2d4",
+        lex_first == "c2d4" and "the lex-first minimizer among the three is `c2d4`" in note,
+        residual=lex_first,
+    )
+
+    forbidden = ("G_" "N", "1/" "r", "1/" "r^2", "Lattice-" "named", "not a " "TOE")
+    checks.check(
+        "forbidden-phrases",
+        "note and runner omit the forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "theorems-displayed",
+        "three theorems are present and the scores are displayed, not adopted",
+        "## Theorem 1 — Three Variances" in note
+        and "## Theorem 2 — Lex-First Minimizer" in note
+        and "## Theorem 3 — No Admissibility Write, L1 Not Attached" in note
+        and "Displayed, not adopted." in note
+        and "displayed, not adopted" in normalized_note,
+    )
+    checks.check(
+        "no-admissibility-write",
+        "the note refuses to write s2, c2d4, or ω into Admissibility",
+        "Do not write `s2`, `c2d4`, or `ω` into Admissibility" in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom
+        and "s2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ω(v→w)" not in axiom,
+    )
+    checks.check(
+        "no-l1-attach",
+        "the note does not attach L1",
+        "This note does not attach L1." in note
+        and "Do not attach L1." in note
+        and "Do not attach L1" not in axiom
+        and 'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "uniqueness-not-claimed",
+        "uniqueness among hop-costs is not claimed",
+        "Uniqueness is not claimed" in note and "not claimed" in normalized_note,
+    )
+    checks.check(
+        "mutation-s2-as-c2d4",
+        "pricing ridge-stay at 3 would identify s2 with c2d4 and erase the displayed split",
+        var_s2 != var_c2d4
+        and s2_cost((1, 1, 1), (2, 1, 1)) == 2
+        and c2d4_cost((1, 1, 1), (2, 1, 1)) == 3,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "s2(v→w)" not in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ω(v→w)" not in axiom,
+    )
+
+    print("per_element: checked exactly — each of the 2624 nonzero B_12(0) sites receives three arrival times")
+    print("per_site: checked exactly — population variance uses |v|_2/t at every nonzero site")
+    print("per_mode: checked exactly — three named hop-costs only; no other clause triple is scored")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Arrival-speed variance on B_12(0) is var_c2d4=0.003575 < var_s2=0.004123 < var_omega=0.004243. Displayed, not adopted. Do not write s2 into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/c2d4_soft_ridge_cost2_var_vs_c2d4_omega_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.