### PR TITLE
feat(rdunrd): deleting unread (2,0,0) does not move c2d4 reverse at k=1

### DIFF
--- a/docs/UNREAD_SITE_DELETION_VS_C2D4_REVERSE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/UNREAD_SITE_DELETION_VS_C2D4_REVERSE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,264 @@
+---
+claim_id: unread_site_deletion_vs_c2d4_reverse_b6_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Same-k reverse and face at k=1 under named c2d4 on B_6(0) versus B_6(0) minus unread (2,0,0) is compared. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py
+---
+
+# Unread-Site Deletion Versus Named c2d4 Reverse And Face Bits At k=1 On B_6(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** two Dijkstra arrival comparisons at k=1 on the finite nearest-neighbor
+graph `B_6(0)` and on `B_6(0)` minus one unread witness, under the named hop-cost
+`c2d4`, displayed for this note only.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py`](../scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+**Cache:** none. `cache_write: false`.
+
+## Result Up Front
+
+Record supplies that a site with no record cannot be read. The displayed
+recorded set on this host is
+
+```text
+R = { (0,0,0), (1,0,0), (1,1,0), (1,1,1) }.
+```
+
+The unread witness is `u = (2,0,0)`. It lies in `B_6(0)` and is not in `R`.
+Uniqueness is not required.
+
+Write `|σ_v|` for the number of nonzero coordinates of `v ∈ Z^3`. Named `c2d4`
+is a separately displayed hop-cost. The parent clauses `ν`, `μ`, and `ρ3` are
+those of the ridge-slide same-k scoring on this ball:
+
+- `ν(v→w) = 3` if `|σ_v|=0` or `(|σ_v|=|σ_w|=1)` or `|σ_w| < |σ_v|`, else `1`;
+- `μ(v→w) = 3` if `ν` would be `3` or `(|σ_v|=|σ_w|=2` and the least nonzero
+  `|w_i|` equals `1)`, else `1`;
+- `ρ3(v→w) = 3` if `μ` would be `3` or `(|σ_v|=|σ_w|=3` and exactly two
+  `|w_i|` equal `1)`, else `1`;
+- `c2d4(v→w) = 3` if `ρ3` would be `3`, else `2` if (`|σ_v|=|σ_w|=2` and
+  `max_i |w_i| > max_i |v_i|` and `max_i |v_i| ≥ 4`), else `1`.
+
+The extra `c2d4` clause is a max≥4 out-face hop priced at `2`. It is
+displayed, not adopted.
+
+The finite host is scored independently. Two Dijkstras from the origin are run:
+first on `B_6(0)`, then on `B_6(0) \ {u}`. The ball is not leftover of a larger-ball table.
+
+```text
+B_6(0) := { v ∈ Z^3 : |v_1| + |v_2| + |v_3| ≤ 6 }.
+```
+
+It has 377 sites. The punctured host has 376 sites. Edges are the cubic
+nearest-neighbor steps that remain inside the scored host.
+
+On the full ball the four arrivals are
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+t(2,0,0) = 6
+t(1,1,0) = 4
+```
+
+The same-k reverse comparison at k=1 is
+
+```text
+t(1,0,0)^2 / 1 = 9 > 25/3 = t(1,1,1)^2 / 3.
+```
+
+Equivalently `27 > 25`. The reverse bit is true.
+
+The same-k face comparison at k=1 is
+
+```text
+t(2,0,0)^2 / 4 = 9 > 8 = t(1,1,0)^2 / 2.
+```
+
+Equivalently `36 > 32`. The face bit is true.
+
+On `B_6(0) \ {u}` the recorded arrivals are unchanged,
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+t(1,1,0) = 4
+```
+
+and t(2,0,0) is absent. Reverse remains defined and true. The face bit is
+undefined because its axis site is the deleted unread witness.
+
+The reverse bit does not move. The face bit is undefined after deletion, so it
+has no comparable value on the punctured host. No defined reverse or face bit moves.
+Record set R is unchanged: `u` is not in `R`, and deleting `u` from the
+host neither adds nor removes a recorded site. Displayed, not adopted.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Two Dijkstras, on B_6(0) then on B_6(0) minus unread (2,0,0), report the k=1 reverse and face bits under named c2d4. The comparison is displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: unread_site_deletion_vs_c2d4_reverse_b6
+target_blocker_text: "whether named c2d4 reverse or face bits at k=1 move after deleting one unread site while R is unchanged"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded unread-site deletion comparison"
+conditional_surface_status: "exact on B_6(0) versus B_6(0) minus unread (2,0,0) under named c2d4; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** the live Lattice sentence supplies nearest-neighbor
+  adjacency on `Z^3`. It is quoted without rewrite. Named `c2d4` is not Lattice
+  content. Record supplies that a site with no record cannot be read; it does
+  not name a hop-cost.
+- **Explicit theorem-domain condition:** the finite set `B_6(0)`, its
+  nearest-neighbor edges, the displayed recorded set `R`, the unread witness
+  `u = (2,0,0)`, and the named directed costs `ν`, `μ`, `ρ3`, and `c2d4` are
+  supplied mathematical data for this theorem.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** writing hop-costs into Admissibility, attaching
+  L1, selecting `c2d4` as a physical cost, or lifting the comparison off
+  `B_6(0)` remain separate obligations. This note does not close them.
+
+## Exact Objects
+
+All runner values are integers. No float is used in the comparison.
+
+The live Lattice sentence, quoted and not rewritten:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+The live Admissibility sentence, quoted and not rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+The live Record unreadability sentence, quoted and not rewritten:
+
+> A site with no record cannot be read.
+
+`c2d4` is a separately named hop-cost on directed nearest-neighbor hops. It is
+not that admissibility rule.
+
+Write `t(v)` for the Dijkstra arrival cost from the origin to `v` under `c2d4`.
+Two Dijkstras are run: the full ball first, then the ball minus `u`.
+
+An explicit axis witness is the single hop `(0,0,0) → (1,0,0)` of cost `3`.
+An explicit face witness is `(0,0,0) → (1,0,0) → (1,1,0)` with costs `3+1=4`.
+An explicit body witness is `(0,0,0) → (1,0,0) → (1,1,0) → (1,1,1)` with costs
+`3+1+1=5`. An explicit unread-axis witness on the full ball is
+`(0,0,0) → (1,0,0) → (2,0,0)` with costs `3+3=6`. Every `c2d4` path has first
+hop cost `3`, and every hop costs at least `1`, so those witnesses are optimal
+once Dijkstra matches them. They are witnesses, not a uniqueness claim.
+
+The k=1 reverse bit uses only recorded sites `(1,0,0)` and `(1,1,1)`. The k=1
+face bit uses `(2,0,0)` and `(1,1,0)`; the first of those is the unread
+witness.
+
+## Theorem 1 — Full-ball arrivals and k=1 reverse and face bits
+
+Under `c2d4` on `B_6(0)`,
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+t(2,0,0) = 6
+t(1,1,0) = 4
+```
+
+The displayed reverse comparison is whether
+
+```text
+t(1,0,0)^2 / 1 > t(1,1,1)^2 / 3.
+```
+
+Substituting the computed times gives `9 > 25/3`, or equivalently `27 > 25`.
+The reverse bit is true.
+
+The displayed face comparison is whether
+
+```text
+t(2,0,0)^2 / 4 > t(1,1,0)^2 / 2.
+```
+
+Substituting the computed times gives `9 > 8`, or equivalently `36 > 32`.
+The face bit is true.
+
+## Theorem 2 — Punctured-ball arrivals and bits if defined
+
+Under `c2d4` on `B_6(0) \ {u}`,
+
+```text
+t(1,0,0) = 3
+t(1,1,1) = 5
+t(1,1,0) = 4
+```
+
+and t(2,0,0) is absent. Reverse remains defined: `9 > 25/3` still holds, so
+the reverse bit is true. The face bit is undefined.
+
+## Theorem 3 — Bit motion after unread deletion; no axiom write and no L1 attachment
+
+The reverse bit does not move. The face bit is undefined after deleting unread
+`u`, because the face-axis site is that unread witness. No defined reverse or face bit moves.
+Record set R is unchanged.
+
+Do not write hop-costs into Admissibility. Do not attach L1.
+
+The live Admissibility wording names one fixed nearest-neighbor
+admissibility rule and does not name `c2d4`, `ρ3`, `μ`, or `ν`. This note
+proposes no axiom edit. The comparison above is a score of one named hop-cost
+on two hosts; it is not an attachment of a coordinate-sum hop-cost.
+
+## What This Does Not Claim
+
+- Uniqueness is not required.
+- No physical identification of `t` as a clock, mass, or force law is made.
+- No claim is made that Record locks these arrival times.
+- Independent leftovers on larger balls are not used as parents.
+- Undefined face after deleting the unread axis site is not a no-go against
+  named hop-costs elsewhere.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to the repository's site graph, the
+unreadability of a site with no record, and the refusal to treat a named
+hop-cost as axiom content.
+
+## Runner Contract
+
+The companion runner builds `B_6(0)` and `B_6(0) \ {u}`, evaluates named
+`c2d4`, and runs two Dijkstras from the origin, full ball then ball minus `u`.
+It reports `t(1,0,0)`, `t(1,1,1)`, `t(2,0,0)`, and `t(1,1,0)` on the full
+ball, the same four arrivals on the punctured ball with `t(2,0,0)` absent, the
+k=1 reverse and face bits when defined, and whether any defined bit moves
+while `R` is unchanged. It checks that the live Admissibility wording does not
+name these hop-costs, refuses to attach L1, and records the import boundary.
+Declared review inputs are this note and the axiom memo only.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -19065,6 +19065,10 @@
   "unraveled_step_law_bi_invariant_quasi_stationarity_split_bounded_theorem_note_2026-06-10": {
    "deps_hash": "fb8954ed7807",
    "out_degree": 9
+  },
+  "unread_site_deletion_vs_c2d4_reverse_b6_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "up_sector_partition_revisit_note_2026-04-19": {
    "deps_hash": "eaecb942382a",

