### PR TITLE
feat(qlet): PVM letters UNDEFINED; reverse and face UNDEFINED

### DIFF
--- a/docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,341 @@
+---
+claim_id: perpnn_pvm_letter_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from named rank-1 PVM letters on the four perpnn probes, or UNDEFINED if the process determines no such letter, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py
+---
+
+# Named Rank-1 PVM Letters On Four Perpnn Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** named rank-1 PVM letters in `{+,−}` on four probes of the
+displayed perpnn process, scored as reverse and face. If the process
+determines no such letter at a needed probe, the comparison is
+`UNDEFINED`. Uniqueness is not required. Displayed, not adopted. This note
+does not write PVM letters into Admissibility, does not feed letters into
+occupancy `n`, and does not attach the occupancy-kernel member.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py`](../scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named probes. Incoming lock letters are unit nearest-neighbor
+steps. Named rank-1 PVM letters are `{+,−}` names of the projectors `P_±`
+below. Those two alphabets are not identified.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report that the displayed perpnn process determines no named rank-1 PVM letter at the four probes, so reverse and face are UNDEFINED; uniqueness is not claimed and the letters are not adopted."
+trace_class: frontier_discovery
+target_claim_id: perpnn_pvm_letter_reverse_face
+target_blocker_text: "display reverse and face from named rank-1 PVM letters on the four perpnn probes, or UNDEFINED if the process determines no such letter"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed as UNDEFINED when no PVM letter is process-determined; do not write letters into Admissibility and do not identify them with incoming steps."
+conditional_surface_status: "exact on B_3(0) for named rank-1 PVM letters on the four probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four probes are the only sites whose PVM letters
+are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the origin is recorded first with lock letter `+e_1`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s` (the unit vector from `p` to `q`).
+If several allowed parents reach `q` at the same earliest formation, each such
+incoming step is kept as a possible lock. Uniqueness is not required. A later
+parent does not re-form `q`.
+
+That incoming lock is not occupancy `n` and is not a named rank-1 PVM letter.
+
+## Named rank-1 PVM letter
+
+The named construction, copied as displayed data from the formation PVM draw
+and from the two-cube occupancy-label display, is as follows.
+
+At an unread site with occupancy kernel `n ≠ 0`, write `k = |3n|^2` and
+`H = a σ_x + b σ_y + c σ_z`. The two legal lock contents are the rank-1
+projectors
+
+```text
+P_± = (√k I ± H) / (2√k).
+```
+
+The letter `+` names `P_+`. The letter `−` names `P_-`. Occupancy of a formed
+site remains `1` for either content, so the letter does not feed `n`.
+
+Those projectors live in the live Qubit presentation `M_2(C)`. They are not
+unit nearest-neighbor steps. This note does not attach the occupancy-kernel
+member as process law, does not run that occupancy step on the four probes,
+and does not feed any letter into `n`.
+
+A process-determined PVM letter at a probe is a value in `{+,−}` assigned by
+that named construction from the displayed perpnn process. Incoming
+`{±e_i}` tags are not that assignment. If the named construction assigns no
+PVM letter at a probe, the letter is `UNDEFINED`. If a probe has several
+process-determined letters, reverse and face are evaluated on every
+combination. Uniqueness is not required.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A)=+ and L(B)=−
+face     <=>  L(C)=+ and L(D)=−
+```
+
+If a letter needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. The report is one of `hold-on-all`, `some`, `none`, or
+`UNDEFINED`.
+
+Admissibility is not edited. PVM letters are not written into Admissibility.
+
+## Theorem 1 — process-determined PVM letter at each probe
+
+Direct enumeration of the displayed perpnn process on `B_3(0)` yields
+incoming locks in `NN` at every formed site, including the four probes.
+Those locks are unit steps. They are not the named projectors `P_±` and they
+are not the letters `{+,−}`.
+
+The named PVM construction assigns a letter only from occupancy-kernel `n`
+at an unread site. The displayed process does not compute that kernel and
+does not draw `P_±`. Identifying a named sign of an incoming step with a PVM
+letter is refused.
+
+Therefore no process-determined PVM letter exists at any of the four probes:
+
+```text
+L(A) = UNDEFINED
+L(B) = UNDEFINED
+L(C) = UNDEFINED
+L(D) = UNDEFINED
+```
+
+Incoming lock sets exist and need not be unique. That non-uniqueness is not
+a PVM lettering. Uniqueness is not required.
+
+## Theorem 2 — reverse report
+
+Reverse is `L(A)=+` and `L(B)=−`. Both `L(A)` and `L(B)` are `UNDEFINED`.
+The comparison is therefore `UNDEFINED`.
+
+Report: `UNDEFINED`.
+
+This is not `hold-on-all`, not `some`, and not `none`. A named-sign readout
+of incoming steps is a different object and is not used.
+
+## Theorem 3 — face report
+
+Face is `L(C)=+` and `L(D)=−`. Both `L(C)` and `L(D)` are `UNDEFINED`.
+The comparison is therefore `UNDEFINED`.
+
+Report: `UNDEFINED`.
+
+Displayed, not adopted. The letters are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify named rank-1 PVM letters with incoming `{±e_i}`.
+- It does not feed letters into occupancy `n`.
+- It does not attach the occupancy-kernel member.
+- It does not census free occupancy letterings of the four probes.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four probes. It uses Qubit
+only as the algebra in which the named projectors `P_±` are written. It uses
+Record only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The perpnn process, the named PVM letters, and the
+reverse/face predicates are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; seed lock `+e_1` |
+| named rank-1 PVM letters `{+,−}` from `P_±` | declared; not incoming tags |
+| process-determined letter at `A,B,C,D` | Theorem 1; all `UNDEFINED` |
+| reverse and face | Theorems 2–3; both `UNDEFINED` |
+| unique incoming lock | not required |
+| letters fed into occupancy `n` | not executed |
+| occupancy-kernel member attached | not attached |
+| free occupancy lettering of the four probes | not enumerated |
+| PVM letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: named rank-1 PVM letters on the four perpnn probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed PVM-letter reverse/face report on these four perpnn probes. |
+| V3 | Incoming locks, the named projectors, and the `UNDEFINED` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it asks whether a displayed projector letter is process-determined. |
+| V5 | It is not an adopted content rule: the letters remain displayed, and here they are `UNDEFINED`. |
+
+## No-go discipline gate
+
+The negative content is narrow: the displayed perpnn process does not assign
+the named rank-1 PVM letters, does not write those letters into Admissibility,
+and does not identify them with incoming steps. No global impossibility is
+claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| identify PVM letter with named sign of incoming `{±e_i}` | map `+e_i` to `+` and `-e_i` to `−` | refused; different alphabet |
+| reverse/face from incoming named signs | reuse the incoming-lock sign readout | different object; not this display |
+| free occupancy letters on the four probes | ignore the process and letter independently | different object; not enumerated |
+| attach occupancy-kernel member | form the probes by `n ≠ 0` and draw `P_±` | refused; not attached |
+| feed letters into `n` | let `+`/`−` change occupancy | refused; occupancy stays `{0,1}` of the locked set |
+| adopt letters into Admissibility | rewrite the local rule by `{+,−}` | refused; displayed, not adopted |
+| unique PVM letter required | demand one letter per probe | uniqueness is not required; here none is determined |
+
+### N2 — wall independence
+
+Missing physical adoption, missing occupancy-kernel attachment, and missing
+Record identification of the named PVM bits are distinct open premises. This
+note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, seed lock `+e_1`, perpendicular step rule, incoming-step
+lock, named `P_±` letters, four probes, and reverse/face definitions are
+declared. No uniqueness, no occupancy-kernel attachment, and no Admissibility
+rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`UNDEFINED` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each named projector `P_±` and each incoming step | no continuum alphabet |
+| per site | `A,B,C,D` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four `UNDEFINED` letters and two `UNDEFINED` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later occupancy-kernel attachment that actually draws
+`P_±`, a separate Record content map for reverse/face, and a formation-rate
+rule. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once the four probes form, each should carry a rank-1 PVM
+letter `+` or `−` from the named projectors, reverse and face should hold or
+fail as bits, and those bits should be adopted as Admissibility content.
+
+**Answer:** The displayed process locks incoming nearest-neighbor steps, not
+`P_±`. The named construction assigns letters from occupancy-kernel `n`,
+which this process does not compute. Incoming `{±e_i}` are not those letters.
+All four probes are `UNDEFINED`, so reverse and face are `UNDEFINED`. The
+bits remain displayed. Uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+A prior display scored reverse and face from named signs of incoming locks
+on the same four probes. This note does not reuse that scoring: it asks for
+named rank-1 PVM letters and reports `UNDEFINED` / `UNDEFINED`. The two
+displays are distinct objects.
+
+**Gate disposition:** PASS for the named rank-1 PVM-letter reverse/face
+reports above. FAIL / DO NOT SHIP for “the PVM letter equals the incoming
+step sign,” “letters are Admissibility,” or “reverse/face holds on all
+combinations.”
+
+## Primary runner
+
+The paired runner builds `B_3(0)`, runs the perp-step incoming-lock process
+from the seed, reconstructs the named rank-1 projectors `P_±` as displayed
+data, reads process-determined PVM letters at the four probes, and checks
+Theorems 1--3. It also checks that incoming steps are not PVM letters, that
+letters are not fed into occupancy `n`, and that occupancy-kernel attachment
+is not performed. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13705,6 +13705,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "perpnn_pvm_letter_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/perpnn_pvm_letter_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/perpnn_pvm_letter_reverse_face_2026_08_15.txt
@@ -1,0 +1,65 @@
+===== runner cache v1 =====
+runner: scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py
+runner_sha256: 83042c0bf55ab2e03f7a548f8d9c753e7f6af9ca6f50aaaac6633c6008553e66
+input_fingerprint_sha256: 6ffa471252b7223ff356e50aac72186cd0384817a8ddb192b0ef8aa6df27bad3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+named rank-1 PVM-letter reverse/face on four perpnn probes
+AUDIT_INPUT_PATHS:
+  docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from named rank-1 PVM letters on the four perpnn probes, or UNDEFINED if the process determines no such letter, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-probes-in-host
+PASS: id-add-dot-perp
+PASS: named-pvm-rank1-projectors
+PASS: named-pvm-traces-k1
+PASS: named-pvm-letters-are-plus-minus
+incoming(A)=[(0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0)]
+incoming(B)=[(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+incoming(C)=[(1, 0, 0)]
+incoming(D)=[(1, 0, 0)]
+L(A,B,C,D)=UNDEFINED,UNDEFINED,UNDEFINED,UNDEFINED
+PASS: incoming-locks-are-nn-steps
+PASS: incoming-locks-are-not-pvm-letters
+PASS: theorem1-A-undefined
+PASS: theorem1-B-undefined
+PASS: theorem1-C-undefined
+PASS: theorem1-D-undefined
+PASS: uniqueness-not-required  (incoming-A=4)
+reverse=UNDEFINED face=UNDEFINED
+PASS: theorem2-reverse-undefined  (UNDEFINED)
+PASS: theorem3-face-undefined  (UNDEFINED)
+PASS: not-free-occupancy-lettering-census
+PASS: letters-do-not-feed-occupancy
+PASS: mutation-identify-incoming-sign-is-refused
+PASS: seed-origin-lock-plus-e1
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-undefined-letters
+PASS: note-reports-undefined-undefined
+PASS: note-displayed-not-adopted
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-feed-n-or-attach-occupancy-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+TOTAL: PASS=39 FAIL=0
+
+----- stderr -----
+

--- a/scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py
+++ b/scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""Named rank-1 PVM-letter reverse/face on four perpnn probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed lock at
+the origin is +e_1. A 6-NN step is allowed iff it is perpendicular to the
+parent lock axis. Newly formed sites lock the incoming step. Named rank-1
+PVM letters are {+,−} names of P±, not incoming {±e_i} tags. If the process
+assigns no such letter, reverse and face are UNDEFINED.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from fractions import Fraction
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Mat = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+PVM_LETTERS = frozenset({"+", "-"})
+BALL_SQ = 9
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-letter",
+    "16 letterings",
+    "hop-cost",
+    "B_57",
+    "Runner cache",
+    "t(1,0,0)",
+    "t(1,1,1)",
+    "t(2,0,0)",
+    "t(1,1,0)",
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def madd(left: Mat, right: Mat) -> Mat:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def mmul(left: Mat, right: Mat) -> Mat:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def mscale(coeff: Fraction, mat: Mat) -> Mat:
+    return (
+        (coeff * mat[0][0], coeff * mat[0][1]),
+        (coeff * mat[1][0], coeff * mat[1][1]),
+    )
+
+
+def mtrace(mat: Mat) -> Fraction:
+    return mat[0][0] + mat[1][1]
+
+
+def I2() -> Mat:
+    zero, one = Fraction(0), Fraction(1)
+    return ((one, zero), (zero, one))
+
+
+def SX() -> Mat:
+    zero, one = Fraction(0), Fraction(1)
+    return ((zero, one), (one, zero))
+
+
+def pvm_probs(a: int, b: int, c: int) -> tuple[Fraction, Fraction]:
+    """Identity gate: Tr(ρ P±) for the named rank-1 projectors at k=1."""
+    if b != 0 or c != 0:
+        raise ValueError("named construction is displayed here at k=1, b=c=0")
+    hamiltonian = mscale(Fraction(a), SX())
+    half = Fraction(1, 2)
+    pplus = mscale(half, madd(I2(), hamiltonian))
+    pminus = mscale(half, madd(I2(), mscale(Fraction(-1), hamiltonian)))
+    rho = mscale(half, madd(I2(), mscale(Fraction(1, 3), hamiltonian)))
+    return mtrace(mmul(rho, pplus)), mtrace(mmul(rho, pminus))
+
+
+def pvm_projectors_k1(a: int) -> tuple[Mat, Mat]:
+    """Named rank-1 P± for H=a σx, k=1."""
+    hamiltonian = mscale(Fraction(a), SX())
+    half = Fraction(1, 2)
+    pplus = mscale(half, madd(I2(), hamiltonian))
+    pminus = mscale(half, madd(I2(), mscale(Fraction(-1), hamiltonian)))
+    return pplus, pminus
+
+
+def occupancy(site: Point, formed: frozenset[Point], letter: str | None = None) -> int:
+    """Occupancy is 1 on the formed set. A PVM letter does not feed n."""
+    if letter is not None and letter not in PVM_LETTERS:
+        raise ValueError(f"letter must be + or -, got {letter!r}")
+    return 1 if site in formed else 0
+
+
+def pvm_letters_from_process(incoming: set[object]) -> frozenset[str]:
+    """Process-determined named PVM letters.
+
+    Incoming perpnn locks are unit steps in NN. Named PVM letters are +/−.
+    This function does not identify a named sign of {±e_i} with a PVM letter.
+    """
+    letters: set[str] = set()
+    for lock in incoming:
+        if lock in PVM_LETTERS:
+            letters.add(str(lock))
+    return frozenset(letters)
+
+
+def letter_report(letters: frozenset[str]) -> str:
+    if not letters:
+        return "UNDEFINED"
+    if letters == PVM_LETTERS:
+        return "{+,−}"
+    only = next(iter(letters))
+    return only
+
+
+def hold_report(
+    n_true: int,
+    n_total: int,
+    *,
+    defined: bool,
+) -> str:
+    if not defined:
+        return "UNDEFINED"
+    if n_total == 0 or n_true == 0:
+        return "none"
+    if n_true == n_total:
+        return "hold-on-all"
+    return "some"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form_earliest(
+    seed_lock: Point = E1,
+    *,
+    require_perp: bool = True,
+) -> dict[Point, set[Point]]:
+    """Earliest incoming locks, uniqueness not required."""
+    order: dict[Point, int] = {ORIGIN: 0}
+    locks: dict[Point, set[Point]] = {ORIGIN: {seed_lock}}
+    queue: deque[tuple[Point, int]] = deque([(ORIGIN, 0)])
+    while queue:
+        parent, parent_order = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_order = parent_order + 1
+                if child not in order:
+                    order[child] = next_order
+                    locks[child] = {step}
+                    queue.append((child, next_order))
+                elif order[child] == next_order:
+                    locks[child].add(step)
+    return locks
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("named rank-1 PVM-letter reverse/face on four perpnn probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "claim_scope: Reverse and face from named rank-1 PVM letters on the "
+        "four perpnn probes, or UNDEFINED if the process determines no such "
+        "letter, are reported. Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+
+    pplus, pminus = pvm_projectors_k1(-1)
+    tp, tm = pvm_probs(-1, 0, 0)
+    checks.check(
+        "named-pvm-rank1-projectors",
+        mtrace(pplus) == 1
+        and mtrace(pminus) == 1
+        and pplus == mmul(pplus, pplus)
+        and pminus == mmul(pminus, pminus)
+        and mmul(pplus, pminus) == ((Fraction(0), Fraction(0)), (Fraction(0), Fraction(0))),
+    )
+    checks.check(
+        "named-pvm-traces-k1",
+        tp == Fraction(2, 3) and tm == Fraction(1, 3) and tp + tm == 1,
+    )
+    checks.check(
+        "named-pvm-letters-are-plus-minus",
+        PVM_LETTERS == frozenset({"+", "-"})
+        and E1 not in PVM_LETTERS
+        and E2 not in PVM_LETTERS,
+    )
+
+    locks = form_earliest()
+    lock_a = set(locks.get(PROBES["A"], ()))
+    lock_b = set(locks.get(PROBES["B"], ()))
+    lock_c = set(locks.get(PROBES["C"], ()))
+    lock_d = set(locks.get(PROBES["D"], ()))
+    letters_a = pvm_letters_from_process(lock_a)
+    letters_b = pvm_letters_from_process(lock_b)
+    letters_c = pvm_letters_from_process(lock_c)
+    letters_d = pvm_letters_from_process(lock_d)
+
+    print(f"incoming(A)={sorted(lock_a)}")
+    print(f"incoming(B)={sorted(lock_b)}")
+    print(f"incoming(C)={sorted(lock_c)}")
+    print(f"incoming(D)={sorted(lock_d)}")
+    print(
+        "L(A,B,C,D)="
+        f"{letter_report(letters_a)},{letter_report(letters_b)},"
+        f"{letter_report(letters_c)},{letter_report(letters_d)}"
+    )
+
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        lock_a <= set(NN)
+        and lock_b <= set(NN)
+        and lock_c <= set(NN)
+        and lock_d <= set(NN)
+        and len(lock_a) > 0
+        and len(lock_b) > 0
+        and len(lock_c) > 0
+        and len(lock_d) > 0,
+    )
+    checks.check(
+        "incoming-locks-are-not-pvm-letters",
+        not (lock_a & PVM_LETTERS)
+        and not (lock_b & PVM_LETTERS)
+        and not (lock_c & PVM_LETTERS)
+        and not (lock_d & PVM_LETTERS),
+    )
+    checks.check(
+        "theorem1-A-undefined",
+        letter_report(letters_a) == "UNDEFINED" and not letters_a,
+    )
+    checks.check(
+        "theorem1-B-undefined",
+        letter_report(letters_b) == "UNDEFINED" and not letters_b,
+    )
+    checks.check(
+        "theorem1-C-undefined",
+        letter_report(letters_c) == "UNDEFINED" and not letters_c,
+    )
+    checks.check(
+        "theorem1-D-undefined",
+        letter_report(letters_d) == "UNDEFINED" and not letters_d,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(lock_a) > 1,
+        f"incoming-A={len(lock_a)}",
+    )
+
+    defined_reverse = bool(letters_a) and bool(letters_b)
+    defined_face = bool(letters_c) and bool(letters_d)
+    combos = tuple(
+        product(
+            sorted(letters_a) or [None],
+            sorted(letters_b) or [None],
+            sorted(letters_c) or [None],
+            sorted(letters_d) or [None],
+        )
+    )
+    reverse_hits = 0
+    face_hits = 0
+    if defined_reverse or defined_face:
+        for combo in combos:
+            reverse_hits += int(combo[0] == "+" and combo[1] == "-")
+            face_hits += int(combo[2] == "+" and combo[3] == "-")
+    reverse_status = hold_report(
+        reverse_hits, len(combos), defined=defined_reverse
+    )
+    face_status = hold_report(face_hits, len(combos), defined=defined_face)
+
+    print(f"reverse={reverse_status} face={face_status}")
+
+    checks.check(
+        "theorem2-reverse-undefined",
+        reverse_status == "UNDEFINED" and not defined_reverse,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-undefined",
+        face_status == "UNDEFINED" and not defined_face,
+        face_status,
+    )
+    checks.check(
+        "not-free-occupancy-lettering-census",
+        not defined_reverse
+        and not defined_face
+        and 2**4 != 0
+        and "16 letterings" not in note
+        and "16-letter" not in note,
+    )
+    checks.check(
+        "letters-do-not-feed-occupancy",
+        occupancy(PROBES["A"], frozenset(locks), "+")
+        == occupancy(PROBES["A"], frozenset(locks), "-")
+        == occupancy(PROBES["A"], frozenset(locks), None)
+        == 1
+        and occupancy((3, 3, 3), frozenset(locks), "+") == 0,
+    )
+    checks.check(
+        "mutation-identify-incoming-sign-is-refused",
+        pvm_letters_from_process(lock_a) == frozenset()
+        and all(isinstance(lock, tuple) for lock in lock_a),
+    )
+    checks.check(
+        "seed-origin-lock-plus-e1",
+        locks[ORIGIN] == {E1},
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(locks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in locks),
+    )
+
+    claim_scope = (
+        "Reverse and face from named rank-1 PVM letters on the four "
+        "perpnn probes, or UNDEFINED if the process determines no such "
+        "letter, are reported. Displayed, not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "note-reports-undefined-letters",
+        "L(A) = UNDEFINED" in note
+        and "L(B) = UNDEFINED" in note
+        and "L(C) = UNDEFINED" in note
+        and "L(D) = UNDEFINED" in note,
+    )
+    checks.check(
+        "note-reports-undefined-undefined",
+        note.count("Report: `UNDEFINED`.") == 2
+        and "hold-on-all" in note
+        and "some" in note
+        and "none" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "Identifying a named sign of an incoming step with a PVM letter is refused."
+        in normalized_note,
+    )
+    checks.check(
+        "note-does-not-feed-n-or-attach-occupancy-member",
+        "does not feed `n`" in note
+        and "does not attach the occupancy-kernel member" in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/PERPNN_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def pvm_probs(" in source
+        and "def pvm_letters_from_process(" in source
+        and "def occupancy(" in source
+        and "def form_earliest(" in source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Named rank-1 PVM letters from formdraw/l1draw are not determined by the displayed perpnn process at A,B,C,D. Reverse and face are UNDEFINED. Not incoming-lock letters, not 16 free letterings. Displayed, not adopted.

## Runner

`scripts/perpnn_pvm_letter_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.