### PR TITLE
feat(parnn): parallel-step reverse and face are undefined

### DIFF
--- a/docs/PARALLEL_STEP_INCOMING_LOCK_FORMATION_B3_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PARALLEL_STEP_INCOMING_LOCK_FORMATION_B3_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,253 @@
+---
+claim_id: parallel_step_incoming_lock_formation_b3_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Parallel-step incoming-lock formation-tick reverse and face at k=1 on B_3(0) with seed lock +e_1 are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py
+---
+
+# Parallel-Step Incoming-Lock Formation On B_3(0)
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact formation-tick report for the displayed parallel-step
+incoming-lock process on the finite host `B_3(0)` with seed lock `+e_1`.
+Reverse and face are displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py`](../scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py)
+
+Do not attach L1. Do not write into Admissibility. Uniqueness is not required.
+
+## Result Up Front
+
+On the cubic lattice, let `B_3(0)` be the nearest-neighbor graph ball of
+radius `3` about the origin: the finite set of sites `x` with
+`|x_1|+|x_2|+|x_3| ≤ 3`. The lock alphabet is the six unit steps
+`{±e_1, ±e_2, ±e_3}`. Seed: the origin is recorded at tick `0` with lock
+letter `+e_1`.
+
+From a recorded site `p` with lock `L(p)=±e_i`, a 6-NN step `s` to `q=p+s`
+is allowed iff `s` is parallel to the current lock, that is `s=±e_i`
+(equivalently `s · e_i ≠ 0` and `s` is a unit NN step). If `q` lies in
+`B_3(0)`, is unformed, and the step is allowed, then `q` forms at `t(p)+1`
+and locks `s`. This is a displayed construction. It is not a Record-rate
+law and is not an Admissibility edit.
+
+The process fills only the seed-lock axis. Off-axis sites in `B_3(0)` remain
+unformed. Consequently the reverse and face predicates, which compare
+on-axis ticks to off-axis ticks, are undefined. That is the load-bearing
+content of the parallel constraint: without perpendicular allowed steps,
+those displays have no second operand.
+
+## Current Premise Boundary
+
+The Lattice and Admissibility premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Admissibility
+does not supply the formation site, probability, or rate.
+
+The current Record boundary is:
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The incoming-lock letter in this note is a displayed step tag on a forming
+site. It is not identified with a physical local possibility in `M_2(C)`,
+and it does not enlarge Record.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite B_3(0) enumeration of a displayed parallel-step incoming-lock process, with reverse and face reported as undefined."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed, not adopted. Do not attach L1. Do not write into Admissibility."
+conditional_surface_status: "exact on B_3(0) for the declared seed and parallel-step rule"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Objects
+
+Write `0=(0,0,0)`, `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`. The open
+six-neighbor set is `N(x)={x±e_1,x±e_2,x±e_3}`. The host is
+
+`B_3(0)={x in Z^3 : |x_1|+|x_2|+|x_3| ≤ 3}`.
+
+Seed: `t(0)=0` and `L(0)=+e_1`.
+
+Allowed-step rule, from recorded `p` with `L(p)=±e_i`: a unit NN step `s`
+is allowed iff `s` is parallel to the current lock, i.e. `s=±e_i`. If
+`q=p+s` is in `B_3(0)` and unformed, then `q` forms at `t(p)+1` and the
+incoming lock is `L(q)=s`. First write wins if several parents could name
+the same child. Uniqueness is not required.
+
+Probes: `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`. All four lie in
+`B_3(0)`. The symbol `t` means formation tick when defined.
+
+The tick-1 6-mask of the origin is the six-tuple of indicators, in the order
+`+e_1,-e_1,+e_2,-e_2,+e_3,-e_3`, that the corresponding neighbor forms at
+tick `1`.
+
+Reverse predicate: `3 t(A)^2 > t(B)^2`. Face predicate:
+`t(C)^2 > 2 t(D)^2`. Each is `hold`, `fail`, or `undefined`. A missing
+operand makes the predicate undefined. Displayed, not adopted.
+
+## Theorem 1 — Tick-1 6-Mask And Probe Ticks
+
+From the origin, the only allowed steps are `±e_1`. Both land in `B_3(0)`
+and are unformed. Therefore the tick-1 6-mask is
+
+`(1,1,0,0,0,0)`.
+
+The two formed neighbors are `A=(1,0,0)` with incoming lock `+e_1` and
+`(-1,0,0)` with incoming lock `-e_1`. So `t(A)=1`.
+
+Every later allowed step remains parallel to `e_1`. By induction the formed
+set is exactly the axial segment `{(n,0,0) : |n| ≤ 3}`, with `t(n,0,0)=|n|`
+and incoming lock `sign(n) e_1` for `n ≠ 0`. In particular `t(C)=t(2,0,0)=2`.
+
+`B=(1,1,1)` and `D=(1,1,0)` are in `B_3(0)` but not on that axis, so they
+never form: `t(B)` and `t(D)` are undefined.
+
+## Theorem 2 — Reverse Display
+
+The reverse predicate is `3 t(A)^2 > t(B)^2`. Here `t(A)=1` is defined and
+`t(B)` is undefined, so reverse is undefined. Displayed, not adopted.
+
+## Theorem 3 — Face Display
+
+The face predicate is `t(C)^2 > 2 t(D)^2`. Here `t(C)=2` is defined and
+`t(D)` is undefined, so face is undefined. Displayed, not adopted.
+
+These two undefined reports are the dual of a perpendicular-step process:
+if off-axis steps were allowed, `B` and `D` could receive ticks and the
+predicates would become boolean. The parallel constraint is therefore
+load-bearing for reverse and face at this seed. The predicates are not
+attached as L1 and are not written into Admissibility.
+
+## Closed Form On The Host
+
+The finite history is:
+
+| site | `t` | incoming lock |
+|---|---|---|
+| `(0,0,0)` | `0` | `+e_1` (seed) |
+| `(n,0,0)`, `n=1,2,3` | `n` | `+e_1` |
+| `(n,0,0)`, `n=-1,-2,-3` | `|n|` | `-e_1` |
+| every other site of `B_3(0)` | undefined | unformed |
+
+No two parents write the same child on this seed. That observation is
+incidental: uniqueness is not required.
+
+## Promotion Value Gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It reports the dual of a perpendicular-step display: allowed steps parallel to the current lock, and whether reverse/face are defined. |
+| V2 | Current main has no landed parallel-step incoming-lock formation-tick report on `B_3(0)` with this seed. |
+| V3 | The host is finite. The allowed-step rule and the four probes are exact. |
+| V4 | The report is more than a restatement of Admissibility because Admissibility does not supply a formation process. |
+| V5 | Reverse and face remain displayed, not adopted. No physical compiler is claimed. |
+
+## No-Go Discipline Gate
+
+The negative content is narrow: parallel-to-lock allowed steps do not form
+the off-axis probes, so reverse and face are undefined on this seed. No
+global compiler impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| parallel-step incoming lock | allow only `s=±e_i` from lock `±e_i` | executed; reverse and face undefined |
+| perpendicular-step dual | allow only `s · e_i = 0` | different displayed process; not executed here |
+| unrestricted 6-NN growth | ignore the lock axis | different process; would fill `B_3(0)` by graph radius |
+| same-sign only | allow `s=L(p)` but not `-L(p)` | still leaves `B` and `D` unformed; not the declared rule |
+| unbounded host | drop the `B_3(0)` cutoff | outside the declared host |
+| attach reverse/face | adopt the predicates as a law | refused; displayed, not adopted |
+
+### N2 — wall independence
+
+The missing off-axis ticks, the un-adopted reverse/face predicates, the
+lock-to-possibility identification, and a physical formation rate are
+distinct residuals. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, the lock alphabet, the seed lock `+e_1`, and the
+parallel-to-current-lock rule are declared. Reverse and face are not
+assumed to hold. Uniqueness is not assumed. Formation uses only the
+declared unit NN steps.
+
+### N4 — source residual matching
+
+The current axiom memo supplies the cubic nearest-neighbor substrate, the
+local-law condition sentence, and the Record lock/content/absence boundary
+used as host language. It does not supply the displayed step rule. The
+residual therefore matches current sources: formation site, probability, and
+rate remain outside Admissibility.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | tick-1 6-mask and four named probes | no exhaustive alphabet classification |
+| per site | incoming lock is the forming NN step | no `M_2(C)` identification |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | reverse and face as hold/fail/undefined | no adopted inequality |
+| lattice wide | checked and not executed | no unbounded-host theorem |
+
+### N6 — live partial-closure paths
+
+Live routes are a perpendicular-step dual on the same host, a separately
+derived formation law, a lock-to-possibility map, and any later decision to
+adopt or reject reverse/face. Those routes are not taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** If reverse and face are the intended k=1 displays, the
+parallel-step process should be judged as failing them.
+
+**Answer:** A predicate with a missing operand is undefined, not false. `B`
+and `D` never form, so the comparisons are not instantiated. Reporting
+`fail` would smuggle an implicit tick at unformed sites. The honest report
+is undefined, and that already shows the parallel constraint is
+load-bearing.
+
+### N8 — cross-cycle echo
+
+This note does not import a perpendicular-step theorem or an adopted
+reverse/face law. It reports one finite displayed process on `B_3(0)`.
+
+**Gate disposition:** PASS for the finite tick-1 6-mask, the four probe
+reports, and the undefined reverse/face displays above. FAIL / DO NOT SHIP
+for “reverse holds,” “face holds,” “attach L1,” or “Admissibility now
+includes this step rule.”
+
+## Primary Runner
+
+The primary runner enumerates `B_3(0)`, executes the parallel-step
+incoming-lock rule from the declared seed, prints the tick-1 6-mask, reports
+`t(A)`, `t(B)`, `t(C)`, `t(D)`, and evaluates reverse and face as
+hold/fail/undefined. It authors no audit verdict.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13641,6 +13641,10 @@
   "paper_outline_2026-04-12": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "parallel_step_incoming_lock_formation_b3_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "parity_operator_basis_dimension5_lv_no_go_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/parallel_step_incoming_lock_formation_b3_2026_08_15.txt
+++ b/logs/runner-cache/parallel_step_incoming_lock_formation_b3_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py
+runner_sha256: baeb7d7401ffa2e0caffd4fc3b33a011f1ffbfbf8a8d518a9432219ad0fcbf5b
+input_fingerprint_sha256: 56078a1dc961f9086f4682d1cec39d3296cd6f300b927230584686b7373ba83d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: current Lattice, Admissibility, and Record boundaries are source-bound; the parallel-step incoming-lock rule is a displayed construction
+integrity_reads: this runner, its note, and the current axiom memo; no other scientific inputs
+construction: B_3(0) host, seed origin lock +e_1, allowed 6-NN steps parallel to the current lock axis
+negative_scope: reverse and face are displayed, not adopted; uniqueness is not required; Admissibility is not edited
+theorem1_tick1_6mask: (1, 1, 0, 0, 0, 0) on NN order +e1,-e1,+e2,-e2,+e3,-e3
+theorem1_ticks: t(A)=1 t(B)=undefined t(C)=2 t(D)=undefined
+theorem2_reverse: undefined
+theorem3_face: undefined
+PASS: audit-inputs static literal AUDIT_INPUT_PATHS names the two declared files and both exist
+PASS: source-lattice current cubic nearest-neighbor wording is pinned
+PASS: source-admissibility-boundary Admissibility does not supply formation site, probability, or rate
+PASS: source-admissibility-wording current local-distribution wording is pinned
+PASS: source-record-boundary current lock, content-only readout, and unreadable absence are pinned
+PASS: host-ball B_3(0) is the NN graph ball of radius 3 and contains the four probes
+PASS: seed origin is recorded at tick 0 with lock +e_1
+PASS: lock-alphabet lock letters are exactly the six unit NN steps
+PASS: allowed-step-rule from lock ±e_i a unit NN step is allowed iff it is parallel to e_i
+PASS: tick1-6mask tick-1 6-mask of the origin is (1,1,0,0,0,0)
+PASS: tick-A t(A) is defined and equals 1
+PASS: tick-B t(B) is undefined
+PASS: tick-C t(C) is defined and equals 2
+PASS: tick-D t(D) is undefined
+PASS: incoming-lock-A A locks the incoming step +e_1
+PASS: incoming-lock-C C locks the incoming step +e_1
+PASS: reverse-undefined reverse 3 t(A)^2 > t(B)^2 is undefined
+PASS: face-undefined face t(C)^2 > 2 t(D)^2 is undefined
+PASS: axis-support every formed site lies on the seed-lock axis inside B_3(0)
+PASS: axis-ticks on-axis formation ticks equal |n| and off-axis ball sites remain unformed
+PASS: perp-load-bearing perpendicular NN steps from the origin stay unformed, so reverse/face have no off-axis ticks
+PASS: no-collision this seed writes each formed site once; uniqueness is not required of the rule
+PASS: ball-cutoff the would-be axial step to (4,0,0) is excluded by the B_3(0) host
+PASS: predicate-gating hold/fail require both ticks; a missing tick yields undefined rather than a boolean
+PASS: note-contract claim scope, display boundary, theorems, and forbidden-phrase hygiene hold
+PASS: claim-scope-field YAML claim_scope matches the declared display sentence
+PASS: no-admissibility-write the displayed step rule is not entered as an Admissibility edit
+per_element: tick-1 6-mask and the four named probes are enumerated
+per_site: incoming lock is the forming NN step on B_3(0)
+per_mode: checked and not executed — no spectral claim
+per_block: reverse and face predicates are evaluated as hold/fail/undefined
+lattice_wide: checked and not executed — no unbounded-host theorem
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py
+++ b/scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Parallel-step incoming-lock formation on B_3(0); reverse/face display."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+
+AUDIT_INPUT_PATHS = (
+    "docs/PARALLEL_STEP_INCOMING_LOCK_FORMATION_B3_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+LOCK_ALPHABET: frozenset[Point] = frozenset(NN)
+SEED_LOCK: Point = E1
+RADIUS = 3
+PROBE_A: Point = (1, 0, 0)
+PROBE_B: Point = (1, 1, 1)
+PROBE_C: Point = (2, 0, 0)
+PROBE_D: Point = (1, 1, 0)
+UNDEFINED = "undefined"
+
+CLAIM_SCOPE = (
+    "Parallel-step incoming-lock formation-tick reverse and face at k=1 "
+    "on B_3(0) with seed lock +e_1 are reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def taxicab(point: Point) -> int:
+    return abs(point[0]) + abs(point[1]) + abs(point[2])
+
+
+def in_ball(point: Point) -> bool:
+    return taxicab(point) <= RADIUS
+
+
+def ball_sites() -> frozenset[Point]:
+    sites: set[Point] = set()
+    for x in range(-RADIUS, RADIUS + 1):
+        for y in range(-RADIUS, RADIUS + 1):
+            for z in range(-RADIUS, RADIUS + 1):
+                point = (x, y, z)
+                if in_ball(point):
+                    sites.add(point)
+    return frozenset(sites)
+
+
+def axis_of(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def is_unit_nn(step: Point) -> bool:
+    return step in LOCK_ALPHABET
+
+
+def parallel_to_lock_axis(step: Point, lock: Point) -> bool:
+    """Allowed iff s = ±e_i when L(p) = ±e_i."""
+    if not is_unit_nn(step):
+        return False
+    return dot(step, axis_of(lock)) != 0
+
+
+def literal_audit_input_paths(source: str) -> tuple[str, ...] | None:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS" for target in node.targets):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Tuple):
+            return None
+        out: list[str] = []
+        for element in value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                return None
+            out.append(element.value)
+        return tuple(out)
+    return None
+
+
+def form_history() -> dict[Point, tuple[int, Point]]:
+    """Incoming-lock parallel-step formation. First write wins; uniqueness not required."""
+    formed: dict[Point, tuple[int, Point]] = {ORIGIN: (0, SEED_LOCK)}
+    frontier: list[Point] = [ORIGIN]
+    while frontier:
+        nxt: list[Point] = []
+        for parent in frontier:
+            tick, lock = formed[parent]
+            for step in NN:
+                if not parallel_to_lock_axis(step, lock):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child) or child in formed:
+                    continue
+                formed[child] = (tick + 1, step)
+                nxt.append(child)
+        frontier = nxt
+    return formed
+
+
+def tick_of(history: dict[Point, tuple[int, Point]], site: Point) -> int | str:
+    if site not in history:
+        return UNDEFINED
+    return history[site][0]
+
+
+def reverse_status(t_a: int | str, t_b: int | str) -> str:
+    if not isinstance(t_a, int) or not isinstance(t_b, int):
+        return UNDEFINED
+    return "hold" if 3 * t_a * t_a > t_b * t_b else "fail"
+
+
+def face_status(t_c: int | str, t_d: int | str) -> str:
+    if not isinstance(t_c, int) or not isinstance(t_d, int):
+        return UNDEFINED
+    return "hold" if t_c * t_c > 2 * t_d * t_d else "fail"
+
+
+def tick1_six_mask(history: dict[Point, tuple[int, Point]]) -> tuple[int, ...]:
+    mask: list[int] = []
+    for step in NN:
+        neighbor = add(ORIGIN, step)
+        formed_at_one = neighbor in history and history[neighbor][0] == 1
+        mask.append(int(formed_at_one))
+    return tuple(mask)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool, residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    source = Path(__file__).read_text(encoding="utf-8")
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    history = form_history()
+    t_a = tick_of(history, PROBE_A)
+    t_b = tick_of(history, PROBE_B)
+    t_c = tick_of(history, PROBE_C)
+    t_d = tick_of(history, PROBE_D)
+    mask = tick1_six_mask(history)
+    reverse = reverse_status(t_a, t_b)
+    face = face_status(t_c, t_d)
+    sites = ball_sites()
+
+    print("external_scientific_inputs: current Lattice, Admissibility, and Record boundaries are source-bound; the parallel-step incoming-lock rule is a displayed construction")
+    print("integrity_reads: this runner, its note, and the current axiom memo; no other scientific inputs")
+    print("construction: B_3(0) host, seed origin lock +e_1, allowed 6-NN steps parallel to the current lock axis")
+    print("negative_scope: reverse and face are displayed, not adopted; uniqueness is not required; Admissibility is not edited")
+    print(f"theorem1_tick1_6mask: {mask} on NN order +e1,-e1,+e2,-e2,+e3,-e3")
+    print(f"theorem1_ticks: t(A)={t_a} t(B)={t_b} t(C)={t_c} t(D)={t_d}")
+    print(f"theorem2_reverse: {reverse}")
+    print(f"theorem3_face: {face}")
+
+    literal_paths = literal_audit_input_paths(source)
+    declared_paths = (
+        "docs/PARALLEL_STEP_INCOMING_LOCK_FORMATION_B3_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+        "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    )
+    checks.check(
+        "audit-inputs",
+        "static literal AUDIT_INPUT_PATHS names the two declared files and both exist",
+        AUDIT_INPUT_PATHS == declared_paths
+        and literal_paths == declared_paths
+        and AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+        residual=literal_paths,
+    )
+
+    lattice_sentence = "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    admissibility_sentence = "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_content = "A readout value is determined by record content alone."
+    record_absence = "A site with no record cannot be read."
+
+    checks.check("source-lattice", "current cubic nearest-neighbor wording is pinned", lattice_sentence in normalized_axiom and lattice_sentence in note)
+    checks.check("source-admissibility-boundary", "Admissibility does not supply formation site, probability, or rate", formation_boundary in normalized_axiom and formation_boundary in normalized_note)
+    checks.check("source-admissibility-wording", "current local-distribution wording is pinned", admissibility_sentence in normalized_axiom)
+    checks.check(
+        "source-record-boundary",
+        "current lock, content-only readout, and unreadable absence are pinned",
+        all(phrase in normalized_axiom for phrase in (record_lock, record_content, record_absence))
+        and all(phrase in note for phrase in (record_lock, record_content, record_absence)),
+    )
+
+    checks.check("host-ball", "B_3(0) is the NN graph ball of radius 3 and contains the four probes", ORIGIN in sites and {PROBE_A, PROBE_B, PROBE_C, PROBE_D}.issubset(sites) and (4, 0, 0) not in sites and len(sites) == 63)
+    checks.check("seed", "origin is recorded at tick 0 with lock +e_1", history[ORIGIN] == (0, E1))
+    checks.check("lock-alphabet", "lock letters are exactly the six unit NN steps", LOCK_ALPHABET == frozenset(NN) and all(taxicab(step) == 1 for step in NN))
+    checks.check(
+        "allowed-step-rule",
+        "from lock ±e_i a unit NN step is allowed iff it is parallel to e_i",
+        parallel_to_lock_axis(E1, E1)
+        and parallel_to_lock_axis((-1, 0, 0), E1)
+        and not parallel_to_lock_axis(E2, E1)
+        and not parallel_to_lock_axis(E3, E1)
+        and parallel_to_lock_axis((-1, 0, 0), (-1, 0, 0)),
+    )
+    checks.check("tick1-6mask", "tick-1 6-mask of the origin is (1,1,0,0,0,0)", mask == (1, 1, 0, 0, 0, 0), residual=mask)
+    checks.check("tick-A", "t(A) is defined and equals 1", t_a == 1)
+    checks.check("tick-B", "t(B) is undefined", t_b == UNDEFINED)
+    checks.check("tick-C", "t(C) is defined and equals 2", t_c == 2)
+    checks.check("tick-D", "t(D) is undefined", t_d == UNDEFINED)
+    checks.check("incoming-lock-A", "A locks the incoming step +e_1", history[PROBE_A][1] == E1)
+    checks.check("incoming-lock-C", "C locks the incoming step +e_1", history[PROBE_C][1] == E1)
+    checks.check("reverse-undefined", "reverse 3 t(A)^2 > t(B)^2 is undefined", reverse == UNDEFINED)
+    checks.check("face-undefined", "face t(C)^2 > 2 t(D)^2 is undefined", face == UNDEFINED)
+
+    formed_sites = frozenset(history)
+    axis_sites = frozenset((n, 0, 0) for n in range(-RADIUS, RADIUS + 1))
+    checks.check("axis-support", "every formed site lies on the seed-lock axis inside B_3(0)", formed_sites == axis_sites)
+    checks.check(
+        "axis-ticks",
+        "on-axis formation ticks equal |n| and off-axis ball sites remain unformed",
+        all(history[(n, 0, 0)][0] == abs(n) for n in range(-RADIUS, RADIUS + 1))
+        and PROBE_B not in history
+        and PROBE_D not in history
+        and all(point in history or point[1] != 0 or point[2] != 0 for point in sites),
+    )
+    checks.check(
+        "perp-load-bearing",
+        "perpendicular NN steps from the origin stay unformed, so reverse/face have no off-axis ticks",
+        add(ORIGIN, E2) not in history
+        and add(ORIGIN, E3) not in history
+        and reverse == UNDEFINED
+        and face == UNDEFINED,
+    )
+    checks.check(
+        "no-collision",
+        "this seed writes each formed site once; uniqueness is not required of the rule",
+        len(history) == 2 * RADIUS + 1
+        and all(history[site][1] in LOCK_ALPHABET for site in history),
+    )
+    checks.check(
+        "ball-cutoff",
+        "the would-be axial step to (4,0,0) is excluded by the B_3(0) host",
+        in_ball((3, 0, 0))
+        and not in_ball((4, 0, 0))
+        and (3, 0, 0) in history
+        and (4, 0, 0) not in history
+        and history[(3, 0, 0)][0] == 3,
+    )
+    checks.check(
+        "predicate-gating",
+        "hold/fail require both ticks; a missing tick yields undefined rather than a boolean",
+        reverse_status(1, 1) == "hold"
+        and reverse_status(1, 2) == "fail"
+        and face_status(3, 2) == "hold"
+        and face_status(2, 2) == "fail"
+        and reverse_status(1, UNDEFINED) == UNDEFINED
+        and face_status(2, UNDEFINED) == UNDEFINED,
+    )
+
+    required = (
+        CLAIM_SCOPE,
+        "Displayed, not adopted",
+        "Do not attach L1",
+        "Do not write into Admissibility",
+        "Uniqueness is not required",
+        "tick-1 6-mask",
+        "3 t(A)^2 > t(B)^2",
+        "t(C)^2 > 2 t(D)^2",
+        "undefined",
+        'hypothetical_axiom_status: "no edit"',
+        "authors no audit verdict",
+        "FAIL / DO NOT SHIP",
+        "parallel to the current lock",
+        "B_3(0)",
+        "seed lock +e_1",
+    )
+    forbidden = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "B_57",
+        "k20",
+        "Dijkstra",
+        "hop-cost table",
+        "new axiom",
+        "Block 12",
+        "trace_class: direct_blocker_closure",
+        "For any finite collection of pairwise-disjoint records",
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-contract",
+        "claim scope, display boundary, theorems, and forbidden-phrase hygiene hold",
+        CLAIM_SCOPE in note
+        and all(phrase in note for phrase in required)
+        and all(line in note for line in allowed_retained)
+        and all(f"### N{i}" in note for i in range(1, 9))
+        and not any(phrase in note for phrase in forbidden)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note
+        and "L1" in note
+        and "attach L1" in note,
+        residual=None,
+    )
+    checks.check(
+        "claim-scope-field",
+        "YAML claim_scope matches the declared display sentence",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note,
+    )
+    checks.check(
+        "no-admissibility-write",
+        "the displayed step rule is not entered as an Admissibility edit",
+        "Do not write into Admissibility" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "parallel-step incoming-lock" in normalized_note
+        and "displayed construction" in normalized_note,
+    )
+
+    print("per_element: tick-1 6-mask and the four named probes are enumerated")
+    print("per_site: incoming lock is the forming NN step on B_3(0)")
+    print("per_mode: checked and not executed — no spectral claim")
+    print("per_block: reverse and face predicates are evaluated as hold/fail/undefined")
+    print("lattice_wide: checked and not executed — no unbounded-host theorem")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Dual of perpnn: allowed steps are parallel to the current lock. Tick-1 mask is axial only. Body and face probes never form, so reverse and face are undefined. The perp constraint is load-bearing for those comparisons. Displayed, not adopted.

## Runner

`scripts/parallel_step_incoming_lock_formation_b3_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.