--- a/logs/runner-cache/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.txt
+++ b/logs/runner-cache/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.txt
@@ -1,0 +1,77 @@
+===== runner cache v1 =====
+runner: scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py
+runner_sha256: 44e3b96075c214a034c0b293c097f421e7f4748eb9d76790da5f13ceda899bf4
+input_fingerprint_sha256: e565370187d8a0828aed53eaa9d65e83cd63c2b115555d2b687cda621ecf7ebd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/UNREAD_SITE_DELETION_VS_C2D4_REVERSE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+cache_write: false
+claim_scope: Same-k reverse and face at k=1 under named c2d4 on B_6(0) versus B_6(0) minus unread (2,0,0) is compared. Displayed, not adopted.
+external_scientific_inputs: none; named c2d4 on B_6(0) versus B_6(0) minus unread (2,0,0) only
+package_local_integrity_reads: proposed source note and live axiom memo only; no cache or governance surface is written
+measure_boundary: integer hop-costs and two Dijkstras; no fit and no leftover larger-ball table
+claim_boundary: same-k reverse and face bits at k=1 are displayed, not adopted
+n_sites_full 377
+n_sites_punct 376
+R [(0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1)]
+unread_witness (2, 0, 0)
+full t(1,0,0) = 3
+full t(1,1,1) = 5
+full t(2,0,0) = 6
+full t(1,1,0) = 4
+full reverse: 3^2 / 1 = 9 versus 5^2 / 3 = 25/3; reverse=True
+full 3 t(1,0,0)^2 = 27
+full t(1,1,1)^2 = 25
+full face: 6^2 / 4 = 36/4 versus 4^2 / 2 = 16/2; face=True
+full t(2,0,0)^2 = 36
+full 2 t(1,1,0)^2 = 32
+punct t(1,0,0) = 3
+punct t(1,1,1) = 5
+punct t(2,0,0) absent
+punct t(1,1,0) = 4
+punct reverse=True
+punct face undefined
+recorded_times_same True
+defined_bit_moved False
+dijkstra_calls 2
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: audit-input-literal AUDIT_INPUT_PATHS is a static string-literal tuple
+PASS: ball-cardinality B_6(0) is the 377-site integer set with coordinate-sum at most 6
+PASS: punctured-cardinality B_6(0) minus unread (2,0,0) has 376 sites
+PASS: recorded-set R is the four recorded sites and the unread witness is outside R
+PASS: two-dijkstras exactly two Dijkstras from the origin are executed, full ball then ball minus u
+PASS: reachable-full every site of B_6(0) is reached on the full ball
+PASS: reachable-punct-recorded every recorded site remains reached on the punctured ball
+PASS: c2d4-clauses seed-exit and axis cost 3; body and face-support hops cost 1; max>=4 out-face costs 2
+PASS: thm1-arrivals on the full ball the four arrivals are the computed Dijkstra times
+PASS: thm1-reverse-face on the full ball reverse and face bits at k=1 both hold
+PASS: thm2-arrivals-punct on the punctured ball the recorded arrivals match and t(2,0,0) is absent
+PASS: thm2-bits-if-defined on the punctured ball reverse remains true and face is undefined
+PASS: thm3-no-defined-bit-move no defined reverse or face bit moves after deleting unread u
+PASS: thm3-r-unchanged the recorded set R is unchanged by deleting unread u
+PASS: thm1-note-reports-full the note reports the full-ball arrivals and both bits
+PASS: thm2-note-reports-punct the note reports the punctured arrivals and undefined face bit
+PASS: thm3-note-reports-comparison the note reports that no defined reverse or face bit moves and R is unchanged
+PASS: thm3-not-in-admissibility the live Admissibility wording is unchanged and hop-costs are not written into it
+PASS: thm3-no-l1-attachment the note refuses to attach L1
+PASS: forbidden-tokens forbidden tokens are absent from the note
+PASS: claim-scope-contract the required claim_scope is source-visible
+PASS: uniqueness-not-required the note does not require uniqueness
+PASS: scope-boundary the theorem stays on B_6(0), uses two Dijkstras, and proposes no axiom edit
+PASS: displayed-not-adopted the comparison is displayed, not adopted
+PASS: no-axiom-edit note records hypothetical axiom status no edit
+PASS: axiom-untouched the axiom memo is an input only and still names the four axioms
+PASS: no-path-dump the runner stores arrival costs only
+PASS: record-unreadability the note quotes that a site with no record cannot be read
+per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.
+per_site: arrival times are reported at (1,0,0), (1,1,1), (2,0,0), and (1,1,0).
+lattice_wide: checked and not executed — the search stays inside B_6(0).
+TOTAL: PASS=29 FAIL=0
+
+----- stderr -----
+

