### PR TITLE
feat(facd): ell1 face reverse fails k=1; c2d4 holds; bits disagree

### DIFF
--- a/docs/L1_LOCKSUPPORT_VS_C2D4_FACE_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/L1_LOCKSUPPORT_VS_C2D4_FACE_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,242 @@
+---
+claim_id: l1_locksupport_vs_c2d4_face_k1_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Face reverse at k=1 under unit ℓ¹ versus named c2d4 on B_6(0) is compared. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py
+---
+
+# Unit ℓ¹ Lock-Support Versus Named c2d4 Face Reverse Bits At k=1 On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** two Dijkstra arrival comparisons at k=1 on the finite nearest-neighbor
+graph `B_6(0)`, under native unit ℓ¹ and the named hop-cost `c2d4`, displayed
+for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py`](../scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. Native unit
+ℓ¹ on the cubic 6-NN graph prices every remaining hop at cost `1`. That unit
+graph is the lock-support cone of the origin: Record locks at a site, and the
+native nearest-neighbor support spreads at unit hop cost. Named `c2d4` is a
+separately displayed hop-cost. The parent clauses `ν`, `μ`, and `ρ3` are those
+of the ridge-slide same-k scoring on this ball:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4`), else `1`.
+
+The extra `c2d4` clause is a max≥4 out-face hop priced at `2`: support stays
+`2`, the destination max absolute coordinate grows, and the source max is
+already at least `4`. It is displayed, not adopted. Uniqueness is not required.
+
+Face reverse at k=1 is the integer comparison
+
+```text
+t(2,0,0)^2 > 2 t(1,1,0)^2.
+```
+
+The finite host is scored independently. Two Dijkstras from the origin are run
+on this ball, unit ℓ¹ first, then `c2d4`. The ball is not leftover of a larger-ball table.
+
+```text
+B_6(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 6 }.
+```
+
+It has 377 sites. Edges are the cubic nearest-neighbor steps that remain
+inside `B_6(0)`.
+
+Under unit ℓ¹ the two arrivals are
+
+```text
+t(2,0,0) = 2
+t(1,1,0) = 2
+```
+
+The face reverse comparison at k=1 is
+
+```text
+t(2,0,0)^2 = 4 > 8 = 2 t(1,1,0)^2.
+```
+
+The inequality fails. The ℓ¹ face bit is false.
+
+Under `c2d4` the two arrivals are
+
+```text
+t(2,0,0) = 6
+t(1,1,0) = 4
+```
+
+The face reverse comparison at k=1 is
+
+```text
+t(2,0,0)^2 = 36 > 32 = 2 t(1,1,0)^2.
+```
+
+The inequality holds. The `c2d4` face bit is true.
+
+The two face bits disagree. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two Dijkstras on B_6(0) report t(2,0,0) and t(1,1,0) under unit ℓ¹ and named c2d4 and compare the k=1 face reverse bits. The comparison is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: l1_locksupport_vs_c2d4_face_k1_b6
+target_blocker_text: "whether native 6-NN ℓ¹ lock-support face reverse bits agree with c2d4 Dijkstra face reverse bits at k=1"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded face-bit comparison"
+conditional_surface_status: "exact on B_6(0) under unit ℓ¹ versus named c2d4; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. Unit ℓ¹ and named `c2d4`
+  are not Lattice content. Record supplies lock of one admissible local
+  possibility; it does not name a hop-cost.
+- **Explicit theorem-domain condition:** the finite set `B_6(0)`, its
+  nearest-neighbor edges, unit ℓ¹ cost `1` on every remaining hop, and the
+  named directed costs `ν`, `μ`, `ρ3`, and `c2d4` are supplied mathematical
+  data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing hop-costs into Admissibility, attaching
+  L1, selecting `c2d4` as a physical cost, or lifting the comparison off
+  `B_6(0)` remain separate obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+The live Record lock sentence, quoted and not rewritten:
+
+> When present, a record locks exactly one admissible local possibility.
+
+Unit ℓ¹ and `c2d4` are separately named hop-costs on directed nearest-neighbor
+hops. Neither is that admissibility rule.
+
+Write `t(v)` for a Dijkstra arrival cost from the origin to `v` on `B_6(0)`,
+with the cost named in each theorem. Two Dijkstras are run: unit ℓ¹ first,
+then `c2d4`.
+
+An explicit axis witness under unit ℓ¹ is two unit hops
+`(0,0,0) → (1,0,0) → (2,0,0)` of total cost `2`. An explicit face witness is
+two unit hops `(0,0,0) → (1,0,0) → (1,1,0)` of total cost `2`. Under `c2d4`
+the corresponding axis witness has costs `3+3=6` and the face witness has
+costs `3+1=4`. Every `c2d4` path has first hop cost `3`, and every hop costs
+at least `1`, so those witnesses are optimal once Dijkstra matches them.
+Under unit ℓ¹ every hop costs `1`, so graph distance is the arrival.
+
+## Theorem 1 — Unit ℓ¹ arrivals and face reverse bit at k=1
+
+Under unit ℓ¹ on `B_6(0)`,
+
+```text
+t(2,0,0) = 2
+t(1,1,0) = 2
+```
+
+The displayed comparison is whether
+
+```text
+t(2,0,0)^2 > 2 t(1,1,0)^2.
+```
+
+Substituting the computed times gives `4 > 8`. The inequality fails. The ℓ¹
+face bit is false.
+
+## Theorem 2 — Named c2d4 arrivals and face reverse bit at k=1
+
+Under `c2d4` on `B_6(0)`,
+
+```text
+t(2,0,0) = 6
+t(1,1,0) = 4
+```
+
+The displayed comparison is whether
+
+```text
+t(2,0,0)^2 > 2 t(1,1,0)^2.
+```
+
+Substituting the computed times gives `36 > 32`. The inequality holds. The
+`c2d4` face bit is true.
+
+## Theorem 3 — Face-bit comparison; no axiom write and no L1 attachment
+
+The two face bits disagree.
+
+Do not write hop-costs into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name unit ℓ¹, `c2d4`, `ρ3`, `μ`, or `ν`.
+This note proposes no axiom edit. The comparison above is a score of two
+named hop-costs at two sites; it is not an attachment of a coordinate-sum
+hop-cost.
+
+## What This Does Not Claim
+
+- Uniqueness is not required.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+- Disagreement on this ball is not a no-go against named hop-costs elsewhere.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_6(0)`, evaluates unit ℓ¹ and named `c2d4`, and
+runs two Dijkstras from the origin, unit ℓ¹ then `c2d4`. It reports
+`t(2,0,0)` and `t(1,1,0)` under each cost, checks the integer form of each
+k=1 face reverse comparison, and checks that the face bits disagree. It
+checks that the live Admissibility wording does not name these hop-costs,
+refuses to attach L1, and records the import boundary. Declared review
+inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11732,6 +11732,10 @@
   },
   "kubo_range_of_validity_note": {
    "deps_hash": "ba29b296b2a4",
+   "out_degree": 1
+  },
+  "l1_locksupport_vs_c2d4_face_k1_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a": {

--- a/logs/runner-cache/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.txt
+++ b/logs/runner-cache/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py
+runner_sha256: 82b91e7e6fc49f802b30bb0f65c78845aa4476fc135b11a5d04ed4029de47e3b
+input_fingerprint_sha256: 1dca7c32b3502450c76085924e7001cebf628c54dced860b8a6d2ea09caad3b6
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/L1_LOCKSUPPORT_VS_C2D4_FACE_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Face reverse at k=1 under unit ℓ¹ versus named c2d4 on B_6(0) is compared. Displayed, not adopted.
+external_scientific_inputs: none; unit ℓ¹ lock-support versus named c2d4 on the finite nearest-neighbor graph B_6(0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and two Dijkstras; no fit and no leftover larger-ball table
+claim_boundary: face reverse bits at k=1 are displayed, not adopted
+n_sites 377
+l1 t(2,0,0) = 2
+l1 t(1,1,0) = 2
+l1 face reverse: 2^2 = 4 versus 2 t(1,1,0)^2 = 8; reverse=False
+c2d4 t(2,0,0) = 6
+c2d4 t(1,1,0) = 4
+c2d4 face reverse: 6^2 = 36 versus 2 t(1,1,0)^2 = 32; reverse=True
+face_bits_agree False
+dijkstra_calls 2
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_6(0) is the 377-site integer set with coordinate-sum at most 6
+PASS: two-dijkstras exactly two Dijkstras from the origin are executed, unit ℓ¹ then c2d4
+PASS: reachable every site of B_6(0) is reached under both costs
+PASS: l1-unit-hops ℓ¹ prices every 6-NN hop at cost 1
+PASS: c2d4-clauses seed-exit, axis, drop, corridor-slide, and ridge-slide cost 3; max>=4 out-face costs 2; 1-to-2 and small 2-to-3 cost 1
+PASS: thm1-l1-times under ℓ¹, t(2,0,0)=2 and t(1,1,0)=2 match the unit-cost arrivals
+PASS: thm1-l1-face-reverse under ℓ¹, t(2,0,0)^2 > 2 t(1,1,0)^2 fails
+PASS: thm2-c2d4-times under c2d4, t(2,0,0)=6 and t(1,1,0)=4 match the named-cost arrivals
+PASS: thm2-c2d4-face-reverse under c2d4, t(2,0,0)^2 > 2 t(1,1,0)^2 holds
+PASS: thm3-bits-disagree the two face bits disagree
+PASS: thm1-note-reports-l1 the note reports the ℓ¹ times and failed face reverse
+PASS: thm2-note-reports-c2d4 the note reports the c2d4 times and holding face reverse
+PASS: thm3-note-reports-disagreement the note reports disagreement of the face bits
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and does not name these hop-costs
+PASS: thm3-no-l1-attachment the note refuses to attach L1
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-required the note does not require uniqueness
+PASS: scope-boundary the theorem stays on B_6(0), uses two Dijkstras, and proposes no axiom edit
+PASS: displayed-not-adopted the comparison is displayed, not adopted
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: no-path-dump the runner stores arrival costs only
+per_element: named hop-costs are integers on nearest-neighbor hops.
+per_site: arrival times are reported only at (2,0,0) and (1,1,0).
+lattice_wide: checked and not executed — the search stays inside B_6(0).
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py
+++ b/scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Face reverse bits at k=1: unit ℓ¹ lock-support versus named c2d4 on B_6(0).
+
+Two Dijkstras from the origin on the finite nearest-neighbor graph: first
+unit ℓ¹ cost on every 6-NN hop, then named c2d4. Face reverse at k=1 is
+t(2,0,0)^2 > 2 t(1,1,0)^2. Face bits are displayed, not adopted. Hop-costs
+are not written into Admissibility. L1 is not attached. No cache or
+governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+from typing import Callable
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "L1_LOCKSUPPORT_VS_C2D4_FACE_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/L1_LOCKSUPPORT_VS_C2D4_FACE_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Face reverse at k=1 under unit ℓ¹ versus named c2d4 "
+    "on B_6(0) is compared. Displayed, not adopted."
+)
+
+RADIUS = 6
+AXIS = (1, 0, 0)
+AXIS2 = (2, 0, 0)
+BODY = (1, 1, 1)
+FACE = (1, 1, 0)
+UNIT_OUT = (2, 1, 0)
+DF_OUT_SRC = (2, 2, 0)
+DF_OUT_DST = (3, 2, 0)
+MAX3_OUT_SRC = (3, 2, 0)
+MAX3_OUT_DST = (4, 2, 0)
+MAX4_OUT_SRC = (4, 2, 0)
+MAX4_OUT_DST = (5, 2, 0)
+MAX4_LIVE_SRC = (4, 1, 0)
+MAX4_LIVE_DST = (5, 1, 0)
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+CostFn = Callable[[Site, Site], int]
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def support_size(site: Site) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def unit_coord_count(site: Site) -> int:
+    return sum(1 for coordinate in site if abs(coordinate) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball_sites(radius: int) -> frozenset[Site]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+def l1_cost(_source: Site, _dest: Site) -> int:
+    return 1
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def omega_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+    )
+
+
+def d4_extra(source: Site, dest: Site) -> bool:
+    return omega_extra(source, dest) and max_abs(source) >= 4
+
+
+def c2d4_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if d4_extra(source, dest):
+        return 2
+    return 1
+
+
+def face_reverse_bit(t_axis2: int, t_face: int) -> bool:
+    return t_axis2 * t_axis2 > 2 * t_face * t_face
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(
+        self,
+        sites: frozenset[Site],
+        origin: Site,
+        cost_fn: CostFn,
+    ) -> dict[Site, int]:
+        self.calls += 1
+        infinity = 10**9
+        dist = {site: infinity for site in sites}
+        dist[origin] = 0
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if cost != dist[site]:
+                continue
+            for step in STEPS:
+                neighbor = add(site, step)
+                if neighbor not in dist:
+                    continue
+                candidate = cost + cost_fn(site, neighbor)
+                if candidate < dist[neighbor]:
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; unit ℓ¹ lock-support versus named "
+        "c2d4 on the finite nearest-neighbor graph B_6(0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and two Dijkstras; no fit and "
+        "no leftover larger-ball table"
+    )
+    print(
+        "claim_boundary: face reverse bits at k=1 are displayed, not adopted"
+    )
+
+    sites = ball_sites(RADIUS)
+    origin = (0, 0, 0)
+    counter = DijkstraCounter()
+    dist_l1 = counter.distances(sites, origin, l1_cost)
+    dist_c2 = counter.distances(sites, origin, c2d4_cost)
+    t_l1_axis2 = dist_l1[AXIS2]
+    t_l1_face = dist_l1[FACE]
+    t_c2_axis2 = dist_c2[AXIS2]
+    t_c2_face = dist_c2[FACE]
+    reverse_l1 = face_reverse_bit(t_l1_axis2, t_l1_face)
+    reverse_c2 = face_reverse_bit(t_c2_axis2, t_c2_face)
+    bits_agree = reverse_l1 == reverse_c2
+
+    print(f"n_sites {len(sites)}")
+    print(f"l1 t(2,0,0) = {t_l1_axis2}")
+    print(f"l1 t(1,1,0) = {t_l1_face}")
+    print(
+        f"l1 face reverse: {t_l1_axis2}^2 = {t_l1_axis2 * t_l1_axis2} versus "
+        f"2 t(1,1,0)^2 = {2 * t_l1_face * t_l1_face}; reverse={reverse_l1}"
+    )
+    print(f"c2d4 t(2,0,0) = {t_c2_axis2}")
+    print(f"c2d4 t(1,1,0) = {t_c2_face}")
+    print(
+        f"c2d4 face reverse: {t_c2_axis2}^2 = {t_c2_axis2 * t_c2_axis2} versus "
+        f"2 t(1,1,0)^2 = {2 * t_c2_face * t_c2_face}; reverse={reverse_c2}"
+    )
+    print(f"face_bits_agree {bits_agree}")
+    print(f"dijkstra_calls {counter.calls}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/L1_LOCKSUPPORT_VS_C2D4_FACE_K1_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_6(0) is the 377-site integer set with coordinate-sum at most 6",
+        len(sites) == 377
+        and origin in sites
+        and AXIS2 in sites
+        and FACE in sites,
+    )
+    checks.check(
+        "two-dijkstras",
+        "exactly two Dijkstras from the origin are executed, unit ℓ¹ then c2d4",
+        counter.calls == 2
+        and "dist_l1 = counter.distances(sites, origin, l1_cost)" in self_source
+        and "dist_c2 = counter.distances(sites, origin, c2d4_cost)" in self_source
+        and self_source.index("l1_cost") < self_source.index("c2d4_cost"),
+    )
+    checks.check(
+        "reachable",
+        "every site of B_6(0) is reached under both costs",
+        all(dist_l1[site] < 10**9 for site in sites)
+        and all(dist_c2[site] < 10**9 for site in sites),
+    )
+    checks.check(
+        "l1-unit-hops",
+        "ℓ¹ prices every 6-NN hop at cost 1",
+        l1_cost(origin, AXIS) == 1
+        and l1_cost(AXIS, AXIS2) == 1
+        and l1_cost(AXIS, FACE) == 1
+        and l1_cost(FACE, BODY) == 1
+        and l1_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 1,
+    )
+    checks.check(
+        "c2d4-clauses",
+        "seed-exit, axis, drop, corridor-slide, and ridge-slide cost 3; max>=4 out-face costs 2; 1-to-2 and small 2-to-3 cost 1",
+        c2d4_cost((0, 0, 0), (1, 0, 0)) == 3
+        and c2d4_cost((1, 0, 0), (2, 0, 0)) == 3
+        and c2d4_cost((1, 1, 0), (1, 0, 0)) == 3
+        and c2d4_cost((1, 1, 0), (2, 1, 0)) == 3
+        and c2d4_cost((1, 1, 1), (2, 1, 1)) == 3
+        and c2d4_cost((4, 2, 0), (5, 2, 0)) == 2
+        and c2d4_cost((4, 1, 0), (5, 1, 0)) == 3
+        and c2d4_cost((1, 0, 0), (1, 1, 0)) == 1
+        and c2d4_cost((1, 1, 0), (1, 1, 1)) == 1
+        and c2d4_cost((2, 2, 2), (3, 2, 2)) == 1
+        and c2d4_cost((2, 2, 0), (3, 2, 0)) == 1
+        and c2d4_cost((3, 2, 0), (4, 2, 0)) == 1
+        and not d4_extra((3, 2, 0), (4, 2, 0))
+        and not d4_extra((1, 1, 0), (2, 1, 0)),
+    )
+    l1_axis2_path = l1_cost(origin, AXIS) + l1_cost(AXIS, AXIS2)
+    l1_face_path = l1_cost(origin, AXIS) + l1_cost(AXIS, FACE)
+    c2_axis2_path = c2d4_cost(origin, AXIS) + c2d4_cost(AXIS, AXIS2)
+    c2_face_path = c2d4_cost(origin, AXIS) + c2d4_cost(AXIS, FACE)
+    checks.check(
+        "thm1-l1-times",
+        "under ℓ¹, t(2,0,0)=2 and t(1,1,0)=2 match the unit-cost arrivals",
+        t_l1_axis2 == 2
+        and t_l1_face == 2
+        and t_l1_axis2 == l1_axis2_path
+        and t_l1_face == l1_face_path,
+    )
+    checks.check(
+        "thm1-l1-face-reverse",
+        "under ℓ¹, t(2,0,0)^2 > 2 t(1,1,0)^2 fails",
+        not reverse_l1
+        and t_l1_axis2 * t_l1_axis2 == 4
+        and 2 * t_l1_face * t_l1_face == 8,
+    )
+    checks.check(
+        "thm2-c2d4-times",
+        "under c2d4, t(2,0,0)=6 and t(1,1,0)=4 match the named-cost arrivals",
+        t_c2_axis2 == 6
+        and t_c2_face == 4
+        and t_c2_axis2 == c2_axis2_path
+        and t_c2_face == c2_face_path,
+    )
+    checks.check(
+        "thm2-c2d4-face-reverse",
+        "under c2d4, t(2,0,0)^2 > 2 t(1,1,0)^2 holds",
+        reverse_c2
+        and t_c2_axis2 * t_c2_axis2 == 36
+        and 2 * t_c2_face * t_c2_face == 32,
+    )
+    checks.check(
+        "thm3-bits-disagree",
+        "the two face bits disagree",
+        not bits_agree and reverse_l1 is False and reverse_c2 is True,
+    )
+    checks.check(
+        "thm1-note-reports-l1",
+        "the note reports the ℓ¹ times and failed face reverse",
+        "t(2,0,0) = 2" in note
+        and "t(1,1,0) = 2" in note
+        and "4 > 8" in note,
+    )
+    checks.check(
+        "thm2-note-reports-c2d4",
+        "the note reports the c2d4 times and holding face reverse",
+        "t(2,0,0) = 6" in note
+        and "t(1,1,0) = 4" in note
+        and "36 > 32" in note,
+    )
+    checks.check(
+        "thm3-note-reports-disagreement",
+        "the note reports disagreement of the face bits",
+        "The two face bits disagree" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and does not name these hop-costs",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ℓ¹" not in axiom
+        and "Do not write hop-costs into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1",
+        "Do not attach L1." in note and "attach L1" in note,
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " ") and CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not require uniqueness",
+        "Uniqueness is not required" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_6(0), uses two Dijkstras, and proposes no axiom edit",
+        "B_6(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "Two Dijkstras" in note
+        and "not leftover of a larger-ball table" in note
+        and "B_" + "57" not in note
+        and "B_" + "57" not in self_source,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the comparison is displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "lock-support" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+    checks.check(
+        "no-path-dump",
+        "the runner stores arrival costs only",
+        ("pre" + "decessor") not in self_source.lower()
+        and ("path " + "dump") not in self_source.lower()
+        and ("path " + "dump") not in note.lower(),
+    )
+
+    print("per_element: named hop-costs are integers on nearest-neighbor hops.")
+    print("per_site: arrival times are reported only at (2,0,0) and (1,1,0).")
+    print("lattice_wide: checked and not executed — the search stays inside B_6(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_6(0), unit ell1 face reverse at k=1 fails (t(2,0,0)=2 vs t(1,1,0)=2) while named c2d4 holds (6 vs 4). Face bits disagree. Displayed, not adopted. Do not write hop-costs into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/l1_locksupport_vs_c2d4_face_k1_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.