### PR TITLE
feat(nssumz): z-probe neighbor-lock sum: reverse fail, face fail

### DIFF
--- a/docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,425 @@
+---
+claim_id: nnseed_zprobe_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the sum of already-recorded 6-NN locks on the four nnseed z-probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py
+---
+
+# Sum Of Already-Recorded Six-Neighbor Locks On Four Nnseed Z-Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** vector sum in `Z^3` or `UNDEFINED` read from the list of
+already-recorded six-neighbor locks at the formation tick of the four nnseed
+z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(0,1,1)` of the displayed
+two-site nnseed process, scored as reverse and face. At the formation tick of
+probe `q`, let `S` be the list of locks of already-recorded six-neighbors of
+`q`. If `S` is empty, the letter is `UNDEFINED`. Else the letter is the vector
+sum of `S` in `Z^3`. Reverse holds iff `L(A)` and `L(B)` are defined and
+`L(A)+L(B)=(0,0,0)`. Face holds iff `L(C)` and `L(D)` are defined and
+`L(C)+L(D)=(0,0,0)`. Occupancy `n` is not used. The probe's own incoming lock
+is not used. Uniqueness of incoming locks is not required. Uniqueness of the
+letter as a singleton in `{±e_i}` is not required. This is not the unique-vector
+singleton leftover on these same four z-probes. This is not named sign. This
+is not unique `f(n)` and is not ndot. Displayed, not adopted. This note does
+not write the sum letter into Admissibility and does not attach a formation
+member from already-recorded six-neighbor lock sums. This is not a
+sixteen-combination free lettering.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py`](../scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming locks are unit nearest-neighbor steps.
+The letter scored here is the vector sum of already-recorded six-neighbor
+locks in `Z^3`, or `UNDEFINED` when that list is empty. Named signs `{+,−}` of
+those locks are a different alphabet and are not identified with the sum.
+A unique singleton in `{±e_i}` of those locks is a different letter and is
+not identified with the sum.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of already-recorded six-neighbor lock lists and the vector-sum letter on the four nnseed z-probes, with reverse fail and face fail; uniqueness of incoming locks is not claimed and the sums are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_zprobe_neighbor_lock_sum_reverse_face
+target_blocker_text: "display reverse and face from the sum of already-recorded 6-NN locks on the four nnseed z-probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write the sum letter into Admissibility, do not use occupancy n, and do not identify the letter with the probe's own incoming step."
+conditional_surface_status: "exact on B_3(0) for vector sums of already-recorded six-neighbor locks on the four nnseed z-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose
+already-recorded six-neighbor lock lists and sum letters are scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (0,1,1).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`.
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not the sum letter scored below.
+
+## Vector sum from already-recorded six-neighbor locks
+
+At the formation tick of a probe `q`, let `S` be the list of locks of
+already-recorded six-neighbors of `q`. A neighbor is already recorded if and
+only if it formed strictly earlier. The probe itself is still unread. This
+display does not use occupancy `n`. It does not use the probe's own incoming
+lock. If a recorded neighbor carries several earliest incoming locks, each
+such lock appears in `S`. Multiplicity in `S` is kept: two neighbors locking
+the same unit step contribute twice.
+
+If `S` is empty, the letter is `UNDEFINED`. Else the letter is the vector sum
+of `S` in `Z^3`.
+
+A process-determined sum letter at a probe is a value in `Z^3` assigned by
+that named construction from already-recorded six-neighbor locks, or
+`UNDEFINED`. Incoming `{±e_i}` tags of the probe itself are not that
+assignment. Identifying a named sign of those locks, or of the probe's own
+incoming step, with the sum is refused. Identifying a unique singleton in
+`{±e_i}` of those locks with the sum is refused. Reverse and face are scored
+on that sum. They are not scored on a sixteen-combination free lettering of
+the four z-probes. Uniqueness of incoming locks is not required. Uniqueness of
+the letter as a singleton in `{±e_i}` is not required.
+
+This is not a unique letter of occupancy `n`. It is not unique `f(n)` and is
+not ndot. A leftover unique-vector display on these same four z-probes
+assigned `+e_1`, `UNDEFINED`, `+e_3`, `+e_2` because `B`'s recorded-neighbor
+locks `{+e_3,+e_1}` are mixed and because `C`'s four copies of `+e_3` collapse
+to the singleton `+e_3`. The *sum* at `B` is `(1,0,1)` and the *sum* at `C`
+is `(0,0,4)`. Named-sign unique letters on these z-probes mapped each lock to
+`{+,−}` and assigned `+` at every z-probe, including `B`. Named-sign reverse
+and face on that leftover were both `none`. Unique-vector reverse and face
+were `UNDEFINED` and `fail`. Sum reverse and face are a different pair of
+predicates.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A) and L(B) are defined and L(A)+L(B)=(0,0,0)
+face     <=>  L(C) and L(D) are defined and L(C)+L(D)=(0,0,0)
+```
+
+If a vector needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. The report is one of `hold`, `fail`, or `UNDEFINED`. Because the
+letter is a single sum per probe, the scored comparisons are not a
+sixteen-combination free lettering, and `some` is not produced. Leftover
+named-sign reports used `all` / `some` / `none`; those are not this display.
+
+Admissibility is not edited. Sum letters are not written into Admissibility.
+
+## Theorem 1 — recorded-neighbor lock list and sum letter at each z-probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+z-probes. Formation ticks are `t(A)=1`, `t(B)=2`, `t(C)=4`, `t(D)=1`. Those
+ticks locate the already-recorded six-neighbor set. They are not occupancy
+kernels and are not the reverse/face scoring.
+
+At each formation tick the already-recorded six-neighbor lock list `S` and
+sum letter are:
+
+```text
+A: +e_1 at (0, 0, 0);                                      S = (+e_1);                 L(A) = (1, 0, 0)
+B: +e_3 at (0, 1, 1), +e_1 at (1, 1, 0);                    S = (+e_3, +e_1);            L(B) = (1, 0, 1)
+C: +e_3 at (1, 0, 2), +e_3 at (-1, 0, 2),
+   +e_3 at (0, -1, 2), +e_3 at (0, 0, 1);                   S = (+e_3, +e_3, +e_3, +e_3); L(C) = (0, 0, 4)
+D: +e_2 at (0, 1, 0);                                      S = (+e_2);                 L(D) = (0, 1, 0)
+```
+
+`A`'s already-recorded neighbor is the origin locking `+e_1`. `D`'s
+already-recorded neighbor is the seed `(0, 1, 0)` locking `+e_2`. `C`'s
+already-recorded neighbors all lock `+e_3`, four times, so `L(C)=(0,0,4)`,
+not the singleton `+e_3`. `B`'s already-recorded neighbors lock two distinct
+vectors `+e_3` and `+e_1`, so `L(B)=(1,0,1)`, not `UNDEFINED`.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps `+e_1` and `+e_3`; `C` has three). That non-uniqueness is not a
+sum-lettering of already-recorded neighbor locks. The sums are not identified
+with those incoming steps. Uniqueness is not required.
+
+No probe has an empty recorded-neighbor lock list, so no probe is
+`UNDEFINED`.
+
+## Theorem 2 — reverse report
+
+Reverse holds iff `L(A)` and `L(B)` are defined and `L(A)+L(B)=(0,0,0)`.
+The sum letters are `L(A)=(1, 0, 0)` and `L(B)=(1, 0, 1)`. Their sum is
+`(2, 0, 1)`, which is not `(0,0,0)`. Reverse does not hold.
+
+Report: `fail`.
+
+This is not `hold` and not `UNDEFINED`. A unique-vector readout of the same
+neighbor locks assigned `UNDEFINED` at `B` and scored reverse as `UNDEFINED`;
+that object is not used. A named-sign readout of the same neighbor locks
+assigned `+` at both `A` and `B` and scored reverse as `none`; that object is
+not used. Unique `f(n)`, ndot, occupancy-kernel `{+,−}` pairs, and a
+sixteen-combination free lettering are different objects and are not used.
+
+## Theorem 3 — face report
+
+Face holds iff `L(C)` and `L(D)` are defined and `L(C)+L(D)=(0,0,0)`. The
+sum letters are `L(C)=(0, 0, 4)` and `L(D)=(0, 1, 0)`. Their sum is
+`(0, 1, 4)`, which is not `(0,0,0)`. Face does not hold.
+
+Report: `fail`.
+
+Displayed, not adopted. The sums are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify sum letters with the probe's own incoming `{±e_i}`.
+- It does not use occupancy `n`.
+- It is not unique `f(n)`.
+- It is not ndot.
+- It does not reprint the unique-vector singleton leftover on these four
+  z-probes.
+- It does not reprint the named-sign unique letters on these four z-probes.
+- It does not reprint already-recorded six-neighbor lock sums on the four
+  x-probes.
+- It does not attach a formation member from already-recorded six-neighbor
+  lock sums.
+- It does not census a sixteen-combination free lettering independent of
+  recorded-neighbor lock sums.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+nnseed process, the already-recorded six-neighbor lock lists, the vector sum
+from those locks, and the reverse/face predicates are displayed
+theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| already-recorded six-neighbor lock lists at each z-probe formation tick | Theorem 1 |
+| vector sum from those locks | Theorem 1; `(1,0,0)`, `(1,0,1)`, `(0,0,4)`, `(0,1,0)` |
+| reverse and face | Theorems 2–3; `fail` and `fail` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| unique `f(n)` | not this display |
+| ndot contraction letter | not this display |
+| probe's own incoming lock as the letter | not used |
+| unique-vector singleton leftover on these z-probes | not this display |
+| named-sign unique letter leftover on these z-probes | not this display |
+| x-probe neighbor-lock sums | not this display |
+| formation member from already-recorded six-neighbor lock sums | not attached |
+| sixteen-combination free lettering independent of neighbor-lock sums | not enumerated |
+| sum letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: vector sum of already-recorded six-neighbor locks on the four nnseed z-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed sum-letter neighbor-lock reverse/face report on these four nnseed z-probes. |
+| V3 | Recorded-neighbor lock lists, vector sums, and the `fail`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads already-recorded six-neighbor locks at formation and names their vector sum in `Z^3`. |
+| V5 | It is not an adopted content rule: the sums remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those sums into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not use occupancy `n`, is not unique `f(n)`, is not ndot, is not the
+unique-vector leftover on these z-probes, and is not named sign. No global
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique-vector singleton leftover on these z-probes | keep a letter only when all recorded-neighbor locks equal one `{±e_i}` | refused; that leftover assigned `UNDEFINED` at `B` and `+e_3` at `C`; sum letters are `(1,0,1)` and `(0,0,4)` |
+| reverse/face from unique vectors | reuse leftover reverse `L(A)=+e_1` and `L(B)=UNDEFINED` | different object; unique-vector reverse was `UNDEFINED`; sum reverse is `fail` |
+| named-sign unique letter on these z-probes | map each lock `±e_i` to `{+,−}` | refused; that leftover assigned `+` at `B`; the sum at `B` is `(1,0,1)` |
+| reverse/face from named signs | reuse leftover reverse `L(A)=+` and `L(B)=−` | different object; named-sign reverse was `none`; sum reverse is `fail` |
+| identify sum with the probe's own incoming `{±e_i}` | map `C`'s incoming `{−e_1,+e_2,+e_1}` to a sum | refused; those incoming steps sum to `(0,1,0)`; `L(C)=(0,0,4)` from already-recorded neighbor locks |
+| reverse/face from self-incoming vectors | reuse incoming steps at the four z-probes | different object; `C` would be mixed incoming, not `(0,0,4)` |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| unique `f(n)` | assign one letter as a function of occupancy `n` | different object; not unique `f(n)` |
+| ndot contraction letter | unique letter `sign(n·v)` | different object; not ndot |
+| reverse/face from formation-tick inequalities | score z-probes by formation order | different object; not this display |
+| formdraw occupancy-kernel `{+,−}` pairs | keep both letters whenever occupancy `n ≠ 0` | different object; the sum is one vector in `Z^3` or `UNDEFINED` |
+| sixteen-combination free letters on the four z-probes | ignore neighbor-lock sums and letter independently | different object; not enumerated |
+| x-probe neighbor-lock sums | copy sums from the x-probes | refused; these are the z-probes `A=(0,0,1)`, `C=(0,0,2)`, `D=(0,1,1)` |
+| attach a formation member from already-recorded six-neighbor lock sums | form the probes by a neighbor-lock sum instead of perp-step | refused; not attached |
+| adopt sums into Admissibility | rewrite the local rule by the sum in `Z^3` | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; both earliest incoming steps at `B` and all three at `C` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from already-recorded
+six-neighbor lock sums, and missing Record identification of the sum bits are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, vector sum of the already-recorded six-neighbor
+lock list, four z-probes, and reverse/face definitions are declared. No
+uniqueness of incoming locks, no uniqueness of a singleton in `{±e_i}`, no
+occupancy `n`, no unique `f(n)`, no ndot, no named-sign collapse of `{±e_i}`,
+no unique-vector collapse of mixed locks, no formation attachment from
+already-recorded six-neighbor lock sums, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail` and `fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each sum from recorded-neighbor locks | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four sum letters and two hold/fail/`UNDEFINED` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide summing rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among sums in `Z^3`. None is
+taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once an already-recorded neighbor exists at a forming z-probe,
+the site should lock a unique `{±e_i}` vector, mixed locks at `B` should leave
+the letter `UNDEFINED`, four copies of `+e_3` at `C` should collapse to
+`+e_3`, reverse and face should track named signs, and occupancy `n` or unique
+`f(n)` or ndot should track that sign.
+
+**Answer:** The named construction assigns sum letters `(1,0,0)`, `(1,0,1)`,
+`(0,0,4)`, `(0,1,0)` at `A,B,C,D` from already-recorded six-neighbor locks.
+Occupancy `n` is not used. This is not unique `f(n)` and is not ndot. Named
+signs at `B` would agree and are not used. Unique vectors at `B` would be
+`UNDEFINED` and are not used. Reverse fails. Face fails. The bits remain
+displayed. Incoming-lock uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+A leftover unique-vector neighbor-lock display on these same four nnseed
+z-probes closed reverse/face as `UNDEFINED`/`fail` with letters `+e_1`,
+`UNDEFINED`, `+e_3`, `+e_2`. This note is not that display: the sum letters
+are `(1,0,0)`, `(1,0,1)`, `(0,0,4)`, `(0,1,0)`, reverse fails, and face fails.
+A leftover unique-letter neighbor-lock display on these same four nnseed
+z-probes closed reverse/face as `none`/`none` with named-sign letters `+`,
+`+`, `+`, `+`. This note is not that display. A leftover formdraw
+occupancy-kernel display on these same four z-probes closed reverse/face as
+`some`/`some` because both `{+,−}` were kept at `n ≠ 0`. This note does not
+reuse occupancy `n`. Unique `f(n)` and ndot letterings are different objects
+and are not used.
+
+**Gate disposition:** PASS for the sum already-recorded six-neighbor-lock
+reverse/face reports on the four nnseed z-probes above. FAIL / DO NOT SHIP
+for “the sum equals the probe's own incoming step,” “the sum is the
+unique-vector leftover,” “the sum is the named-sign leftover,” “sums are
+Admissibility,” “the letter is occupancy `n`,” “unique `f(n)`,” “ndot,” or
+“reverse/face holds on all combinations.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, collects already-recorded six-neighbor locks at each
+z-probe's formation tick, reads the vector sum at the four z-probes, and
+checks Theorems 1--3. It also checks that the probe's own incoming step is
+not the sum letter, that occupancy `n` is not used, that the scoring is not
+unique `f(n)` and not ndot, that the scoring is not named-sign lettering,
+that the scoring is not the unique-vector singleton leftover, and that a
+formation member from already-recorded six-neighbor lock sums is not
+attached. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_zprobe_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.txt
@@ -1,0 +1,82 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py
+runner_sha256: 116c1ffdce4c0c1955d846a2936e359754fbb634b09920782158f0b465a1e41b
+input_fingerprint_sha256: 43875e2850210c0396fd7b7a9ea683fba00d76b40d52d93b9672c9cc956c09fa
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+sum of already-recorded 6-NN locks on nnseed z-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the sum of already-recorded 6-NN locks on the four nnseed z-probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: z-probes-are-not-x-probes
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: sum-identity-from-neighbor-locks
+PASS: mixed-locks-have-a-sum-not-undefined
+PASS: multiplicity-is-kept-in-the-sum
+PASS: reverse-face-undefined-when-sum-undefined
+A t=1 recorded-neighbor-locks=[+e_1 at (0, 0, 0)] L=(1, 0, 0) incoming=+e_3
+B t=2 recorded-neighbor-locks=[+e_3 at (0, 1, 1), +e_1 at (1, 1, 0)] L=(1, 0, 1) incoming=+e_3,+e_1
+C t=4 recorded-neighbor-locks=[+e_3 at (1, 0, 2), +e_3 at (-1, 0, 2), +e_3 at (0, -1, 2), +e_3 at (0, 0, 1)] L=(0, 0, 4) incoming=−e_1,+e_2,+e_1
+D t=1 recorded-neighbor-locks=[+e_2 at (0, 1, 0)] L=(0, 1, 0) incoming=+e_3
+reverse=fail face=fail
+PASS: theorem1-A-neighbor-lock-list-and-sum  (((((0, 0, 0), (1, 0, 0)),), (1, 0, 0)))
+PASS: theorem1-B-neighbor-lock-list-and-sum  (((((0, 1, 1), (0, 0, 1)), ((1, 1, 0), (1, 0, 0))), (1, 0, 1)))
+PASS: theorem1-C-neighbor-lock-list-and-sum  (((((1, 0, 2), (0, 0, 1)), ((-1, 0, 2), (0, 0, 1)), ((0, -1, 2), (0, 0, 1)), ((0, 0, 1), (0, 0, 1))), (0, 0, 4)))
+PASS: theorem1-D-neighbor-lock-list-and-sum  (((((0, 1, 0), (0, 1, 0)),), (0, 1, 0)))
+PASS: theorem1-sums-e1-mixed-four-e3-e2
+PASS: theorem1-formation-ticks
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-fail  (fail)
+PASS: not-self-incoming-at-C  ((0, 1, 0))
+PASS: not-probe-own-incoming-as-sum-source
+PASS: incoming-locks-are-nn-steps-not-sign-letters
+PASS: uniqueness-not-required  (([(0, 0, 1), (1, 0, 0)], [(-1, 0, 0), (0, 1, 0), (1, 0, 0)]))
+PASS: two-site-seed-locks
+PASS: already-recorded-not-self-or-later
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: no-sixteen-combo-census
+PASS: not-unique-vector-leftover
+PASS: not-named-sign-leftover-all-plus
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-mixed-neighbor-vectors-still-sum
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-lists-and-sums
+PASS: note-reports-fail-fail
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-does-not-identify-incoming
+PASS: note-not-unique-fn-or-ndot
+PASS: note-not-unique-vector-leftover
+PASS: note-not-named-sign
+PASS: note-does-not-attach-formation-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-not-sixteen-free-letters
+PASS: note-not-occupancy-letter-or-self-incoming
+PASS: note-not-x-probe-reprint
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-sum-from-neighbor-locks-only
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py
@@ -1,0 +1,689 @@
+#!/usr/bin/env python3
+"""Sum of already-recorded 6-NN locks on four nnseed z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each z-probe's formation tick, S is the list of locks of
+already-recorded six-neighbors. If S is empty, the letter is UNDEFINED; else
+the letter is the vector sum of S in Z^3. Reverse holds iff L(A) and L(B) are
+defined and L(A)+L(B)=(0,0,0). Face holds iff L(C) and L(D) are defined and
+L(C)+L(D)=(0,0,0). Occupancy n is not used. The probe's own incoming lock is
+not used. Uniqueness of incoming locks is not required. Not unique f(n).
+Not ndot. Not named sign. Not the unique-vector singleton leftover.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Letter = Point | str
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (0, 1, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    (-1, 0, 0): "−e_1",
+    E2: "+e_2",
+    (0, -1, 0): "−e_2",
+    E3: "+e_3",
+    (0, 0, -1): "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from the sum of already-recorded 6-NN "
+    "locks on the four nnseed z-probes are reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def sum_from_neighbor_locks(locks: tuple[Point, ...]) -> Letter:
+    """Vector sum of recorded-neighbor locks, or UNDEFINED if the list is empty."""
+    if not locks:
+        return "UNDEFINED"
+    total = ORIGIN
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def reverse_report(letter_a: Letter, letter_b: Letter) -> str:
+    """Reverse iff L(A)+L(B)=(0,0,0). UNDEFINED if a needed vector is UNDEFINED."""
+    if letter_a == "UNDEFINED" or letter_b == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter_a, tuple) or not isinstance(letter_b, tuple):
+        return "UNDEFINED"
+    holds = add(letter_a, letter_b) == ORIGIN
+    return "hold" if holds else "fail"
+
+
+def face_report(letter_c: Letter, letter_d: Letter) -> str:
+    """Face iff L(C)+L(D)=(0,0,0). UNDEFINED if a needed vector is UNDEFINED."""
+    if letter_c == "UNDEFINED" or letter_d == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter_c, tuple) or not isinstance(letter_d, tuple):
+        return "UNDEFINED"
+    holds = add(letter_c, letter_d) == ORIGIN
+    return "hold" if holds else "fail"
+
+
+def letter_display(letter: Letter) -> str:
+    if letter == "UNDEFINED":
+        return "UNDEFINED"
+    if isinstance(letter, tuple):
+        return str(letter)
+    return str(letter)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def recorded_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of already-recorded six-neighbors at the formation tick of site."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("sum of already-recorded 6-NN locks on nnseed z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (0, 1, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "z-probes-are-not-x-probes",
+        probe_sites != x_probe_sites
+        and x_probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0)),
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "sum-identity-from-neighbor-locks",
+        sum_from_neighbor_locks((E1,)) == E1
+        and sum_from_neighbor_locks((E1, E1)) == (2, 0, 0)
+        and sum_from_neighbor_locks(((0, -1, 0),)) == (0, -1, 0)
+        and sum_from_neighbor_locks((E1, E2)) == (1, 1, 0)
+        and sum_from_neighbor_locks((E1, E3)) == (1, 0, 1)
+        and sum_from_neighbor_locks((E1, (-1, 0, 0))) == ORIGIN
+        and sum_from_neighbor_locks((E3, E3, E3, E3)) == (0, 0, 4)
+        and sum_from_neighbor_locks(()) == "UNDEFINED",
+    )
+    checks.check(
+        "mixed-locks-have-a-sum-not-undefined",
+        sum_from_neighbor_locks((E1, E3)) == (1, 0, 1)
+        and sum_from_neighbor_locks((E1, E2)) == (1, 1, 0)
+        and sum_from_neighbor_locks((E1, E3)) != "UNDEFINED",
+    )
+    checks.check(
+        "multiplicity-is-kept-in-the-sum",
+        sum_from_neighbor_locks((E3, E3, E3, E3)) == (0, 0, 4)
+        and sum_from_neighbor_locks((E3,)) == E3
+        and sum_from_neighbor_locks((E3, E3, E3, E3)) != E3,
+    )
+    checks.check(
+        "reverse-face-undefined-when-sum-undefined",
+        reverse_report("UNDEFINED", (-1, 0, 0)) == "UNDEFINED"
+        and reverse_report(E1, "UNDEFINED") == "UNDEFINED"
+        and face_report("UNDEFINED", (0, -1, 0)) == "UNDEFINED"
+        and face_report(E3, "UNDEFINED") == "UNDEFINED"
+        and reverse_report(E1, (-1, 0, 0)) == "hold"
+        and reverse_report(E1, E2) == "fail"
+        and reverse_report(E1, E1) == "fail"
+        and reverse_report(E1, (1, 0, 1)) == "fail"
+        and face_report(E3, (0, 0, -1)) == "hold"
+        and face_report((0, 0, 4), E2) == "fail"
+        and face_report(E3, E3) == "fail",
+    )
+
+    ticks, locks = form()
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    letters: dict[str, Letter] = {}
+    for name, site in PROBES.items():
+        pairs = recorded_neighbor_locks(site, ticks, locks)
+        neighbor_lists[name] = pairs
+        letter = sum_from_neighbor_locks(tuple(lock for _n, lock in pairs))
+        letters[name] = letter
+        lock_text = ", ".join(
+            f"{lock_display(lock)} at {neighbor}" for neighbor, lock in pairs
+        )
+        incoming = ",".join(lock_display(step) for step in sorted(locks[site]))
+        print(
+            f"{name} t={ticks[site]} recorded-neighbor-locks=[{lock_text}] "
+            f"L={letter_display(letter)} incoming={incoming}"
+        )
+
+    reverse_status = reverse_report(letters["A"], letters["B"])
+    face_status = face_report(letters["C"], letters["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+
+    incoming_c_sum = sum_from_neighbor_locks(tuple(sorted(locks[PROBES["C"]])))
+    checks.check(
+        "theorem1-A-neighbor-lock-list-and-sum",
+        neighbor_lists["A"] == ((ORIGIN, E1),) and letters["A"] == E1,
+        str((neighbor_lists["A"], letters["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-list-and-sum",
+        neighbor_lists["B"] == ((PROBES["D"], E3), (X_PROBES["D"], E1))
+        and letters["B"] == (1, 0, 1),
+        str((neighbor_lists["B"], letters["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-list-and-sum",
+        neighbor_lists["C"]
+        == (
+            ((1, 0, 2), E3),
+            ((-1, 0, 2), E3),
+            ((0, -1, 2), E3),
+            (PROBES["A"], E3),
+        )
+        and letters["C"] == (0, 0, 4),
+        str((neighbor_lists["C"], letters["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-list-and-sum",
+        neighbor_lists["D"] == ((E2, E2),) and letters["D"] == E2,
+        str((neighbor_lists["D"], letters["D"])),
+    )
+    checks.check(
+        "theorem1-sums-e1-mixed-four-e3-e2",
+        letters["A"] == E1
+        and letters["B"] == (1, 0, 1)
+        and letters["C"] == (0, 0, 4)
+        and letters["D"] == E2,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 1
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 4
+        and ticks[PROBES["D"]] == 1,
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and letters["A"] == E1
+        and letters["B"] == (1, 0, 1)
+        and add(E1, (1, 0, 1)) == (2, 0, 1)
+        and add(E1, (1, 0, 1)) != ORIGIN,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and letters["C"] == (0, 0, 4)
+        and letters["D"] == E2
+        and add((0, 0, 4), E2) == (0, 1, 4)
+        and add((0, 0, 4), E2) != ORIGIN,
+        face_status,
+    )
+    checks.check(
+        "not-self-incoming-at-C",
+        locks[PROBES["C"]] == {(-1, 0, 0), E2, E1}
+        and incoming_c_sum == E2
+        and letters["C"] == (0, 0, 4)
+        and incoming_c_sum != letters["C"],
+        incoming_c_sum,
+    )
+    checks.check(
+        "not-probe-own-incoming-as-sum-source",
+        locks[PROBES["A"]] == {E3}
+        and letters["A"] == E1
+        and letters["A"] != next(iter(locks[PROBES["A"]]))
+        and incoming_c_sum != letters["C"],
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps-not-sign-letters",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 3
+        and letters["B"] == (1, 0, 1)
+        and letters["C"] == (0, 0, 4),
+        str((sorted(locks[PROBES["B"]]), sorted(locks[PROBES["C"]]))),
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2},
+    )
+    checks.check(
+        "already-recorded-not-self-or-later",
+        all(neighbor != PROBES[name] for name in PROBES for neighbor, _lock in neighbor_lists[name])
+        and all(
+            ticks[neighbor] < ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "no-sixteen-combo-census",
+        reverse_status == "fail"
+        and face_status == "fail"
+        and reverse_status != "some"
+        and face_status != "some",
+    )
+    checks.check(
+        "not-unique-vector-leftover",
+        letters["B"] == (1, 0, 1)
+        and letters["B"] != "UNDEFINED"
+        and letters["C"] == (0, 0, 4)
+        and letters["C"] != E3
+        and reverse_status == "fail"
+        and reverse_status != "UNDEFINED",
+    )
+    checks.check(
+        "not-named-sign-leftover-all-plus",
+        letters["B"] == (1, 0, 1)
+        and letters["A"] == E1
+        and letters["C"] == (0, 0, 4)
+        and letters["D"] == E2,
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        sum_from_neighbor_locks(()) == "UNDEFINED"
+        and reverse_report("UNDEFINED", letters["D"] if isinstance(letters["D"], tuple) else E2)
+        == "UNDEFINED"
+        and face_report(letters["C"], "UNDEFINED") == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-mixed-neighbor-vectors-still-sum",
+        sum_from_neighbor_locks((E1, E3)) == (1, 0, 1)
+        and reverse_report((1, 0, 1), E1) == "fail",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-lists-and-sums",
+        "L(A) = (1, 0, 0)" in note
+        and "L(B) = (1, 0, 1)" in note
+        and "L(C) = (0, 0, 4)" in note
+        and "L(D) = (0, 1, 0)" in note
+        and "S = (+e_1)" in note
+        and "S = (+e_3, +e_1)" in note
+        and "S = (+e_3, +e_3, +e_3, +e_3)" in note
+        and "S = (+e_2)" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_3 at (0, 1, 1)" in note
+        and "+e_1 at (1, 1, 0)" in note
+        and "+e_3 at (1, 0, 2)" in note
+        and "+e_3 at (-1, 0, 2)" in note
+        and "+e_3 at (0, -1, 2)" in note
+        and "+e_3 at (0, 0, 1)" in note
+        and "+e_2 at (0, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-fail-fail",
+        note.count("Report: `fail`.") == 2
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note,
+    )
+    checks.check(
+        "note-not-unique-fn-or-ndot",
+        "not unique `f(n)`" in note and "not ndot" in note,
+    )
+    checks.check(
+        "note-not-unique-vector-leftover",
+        "not the unique-vector singleton leftover" in normalized_note
+        and "L(B)=(1,0,1)" in note.replace(" ", "")
+        and "L(C)=(0,0,4)" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-not-named-sign",
+        "not named sign" in normalized_note
+        and "Named signs" in note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor lock sums"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-not-sixteen-free-letters",
+        "not a sixteen-combination free lettering" in normalized_note
+        and "16-census" not in note
+        and "16-letter" not in note,
+    )
+    checks.check(
+        "note-not-occupancy-letter-or-self-incoming",
+        "not a unique letter of occupancy" in normalized_note
+        and "self-incoming" in normalized_note,
+    )
+    checks.check(
+        "note-not-x-probe-reprint",
+        "not the x-probes" in normalized_note
+        and "A = (0,0,1)" in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_ZPROBE_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def sum_from_neighbor_locks(" in source
+        and "def recorded_neighbor_locks(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] >= 1
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-sum-from-neighbor-locks-only",
+        "sum_from_neighbor_locks" in defined_fns
+        and "recorded_neighbor_locks" in defined_fns
+        and "named_sign" not in defined_fns
+        and "unique_vector_from_neighbor_locks" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and not any("ndot" in name for name in defined_fns),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Sum of recorded-neighbor locks on nnseed z-probes. Reverse fail; face fail. Displayed, not adopted. No axiom edit.

## Runner

`scripts/nnseed_zprobe_neighbor_lock_sum_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.