### PR TITLE
feat(nsfz): z-probe formdraw PVM reverse/face some; n(Cz) != n(Dz)

### DIFF
--- a/docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,404 @@
+---
+claim_id: nnseed_zprobe_formdraw_kernel_pvm_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from formdraw occupancy-kernel PVM letters on the four nnseed z-probes, or UNDEFINED, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py
+---
+
+# Formdraw Occupancy-Kernel PVM Letters On Four Nnseed Z-Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** named rank-1 PVM letters in `{+,−}` read from the formdraw occupancy
+kernel `n` at the formation tick of the four nnseed z-probes
+`A_z=(0,0,1)`, `B=(1,1,1)`, `C_z=(0,0,2)`, `D_z=(0,1,1)` of the displayed
+two-site nnseed process, scored as reverse and face. If `n=0` or the named
+construction assigns no letter, the comparison is `UNDEFINED`. Both legal
+letters `{+,−}` are kept whenever `n≠0`. Uniqueness is not required. This is
+not unique `f(n)` on the x-probes and is not ndot. Displayed, not adopted.
+This note does not write PVM letters into Admissibility, does not feed letters
+into occupancy `n`, and does not attach the occupancy-kernel formation member.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py`](../scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming lock letters are unit nearest-neighbor
+steps. Named rank-1 PVM letters are `{+,−}` names of the projectors `P_±`
+read from occupancy-kernel `n`. Those two alphabets are not identified.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of formdraw occupancy-kernel n and named rank-1 P_± letters on the four nnseed z-probes, with reverse and face scored as some; uniqueness is not claimed and the letters are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_zprobe_formdraw_kernel_pvm_reverse_face
+target_blocker_text: "display reverse and face from formdraw occupancy-kernel PVM letters on the four nnseed z-probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write letters into Admissibility, do not feed letters into n, and do not identify them with incoming steps."
+conditional_surface_status: "exact on B_3(0) for occupancy-kernel PVM letters on the four nnseed z-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose occupancy
+kernel and PVM letters are scored:
+
+```text
+A_z = (0,0,1),  B = (1,1,1),  C_z = (0,0,2),  D_z = (0,1,1).
+```
+
+These are the nsiso z-probe sites. Formation ticks of those sites locate the
+already-recorded six-neighbor set. The ticks are not occupancy kernels and
+are not the reverse/face scoring.
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not occupancy `n` and is not a named rank-1 PVM letter.
+
+## Named occupancy kernel and rank-1 PVM letter
+
+At the formation tick of a probe, occupancy is read from already-recorded
+sites only: a neighbor is occupied if and only if it formed strictly earlier.
+The probe itself is still unread. Occupancy is in `{0,1}` and does not depend
+on any later PVM letter.
+
+The named formdraw occupancy kernel is the triple
+
+```text
+n_μ = (o_{+μ} − o_{−μ}) / 3,     μ = 1,2,3.
+```
+
+Write `k = |3n|^2`. If `n = 0`, the named construction assigns no letter and
+the probe is `UNDEFINED`. If `n ≠ 0`, write `H = a σ_x + b σ_y + c σ_z` with
+`(a,b,c) = 3n`. Then `H^2 = k I`, and the two legal lock contents are the
+rank-1 projectors
+
+```text
+P_± = (√k I ± H) / (2√k).
+```
+
+The letter `+` names `P_+`. The letter `−` names `P_-`. Both letters are
+legal whenever `n ≠ 0`. Occupancy of a formed site remains `1` for either
+content, so the letter does not feed `n`.
+
+Those projectors live in the live Qubit presentation `M_2(C)`. They are not
+unit nearest-neighbor steps. This note reads `n` at each z-probe's formation
+tick as displayed theorem-domain data. It does not attach the occupancy-kernel
+formation member: sites form by the nnseed perp-step incoming-lock process,
+not by an `n ≠ 0` formation rule.
+
+A process-determined PVM letter at a probe is a value in `{+,−}` assigned by
+that named construction from `n`. Incoming `{±e_i}` tags are not that
+assignment. Identifying a named sign of an incoming step with a PVM letter
+is refused. If a probe has several process-determined letters, reverse and
+face are evaluated on every combination. Uniqueness is not required. Both
+`{+,−}` at `n≠0` are the letter set; a 16-letter occupancy census independent
+of `n` is not taken.
+
+This display is not unique `f(n)` on the x-probes
+`A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`. It does not select one
+letter as a function of `n` (along `n`, by `sign(n_1)`, or by a maximal
+component). It is not ndot: it does not assign a unique letter by the sign of
+a contraction `n·v`.
+
+The equality `n(C)=n(D)` is an x-probe fact of the formdraw occupancy kernel
+on those x-probes. It is not an input to these z-probes.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A_z)=+ and L(B)=−
+face     <=>  L(C_z)=+ and L(D_z)=−
+```
+
+If a letter needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. The report is one of `all`, `some`, `none`, or `UNDEFINED`.
+
+Admissibility is not edited. PVM letters are not written into Admissibility.
+
+## Theorem 1 — occupancy kernel and PVM letter at each z-probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+z-probes. Formation ticks are `t(A_z)=t(0,0,1)=1`, `t(B)=t(1,1,1)=2`,
+`t(C_z)=t(0,0,2)=4`, `t(D_z)=t(0,1,1)=1`. Those ticks match the nsiso z-probe
+formation order and locate the already-recorded set. They are not the
+reverse/face kernel.
+
+At each formation tick the occupancy kernel from already-recorded
+six-neighbor occupancy is nonzero, so both named rank-1 letters are assigned:
+
+```text
+n(A_z) = (0, 0, −1/3),      k(A_z) = 1,     L(A_z) = {+,−}
+n(B)   = (−1/3, 0, −1/3),   k(B) = 2,       L(B) = {+,−}
+n(C_z) = (0, −1/3, −1/3),   k(C_z) = 2,     L(C_z) = {+,−}
+n(D_z) = (0, 0, −1/3),      k(D_z) = 1,     L(D_z) = {+,−}
+```
+
+In particular `n(C_z) ≠ n(D_z)`. The x-probe equality `n(C)=n(D)` is not used.
+
+Neighbor occupancies at those formation ticks:
+
+- `A_z`: already recorded on `−e_3`;
+- `B`: already recorded on `−e_1` and `−e_3`;
+- `C_z`: already recorded on `+e_1`, `−e_1`, `−e_2`, and `−e_3`;
+- `D_z`: already recorded on `−e_3`.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps; `C_z` has three). That non-uniqueness is not a PVM lettering. The PVM
+letters are not identified with those incoming steps. Uniqueness is not
+required.
+
+On the `k=1` z-probes `A_z` and `D_z`, the named traces are `Tr(ρ P_+)=2/3`
+and `Tr(ρ P_-)=1/3`. Both contents occupy the site.
+
+## Theorem 2 — reverse report
+
+Reverse is `L(A_z)=+` and `L(B)=−`. Both probes have letter set `{+,−}`, so
+every combination of the four z-probes is scored. There are 16 combinations.
+Reverse holds on exactly 4 of them and fails on the other 12.
+
+Report: `some`.
+
+This is not `all`, not `none`, and not `UNDEFINED`. A unique `f(n)` letter, an
+ndot contraction letter, a named-sign readout of incoming steps, and a
+formation-tick inequality are different objects and are not used.
+
+## Theorem 3 — face report
+
+Face is `L(C_z)=+` and `L(D_z)=−`. Both probes have letter set `{+,−}`. Face
+holds on exactly 4 of the 16 combinations and fails on the other 12.
+
+Report: `some`.
+
+Displayed, not adopted. The letters are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock or a unique PVM letter.
+- It is not unique `f(n)` on the x-probes.
+- It is not ndot.
+- It does not import `n(C)=n(D)` from the x-probes.
+- It does not identify named rank-1 PVM letters with incoming `{±e_i}`.
+- It does not feed letters into occupancy `n`.
+- It does not attach the occupancy-kernel formation member.
+- It does not census free occupancy letterings independent of `n`.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra in which the named projectors `P_±` are written. It uses
+Record only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The nnseed process, the occupancy kernel, the named PVM
+letters, and the reverse/face predicates are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| occupancy kernel `n` at each z-probe formation tick | Theorem 1; all four `n ≠ 0`; `n(C_z) ≠ n(D_z)` |
+| named rank-1 PVM letters `{+,−}` from `P_±` | Theorem 1; `{+,−}` at each z-probe |
+| reverse and face | Theorems 2–3; both `some` |
+| unique incoming lock or unique PVM letter | not required |
+| unique `f(n)` on the x-probes | not this display |
+| ndot contraction letter | not this display |
+| `n(C)=n(D)` imported from x-probes | not used |
+| letters fed into occupancy `n` | not executed |
+| occupancy-kernel formation member attached | not attached |
+| free occupancy lettering independent of `n` | not enumerated |
+| PVM letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: formdraw occupancy-kernel PVM letters on the four nnseed z-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed occupancy-kernel PVM-letter reverse/face report on these four nnseed z-probes. |
+| V3 | Occupancy kernels, named projectors, and the `some`/`some` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads `n` at formation and names `P_±`. |
+| V5 | It is not an adopted content rule: the letters remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those letters into
+Admissibility, does not identify them with incoming steps, does not feed them
+into `n`, does not import `n(C)=n(D)` from the x-probes, and is not unique
+`f(n)` or ndot. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| identify PVM letter with named sign of incoming `{±e_i}` | map `+e_i` to `+` and `-e_i` to `−` | refused; different alphabet |
+| reverse/face from incoming named signs | reuse the incoming-lock sign readout | different object; not this display |
+| reverse/face from formation-tick inequalities | score z-probes by nsiso tick order | different object; ticks locate occupancy only |
+| unique `f(n)` on the x-probes | assign one letter as a function of `n` | different object; both `{+,−}` are kept |
+| ndot contraction letter | unique letter `sign(n·v)` | different object; not ndot |
+| import `n(C)=n(D)` from x-probes | copy the nsfrm x-probe kernel equality | refused; `n(C_z) ≠ n(D_z)` |
+| free occupancy letters on the four z-probes | ignore `n` and letter independently | different object; not enumerated |
+| attach occupancy-kernel formation member | form the probes by `n ≠ 0` instead of perp-step | refused; not attached |
+| feed letters into `n` | let `+`/`−` change occupancy | refused; occupancy stays `{0,1}` of the already-recorded set |
+| adopt letters into Admissibility | rewrite the local rule by `{+,−}` | refused; displayed, not adopted |
+| unique PVM letter required | demand one letter per probe | uniqueness is not required; both letters are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing occupancy-kernel formation attachment, and
+missing Record identification of the named PVM bits are distinct open
+premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, occupancy kernel from already-recorded neighbors,
+named `P_±` letters, four z-probes, and reverse/face definitions are declared.
+No uniqueness, no occupancy-kernel formation attachment, no Admissibility
+rewrite, no unique `f(n)`, no ndot, and no imported `n(C)=n(D)` are silently
+assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`some` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each named projector `P_±` and each occupancy component | no continuum alphabet |
+| per site | `A_z,B,C_z,D_z` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four `{+,−}` letter sets and two `some` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{+,−}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once `n ≠ 0` at a forming z-probe, the site should lock a unique
+letter `+` or `−` by unique `f(n)` or by ndot, reverse and face should hold on
+all combinations or be adopted as Admissibility content, occupancy should
+track that sign, and `n(C_z)` should equal `n(D_z)` because that held on the
+x-probes.
+
+**Answer:** The named construction assigns both `P_+` and `P_-` whenever
+`n ≠ 0`. Occupancy stays `{0,1}` of the already-recorded set. Reverse and
+face hold on some combinations and fail on others. `n(C_z) ≠ n(D_z)`. The
+bits remain displayed. Uniqueness is not required. This is not unique `f(n)`
+and is not ndot.
+
+### N8 — cross-cycle echo
+
+A prior display scored named rank-1 PVM letters from occupancy-kernel `n` on
+the four nnseed x-probes and reported `some` / `some`, including the x-probe
+fact `n(C)=n(D)`. This note is not that display: it reads `n` on the four
+z-probes, where `n(C_z) ≠ n(D_z)`. A second prior display scored reverse and
+face from formation-tick inequalities on the same z-probes. This note does
+not reuse that scoring. Unique `f(n)` letterings on the x-probes reported
+`none` / `none`; those selectors are not used here.
+
+**Gate disposition:** PASS for the occupancy-kernel PVM-letter reverse/face
+reports on the four nnseed z-probes above. FAIL / DO NOT SHIP for “the PVM
+letter equals the incoming step sign,” “letters are Admissibility,” “letters
+feed `n`,” “unique `f(n)` on the x-probes,” “ndot,” “`n(C)=n(D)` imported
+from the x-probes,” or “reverse/face holds on all combinations.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, computes the formdraw occupancy kernel `n` from
+already-recorded six-neighbor occupancy at each z-probe's formation tick,
+reconstructs the named rank-1 projectors `P_±` as displayed data, reads
+process-determined PVM letters at the four z-probes, and checks Theorems 1--3.
+It also checks that incoming steps are not PVM letters, that letters are not
+fed into occupancy `n`, that the occupancy-kernel formation member is not
+attached, that `n(C_z) ≠ n(D_z)`, that the scoring is not unique `f(n)` and
+not ndot, and that formation ticks match the nsiso z-probe order. No runner
+cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_zprobe_formdraw_kernel_pvm_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.txt
@@ -1,0 +1,78 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py
+runner_sha256: 7ba2bc18a53d7ee6556a437ebd93489ccdb00f28f69886eb3a16da32ed93bb70
+input_fingerprint_sha256: 391af1662d4362fd5eede014dfd4644eafb025140d437ac3277f4956ed383f1b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+formdraw occupancy-kernel PVM-letter reverse/face on four nnseed z-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from formdraw occupancy-kernel PVM letters on the four nnseed z-probes, or UNDEFINED, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-euclidean-b3
+PASS: z-probes-in-host
+PASS: perp-step-blocks-parallel
+PASS: named-pvm-rank1-projectors
+PASS: named-pvm-traces-k1
+PASS: named-pvm-letters-are-plus-minus
+A n=(0,0,-1/3) k=1 abc=(0,0,-1) L={+,−} t=1 incoming=[(0, 0, 1)]
+B n=(-1/3,0,-1/3) k=2 abc=(-1,0,-1) L={+,−} t=2 incoming=[(0, 0, 1), (1, 0, 0)]
+C n=(0,-1/3,-1/3) k=2 abc=(0,-1,-1) L={+,−} t=4 incoming=[(-1, 0, 0), (0, 1, 0), (1, 0, 0)]
+D n=(0,0,-1/3) k=1 abc=(0,0,-1) L={+,−} t=1 incoming=[(0, 0, 1)]
+PASS: theorem1-n-A  ((Fraction(0, 1), Fraction(0, 1), Fraction(-1, 3)))
+PASS: theorem1-n-B  ((Fraction(-1, 3), Fraction(0, 1), Fraction(-1, 3)))
+PASS: theorem1-n-C  ((Fraction(0, 1), Fraction(-1, 3), Fraction(-1, 3)))
+PASS: theorem1-n-D  ((Fraction(0, 1), Fraction(0, 1), Fraction(-1, 3)))
+PASS: theorem1-n-C-neq-n-D  (zC=(Fraction(0, 1), Fraction(-1, 3), Fraction(-1, 3)) zD=(Fraction(0, 1), Fraction(0, 1), Fraction(-1, 3)) xC=(Fraction(-1, 3), Fraction(0, 1), Fraction(0, 1)))
+PASS: theorem1-letters-all-plus-minus
+PASS: theorem1-z-ticks-match-nsiso  ({'A': 1, 'B': 2, 'C': 4, 'D': 1})
+PASS: n-nonzero-assigns-both-letters
+PASS: hamiltonian-square-matches-k
+PASS: incoming-locks-are-nn-steps-not-letters
+PASS: uniqueness-not-required  (B=[(0, 0, 1), (1, 0, 0)] C=[(-1, 0, 0), (0, 1, 0), (1, 0, 0)])
+PASS: two-site-seed-locks
+combos=16 reverse_hits=4 face_hits=4
+reverse=some face=some
+PASS: theorem2-reverse-some  (some)
+PASS: theorem3-face-some  (some)
+PASS: not-unique-fn-on-x-probes
+PASS: not-ndot
+PASS: letters-do-not-feed-occupancy
+PASS: n-independent-of-letter-branch
+PASS: mutation-identify-incoming-sign-is-refused
+PASS: mutation-minus-as-vacant-changes-n
+PASS: mutation-one-site-seed-changes-n  ({'A': (Fraction(0, 1), Fraction(0, 1), Fraction(-1, 3)), 'B': (Fraction(-1, 3), Fraction(-1, 3), Fraction(-1, 3)), 'C': (Fraction(0, 1), Fraction(0, 1), Fraction(-1, 3)), 'D': (Fraction(0, 1), Fraction(-1, 3), Fraction(-1, 3))})
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: not-t-as-comparator
+PASS: no-sixteen-letter-census-beyond-pm
+PASS: note-claim-scope
+PASS: note-reports-n-and-letters
+PASS: note-reports-some-some
+PASS: note-nC-neq-nD-not-x-fact
+PASS: note-not-unique-fn-or-ndot
+PASS: note-z-ticks-nsiso
+PASS: note-displayed-not-adopted
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-feed-n-or-attach-formation-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+TOTAL: PASS=52 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""Formdraw occupancy-kernel PVM letters on four nnseed z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each z-probe's formation tick, n is the formdraw occupancy kernel
+from already-recorded six-neighbor occupancy. If n≠0 the named rank-1 P_±
+letters are {+,−}. Letters do not feed n and are not incoming {±e_i}.
+Uniqueness is not required. Not unique f(n) on x-probes. Not ndot.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from fractions import Fraction
+from itertools import product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Vec3 = tuple[Fraction, Fraction, Fraction]
+Cpx = tuple[Fraction, Fraction]
+Mat = tuple[tuple[Cpx, Cpx], tuple[Cpx, Cpx]]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+AXES: tuple[Point, Point, Point] = (E1, E2, E3)
+PVM_LETTERS = frozenset({"+", "-"})
+ZERO_N: Vec3 = (Fraction(0), Fraction(0), Fraction(0))
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (0, 1, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+EXPECTED_N = {
+    "A": (Fraction(0), Fraction(0), Fraction(-1, 3)),
+    "B": (Fraction(-1, 3), Fraction(0), Fraction(-1, 3)),
+    "C": (Fraction(0), Fraction(-1, 3), Fraction(-1, 3)),
+    "D": (Fraction(0), Fraction(0), Fraction(-1, 3)),
+}
+EXPECTED_TICKS = {"A": 1, "B": 2, "C": 4, "D": 1}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "L1",
+    "Runner cache",
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def cz(re: int | Fraction, im: int | Fraction = 0) -> Cpx:
+    return (Fraction(re), Fraction(im))
+
+
+def cadd(left: Cpx, right: Cpx) -> Cpx:
+    return (left[0] + right[0], left[1] + right[1])
+
+
+def cmul(left: Cpx, right: Cpx) -> Cpx:
+    return (
+        left[0] * right[0] - left[1] * right[1],
+        left[0] * right[1] + left[1] * right[0],
+    )
+
+
+def cscale(coeff: Fraction, value: Cpx) -> Cpx:
+    return (coeff * value[0], coeff * value[1])
+
+
+def madd(left: Mat, right: Mat) -> Mat:
+    return (
+        (cadd(left[0][0], right[0][0]), cadd(left[0][1], right[0][1])),
+        (cadd(left[1][0], right[1][0]), cadd(left[1][1], right[1][1])),
+    )
+
+
+def mmul(left: Mat, right: Mat) -> Mat:
+    return (
+        (
+            cadd(cmul(left[0][0], right[0][0]), cmul(left[0][1], right[1][0])),
+            cadd(cmul(left[0][0], right[0][1]), cmul(left[0][1], right[1][1])),
+        ),
+        (
+            cadd(cmul(left[1][0], right[0][0]), cmul(left[1][1], right[1][0])),
+            cadd(cmul(left[1][0], right[0][1]), cmul(left[1][1], right[1][1])),
+        ),
+    )
+
+
+def mscale(coeff: Fraction, mat: Mat) -> Mat:
+    return (
+        (cscale(coeff, mat[0][0]), cscale(coeff, mat[0][1])),
+        (cscale(coeff, mat[1][0]), cscale(coeff, mat[1][1])),
+    )
+
+
+def mtrace(mat: Mat) -> Cpx:
+    return cadd(mat[0][0], mat[1][1])
+
+
+def I2() -> Mat:
+    zero, one = cz(0), cz(1)
+    return ((one, zero), (zero, one))
+
+
+def SX() -> Mat:
+    zero, one = cz(0), cz(1)
+    return ((zero, one), (one, zero))
+
+
+def SY() -> Mat:
+    zero, i, mi = cz(0), cz(0, 1), cz(0, -1)
+    return ((zero, mi), (i, zero))
+
+
+def SZ() -> Mat:
+    zero, one, mone = cz(0), cz(1), cz(-1)
+    return ((one, zero), (zero, mone))
+
+
+def hamiltonian(a: int, b: int, c: int) -> Mat:
+    return madd(madd(mscale(Fraction(a), SX()), mscale(Fraction(b), SY())), mscale(Fraction(c), SZ()))
+
+
+def zero_mat() -> Mat:
+    z = cz(0)
+    return ((z, z), (z, z))
+
+
+def pvm_projectors_k1(a: int, b: int, c: int) -> tuple[Mat, Mat]:
+    """Named rank-1 P± for H=aσx+bσy+cσz with k=1."""
+    if a * a + b * b + c * c != 1:
+        raise ValueError("named k=1 projectors require a^2+b^2+c^2=1")
+    ham = hamiltonian(a, b, c)
+    half = Fraction(1, 2)
+    pplus = mscale(half, madd(I2(), ham))
+    pminus = mscale(half, madd(I2(), mscale(Fraction(-1), ham)))
+    return pplus, pminus
+
+
+def pvm_probs_k1(a: int, b: int, c: int) -> tuple[Fraction, Fraction]:
+    """Identity gate: Tr(ρ P±) for named rank-1 projectors at k=1."""
+    pplus, pminus = pvm_projectors_k1(a, b, c)
+    ham = hamiltonian(a, b, c)
+    half = Fraction(1, 2)
+    rho = mscale(half, madd(I2(), mscale(Fraction(1, 3), ham)))
+    tp = mtrace(mmul(rho, pplus))
+    tm = mtrace(mmul(rho, pminus))
+    if tp[1] != 0 or tm[1] != 0:
+        raise ValueError("named k=1 traces left the reals")
+    return tp[0], tm[0]
+
+
+def occupancy(site: Point, formed: frozenset[Point], letter: str | None = None) -> int:
+    """Occupancy is 1 on already-recorded sites. A PVM letter does not feed n."""
+    if letter is not None and letter not in PVM_LETTERS:
+        raise ValueError(f"letter must be + or -, got {letter!r}")
+    return 1 if site in formed else 0
+
+
+def n_vector(site: Point, formed: frozenset[Point]) -> Vec3:
+    """Formdraw occupancy kernel n_μ = (o_{+μ} − o_{−μ}) / 3."""
+    components = []
+    for axis in AXES:
+        plus = occupancy(add(site, axis), formed)
+        minus = occupancy(add(site, (-axis[0], -axis[1], -axis[2])), formed)
+        components.append(Fraction(plus - minus, 3))
+    return (components[0], components[1], components[2])
+
+
+def k_value(n: Vec3) -> int:
+    squared = sum((3 * component) ** 2 for component in n)
+    if squared.denominator != 1:
+        raise ValueError(f"k left Q: {squared}")
+    return int(squared)
+
+
+def abc_from_n(n: Vec3) -> tuple[int, int, int]:
+    return (int(3 * n[0]), int(3 * n[1]), int(3 * n[2]))
+
+
+def pvm_letters_from_n(n: Vec3) -> frozenset[str]:
+    """Named rank-1 P_± letters from occupancy kernel n. Not incoming {±e_i}."""
+    if n == ZERO_N:
+        return frozenset()
+    return frozenset(PVM_LETTERS)
+
+
+def unique_plus_from_n(n: Vec3) -> frozenset[str]:
+    """Refused unique f(n): P_+ along n. Not used for reverse/face."""
+    if n == ZERO_N:
+        return frozenset()
+    return frozenset({"+"})
+
+
+def ndot_letter_from_n(n: Vec3, direction: Point) -> frozenset[str]:
+    """Refused ndot: unique letter sign(n·v). Not used for reverse/face."""
+    contraction = n[0] * direction[0] + n[1] * direction[1] + n[2] * direction[2]
+    if contraction == 0:
+        return frozenset()
+    return frozenset({"+"} if contraction > 0 else {"-"})
+
+
+def letter_report(letters: frozenset[str]) -> str:
+    if not letters:
+        return "UNDEFINED"
+    if letters == PVM_LETTERS:
+        return "{+,−}"
+    only = next(iter(letters))
+    return only
+
+
+def hold_report(
+    n_true: int,
+    n_total: int,
+    *,
+    defined: bool,
+) -> str:
+    if not defined:
+        return "UNDEFINED"
+    if n_total == 0 or n_true == 0:
+        return "none"
+    if n_true == n_total:
+        return "all"
+    return "some"
+
+
+def hamiltonian_square_k(a: int, b: int, c: int) -> int:
+    """Identity gate: Pauli H=aσx+bσy+cσz satisfies H^2 = (a^2+b^2+c^2) I."""
+    return a * a + b * b + c * c
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def already_recorded(site: Point, ticks: dict[Point, int]) -> frozenset[Point]:
+    formation = ticks[site]
+    return frozenset(other for other, tick in ticks.items() if tick < formation)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("formdraw occupancy-kernel PVM-letter reverse/face on four nnseed z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "claim_scope: Reverse and face from formdraw occupancy-kernel PVM "
+        "letters on the four nnseed z-probes, or UNDEFINED, are reported. "
+        "Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    checks.check(
+        "host-is-euclidean-b3",
+        ORIGIN in host and len(host) == 123 and BALL_SQ == 9,
+    )
+    checks.check(
+        "z-probes-in-host",
+        {PROBES["A"], PROBES["B"], PROBES["C"], PROBES["D"]} <= host,
+    )
+    checks.check(
+        "perp-step-blocks-parallel",
+        perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+
+    pplus, pminus = pvm_projectors_k1(0, 0, -1)
+    tp, tm = pvm_probs_k1(0, 0, -1)
+    ham = hamiltonian(0, 0, -1)
+    checks.check(
+        "named-pvm-rank1-projectors",
+        mtrace(pplus) == cz(1)
+        and mtrace(pminus) == cz(1)
+        and pplus == mmul(pplus, pplus)
+        and pminus == mmul(pminus, pminus)
+        and mmul(pplus, pminus) == zero_mat()
+        and mmul(ham, ham) == I2(),
+    )
+    checks.check(
+        "named-pvm-traces-k1",
+        tp == Fraction(2, 3) and tm == Fraction(1, 3) and tp + tm == 1,
+    )
+    checks.check(
+        "named-pvm-letters-are-plus-minus",
+        PVM_LETTERS == frozenset({"+", "-"})
+        and E1 not in PVM_LETTERS
+        and E2 not in PVM_LETTERS,
+    )
+
+    ticks, locks = form()
+    kernels: dict[str, Vec3] = {}
+    letters: dict[str, frozenset[str]] = {}
+    for name, site in PROBES.items():
+        formed_before = already_recorded(site, ticks)
+        n = n_vector(site, formed_before)
+        kernels[name] = n
+        letters[name] = pvm_letters_from_n(n)
+        a, b, c = abc_from_n(n)
+        print(
+            f"{name} n=({n[0]},{n[1]},{n[2]}) k={k_value(n)} "
+            f"abc=({a},{b},{c}) L={letter_report(letters[name])} "
+            f"t={ticks[site]} incoming={sorted(locks.get(site, ()))}"
+        )
+
+    x_kernels = {
+        name: n_vector(site, already_recorded(site, ticks))
+        for name, site in X_PROBES.items()
+    }
+
+    checks.check(
+        "theorem1-n-A",
+        kernels["A"] == EXPECTED_N["A"] and k_value(kernels["A"]) == 1,
+        str(kernels["A"]),
+    )
+    checks.check(
+        "theorem1-n-B",
+        kernels["B"] == EXPECTED_N["B"] and k_value(kernels["B"]) == 2,
+        str(kernels["B"]),
+    )
+    checks.check(
+        "theorem1-n-C",
+        kernels["C"] == EXPECTED_N["C"] and k_value(kernels["C"]) == 2,
+        str(kernels["C"]),
+    )
+    checks.check(
+        "theorem1-n-D",
+        kernels["D"] == EXPECTED_N["D"] and k_value(kernels["D"]) == 1,
+        str(kernels["D"]),
+    )
+    checks.check(
+        "theorem1-n-C-neq-n-D",
+        kernels["C"] != kernels["D"]
+        and x_kernels["C"] == x_kernels["D"]
+        and x_kernels["C"] == (Fraction(-1, 3), Fraction(0), Fraction(0)),
+        f"zC={kernels['C']} zD={kernels['D']} xC={x_kernels['C']}",
+    )
+    checks.check(
+        "theorem1-letters-all-plus-minus",
+        all(letters[name] == PVM_LETTERS for name in ("A", "B", "C", "D"))
+        and all(letter_report(letters[name]) == "{+,−}" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-z-ticks-match-nsiso",
+        all(ticks[PROBES[name]] == EXPECTED_TICKS[name] for name in ("A", "B", "C", "D")),
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "n-nonzero-assigns-both-letters",
+        pvm_letters_from_n(ZERO_N) == frozenset()
+        and pvm_letters_from_n(EXPECTED_N["A"]) == PVM_LETTERS,
+    )
+    checks.check(
+        "hamiltonian-square-matches-k",
+        all(
+            hamiltonian_square_k(*abc_from_n(kernels[name])) == k_value(kernels[name])
+            for name in ("A", "B", "C", "D")
+        )
+        and mmul(hamiltonian(*abc_from_n(kernels["B"])), hamiltonian(*abc_from_n(kernels["B"])))
+        == mscale(Fraction(2), I2())
+        and mmul(hamiltonian(*abc_from_n(kernels["C"])), hamiltonian(*abc_from_n(kernels["C"])))
+        == mscale(Fraction(2), I2()),
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps-not-letters",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D"))
+        and all(not (locks[PROBES[name]] & PVM_LETTERS) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 3
+        and letters["B"] == PVM_LETTERS,
+        f"B={sorted(locks[PROBES['B']])} C={sorted(locks[PROBES['C']])}",
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2},
+    )
+
+    defined_reverse = bool(letters["A"]) and bool(letters["B"])
+    defined_face = bool(letters["C"]) and bool(letters["D"])
+    combos = tuple(
+        product(
+            sorted(letters["A"]),
+            sorted(letters["B"]),
+            sorted(letters["C"]),
+            sorted(letters["D"]),
+        )
+    )
+    reverse_hits = sum(combo[0] == "+" and combo[1] == "-" for combo in combos)
+    face_hits = sum(combo[2] == "+" and combo[3] == "-" for combo in combos)
+    reverse_status = hold_report(reverse_hits, len(combos), defined=defined_reverse)
+    face_status = hold_report(face_hits, len(combos), defined=defined_face)
+    print(f"combos={len(combos)} reverse_hits={reverse_hits} face_hits={face_hits}")
+    print(f"reverse={reverse_status} face={face_status}")
+
+    unique_plus = {name: unique_plus_from_n(kernels[name]) for name in ("A", "B", "C", "D")}
+    unique_combos = tuple(
+        product(
+            sorted(unique_plus["A"]),
+            sorted(unique_plus["B"]),
+            sorted(unique_plus["C"]),
+            sorted(unique_plus["D"]),
+        )
+    )
+    unique_reverse = sum(combo[0] == "+" and combo[1] == "-" for combo in unique_combos)
+    ndot_letters = {name: ndot_letter_from_n(kernels[name], E3) for name in ("A", "B", "C", "D")}
+    ndot_combos = tuple(
+        product(
+            sorted(ndot_letters["A"]),
+            sorted(ndot_letters["B"]),
+            sorted(ndot_letters["C"]),
+            sorted(ndot_letters["D"]),
+        )
+    )
+    ndot_reverse = sum(combo[0] == "+" and combo[1] == "-" for combo in ndot_combos)
+    ndot_defined = all(ndot_letters[name] for name in ("A", "B", "C", "D"))
+
+    checks.check(
+        "theorem2-reverse-some",
+        reverse_status == "some"
+        and defined_reverse
+        and reverse_hits == 4
+        and len(combos) == 16,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-some",
+        face_status == "some" and defined_face and face_hits == 4,
+        face_status,
+    )
+    checks.check(
+        "not-unique-fn-on-x-probes",
+        all(unique_plus[name] == frozenset({"+"}) for name in ("A", "B", "C", "D"))
+        and unique_reverse == 0
+        and reverse_status == "some"
+        and letters["A"] != unique_plus["A"],
+    )
+    checks.check(
+        "not-ndot",
+        ndot_defined
+        and all(ndot_letters[name] == frozenset({"-"}) for name in ("A", "B", "C", "D"))
+        and ndot_reverse == 0
+        and reverse_status == "some"
+        and letters["A"] != ndot_letters["A"],
+    )
+    checks.check(
+        "letters-do-not-feed-occupancy",
+        occupancy(PROBES["A"], frozenset(ticks), "+")
+        == occupancy(PROBES["A"], frozenset(ticks), "-")
+        == occupancy(PROBES["A"], frozenset(ticks), None)
+        == 1
+        and occupancy((4, 0, 0), frozenset(ticks), "+") == 0,
+    )
+    formed_before_a = already_recorded(PROBES["A"], ticks)
+    checks.check(
+        "n-independent-of-letter-branch",
+        n_vector(PROBES["A"], formed_before_a) == EXPECTED_N["A"],
+    )
+    checks.check(
+        "mutation-identify-incoming-sign-is-refused",
+        all(isinstance(lock, tuple) for lock in locks[PROBES["A"]])
+        and pvm_letters_from_n(kernels["A"]) == PVM_LETTERS
+        and E1 not in PVM_LETTERS
+        and E3 not in PVM_LETTERS,
+    )
+    signed_minus_as_vacant = frozenset(site for site in formed_before_a if site != ORIGIN)
+    checks.check(
+        "mutation-minus-as-vacant-changes-n",
+        n_vector(PROBES["A"], signed_minus_as_vacant) != EXPECTED_N["A"],
+    )
+    one_site_ticks, _ = form(seeds=((ORIGIN, E1),))
+    one_site_n = {
+        name: n_vector(PROBES[name], already_recorded(PROBES[name], one_site_ticks))
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in one_site_ticks
+    }
+    checks.check(
+        "mutation-one-site-seed-changes-n",
+        one_site_n != kernels,
+        str(one_site_n),
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "not-t-as-comparator",
+        reverse_status == "some"
+        and face_status == "some"
+        and reverse_hits != 0
+        and "3 t(" not in note,
+    )
+    checks.check(
+        "no-sixteen-letter-census-beyond-pm",
+        len(combos) == 16
+        and all(letters[name] == PVM_LETTERS for name in ("A", "B", "C", "D"))
+        and "16-letter occupancy census independent of `n` is not taken"
+        in normalized_note,
+    )
+
+    claim_scope = (
+        "Reverse and face from formdraw occupancy-kernel PVM letters "
+        "on the four nnseed z-probes, or UNDEFINED, are reported. Displayed, "
+        "not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "note-reports-n-and-letters",
+        "n(A_z) = (0, 0, −1/3)" in note
+        and "n(B)   = (−1/3, 0, −1/3)" in note
+        and "n(C_z) = (0, −1/3, −1/3)" in note
+        and "n(D_z) = (0, 0, −1/3)" in note
+        and "L(A_z) = {+,−}" in note
+        and "L(B) = {+,−}" in note
+        and "L(C_z) = {+,−}" in note
+        and "L(D_z) = {+,−}" in note,
+    )
+    checks.check(
+        "note-reports-some-some",
+        note.count("Report: `some`.") == 2
+        and "all" in note
+        and "some" in note
+        and "none" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-nC-neq-nD-not-x-fact",
+        "n(C_z) ≠ n(D_z)" in note
+        and "`n(C)=n(D)` is an x-probe fact" in note,
+    )
+    checks.check(
+        "note-not-unique-fn-or-ndot",
+        "not unique `f(n)` on the x-probes" in note and "not ndot" in note,
+    )
+    checks.check(
+        "note-z-ticks-nsiso",
+        "t(A_z)=t(0,0,1)=1" in note
+        and "t(B)=t(1,1,1)=2" in note
+        and "t(C_z)=t(0,0,2)=4" in note
+        and "t(D_z)=t(0,1,1)=1" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "Identifying a named sign of an incoming step with a PVM letter is refused."
+        in normalized_note,
+    )
+    checks.check(
+        "note-does-not-feed-n-or-attach-formation-member",
+        "does not feed `n`" in note
+        and "does not attach the occupancy-kernel formation member" in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_ZPROBE_FORMDRAW_KERNEL_PVM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def occupancy(" in source
+        and "def n_vector(" in source
+        and "def pvm_letters_from_n(" in source
+        and "def form(" in source
+        and "def pvm_probs_k1(" in source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Formdraw occupancy-kernel PVM letters on nnseed #7050 z-probes: n(Az)=(0,0,-1/3), n(B)=(-1/3,0,-1/3), n(Cz)=(0,-1/3,-1/3), n(Dz)=(0,0,-1/3). n(Cz) != n(Dz). Both {+,−} legal; reverse some; face some. Displayed, not adopted. No axiom edit.

## Runner

`scripts/nnseed_zprobe_formdraw_kernel_pvm_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.