### PR TITLE
feat(nnlock): incoming-lock letters: reverse and face hold on none

### DIFF
--- a/docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,328 @@
+---
+claim_id: perpnn_incoming_lock_letter_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face content-bits from perpnn earliest incoming locks on four probes are reported as all/some/none. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py
+---
+
+# Incoming-Lock Named Signs: Reverse And Face Hold Reports
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** named signs of earliest incoming locks on four probes inside
+`B_3(0)`, scored as reverse and face content-bits. The report is
+`hold-on-all` / `some` / `none`. Uniqueness is not required. Displayed, not
+adopted. This note does not write locks into Admissibility and does not treat
+the bits as a free lettering space.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py`](../scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, and the Record
+  sentences that records form and that a present record locks exactly one
+  admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named probes. Lock letters are unit nearest-neighbor steps. Named
+signs are `{+,−}` labels of those steps. They are not a new axiom alphabet.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite incoming-lock sets on four probes, named signs, and reverse/face hold-on-all/some/none reports; uniqueness is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: perpnn_incoming_lock_letter_reverse_face
+target_blocker_text: "display reverse and face as named-sign content-bits of earliest incoming locks without adopting them or requiring unique locks"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed as all/some/none; do not write locks into Admissibility and do not require unique incoming locks."
+conditional_surface_status: "exact on B_3(0) for named signs of earliest incoming locks on the four probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four probes are the only sites whose incoming
+locks are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+Lock alphabet: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the origin is recorded first with lock letter `+e_1`.
+
+From a recorded site `p` with lock `L(p)=±e_i`, a six-neighbor step `s in NN`
+to `q=p+s` is allowed if and only if `s` is perpendicular to `e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s` (the unit vector from `p` to `q`).
+If several allowed parents reach `q` at the same earliest formation, each such
+incoming step is kept as a possible lock. Uniqueness is not required. A later
+parent does not re-form `q`.
+
+Named sign of an incoming lock:
+
+```text
+sign(s) = +  if s in {+e_1,+e_2,+e_3},
+sign(s) = −  otherwise.
+```
+
+If a probe has several earliest incoming locks, reverse and face are evaluated
+on every combination of those earliest locks. The report is one of
+`hold-on-all`, `some`, or `none`. The bits are not scored from a clock
+parameter and are not scored on a free lettering space.
+
+Reverse and face (displayed, as in the four-site letter bits):
+
+```text
+reverse  <=>  L(A)=+ and L(B)=−
+face     <=>  L(C)=+ and L(D)=−
+```
+
+Admissibility is not edited. The process is a displayed Record-like lock on
+the six-letter step alphabet, then a named-sign readout of those letters.
+
+## Theorem 1 — earliest incoming locks at the four probes
+
+Direct enumeration of the displayed process on `B_3(0)` yields
+
+```text
+locks(A) = {+e_2,-e_2,+e_3,-e_3}
+locks(B) = {+e_1,+e_2,+e_3}
+locks(C) = {+e_1}
+locks(D) = {+e_1}
+```
+
+Witness parents (not claimed unique):
+
+- `A` is reached from `(1,1,0)` by `-e_2`, from `(1,-1,0)` by `+e_2`, from
+  `(1,0,1)` by `-e_3`, and from `(1,0,-1)` by `+e_3`.
+- `B` is reached from `(1,1,0)` by `+e_3`, from `(1,0,1)` by `+e_2`, and from
+  `(0,1,1)` by `+e_1`.
+- `C` is reached from `A` by `+e_1`. Every earliest lock at `A` is
+  perpendicular to `e_1`, so the incoming lock at `C` is `+e_1` in every
+  earliest case.
+- `D` is reached from `(0,1,0)` by `+e_1`.
+
+Named signs of those lock sets:
+
+```text
+sign(locks(A)) = {+,−}
+sign(locks(B)) = {+}
+sign(locks(C)) = {+}
+sign(locks(D)) = {+}
+```
+
+The cartesian product of earliest lock sets has
+
+```text
+|locks(A)| · |locks(B)| · |locks(C)| · |locks(D)| = 4 · 3 · 1 · 1 = 12
+```
+
+combinations. Incoming lock at `A` is not unique. Incoming lock at `B` is not
+unique. Uniqueness is not required.
+
+## Theorem 2 — reverse hold report
+
+Reverse is `L(A)=+` and `L(B)=−`. Every earliest lock at `B` lies in
+`{+e_1,+e_2,+e_3}`, so `L(B)=+` on every combination. The second conjunct
+never holds. Therefore reverse is true on `0` of the `12` combinations.
+
+Report: `none`.
+
+This is not `hold-on-all` and not `some`. Two of the four locks at `A` have
+named sign `+`, but reverse still fails because `B` never supplies `−`.
+
+## Theorem 3 — face hold report
+
+Face is `L(C)=+` and `L(D)=−`. The unique earliest lock at `C` is `+e_1`, so
+`L(C)=+` on every combination. The unique earliest lock at `D` is `+e_1`, so
+`L(D)=+` on every combination. The second conjunct never holds. Therefore
+face is true on `0` of the `12` combinations.
+
+Report: `none`.
+
+Displayed, not adopted. The bits are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not score reverse or face from a clock parameter.
+- It does not enumerate a free lettering space of the four probes.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four probes. It uses Record
+only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The lock alphabet, named signs, and reverse/face predicates
+are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; seed lock `+e_1` |
+| earliest incoming locks at `A,B,C,D` | Theorem 1 |
+| named signs `{+,−}` | declared from `{±e_i}` |
+| reverse and face on every earliest combination | Theorems 2–3; both `none` |
+| unique incoming lock | not required; `A` has four |
+| free lettering space of the four probes | not enumerated |
+| locks as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: named signs of earliest incoming locks, reverse/face as `hold-on-all` / `some` / `none`. |
+| V2 | Current main has no landed named-sign reverse/face hold report on these four probes. |
+| V3 | The lock sets, the twelve combinations, and the two hold reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads a displayed sign of incoming steps on named probes. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the named-sign bits do not force a unique
+incoming lock, do not write locks into Admissibility, and do not replace
+reverse/face by a clock comparison. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique incoming lock at `A` | require one lock | fails; four earliest incoming steps |
+| reverse as `L(A)=+` only | drop the `L(B)=−` conjunct | would be `some` (six of twelve), not `none` |
+| face as `L(C)=+` only | drop the `L(D)=−` conjunct | would be `hold-on-all`, not `none` |
+| free independent letters on the four probes | ignore the incoming-lock sets | different object; not this display |
+| clock comparison | score reverse/face from formation order | different display; not used here |
+| adopt locks into Admissibility | rewrite the local rule by `{+,−}` | refused; displayed, not adopted |
+| formation mask | let bits choose which sites form | not executed; probes are declared |
+
+### N2 — wall independence
+
+Missing physical adoption, missing unique-lock selector, and missing Record
+identification of the named bits are distinct open premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, seed lock `+e_1`, perpendicular step rule, incoming-step
+lock, named-sign map, four probes, and reverse/face definitions are declared.
+No uniqueness and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, content-conditional-on-formation,
+and unreadable absence. The residual that formation site, probability, and
+rate remain unsupplied is unchanged. The hold reports do not close that
+residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each earliest incoming step and its named sign | no continuum alphabet |
+| per site | `A,B,C,D` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | twelve combinations and two hold reports | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later unique-lock selector, a separate formation-rate
+rule, and a Record content map for reverse/face. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Earliest incoming locks on four formed probes should pick one
+reverse letter and one face letter, and those bits should be adopted as
+Admissibility content.
+
+**Answer:** `A` has four earliest incoming locks and `B` has three, so the
+display is a combination report, not a unique lettering. Reverse needs
+`L(B)=−`, which never occurs among earliest locks at `B`. Face needs
+`L(D)=−`, which never occurs. The bits remain displayed. Uniqueness is not
+required.
+
+### N8 — cross-cycle echo
+
+A prior formation-order display scored reverse and face as tick comparisons
+on the same four probes. This note does not reuse that scoring: it reads
+named signs of incoming locks and reports `none` / `none`. The two displays
+are distinct objects.
+
+**Gate disposition:** PASS for the incoming-lock named-sign reverse/face hold
+reports above. FAIL / DO NOT SHIP for “the incoming lock is unique,” “letters
+are Admissibility,” or “reverse/face holds on all combinations.”
+
+## Primary runner
+
+The paired runner builds `B_3(0)`, runs the perp-step incoming-lock process
+from the seed, lists earliest incoming locks at the four probes, maps them to
+named signs, evaluates reverse and face on every earliest combination, and
+checks Theorems 1--3. It also checks that dropping the `L(B)=−` conjunct
+changes reverse from `none` to `some`, that uniqueness is not required at
+`A`, and that a free lettering space is not enumerated. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13705,6 +13705,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "perpnn_incoming_lock_letter_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/perpnn_incoming_lock_letter_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/perpnn_incoming_lock_letter_reverse_face_2026_08_15.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py
+runner_sha256: 4a6be3f0bad27cf8dbadb57d8dae3efea58aca95adf2307ef9cb1f19d7fba60d
+input_fingerprint_sha256: b60bdb2304832ad105c734727a36999ae1ea13f024446f4f312a7551020654ab
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+incoming-lock named-sign reverse/face on B_3(0)
+AUDIT_INPUT_PATHS:
+  docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face content-bits from perpnn earliest incoming locks on four probes are reported as all/some/none. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-probes-in-host
+locks(A)=[(0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0)]
+locks(B)=[(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+locks(C)=[(1, 0, 0)]
+locks(D)=[(1, 0, 0)]
+PASS: theorem1-locks-A  ([(0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0)])
+PASS: theorem1-locks-B  ([(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+PASS: theorem1-locks-C  ([(1, 0, 0)])
+PASS: theorem1-locks-D  ([(1, 0, 0)])
+PASS: theorem1-uniqueness-not-required  (A=4 B=3)
+PASS: named-sign-definition
+PASS: named-sign-sets
+n_combos=12 reverse_hits=0 face_hits=0
+reverse=none face=none
+PASS: combinations-are-earliest-product  (12)
+PASS: theorem2-reverse-none  (none)
+PASS: theorem3-face-none  (none)
+PASS: mutation-drop-b-minus-is-some  (6)
+PASS: mutation-drop-d-minus-is-hold-on-all  (12)
+PASS: seed-origin-lock-plus-e1
+PASS: formation-stays-in-host
+PASS: note-claim-scope
+PASS: note-reports-lock-sets
+PASS: note-reports-none-none
+PASS: note-displayed-not-adopted
+PASS: note-no-clock-scoring
+PASS: note-not-free-lettering-space
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+TOTAL: PASS=33 FAIL=0
+
+----- stderr -----
+

--- a/scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py
+++ b/scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Named-sign reverse/face hold reports from perp-step incoming locks.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed lock at
+the origin is +e_1. A 6-NN step is allowed iff it is perpendicular to the
+parent lock axis. Newly formed sites lock the incoming step. Uniqueness is
+not required: reverse and face are scored on every earliest combination.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+PLUS_LOCKS = frozenset({E1, E2, E3})
+BALL_SQ = 9
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "L1",
+    "16-letter",
+    "16 letterings",
+    "hop-cost",
+    "B_57",
+    "Runner cache",
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    return "+" if lock in PLUS_LOCKS else "-"
+
+
+def hold_report(n_true: int, n_total: int) -> str:
+    if n_total == 0 or n_true == 0:
+        return "none"
+    if n_true == n_total:
+        return "hold-on-all"
+    return "some"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seed_lock: Point = E1,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation order and possible incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {ORIGIN: 0}
+    locks: dict[Point, set[Point]] = {ORIGIN: {seed_lock}}
+    queue: deque[tuple[Point, int]] = deque([(ORIGIN, 0)])
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("incoming-lock named-sign reverse/face on B_3(0)")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "claim_scope: Reverse and face content-bits from perpnn earliest "
+        "incoming locks on four probes are reported as all/some/none. "
+        "Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+
+    _ticks, locks = form()
+    lock_a = frozenset(locks.get(PROBES["A"], ()))
+    lock_b = frozenset(locks.get(PROBES["B"], ()))
+    lock_c = frozenset(locks.get(PROBES["C"], ()))
+    lock_d = frozenset(locks.get(PROBES["D"], ()))
+    expected_a = frozenset({E2, (0, -1, 0), E3, (0, 0, -1)})
+    expected_b = frozenset({E1, E2, E3})
+    expected_c = frozenset({E1})
+    expected_d = frozenset({E1})
+
+    print(f"locks(A)={sorted(lock_a)}")
+    print(f"locks(B)={sorted(lock_b)}")
+    print(f"locks(C)={sorted(lock_c)}")
+    print(f"locks(D)={sorted(lock_d)}")
+
+    checks.check("theorem1-locks-A", lock_a == expected_a, str(sorted(lock_a)))
+    checks.check("theorem1-locks-B", lock_b == expected_b, str(sorted(lock_b)))
+    checks.check("theorem1-locks-C", lock_c == expected_c, str(sorted(lock_c)))
+    checks.check("theorem1-locks-D", lock_d == expected_d, str(sorted(lock_d)))
+    checks.check(
+        "theorem1-uniqueness-not-required",
+        len(lock_a) == 4 and len(lock_b) == 3,
+        f"A={len(lock_a)} B={len(lock_b)}",
+    )
+    checks.check(
+        "named-sign-definition",
+        named_sign(E1) == named_sign(E2) == named_sign(E3) == "+"
+        and named_sign((-1, 0, 0))
+        == named_sign((0, -1, 0))
+        == named_sign((0, 0, -1))
+        == "-",
+    )
+    checks.check(
+        "named-sign-sets",
+        {named_sign(lock) for lock in lock_a} == {"+", "-"}
+        and {named_sign(lock) for lock in lock_b} == {"+"}
+        and {named_sign(lock) for lock in lock_c} == {"+"}
+        and {named_sign(lock) for lock in lock_d} == {"+"},
+    )
+
+    combos = tuple(product(sorted(lock_a), sorted(lock_b), sorted(lock_c), sorted(lock_d)))
+    n_combos = len(combos)
+    reverse_hits = 0
+    face_hits = 0
+    for lock_tuple in combos:
+        signs = tuple(named_sign(lock) for lock in lock_tuple)
+        reverse_hits += int(signs[0] == "+" and signs[1] == "-")
+        face_hits += int(signs[2] == "+" and signs[3] == "-")
+    reverse_status = hold_report(reverse_hits, n_combos)
+    face_status = hold_report(face_hits, n_combos)
+    drop_b_hits = sum(1 for lock_tuple in combos if named_sign(lock_tuple[0]) == "+")
+    drop_d_hits = sum(1 for lock_tuple in combos if named_sign(lock_tuple[2]) == "+")
+
+    print(f"n_combos={n_combos} reverse_hits={reverse_hits} face_hits={face_hits}")
+    print(f"reverse={reverse_status} face={face_status}")
+
+    checks.check(
+        "combinations-are-earliest-product",
+        n_combos == 12 == len(lock_a) * len(lock_b) * len(lock_c) * len(lock_d)
+        and n_combos != 2**4,
+        str(n_combos),
+    )
+    checks.check(
+        "theorem2-reverse-none",
+        reverse_status == "none" and reverse_hits == 0,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-none",
+        face_status == "none" and face_hits == 0,
+        face_status,
+    )
+    checks.check(
+        "mutation-drop-b-minus-is-some",
+        hold_report(drop_b_hits, n_combos) == "some" and drop_b_hits == 6,
+        str(drop_b_hits),
+    )
+    checks.check(
+        "mutation-drop-d-minus-is-hold-on-all",
+        hold_report(drop_d_hits, n_combos) == "hold-on-all" and drop_d_hits == n_combos,
+        str(drop_d_hits),
+    )
+    checks.check(
+        "seed-origin-lock-plus-e1",
+        locks[ORIGIN] == {E1},
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(locks) <= host,
+    )
+
+    claim_scope = (
+        "Reverse and face content-bits from perpnn earliest incoming locks "
+        "on four probes are reported as all/some/none. Displayed, not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "note-reports-lock-sets",
+        "locks(A) = {+e_2,-e_2,+e_3,-e_3}" in note
+        and "locks(B) = {+e_1,+e_2,+e_3}" in note
+        and "locks(C) = {+e_1}" in note
+        and "locks(D) = {+e_1}" in note,
+    )
+    checks.check(
+        "note-reports-none-none",
+        "Report: `none`." in note
+        and note.count("Report: `none`.") == 2
+        and "hold-on-all" in note
+        and "some" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-no-clock-scoring",
+        "t(1,0,0)" not in note
+        and "3 t(" not in note
+        and "not scored from a clock parameter" in normalized_note,
+    )
+    checks.check(
+        "note-not-free-lettering-space",
+        "free lettering space" in note
+        and "16 letterings" not in note
+        and "16-letter" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/PERPNN_INCOMING_LOCK_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On the four probes under the perpnn incoming-lock process, earliest locks are non-unique at A and B. Named sign map: + iff lock in {+e1,+e2,+e3}. Reverse (L(A)=+ and L(B)=- ) holds on none of 12 combinations (L(B) always +). Face (L(C)=+ and L(D)=- ) holds on none of 12 (L(D) always +). Displayed, not adopted.

## Runner

`scripts/perpnn_incoming_lock_letter_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.