### PR TITLE
feat(nsfrm): formdraw PVM reverse/face hold on some (4 of 16)

### DIFF
--- a/docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,360 @@
+---
+claim_id: nnseed_formdraw_kernel_pvm_letter_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from formdraw occupancy-kernel PVM letters on the four nnseed probes, or UNDEFINED, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py
+---
+
+# Formdraw Occupancy-Kernel PVM Letters On Four Nnseed Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** named rank-1 PVM letters in `{+,−}` read from the formdraw occupancy
+kernel `n` at the formation tick of four probes of the displayed two-site
+nnseed process, scored as reverse and face. If `n=0` or the named construction
+assigns no letter, the comparison is `UNDEFINED`. Uniqueness is not required.
+Displayed, not adopted. This note does not write PVM letters into
+Admissibility, does not feed letters into occupancy `n`, and does not attach
+the occupancy-kernel formation member.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py`](../scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named probes. Incoming lock letters are unit nearest-neighbor
+steps. Named rank-1 PVM letters are `{+,−}` names of the projectors `P_±`
+read from occupancy-kernel `n`. Those two alphabets are not identified.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of formdraw occupancy-kernel n and named rank-1 P_± letters on the four nnseed probes, with reverse and face scored as some; uniqueness is not claimed and the letters are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_formdraw_kernel_pvm_letter_reverse_face
+target_blocker_text: "display reverse and face from formdraw occupancy-kernel PVM letters on the four nnseed probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write letters into Admissibility, do not feed letters into n, and do not identify them with incoming steps."
+conditional_surface_status: "exact on B_3(0) for occupancy-kernel PVM letters on the four nnseed probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four probes are the only sites whose occupancy
+kernel and PVM letters are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not occupancy `n` and is not a named rank-1 PVM letter.
+
+## Named occupancy kernel and rank-1 PVM letter
+
+At the formation tick of a probe, occupancy is read from already-recorded
+sites only: a neighbor is occupied if and only if it formed strictly earlier.
+The probe itself is still unread. Occupancy is in `{0,1}` and does not depend
+on any later PVM letter.
+
+The named formdraw occupancy kernel is the triple
+
+```text
+n_μ = (o_{+μ} − o_{−μ}) / 3,     μ = 1,2,3.
+```
+
+Write `k = |3n|^2`. If `n = 0`, the named construction assigns no letter and
+the probe is `UNDEFINED`. If `n ≠ 0`, write `H = a σ_x + b σ_y + c σ_z` with
+`(a,b,c) = 3n`. Then `H^2 = k I`, and the two legal lock contents are the
+rank-1 projectors
+
+```text
+P_± = (√k I ± H) / (2√k).
+```
+
+The letter `+` names `P_+`. The letter `−` names `P_-`. Both letters are
+legal whenever `n ≠ 0`. Occupancy of a formed site remains `1` for either
+content, so the letter does not feed `n`.
+
+Those projectors live in the live Qubit presentation `M_2(C)`. They are not
+unit nearest-neighbor steps. This note reads `n` at each probe's formation
+tick as displayed theorem-domain data. It does not attach the occupancy-kernel
+formation member: sites form by the nnseed perp-step incoming-lock process,
+not by an `n ≠ 0` formation rule.
+
+A process-determined PVM letter at a probe is a value in `{+,−}` assigned by
+that named construction from `n`. Incoming `{±e_i}` tags are not that
+assignment. Identifying a named sign of an incoming step with a PVM letter
+is refused. If a probe has several process-determined letters, reverse and
+face are evaluated on every combination. Uniqueness is not required.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A)=+ and L(B)=−
+face     <=>  L(C)=+ and L(D)=−
+```
+
+If a letter needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. The report is one of `all`, `some`, `none`, or `UNDEFINED`.
+
+Admissibility is not edited. PVM letters are not written into Admissibility.
+
+## Theorem 1 — occupancy kernel and PVM letter at each probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+probes. At each formation tick the occupancy kernel from already-recorded
+six-neighbor occupancy is nonzero, so both named rank-1 letters are assigned:
+
+```text
+n(A) = (−1/3, 1/3, 0),     k(A) = 2,     L(A) = {+,−}
+n(B) = (−1/3, 0, −1/3),    k(B) = 2,     L(B) = {+,−}
+n(C) = (−1/3, 0, 0),       k(C) = 1,     L(C) = {+,−}
+n(D) = (−1/3, 0, 0),       k(D) = 1,     L(D) = {+,−}
+```
+
+Neighbor occupancies at those formation ticks:
+
+- `A`: already recorded on `−e_1` and `+e_2`;
+- `B`: already recorded on `−e_1` and `−e_3`;
+- `C`: already recorded on `−e_1`;
+- `D`: already recorded on `−e_1`.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps). That non-uniqueness is not a PVM lettering. The PVM letters are not
+identified with those incoming steps. Uniqueness is not required.
+
+On the `k=1` probes `C` and `D`, the named traces are `Tr(ρ P_+)=2/3` and
+`Tr(ρ P_-)=1/3`. Both contents occupy the site.
+
+## Theorem 2 — reverse report
+
+Reverse is `L(A)=+` and `L(B)=−`. Both probes have letter set `{+,−}`, so
+every combination of the four probes is scored. There are 16 combinations.
+Reverse holds on exactly 4 of them and fails on the other 12.
+
+Report: `some`.
+
+This is not `all`, not `none`, and not `UNDEFINED`. A named-sign readout of
+incoming steps is a different object and is not used.
+
+## Theorem 3 — face report
+
+Face is `L(C)=+` and `L(D)=−`. Both probes have letter set `{+,−}`. Face
+holds on exactly 4 of the 16 combinations and fails on the other 12.
+
+Report: `some`.
+
+Displayed, not adopted. The letters are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock or a unique PVM letter.
+- It does not identify named rank-1 PVM letters with incoming `{±e_i}`.
+- It does not feed letters into occupancy `n`.
+- It does not attach the occupancy-kernel formation member.
+- It does not census free occupancy letterings independent of `n`.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four probes. It uses Qubit
+only as the algebra in which the named projectors `P_±` are written. It uses
+Record only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The nnseed process, the occupancy kernel, the named PVM
+letters, and the reverse/face predicates are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| occupancy kernel `n` at each probe formation tick | Theorem 1; all four `n ≠ 0` |
+| named rank-1 PVM letters `{+,−}` from `P_±` | Theorem 1; `{+,−}` at each probe |
+| reverse and face | Theorems 2–3; both `some` |
+| unique incoming lock or unique PVM letter | not required |
+| letters fed into occupancy `n` | not executed |
+| occupancy-kernel formation member attached | not attached |
+| free occupancy lettering independent of `n` | not enumerated |
+| PVM letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: formdraw occupancy-kernel PVM letters on the four nnseed probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed occupancy-kernel PVM-letter reverse/face report on these four nnseed probes. |
+| V3 | Occupancy kernels, named projectors, and the `some`/`some` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads `n` at formation and names `P_±`. |
+| V5 | It is not an adopted content rule: the letters remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those letters into
+Admissibility, does not identify them with incoming steps, and does not feed
+them into `n`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| identify PVM letter with named sign of incoming `{±e_i}` | map `+e_i` to `+` and `-e_i` to `−` | refused; different alphabet |
+| reverse/face from incoming named signs | reuse the incoming-lock sign readout | different object; not this display |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; not this display |
+| free occupancy letters on the four probes | ignore `n` and letter independently | different object; not enumerated |
+| attach occupancy-kernel formation member | form the probes by `n ≠ 0` instead of perp-step | refused; not attached |
+| feed letters into `n` | let `+`/`−` change occupancy | refused; occupancy stays `{0,1}` of the already-recorded set |
+| adopt letters into Admissibility | rewrite the local rule by `{+,−}` | refused; displayed, not adopted |
+| unique PVM letter required | demand one letter per probe | uniqueness is not required; both letters are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing occupancy-kernel formation attachment, and
+missing Record identification of the named PVM bits are distinct open
+premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, occupancy kernel from already-recorded neighbors,
+named `P_±` letters, four probes, and reverse/face definitions are declared.
+No uniqueness, no occupancy-kernel formation attachment, and no Admissibility
+rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`some` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each named projector `P_±` and each occupancy component | no continuum alphabet |
+| per site | `A,B,C,D` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four `{+,−}` letter sets and two `some` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{+,−}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once `n ≠ 0` at a forming probe, the site should lock a unique
+letter `+` or `−`, reverse and face should hold on all combinations or be
+adopted as Admissibility content, and occupancy should track that sign.
+
+**Answer:** The named construction assigns both `P_+` and `P_-` whenever
+`n ≠ 0`. Occupancy stays `{0,1}` of the already-recorded set. Reverse and
+face hold on some combinations and fail on others. The bits remain
+displayed. Uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+A prior display scored named rank-1 PVM letters on the one-site perpnn
+process without reading occupancy-kernel `n`, and reported `UNDEFINED`. This
+note is not that display: it reads `n` on the two-site nnseed process and
+reports `some` / `some`. A second prior display scored reverse and face from
+formation-tick inequalities on the same four nnseed probes. This note does
+not reuse that scoring.
+
+**Gate disposition:** PASS for the occupancy-kernel PVM-letter reverse/face
+reports above. FAIL / DO NOT SHIP for “the PVM letter equals the incoming
+step sign,” “letters are Admissibility,” “letters feed `n`,” or “reverse/face
+holds on all combinations.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, computes the formdraw occupancy kernel `n` from
+already-recorded six-neighbor occupancy at each probe's formation tick,
+reconstructs the named rank-1 projectors `P_±` as displayed data, reads
+process-determined PVM letters at the four probes, and checks Theorems 1--3.
+It also checks that incoming steps are not PVM letters, that letters are not
+fed into occupancy `n`, and that the occupancy-kernel formation member is not
+attached. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_formdraw_kernel_pvm_letter_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.txt
@@ -1,0 +1,70 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py
+runner_sha256: 05a85bced798a940c9f4f90e967f98128866e9d9a55886dccfcf003568509859
+input_fingerprint_sha256: 473c3d910d08c66722e36567b8e4b0f9d85943fe5a4c2d702856bdab3453b847
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+formdraw occupancy-kernel PVM-letter reverse/face on four nnseed probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from formdraw occupancy-kernel PVM letters on the four nnseed probes, or UNDEFINED, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: named-pvm-rank1-projectors
+PASS: named-pvm-traces-k1
+PASS: named-pvm-letters-are-plus-minus
+A n=(-1/3,1/3,0) k=2 abc=(-1,1,0) L={+,−} incoming=[(0, -1, 0)]
+B n=(-1/3,0,-1/3) k=2 abc=(-1,0,-1) L={+,−} incoming=[(0, 0, 1), (1, 0, 0)]
+C n=(-1/3,0,0) k=1 abc=(-1,0,0) L={+,−} incoming=[(1, 0, 0)]
+D n=(-1/3,0,0) k=1 abc=(-1,0,0) L={+,−} incoming=[(1, 0, 0)]
+PASS: theorem1-n-A  ((Fraction(-1, 3), Fraction(1, 3), Fraction(0, 1)))
+PASS: theorem1-n-B  ((Fraction(-1, 3), Fraction(0, 1), Fraction(-1, 3)))
+PASS: theorem1-n-C  ((Fraction(-1, 3), Fraction(0, 1), Fraction(0, 1)))
+PASS: theorem1-n-D  ((Fraction(-1, 3), Fraction(0, 1), Fraction(0, 1)))
+PASS: theorem1-letters-all-plus-minus
+PASS: n-nonzero-assigns-both-letters
+PASS: hamiltonian-square-matches-k
+PASS: incoming-locks-are-nn-steps-not-letters
+PASS: uniqueness-not-required  ([(0, 0, 1), (1, 0, 0)])
+PASS: two-site-seed-locks
+combos=16 reverse_hits=4 face_hits=4
+reverse=some face=some
+PASS: theorem2-reverse-some  (some)
+PASS: theorem3-face-some  (some)
+PASS: letters-do-not-feed-occupancy
+PASS: n-independent-of-letter-branch
+PASS: mutation-identify-incoming-sign-is-refused
+PASS: mutation-minus-as-vacant-changes-n
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: not-t-as-comparator
+PASS: note-claim-scope
+PASS: note-reports-n-and-letters
+PASS: note-reports-some-some
+PASS: note-displayed-not-adopted
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-feed-n-or-attach-formation-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+TOTAL: PASS=44 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""Formdraw occupancy-kernel PVM letters on four nnseed probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each probe's formation tick, n is the formdraw occupancy kernel from
+already-recorded six-neighbor occupancy. If n≠0 the named rank-1 P_± letters
+are {+,−}. Letters do not feed n and are not incoming {±e_i}. Uniqueness is
+not required.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from fractions import Fraction
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Vec3 = tuple[Fraction, Fraction, Fraction]
+Mat = tuple[tuple[Fraction, Fraction], tuple[Fraction, Fraction]]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+AXES: tuple[Point, Point, Point] = (E1, E2, E3)
+PVM_LETTERS = frozenset({"+", "-"})
+ZERO_N: Vec3 = (Fraction(0), Fraction(0), Fraction(0))
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+EXPECTED_N = {
+    "A": (Fraction(-1, 3), Fraction(1, 3), Fraction(0)),
+    "B": (Fraction(-1, 3), Fraction(0), Fraction(-1, 3)),
+    "C": (Fraction(-1, 3), Fraction(0), Fraction(0)),
+    "D": (Fraction(-1, 3), Fraction(0), Fraction(0)),
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "L1",
+    "Runner cache",
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def madd(left: Mat, right: Mat) -> Mat:
+    return (
+        (left[0][0] + right[0][0], left[0][1] + right[0][1]),
+        (left[1][0] + right[1][0], left[1][1] + right[1][1]),
+    )
+
+
+def mmul(left: Mat, right: Mat) -> Mat:
+    return (
+        (
+            left[0][0] * right[0][0] + left[0][1] * right[1][0],
+            left[0][0] * right[0][1] + left[0][1] * right[1][1],
+        ),
+        (
+            left[1][0] * right[0][0] + left[1][1] * right[1][0],
+            left[1][0] * right[0][1] + left[1][1] * right[1][1],
+        ),
+    )
+
+
+def mscale(coeff: Fraction, mat: Mat) -> Mat:
+    return (
+        (coeff * mat[0][0], coeff * mat[0][1]),
+        (coeff * mat[1][0], coeff * mat[1][1]),
+    )
+
+
+def mtrace(mat: Mat) -> Fraction:
+    return mat[0][0] + mat[1][1]
+
+
+def I2() -> Mat:
+    zero, one = Fraction(0), Fraction(1)
+    return ((one, zero), (zero, one))
+
+
+def SX() -> Mat:
+    zero, one = Fraction(0), Fraction(1)
+    return ((zero, one), (one, zero))
+
+
+def pvm_probs(a: int, b: int, c: int) -> tuple[Fraction, Fraction]:
+    """Identity gate: Tr(ρ P±) for the named rank-1 projectors at k=1."""
+    if b != 0 or c != 0:
+        raise ValueError("named k=1 traces are displayed here at b=c=0")
+    if a * a != 1:
+        raise ValueError("named k=1 traces require a=±1")
+    hamiltonian = mscale(Fraction(a), SX())
+    half = Fraction(1, 2)
+    pplus = mscale(half, madd(I2(), hamiltonian))
+    pminus = mscale(half, madd(I2(), mscale(Fraction(-1), hamiltonian)))
+    rho = mscale(half, madd(I2(), mscale(Fraction(1, 3), hamiltonian)))
+    return mtrace(mmul(rho, pplus)), mtrace(mmul(rho, pminus))
+
+
+def pvm_projectors_k1(a: int) -> tuple[Mat, Mat]:
+    """Named rank-1 P± for H=a σx, k=1."""
+    hamiltonian = mscale(Fraction(a), SX())
+    half = Fraction(1, 2)
+    pplus = mscale(half, madd(I2(), hamiltonian))
+    pminus = mscale(half, madd(I2(), mscale(Fraction(-1), hamiltonian)))
+    return pplus, pminus
+
+
+def occupancy(site: Point, formed: frozenset[Point], letter: str | None = None) -> int:
+    """Occupancy is 1 on already-recorded sites. A PVM letter does not feed n."""
+    if letter is not None and letter not in PVM_LETTERS:
+        raise ValueError(f"letter must be + or -, got {letter!r}")
+    return 1 if site in formed else 0
+
+
+def n_vector(site: Point, formed: frozenset[Point]) -> Vec3:
+    """Formdraw occupancy kernel n_μ = (o_{+μ} − o_{−μ}) / 3."""
+    components = []
+    for axis in AXES:
+        plus = occupancy(add(site, axis), formed)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), formed)
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+def k_value(n: Vec3) -> int:
+    squared = sum((3 * component) ** 2 for component in n)
+    if squared.denominator != 1:
+        raise ValueError(f"k left Q: {squared}")
+    return int(squared)
+
+
+def abc_from_n(n: Vec3) -> tuple[int, int, int]:
+    return (int(3 * n[0]), int(3 * n[1]), int(3 * n[2]))
+
+
+def pvm_letters_from_n(n: Vec3) -> frozenset[str]:
+    """Named rank-1 P_± letters from occupancy kernel n. Not incoming {±e_i}."""
+    if n == ZERO_N:
+        return frozenset()
+    return frozenset(PVM_LETTERS)
+
+
+def letter_report(letters: frozenset[str]) -> str:
+    if not letters:
+        return "UNDEFINED"
+    if letters == PVM_LETTERS:
+        return "{+,−}"
+    only = next(iter(letters))
+    return only
+
+
+def hold_report(
+    n_true: int,
+    n_total: int,
+    *,
+    defined: bool,
+) -> str:
+    if not defined:
+        return "UNDEFINED"
+    if n_total == 0 or n_true == 0:
+        return "none"
+    if n_true == n_total:
+        return "all"
+    return "some"
+
+
+def hamiltonian_square_k(a: int, b: int, c: int) -> int:
+    """Identity gate: Pauli H=aσx+bσy+cσz satisfies H^2 = (a^2+b^2+c^2) I."""
+    return a * a + b * b + c * c
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def already_recorded(site: Point, ticks: dict[Point, int]) -> frozenset[Point]:
+    formation = ticks[site]
+    return frozenset(other for other, tick in ticks.items() if tick < formation)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("formdraw occupancy-kernel PVM-letter reverse/face on four nnseed probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "claim_scope: Reverse and face from formdraw occupancy-kernel PVM "
+        "letters on the four nnseed probes, or UNDEFINED, are reported. "
+        "Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+
+    pplus, pminus = pvm_projectors_k1(-1)
+    tp, tm = pvm_probs(-1, 0, 0)
+    checks.check(
+        "named-pvm-rank1-projectors",
+        mtrace(pplus) == 1
+        and mtrace(pminus) == 1
+        and pplus == mmul(pplus, pplus)
+        and pminus == mmul(pminus, pminus)
+        and mmul(pplus, pminus)
+        == ((Fraction(0), Fraction(0)), (Fraction(0), Fraction(0))),
+    )
+    checks.check(
+        "named-pvm-traces-k1",
+        tp == Fraction(2, 3) and tm == Fraction(1, 3) and tp + tm == 1,
+    )
+    checks.check(
+        "named-pvm-letters-are-plus-minus",
+        PVM_LETTERS == frozenset({"+", "-"})
+        and E1 not in PVM_LETTERS
+        and E2 not in PVM_LETTERS,
+    )
+
+    ticks, locks = form()
+    kernels: dict[str, Vec3] = {}
+    letters: dict[str, frozenset[str]] = {}
+    for name, site in PROBES.items():
+        formed_before = already_recorded(site, ticks)
+        n = n_vector(site, formed_before)
+        kernels[name] = n
+        letters[name] = pvm_letters_from_n(n)
+        a, b, c = abc_from_n(n)
+        print(
+            f"{name} n=({n[0]},{n[1]},{n[2]}) k={k_value(n)} "
+            f"abc=({a},{b},{c}) L={letter_report(letters[name])} "
+            f"incoming={sorted(locks.get(site, ()))}"
+        )
+
+    checks.check(
+        "theorem1-n-A",
+        kernels["A"] == EXPECTED_N["A"] and k_value(kernels["A"]) == 2,
+        str(kernels["A"]),
+    )
+    checks.check(
+        "theorem1-n-B",
+        kernels["B"] == EXPECTED_N["B"] and k_value(kernels["B"]) == 2,
+        str(kernels["B"]),
+    )
+    checks.check(
+        "theorem1-n-C",
+        kernels["C"] == EXPECTED_N["C"] and k_value(kernels["C"]) == 1,
+        str(kernels["C"]),
+    )
+    checks.check(
+        "theorem1-n-D",
+        kernels["D"] == EXPECTED_N["D"] and k_value(kernels["D"]) == 1,
+        str(kernels["D"]),
+    )
+    checks.check(
+        "theorem1-letters-all-plus-minus",
+        all(letters[name] == PVM_LETTERS for name in ("A", "B", "C", "D"))
+        and all(letter_report(letters[name]) == "{+,−}" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "n-nonzero-assigns-both-letters",
+        pvm_letters_from_n(ZERO_N) == frozenset()
+        and pvm_letters_from_n(EXPECTED_N["A"]) == PVM_LETTERS,
+    )
+    checks.check(
+        "hamiltonian-square-matches-k",
+        all(
+            hamiltonian_square_k(*abc_from_n(kernels[name])) == k_value(kernels[name])
+            for name in ("A", "B", "C", "D")
+        ),
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps-not-letters",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D"))
+        and all(not (locks[PROBES[name]] & PVM_LETTERS) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2 and letters["B"] == PVM_LETTERS,
+        str(sorted(locks[PROBES["B"]])),
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2},
+    )
+
+    defined_reverse = bool(letters["A"]) and bool(letters["B"])
+    defined_face = bool(letters["C"]) and bool(letters["D"])
+    combos = tuple(
+        product(
+            sorted(letters["A"]),
+            sorted(letters["B"]),
+            sorted(letters["C"]),
+            sorted(letters["D"]),
+        )
+    )
+    reverse_hits = sum(combo[0] == "+" and combo[1] == "-" for combo in combos)
+    face_hits = sum(combo[2] == "+" and combo[3] == "-" for combo in combos)
+    reverse_status = hold_report(reverse_hits, len(combos), defined=defined_reverse)
+    face_status = hold_report(face_hits, len(combos), defined=defined_face)
+    print(f"combos={len(combos)} reverse_hits={reverse_hits} face_hits={face_hits}")
+    print(f"reverse={reverse_status} face={face_status}")
+
+    checks.check(
+        "theorem2-reverse-some",
+        reverse_status == "some"
+        and defined_reverse
+        and reverse_hits == 4
+        and len(combos) == 16,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-some",
+        face_status == "some" and defined_face and face_hits == 4,
+        face_status,
+    )
+    checks.check(
+        "letters-do-not-feed-occupancy",
+        occupancy(PROBES["A"], frozenset(ticks), "+")
+        == occupancy(PROBES["A"], frozenset(ticks), "-")
+        == occupancy(PROBES["A"], frozenset(ticks), None)
+        == 1
+        and occupancy((4, 0, 0), frozenset(ticks), "+") == 0,
+    )
+    formed_before_a = already_recorded(PROBES["A"], ticks)
+    n_plus = n_vector(PROBES["A"], formed_before_a)
+    n_minus = n_vector(PROBES["A"], formed_before_a)
+    checks.check("n-independent-of-letter-branch", n_plus == n_minus == EXPECTED_N["A"])
+    checks.check(
+        "mutation-identify-incoming-sign-is-refused",
+        all(isinstance(lock, tuple) for lock in locks[PROBES["A"]])
+        and pvm_letters_from_n(kernels["A"]) == PVM_LETTERS
+        and E1 not in PVM_LETTERS,
+    )
+    signed_minus_as_vacant = frozenset(
+        site for site in already_recorded(PROBES["A"], ticks) if site != PROBES["D"]
+    )
+    checks.check(
+        "mutation-minus-as-vacant-changes-n",
+        n_vector(PROBES["A"], signed_minus_as_vacant) != EXPECTED_N["A"],
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "not-t-as-comparator",
+        reverse_status == "some"
+        and face_status == "some"
+        and reverse_hits != 0
+        and "3 t(" not in note,
+    )
+
+    claim_scope = (
+        "Reverse and face from formdraw occupancy-kernel PVM letters "
+        "on the four nnseed probes, or UNDEFINED, are reported. Displayed, "
+        "not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "note-reports-n-and-letters",
+        "n(A) = (−1/3, 1/3, 0)" in note
+        and "n(B) = (−1/3, 0, −1/3)" in note
+        and "n(C) = (−1/3, 0, 0)" in note
+        and "n(D) = (−1/3, 0, 0)" in note
+        and "L(A) = {+,−}" in note
+        and "L(B) = {+,−}" in note
+        and "L(C) = {+,−}" in note
+        and "L(D) = {+,−}" in note,
+    )
+    checks.check(
+        "note-reports-some-some",
+        note.count("Report: `some`.") == 2
+        and "all" in note
+        and "some" in note
+        and "none" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "Identifying a named sign of an incoming step with a PVM letter is refused."
+        in normalized_note,
+    )
+    checks.check(
+        "note-does-not-feed-n-or-attach-formation-member",
+        "does not feed `n`" in note
+        and "does not attach the occupancy-kernel formation member" in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_FORMDRAW_KERNEL_PVM_LETTER_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def occupancy(" in source
+        and "def n_vector(" in source
+        and "def pvm_letters_from_n(" in source
+        and "def form(" in source
+        and "def pvm_probs(" in source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

On nnseed #7050, formdraw occupancy-kernel n is nonzero at each of A,B,C,D at formation tick, so both named rank-1 letters {+,−} are assigned. Reverse and face each hold on 4 of 16 combinations (some/some). Letters are not fed into n and are not incoming {±e_i}. Displayed, not adopted.

## Runner

`scripts/nnseed_formdraw_kernel_pvm_letter_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.