### PR TITLE
feat(nssfrm): nssame formdraw n(C) != n(D); unique f(n) leftover does not transfer

### DIFF
--- a/docs/NSSAME_FORMDRAW_KERNEL_N_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NSSAME_FORMDRAW_KERNEL_N_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,235 @@
+---
+claim_id: nssame_formdraw_kernel_n_equality_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Formdraw occupancy kernels on the four nssame probes, and whether n(C)=n(D), are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py
+---
+
+# Formdraw Occupancy Kernels On Four Nssame Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** formdraw occupancy kernels `n` at the formation tick of four probes
+of the displayed two-site same-lock nssame process. Whether `n(C)=n(D)`, and
+whether the four-`n` tuple equals the mixed-lock formdraw occupancy-kernel
+display on the same probes, are reported. Uniqueness is not required. No unique
+`{+,−}` letter is assigned. Displayed, not adopted. This note does not write
+the occupancy kernel into Admissibility and does not attach the occupancy-kernel
+formation member.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py`](../scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py)
+**Parents:** the live axiom memo
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) only.
+
+## Result Up Front
+
+Host Euclidean `B_3(0)`. Seed at tick 0: the origin is recorded with lock
+`+e_1`, and `(0,1,0)` is recorded with the same lock `+e_1`. Growth is the
+perp-step incoming-lock rule. At the formation tick of each probe, occupancy
+kernel `n` is read from already-recorded six-neighbor occupancy. The four
+kernels are
+
+```text
+n(A) = (−1/3, −1/3, 0)
+n(B) = (−1/3, 0, 0)
+n(C) = (−1/3, 0, 0)
+n(D) = (−1/3, 1/3, 0)
+```
+
+So `n(C) ≠ n(D)`. The four-`n` tuple is not the mixed-lock formdraw occupancy
+kernel on the same probes. The unique `f(n)` leftover closed there because
+`n(C)=n(D)` does not transfer. No unique letter is assigned here.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact formdraw occupancy kernels on the four nssame probes, with n(C)=n(D) reported false and the mixed-lock four-n tuple reported unequal."
+trace_class: frontier_discovery
+target_claim_id: nssame_formdraw_kernel_n_equality
+target_blocker_text: "display formdraw occupancy kernels on the four nssame probes and whether n(C)=n(D)"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "independent audit of the bounded occupancy-kernel report"
+conditional_surface_status: "exact on B_3(0) for occupancy kernels on the four nssame probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four probes are the only sites whose occupancy
+kernel is scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+Seed, at tick 0:
+
+```text
+t(0) = 0,     L(0) = +e_1,
+t(0,1,0) = 0, L(0,1,0) = +e_1.
+```
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not occupancy `n`. This same-lock seed is outside the
+proper cubic orbit of the mixed-lock two-site seed with letters `+e_1` and
+`+e_2`.
+
+## Named occupancy kernel
+
+At the formation tick of a probe, occupancy is read from already-recorded
+sites only: a neighbor is occupied if and only if it formed strictly earlier.
+The probe itself is still unread. Occupancy is in `{0,1}`.
+
+The named formdraw occupancy kernel is the triple
+
+```text
+n_μ = (o_{+μ} − o_{−μ}) / 3,     μ = 1,2,3.
+```
+
+This note reads `n` at each probe's formation tick as displayed theorem-domain
+data. It does not attach the occupancy-kernel formation member: sites form by
+the nssame perp-step incoming-lock process, not by an `n ≠ 0` formation rule.
+No unique `{+,−}` letter is assigned from `n`.
+
+The occupancy kernel is displayed, not adopted. It is not written into
+Admissibility.
+
+## Theorem 1 — occupancy kernel at each probe
+
+Direct enumeration of the displayed nssame process on `B_3(0)` forms all four
+probes. At each formation tick the occupancy kernel from already-recorded
+six-neighbor occupancy is
+
+```text
+n(A) = (−1/3, −1/3, 0)
+n(B) = (−1/3, 0, 0)
+n(C) = (−1/3, 0, 0)
+n(D) = (−1/3, 1/3, 0)
+```
+
+Neighbor occupancies at those formation ticks:
+
+- `A`: already recorded on `−e_1`, `−e_2`, `+e_3`, and `−e_3`;
+- `B`: already recorded on `−e_1`;
+- `C`: already recorded on `−e_1`;
+- `D`: already recorded on `−e_1`, `+e_2`, `+e_3`, and `−e_3`.
+
+Incoming locks exist and need not be unique. That non-uniqueness is not a
+lettering. Uniqueness is not required.
+
+## Theorem 2 — `n(C)` and `n(D)`
+
+The kernels of Theorem 1 give `n(C) = (−1/3, 0, 0)` and
+`n(D) = (−1/3, 1/3, 0)`. Componentwise comparison yields `n(C) ≠ n(D)`.
+
+## Theorem 3 — mixed-lock formdraw four-`n` tuple
+
+The mixed-lock two-site process with `L(0)=+e_1` and `L(0,1,0)=+e_2`, on the
+same host and the same four probes, with the same formdraw occupancy kernel,
+displays
+
+```text
+n(A) = (−1/3, 1/3, 0)
+n(B) = (−1/3, 0, −1/3)
+n(C) = (−1/3, 0, 0)
+n(D) = (−1/3, 0, 0)
+```
+
+That four-`n` tuple is not the nssame tuple of Theorem 1. On the mixed-lock
+display, `n(C)=n(D)`, which closed a unique `f(n)` leftover. That leftover
+does not transfer: here `n(C) ≠ n(D)`. No unique `f(n)` is constructed.
+
+The mixed-lock display is a contrast, not a parent theorem.
+
+## Inputs And Import Boundary
+
+- **Framework dependency:** Lattice supplies the cubic nearest-neighbor
+  geometry of `Z^3`. Record supplies permanence and single-site locking
+  vocabulary. Both are quoted without rewrite.
+- **Explicit theorem-domain condition:** the host is the Euclidean ball
+  `B_3(0)={n∈Z^3:n·n≤9}` only. The same-lock seed, the perp-step incoming-lock
+  rule, the formdraw occupancy kernel, and the four probes are supplied data
+  for this display.
+- **External empirical or literature inputs:** none.
+- **Open physical bridge:** adopting occupancy `n` as an Admissibility
+  constraint or a formation law remains a separate obligation. This note does
+  not attach that bridge.
+
+## What This Does Not Claim
+
+- No unique `{+,−}` letter is assigned from `n`.
+- Occupancy-kernel letters are not written into Admissibility.
+- The display is not written into Admissibility.
+- The occupancy-kernel formation member is not attached.
+- Incoming-step uniqueness is not required and is not proved.
+- The mixed-lock four-`n` tuple is a contrast, not a parent.
+- No continuum limit and no comparison beyond the four probes on this host
+  is claimed.
+
+These are scope boundaries, not impossibility or route-exhaustion claims.
+Accordingly, no no-go verdict is authored here.
+
+## Live Parent Quotes
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site.
+
+> When present, a record locks exactly one admissible local possibility.
+
+> A site with no record cannot be read.
+
+Their dependency role is limited to cubic nearest-neighbor geometry and
+lock/permanence vocabulary. This theorem separately supplies the Euclidean
+host, the two-site same-lock seed, the perp-step protocol, and the formdraw
+occupancy kernel. Readout of unrecorded sites remains outside the target: the
+four probes are recorded before `n` is read at neighboring unread sites.
+
+## Runner Contract
+
+The companion runner enumerates `B_3(0)` by `n·n≤9`, grows by simultaneous
+tick under the perp-step incoming-lock rule, and computes the formdraw
+occupancy kernel `n` from already-recorded six-neighbor occupancy at each
+probe's formation tick. It reports the four kernels, checks `n(C)≠n(D)`, and
+compares the four-`n` tuple to the mixed-lock formdraw kernels on the same
+probes. It pins the declared review inputs to this note and the axiom memo
+only. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13257,6 +13257,10 @@
   "nspt_high_order_lattice_alpha_n_coefficient_external_narrow_theorem_note_2026-05-16": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "nssame_formdraw_kernel_n_equality_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "observable_generator_additivity_from_cluster_decomposition_theorem_note_2026-05-10": {
    "deps_hash": "d522a9c08709",

--- a/logs/runner-cache/nssame_formdraw_kernel_n_equality_2026_08_15.txt
+++ b/logs/runner-cache/nssame_formdraw_kernel_n_equality_2026_08_15.txt
@@ -1,0 +1,51 @@
+===== runner cache v1 =====
+runner: scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py
+runner_sha256: 02a0b598e62a9ea48052e0c17745130fc6c4210892cf0099b2487f0646e6a4ef
+input_fingerprint_sha256: 300a02b41eacf4b255c87c3e64e9a33e114651de022e432349c67d91afd34875
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+external_scientific_inputs: none; exact occupancy kernels only
+package_local_integrity_reads: proposed source note and live axiom memo only
+host: Euclidean B_3(0) with n·n<=9
+host_site_count: 123
+seed: {0,(0,1,0)} both locking +e_1 at tick 0
+process: nssame perp-step incoming-lock
+kernel: formdraw n_μ=(o_{+μ}−o_{−μ})/3 from already-recorded 6-NN
+n(A)=(−1/3, −1/3, 0) occ=+−e1(0, 1) +−e2(0, 1) +−e3(1, 1) incoming=[(0, 0, -1), (0, 0, 1), (0, 1, 0)]
+n(B)=(−1/3, 0, 0) occ=+−e1(0, 1) +−e2(0, 0) +−e3(0, 0) incoming=[(1, 0, 0)]
+n(C)=(−1/3, 0, 0) occ=+−e1(0, 1) +−e2(0, 0) +−e3(0, 0) incoming=[(1, 0, 0)]
+n(D)=(−1/3, 1/3, 0) occ=+−e1(0, 1) +−e2(1, 0) +−e3(1, 1) incoming=[(0, -1, 0), (0, 0, -1), (0, 0, 1)]
+n(C)=n(D): False
+four-n equals mixed-lock formdraw n: False
+unique f(n) leftover transfers: no
+claim_boundary: displayed, not adopted; not written into Admissibility
+cache_write: false
+AUDIT_TIMEOUT_SEC: 120
+PASS: audit-input-paths-literal AUDIT_INPUT_PATHS is the declared two-path static tuple
+PASS: audit-input-files declared review inputs exist
+PASS: host-euclidean-ball host is exactly {n in Z^3 : n·n <= 9}
+PASS: seed-two-site-same-lock tick-0 records are origin and (0,1,0), both locking +e_1
+PASS: identity-gates-present occupancy, n_vector, and grow are computed, not hardcoded
+PASS: thm1-n-A computed n(A) is recorded in the note
+PASS: thm1-n-B computed n(B) is recorded in the note
+PASS: thm1-n-C computed n(C) is recorded in the note
+PASS: thm1-n-D computed n(D) is recorded in the note
+PASS: thm2-nC-not-equal-nD n(C)=n(D) fails on the nssame seed
+PASS: thm3-tuple-disagrees-mixed-formdraw four-n tuple is not the mixed-lock formdraw tuple
+PASS: already-recorded-six-nn occupancy reads strictly earlier 6-NN, not the unread probe
+PASS: uniqueness-not-required first-arrival incoming locks at A and D need not be unique
+PASS: not-mixed-cubic-orbit same-lock seed is outside the proper cubic orbit of mixed +e_1/+e_2
+PASS: perp-step-incoming-lock origin lock +e_1 blocks parallel steps and allows the four perpendicular steps
+PASS: note-claim-scope note claim_scope matches the occupancy-kernel report
+PASS: no-letter-assignment no unique {+,−} letter is assigned and reverse/face are not scored from n
+PASS: no-admissibility-write display is not written into Admissibility and names no extra axiom
+PASS: forbidden-phrases-absent note omits excluded claim language and does not attach a first-lemma tag
+PASS: axiom-quotes-unedited Lattice and Record sentences are quoted from the live axiom memo
+PASS: no-larger-ball formation stays inside B_3(0)
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py
+++ b/scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Formdraw occupancy kernels on the four nssame probes.
+
+Host Euclidean B_3(0) = {n in Z^3 : n·n <= 9}. Seed at tick 0 records the
+origin and (0,1,0), both locking +e_1. Growth is the nssame perp-step
+incoming-lock process. At each probe's formation tick, n is the formdraw
+occupancy kernel from already-recorded six-neighbor occupancy. No unique
+{+,−} letter is assigned. Reverse and face are not scored. Displayed, not
+adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from fractions import Fraction
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "NSSAME_FORMDRAW_KERNEL_N_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/NSSAME_FORMDRAW_KERNEL_N_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+Point = tuple[int, int, int]
+Vec3 = tuple[Fraction, Fraction, Fraction]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+STEPS: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+AXES: tuple[Point, Point, Point] = (E1, E2, E3)
+PROBES: dict[str, Point] = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def lock_axis(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def euclidean_ball() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x, y, z in product(range(-3, 4), repeat=3)
+        if x * x + y * y + z * z <= 9
+    )
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return tuple(
+        matrix[row][0] * point[0]
+        + matrix[row][1] * point[1]
+        + matrix[row][2] * point[2]
+        for row in range(3)
+    )
+
+
+def matrix_det(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations((0, 1, 2)):
+        for signs in product((1, -1), repeat=3):
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for col in range(3):
+                matrix[perm[col]][col] = signs[col]
+            packed = tuple(tuple(row) for row in matrix)
+            if matrix_det(packed) == 1:
+                rotations.append(packed)
+    return tuple(rotations)
+
+
+def grow(
+    host: frozenset[Point],
+    seed: tuple[tuple[Point, Point], ...],
+) -> dict[Point, tuple[int, frozenset[Point]]]:
+    recorded: dict[Point, tuple[int, frozenset[Point]]] = {
+        site: (0, frozenset({lock})) for site, lock in seed
+    }
+    by_tick: dict[int, list[Point]] = defaultdict(list)
+    for site, _lock in seed:
+        if site not in host:
+            raise ValueError("seed site outside host")
+        by_tick[0].append(site)
+    tick = 0
+    while by_tick[tick]:
+        arrivals: dict[Point, set[Point]] = defaultdict(set)
+        for site in by_tick[tick]:
+            _time, locks = recorded[site]
+            for lock in locks:
+                axis = lock_axis(lock)
+                for step in STEPS:
+                    if dot(step, axis) != 0:
+                        continue
+                    image = add(site, step)
+                    if image not in host or image in recorded:
+                        continue
+                    arrivals[image].add(step)
+        for image, incoming in arrivals.items():
+            recorded[image] = (tick + 1, frozenset(incoming))
+            by_tick[tick + 1].append(image)
+        tick += 1
+    return recorded
+
+
+def occupancy(site: Point, formed: frozenset[Point]) -> int:
+    """Occupancy is 1 on already-recorded sites only."""
+    return 1 if site in formed else 0
+
+
+def n_vector(site: Point, formed: frozenset[Point]) -> Vec3:
+    """Formdraw occupancy kernel n_μ = (o_{+μ} − o_{−μ}) / 3."""
+    components = []
+    for axis in AXES:
+        plus = occupancy(add(site, axis), formed)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), formed)
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+def already_recorded(
+    site: Point, recorded: dict[Point, tuple[int, frozenset[Point]]]
+) -> frozenset[Point]:
+    formation = recorded[site][0]
+    return frozenset(
+        other for other, (tick, _locks) in recorded.items() if tick < formation
+    )
+
+
+def probe_kernels(
+    recorded: dict[Point, tuple[int, frozenset[Point]]],
+) -> dict[str, Vec3]:
+    kernels: dict[str, Vec3] = {}
+    for name, site in PROBES.items():
+        kernels[name] = n_vector(site, already_recorded(site, recorded))
+    return kernels
+
+
+def format_component(value: Fraction) -> str:
+    if value == 0:
+        return "0"
+    sign = "−" if value < 0 else ""
+    magnitude = abs(value)
+    if magnitude.denominator == 1:
+        return f"{sign}{magnitude.numerator}"
+    return f"{sign}{magnitude.numerator}/{magnitude.denominator}"
+
+
+def format_n(n: Vec3) -> str:
+    return f"({format_component(n[0])}, {format_component(n[1])}, {format_component(n[2])})"
+
+
+def neighbor_occupancy(
+    site: Point, formed: frozenset[Point]
+) -> dict[str, tuple[int, int]]:
+    bits: dict[str, tuple[int, int]] = {}
+    names = ("e1", "e2", "e3")
+    for name, axis in zip(names, AXES):
+        plus = occupancy(add(site, axis), formed)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), formed)
+        bits[name] = (plus, minus)
+    return bits
+
+
+def audit_paths_literal(source: str) -> tuple[str, ...] | None:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                value = ast.literal_eval(node.value)
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    self_source = Path(__file__).read_text(encoding="utf-8")
+    host = euclidean_ball()
+    seed_same: tuple[tuple[Point, Point], ...] = (
+        (ORIGIN, E1),
+        (E2, E1),
+    )
+    seed_mixed: tuple[tuple[Point, Point], ...] = (
+        (ORIGIN, E1),
+        (E2, E2),
+    )
+
+    recorded_same = grow(host, seed_same)
+    recorded_mixed = grow(host, seed_mixed)
+    kernels = probe_kernels(recorded_same)
+    mixed_kernels = probe_kernels(recorded_mixed)
+    n_tuple = tuple(kernels[name] for name in ("A", "B", "C", "D"))
+    mixed_tuple = tuple(mixed_kernels[name] for name in ("A", "B", "C", "D"))
+    equal_cd = kernels["C"] == kernels["D"]
+    tuples_equal = n_tuple == mixed_tuple
+
+    print("external_scientific_inputs: none; exact occupancy kernels only")
+    print("package_local_integrity_reads: proposed source note and live axiom memo only")
+    print("host: Euclidean B_3(0) with n·n<=9")
+    print(f"host_site_count: {len(host)}")
+    print("seed: {0,(0,1,0)} both locking +e_1 at tick 0")
+    print("process: nssame perp-step incoming-lock")
+    print("kernel: formdraw n_μ=(o_{+μ}−o_{−μ})/3 from already-recorded 6-NN")
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        formed = already_recorded(site, recorded_same)
+        occ = neighbor_occupancy(site, formed)
+        print(
+            f"n({name})={format_n(kernels[name])} "
+            f"occ=+−e1{occ['e1']} +−e2{occ['e2']} +−e3{occ['e3']} "
+            f"incoming={sorted(recorded_same[site][1])}"
+        )
+    print(f"n(C)=n(D): {equal_cd}")
+    print(f"four-n equals mixed-lock formdraw n: {tuples_equal}")
+    print("unique f(n) leftover transfers: no")
+    print("claim_boundary: displayed, not adopted; not written into Admissibility")
+    print("cache_write: false")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+
+    declared = audit_paths_literal(self_source)
+    checks.check(
+        "audit-input-paths-literal",
+        "AUDIT_INPUT_PATHS is the declared two-path static tuple",
+        declared == AUDIT_INPUT_PATHS
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/NSSAME_FORMDRAW_KERNEL_N_EQUALITY_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    checks.check(
+        "audit-input-files",
+        "declared review inputs exist",
+        AUDIT_TIMEOUT_SEC == 120
+        and all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    wide_host = frozenset(
+        (x, y, z)
+        for x, y, z in product(range(-4, 5), repeat=3)
+        if x * x + y * y + z * z <= 9
+    )
+    checks.check(
+        "host-euclidean-ball",
+        "host is exactly {n in Z^3 : n·n <= 9}",
+        host == wide_host
+        and all(dot(site, site) <= 9 for site in host)
+        and len(host) == 123,
+    )
+    checks.check(
+        "seed-two-site-same-lock",
+        "tick-0 records are origin and (0,1,0), both locking +e_1",
+        recorded_same[ORIGIN] == (0, frozenset({E1}))
+        and recorded_same[E2] == (0, frozenset({E1}))
+        and sum(time == 0 for time, _locks in recorded_same.values()) == 2,
+    )
+    checks.check(
+        "identity-gates-present",
+        "occupancy, n_vector, and grow are computed, not hardcoded",
+        "def occupancy(" in self_source
+        and "def n_vector(" in self_source
+        and "def grow(" in self_source
+        and "n_μ = (o_{+μ} − o_{−μ}) / 3" in self_source,
+    )
+    for name in ("A", "B", "C", "D"):
+        rendered = f"n({name}) = {format_n(kernels[name])}"
+        checks.check(
+            f"thm1-n-{name}",
+            f"computed n({name}) is recorded in the note",
+            rendered in note and PROBES[name] in recorded_same,
+        )
+    checks.check(
+        "thm2-nC-not-equal-nD",
+        "n(C)=n(D) fails on the nssame seed",
+        (not equal_cd)
+        and kernels["C"] != kernels["D"]
+        and "n(C) ≠ n(D)" in note,
+    )
+    checks.check(
+        "thm3-tuple-disagrees-mixed-formdraw",
+        "four-n tuple is not the mixed-lock formdraw tuple",
+        (not tuples_equal)
+        and mixed_kernels["A"]
+        == (Fraction(-1, 3), Fraction(1, 3), Fraction(0))
+        and mixed_kernels["B"]
+        == (Fraction(-1, 3), Fraction(0), Fraction(-1, 3))
+        and mixed_kernels["C"]
+        == (Fraction(-1, 3), Fraction(0), Fraction(0))
+        and mixed_kernels["D"]
+        == (Fraction(-1, 3), Fraction(0), Fraction(0))
+        and "does not transfer" in note,
+    )
+    formed_a = already_recorded(PROBES["A"], recorded_same)
+    formed_d = already_recorded(PROBES["D"], recorded_same)
+    checks.check(
+        "already-recorded-six-nn",
+        "occupancy reads strictly earlier 6-NN, not the unread probe",
+        occupancy(PROBES["A"], formed_a) == 0
+        and occupancy(ORIGIN, formed_a) == 1
+        and occupancy(PROBES["D"], formed_a) == 0
+        and occupancy(add(PROBES["A"], (0, -1, 0)), formed_a) == 1
+        and occupancy(add(PROBES["D"], E2), formed_d) == 1
+        and occupancy(PROBES["A"], formed_d) == 0,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        "first-arrival incoming locks at A and D need not be unique",
+        len(recorded_same[PROBES["A"]][1]) > 1
+        and len(recorded_same[PROBES["D"]][1]) > 1
+        and "Uniqueness is not required" in note,
+    )
+    same_seed_locks = frozenset(seed_same)
+    mixed_orbit = False
+    for matrix in proper_cubic_rotations():
+        image = frozenset(
+            (apply_matrix(matrix, site), apply_matrix(matrix, lock))
+            for site, lock in seed_mixed
+        )
+        if image == same_seed_locks:
+            mixed_orbit = True
+            break
+    checks.check(
+        "not-mixed-cubic-orbit",
+        "same-lock seed is outside the proper cubic orbit of mixed +e_1/+e_2",
+        (not mixed_orbit)
+        and len(proper_cubic_rotations()) == 24
+        and seed_same[0][1] == seed_same[1][1]
+        and seed_mixed[0][1] != seed_mixed[1][1],
+    )
+    origin_parallel_blocked = all(
+        recorded_same[ORIGIN][0] + 1
+        != recorded_same.get(add(ORIGIN, step), (None, frozenset()))[0]
+        for step in (E1, (-1, 0, 0))
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        "origin lock +e_1 blocks parallel steps and allows the four perpendicular steps",
+        origin_parallel_blocked
+        and recorded_same[(0, -1, 0)][0] == 1
+        and recorded_same[E3][0] == 1
+        and recorded_same[(0, 0, -1)][0] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    claim_scope = (
+        "Formdraw occupancy kernels on the four nssame probes, and whether "
+        "n(C)=n(D), are reported. Displayed, not adopted."
+    )
+    checks.check(
+        "note-claim-scope",
+        "note claim_scope matches the occupancy-kernel report",
+        claim_scope in note,
+    )
+    checks.check(
+        "no-letter-assignment",
+        "no unique {+,−} letter is assigned and reverse/face are not scored from n",
+        "L(A)" not in note
+        and "L(B)" not in note
+        and "L(C)" not in note
+        and "L(D)" not in note
+        and "P_±" not in note
+        and "3 t(" not in note
+        and "t(C)^2" not in note
+        and "no unique" in note.lower(),
+    )
+    checks.check(
+        "no-admissibility-write",
+        "display is not written into Admissibility and names no extra axiom",
+        "not written into Admissibility" in note
+        and 'hypothetical_axiom_status: "no edit"' in note
+        and "Admissibility / Local Constraint" in axiom,
+    )
+    checks.check(
+        "forbidden-phrases-absent",
+        "note omits excluded claim language and does not attach a first-lemma tag",
+        "G_" + "N" not in note
+        and "1/" + "r" not in note
+        and "Lattice" + "-named" not in note
+        and "not a " + "TOE" not in note
+        and "Dijk" + "stra" not in note
+        and "Gr" + "am" not in note
+        and "L" + "1" not in note
+        and "par" + "nn" not in note
+        and "k" + "20" not in note
+        and "Runner" + " cache" not in note,
+    )
+    lattice_quote = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with "
+        "nearest-neighbor adjacency, standard translations, and proper cubic "
+        "rotations about each site."
+    )
+    record_quote = (
+        "When present, a record locks exactly one admissible local possibility."
+    )
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    checks.check(
+        "axiom-quotes-unedited",
+        "Lattice and Record sentences are quoted from the live axiom memo",
+        lattice_quote in normalized_axiom
+        and record_quote in normalized_axiom
+        and lattice_quote in normalized_note
+        and record_quote in normalized_note,
+    )
+    checks.check(
+        "no-larger-ball",
+        "formation stays inside B_3(0)",
+        all(dot(site, site) <= 9 for site in recorded_same)
+        and set(recorded_same) <= host
+        and "No larger host is used." in normalized_note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Formdraw occupancy kernels on nssame #7060 probes: n(A)=(-1/3,-1/3,0), n(B)=n(C)=(-1/3,0,0), n(D)=(-1/3,1/3,0). So n(C) != n(D); the nsfrm n(C)=n(D) leftover does not transfer. Displayed, not adopted. No unique letter. No axiom edit.

## Runner

`scripts/nssame_formdraw_kernel_n_equality_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.