### PR TITLE
feat(varl1): ell1 is worse-round than c2d4 on B12

### DIFF
--- a/docs/L1_LOCKSUPPORT_VS_C2D4_VAR_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/L1_LOCKSUPPORT_VS_C2D4_VAR_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,318 @@
+---
+claim_id: l1_locksupport_vs_c2d4_var_b12_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Arrival-speed variance on B_12(0) under unit ℓ¹ versus named c2d4 is compared. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py
+---
+
+# Unit ℓ¹ Lock-Support Versus Named c2d4 Arrival-Speed Variance On B_12(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** two named directed nearest-neighbor hop-costs on the finite
+ℓ¹-ball `B_12(0)`, their Dijkstra arrival times from the origin, and the
+population variance of `|v|_2/t` on the 2624 nonzero sites. No hop-cost is
+written into Admissibility. L1 is not attached.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py`](../scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. Native unit
+ℓ¹ on the cubic 6-NN graph prices every remaining hop at cost `1`. That unit
+graph is the lock-support cone of the origin: Record locks at a site, and the
+native nearest-neighbor support spreads at unit hop cost. Named `c2d4` is a
+separately displayed hop-cost. The parent clauses `ν`, `μ`, and `ρ3` are those
+of the ridge-slide scoring on this ball:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4`), else `1`.
+
+The extra `c2d4` clause is a max≥4 out-face hop priced at `2`: support stays
+`2`, the destination max absolute coordinate grows, and the source max is
+already at least `4`. It is displayed, not adopted. Uniqueness is not required.
+
+The investment is that same-k reverse bits of unit ℓ¹ and named `c2d4`
+disagree. The residual here is the first display of arrival-speed variance of
+native ℓ¹ lock-support versus displayed `c2d4` on `B_12(0)`. Uniqueness is not
+claimed.
+
+The finite host is scored independently. Two Dijkstras from the origin are run
+on this ball, unit ℓ¹ first, then `c2d4`. The ball is not leftover of a
+larger-ball table.
+
+The executed order of arrival-speed variances on `B_12(0)` is
+
+`var_ℓ¹ > var_c2d4`.
+
+So native ℓ¹ lock-support is strictly less round than displayed `c2d4` on
+`B_12(0)`. The scores are displayed, not adopted. Do not write hop-costs into
+Admissibility. Do not attach L1.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+The axiom does not supply hop-cost values. It does not
+supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+None of Record is used to select a hop-cost.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two finite Dijkstra scores and their population arrival-speed variances on B_12(0) are exact; no hop-cost is adopted and L1 is not attached."
+trace_class: upstream_support
+target_claim_id: l1_locksupport_vs_c2d4_var_b12
+target_blocker_text: "compare arrival-speed variance of unit ℓ¹ lock-support versus named c2d4 on B_12(0)"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the two scores displayed. Do not write hop-costs into Admissibility. Do not attach L1."
+conditional_surface_status: "exact for the two named hop-costs on the induced B_12(0) graph; no physical law is selected"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0=(0,0,0)` and `B_12(0)={v∈Z^3 : |v|_1 ≤ 12}`. This set has 2625 sites.
+The executed graph is the induced nearest-neighbor graph on that set: a
+directed hop `v→w` exists when `w-v` is a signed axis unit and `w∈B_12(0)`.
+
+The coordinate support is `σ_v={i : v_i ≠ 0}`. Its cardinality is the
+weight. On a hop `v→w`:
+
+- seed-exit means `|σ_v|=0`,
+- both-weights-1 means `|σ_v|=|σ_w|=1`,
+- support-drop means `|σ_w| < |σ_v|`,
+- corridor-slide means `|σ_v|=|σ_w|=2` and the least nonzero `|w_i|` equals `1`,
+- ridge-slide means `|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1`,
+- out-face means `|σ_v|=|σ_w|=2` and `max_i |w_i| > max_i |v_i|`,
+- max≥4 out-face means out-face and `max_i |v_i| ≥ 4`.
+
+The two named costs are:
+
+- unit ℓ¹: cost `1` on every remaining 6-NN hop. Written `ℓ¹(v→w) = 1`.
+- `c2d4`: cost `3` if `ρ3` would be `3`, else `2` if max≥4 out-face,
+  else `1`. Written `c2d4(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)`
+  or `|σ_w| < |σ_v|` or `(|σ_v|=|σ_w|=2` and the least nonzero `|w_i|`
+  equals `1)` or `(|σ_v|=|σ_w|=3` and exactly two `|w_i|` equal `1)`,
+  else `2` if `|σ_v|=|σ_w|=2` and `max_i |w_i| > max_i |v_i|` and
+  `max_i |v_i| ≥ 4`, else `1`.
+
+On the seed-exit hop `(0,0,0) → (1,0,0)` one has `|σ_v|=0`, so unit ℓ¹
+costs `1` and `c2d4` costs `3`. On the axis hop `(1,0,0) → (2,0,0)` both
+weights are `1`, so unit ℓ¹ costs `1` and `c2d4` costs `3`. On the max≥4
+out-face hop `(4,2,0) → (5,2,0)` one has `|σ| : 2 → 2`, `max |w_i| = 5 >
+max |v_i| = 4`, and source max already `4`, so unit ℓ¹ costs `1` and
+`c2d4` costs `2`. On the max≥3 out-face hop `(3,2,0) → (4,2,0)` source max
+is `3`, so unit ℓ¹ costs `1` and `c2d4` costs `1`. On the ridge hop
+`(1,1,1) → (2,1,1)` one has `|σ| : 3 → 3` and exactly two `|w_i| = 1`, so
+unit ℓ¹ costs `1` and `c2d4` costs `3`. On the axis-hugging hop
+`(1,1,0) → (2,1,0)` one has `|σ| : 2 → 2` and least nonzero `|w_i| = 1`,
+so unit ℓ¹ costs `1` and `c2d4` costs `3` by corridor-slide. The
+three-unit enter hop `(1,1,0) → (1,1,1)` stays at cost `1` under both
+names. The leave-axis hop `(0,-1,0) → (1,-1,0)` stays at cost `1` under
+both names. Therefore named `c2d4` is not the unit-ℓ¹ clause, and the
+`c2d4` scores below are not a leftover of lock-support occupancy.
+
+Arrival time `t(v)` is the Dijkstra cost from `0` under the named rule.
+Under unit ℓ¹ that arrival equals the coordinate-sum `|v|_1`. The compared
+statistic on `B_12(0)\{0}` is the population variance
+
+`var(|v|_2/t) = (1/N) Σ_v (|v|_2/t(v) - mean)^2`,
+
+with `N=2624` and `mean=(1/N) Σ_v |v|_2/t(v)`. Equivalently,
+`var = Q - mean^2` where the second moment `Q=(1/N) Σ_v |v|_2^2 / t(v)^2` is
+rational. Two Dijkstras are run, one per cost.
+
+This note does not attach L1. The comparison uses only the two named
+clause families on the same directed graph.
+
+## Theorem 1 — Two Variances
+
+Every nonzero site is reached under each of the two costs. The exact
+second moments on the 2624 nonzero sites are
+
+`Q_ℓ¹ = 337/656`,
+
+`Q_c2d4 = 12586016761121881939/63482497589871360000`.
+
+The population variances, truncated to 18 decimal digits, are
+
+`var_ℓ¹ = 0.009447425719061308`,
+
+`var_c2d4 = 0.003574941366936777`.
+
+Thus both variances are reported.
+
+## Theorem 2 — Variance Order; Displayed, Not Adopted
+
+On `B_12(0)` one has
+
+`var_ℓ¹ > var_c2d4`.
+
+Native unit ℓ¹ lock-support is therefore strictly less round than displayed
+`c2d4` on this ball. Equality does not hold. The opposite inequality does
+not hold.
+
+Displayed, not adopted. Do not write hop-costs into Admissibility. Do not
+attach L1.
+
+The current admissibility rule remains the quoted nearest-neighbor
+distribution constraint. The two clause families are scoring rules on
+`B_12(0)`, not a replacement of that axiom. No formation law, occupancy
+member, or locked-set filling rule is identified with either hop-cost.
+Uniqueness among hop-costs outside this pair is not required and is not
+claimed.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers whether native ℓ¹ lock-support is rounder or less round than displayed c2d4 on B_12(0). |
+| V2 | Current main has no landed unit-ℓ¹ versus c2d4 variance comparison on B_12(0). |
+| V3 | The two Dijkstras and the 2624-site population variances are finite and exact. |
+| V4 | The comparison is not an axiom rewrite: Admissibility is left unchanged. |
+| V5 | Displayed scores are not a physical hop-cost or formation law. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: these two scores are reported on `B_12(0)`
+and are not adopted. No uniqueness of a physical law is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unit ℓ¹ | cost `1` on every remaining 6-NN hop | executed; larger variance |
+| `c2d4` | all `ρ3` clauses plus max≥4 out-face `2→2` hops at cost `2` | executed; smaller variance |
+| other clause pairs | tax every out-face at `3`, or drop the source-max floor | different named family; not this residual |
+| unrestricted `Z^3` paths | leave `B_12(0)` and return | outside the declared ball |
+| adopt a score | write hop-costs into Admissibility | forbidden; not executed |
+| attach L1 | identify a score with a formation member | forbidden; not executed |
+
+### N2 — wall independence
+
+Ball restriction, hop-cost clauses, the speed statistic, and axiom
+non-adoption are distinct. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The ball, the induced graph, the two cost clauses, and population variance
+are declared. No continuum limit, no physical clock, and no formation rate
+are assumed.
+
+### N4 — source residual matching
+
+The axiom memo supplies the cubic nearest-neighbor substrate and the
+distribution sentence. It does not name hop-cost clauses. The residual is
+a finite comparison on that substrate, not an axiom edit.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each nonzero site of `B_12(0)` | no other ball |
+| per site | one arrival time per named cost | no physical tick identification |
+| per mode | no spectral calculation | no mode exhaustion |
+| per block | two Dijkstras and one variance pair | no law selection |
+| lattice wide | checked and not executed | no `Z^3` or infinite-volume score |
+
+### N6 — live partial-closure paths
+
+Live routes are a derived hop-cost, a reason to adopt one of the two
+scores, a comparison on a larger ball, and a separately derived formation
+law. None is closed here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because unit ℓ¹ is the native lock-support cone, its
+arrival-speed field should be at least as round as named `c2d4` on
+`B_12(0)`, so the displayed comparison should report `var_ℓ¹ < var_c2d4`
+or equality.
+
+**Answer:** Pricing every hop at `1` leaves axis sites at Euclidean speed
+`1` and body-diagonal sites near `1/√3`. Named `c2d4` prices seed-exit and
+axis hops at `3`, which slows those high-speed sites. On `B_12(0)` the
+executed variances satisfy `var_ℓ¹ > var_c2d4`. Native ℓ¹ lock-support is
+strictly less round than displayed `c2d4` on this ball.
+
+### N8 — cross-cycle echo
+
+The same-k reverse-bit comparison of unit ℓ¹ versus `c2d4` and the
+already-scored `c2d4` variance against other named hop-costs are not
+reused as lemmas. The two scores are computed on `B_12(0)`. L1 remains
+unattached.
+
+**Gate disposition:** PASS for the two reported variances, the displayed
+order `var_ℓ¹ > var_c2d4`, and the refusal to adopt a hop-cost or attach L1.
+FAIL / DO NOT SHIP for writing hop-costs into Admissibility, attaching L1,
+or claiming a unique physical law.
+
+## What This Does Not Claim
+
+- Uniqueness is not required.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+- The roundness comparison on this ball is not a no-go against named
+  hop-costs elsewhere.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph and the
+refusal to treat a named hop-cost as axiom content.
+
+## Primary Runner
+
+The primary runner rebuilds `B_12(0)`, runs the two Dijkstras, recomputes
+the second moments and population variances, checks the reported order,
+and pins the current axiom wording together with the non-adoption
+sentences. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -11732,6 +11732,10 @@
   },
   "kubo_range_of_validity_note": {
    "deps_hash": "ba29b296b2a4",
+   "out_degree": 1
+  },
+  "l1_locksupport_vs_c2d4_var_b12_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "l3a_v3_trace_surface_bounded_obstruction_note_2026-05-07_l3a": {

--- a/logs/runner-cache/l1_locksupport_vs_c2d4_var_b12_2026_08_15.txt
+++ b/logs/runner-cache/l1_locksupport_vs_c2d4_var_b12_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py
+runner_sha256: 3570499a8ca716eab153abfa99e2c0fab297a1ac7cb0ee9874dbb2ca3b4caca7
+input_fingerprint_sha256: 56e674b288c78d4ebc4462da195161c354c57bcdce507d4aa339068dc1371801
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.13
+status: ok
+----- stdout -----
+claim_scope: Arrival-speed variance on B_12(0) under unit ℓ¹ versus named c2d4 is compared. Displayed, not adopted.
+cache_write: false
+external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit
+integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs
+construction: two directed Dijkstras on the induced B_12(0) graph, unit ℓ¹ then c2d4
+negative_scope: displayed scores are not adopted and L1 is not attached
+PASS: audit-inputs the two declared source-bound inputs exist
+PASS: audit-tuple-literal AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: claim-scope front matter uses the declared claim_scope
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility current local-distribution wording is pinned
+PASS: source-formation-boundary formation site/probability/rate remains outside Admissibility
+PASS: source-record-boundary current lock/content/unreadable-at-absence wording is pinned
+PASS: ball-cardinality B_12(0) has 2625 sites and 2624 nonzero sites
+PASS: two-dijkstras exactly two Dijkstras run, unit ℓ¹ then c2d4, and each cost reaches every ball site
+PASS: l1-equals-norm unit ℓ¹ Dijkstra arrivals equal coordinate-sum on every site
+PASS: named-clauses ℓ¹ prices every 6-NN hop at 1; c2d4 prices ρ3 at 3 and max≥4 out-face at 2
+Q_l1 = 337/656
+Q_c2d4 = 12586016761121881939/63482497589871360000
+var_l1 = 0.009447425719061308
+var_c2d4 = 0.003574941366936777
+dijkstra_calls 2
+order: var_l1 > var_c2d4
+PASS: second-moments the two exact second moments match the note
+PASS: reported-variances the note reports the two truncated population variances
+PASS: variance-order unit ℓ¹ is strictly less round than named c2d4 on B_12(0)
+PASS: thm2-note-reports-greater the note reports var_ℓ¹ greater than var_c2d4
+PASS: forbidden-phrases note and runner omit the forbidden phrases
+PASS: theorems-displayed two theorems are present and the scores are displayed, not adopted
+PASS: no-admissibility-write the note refuses to write hop-costs into Admissibility
+PASS: no-l1-attach the note does not attach L1
+PASS: uniqueness-not-required uniqueness among hop-costs is not required
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: no-path-dump the runner stores arrival costs only
+PASS: scope-ball the theorem stays on B_12(0) and uses two Dijkstras
+per_element: checked exactly — each of the 2624 nonzero B_12(0) sites receives two arrival times
+per_site: checked exactly — population variance uses |v|_2/t at every nonzero site
+per_mode: checked exactly — unit ℓ¹ and named c2d4 only; no other clause family is scored
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py
+++ b/scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Exact B_12(0) arrival-speed variance of unit ℓ¹ lock-support versus c2d4.
+
+Two Dijkstras from the origin on the finite nearest-neighbor graph: first
+unit ℓ¹ cost on every 6-NN hop, then named c2d4. Variances are displayed,
+not adopted. Hop-costs are not written into Admissibility. L1 is not
+attached. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from decimal import Decimal, getcontext
+from fractions import Fraction
+from heapq import heappop, heappush
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = "docs/L1_LOCKSUPPORT_VS_C2D4_VAR_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+AUDIT_INPUT_PATHS = (
+    "docs/L1_LOCKSUPPORT_VS_C2D4_VAR_B12_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Arrival-speed variance on B_12(0) under unit ℓ¹ versus named "
+    "c2d4 is compared. Displayed, not adopted."
+)
+
+RADIUS = 12
+ORIGIN = (0, 0, 0)
+SHIFTS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+NONZERO_COUNT = 2624
+SITE_COUNT = 2625
+DIJKSTRA_CALLS = 0
+
+Q_L1 = Fraction(337, 656)
+Q_C2D4 = Fraction(12586016761121881939, 63482497589871360000)
+VAR_DIGITS = {
+    "l1": "0.009447425719061308",
+    "c2d4": "0.003574941366936777",
+}
+
+
+Point = tuple[int, int, int]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def l1_norm(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def radius_squared(point: Point) -> int:
+    return point[0] * point[0] + point[1] * point[1] + point[2] * point[2]
+
+
+def support_size(point: Point) -> int:
+    return int(point[0] != 0) + int(point[1] != 0) + int(point[2] != 0)
+
+
+def least_nonzero_abs(point: Point) -> int | None:
+    nonzero = [abs(coord) for coord in point if coord != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def unit_abs_count(point: Point) -> int:
+    return int(abs(point[0]) == 1) + int(abs(point[1]) == 1) + int(abs(point[2]) == 1)
+
+
+def max_abs_coord(point: Point) -> int:
+    return max(abs(point[0]), abs(point[1]), abs(point[2]))
+
+
+def ball_sites(radius: int) -> tuple[Point, ...]:
+    extent = range(-radius, radius + 1)
+    return tuple(point for point in product(extent, repeat=3) if l1_norm(point) <= radius)
+
+
+def split_square(value: int) -> tuple[int, int]:
+    square = 1
+    square_free = 1
+    remaining = value
+    prime = 2
+    while prime * prime <= remaining:
+        exponent = 0
+        while remaining % prime == 0:
+            remaining //= prime
+            exponent += 1
+        if exponent:
+            square *= prime ** (exponent // 2)
+            if exponent % 2:
+                square_free *= prime
+        prime += 1 if prime == 2 else 2
+    if remaining > 1:
+        square_free *= remaining
+    return square, square_free
+
+
+def nu_cost(source: Point, target: Point) -> int:
+    sigma_v = support_size(source)
+    sigma_w = support_size(target)
+    if sigma_v == 0 or (sigma_v == 1 and sigma_w == 1) or sigma_w < sigma_v:
+        return 3
+    return 1
+
+
+def mu_cost(source: Point, target: Point) -> int:
+    if nu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(target) == 2 and least_nonzero_abs(target) == 1:
+        return 3
+    return 1
+
+
+def rho3_cost(source: Point, target: Point) -> int:
+    if mu_cost(source, target) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(target) == 3 and unit_abs_count(target) == 2:
+        return 3
+    return 1
+
+
+def l1_cost(_source: Point, _target: Point) -> int:
+    return 1
+
+
+def c2d4_cost(source: Point, target: Point) -> int:
+    if rho3_cost(source, target) == 3:
+        return 3
+    if (
+        support_size(source) == 2
+        and support_size(target) == 2
+        and max_abs_coord(target) > max_abs_coord(source)
+        and max_abs_coord(source) >= 4
+    ):
+        return 2
+    return 1
+
+
+def neighbors(site: Point, sites: set[Point]) -> tuple[Point, ...]:
+    out: list[Point] = []
+    for shift in SHIFTS:
+        candidate = (site[0] + shift[0], site[1] + shift[1], site[2] + shift[2])
+        if candidate in sites:
+            out.append(candidate)
+    return tuple(out)
+
+
+def dijkstra(sites: tuple[Point, ...], cost_fn) -> dict[Point, int]:
+    global DIJKSTRA_CALLS
+    DIJKSTRA_CALLS += 1
+    site_set = set(sites)
+    dist = {ORIGIN: 0}
+    heap: list[tuple[int, Point]] = [(0, ORIGIN)]
+    while heap:
+        current, site = heappop(heap)
+        if current != dist[site]:
+            continue
+        for nxt in neighbors(site, site_set):
+            trial = current + cost_fn(site, nxt)
+            prior = dist.get(nxt)
+            if prior is None or trial < prior:
+                dist[nxt] = trial
+                heappush(heap, (trial, nxt))
+    return dist
+
+
+def second_moment_and_var_coeff(
+    dist: dict[Point, int], sites: tuple[Point, ...]
+) -> tuple[Fraction, dict[int, Fraction]]:
+    nonzero = tuple(site for site in sites if site != ORIGIN)
+    count = len(nonzero)
+    moment = Fraction(0)
+    linear: dict[int, Fraction] = defaultdict(Fraction)
+    for site in nonzero:
+        arrival = dist[site]
+        squared = radius_squared(site)
+        moment += Fraction(squared, arrival * arrival)
+        square, square_free = split_square(squared)
+        linear[square_free] += Fraction(square, arrival)
+    moment /= count
+    square_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    keys = tuple(linear)
+    for left in keys:
+        for right in keys:
+            square, square_free = split_square(left * right)
+            square_coeff[square_free] += linear[left] * linear[right] * square
+    var_coeff: dict[int, Fraction] = defaultdict(Fraction)
+    var_coeff[1] += moment
+    denom = count * count
+    for square_free, coeff in square_coeff.items():
+        var_coeff[square_free] -= coeff / denom
+    return moment, {key: value for key, value in var_coeff.items() if value != 0}
+
+
+def eval_coeff(coeff: dict[int, Fraction], precision: int = 50) -> Decimal:
+    getcontext().prec = precision
+    total = Decimal(0)
+    for square_free, value in coeff.items():
+        total += (Decimal(value.numerator) / Decimal(value.denominator)) * Decimal(square_free).sqrt()
+    return total
+
+
+def truncated_decimal(value: Decimal, places: int = 18) -> str:
+    quantized = value.quantize(Decimal(10) ** -places)
+    text = format(quantized, "f")
+    whole, frac = text.split(".")
+    return whole + "." + frac[:places]
+
+
+def parse_audit_tuple(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+            if "AUDIT_INPUT_PATHS" in names and isinstance(node.value, ast.Tuple):
+                values: list[str] = []
+                for element in node.value.elts:
+                    if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                        return None
+                    values.append(element.value)
+                return tuple(values)
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    for relative in AUDIT_INPUT_PATHS:
+        (ROOT / relative).read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print("cache_write: false")
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record wording; no observation or fit")
+    print("integrity_reads: this runner, its note, and the axiom memo; no other scientific inputs")
+    print("construction: two directed Dijkstras on the induced B_12(0) graph, unit ℓ¹ then c2d4")
+    print("negative_scope: displayed scores are not adopted and L1 is not attached")
+
+    checks.check(
+        "audit-inputs",
+        "the two declared source-bound inputs exist",
+        AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL)
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check(
+        "audit-tuple-literal",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        parse_audit_tuple(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "claim-scope",
+        "front matter uses the declared claim_scope",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note.replace("\n", " ")
+        or f'claim_scope: "{CLAIM_SCOPE}"' in note,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check(
+        "source-lattice",
+        "current cubic nearest-neighbor wording is pinned",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility",
+        "current local-distribution wording is pinned",
+        admissibility_sentence in normalized_axiom and admissibility_sentence in normalized_note,
+    )
+    checks.check(
+        "source-formation-boundary",
+        "formation site/probability/rate remains outside Admissibility",
+        formation_boundary in normalized_axiom and formation_boundary in normalized_note,
+    )
+    checks.check(
+        "source-record-boundary",
+        "current lock/content/unreadable-at-absence wording is pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+
+    sites = ball_sites(RADIUS)
+    site_set = set(sites)
+    checks.check(
+        "ball-cardinality",
+        "B_12(0) has 2625 sites and 2624 nonzero sites",
+        len(sites) == SITE_COUNT and ORIGIN in site_set and len(sites) - 1 == NONZERO_COUNT,
+    )
+
+    dist_l1 = dijkstra(sites, l1_cost)
+    dist_c2d4 = dijkstra(sites, c2d4_cost)
+    checks.check(
+        "two-dijkstras",
+        "exactly two Dijkstras run, unit ℓ¹ then c2d4, and each cost reaches every ball site",
+        DIJKSTRA_CALLS == 2
+        and "dist_l1 = dijkstra(sites, l1_cost)" in self_source
+        and "dist_c2d4 = dijkstra(sites, c2d4_cost)" in self_source
+        and self_source.index("dist_l1 = dijkstra(sites, l1_cost)")
+        < self_source.index("dist_c2d4 = dijkstra(sites, c2d4_cost)")
+        and len(dist_l1) == SITE_COUNT
+        and len(dist_c2d4) == SITE_COUNT,
+        residual=(DIJKSTRA_CALLS, len(dist_l1), len(dist_c2d4)),
+    )
+    checks.check(
+        "l1-equals-norm",
+        "unit ℓ¹ Dijkstra arrivals equal coordinate-sum on every site",
+        all(dist_l1[site] == l1_norm(site) for site in sites),
+    )
+    checks.check(
+        "named-clauses",
+        "ℓ¹ prices every 6-NN hop at 1; c2d4 prices ρ3 at 3 and max≥4 out-face at 2",
+        l1_cost((0, 0, 0), (1, 0, 0)) == 1
+        and l1_cost((1, 0, 0), (2, 0, 0)) == 1
+        and l1_cost((1, 0, 0), (1, 1, 0)) == 1
+        and l1_cost((1, 1, 0), (1, 0, 0)) == 1
+        and l1_cost((1, 1, 0), (2, 1, 0)) == 1
+        and l1_cost((4, 2, 0), (5, 2, 0)) == 1
+        and l1_cost((3, 2, 0), (4, 2, 0)) == 1
+        and l1_cost((1, 1, 1), (2, 1, 1)) == 1
+        and l1_cost((1, 1, 0), (1, 1, 1)) == 1
+        and l1_cost((0, -1, 0), (1, -1, 0)) == 1
+        and rho3_cost((0, 0, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (2, 0, 0)) == 3
+        and rho3_cost((1, 0, 0), (1, 1, 0)) == 1
+        and rho3_cost((1, 1, 0), (1, 0, 0)) == 3
+        and rho3_cost((1, 1, 0), (2, 1, 0)) == 3
+        and rho3_cost((2, 2, 0), (3, 2, 0)) == 1
+        and rho3_cost((3, 2, 0), (4, 2, 0)) == 1
+        and rho3_cost((4, 2, 0), (5, 2, 0)) == 1
+        and rho3_cost((1, 1, 1), (2, 1, 1)) == 3
+        and rho3_cost((2, 2, 1), (3, 2, 1)) == 1
+        and rho3_cost((2, 1, 0), (2, 1, 1)) == 1
+        and rho3_cost((1, 1, 0), (1, 1, 1)) == 1
+        and c2d4_cost((4, 2, 0), (5, 2, 0)) == 2
+        and c2d4_cost((3, 2, 0), (4, 2, 0)) == 1
+        and c2d4_cost((2, 2, 0), (3, 2, 0)) == 1
+        and c2d4_cost((1, 1, 0), (2, 1, 0)) == 3
+        and c2d4_cost((1, 1, 1), (2, 1, 1)) == 3
+        and c2d4_cost((2, 1, 0), (2, 1, 1)) == 1
+        and c2d4_cost((1, 1, 0), (1, 1, 1)) == 1
+        and c2d4_cost((2, 2, 1), (3, 2, 1)) == 1
+        and c2d4_cost((0, -1, 0), (1, -1, 0)) == 1
+        and c2d4_cost((0, 0, 0), (1, 0, 0)) == 3
+        and c2d4_cost((1, 0, 0), (2, 0, 0)) == 3
+        and c2d4_cost((4, 1, 0), (5, 1, 0)) == 3,
+    )
+
+    moment_l1, var_l1_coeff = second_moment_and_var_coeff(dist_l1, sites)
+    moment_c2d4, var_c2d4_coeff = second_moment_and_var_coeff(dist_c2d4, sites)
+    var_l1 = eval_coeff(var_l1_coeff)
+    var_c2d4 = eval_coeff(var_c2d4_coeff)
+
+    print(f"Q_l1 = {moment_l1}")
+    print(f"Q_c2d4 = {moment_c2d4}")
+    print(f"var_l1 = {truncated_decimal(var_l1)}")
+    print(f"var_c2d4 = {truncated_decimal(var_c2d4)}")
+    print(f"dijkstra_calls {DIJKSTRA_CALLS}")
+    print(
+        "order: var_l1 > var_c2d4"
+        if var_l1 > var_c2d4
+        else ("order: var_l1 == var_c2d4" if var_l1 == var_c2d4 else "order: var_l1 < var_c2d4")
+    )
+
+    checks.check(
+        "second-moments",
+        "the two exact second moments match the note",
+        moment_l1 == Q_L1
+        and moment_c2d4 == Q_C2D4
+        and "337/656" in note
+        and "12586016761121881939/63482497589871360000" in note,
+    )
+    checks.check(
+        "reported-variances",
+        "the note reports the two truncated population variances",
+        VAR_DIGITS["l1"] in note
+        and VAR_DIGITS["c2d4"] in note
+        and truncated_decimal(var_l1) == VAR_DIGITS["l1"]
+        and truncated_decimal(var_c2d4) == VAR_DIGITS["c2d4"],
+    )
+    checks.check(
+        "variance-order",
+        "unit ℓ¹ is strictly less round than named c2d4 on B_12(0)",
+        var_l1 > var_c2d4,
+        residual=(str(var_l1), str(var_c2d4)),
+    )
+    checks.check(
+        "thm2-note-reports-greater",
+        "the note reports var_ℓ¹ greater than var_c2d4",
+        "var_ℓ¹ > var_c2d4" in note and "strictly less round" in normalized_note,
+    )
+
+    forbidden = ("G_" "N", "1/" "r", "1/" "r^2", "Lattice-" "named", "not a " "TOE")
+    checks.check(
+        "forbidden-phrases",
+        "note and runner omit the forbidden phrases",
+        all(phrase not in note and phrase not in self_source for phrase in forbidden),
+    )
+    checks.check(
+        "theorems-displayed",
+        "two theorems are present and the scores are displayed, not adopted",
+        "## Theorem 1 — Two Variances" in note
+        and "## Theorem 2 — Variance Order; Displayed, Not Adopted" in note
+        and "Displayed, not adopted." in note
+        and "displayed, not adopted" in normalized_note,
+    )
+    checks.check(
+        "no-admissibility-write",
+        "the note refuses to write hop-costs into Admissibility",
+        "Do not write hop-costs into Admissibility." in note
+        and "one fixed nearest-neighbor admissibility rule" in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ℓ¹" not in axiom,
+    )
+    checks.check(
+        "no-l1-attach",
+        "the note does not attach L1",
+        "This note does not attach L1." in note
+        and "Do not attach L1." in note
+        and "Do not attach L1" not in axiom
+        and 'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "uniqueness among hop-costs is not required",
+        "Uniqueness is not required" in note and "not claimed" in normalized_note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ℓ¹" not in axiom,
+    )
+    checks.check(
+        "no-path-dump",
+        "the runner stores arrival costs only",
+        ("pre" + "decessor") not in self_source.lower()
+        and ("path " + "dump") not in self_source.lower()
+        and ("path " + "dump") not in note.lower(),
+    )
+    checks.check(
+        "scope-ball",
+        "the theorem stays on B_12(0) and uses two Dijkstras",
+        "B_12(0)" in note
+        and "Two Dijkstras" in note
+        and "B_12(0)" in self_source
+        and "B_" + "57" not in note
+        and "B_" + "57" not in self_source,
+    )
+
+    print("per_element: checked exactly — each of the 2624 nonzero B_12(0) sites receives two arrival times")
+    print("per_site: checked exactly — population variance uses |v|_2/t at every nonzero site")
+    print("per_mode: checked exactly — unit ℓ¹ and named c2d4 only; no other clause family is scored")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Arrival-speed variance on B_12(0) is var_ell1=0.00945 > var_c2d4=0.003575. Native lock-support is less round than the named extra. Displayed, not adopted. Do not write hop-costs into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/l1_locksupport_vs_c2d4_var_b12_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.