### PR TITLE
feat(recperp): perpnn-tick axis is time; recint axis is null

### DIFF
--- a/docs/PERPNN_TICK_INTERVAL_VS_RECINT_FOUR_EVENTS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PERPNN_TICK_INTERVAL_VS_RECINT_FOUR_EVENTS_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,211 @@
+---
+claim_id: perpnn_tick_interval_vs_recint_four_events_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Interval s^2 under perpnn formation-ticks on four named recorded events, versus recint axis/body classes, is reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py
+---
+
+# Perpnn Formation-Tick Interval Versus Recint Classes On Four Events
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact display of `s^2=t^2-|x|_2^2` on one named recorded set of
+four events under displayed perpnn formation-ticks, and the axis versus body
+space/null/time class compared with the displayed recint classes. Displayed,
+not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py`](../scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py)
+
+## Result Up Front
+
+Let the recorded set be
+
+```text
+R = {(0,0,0), (1,0,0), (1,1,0), (1,1,1)}.
+```
+
+Current Record in
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+makes only records readable. The interval below is therefore evaluated only
+on `R`. Unread sites are not scored.
+
+The perpnn formation-ticks on these four events are displayed, not recomputed by path dump:
+
+```text
+t(0,0,0) = 0,
+t(1,0,0) = 3,
+t(1,1,0) = 2,
+t(1,1,1) = 3.
+```
+
+Spatial quadratic is the Euclidean square
+
+```text
+Q(x) = |x|_2^2.
+```
+
+This display does not attach L1. It is not a second occupancy lock-order
+table.
+
+The interval on events in `R` is
+
+```text
+s^2(x) = t(x)^2 - Q(x).
+```
+
+Sign class: space if `s^2<0`, null if `s^2=0`, time if `s^2>0`.
+
+On this named display the four values are
+
+| event | role | `t` | `Q` | `s^2` | class |
+|---|---|---:|---:|---:|---|
+| `(0,0,0)` | origin | `0` | `0` | `0` | null |
+| `(1,0,0)` | axis | `3` | `1` | `8` | time |
+| `(1,1,0)` | face | `2` | `2` | `2` | time |
+| `(1,1,1)` | body | `3` | `3` | `6` | time |
+
+The axis event is time. The body event is time.
+
+The displayed recint classes on the same four events are axis null and body
+time. Axis therefore disagrees with recint. Body agrees with recint. The
+axis/body class pair does not agree with recint. That comparison is reported.
+Displayed, not adopted. The note does not write a metric into Admissibility.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Q and s^2 are exact on the four named recorded events under displayed perpnn ticks; axis is time and body is time. Recint reports axis null and body time. Uniqueness of the ticks, a physical time metric, and adoption into Admissibility remain outside the claim."
+trace_class: upstream_support
+target_claim_id: physical_lorentzian_clock_map
+target_blocker_text: "construct a physical clock and interval on recorded events without writing a metric into Admissibility"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep the interval displayed on the recorded set with displayed perpnn formation-ticks and Euclidean square; do not attach L1, do not reprint occupancy lock-order, and do not recompute ticks by path dump."
+conditional_surface_status: "exact for the named four-event recorded set and named perpnn ticks versus displayed recint classes; not adopted as a metric or uniqueness theorem"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise Boundary
+
+The current Record axiom supplies formation, one locked admissible
+possibility per present record, content-only readout, and unreadability at
+absence. It does not supply a scalar collection functional, a uniqueness
+theorem for formation ticks, or a spacetime metric.
+
+The current Admissibility axiom supplies one fixed nearest-neighbor
+probability rule, covariant under lattice translations and proper cubic
+rotations. It does not define a time metric. This display therefore cannot
+be written into Admissibility.
+
+The four sites of `R` are ordinary points of `Z^3`. The integers `t` are
+named display data. They are not recomputed here by path dump.
+
+## Exact Objects
+
+Let `R` be as above. Let `t:R -> {0,2,3}` be the named map displayed in the
+result section. Define
+
+```text
+Q:R -> Z,     Q(x) = x_1^2 + x_2^2 + x_3^2,
+s^2:R -> Z,   s^2(x) = t(x)^2 - Q(x).
+```
+
+The axis event is `(1,0,0)`. The body event is `(1,1,1)`. The score domain is exactly `R`.
+
+The displayed recint classes used for comparison, and not recomputed here, are
+
+```text
+recint axis class = null,
+recint body class = time.
+```
+
+Those two labels are the comparison target. This note does not reprint the
+occupancy lock-order table that produced them.
+
+## Theorem 1 — Quadratic And Interval Under Perpnn Ticks
+
+Direct evaluation of `Q` from coordinates gives
+
+```text
+Q(0,0,0) = 0,
+Q(1,0,0) = 1,
+Q(1,1,0) = 2,
+Q(1,1,1) = 3.
+```
+
+With the named perpnn ticks,
+
+```text
+s^2(0,0,0) = 0^2 - 0 = 0,
+s^2(1,0,0) = 3^2 - 1 = 8,
+s^2(1,1,0) = 2^2 - 2 = 2,
+s^2(1,1,1) = 3^2 - 3 = 6.
+```
+
+Sign classes are therefore null, time, time, time.
+
+## Theorem 2 — Axis Versus Body Class
+
+The axis event `(1,0,0)` has `s^2=8>0`, hence time class.
+
+The body event `(1,1,1)` has `s^2=6>0`, hence time class.
+
+## Theorem 3 — Comparison With Recint Classes
+
+Recint reports axis null and body time.
+
+Time is not null, so the axis class under perpnn ticks disagrees with recint.
+
+Both reports assign time to the body event, so the body class agrees with
+recint.
+
+The axis/body class pair therefore does not agree with recint.
+
+The comparison is reported. It is displayed, not adopted. It does not select
+a physical metric, write an interval into Admissibility, claim uniqueness of
+the ticks, or reprint occupancy lock-order.
+
+## Mutations That Stay Outside The Claim
+
+On these four `{0,1}`-coordinate events the coordinate L1 length equals
+`Q`. That numerical coincidence is not a license to attach L1. The
+definition used here remains the Euclidean square.
+
+A different assignment of ticks on `R` can change classes. Replacing only
+`t(1,0,0)` by `1` makes the axis event null, matching the recint axis class.
+Uniqueness of the displayed ticks is not required and is not claimed.
+
+The four events are the whole score. No further site is scored.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance / status |
+|---|---|---|
+| Record unreadability at absence | score domain is `R` only | current axiom memo |
+| Admissibility does not define a time metric | forbids writing the display into Admissibility | current axiom memo |
+| `R` and named perpnn ticks | displayed recorded events and clock | named mathematical input |
+| recint axis null, body time | comparison labels | named displayed classes |
+| `Q=|x|_2^2` | spatial quadratic | declared Euclidean square |
+| `s^2=t^2-Q` | interval | declared combination on `R` |
+| space/null/time by sign of `s^2` | class labels | declared sign rule |
+
+There are no measured, fitted, literature, or observational inputs. No
+physical time metric is selected. No uniqueness theorem is claimed.
+
+## Primary Runner
+
+The paired runner computes `Q` and `s^2` from the named events and displayed
+perpnn ticks, classifies axis versus body, compares those classes with the
+displayed recint labels, checks that L1 is not attached, checks that a mutated
+tick can change the axis class, and pins the current Record/Admissibility
+boundary together with the displayed-not-adopted scope of the note.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13705,6 +13705,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "perpnn_tick_interval_vs_recint_four_events_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/perpnn_tick_interval_vs_recint_four_events_2026_08_15.txt
+++ b/logs/runner-cache/perpnn_tick_interval_vs_recint_four_events_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py
+runner_sha256: a32f47311d6d3904ce73d3c0c3de287a58ebd596256c9369fecaf6e21bf525f6
+input_fingerprint_sha256: 53b789672d0ac3fe389f29e0a277122582b250cc924394593be1968af7751d75
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+AUDIT_INPUT_PATHS:
+  docs/PERPNN_TICK_INTERVAL_VS_RECINT_FOUR_EVENTS_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+external_scientific_inputs: none; R and the named perpnn ticks are displayed mathematical inputs; recint axis/body classes are named displayed labels; Q is the Euclidean square
+score_domain: recorded set R only
+claim_scope: Interval s^2 under perpnn formation-ticks on four named recorded events, versus recint axis/body classes, is reported. Displayed, not adopted.
+PASS: audit-input-paths declared inputs are exactly the note and current axiom memo
+PASS: audit-timeout the declared audit timeout is 120 seconds
+PASS: current-record-readable only records are readable and readout is content-determined
+PASS: current-record-unreadability a site with no record cannot be read
+PASS: current-admissibility-no-time-metric Admissibility does not define a time metric
+event (0, 0, 0): t=0 Q=0 s^2=0 class=null
+event (1, 0, 0): t=3 Q=1 s^2=8 class=time
+event (1, 1, 0): t=2 Q=2 s^2=2 class=time
+event (1, 1, 1): t=3 Q=3 s^2=6 class=time
+PASS: recorded-set-four the score domain is exactly the four named recorded events
+PASS: displayed-perpnn-ticks perpnn ticks on R are the displayed values 0, 3, 2, 3
+PASS: theorem1-quadratic Q is the Euclidean square on each recorded event
+PASS: theorem1-interval s^2 equals t^2 minus Q on each recorded event
+PASS: theorem1-sign-classes sign of s^2 assigns null, time, time, time under perpnn ticks
+PASS: theorem2-axis-time the axis event (1,0,0) is time
+PASS: theorem2-body-time the body event (1,1,1) is time
+PASS: theorem3-recint-labels recint comparison labels are axis null and body time
+PASS: theorem3-axis-disagrees axis class under perpnn ticks disagrees with recint
+PASS: theorem3-body-agrees body class under perpnn ticks agrees with recint
+PASS: theorem3-pair-disagrees the axis/body class pair does not agree with recint
+PASS: l1-not-attached Q is the Euclidean square even though L1 coincides on this R
+PASS: not-occupancy-lock-order-table the note is not a second occupancy lock-order table
+PASS: uniqueness-not-required a mutated tick assignment can make the axis class match recint
+PASS: note-claim-scope the note reports the displayed interval versus recint classes
+PASS: note-contract machine fields, display scope, and hygiene hold
+PASS: note-runner-table the note table matches the computed four-event display
+per_element: Q and s^2 are evaluated on each of the four recorded events
+per_site: only the four named recorded events are scored
+per_mode: checked and not executed — no spectral object appears
+lattice_wide: checked and not executed — only R is scored
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py
+++ b/scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Exact display checks for s^2 under perpnn ticks versus recint classes.
+
+Clock is the displayed perpnn formation-tick map on the recorded set R.
+Spatial quadratic is the Euclidean square. Axis versus body class is compared
+with the displayed recint labels. Displayed, not adopted. No cache or
+governance surface is written.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/PERPNN_TICK_INTERVAL_VS_RECINT_FOUR_EVENTS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Site = tuple[int, int, int]
+
+RECORDED: tuple[Site, ...] = (
+    (0, 0, 0),
+    (1, 0, 0),
+    (1, 1, 0),
+    (1, 1, 1),
+)
+T_PERPNN: dict[Site, int] = {
+    (0, 0, 0): 0,
+    (1, 0, 0): 3,
+    (1, 1, 0): 2,
+    (1, 1, 1): 3,
+}
+AXIS: Site = (1, 0, 0)
+BODY: Site = (1, 1, 1)
+ORIGIN: Site = (0, 0, 0)
+FACE: Site = (1, 1, 0)
+RECINT_AXIS_CLASS = "null"
+RECINT_BODY_CLASS = "time"
+
+
+def quadratic(site: Site) -> int:
+    return site[0] * site[0] + site[1] * site[1] + site[2] * site[2]
+
+
+def interval(site: Site, ticks: dict[Site, int] = T_PERPNN) -> int:
+    tick = ticks[site]
+    return tick * tick - quadratic(site)
+
+
+def interval_class(value: int) -> str:
+    if value < 0:
+        return "space"
+    if value == 0:
+        return "null"
+    return "time"
+
+
+def l1_length(site: Site) -> int:
+    return abs(site[0]) + abs(site[1]) + abs(site[2])
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(
+        self,
+        label: str,
+        statement: str,
+        condition: bool,
+        residual: object | None = None,
+    ) -> None:
+        result = bool(condition)
+        self.passed += int(result)
+        self.failed += int(not result)
+        print(f"{'PASS' if result else 'FAIL'}: {label} {statement}")
+        if not result and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "external_scientific_inputs: none; R and the named perpnn ticks are "
+        "displayed mathematical inputs; recint axis/body classes are named "
+        "displayed labels; Q is the Euclidean square"
+    )
+    print("score_domain: recorded set R only")
+    print(
+        "claim_scope: Interval s^2 under perpnn formation-ticks on four named "
+        "recorded events, versus recint axis/body classes, is reported. "
+        "Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths",
+        "declared inputs are exactly the note and current axiom memo",
+        AUDIT_INPUT_PATHS
+        == (
+            "docs/PERPNN_TICK_INTERVAL_VS_RECINT_FOUR_EVENTS_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        )
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)),
+    )
+    checks.check(
+        "audit-timeout",
+        "the declared audit timeout is 120 seconds",
+        AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    checks.check(
+        "current-record-readable",
+        "only records are readable and readout is content-determined",
+        "Only records are readable." in axiom
+        and "A readout value is determined by record content alone." in axiom_flat,
+    )
+    checks.check(
+        "current-record-unreadability",
+        "a site with no record cannot be read",
+        "A site with no record cannot be read." in axiom,
+    )
+    checks.check(
+        "current-admissibility-no-time-metric",
+        "Admissibility does not define a time metric",
+        "define a time metric" in axiom_flat
+        and "It does not" in axiom,
+    )
+
+    values = {
+        site: {
+            "t": T_PERPNN[site],
+            "Q": quadratic(site),
+            "s2": interval(site),
+            "class": interval_class(interval(site)),
+        }
+        for site in RECORDED
+    }
+    for site in RECORDED:
+        row = values[site]
+        print(
+            f"event {site}: t={row['t']} Q={row['Q']} "
+            f"s^2={row['s2']} class={row['class']}"
+        )
+
+    checks.check(
+        "recorded-set-four",
+        "the score domain is exactly the four named recorded events",
+        RECORDED == ((0, 0, 0), (1, 0, 0), (1, 1, 0), (1, 1, 1))
+        and set(T_PERPNN) == set(RECORDED)
+        and len(RECORDED) == 4,
+    )
+    checks.check(
+        "displayed-perpnn-ticks",
+        "perpnn ticks on R are the displayed values 0, 3, 2, 3",
+        tuple(T_PERPNN[site] for site in RECORDED) == (0, 3, 2, 3)
+        and "not recomputed by path dump" in note_flat,
+        tuple(T_PERPNN[site] for site in RECORDED),
+    )
+    checks.check(
+        "theorem1-quadratic",
+        "Q is the Euclidean square on each recorded event",
+        values[ORIGIN]["Q"] == 0
+        and values[AXIS]["Q"] == 1
+        and values[FACE]["Q"] == 2
+        and values[BODY]["Q"] == 3
+        and all(values[site]["Q"] == quadratic(site) for site in RECORDED),
+        {site: values[site]["Q"] for site in RECORDED},
+    )
+    checks.check(
+        "theorem1-interval",
+        "s^2 equals t^2 minus Q on each recorded event",
+        values[ORIGIN]["s2"] == 0
+        and values[AXIS]["s2"] == 8
+        and values[FACE]["s2"] == 2
+        and values[BODY]["s2"] == 6
+        and all(
+            values[site]["s2"] == values[site]["t"] * values[site]["t"] - values[site]["Q"]
+            for site in RECORDED
+        ),
+        {site: values[site]["s2"] for site in RECORDED},
+    )
+    origin_class = values[ORIGIN]["class"]
+    axis_class = values[AXIS]["class"]
+    face_class = values[FACE]["class"]
+    body_class = values[BODY]["class"]
+    checks.check(
+        "theorem1-sign-classes",
+        "sign of s^2 assigns null, time, time, time under perpnn ticks",
+        origin_class == "null"
+        and axis_class == "time"
+        and face_class == "time"
+        and body_class == "time"
+        and values[ORIGIN]["s2"] == 0
+        and values[AXIS]["s2"] > 0
+        and values[FACE]["s2"] > 0
+        and values[BODY]["s2"] > 0,
+        {site: (values[site]["s2"], values[site]["class"]) for site in RECORDED},
+    )
+    checks.check(
+        "theorem2-axis-time",
+        "the axis event (1,0,0) is time",
+        AXIS == (1, 0, 0) and axis_class == "time" and values[AXIS]["s2"] == 8,
+        (values[AXIS]["s2"], axis_class),
+    )
+    checks.check(
+        "theorem2-body-time",
+        "the body event (1,1,1) is time",
+        BODY == (1, 1, 1) and body_class == "time" and values[BODY]["s2"] == 6,
+        (values[BODY]["s2"], body_class),
+    )
+    checks.check(
+        "theorem3-recint-labels",
+        "recint comparison labels are axis null and body time",
+        RECINT_AXIS_CLASS == "null"
+        and RECINT_BODY_CLASS == "time"
+        and "recint axis class = null" in note
+        and "recint body class = time" in note,
+    )
+    checks.check(
+        "theorem3-axis-disagrees",
+        "axis class under perpnn ticks disagrees with recint",
+        axis_class != RECINT_AXIS_CLASS
+        and axis_class == "time"
+        and RECINT_AXIS_CLASS == "null",
+        (axis_class, RECINT_AXIS_CLASS),
+    )
+    checks.check(
+        "theorem3-body-agrees",
+        "body class under perpnn ticks agrees with recint",
+        body_class == RECINT_BODY_CLASS == "time",
+        (body_class, RECINT_BODY_CLASS),
+    )
+    checks.check(
+        "theorem3-pair-disagrees",
+        "the axis/body class pair does not agree with recint",
+        (axis_class, body_class) != (RECINT_AXIS_CLASS, RECINT_BODY_CLASS),
+        ((axis_class, body_class), (RECINT_AXIS_CLASS, RECINT_BODY_CLASS)),
+    )
+
+    checks.check(
+        "l1-not-attached",
+        "Q is the Euclidean square even though L1 coincides on this R",
+        all(l1_length(site) == quadratic(site) for site in RECORDED)
+        and "This display does not attach L1." in note
+        and "Q(x) = |x|_2^2" in note,
+    )
+    checks.check(
+        "not-occupancy-lock-order-table",
+        "the note is not a second occupancy lock-order table",
+        "not a second occupancy lock-order table" in note_flat
+        and "does not reprint the occupancy lock-order table" in note_flat,
+    )
+
+    mutated_ticks = dict(T_PERPNN)
+    mutated_ticks[AXIS] = 1
+    mutated_axis = interval_class(interval(AXIS, mutated_ticks))
+    mutated_body = interval_class(interval(BODY, mutated_ticks))
+    checks.check(
+        "uniqueness-not-required",
+        "a mutated tick assignment can make the axis class match recint",
+        mutated_axis == RECINT_AXIS_CLASS == "null"
+        and mutated_body == body_class == "time"
+        and axis_class != RECINT_AXIS_CLASS
+        and "Uniqueness of the displayed ticks is not required" in note_flat,
+        (mutated_axis, mutated_body),
+    )
+
+    required = (
+        "**Type:** bounded_theorem",
+        "actual_current_surface_status: bounded-support",
+        "hypothetical_axiom_status: no edit",
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "Displayed, not adopted.",
+        "The note does not write a metric into Admissibility.",
+        "This display does not attach L1.",
+        "not recomputed by path dump",
+        "score domain is exactly `R`",
+    )
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "Dijkstra",
+        "B_57",
+        "runner-cache",
+    )
+    checks.check(
+        "note-claim-scope",
+        "the note reports the displayed interval versus recint classes",
+        'claim_scope: "Interval s^2 under perpnn formation-ticks on four named recorded events, versus recint axis/body classes, is reported. Displayed, not adopted."'
+        in note,
+    )
+    checks.check(
+        "note-contract",
+        "machine fields, display scope, and hygiene hold",
+        all(phrase in note for phrase in required)
+        and all(phrase not in note for phrase in forbidden),
+        [phrase for phrase in required if phrase not in note]
+        + [phrase for phrase in forbidden if phrase in note],
+    )
+    table_needles = (
+        "`0` | `0` | `0` | null",
+        "`3` | `1` | `8` | time",
+        "`2` | `2` | `2` | time",
+        "`3` | `3` | `6` | time",
+    )
+    checks.check(
+        "note-runner-table",
+        "the note table matches the computed four-event display",
+        all(needle in note for needle in table_needles)
+        and values[AXIS]["s2"] == T_PERPNN[AXIS] * T_PERPNN[AXIS] - quadratic(AXIS)
+        and values[BODY]["s2"] == T_PERPNN[BODY] * T_PERPNN[BODY] - quadratic(BODY),
+        [needle for needle in table_needles if needle not in note],
+    )
+
+    print("per_element: Q and s^2 are evaluated on each of the four recorded events")
+    print("per_site: only the four named recorded events are scored")
+    print("per_mode: checked and not executed — no spectral object appears")
+    print("lattice_wide: checked and not executed — only R is scored")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On recorded R={(0,0,0),(1,0,0),(1,1,0),(1,1,1)} with displayed perpnn ticks t=(0,3,2,3), s^2=t^2-Q is (0,8,2,6): axis time, body time. Recint reports axis null / body time. Axis disagrees; class pair disagrees. Displayed, not adopted.

## Runner

`scripts/perpnn_tick_interval_vs_recint_four_events_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.