--- a/scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py
+++ b/scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Unread-site deletion versus named c2d4 reverse and face bits at k=1 on B_6(0).
+
+Two Dijkstras from the origin: first on the finite nearest-neighbor graph
+B_6(0), then on B_6(0) minus the unread witness (2,0,0). Reverse and face
+bits are displayed, not adopted. Hop-costs are not written into
+Admissibility. L1 is not attached. No cache or governance surface is written.
+"""
+
+from __future__ import annotations
+
+import ast
+import heapq
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "UNREAD_SITE_DELETION_VS_C2D4_REVERSE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/UNREAD_SITE_DELETION_VS_C2D4_REVERSE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+CLAIM_SCOPE = (
+    "Same-k reverse and face at k=1 under named c2d4 on B_6(0) "
+    "versus B_6(0) minus unread (2,0,0) is compared. Displayed, not adopted."
+)
+
+RADIUS = 6
+ORIGIN = (0, 0, 0)
+AXIS = (1, 0, 0)
+BODY = (1, 1, 1)
+FACE = (1, 1, 0)
+UNREAD = (2, 0, 0)
+RECORDED = frozenset({ORIGIN, AXIS, FACE, BODY})
+MAX4_OUT_SRC = (4, 2, 0)
+MAX4_OUT_DST = (5, 2, 0)
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+Site = tuple[int, int, int]
+INFINITY = 10**9
+
+
+def add(site: Site, step: Site) -> Site:
+    return (site[0] + step[0], site[1] + step[1], site[2] + step[2])
+
+
+def support_size(site: Site) -> int:
+    return sum(1 for coordinate in site if coordinate != 0)
+
+
+def unit_coord_count(site: Site) -> int:
+    return sum(1 for coordinate in site if abs(coordinate) == 1)
+
+
+def max_abs(site: Site) -> int:
+    return max(abs(coordinate) for coordinate in site)
+
+
+def min_nonzero_abs(site: Site) -> int | None:
+    nonzero = [abs(coordinate) for coordinate in site if coordinate != 0]
+    if not nonzero:
+        return None
+    return min(nonzero)
+
+
+def ball_sites(radius: int) -> frozenset[Site]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-radius, radius + 1)
+        for y in range(-radius, radius + 1)
+        for z in range(-radius, radius + 1)
+        if abs(x) + abs(y) + abs(z) <= radius
+    )
+
+
+def nu_cost(source: Site, dest: Site) -> int:
+    source_support = support_size(source)
+    dest_support = support_size(dest)
+    if (
+        source_support == 0
+        or (source_support == 1 and dest_support == 1)
+        or dest_support < source_support
+    ):
+        return 3
+    return 1
+
+
+def mu_cost(source: Site, dest: Site) -> int:
+    if nu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 2 and support_size(dest) == 2:
+        least = min_nonzero_abs(dest)
+        if least == 1:
+            return 3
+    return 1
+
+
+def rho3_cost(source: Site, dest: Site) -> int:
+    if mu_cost(source, dest) == 3:
+        return 3
+    if support_size(source) == 3 and support_size(dest) == 3:
+        if unit_coord_count(dest) == 2:
+            return 3
+    return 1
+
+
+def d4_extra(source: Site, dest: Site) -> bool:
+    return (
+        support_size(source) == 2
+        and support_size(dest) == 2
+        and max_abs(dest) > max_abs(source)
+        and max_abs(source) >= 4
+    )
+
+
+def c2d4_cost(source: Site, dest: Site) -> int:
+    if rho3_cost(source, dest) == 3:
+        return 3
+    if d4_extra(source, dest):
+        return 2
+    return 1
+
+
+def reverse_bit(t_axis: int, t_body: int) -> bool:
+    return 3 * t_axis * t_axis > t_body * t_body
+
+
+def face_bit(t_face_axis: int, t_face: int) -> bool:
+    return t_face_axis * t_face_axis > 2 * t_face * t_face
+
+
+class DijkstraCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def distances(self, sites: frozenset[Site], origin: Site) -> dict[Site, int]:
+        self.calls += 1
+        dist = {site: INFINITY for site in sites}
+        dist[origin] = 0
+        queue: list[tuple[int, Site]] = [(0, origin)]
+        while queue:
+            cost, site = heapq.heappop(queue)
+            if cost != dist[site]:
+                continue
+            for step in STEPS:
+                neighbor = add(site, step)
+                if neighbor not in dist:
+                    continue
+                candidate = cost + c2d4_cost(site, neighbor)
+                if candidate < dist[neighbor]:
+                    dist[neighbor] = candidate
+                    heapq.heappush(queue, (candidate, neighbor))
+        return dist
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    module = ast.parse(source)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                return None
+            out.append(elt.value)
+        return tuple(out)
+    return None
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+    print(
+        "external_scientific_inputs: none; named c2d4 on B_6(0) versus "
+        "B_6(0) minus unread (2,0,0) only"
+    )
+    print(
+        "package_local_integrity_reads: proposed source note and live axiom "
+        "memo only; no cache or governance surface is written"
+    )
+    print(
+        "measure_boundary: integer hop-costs and two Dijkstras; no fit and "
+        "no leftover larger-ball table"
+    )
+    print(
+        "claim_boundary: same-k reverse and face bits at k=1 are displayed, "
+        "not adopted"
+    )
+
+    sites = ball_sites(RADIUS)
+    sites_punct = frozenset(site for site in sites if site != UNREAD)
+    counter = DijkstraCounter()
+    dist_full = counter.distances(sites, ORIGIN)
+    dist_punct = counter.distances(sites_punct, ORIGIN)
+
+    t_axis = dist_full[AXIS]
+    t_body = dist_full[BODY]
+    t_unread = dist_full[UNREAD]
+    t_face = dist_full[FACE]
+    reverse_full = reverse_bit(t_axis, t_body)
+    face_full = face_bit(t_unread, t_face)
+
+    punct_unread_absent = UNREAD not in dist_punct
+    t_axis_p = dist_punct[AXIS]
+    t_body_p = dist_punct[BODY]
+    t_face_p = dist_punct[FACE]
+    reverse_punct = reverse_bit(t_axis_p, t_body_p)
+    face_punct_defined = not punct_unread_absent
+    recorded_times_same = all(dist_full[site] == dist_punct[site] for site in RECORDED)
+    reverse_moved = reverse_full != reverse_punct
+    defined_bit_moved = reverse_moved or (
+        face_punct_defined and face_full != face_bit(dist_punct[UNREAD], t_face_p)
+    )
+
+    print(f"n_sites_full {len(sites)}")
+    print(f"n_sites_punct {len(sites_punct)}")
+    print(f"R {sorted(RECORDED)}")
+    print(f"unread_witness {UNREAD}")
+    print(f"full t(1,0,0) = {t_axis}")
+    print(f"full t(1,1,1) = {t_body}")
+    print(f"full t(2,0,0) = {t_unread}")
+    print(f"full t(1,1,0) = {t_face}")
+    print(
+        f"full reverse: {t_axis}^2 / 1 = {t_axis * t_axis} versus "
+        f"{t_body}^2 / 3 = {t_body * t_body}/3; reverse={reverse_full}"
+    )
+    print(f"full 3 t(1,0,0)^2 = {3 * t_axis * t_axis}")
+    print(f"full t(1,1,1)^2 = {t_body * t_body}")
+    print(
+        f"full face: {t_unread}^2 / 4 = {t_unread * t_unread}/4 versus "
+        f"{t_face}^2 / 2 = {t_face * t_face}/2; face={face_full}"
+    )
+    print(f"full t(2,0,0)^2 = {t_unread * t_unread}")
+    print(f"full 2 t(1,1,0)^2 = {2 * t_face * t_face}")
+    print(f"punct t(1,0,0) = {t_axis_p}")
+    print(f"punct t(1,1,1) = {t_body_p}")
+    print("punct t(2,0,0) absent")
+    print(f"punct t(1,1,0) = {t_face_p}")
+    print(f"punct reverse={reverse_punct}")
+    print("punct face undefined")
+    print(f"recorded_times_same {recorded_times_same}")
+    print(f"defined_bit_moved {defined_bit_moved}")
+    print(f"dijkstra_calls {counter.calls}")
+
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/UNREAD_SITE_DELETION_VS_C2D4_REVERSE_B6_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    checks.check(
+        "audit-input-literal",
+        "AUDIT_INPUT_PATHS is a static string-literal tuple",
+        literal_audit_paths(self_source) == AUDIT_INPUT_PATHS,
+    )
+    checks.check(
+        "ball-cardinality",
+        "B_6(0) is the 377-site integer set with coordinate-sum at most 6",
+        len(sites) == 377
+        and ORIGIN in sites
+        and AXIS in sites
+        and BODY in sites
+        and FACE in sites
+        and UNREAD in sites,
+    )
+    checks.check(
+        "punctured-cardinality",
+        "B_6(0) minus unread (2,0,0) has 376 sites",
+        len(sites_punct) == 376
+        and UNREAD not in sites_punct
+        and RECORDED <= sites_punct,
+    )
+    checks.check(
+        "recorded-set",
+        "R is the four recorded sites and the unread witness is outside R",
+        RECORDED == frozenset({ORIGIN, AXIS, FACE, BODY})
+        and UNREAD not in RECORDED
+        and UNREAD in sites,
+    )
+    checks.check(
+        "two-dijkstras",
+        "exactly two Dijkstras from the origin are executed, full ball then ball minus u",
+        counter.calls == 2
+        and "dist_full = counter.distances(sites, ORIGIN)" in self_source
+        and "dist_punct = counter.distances(sites_punct, ORIGIN)" in self_source
+        and self_source.index("dist_full = counter.distances(sites, ORIGIN)")
+        < self_source.index("dist_punct = counter.distances(sites_punct, ORIGIN)"),
+    )
+    checks.check(
+        "reachable-full",
+        "every site of B_6(0) is reached on the full ball",
+        all(dist_full[site] < INFINITY for site in sites),
+    )
+    checks.check(
+        "reachable-punct-recorded",
+        "every recorded site remains reached on the punctured ball",
+        all(dist_punct[site] < INFINITY for site in RECORDED)
+        and all(dist_punct[site] < INFINITY for site in sites_punct),
+    )
+    checks.check(
+        "c2d4-clauses",
+        "seed-exit and axis cost 3; body and face-support hops cost 1; max>=4 out-face costs 2",
+        c2d4_cost(ORIGIN, AXIS) == 3
+        and c2d4_cost(AXIS, UNREAD) == 3
+        and c2d4_cost(AXIS, FACE) == 1
+        and c2d4_cost(FACE, BODY) == 1
+        and c2d4_cost(MAX4_OUT_SRC, MAX4_OUT_DST) == 2
+        and not d4_extra(AXIS, UNREAD),
+    )
+    axis_path = c2d4_cost(ORIGIN, AXIS)
+    face_path = axis_path + c2d4_cost(AXIS, FACE)
+    body_path = face_path + c2d4_cost(FACE, BODY)
+    unread_path = axis_path + c2d4_cost(AXIS, UNREAD)
+    checks.check(
+        "thm1-arrivals",
+        "on the full ball the four arrivals are the computed Dijkstra times",
+        t_axis == 3
+        and t_body == 5
+        and t_unread == 6
+        and t_face == 4
+        and t_axis == axis_path
+        and t_body == body_path
+        and t_unread == unread_path
+        and t_face == face_path,
+    )
+    checks.check(
+        "thm1-reverse-face",
+        "on the full ball reverse and face bits at k=1 both hold",
+        reverse_full
+        and face_full
+        and 3 * t_axis * t_axis == 27
+        and t_body * t_body == 25
+        and t_unread * t_unread == 36
+        and 2 * t_face * t_face == 32,
+    )
+    checks.check(
+        "thm2-arrivals-punct",
+        "on the punctured ball the recorded arrivals match and t(2,0,0) is absent",
+        t_axis_p == 3
+        and t_body_p == 5
+        and t_face_p == 4
+        and punct_unread_absent
+        and recorded_times_same,
+    )
+    checks.check(
+        "thm2-bits-if-defined",
+        "on the punctured ball reverse remains true and face is undefined",
+        reverse_punct
+        and not face_punct_defined
+        and reverse_punct == reverse_full,
+    )
+    checks.check(
+        "thm3-no-defined-bit-move",
+        "no defined reverse or face bit moves after deleting unread u",
+        not defined_bit_moved
+        and not reverse_moved
+        and not face_punct_defined,
+    )
+    checks.check(
+        "thm3-r-unchanged",
+        "the recorded set R is unchanged by deleting unread u",
+        UNREAD not in RECORDED
+        and RECORDED <= sites
+        and RECORDED <= sites_punct
+        and recorded_times_same,
+    )
+    checks.check(
+        "thm1-note-reports-full",
+        "the note reports the full-ball arrivals and both bits",
+        "t(1,0,0) = 3" in note
+        and "t(1,1,1) = 5" in note
+        and "t(2,0,0) = 6" in note
+        and "t(1,1,0) = 4" in note
+        and "9 > 25/3" in note
+        and "27 > 25" in note
+        and "36 > 32" in note,
+    )
+    checks.check(
+        "thm2-note-reports-punct",
+        "the note reports the punctured arrivals and undefined face bit",
+        "t(2,0,0) is absent" in note
+        and "The reverse bit does not move" in note
+        and "The face bit is undefined" in note,
+    )
+    checks.check(
+        "thm3-note-reports-comparison",
+        "the note reports that no defined reverse or face bit moves and R is unchanged",
+        "No defined reverse or face bit moves" in note
+        and "Record set R is unchanged" in note
+        and "Displayed, not adopted" in note,
+    )
+    checks.check(
+        "thm3-not-in-admissibility",
+        "the live Admissibility wording is unchanged and hop-costs are not written into it",
+        "There is one fixed nearest-neighbor admissibility rule" in axiom
+        and "c2d4(v→w)" not in axiom
+        and "Do not write hop-costs into Admissibility." in note,
+    )
+    checks.check(
+        "thm3-no-l1-attachment",
+        "the note refuses to attach L1",
+        "Do not attach L1." in note and "attach L1" in note,
+    )
+    forbidden = (
+        "G_" + "N",
+        "1/" + "r",
+        "1/" + "r^2",
+        "Lattice-" + "named",
+        "not a " + "TOE",
+    )
+    checks.check(
+        "forbidden-tokens",
+        "forbidden tokens are absent from the note",
+        all(token not in note for token in forbidden),
+    )
+    checks.check(
+        "claim-scope-contract",
+        "the required claim_scope is source-visible",
+        CLAIM_SCOPE in note.replace("\n", " ") and CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "the note does not require uniqueness",
+        "Uniqueness is not required" in note and "unique hop-cost" not in note,
+    )
+    checks.check(
+        "scope-boundary",
+        "the theorem stays on B_6(0), uses two Dijkstras, and proposes no axiom edit",
+        "B_6(0)" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "Two Dijkstras" in note
+        and "not leftover of a larger-ball table" in note
+        and "B_" + "57" not in note
+        and "B_" + "57" not in self_source,
+    )
+    checks.check(
+        "displayed-not-adopted",
+        "the comparison is displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "unread witness" in note,
+    )
+    checks.check(
+        "no-axiom-edit",
+        "note records hypothetical axiom status no edit",
+        'hypothetical_axiom_status: "no edit"' in note,
+    )
+    checks.check(
+        "axiom-untouched",
+        "the axiom memo is an input only and still names the four axioms",
+        "### Admissibility / Local Constraint" in axiom
+        and "A site with no record cannot be read." in axiom
+        and "c2d4(v→w)" not in axiom
+        and "ρ3(v→w)" not in axiom,
+    )
+    checks.check(
+        "no-path-dump",
+        "the runner stores arrival costs only",
+        ("pre" + "decessor") not in self_source.lower()
+        and ("path " + "dump") not in self_source.lower()
+        and ("path " + "dump") not in note.lower(),
+    )
+    checks.check(
+        "record-unreadability",
+        "the note quotes that a site with no record cannot be read",
+        "A site with no record cannot be read." in note
+        and "A site with no record cannot be read." in axiom,
+    )
+
+    print("per_element: named hop-cost values are 1, 2, or 3 on nearest-neighbor hops.")
+    print(
+        "per_site: arrival times are reported at (1,0,0), (1,1,1), (2,0,0), and (1,1,0)."
+    )
+    print("lattice_wide: checked and not executed — the search stays inside B_6(0).")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On B_6(0) under named c2d4, reverse at k=1 stays 3 vs 5 after deleting unread u=(2,0,0). Face bit becomes undefined because u is the face-axis site. No defined reverse/face bit moves. Record set R unchanged. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/unread_site_deletion_vs_c2d4_reverse_b6_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.