### PR TITLE
feat(cntnchi): L1 occupancy formation is P-even; leftover-frame lock-content f is P-odd

### DIFF
--- a/docs/LOCK_CONTENT_LEFTOVER_FRAME_P_ODD_VS_L1CHI_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/LOCK_CONTENT_LEFTOVER_FRAME_P_ODD_VS_L1CHI_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,435 @@
+---
+claim_id: lock_content_leftover_frame_p_odd_vs_l1chi_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "On the six-neighbor occupancy star, whether leftover-frame lock-content section f is P-odd while L1 occupancy formation is P-even is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py
+---
+
+# Leftover-Frame Lock-Content Section Versus L1 Occupancy Achirality (Bounded Theorem)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact census of displayed L1 formation `n = d/3` and of
+leftover-frame-positive lock-content section `f` on the six-neighbor
+occupancy star `{0,1}^6`. Occupancy formation is two-letter and
+`P`-even. Lock-content `f` is named as in the leftover-frame-positive
+section of the July-3 pair. Uniqueness is not required. The `P`-parity
+split is displayed, not adopted. Do not attach L1. Do not write `f` or
+V−A into Admissibility. Do not reopen `color-unital-m3`. No occupancy
+step on a new spatial patch.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py`](../scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+and the July-3 classification
+[`ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md`](ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md).
+Declared audit inputs are this note and the axiom memo only.
+
+## Result Up Front
+
+Work on one six-neighbor star. Order the axis directions
+
+```text
+D = {+x, -x, +y, -y, +z, -z}.
+```
+
+An occupancy coloring is a tuple `c ∈ {0,1}^6`. Write
+`d_μ = c_{+μ} − c_{−μ}` and `n = d/3`. Displayed L1 formation is
+`n ≠ 0`. Inversion `P` swaps `+μ` with `−μ` and sends `n → −n`, so
+`{c : n(c) ≠ 0}` is `P`-invariant. July-3 theorem 2 applies: a
+proper-covariant two-letter openness rule is automatically full-cubic
+covariant. Occupancy formation is automatically achiral.
+
+Letters of lock content are `{0, +, −}` with `0` empty. Completions of
+an occupancy `σ` and an age bit `b` are the July-3 pair members that
+match occupancy `σ` and write opposite letters on the unique full axis
+according to `b`. The leftover-frame sign of a completion is the
+determinant of the ordered triple of directions (leftover `+`, leftover
+`−`, full-axis `+` letter). Leftover-frame-positive section `f` takes a
+completion of sign `+1`. Uniqueness is not required.
+
+On each of the 64 occupancy tuples the lock-content bit is
+
+```text
+f(c) = 1  iff  leftover-frame-positive section exists at occupancy c
+               for some age bit b ∈ {0,1}.
+```
+
+This is named lock content, not occupancy `n ≠ 0`. The runner reports
+
+```text
+N_form = 56,    N_P_form = 56,    N_both = 56
+N_f    = 12,    N_P_f    = 12,    N_both = 12.
+```
+
+The occupancy set `{c : f(c)=1}` is `P`-invariant, so it is not `P`-odd
+as a set of 6-tuples. The lock-content section itself is `P`-odd: `P`
+sends leftover-frame sign `+1` to sign `−1`, and the 24 leftover-frame-
+positive 3-letter colorings are disjoint from their inversion images.
+July-3 theorem 2 does not apply to that 3-letter section. Occupancy
+formation is automatically achiral; lock-content `f` is not.
+
+Displayed, not adopted. Do not write f or V−A into Admissibility. Do
+not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact enumeration of the 64 occupancy tuples establishes that displayed L1 formation is a two-letter P-even openness rule, that the occupancy fire-set of leftover-frame-positive f is P-invariant with N_f=12, and that the lock-content section itself is P-odd on the July-3 pair. Nothing is adopted."
+trace_class: negative_route_pruning
+target_claim_id: lock_content_leftover_frame_p_odd_vs_l1chi
+target_blocker_text: "is leftover-frame lock-content section f P-odd on the same 64 occupancy tuples while L1 occupancy formation is P-even"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the 64-tuple census; do not attach L1 or write f or V-A into Admissibility"
+conditional_surface_status: "exact for displayed n≠0 and leftover-frame-positive f on {0,1}^6; physical rule selection remains unclaimed"
+hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"
+admitted_observation_status: "V-A / P-odd is used only as the displayed comparison language; it is not derived"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target And Proof Obligations
+
+**Exact target.** On the six-neighbor occupancy star, report
+`N_form`, `N_P_form`, `N_both` for displayed L1 formation `n ≠ 0`;
+report `N_f`, `N_P_f`, `N_both` for leftover-frame lock-content section
+`f`; say whether `{c : f(c)=1}` is `P`-odd (not `P`-invariant) as a set
+of occupancy 6-tuples; and say whether occupancy formation is
+automatically achiral while lock-content `f` is or is not. Displayed,
+not adopted.
+
+| Obligation | Disposition |
+|---|---|
+| occupancy `{c : n ≠ 0}` is `P`-invariant | proved here in Theorem 1 |
+| census `N_form = N_P_form = N_both = 56` | proved here in Theorem 1 |
+| July-3 theorem 2 applies to occupancy | cited and locally re-earned in Theorem 1 |
+| lock-content bit `f` on the same 64 rows | proved here in Theorem 2 |
+| census `N_f = N_P_f = N_both = 12` | proved here in Theorem 2 |
+| occupancy `{c : f(c)=1}` is not `P`-odd | proved here in Theorem 2 |
+| lock-content section is `P`-odd on the pair | proved here in Theorem 2 |
+| occupancy automatically achiral; `f` is not | proved here in Theorem 3 |
+| no attachment, no Admissibility rewrite | stated here and gated |
+
+Boundary cases are not hidden. The eight colorings with `n = 0` do not
+form. Occupancies without a unique full axis have `f(c) = 0`. Each
+occupancy with `f(c) = 1` has two leftover-frame-positive completions,
+one per age bit; uniqueness is not required. Occupancy evolution on a
+new spatial patch is outside the target. No terminal lemma equivalent
+to the target is left open.
+
+## Inputs And Support Inventory
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  the nearest-neighbor Admissibility covariance sentence (proper cubic
+  rotations), the reading note that Admissibility does not supply the
+  formation site, the Record sentence that a readout value is
+  determined by record content alone, and the Qubit presentation
+  `M_2(C)`. As the registered `minimal_axioms` premise, it is not a
+  bounded-status source.
+- The July-3 classification supplies theorem 2 (openness-level patterns
+  are automatically achiral) and theorem 3 (chirality requires three
+  condition values; one chiral pair at `k = 3`). Those statements are
+  cited as parents. The two-letter half is re-earned on this star. The
+  pair is rebuilt as the union of proper orbits that are not
+  `P`-invariant; the orbit census is not dumped.
+- Occupancy bits, the formula `n = d/3`, the predicate `n ≠ 0`, and
+  leftover-frame-positive section `f` are displayed mathematical
+  hypotheses for this note. They are not a derived physical selector
+  and are not attached as the framework's fixed rule.
+- No measured, fitted, scale, or other phenomenological value is used.
+- No new spatial patch is introduced.
+
+## Exact Objects
+
+Directions, inversion, dipole, and formation:
+
+```text
+c = (c_{+x}, c_{-x}, c_{+y}, c_{-y}, c_{+z}, c_{-z}) ∈ {0,1}^6
+d_μ = c_{+μ} − c_{−μ} ∈ {−1, 0, +1}
+n_μ = d_μ / 3 ∈ {−1/3, 0, +1/3}
+f_L1(c) = 1  iff  n ≠ 0
+P(c) = (c_{-x}, c_{+x}, c_{-y}, c_{+y}, c_{-z}, c_{+z})
+n(P(c)) = −n(c)
+```
+
+Lock-content letters `{0, +, −}` encode as `0 ↦ 0`, `+ ↦ 1`, `− ↦ 2`.
+Occupancy of a 3-letter coloring is its support. A unique full axis is
+the unique axis with both slots occupied. Age bit `b` writes opposite
+letters on that axis. Leftover-frame sign is
+
+```text
+sgn = det( leftover +, leftover −, full-axis + letter ).
+```
+
+Leftover-frame-positive `f` is a completion with `sgn = +1`. The
+occupancy lock-content bit is `f(c) = 1` iff such a completion exists
+for some `b`.
+
+The live Admissibility, Record, and Qubit sentences, quoted and not
+rewritten:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> Read with Record, the distribution concerns which possibility a forming record locks, conditional
+> on formation at that site; it does not supply the formation site, probability,
+> or rate.
+
+> A readout value is determined by record content alone.
+
+> The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+## Theorem 1 — occupancy `{c : n ≠ 0}` is `P`-invariant
+
+The occupancy alphabet is `{0,1}`. Inversion swaps each pair
+`(+μ, −μ)`, so each `d_μ` changes sign and `n(P(c)) = −n(c)`. Therefore
+`n(c) ≠ 0` if and only if `n(P(c)) ≠ 0`. The set `{c : n(c) ≠ 0}` is
+`P`-invariant.
+
+The zero set is the product over three axes of the balanced pairs
+`{(0,0), (1,1)}`, hence `2^3 = 8` tuples. The complementary formation
+set has 56 members. Because the set is `P`-invariant,
+
+```text
+N_form = |{c : n(c) ≠ 0}| = 56
+N_P_form = |{c : n(P(c)) ≠ 0}| = 56
+N_both = |{c : n(c) ≠ 0 and n(P(c)) ≠ 0}| = 56.
+```
+
+July-3 theorem 2 states that every proper-covariant rule depending
+only on the recorded/open pattern of the six neighbors is covariant
+under the full cubic group. The runner re-earns the supporting fact:
+each of the 64 two-letter colorings is proper-equivalent to its
+`P`-image. Displayed L1 formation is automatically achiral.
+
+## Theorem 2 — lock-content `f` on the same 64 rows
+
+Leftover-frame-positive section `f` is a 3-letter object. Evaluated as
+a lock-content bit on each occupancy 6-tuple, `f(c) = 1` exactly on the
+twelve occupancies that admit a unique full axis and a leftover mixed
+`{+,−}` pair — the perpendicular weight-4 masks. The runner finds
+
+```text
+N_f = 12,    N_P_f = 12,    N_both = 12.
+```
+
+`P` permutes those twelve among themselves, so `{c : f(c)=1}` is
+`P`-invariant as a set of occupancy 6-tuples. It is not `P`-odd in the
+sense “not `P`-invariant”. The set is not `{c : n(c) ≠ 0}`.
+
+The lock-content section itself is a different object. The July-3 pair
+has 48 colorings, 24 of leftover-frame sign `+1` and 24 of sign `−1`.
+Sign is `P`-odd: `sgn(P(λ)) = −sgn(λ)`. The leftover-frame-positive
+set is disjoint from its inversion image. Each occupancy with
+`f(c) = 1` has two leftover-frame-positive completions (one per age
+bit); uniqueness is not required. Those 24 colorings push forward onto
+exactly the twelve occupancy tuples of the fire-set.
+
+## Theorem 3 — occupancy formation is automatically achiral; lock-content `f` is not
+
+Occupancy formation is a two-letter `P`-invariant openness predicate.
+July-3 theorem 2 applies; it is automatically achiral.
+
+Lock-content leftover-frame-positive `f` is a section of the unique
+July-3 `k = 3` chiral pair. July-3 theorem 2 does not apply: the
+alphabet has three letters, not two. The section is `P`-odd. It is not
+automatically achiral.
+
+The occupancy fire-set of `f` being `P`-invariant does not make the
+3-letter section automatically achiral. That fire-set is a two-letter
+projection. The section is lock content.
+
+Displayed, not adopted. Do not write f or V−A into Admissibility. Do
+not attach L1. Qubit remains `M_2(C)`. No axiom edit.
+
+## Mutations
+
+1. Identify occupancy `{c : f(c)=1}` with `{c : n(c) ≠ 0}`: the
+   censuses are 12 and 56.
+2. Treat occupancy `{c : f(c)=1}` as `P`-odd: the set is
+   `P`-invariant, with `N_f = N_P_f = N_both = 12`.
+3. Treat the occupancy fire-set as making lock-content `f`
+   automatically achiral: the 3-letter section remains `P`-odd.
+4. Require a unique leftover-frame-positive completion per occupancy:
+   each fire-set occupancy has two, one per age bit.
+5. Adopt `f` or write `f` / V−A into Admissibility: refused.
+6. Run the occupancy step on a new spatial patch: refused; the census
+   is the 64-tuple star only.
+
+## What This Does Not Claim
+
+- Do not attach L1 as the framework's fixed physical rule.
+- Do not write `f` or V−A into Admissibility.
+- Do not adopt a chirality bit.
+- Do not reopen `color-unital-m3`.
+- No occupancy step on a new spatial patch.
+- No formation rate, no host rebuild, no hop-cost filter.
+- Uniqueness of leftover-frame-positive completion is not required
+  and is not claimed.
+
+## No-Go Discipline Gate
+
+The negative claim is only this: on the six-neighbor occupancy star,
+displayed L1 formation is a two-letter automatically achiral rule,
+while leftover-frame lock-content section `f` is not automatically
+achiral. Occupancy `{c : f(c)=1}` is not itself `P`-odd. It is not a
+claim that weak chirality is impossible in the framework, and it is
+not a claim that some other, unstated content rule is the physical
+rule.
+
+### N1 — materially distinct routes
+
+| Route | Exact attack | Result and authority | Marker |
+|---|---|---|---|
+| identify `f` with `n ≠ 0` | Treat leftover-frame occupancy fire as L1 formation. | Theorem 2 and runner check `thm2-f-is-not-n-nonzero` separate 12 from 56. | **ATTEMPTED** |
+| occupancy fire-set is `P`-odd | Read `{c : f(c)=1}` as not `P`-invariant. | Theorem 2 and check `thm2-occupancy-f-set-not-p-odd` keep `N_f = N_P_f = N_both = 12`. | **ATTEMPTED** |
+| fire-set implies automatic achirality of `f` | Apply July-3 theorem 2 to the occupancy projection and stop. | Theorem 3 and check `thm3-lock-content-not-automatically-achiral` keep the 3-letter section `P`-odd. | **ATTEMPTED** |
+| unique completion | Demand one leftover-frame-positive coloring per occupancy. | Theorem 2 and check `thm2-uniqueness-not-required` find two per fire-set occupancy. | **ATTEMPTED** |
+| adopt or rewrite | Write `f` or V−A into Admissibility, or attach L1. | Theorem 3 and check `thm3-displayed-not-adopted` refuse the rewrite. | **ATTEMPTED** |
+| new spatial patch | Evolve occupancy on a new patch and read `f` there. | Check `no-new-spatial-patch`; the census is the 64-tuple star. | **ATTEMPTED** |
+
+### N2 — wall independence and collapse
+
+There are two conclusions, not a six-wall headline. Occupancy
+automatic achirality is one conclusion (Theorem 1). Lock-content `f`
+not being automatically achiral is the second (Theorems 2–3). The
+fire-set `P`-invariance, the 12-versus-56 split, and uniqueness
+refusal are certificates, not extra walls. Attachment refusal is a
+scope marker.
+
+| Pair | First closes second? | Second closes first? | Disposition |
+|---|---:|---:|---|
+| occupancy achirality / lock-content not achiral | no: a `P`-even openness rule does not classify a 3-letter section | no: a `P`-odd section does not by itself classify two-letter formation | independent conclusions on two alphabets |
+| occupancy fire-set `P`-invariance / content `P`-oddness | no | no | projection versus section |
+| 12-versus-56 split / uniqueness | no | no | supporting certificates, not walls |
+
+### N3 — hidden-condition scan
+
+| Phrase or premise | Classification |
+|---|---|
+| “displayed L1 formation” and `n = d/3` | explicit theorem hypothesis; not a derived physical selector |
+| leftover-frame-positive section `f` | explicit named displayed section; rebuilt from the July-3 pair |
+| occupancy alphabet `{0,1}` | explicit theorem hypothesis |
+| July-3 theorems 2 and 3 | cited parent classification; two-letter half re-earned here |
+| “automatically achiral” | July-3 theorem 2 applied only to the two-letter occupancy rule |
+| “Do not attach L1” | scope refusal, not a hidden residual |
+| Admissibility proper covariance | cited registered axiom premise |
+| Admissibility does not supply formation | cited reading note; used only as a boundary |
+
+### N4 — citation-to-residual matching
+
+| Evidence path:line | Residual attacked | Residual claimed closed | Match? |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:57` | proper-only covariance of the named rule | Admissibility names proper cubic rotations | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:67` | formation site supplied by Admissibility | reading note: formation site is not supplied | yes; boundary stays open |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:82` | readout from lock content | readout is determined by record content alone | yes |
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:47` | Qubit presentation | `M_2(C)`; Qubit remains `M_2(C)` | yes |
+| `scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py:274` | formation census | `N_form = 56` | yes |
+| `scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py:275` | `P`-image and intersection census | `N_P_form = N_both = 56` | yes |
+| `scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py:287` | `P`-invariance of the formation set | `{c : n(c) ≠ 0}` is `P`-invariant | yes |
+| `scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py:312` | occupancy lock-content census | `N_f = N_P_f = N_both = 12` | yes |
+| `scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py:316` | occupancy fire-set `P`-oddness | `{c : f(c)=1}` is `P`-invariant, not `P`-odd | yes |
+| `scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py:343` | lock-content section `P`-oddness | leftover-frame-positive set is disjoint from its `P`-image | yes |
+
+No evidence citation is used to claim that L1 or `f` is the physical
+rule, or that Admissibility has been rewritten.
+
+### N5 — rhetoric and resolution audit
+
+| Resolution | Executed? | Narrow negative supported? |
+|---|---:|---|
+| per element | yes: all 64 occupancy tuples | each has `n = d/3`, forms iff `n ≠ 0`, and a leftover-frame lock-content bit |
+| per site | yes: one six-neighbor star | no host rebuild; no other site is used |
+| per mode | yes: two-letter occupancy versus three-letter leftover-frame-positive `f` | occupancy is automatically achiral; lock-content `f` is not |
+| per block | yes: 56/56/56 and 12/12/12 censuses | occupancy fire-set is `P`-even; content section is `P`-odd |
+| lattice wide | no | no occupancy step on a new spatial patch |
+
+The runner prints the same five resolution statements verbatim.
+
+### N6 — partial closure and primitive scan
+
+The primitive registry at `docs/audit/data/axiom_premise_nodes.json` was
+checked. The only dependency used is the registered `minimal_axioms`
+node. Approved primitives `scale_reference_primitive`,
+`kinetic_isotropy_primitive`, and `realized_state_primitive` are not
+used. Open derivation obligations on occupancy grain and readout are
+not this star census. July-3 theorems 2 and 3 are cited parent
+mathematics, not new primitives. None is reclassified as an import or
+wall.
+
+Two partial-closure mechanisms were tested rather than suppressed.
+Identifying occupancy `{c : f(c)=1}` with a `P`-odd set would have made
+lock-content `P`-odd already at two letters; that set is `P`-invariant.
+Treating that `P`-invariance as automatic achirality of `f` would have
+erased the 3-letter section; the section remains `P`-odd.
+
+### N7 — hostile steelman
+
+The strongest objection is that leftover-frame-positive `f` is already
+classified by its occupancy fire-set: that set is `P`-invariant, every
+two-letter coloring is proper-equivalent to its `P`-image, and July-3
+theorem 2 would then make `f` automatically achiral. That objection
+names the occupancy projection, not the lock-content section. The
+section is a 3-letter coloring of leftover-frame sign `+1`. Inversion
+flips that sign, and the positive set is disjoint from its inversion
+image. To overturn the negative claim the objection would have to show
+that the 3-letter section is proper-equivalent to its `P`-image, or
+that leftover-frame sign is `P`-even. Both fail on the rebuilt pair.
+
+### N8 — cross-cycle echo
+
+Repository search found three nearby landed mechanisms. They are
+context, not load-bearing dependencies, and the star census is
+recomputed here.
+
+| Earlier surface | Similar issue | Mechanism considered here |
+|---|---|---|
+| `docs/ADMISSIBILITY_RULE_COVARIANCE_EXTENSION_CLASSIFICATION_OPENNESS_ACHIRAL_ORIENTED_FRAME_MINIMAL_CHIRAL_CHANNEL_BOUNDED_THEOREM_NOTE_2026-07-03.md` | two-letter openness is automatically achiral; chirality starts at `k = 3` | applied to displayed `n ≠ 0`; lock-content `f` is kept on the `k = 3` pair |
+| `docs/ADMISSIBILITY_SUPPORT_CONSTRAINS_CONTENT_NOT_FORMATION_SITE_BOUNDED_THEOREM_NOTE_2026-08-13.md` | Admissibility constrains content, not the formation site | formation and lock-content bits are displayed predicates; neither is written into Admissibility |
+| `docs/ONLY_CUBIC_INVARIANT_BLOCH_VECTOR_IS_ZERO_BOUNDED_THEOREM_NOTE_2026-08-13.md` | cubic invariants can vanish while a directed object does not | occupancy formation can be `P`-even while a lock-content section is `P`-odd |
+
+No earlier mechanism attaches L1 or writes leftover-frame-positive `f`
+into Admissibility. This note does not reopen `color-unital-m3`.
+
+No-Go Discipline disposition: **PASS** for the algebraic negative
+boundary stated at the start of this section.
+
+## Live Parent Quotes
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+> it does not supply the formation site, probability,
+> or rate.
+
+> A readout value is determined by record content alone.
+
+> For the two-letter alphabet (recorded/open — content-blind conditions),
+> every coloring of the six directions is proper-equivalent to its
+> `P`-image (all 64, exhaustively; Burnside orbit counts agree at 10 and
+> 10). Every proper-covariant rule depending only on the openness
+> pattern is therefore automatically covariant under the full cubic
+> group. **A chiral admissibility rule cannot live at the openness
+> level**; chirality requires distinguishable record contents.
+
+> At `k = 2` there is no chiral pair (Theorem 2); at `k = 3` there is
+> exactly one, whose members are the handed fully-mixed patterns
+
+## Runner Contract
+
+The companion runner enumerates all 64 occupancy tuples, computes
+`n = d/3` over `Fraction`, reports `N_form`, `N_P_form`, and
+`N_both`, rebuilds leftover-frame-positive section `f` from the July-3
+pair, reports `N_f`, `N_P_f`, and `N_both`, checks that occupancy
+`{c : f(c)=1}` is `P`-invariant, checks that the lock-content section
+is `P`-odd, and verifies the refusal and no-go gate. Declared audit
+inputs are this note and the axiom memo. No runner cache is written.
+No occupancy step is run on a new spatial patch.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15754,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -12245,6 +12245,10 @@
   "localized_source_response_sweep_note_2026-05-17": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "lock_content_leftover_frame_p_odd_vs_l1chi_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "8fe1555943b9",
+   "out_degree": 2
   },
   "lock_point_menu_record_and_likelihood_lemma_cycle911_bounded_theorem_note_2026-07-28": {
    "deps_hash": "9250d476c7ae",

--- a/logs/runner-cache/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.txt
+++ b/logs/runner-cache/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py
+runner_sha256: ef71307b701c70831c49333f5c45a90da68d0aef14e26743a801ddfd6f156200
+input_fingerprint_sha256: 41bd22147badd43cc7a1c6b9e412202170da320e29e993af0f0b0b9d72383a0b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; occupancy alphabet, n=d/3, leftover-frame-positive f displayed
+package_local_integrity_reads: runner source, proposed source note, live axiom memo
+measure_boundary: exact Fraction and exact pair section on the 64 occupancy tuples; no spatial patch
+negative_scope: occupancy n≠0 is automatically achiral; lock-content f is not
+PASS: alphabet-two-letter occupancy alphabet is {0,1}
+PASS: star-cardinality six-neighbor occupancy star has 64 tuples
+PASS: cubic-group-size full signed-permutation group has 48 elements
+PASS: proper-group-size proper cubic rotations number 24
+PASS: thm1-n-empty-zero n(empty) = 0
+PASS: thm1-n-full-zero n(full) = 0
+PASS: thm1-n-axis-one-third n(+x occupied) = (1/3, 0, 0)
+PASS: thm1-forms-is-n-nonzero forms iff n ≠ 0 on the three witnesses
+PASS: thm1-n-form N_form = 56
+PASS: thm1-n-p-form N_P_form = 56
+PASS: thm1-n-both N_both = 56
+PASS: thm1-p-sends-n-to-minus-n n(P(c)) = -n(c) on all 64 tuples
+PASS: thm1-formation-set-p-invariant {c : n(c) ≠ 0} is P-invariant
+PASS: thm1-july3-t2-local every 2-letter coloring is proper-equivalent to its P-image
+PASS: thm2-n-f N_f = 12
+PASS: thm2-n-p-f N_P_f = 12
+PASS: thm2-n-both N_both = 12
+PASS: thm2-occupancy-f-set-not-p-odd {c : f(c)=1} is P-invariant, not P-odd
+PASS: thm2-f-is-not-n-nonzero lock-content f is not occupancy n≠0
+PASS: thm2-f-set-has-unique-full-axis every occupancy with f=1 has a unique full axis
+PASS: thm2-july3-pair-size July-3 chiral pair has 48 colorings
+PASS: thm2-content-positive-count leftover-frame-positive colorings number 24
+PASS: thm2-content-negative-count leftover-frame-negative colorings number 24
+PASS: thm2-content-p-odd lock-content leftover-frame-positive set is disjoint from its P-image
+PASS: thm2-content-sign-flips leftover-frame sign is P-odd on the pair
+PASS: thm2-uniqueness-not-required each f=1 occupancy has two leftover-frame-positive completions
+PASS: thm2-content-supports-are-f-set occupancy supports of leftover-frame-positive colorings are exactly {c : f(c)=1}
+PASS: thm3-occupancy-automatically-achiral occupancy n≠0 is two-letter P-invariant, so July-3 theorem 2 applies
+PASS: thm3-lock-content-not-automatically-achiral lock-content f lives on the July-3 k=3 chiral pair and is P-odd
+PASS: thm3-displayed-not-adopted note reports the split as displayed, not adopted
+PASS: claim-scope note reports the displayed claim_scope verbatim
+PASS: axiom-boundary Admissibility is proper-covariant and does not supply formation
+PASS: audit-input-paths AUDIT_INPUT_PATHS is the required string-literal tuple
+PASS: forbidden-phrases-absent forbidden phrases are absent from note and runner
+PASS: no-new-spatial-patch runner never steps occupancy on a new spatial patch
+PASS: no-orbit-dump runner does not dump the proper-orbit census
+PASS: claim-type-and-gate bounded theorem type and a passing N1-N8 gate are source-visible
+PASS: machine-status-contract note carries the bounded-support status and no hypothetical axiom adoption
+PASS: qubit-unchanged Qubit remains M_2(C); no axiom edit
+PASS: mutation-occupancy-f-equals-forms-fails predicate f-set == n≠0 fails
+PASS: mutation-occupancy-f-is-p-odd-fails predicate occupancy {c : f(c)=1} is P-odd fails
+per_element: checked exactly — each of the 64 occupancy tuples has n=d/3, forms iff n≠0, and a leftover-frame lock-content bit
+per_site: checked exactly — one six-neighbor star; no host rebuild and no occupancy step
+per_mode: checked exactly — two-letter occupancy n≠0 versus three-letter leftover-frame-positive f
+per_block: checked exactly — N_form=56/56/56 P-even; occupancy N_f=12/12/12; content f is P-odd
+lattice_wide: checked and not executed — no occupancy step on a new spatial patch
+TOTAL: PASS=41 FAIL=0
+
+----- stderr -----
+

--- a/scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py
+++ b/scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Leftover-frame lock-content section versus L1 occupancy achirality.
+
+On the 64 occupancy 6-tuples: n=d/3 formation is P-even (l1chi algebra);
+leftover-frame-positive f is a lock-content bit, named as in ridclk.
+Uniqueness is not required. Displayed, not adopted. No axiom edit, no
+cache write, no new spatial patch, no L1 attachment.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "LOCK_CONTENT_LEFTOVER_FRAME_P_ODD_VS_L1CHI_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/LOCK_CONTENT_LEFTOVER_FRAME_P_ODD_VS_L1CHI_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+DIRS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+DIR_INDEX = {direction: index for index, direction in enumerate(DIRS)}
+AXES = ((0, 1), (2, 3), (4, 5))
+EMPTY, PLUS, MINUS = 0, 1, 2
+OCCUPANCY_ALPHABET = (0, 1)
+
+CLAIM_SCOPE = (
+    "On the six-neighbor occupancy star, whether leftover-frame "
+    "lock-content section f is P-odd while L1 occupancy formation is "
+    "P-even is reported. Displayed, not adopted."
+)
+
+FORBIDDEN = ("G_N", "1/r", "1/r^2", "Lattice-named", "not a TOE")
+
+
+def mat_vec(matrix: tuple[tuple[int, int, int], ...], vec: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(sum(matrix[i][j] * vec[j] for j in range(3)) for i in range(3))
+
+
+def det3(matrix: tuple[tuple[int, int, int], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def dperm(matrix: tuple[tuple[int, int, int], ...]) -> tuple[int, ...]:
+    return tuple(DIR_INDEX[mat_vec(matrix, direction)] for direction in DIRS)
+
+
+def act_col(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    out = [0] * len(coloring)
+    for source, image in enumerate(perm):
+        out[image] = coloring[source]
+    return tuple(out)
+
+
+def inversion_matrix() -> tuple[tuple[int, int, int], ...]:
+    return ((-1, 0, 0), (0, -1, 0), (0, 0, -1))
+
+
+def signed_permutation_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[int, ...]] = set()
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rows = []
+            for row, axis in enumerate(perm):
+                entry = [0, 0, 0]
+                entry[axis] = signs[row]
+                rows.append(tuple(entry))
+            matrix = tuple(rows)
+            key = tuple(value for row in matrix for value in row)
+            if key in seen:
+                continue
+            seen.add(key)
+            records.append({"M": matrix, "det": det3(matrix), "perm": dperm(matrix)})
+    return records
+
+
+def dipole(occupancy: tuple[int, ...]) -> tuple[int, int, int]:
+    return (
+        occupancy[0] - occupancy[1],
+        occupancy[2] - occupancy[3],
+        occupancy[4] - occupancy[5],
+    )
+
+
+def n_from_occupancy(occupancy: tuple[int, ...]) -> tuple[Fraction, Fraction, Fraction]:
+    d_vec = dipole(occupancy)
+    return (Fraction(d_vec[0], 3), Fraction(d_vec[1], 3), Fraction(d_vec[2], 3))
+
+
+def forms(occupancy: tuple[int, ...]) -> bool:
+    return n_from_occupancy(occupancy) != (Fraction(0), Fraction(0), Fraction(0))
+
+
+def invert_tuple(perm: tuple[int, ...], coloring: tuple[int, ...]) -> tuple[int, ...]:
+    return act_col(perm, coloring)
+
+
+def support(coloring: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(int(slot != EMPTY) for slot in coloring)
+
+
+def unique_full_axis(sigma: tuple[int, ...]) -> int | None:
+    named = [
+        axis_index
+        for axis_index, (plus, minus) in enumerate(AXES)
+        if sigma[plus] == 1 and sigma[minus] == 1
+    ]
+    if len(named) == 1:
+        return named[0]
+    return None
+
+
+def leftover_frame_sign(coloring: tuple[int, ...]) -> int:
+    named = unique_full_axis(support(coloring))
+    if named is None:
+        raise AssertionError("completion has no unique full axis")
+    leftover = [
+        index
+        for index in range(6)
+        if support(coloring)[index] == 1 and index not in AXES[named]
+    ]
+    plus_left = next(index for index in leftover if coloring[index] == PLUS)
+    minus_left = next(index for index in leftover if coloring[index] == MINUS)
+    plus_full = next(index for index in AXES[named] if coloring[index] == PLUS)
+    return det3((DIRS[plus_left], DIRS[minus_left], DIRS[plus_full]))
+
+
+def axis_letters(bit: int) -> tuple[int, int]:
+    if bit == 1:
+        return (PLUS, MINUS)
+    return (MINUS, PLUS)
+
+
+def july3_k3_pair(proper_perms: list[tuple[int, ...]], inversion: tuple[int, ...]) -> frozenset[tuple[int, ...]]:
+    unseen = set(product(range(3), repeat=6))
+    pair: set[tuple[int, ...]] = set()
+    while unseen:
+        seed = min(unseen)
+        orbit = {act_col(perm, seed) for perm in proper_perms}
+        unseen -= orbit
+        image = act_col(inversion, next(iter(orbit)))
+        if image not in orbit:
+            pair |= orbit
+    return frozenset(pair)
+
+
+def completions(
+    sigma: tuple[int, ...],
+    bit: int,
+    pair: frozenset[tuple[int, ...]],
+) -> tuple[tuple[int, ...], ...]:
+    named = unique_full_axis(sigma)
+    if named is None:
+        return ()
+    plus, minus = AXES[named]
+    plus_letter, minus_letter = axis_letters(bit)
+    matches = [
+        item
+        for item in pair
+        if support(item) == sigma
+        and item[plus] == plus_letter
+        and item[minus] == minus_letter
+    ]
+    return tuple(sorted(matches))
+
+
+def leftover_frame_positive(
+    sigma: tuple[int, ...],
+    bit: int,
+    pair: frozenset[tuple[int, ...]],
+) -> tuple[int, ...] | None:
+    found = completions(sigma, bit, pair)
+    positive = [item for item in found if leftover_frame_sign(item) == 1]
+    if not positive:
+        return None
+    return positive[0]
+
+
+def occupancy_lock_content_bit(
+    sigma: tuple[int, ...],
+    pair: frozenset[tuple[int, ...]],
+) -> bool:
+    if unique_full_axis(sigma) is None:
+        return False
+    return any(leftover_frame_positive(sigma, bit, pair) is not None for bit in (0, 1))
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        if condition:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if condition else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+
+    print("external_scientific_inputs: none; occupancy alphabet, n=d/3, leftover-frame-positive f displayed")
+    print("package_local_integrity_reads: runner source, proposed source note, live axiom memo")
+    print("measure_boundary: exact Fraction and exact pair section on the 64 occupancy tuples; no spatial patch")
+    print("negative_scope: occupancy n≠0 is automatically achiral; lock-content f is not")
+
+    stars = list(product(OCCUPANCY_ALPHABET, repeat=6))
+    records = signed_permutation_records()
+    proper = [record for record in records if record["det"] == 1]
+    p_perm = dperm(inversion_matrix())
+    proper_perms = [record["perm"] for record in proper]
+    pair = july3_k3_pair(proper_perms, p_perm)
+
+    checks.check("alphabet-two-letter", "occupancy alphabet is {0,1}", OCCUPANCY_ALPHABET == (0, 1))
+    checks.check("star-cardinality", "six-neighbor occupancy star has 64 tuples", len(stars) == 64)
+    checks.check("cubic-group-size", "full signed-permutation group has 48 elements", len(records) == 48)
+    checks.check("proper-group-size", "proper cubic rotations number 24", len(proper) == 24)
+
+    empty = (0, 0, 0, 0, 0, 0)
+    full = (1, 1, 1, 1, 1, 1)
+    axis_plus = (1, 0, 0, 0, 0, 0)
+    zero_n = (Fraction(0), Fraction(0), Fraction(0))
+
+    checks.check("thm1-n-empty-zero", "n(empty) = 0", n_from_occupancy(empty) == zero_n)
+    checks.check("thm1-n-full-zero", "n(full) = 0", n_from_occupancy(full) == zero_n)
+    checks.check(
+        "thm1-n-axis-one-third",
+        "n(+x occupied) = (1/3, 0, 0)",
+        n_from_occupancy(axis_plus) == (Fraction(1, 3), Fraction(0), Fraction(0)),
+    )
+    checks.check(
+        "thm1-forms-is-n-nonzero",
+        "forms iff n ≠ 0 on the three witnesses",
+        (not forms(empty)) and (not forms(full)) and forms(axis_plus),
+    )
+
+    n_form = sum(1 for occupancy in stars if forms(occupancy))
+    n_p_form = sum(1 for occupancy in stars if forms(invert_tuple(p_perm, occupancy)))
+    n_both_form = sum(
+        1
+        for occupancy in stars
+        if forms(occupancy) and forms(invert_tuple(p_perm, occupancy))
+    )
+    checks.check("thm1-n-form", "N_form = 56", n_form == 56)
+    checks.check("thm1-n-p-form", "N_P_form = 56", n_p_form == 56)
+    checks.check("thm1-n-both", "N_both = 56", n_both_form == 56)
+
+    p_flips_n = all(
+        n_from_occupancy(invert_tuple(p_perm, occupancy))
+        == tuple(-component for component in n_from_occupancy(occupancy))
+        for occupancy in stars
+    )
+    form_p_invariant = all(
+        forms(occupancy) == forms(invert_tuple(p_perm, occupancy)) for occupancy in stars
+    )
+    checks.check("thm1-p-sends-n-to-minus-n", "n(P(c)) = -n(c) on all 64 tuples", p_flips_n)
+    checks.check("thm1-formation-set-p-invariant", "{c : n(c) ≠ 0} is P-invariant", form_p_invariant)
+
+    all_binary_p_related = True
+    for coloring in stars:
+        p_image = act_col(p_perm, coloring)
+        if not any(act_col(perm, coloring) == p_image for perm in proper_perms):
+            all_binary_p_related = False
+            break
+    checks.check(
+        "thm1-july3-t2-local",
+        "every 2-letter coloring is proper-equivalent to its P-image",
+        all_binary_p_related,
+    )
+
+    f_set = {occupancy for occupancy in stars if occupancy_lock_content_bit(occupancy, pair)}
+    n_f = len(f_set)
+    n_p_f = sum(1 for occupancy in stars if invert_tuple(p_perm, occupancy) in f_set)
+    n_both_f = sum(
+        1 for occupancy in stars if occupancy in f_set and invert_tuple(p_perm, occupancy) in f_set
+    )
+    f_p_invariant = all(
+        (occupancy in f_set) == (invert_tuple(p_perm, occupancy) in f_set) for occupancy in stars
+    )
+    f_p_odd_as_set = not f_p_invariant
+
+    checks.check("thm2-n-f", "N_f = 12", n_f == 12)
+    checks.check("thm2-n-p-f", "N_P_f = 12", n_p_f == 12)
+    checks.check("thm2-n-both", "N_both = 12", n_both_f == 12)
+    checks.check(
+        "thm2-occupancy-f-set-not-p-odd",
+        "{c : f(c)=1} is P-invariant, not P-odd",
+        f_p_invariant and (not f_p_odd_as_set) and n_f == n_p_f == n_both_f,
+    )
+    form_set = {occupancy for occupancy in stars if forms(occupancy)}
+    checks.check("thm2-f-is-not-n-nonzero", "lock-content f is not occupancy n≠0", f_set != form_set and n_f != n_form)
+    checks.check(
+        "thm2-f-set-has-unique-full-axis",
+        "every occupancy with f=1 has a unique full axis",
+        all(unique_full_axis(occupancy) is not None for occupancy in f_set),
+    )
+    checks.check("thm2-july3-pair-size", "July-3 chiral pair has 48 colorings", len(pair) == 48)
+
+    pos_content = [item for item in pair if leftover_frame_sign(item) == 1]
+    neg_content = [item for item in pair if leftover_frame_sign(item) == -1]
+    pos_set = set(pos_content)
+    p_of_pos = {invert_tuple(p_perm, item) for item in pos_content}
+    sign_flips = all(
+        leftover_frame_sign(invert_tuple(p_perm, item)) == -leftover_frame_sign(item) for item in pair
+    )
+    per_support = {}
+    for item in pos_content:
+        per_support.setdefault(support(item), []).append(item)
+
+    checks.check("thm2-content-positive-count", "leftover-frame-positive colorings number 24", len(pos_content) == 24)
+    checks.check("thm2-content-negative-count", "leftover-frame-negative colorings number 24", len(neg_content) == 24)
+    checks.check(
+        "thm2-content-p-odd",
+        "lock-content leftover-frame-positive set is disjoint from its P-image",
+        pos_set.isdisjoint(p_of_pos) and p_of_pos == set(neg_content),
+    )
+    checks.check("thm2-content-sign-flips", "leftover-frame sign is P-odd on the pair", sign_flips)
+    checks.check(
+        "thm2-uniqueness-not-required",
+        "each f=1 occupancy has two leftover-frame-positive completions",
+        all(len(items) == 2 for items in per_support.values()) and len(per_support) == 12,
+    )
+    checks.check(
+        "thm2-content-supports-are-f-set",
+        "occupancy supports of leftover-frame-positive colorings are exactly {c : f(c)=1}",
+        set(per_support) == f_set,
+    )
+
+    checks.check(
+        "thm3-occupancy-automatically-achiral",
+        "occupancy n≠0 is two-letter P-invariant, so July-3 theorem 2 applies",
+        form_p_invariant and all_binary_p_related and len(OCCUPANCY_ALPHABET) == 2,
+    )
+    checks.check(
+        "thm3-lock-content-not-automatically-achiral",
+        "lock-content f lives on the July-3 k=3 chiral pair and is P-odd",
+        sign_flips and pos_set.isdisjoint(p_of_pos) and len(pair) == 48,
+    )
+    checks.check(
+        "thm3-displayed-not-adopted",
+        "note reports the split as displayed, not adopted",
+        "Displayed, not adopted" in note
+        and "Do not write f or V" + "−A into Admissibility" in note
+        and "Do not attach L1" in note,
+    )
+
+    checks.check("claim-scope", "note reports the displayed claim_scope verbatim", CLAIM_SCOPE in note)
+    axiom_flat = " ".join(axiom.split())
+    checks.check(
+        "axiom-boundary",
+        "Admissibility is proper-covariant and does not supply formation",
+        "covariant under lattice translations and proper cubic rotations" in axiom_flat
+        and "it does not supply the formation site, probability, or rate." in axiom_flat
+        and "A readout value is determined by record content alone." in axiom_flat,
+    )
+    checks.check(
+        "audit-input-paths",
+        "AUDIT_INPUT_PATHS is the required string-literal tuple",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/LOCK_CONTENT_LEFTOVER_FRAME_P_ODD_VS_L1CHI_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and 'AUDIT_INPUT_PATHS = (\n    "docs/LOCK_CONTENT_LEFTOVER_FRAME_P_ODD_VS_L1CHI_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n)'
+        in self_source
+        and NOTE_PATH.is_file()
+        and AXIOM_PATH.is_file(),
+    )
+    script_lines = [line for line in self_source.splitlines() if "FORBIDDEN" not in line]
+    forbidden_hit = any(
+        token in note or any(token in line for line in script_lines) for token in FORBIDDEN
+    )
+    checks.check("forbidden-phrases-absent", "forbidden phrases are absent from note and runner", not forbidden_hit)
+    checks.check(
+        "no-new-spatial-patch",
+        "runner never steps occupancy on a new spatial patch",
+        "new spatial patch" in note
+        and "product(OCCUPANCY_ALPHABET, repeat=6)" in self_source
+        and "lattice_wide: checked and not executed" in self_source
+        and ("ba" + "ll(") not in self_source
+        and ("B_" + "3") not in self_source,
+    )
+    checks.check(
+        "no-orbit-dump",
+        "runner does not dump the proper-orbit census",
+        ("B_" + "57") not in self_source
+        and ("B_" + "57") not in note
+        and ("path " + "dump") not in self_source.lower(),
+    )
+    checks.check(
+        "claim-type-and-gate",
+        "bounded theorem type and a passing N1-N8 gate are source-visible",
+        "**Type:** bounded_theorem" in note
+        and all(f"### N{index}" in note for index in range(1, 9))
+        and "No-Go Discipline disposition: **PASS**" in note
+        and note.count("**ATTEMPTED**") == 6
+        and ("import " + "qcd") not in self_source.lower(),
+    )
+    checks.check(
+        "machine-status-contract",
+        "note carries the bounded-support status and no hypothetical axiom adoption",
+        'hypothetical_axiom_status: "not proposed; no axiom or approved primitive is added"'
+        in note
+        and "actual_current_surface_status: bounded-support" in note
+        and "next_trace_action:" in note,
+    )
+    checks.check(
+        "qubit-unchanged",
+        "Qubit remains M_2(C); no axiom edit",
+        "Qubit remains `M_2(C)`" in note and "No axiom edit" in note,
+    )
+    checks.check(
+        "mutation-occupancy-f-equals-forms-fails",
+        "predicate f-set == n≠0 fails",
+        f_set != form_set,
+    )
+    checks.check(
+        "mutation-occupancy-f-is-p-odd-fails",
+        "predicate occupancy {c : f(c)=1} is P-odd fails",
+        not f_p_odd_as_set,
+    )
+
+    print("per_element: checked exactly — each of the 64 occupancy tuples has n=d/3, forms iff n≠0, and a leftover-frame lock-content bit")
+    print("per_site: checked exactly — one six-neighbor star; no host rebuild and no occupancy step")
+    print("per_mode: checked exactly — two-letter occupancy n≠0 versus three-letter leftover-frame-positive f")
+    print("per_block: checked exactly — N_form=56/56/56 P-even; occupancy N_f=12/12/12; content f is P-odd")
+    print("lattice_wide: checked and not executed — no occupancy step on a new spatial patch")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the 64 occupancy 6-tuples, L1 n≠0 has N_form=N_P_form=N_both=56 (automatically achiral). Leftover-frame lock-content section f has N_f=12 and is not automatically achiral. Displayed, not adopted. Do not write f into Admissibility. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/lock_content_leftover_frame_p_odd_vs_l1chi_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.