### PR TITLE
feat(nnseed): two-site seed: reverse and face hold

### DIFF
--- a/docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,230 @@
+---
+claim_id: perpnn_two_site_seed_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Perp-step incoming-lock formation-tick reverse and face at k=1 on B_3(0) with two-site seed {0,(0,1,0)} and locks +e_1/+e_2 are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py
+---
+
+# Perp-Step Two-Site Seed Reverse And Face On B_3(0)
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** displayed formation-tick reverse and face at `k=1` on the finite
+host `B_3(0)`, with lock alphabet `{±e_i}`, perp-step formation, incoming-step
+lock, and two-record seed `{0,(0,1,0)}` already formed at tick `0` with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`. Cardinality-of-seed, not a 1-site clone. Uniqueness is not required. The inequalities are
+displayed, not adopted. This note does not write into Admissibility and does
+not identify the tick with six-neighbor distance.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py`](../scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, and the Record
+  sentences that records form and that a present record locks exactly one
+  admissible local possibility.
+
+Everything after that quoted input is defined here as a finite displayed
+process on `B_3(0)`. The lock letters below are unit nearest-neighbor steps,
+not a new axiom alphabet.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite formation on B_3(0) reports the origin tick-1 6-mask and the k=1 reverse and face comparisons for a two-site seed; uniqueness is not claimed and the inequalities are not adopted."
+trace_class: upstream_support
+target_claim_id: two_site_seed_k1_reverse_face_display
+target_blocker_text: "display two-site-seed formation-tick reverse and face at k=1 without adopting a distance identification or an Admissibility edit"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep the inequalities displayed only; do not write them into Admissibility and do not require unique incoming locks."
+conditional_surface_status: "exact on B_3(0) for the declared perp-step incoming-lock process with two-site seed {0,(0,1,0)} and locks +e_1/+e_2"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used.
+
+Lock alphabet: `{±e_1, ±e_2, ±e_3}`.
+
+Seed at tick `0`: the origin is already recorded with lock letter `+e_1`, and
+`(0,1,0)` is already recorded with lock letter `+e_2`. Both sites are already
+formed. The pair is perp-consistent: the connecting step `+e_2` is
+perpendicular to the origin lock `+e_1`. This is a two-record set, not a
+1-site origin letter with a cloned second copy of the same lock.
+
+From a recorded site `p` with lock `L(p)=±e_i`, a six-neighbor step `s in NN`
+to `q=p+s` is allowed if and only if `s` is perpendicular to `e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms at tick `t(p)+1` and locks the incoming step `s` (the unit vector from
+`p` to `q`). If several allowed parents reach `q` at the same earliest tick,
+each such incoming step is recorded as a possible lock. Uniqueness is not
+required. A later parent does not re-form `q`. A seed site is already formed,
+so it is not re-formed.
+
+The tick `t` is this formation tick. Seed sites have `t=0`. The tick is not a
+weighted path table.
+
+Admissibility is not edited. The process is a displayed Record-like lock on
+the six-letter step alphabet, not a derivation of a physical rate.
+
+Probes stay on `x`: `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`.
+
+## Theorem 1 — origin tick-1 6-mask and probe ticks
+
+Order the six neighbors of the origin as
+
+```text
+(+e_1, -e_1, +e_2, -e_2, +e_3, -e_3).
+```
+
+The origin lock is `+e_1`, so the two axial steps `±e_1` are parallel to `e_1`
+and are not allowed from the origin. The four steps `±e_2, ±e_3` are
+perpendicular to `e_1` and land in `B_3(0)`. The neighbor `+e_2=(0,1,0)` is
+already a seed, so it is not formed at tick `1`. The remaining three
+perpendicular neighbors form at tick `1` from the origin and lock the
+incoming step:
+
+```text
+t(0,1,0)=0,  L includes +e_2  (seed),
+t(0,-1,0)=1, L includes -e_2,
+t(0,0,1)=1,  L includes +e_3,
+t(0,0,-1)=1, L includes -e_3.
+```
+
+The axial neighbors of the origin do not form at tick `1`:
+
+```text
+t(1,0,0) != 1,  t(-1,0,0) != 1.
+```
+
+The origin tick-1 6-mask is therefore
+
+```text
+tick-1 6-mask, order (+e_1,-e_1,+e_2,-e_2,+e_3,-e_3): (0,0,0,1,1,1).
+```
+
+This is not the four-site perpendicular mask of a 1-site origin seed, which
+would have bit `+e_2` set because `(0,1,0)` would then form at tick `1`.
+Cardinality-of-seed is load-bearing for the mask.
+
+The same process, grown from this two-site seed, gives defined probe ticks
+
+```text
+t(1,0,0)=2,
+t(1,1,1)=2,
+t(2,0,0)=3,
+t(1,1,0)=1.
+```
+
+Witness paths (not claimed unique):
+
+- Seed `(0,1,0) --+e_1--> (1,1,0)` at tick `1`, lock `+e_1`. Thus `t(D)=1`.
+- `(1,1,0) -- -e_2 --> (1,0,0)` at tick `2`, lock `-e_2`. Thus `t(A)=2`.
+- `(1,1,0) --+e_3--> (1,1,1)` at tick `2`, lock `+e_3`; also
+  seed-neighbor `(0,1,1)` (formed at tick `1` with lock `+e_3`) steps `+e_1`
+  into `(1,1,1)` at the same tick. Thus `t(B)=2` with at least two earliest
+  locks `{+e_1,+e_3}`.
+- `(1,0,0)` has earliest lock `-e_2`, which is perpendicular to `+e_1`, so
+  `(1,0,0) --+e_1--> (2,0,0)` at tick `3`, lock `+e_1`. Thus `t(C)=3`.
+
+Uniqueness is not required: `t(B)` is defined even though two earliest
+incoming locks occur.
+
+These values are not six-neighbor distances from a single origin: the
+six-neighbor distance of `(1,0,0)` from the origin is `1`, while `t(1,0,0)=2`.
+
+A 1-site origin seed with lock `+e_1` on the same host yields a different
+mask and different probe ticks. The two-site display is therefore not a
+1-site clone.
+
+## Theorem 2 — displayed k=1 reverse
+
+All four ticks in Theorem 1 are defined, so the `k=1` reverse comparison is
+defined. Direct integer arithmetic gives
+
+```text
+3 t(1,0,0)^2 = 3 * 4 = 12,
+t(1,1,1)^2 = 4,
+12 > 4.
+```
+
+Thus reverse holds:
+
+```text
+3 t(1,0,0)^2 > t(1,1,1)^2.
+```
+
+Status: hold.
+
+## Theorem 3 — displayed k=1 face
+
+The face comparison is likewise defined. Direct integer arithmetic gives
+
+```text
+t(2,0,0)^2 = 9,
+2 t(1,1,0)^2 = 2 * 1 = 2,
+9 > 2.
+```
+
+Thus face holds:
+
+```text
+t(2,0,0)^2 > 2 t(1,1,0)^2.
+```
+
+Status: hold.
+
+The reverse and face inequalities are displayed, not adopted. They are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify `t` with six-neighbor distance or with a weighted
+  path table.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not replace the two-site seed by a 1-site origin letter.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Primary runner
+
+The paired runner builds `B_3(0)`, seeds the two-record set `{0,(0,1,0)}` at
+tick `0` with locks `+e_1` and `+e_2`, runs the perp-step incoming-lock
+process, and checks Theorems 1--3 by direct enumeration. It also checks that
+the origin-only 1-site seed on the same host is a different mask and a
+different probe-tick tuple. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13705,6 +13705,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "perpnn_two_site_seed_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/perpnn_two_site_seed_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/perpnn_two_site_seed_reverse_face_2026_08_15.txt
@@ -1,0 +1,53 @@
+===== runner cache v1 =====
+runner: scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py
+runner_sha256: b49088c2587020b11850996665ce7b1c4d39d8a33a43666debdc198161fd3794
+input_fingerprint_sha256: 3f62c3b0f3a8e445a8bab9301dd7fe53d86433f34ca3da52cc88137bdd72d7d7
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+perp-step two-site seed reverse/face on B_3(0)
+AUDIT_INPUT_PATHS:
+  docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Perp-step incoming-lock formation-tick reverse and face at k=1 on B_3(0) with two-site seed {0,(0,1,0)} and locks +e_1/+e_2 are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: k1-probes-in-host
+PASS: two-site-seed-in-host
+tick-1 6-mask: (0, 0, 0, 1, 1, 1)
+t(1,0,0)=2 t(1,1,1)=2 t(2,0,0)=3 t(1,1,0)=1
+locks(1,0,0)=[(0, -1, 0)]
+locks(1,1,1)=[(0, 0, 1), (1, 0, 0)]
+seed ticks: t(0,0,0)=0 t(0,1,0)=0
+PASS: theorem1-tick1-mask  ((0, 0, 0, 1, 1, 1))
+PASS: theorem1-seed-and-tick1-locks
+PASS: theorem1-plus-e2-neighbor-is-seed-not-tick1
+PASS: theorem1-defined-ticks  (2,2,3,1)
+PASS: theorem1-uniqueness-not-required  ([(0, 0, 1), (1, 0, 0)])
+PASS: theorem1-not-six-neighbor-distance
+PASS: cardinality-not-one-site-clone  (two=(0, 0, 0, 1, 1, 1) one=(0, 0, 1, 1, 1, 1))
+PASS: theorem2-reverse-defined-and-holds  (3*2^2=12 vs 4)
+PASS: theorem3-face-defined-and-holds  (3^2=9 vs 2*1^2=2)
+PASS: mutation-drop-perp-changes-origin-mask  ((1, 1, 0, 1, 1, 1))
+PASS: formation-stays-in-host
+PASS: perp-consistent-seed-locks
+PASS: note-claim-scope
+PASS: note-reports-mask-and-ticks
+PASS: note-reverse-and-face-hold
+PASS: note-displayed-not-adopted
+PASS: note-cardinality-not-clone
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-machine-status-no-axiom-edit
+PASS: source-audit-paths-are-static-literals
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py
+++ b/scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Perp-step two-site seed reverse and face on B_3(0).
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is the two-record set {0, (0,1,0)} with perp-consistent locks +e_1 and +e_2.
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Uniqueness is not required: all
+earliest incoming steps are kept. Cardinality-of-seed, not a 1-site clone.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+ONE_SITE_SEEDS: tuple[tuple[Point, Point], ...] = ((ORIGIN, E1),)
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "hop-cost",
+    "parnn",
+    "k20",
+    "B_57",
+    "L1",
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and possible incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("perp-step two-site seed reverse/face on B_3(0)")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "claim_scope: Perp-step incoming-lock formation-tick reverse and face "
+        "at k=1 on B_3(0) with two-site seed {0,(0,1,0)} and locks +e_1/+e_2 "
+        "are reported. Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "k1-probes-in-host",
+        {(1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0)} <= host,
+    )
+    checks.check(
+        "two-site-seed-in-host",
+        {ORIGIN, E2} <= host,
+    )
+
+    ticks, locks = form()
+    mask = tuple(int(ticks.get(step) == 1) for step in NN)
+    t100 = ticks.get((1, 0, 0))
+    t111 = ticks.get((1, 1, 1))
+    t200 = ticks.get((2, 0, 0))
+    t110 = ticks.get((1, 1, 0))
+
+    print(f"tick-1 6-mask: {mask}")
+    print(f"t(1,0,0)={t100} t(1,1,1)={t111} t(2,0,0)={t200} t(1,1,0)={t110}")
+    print(f"locks(1,0,0)={sorted(locks.get((1, 0, 0), ()))}")
+    print(f"locks(1,1,1)={sorted(locks.get((1, 1, 1), ()))}")
+    print(f"seed ticks: t(0,0,0)={ticks[ORIGIN]} t(0,1,0)={ticks[E2]}")
+
+    checks.check(
+        "theorem1-tick1-mask",
+        mask == (0, 0, 0, 1, 1, 1),
+        str(mask),
+    )
+    checks.check(
+        "theorem1-seed-and-tick1-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2}
+        and locks[(0, -1, 0)] == {(0, -1, 0)}
+        and locks[E3] == {E3}
+        and locks[(0, 0, -1)] == {(0, 0, -1)},
+    )
+    checks.check(
+        "theorem1-plus-e2-neighbor-is-seed-not-tick1",
+        ticks[E2] == 0 and mask[2] == 0,
+    )
+    checks.check(
+        "theorem1-defined-ticks",
+        t100 == 2 and t111 == 2 and t200 == 3 and t110 == 1,
+        f"{t100},{t111},{t200},{t110}",
+    )
+    checks.check(
+        "theorem1-uniqueness-not-required",
+        t111 is not None and len(locks[(1, 1, 1)]) == 2,
+        str(sorted(locks.get((1, 1, 1), ()))),
+    )
+    checks.check(
+        "theorem1-not-six-neighbor-distance",
+        t100 != 1 and t200 != 2,
+    )
+
+    one_ticks, _one_locks = form(seeds=ONE_SITE_SEEDS)
+    one_mask = tuple(int(one_ticks.get(step) == 1) for step in NN)
+    checks.check(
+        "cardinality-not-one-site-clone",
+        one_mask == (0, 0, 1, 1, 1, 1)
+        and mask != one_mask
+        and (
+            one_ticks.get((1, 0, 0)),
+            one_ticks.get((1, 1, 1)),
+            one_ticks.get((2, 0, 0)),
+            one_ticks.get((1, 1, 0)),
+        )
+        == (3, 3, 4, 2)
+        and (t100, t111, t200, t110) != (3, 3, 4, 2),
+        f"two={mask} one={one_mask}",
+    )
+
+    reverse_defined = t100 is not None and t111 is not None
+    face_defined = t200 is not None and t110 is not None
+    reverse_holds = reverse_defined and 3 * t100 * t100 > t111 * t111
+    face_holds = face_defined and t200 * t200 > 2 * t110 * t110
+    checks.check(
+        "theorem2-reverse-defined-and-holds",
+        reverse_holds,
+        f"3*{t100}^2={3 * t100 * t100 if reverse_defined else 'undef'} vs {t111 * t111 if reverse_defined else 'undef'}",
+    )
+    checks.check(
+        "theorem3-face-defined-and-holds",
+        face_holds,
+        f"{t200}^2={t200 * t200 if face_defined else 'undef'} vs 2*{t110}^2={2 * t110 * t110 if face_defined else 'undef'}",
+    )
+
+    free_ticks, _ = form(require_perp=False)
+    free_mask = tuple(int(free_ticks.get(step) == 1) for step in NN)
+    checks.check(
+        "mutation-drop-perp-changes-origin-mask",
+        free_mask == (1, 1, 0, 1, 1, 1) and free_mask != mask,
+        str(free_mask),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "perp-consistent-seed-locks",
+        perpendicular(E1, E2) and add(ORIGIN, E2) == E2,
+    )
+
+    claim_scope = (
+        "Perp-step incoming-lock formation-tick reverse and face at k=1 "
+        "on B_3(0) with two-site seed {0,(0,1,0)} and locks +e_1/+e_2 are "
+        "reported. Displayed, not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "note-reports-mask-and-ticks",
+        "tick-1 6-mask, order (+e_1,-e_1,+e_2,-e_2,+e_3,-e_3): (0,0,0,1,1,1)"
+        in note
+        and "t(1,0,0)=2" in note
+        and "t(1,1,1)=2" in note
+        and "t(2,0,0)=3" in note
+        and "t(1,1,0)=1" in note,
+    )
+    checks.check(
+        "note-reverse-and-face-hold",
+        "3 t(1,0,0)^2 > t(1,1,1)^2" in note
+        and "t(2,0,0)^2 > 2 t(1,1,0)^2" in note
+        and "Status: hold." in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in note.lower()
+        and "not written into Admissibility" in note,
+    )
+    checks.check(
+        "note-cardinality-not-clone",
+        "Cardinality-of-seed, not a 1-site clone" in note
+        and "not a 1-site clone" in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in note
+        and "B_3(0)" in note
+        and "No runner cache is written." in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        "hypothetical_axiom_status: no edit" in note
+        and "claim_type: bounded_theorem" in note,
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/PERPNN_TWO_SITE_SEED_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Seed {0,(0,1,0)} with locks +e1/+e2. Origin tick-1 mask (0,0,0,1,1,1). t(A,B,C,D)=(2,2,3,1). Reverse 12>4 holds. Face 9>2 holds. Cardinality-of-seed is load-bearing vs 1-site origin. Displayed, not adopted.

## Runner

`scripts/perpnn_two_site_seed_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.