### PR TITLE
feat(nfsum): neighbor-lock sum: reverse fail, face holds

### DIFF
--- a/docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,379 @@
+---
+claim_id: nnseed_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the sum of already-recorded 6-NN locks on the four nnseed x-probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py
+---
+
+# Sum Of Recorded-Neighbor Locks Reverse And Face On Four Nnseed X-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** letter in `Z^3` or `UNDEFINED` read as the sum of already-recorded
+six-neighbor lock vectors at the formation tick of four x-probes of the
+displayed two-site nnseed process, scored as reverse and face. The letter is
+the vector sum of that already-recorded neighbor lock list, or `UNDEFINED`
+if the list is empty. Mixed lists remain defined. Occupancy `n` is not used.
+The probe's own incoming lock is not used. This is not named-sign lettering.
+This is not a singleton leftover of unique lock-vector lettering. Uniqueness
+of incoming locks is not required. Displayed, not adopted. This note does not
+write the sum letter into Admissibility and does not attach a formation
+member from already-recorded six-neighbor locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py`](../scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named probes. Incoming lock letters are unit nearest-neighbor
+steps. The scored letter is a vector in `Z^3`, or `UNDEFINED`. Named signs
+`{+,−}` are a coarser readout and are not the letter. A singleton unique
+lock-vector letter is a different readout and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of already-recorded six-neighbor lock lists and the Z^3 sum letter on the four nnseed x-probes, with reverse fail and face hold; uniqueness of incoming locks is not claimed and the letters are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_neighbor_lock_sum_reverse_face
+target_blocker_text: "display reverse and face from the sum of already-recorded 6-NN locks on the four nnseed x-probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write the sum letter into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not use occupancy n, and do not identify the letter with the probe's own incoming step."
+conditional_surface_status: "exact on B_3(0) for sum letters from already-recorded six-neighbor locks on the four nnseed x-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four probes are the only sites whose
+already-recorded six-neighbor lock lists and sum letters are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not the sum letter scored below.
+
+## Named sum letter from already-recorded six-neighbor locks
+
+At the formation tick of a probe `q`, let `S` be the list of locks of
+already-recorded six-neighbors of `q`. A neighbor is already recorded if and
+only if it formed strictly earlier. The probe itself is still unread. This
+display does not use occupancy `n`. It does not use the probe's own incoming
+lock.
+
+If `S` is empty, the letter is `UNDEFINED`. Else the letter is the vector sum
+of `S` in `Z^3`. Mixed lists remain defined: mixed no longer kills the letter.
+The construction does not require `S` to be a singleton. It is not a
+singleton leftover of unique lock-vector lettering.
+
+A process-determined sum letter at a probe is a value in `Z^3` assigned by
+that named construction from already-recorded six-neighbor locks, or
+`UNDEFINED`. Incoming `{±e_i}` tags of the probe itself are not that
+assignment. Identifying a named sign of those locks with the sum letter is
+refused: named-sign lettering lost the axis. Reverse and face are scored on
+the sum vector. They are not scored on `{+,−}` names and are not an
+occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A) and L(B) defined and L(A)+L(B)=(0,0,0)
+face     <=>  L(C) and L(D) defined and L(C)+L(D)=(0,0,0)
+```
+
+If a letter needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. If both letters are defined and the vector sum is not zero, the
+comparison fails. The report is one of `hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Sum letters are not written into Admissibility.
+
+## Theorem 1 — recorded-neighbor lock list and sum letter at each probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+probes. At each formation tick the already-recorded six-neighbor lock list
+and sum letter are:
+
+```text
+A: +e_1 at (0, 0, 0), +e_1 at (1, 1, 0);     L(A) = (2, 0, 0)
+B: +e_3 at (0, 1, 1), +e_1 at (1, 1, 0);     L(B) = (1, 0, 1)
+C: −e_2 at (1, 0, 0);                        L(C) = −e_2
+D: +e_2 at (0, 1, 0);                        L(D) = +e_2
+```
+
+`C`'s already-recorded neighbor is `A` locking `−e_2`. `D`'s already-recorded
+neighbor is the seed `(0, 1, 0)` locking `+e_2`. The sum letters at `C` and
+`D` are opposite axis vectors. Named-sign lettering of the same lists is
+`C−/D+` and lost the axis: those signs are not opposites in the `C+` and `D−`
+face predicate, while `L(C)+L(D)=(0,0,0)`.
+
+`B`'s already-recorded neighbor locks are `+e_3` and `+e_1`. Those two vectors
+are mixed. Unique lock-vector lettering would report `UNDEFINED`. The sum
+letter is `(1, 0, 1)`. They share a named sign `+`; reducing to named sign
+would hide that mix.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps `+e_1` and `+e_3`). That non-uniqueness is not a unique-lettering of
+already-recorded neighbor lock vectors. The sum letters are not identified
+with those incoming steps. Uniqueness is not required.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if `L(A)` and `L(B)` are defined and
+`L(A)+L(B)=(0,0,0)`. The sum letters are `L(A)=(2, 0, 0)` and
+`L(B)=(1, 0, 1)`, so `L(A)+L(B)=(3, 0, 1)`. Reverse fails.
+
+Reverse: fail
+
+This is not `hold` and not `UNDEFINED`. Unique lock-vector lettering of the
+same lists would assign `L(B)=UNDEFINED` and would report reverse
+`UNDEFINED`. That readout is a different object and is not used. A named-sign
+readout of the same neighbor locks would assign `L(A)=+` and `L(B)=+` and
+would report reverse fail for a different reason.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if `L(C)` and `L(D)` are defined and
+`L(C)+L(D)=(0,0,0)`. The sum letters are `L(C)=−e_2` and `L(D)=+e_2`,
+so `L(C)+L(D)=(0,0,0)`. Face holds.
+
+Face: hold
+
+Displayed, not adopted. The letters are not written into Admissibility.
+
+Named-sign lettering of the same lists is `C−/D+`. Face as `C+` and `D−`
+fails on those signs. The vectors remain opposites. This note keeps the
+vectors.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify sum letters with the probe's own incoming `{±e_i}`.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the recorded-neighbor lock list to be a singleton.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not census a sixteen-combination free lettering independent of
+  recorded-neighbor lock vectors.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+nnseed process, the already-recorded six-neighbor lock lists, the sum letter
+from those locks, and the reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| already-recorded six-neighbor lock lists at each probe formation tick | Theorem 1 |
+| sum letter from those locks | Theorem 1; `(2, 0, 0)`, `(1, 0, 1)`, `−e_2`, `+e_2` |
+| reverse and face | Theorems 2–3; `fail` / `hold` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used; mixed no longer kills |
+| occupancy-kernel inner product | not used |
+| probe's own incoming lock as the letter | not used |
+| formation member from already-recorded six-neighbor locks | not attached |
+| sum letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: sum letter from already-recorded six-neighbor locks on the four nnseed x-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed neighbor-lock-sum reverse/face report on these four nnseed x-probes. |
+| V3 | Recorded-neighbor lock lists, sum letters, and the `fail`/`hold` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads already-recorded six-neighbor lock vectors at formation and scores their sum. |
+| V5 | It is not an adopted content rule: the letters remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those letters into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not reduce them to named signs, does not require a singleton lock
+vector, and does not use occupancy `n`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique lock-vector lettering of the same neighbor locks | require a singleton `{v}` subset `{±e_i}` | refused; leftover; `L(B)` would be `UNDEFINED` while the sum is `(1, 0, 1)` |
+| named-sign lettering of the same neighbor locks | map `±e_i` to `{+,−}` | refused; lost the axis; `C−/D+` fails face while `−e_2+(+e_2)=0` |
+| identify sum letter with the probe's own incoming `{±e_i}` | map `A`'s incoming `−e_2` to `L(A)` | refused; `L(A)=(2, 0, 0)` from already-recorded neighbor locks |
+| reverse/face from self-incoming named signs | reuse incoming `+e_1` at both `C` and `D` | different object; both `+e_1`; not this display |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; not this display |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt letters into Admissibility | rewrite the local rule by `Z^3` sums | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; both earliest incoming steps at `B` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from already-recorded
+six-neighbor locks, and missing Record identification of the sum letter are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, sum letter from already-recorded six-neighbor
+locks, four probes, and reverse/face as vector-sum zero are declared. No
+uniqueness of incoming locks, no occupancy `n`, no named-sign reduction, no
+singleton leftover, no formation attachment from already-recorded
+six-neighbor locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each sum letter from recorded-neighbor lock vectors | no continuum alphabet |
+| per site | `A,B,C,D` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four sum letters and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `Z^3` sums. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once an already-recorded neighbor exists at a forming probe, the
+site should lock that unique vector as incoming content, mixed neighbor locks
+should make the letter `UNDEFINED`, reverse and face should both hold, named
+signs should suffice because they keep orientation, and occupancy `n` should
+track that vector.
+
+**Answer:** The named construction assigns sum letters `(2, 0, 0)`,
+`(1, 0, 1)`, `−e_2`, `+e_2` at `A,B,C,D` from already-recorded six-neighbor
+locks. Mixed no longer kills the letter. Occupancy `n` is not used. Named
+signs lost the axis. Reverse fails. Face holds. The bits remain displayed.
+Incoming-lock uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+A leftover unique-letter-of-occupancy display on the same four nnseed probes
+closed reverse/face as `none`/`none` because occupancy at `C` and at `D`
+agrees. An occupancy-kernel inner product on the same probes reports reverse
+and face fail. A named-sign neighbor-lock lettering on the same lists reports
+`C−/D+` and face fail, having lost the axis. Unique lock-vector lettering of
+the same lists reports reverse `UNDEFINED` because `L(B)` is mixed vectors,
+while face holds. This note is not those displays: mixed no longer kills the
+letter, `L(B)=(1, 0, 1)`, reverse fails, and `L(C)+L(D)=(0,0,0)` so face
+holds. A self-incoming named-sign readout on the same process has `C` and `D`
+both `+e_1`. This note does not reuse that scoring.
+
+**Gate disposition:** PASS for the already-recorded six-neighbor-lock-sum
+reverse/face reports above. FAIL / DO NOT SHIP for “the sum letter equals the
+named sign,” “the sum letter equals the unique singleton lock vector,” “the
+sum letter equals the probe's own incoming step,” “letters are
+Admissibility,” “the letter is occupancy `n`,” or “reverse holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, collects already-recorded six-neighbor locks at each
+probe's formation tick, reads the `Z^3` sum letter at the four probes, and
+checks Theorems 1--3. It also checks that the construction is not named-sign
+lettering, that mixed lists remain defined, that the probe's own incoming
+step is not the sum letter, that occupancy `n` is not used, and that a
+formation member from already-recorded six-neighbor locks is not attached.
+No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.txt
@@ -1,0 +1,76 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py
+runner_sha256: 9c5628da5788753dd433eefd9286dd912eb8ea71f5590194f600fbccd98edd40
+input_fingerprint_sha256: 717bb1b500364d796750fff41497a2bf10bb0f5b644c46f6379068ee464b944f
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+sum of recorded-neighbor locks reverse/face on nnseed x-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the sum of already-recorded 6-NN locks on the four nnseed x-probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: sum-letter-identity
+PASS: mixed-no-longer-kills-letter
+PASS: not-named-sign-reduction
+PASS: not-singleton-vector-leftover
+PASS: reverse-face-identity
+A t=2 recorded-neighbor-locks=[+e_1 at (0, 0, 0), +e_1 at (1, 1, 0)] L=(2, 0, 0) incoming=−e_2
+B t=2 recorded-neighbor-locks=[+e_3 at (0, 1, 1), +e_1 at (1, 1, 0)] L=(1, 0, 1) incoming=+e_3,+e_1
+C t=3 recorded-neighbor-locks=[−e_2 at (1, 0, 0)] L=−e_2 incoming=+e_1
+D t=1 recorded-neighbor-locks=[+e_2 at (0, 1, 0)] L=+e_2 incoming=+e_1
+reverse=fail face=hold
+PASS: theorem1-A-neighbor-lock-list-and-letter  (((((0, 0, 0), (1, 0, 0)), ((1, 1, 0), (1, 0, 0))), (2, 0, 0)))
+PASS: theorem1-B-neighbor-lock-list-and-letter  (((((0, 1, 1), (0, 0, 1)), ((1, 1, 0), (1, 0, 0))), (1, 0, 1)))
+PASS: theorem1-C-neighbor-lock-list-and-letter  (((((1, 0, 0), (0, -1, 0)),), (0, -1, 0)))
+PASS: theorem1-D-neighbor-lock-list-and-letter  (((((0, 1, 0), (0, 1, 0)),), (0, 1, 0)))
+PASS: theorem1-B-mixed-vectors-still-sum
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-hold  (hold)
+PASS: sign-lettering-loses-axis-and-fails-face
+PASS: not-self-incoming-nnlock
+PASS: not-probe-own-incoming-lock
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required  ([(0, 0, 1), (1, 0, 0)])
+PASS: two-site-seed-locks
+PASS: already-recorded-not-self-or-later
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-mixed-neighbor-vectors-defined-sum
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-lists-and-letters
+PASS: note-reports-fail-hold
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-attach-formation-member
+PASS: note-not-singleton-vector-leftover
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-neighbor-lock-sum-only
+TOTAL: PASS=51 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Sum of recorded-neighbor locks reverse/face on four nnseed x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each probe's formation tick, S is the list of locks of already-
+recorded six-neighbors. If S is empty the letter is UNDEFINED; else the
+letter is the vector sum of S in Z^3. Mixed lists remain defined. Reverse
+holds iff L(A) and L(B) are defined and L(A)+L(B)=(0,0,0). Face holds iff
+L(C) and L(D) are defined and L(C)+L(D)=(0,0,0). Not singleton-vector
+leftover. Not named-sign lettering. Occupancy n is not used. The probe's
+own incoming lock is not used. Uniqueness of incoming locks is not required.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Letter = Point | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E2: Point = (0, -1, 0)
+TWO_E1: Point = (2, 0, 0)
+E1_PLUS_E3: Point = (1, 0, 1)
+REVERSE_SUM: Point = (3, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    NEG_E2,
+    E3,
+    (0, 0, -1),
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({(-1, 0, 0), NEG_E2, (0, 0, -1)})
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    (-1, 0, 0): "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    (0, 0, -1): "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from the sum of already-recorded 6-NN "
+    "locks on the four nnseed x-probes are reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the sum letter."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def sum_letter(locks: tuple[Point, ...]) -> Letter:
+    """Letter is the Z^3 sum of the recorded-neighbor lock list, or UNDEFINED."""
+    if not locks:
+        return "UNDEFINED"
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def comparison_report(left: Letter, right: Letter) -> str:
+    """Hold iff both letters are defined lock sums that add to zero."""
+    if left == "UNDEFINED" or right == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(left, tuple) or not isinstance(right, tuple):
+        return "UNDEFINED"
+    if add(left, right) == ZERO:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(letter_a: Letter, letter_b: Letter) -> str:
+    """Reverse iff L(A) and L(B) are defined and L(A)+L(B)=(0,0,0)."""
+    return comparison_report(letter_a, letter_b)
+
+
+def face_report(letter_c: Letter, letter_d: Letter) -> str:
+    """Face iff L(C) and L(D) are defined and L(C)+L(D)=(0,0,0)."""
+    return comparison_report(letter_c, letter_d)
+
+
+def letter_display(letter: Letter) -> str:
+    if letter == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter, tuple):
+        raise TypeError(f"letter is not a lock-sum vector: {letter!r}")
+    return LOCK_NAME.get(letter, str(letter))
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def recorded_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of already-recorded six-neighbors at the formation tick of site."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("sum of recorded-neighbor locks reverse/face on nnseed x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E2, E2) == ZERO
+        and add(TWO_E1, E1_PLUS_E3) == REVERSE_SUM
+        and REVERSE_SUM != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "sum-letter-identity",
+        sum_letter((E1,)) == E1
+        and sum_letter((E1, E1)) == TWO_E1
+        and sum_letter((NEG_E2,)) == NEG_E2
+        and sum_letter((E2,)) == E2
+        and sum_letter((E1, E2)) == (1, 1, 0)
+        and sum_letter((E1, E3)) == E1_PLUS_E3
+        and sum_letter((E2, NEG_E2)) == ZERO
+        and sum_letter(()) == "UNDEFINED",
+    )
+    checks.check(
+        "mixed-no-longer-kills-letter",
+        sum_letter((E1, E3)) == E1_PLUS_E3
+        and sum_letter((E1, E1)) == TWO_E1
+        and sum_letter((E1, E3)) != "UNDEFINED"
+        and len(set((E1, E3))) != 1,
+    )
+    checks.check(
+        "not-named-sign-reduction",
+        sum_letter((E1, E3)) == E1_PLUS_E3
+        and named_sign(E1) == named_sign(E3) == "+"
+        and E1_PLUS_E3 not in POSITIVE_LOCKS
+        and E1_PLUS_E3 not in NEGATIVE_LOCKS,
+    )
+    checks.check(
+        "not-singleton-vector-leftover",
+        sum_letter((E1, E1)) != E1
+        and sum_letter((E1, E3)) != "UNDEFINED",
+    )
+    checks.check(
+        "reverse-face-identity",
+        reverse_report("UNDEFINED", NEG_E2) == "UNDEFINED"
+        and reverse_report(E1, "UNDEFINED") == "UNDEFINED"
+        and reverse_report(E1, (-1, 0, 0)) == "hold"
+        and reverse_report(E1, E1) == "fail"
+        and reverse_report(E1, E2) == "fail"
+        and reverse_report(TWO_E1, E1_PLUS_E3) == "fail"
+        and face_report(NEG_E2, E2) == "hold"
+        and face_report(E2, NEG_E2) == "hold"
+        and face_report(NEG_E2, NEG_E2) == "fail"
+        and face_report("UNDEFINED", E2) == "UNDEFINED"
+        and face_report(NEG_E2, "UNDEFINED") == "UNDEFINED",
+    )
+
+    ticks, locks = form()
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    letters: dict[str, Letter] = {}
+    for name, site in PROBES.items():
+        pairs = recorded_neighbor_locks(site, ticks, locks)
+        neighbor_lists[name] = pairs
+        letter = sum_letter(tuple(lock for _n, lock in pairs))
+        letters[name] = letter
+        lock_text = ", ".join(
+            f"{lock_display(lock)} at {neighbor}" for neighbor, lock in pairs
+        )
+        incoming = ",".join(lock_display(step) for step in sorted(locks[site]))
+        print(
+            f"{name} t={ticks[site]} recorded-neighbor-locks=[{lock_text}] "
+            f"L={letter_display(letter)} incoming={incoming}"
+        )
+
+    reverse_status = reverse_report(letters["A"], letters["B"])
+    face_status = face_report(letters["C"], letters["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+
+    checks.check(
+        "theorem1-A-neighbor-lock-list-and-letter",
+        neighbor_lists["A"] == ((ORIGIN, E1), (PROBES["D"], E1))
+        and letters["A"] == TWO_E1,
+        str((neighbor_lists["A"], letters["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-list-and-letter",
+        neighbor_lists["B"] == (((0, 1, 1), E3), (PROBES["D"], E1))
+        and letters["B"] == E1_PLUS_E3,
+        str((neighbor_lists["B"], letters["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-list-and-letter",
+        neighbor_lists["C"] == ((PROBES["A"], NEG_E2),)
+        and letters["C"] == NEG_E2,
+        str((neighbor_lists["C"], letters["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-list-and-letter",
+        neighbor_lists["D"] == ((E2, E2),) and letters["D"] == E2,
+        str((neighbor_lists["D"], letters["D"])),
+    )
+    checks.check(
+        "theorem1-B-mixed-vectors-still-sum",
+        letters["B"] == E1_PLUS_E3
+        and {lock for _n, lock in neighbor_lists["B"]} == {E1, E3}
+        and named_sign(E1) == named_sign(E3) == "+",
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and letters["A"] == TWO_E1
+        and letters["B"] == E1_PLUS_E3
+        and add(TWO_E1, E1_PLUS_E3) == REVERSE_SUM
+        and REVERSE_SUM != ZERO,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and letters["C"] == NEG_E2
+        and letters["D"] == E2
+        and add(NEG_E2, E2) == ZERO,
+        face_status,
+    )
+    checks.check(
+        "sign-lettering-loses-axis-and-fails-face",
+        named_sign(letters["C"]) == "-"
+        and named_sign(letters["D"]) == "+"
+        and not (named_sign(letters["C"]) == "+" and named_sign(letters["D"]) == "-")
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-self-incoming-nnlock",
+        locks[PROBES["C"]] == {E1}
+        and locks[PROBES["D"]] == {E1}
+        and letters["C"] == NEG_E2
+        and letters["D"] == E2,
+    )
+    checks.check(
+        "not-probe-own-incoming-lock",
+        locks[PROBES["A"]] == {NEG_E2}
+        and letters["A"] == TWO_E1
+        and letters["A"] != next(iter(locks[PROBES["A"]])),
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2 and letters["B"] == E1_PLUS_E3,
+        str(sorted(locks[PROBES["B"]])),
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2},
+    )
+    checks.check(
+        "already-recorded-not-self-or-later",
+        all(neighbor != PROBES[name] for name in PROBES for neighbor, _lock in neighbor_lists[name])
+        and all(
+            ticks[neighbor] < ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        sum_letter(()) == "UNDEFINED"
+        and reverse_report("UNDEFINED", letters["B"]) == "UNDEFINED"
+        and face_report(letters["C"], "UNDEFINED") == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-mixed-neighbor-vectors-defined-sum",
+        sum_letter((E1, E3)) == E1_PLUS_E3
+        and reverse_report(TWO_E1, E1_PLUS_E3) == "fail",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-lists-and-letters",
+        "L(A) = (2, 0, 0)" in note
+        and "L(B) = (1, 0, 1)" in note
+        and "L(C) = −e_2" in note
+        and "L(D) = +e_2" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_1 at (1, 1, 0)" in note
+        and "+e_3 at (0, 1, 1)" in note
+        and "−e_2 at (1, 0, 0)" in note
+        and "+e_2 at (0, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-fail-hold",
+        "Reverse: fail" in note
+        and "Face: hold" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note
+        and "C−/D+" in note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-not-singleton-vector-leftover",
+        "not a singleton leftover" in normalized_note
+        and "mixed no longer kills" in normalized_note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem"
+        in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def sum_letter(" in source
+        and "def recorded_neighbor_locks(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] >= 1
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-neighbor-lock-sum-only",
+        "sum_letter" in defined_fns
+        and "recorded_neighbor_locks" in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns
+        and "unique_vector_letter" not in defined_fns,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Sum of already-recorded 6-NN locks on nnseed x-probes: L(A)=(2,0,0), L(B)=(1,0,1), L(C)=-e2, L(D)=+e2. Reverse fail; face holds. Mixed B is defined (unlike nfvec). Displayed, not adopted. No axiom edit.

## Runner

`scripts/nnseed_neighbor_lock_sum_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.