### PR TITLE
feat(nssums): nssame neighbor-lock sum: reverse fail, face fail

### DIFF
--- a/docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,397 @@
+---
+claim_id: nssame_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the sum of already-recorded 6-NN locks on the four nssame probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py
+---
+
+# Sum Of Already-Recorded Six-Neighbor Locks On Four Nssame Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** vector-sum letter in `Z^3` or `UNDEFINED` read from the
+already-recorded six-neighbor locks at the formation tick of four probes of
+the displayed two-site same-lock nssame process, scored as reverse and face.
+The letter is the vector sum of that lock list, or `UNDEFINED` if the list
+is empty. Occupancy `n` is not used. The probe's own incoming lock is not
+used. Uniqueness is not required. This is not the unique leftover of the
+nsvecs singleton construction. This is not sign-lettering. Displayed, not
+adopted. This note does not write the sum letter into Admissibility and
+does not attach a formation member from already-recorded six-neighbor
+locks. This is not a sixteen-combination free lettering.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py`](../scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named probes. Incoming lock letters are unit nearest-neighbor
+steps. The scored letter is a vector in `Z^3` when the already-recorded
+six-neighbor lock list is nonempty, or `UNDEFINED` when that list is empty.
+Those two alphabets are not identified.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of already-recorded six-neighbor lock lists and the vector-sum letter on the four nssame probes, with reverse fail and face fail; uniqueness is not claimed and the sums are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nssame_neighbor_lock_sum_reverse_face
+target_blocker_text: "display reverse and face from the sum of already-recorded 6-NN locks on the four nssame probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write the sum letter into Admissibility, do not use occupancy n, and do not identify the letter with the unique leftover of nsvecs or the probe's own incoming step."
+conditional_surface_status: "exact on B_3(0) for vector-sum letters from already-recorded six-neighbor locks on the four nssame probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four probes are the only sites whose
+already-recorded six-neighbor lock lists and sum letters are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+the same lock `L(0)=L(0,1,0)=+e_1`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not the sum letter scored below.
+
+This same-lock seed is outside the proper cubic orbit of the mixed-lock
+two-site seed with letters `+e_1` and `+e_2`.
+
+## Vector-sum letter from already-recorded six-neighbor locks
+
+At the formation tick of a probe `q`, collect the locks of already-recorded
+six-neighbors of `q` as a list `S`. A neighbor is already recorded if and
+only if it formed strictly earlier. If that neighbor keeps several earliest
+incoming locks, each lock appears in `S`. The probe itself is still unread.
+This display does not use occupancy `n`. It does not use the probe's own
+incoming lock.
+
+If `S` is empty, the letter is `UNDEFINED`. Else the letter is the vector
+sum of `S` in `Z^3`. Multiplicity is kept: four recorded neighbors locking
+`+e_1` sum to `(4, 0, 0)`, not to the singleton leftover `+e_1`.
+
+A process-determined sum letter at a probe is a value in `Z^3` assigned by
+that named construction from already-recorded six-neighbor locks, or
+`UNDEFINED`. Incoming `{±e_i}` tags of the probe itself are not that
+assignment. Identifying a lock vector of the probe's own incoming step with
+the sum letter is refused. Reverse and face are scored on that sum. They are
+not scored on a sixteen-combination free lettering of the four probes.
+Uniqueness is not required. This is not the unique leftover of nsvecs: that
+leftover assigns a letter only when `S` is a singleton in `{±e_i}`, and
+otherwise `UNDEFINED`.
+
+This is not sign-lettering. Named-sign collapse of `{±e_i}` to `{+,−}` is a
+different object: `+e_1` and `+e_3` share a named sign and are distinct
+vectors. This is not a unique letter of occupancy `n`. Occupancy bits at a
+probe can be well-defined while the recorded-neighbor lock list is empty or
+mixed. Neighbor-lock sums need not exist whenever occupancy exists.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A) and L(B) are defined and L(A)+L(B)=(0,0,0)
+face     <=>  L(C) and L(D) are defined and L(C)+L(D)=(0,0,0)
+```
+
+If a letter needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. If both letters are defined and the vector sum is the origin,
+the comparison is `hold`. If both letters are defined and the vector sum is
+not the origin, the comparison is `fail`.
+
+Admissibility is not edited. Sum letters are not written into
+Admissibility.
+
+## Theorem 1 — recorded-neighbor lock list and sum letter at each probe
+
+Direct enumeration of the displayed nssame process on `B_3(0)` forms all four
+probes. At each formation tick the already-recorded six-neighbor lock list
+and sum letter are:
+
+```text
+A: +e_1 at (0, 0, 0), +e_1 at (1, -1, 0), +e_1 at (1, 0, 1), +e_1 at (1, 0, -1);  L(A) = (4, 0, 0)
+B: +e_3 at (0, 1, 1);                                                             L(B) = (0, 0, 1)
+C: −e_3 at (1, 0, 0), +e_3 at (1, 0, 0), +e_2 at (1, 0, 0);                      L(C) = (0, 1, 0)
+D: +e_1 at (0, 1, 0), +e_1 at (1, 2, 0), +e_1 at (1, 1, 1), +e_1 at (1, 1, -1);  L(D) = (4, 0, 0)
+```
+
+`C`'s already-recorded neighbor is `A`. The incoming locks kept at `A` are
+`+e_2`, `+e_3`, and `−e_3`. Their sum is `(0, 1, 0)`, so `L(C)` is defined.
+`D`'s already-recorded neighbors all lock `+e_1`; the list has four entries
+and sums to `(4, 0, 0)`.
+
+Incoming locks exist and need not be unique (`A` keeps three earliest
+incoming steps). That non-uniqueness is not a unique-lettering of
+already-recorded neighbor locks at `A`: those neighbor locks all equal
+`+e_1`, and the sum letter at `A` is `(4, 0, 0)`. The sum letters are not
+identified with those incoming steps. Uniqueness is not required.
+
+No probe has an empty recorded-neighbor lock list. Empty `S` would be
+`UNDEFINED`; that case does not occur at these four probes. Mixed lock
+vectors at `C` still yield a defined sum.
+
+## Theorem 2 — reverse report
+
+Reverse holds iff `L(A)` and `L(B)` are defined and `L(A)+L(B)=(0,0,0)`. The
+sum letters are `L(A)=(4, 0, 0)` and `L(B)=(0, 0, 1)`. Both are defined.
+Their sum is `(4, 0, 1)`, not the origin. Reverse does not hold.
+
+Report: `fail`.
+
+This is not `hold` and not `UNDEFINED`. A named-sign readout of the probe's
+own incoming step is a different object and is not used. A sixteen-combination
+free lettering is a different object and is not used. The unique leftover of
+nsvecs would assign `L(A)=+e_1` and is not this display. Sign-lettering of
+the same neighbor locks would collapse `L(B)` to `+` and is not this display.
+
+## Theorem 3 — face report
+
+Face holds iff `L(C)` and `L(D)` are defined and `L(C)+L(D)=(0,0,0)`. The
+sum letters are `L(C)=(0, 1, 0)` and `L(D)=(4, 0, 0)`. Both are defined.
+Their sum is `(4, 1, 0)`, not the origin. Face does not hold.
+
+Report: `fail`.
+
+This is not `hold` and not `UNDEFINED`. Displayed, not adopted. The sums are
+not written into Admissibility. The unique leftover of nsvecs would leave
+`C` undefined and would score face as `UNDEFINED`; that leftover is not this
+display.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify sum letters with the probe's own incoming `{±e_i}`.
+- It does not use occupancy `n`.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not census a sixteen-combination free lettering independent of
+  recorded-neighbor lock sums.
+- It does not collapse lock vectors to named signs.
+- It does not reuse the unique leftover of nsvecs.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+nssame process, the already-recorded six-neighbor lock lists, the vector-sum
+letter from those neighbor locks, and the reverse/face predicates are
+displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site same-lock seed `+e_1/+e_1` |
+| already-recorded six-neighbor lock lists at each probe formation tick | Theorem 1 |
+| vector-sum letter from those neighbor locks | Theorem 1; `(4, 0, 0)`, `(0, 0, 1)`, `(0, 1, 0)`, `(4, 0, 0)` |
+| reverse and face | Theorems 2–3; `fail` and `fail` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| probe's own incoming lock as the letter | not used |
+| unique leftover of nsvecs | not used |
+| named-sign collapse of `{±e_i}` | not used; not sign-lettering |
+| formation member from already-recorded six-neighbor locks | not attached |
+| sixteen-combination free lettering independent of neighbor-lock sums | not enumerated |
+| sum letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: vector-sum letter from already-recorded six-neighbor locks on the four nssame probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed sum-letter neighbor-lock reverse/face report on these four nssame probes. |
+| V3 | Recorded-neighbor lock lists, vector sums, and the `fail`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads already-recorded six-neighbor locks at formation and names their vector sum. |
+| V5 | It is not an adopted content rule: the sums remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those sums into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not reuse the unique leftover of nsvecs, and does not use occupancy
+`n`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| identify sum letter with the probe's own incoming `{±e_i}` | map `A`'s mixed incoming `{+e_2,+e_3,−e_3}` to the letter | refused; `L(A)=(4, 0, 0)` from already-recorded neighbor locks |
+| reverse/face from self-incoming lock vectors | reuse mixed incoming at `A` and at `D` | different object; not this display |
+| unique leftover of nsvecs | assign a letter only when `S` is a singleton in `{±e_i}` | refused; `L(A)=(4, 0, 0)` not `+e_1`; `L(C)=(0, 1, 0)` while that leftover is `UNDEFINED` |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy at `C` is not this sum |
+| reverse/face from named signs `{+,−}` | collapse each lock to its named sign | refused; not sign-lettering; `L(B)=(0, 0, 1)` is not `+` |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; not this display |
+| both named rank-1 occupancy-kernel letters | keep `{+,−}` whenever occupancy `n ≠ 0` | different object; occupancy `n` is not used |
+| sixteen-combination free letters on the four probes | ignore neighbor-lock sums and letter independently | different object; not enumerated |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock sum instead of perp-step | refused; not attached |
+| adopt sums into Admissibility | rewrite the local rule by `Z^3` sums | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; the three earliest incoming steps at `A` are kept, and their sum is why `L(C)=(0, 1, 0)` |
+
+Honesty marker for each row: `ATTEMPTED`.
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from already-recorded
+six-neighbor locks, and missing Record identification of the sum-letter
+bits are distinct open premises. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site same-lock seed, perpendicular step rule,
+incoming-step lock, sum letter from already-recorded six-neighbor lock
+lists, four probes, and reverse/face definitions are declared. No uniqueness
+of incoming locks, no occupancy `n`, no unique leftover of nsvecs, no
+formation attachment from already-recorded six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail` and `fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each sum letter from recorded-neighbor lock lists | no continuum alphabet |
+| per site | `A,B,C,D` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four sum letters and `hold`/`fail`/`UNDEFINED` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `Z^3` sums. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once an already-recorded neighbor exists at a forming probe, the
+site should lock a unique leftover in `{±e_i}` as incoming content, reverse
+should hold because the neighbor locks are unit steps, face should stay
+`UNDEFINED` when `A`'s incoming locks mix, and occupancy `n` should track
+that leftover. Mixed incoming locks at `A` should not yield a defined sum at
+`C`; summing the list with multiplicity should be refused as an extra rule.
+
+**Answer:** The named construction assigns sum letters `(4, 0, 0)`,
+`(0, 0, 1)`, `(0, 1, 0)`, `(4, 0, 0)` at `A,B,C,D` from already-recorded
+six-neighbor lock lists. Occupancy `n` is not used. Reverse is `fail`
+because `(4, 0, 0)+(0, 0, 1)≠0`. Face is `fail` because `(0, 1, 0)+(4, 0, 0)≠0`.
+The bits remain displayed. Incoming-lock uniqueness is not required. The
+unique leftover of nsvecs is a different object.
+
+### N8 — cross-cycle echo
+
+A unique-vector leftover display on this same process assigns `L(A)=+e_1`,
+`L(B)=+e_3`, leaves `C` undefined from mixed lock vectors, and scores reverse
+`fail` with face `UNDEFINED`. That is not this display: here `L(A)=(4, 0, 0)`,
+`L(C)=(0, 1, 0)`, and face is `fail`. A named-sign neighbor-lock display on
+this same process collapses every recorded-neighbor lock to `{+,−}` and can
+score reverse as `none` with `L(A)=+` and `L(B)=+`. That is not this display.
+A mixed-lock two-site neighbor-lock display on the same four probes can close
+unique letters at every probe because that seed is not this same-lock seed
+and is not in its proper cubic orbit. A leftover unique-letter-of-occupancy
+display is a different object: occupancy bits need not mix when lock vectors
+mix. A self-incoming lock-vector readout on this same process sees mixed
+incoming steps at `A` and at `D`. This note does not reuse those scorings.
+
+**Gate disposition:** PASS for the vector-sum already-recorded
+six-neighbor-lock reverse/face reports above. FAIL / DO NOT SHIP for “the
+sum letter equals the probe's own incoming step,” “sums are
+Admissibility,” “the letter is occupancy `n`,” “the letter is the unique
+leftover of nsvecs,” or “reverse/face holds on all combinations.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site same-lock
+perp-step incoming-lock process, collects already-recorded six-neighbor locks
+at each probe's formation tick, reads the vector-sum letter at the four
+probes, and checks Theorems 1--3. It also checks that the probe's own
+incoming step is not the sum letter, that occupancy `n` is not used, that
+the unique leftover of nsvecs is not used, and that a formation member from
+already-recorded six-neighbor locks is not attached. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13257,6 +13257,10 @@
   "nspt_high_order_lattice_alpha_n_coefficient_external_narrow_theorem_note_2026-05-16": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "nssame_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "observable_generator_additivity_from_cluster_decomposition_theorem_note_2026-05-10": {
    "deps_hash": "d522a9c08709",

--- a/logs/runner-cache/nssame_neighbor_lock_sum_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nssame_neighbor_lock_sum_reverse_face_2026_08_15.txt
@@ -1,0 +1,83 @@
+===== runner cache v1 =====
+runner: scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py
+runner_sha256: b3b7cfb12f58a37c9c7c86d84de69999f97d3aeccc4a57e772963ffbdd5b7ba8
+input_fingerprint_sha256: afacecabe384e5e18a0ce26e74780ea0c8127438047c6a237a692db0e3901988
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+sum of already-recorded 6-NN locks reverse/face
+AUDIT_INPUT_PATHS:
+  docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the sum of already-recorded 6-NN locks on the four nssame probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-euclidean-ball
+PASS: four-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: sum-letter-identity-from-neighbor-lock-vectors
+PASS: not-singleton-leftover-identity
+PASS: not-sign-lettering-identity
+PASS: reverse-face-hold-fail-undefined
+A recorded-neighbor-locks=[+e_1 at (0, 0, 0), +e_1 at (1, -1, 0), +e_1 at (1, 0, 1), +e_1 at (1, 0, -1)] L=(4, 0, 0) incoming=−e_3,+e_3,+e_2
+B recorded-neighbor-locks=[+e_3 at (0, 1, 1)] L=(0, 0, 1) incoming=+e_1
+C recorded-neighbor-locks=[−e_3 at (1, 0, 0), +e_3 at (1, 0, 0), +e_2 at (1, 0, 0)] L=(0, 1, 0) incoming=+e_1
+D recorded-neighbor-locks=[+e_1 at (0, 1, 0), +e_1 at (1, 2, 0), +e_1 at (1, 1, 1), +e_1 at (1, 1, -1)] L=(4, 0, 0) incoming=−e_2,−e_3,+e_3
+reverse=fail face=fail
+per_element: letter is the vector sum of already-recorded six-neighbor locks in Z^3, else UNDEFINED if that list is empty
+per_site: scored only at probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four sum letters plus reverse/face as hold, fail, or UNDEFINED
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: theorem1-A-neighbor-lock-list-and-letter  (((((0, 0, 0), (1, 0, 0)), ((1, -1, 0), (1, 0, 0)), ((1, 0, 1), (1, 0, 0)), ((1, 0, -1), (1, 0, 0))), (4, 0, 0)))
+PASS: theorem1-B-neighbor-lock-list-and-letter  (((((0, 1, 1), (0, 0, 1)),), (0, 0, 1)))
+PASS: theorem1-C-neighbor-lock-list-and-letter  (((((1, 0, 0), (0, 0, -1)), ((1, 0, 0), (0, 0, 1)), ((1, 0, 0), (0, 1, 0))), (0, 1, 0)))
+PASS: theorem1-D-neighbor-lock-list-and-letter  (((((0, 1, 0), (1, 0, 0)), ((1, 2, 0), (1, 0, 0)), ((1, 1, 1), (1, 0, 0)), ((1, 1, -1), (1, 0, 0))), (4, 0, 0)))
+PASS: theorem1-C-defined-from-mixed-A-locks-sum
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-fail  (fail)
+PASS: not-probe-own-incoming-lock
+PASS: incoming-locks-are-nn-steps-not-letters
+PASS: uniqueness-not-required  ([(0, 0, -1), (0, 0, 1), (0, 1, 0)])
+PASS: not-nsvecs-unique-leftover
+PASS: two-site-same-lock-seed
+PASS: already-recorded-not-self-or-later
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: perp-step-incoming-lock
+PASS: not-mixed-cubic-orbit
+PASS: no-sixteen-combo-census
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-mixed-neighbor-vectors-sum-defined
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-lists-and-letters
+PASS: note-reports-fail-and-fail
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-attach-formation-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-not-sixteen-free-letters
+PASS: note-not-tick-or-occupancy-reprint
+PASS: note-not-sign-lettering
+PASS: note-not-nsvecs-leftover
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-letter-from-neighbor-locks-only
+PASS: source-formation-is-perp-step-tick
+TOTAL: PASS=53 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py
+++ b/scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py
@@ -1,0 +1,775 @@
+#!/usr/bin/env python3
+"""Sum of already-recorded 6-NN locks on four nssame probes.
+
+Host Euclidean B_3(0) = {n in Z^3 : n·n <= 9}. Seed at tick 0 records the
+origin and (0,1,0), both locking +e_1. Growth is the nssame perp-step
+incoming-lock process. At each probe's formation tick, collect locks of
+already-recorded six-neighbors as a list S. If S is empty, the letter is
+UNDEFINED. Else the letter is the vector sum of S in Z^3. Reverse holds
+iff L(A)+L(B)=(0,0,0). Face holds iff L(C)+L(D)=(0,0,0). Occupancy n is
+not used. The probe's own incoming lock is not used. Uniqueness is not
+required. Not the unique leftover of nsvecs. Not sign-lettering.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from itertools import permutations, product
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Letter = Point | str
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+STEPS: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+AXIS_LOCKS = frozenset(STEPS)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    (-1, 0, 0): "−e_1",
+    E2: "+e_2",
+    (0, -1, 0): "−e_2",
+    E3: "+e_3",
+    (0, 0, -1): "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "ndot",
+    "n_μ",
+    "3 t(",
+    "t(C)^2",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from the sum of already-recorded 6-NN "
+    "locks on the four nssame probes are reported. Displayed, not adopted."
+)
+SEED_SAME: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+SEED_MIXED: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def lock_axis(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def euclidean_ball() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x, y, z in product(range(-3, 4), repeat=3)
+        if x * x + y * y + z * z <= 9
+    )
+
+
+def apply_matrix(matrix: tuple[tuple[int, ...], ...], point: Point) -> Point:
+    return tuple(
+        matrix[row][0] * point[0]
+        + matrix[row][1] * point[1]
+        + matrix[row][2] * point[2]
+        for row in range(3)
+    )
+
+
+def matrix_det(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def proper_cubic_rotations() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rotations: list[tuple[tuple[int, ...], ...]] = []
+    for perm in permutations((0, 1, 2)):
+        for signs in product((1, -1), repeat=3):
+            matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for col in range(3):
+                matrix[perm[col]][col] = signs[col]
+            packed = tuple(tuple(row) for row in matrix)
+            if matrix_det(packed) == 1:
+                rotations.append(packed)
+    return tuple(rotations)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def sum_letter_from_neighbor_locks(locks: tuple[Point, ...]) -> Letter:
+    """Vector sum of recorded-neighbor locks in Z^3, or UNDEFINED if empty."""
+    if not locks:
+        return "UNDEFINED"
+    total = ORIGIN
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def reverse_report(letter_a: Letter, letter_b: Letter) -> str:
+    """Reverse iff L(A)+L(B)=(0,0,0). UNDEFINED if a needed letter is UNDEFINED."""
+    if letter_a == "UNDEFINED" or letter_b == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter_a, tuple) or not isinstance(letter_b, tuple):
+        return "UNDEFINED"
+    holds = add(letter_a, letter_b) == ORIGIN
+    return "hold" if holds else "fail"
+
+
+def face_report(letter_c: Letter, letter_d: Letter) -> str:
+    """Face iff L(C)+L(D)=(0,0,0). UNDEFINED if a needed letter is UNDEFINED."""
+    if letter_c == "UNDEFINED" or letter_d == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter_c, tuple) or not isinstance(letter_d, tuple):
+        return "UNDEFINED"
+    holds = add(letter_c, letter_d) == ORIGIN
+    return "hold" if holds else "fail"
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def letter_display(letter: Letter) -> str:
+    if letter == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter, tuple):
+        return "UNDEFINED"
+    return f"({letter[0]}, {letter[1]}, {letter[2]})"
+
+
+def grow(
+    host: frozenset[Point],
+    seed: tuple[tuple[Point, Point], ...],
+) -> dict[Point, tuple[int, frozenset[Point]]]:
+    recorded: dict[Point, tuple[int, frozenset[Point]]] = {
+        site: (0, frozenset({lock})) for site, lock in seed
+    }
+    by_tick: dict[int, list[Point]] = defaultdict(list)
+    for site, _lock in seed:
+        if site not in host:
+            raise ValueError("seed site outside host")
+        by_tick[0].append(site)
+    tick = 0
+    while by_tick[tick]:
+        arrivals: dict[Point, set[Point]] = defaultdict(set)
+        for site in by_tick[tick]:
+            _time, locks = recorded[site]
+            for lock in locks:
+                axis = lock_axis(lock)
+                for step in STEPS:
+                    if dot(step, axis) != 0:
+                        continue
+                    image = add(site, step)
+                    if image not in host or image in recorded:
+                        continue
+                    arrivals[image].add(step)
+        for image, incoming in arrivals.items():
+            recorded[image] = (tick + 1, frozenset(incoming))
+            by_tick[tick + 1].append(image)
+        tick += 1
+    return recorded
+
+
+def recorded_neighbor_locks(
+    site: Point,
+    recorded: dict[Point, tuple[int, frozenset[Point]]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of already-recorded six-neighbors at the formation tick of site."""
+    formation = recorded[site][0]
+    pairs: list[tuple[Point, Point]] = []
+    for step in STEPS:
+        neighbor = add(site, step)
+        if neighbor not in recorded:
+            continue
+        neighbor_tick, locks = recorded[neighbor]
+        if neighbor_tick >= formation:
+            continue
+        for lock in sorted(locks):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("sum of already-recorded 6-NN locks reverse/face")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = euclidean_ball()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    wide_host = frozenset(
+        (x, y, z)
+        for x, y, z in product(range(-4, 5), repeat=3)
+        if x * x + y * y + z * z <= 9
+    )
+    checks.check(
+        "host-euclidean-ball",
+        host == wide_host
+        and ORIGIN in host
+        and len(host) == 123
+        and all(dot(site, site) <= 9 for site in host),
+    )
+    checks.check(
+        "four-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and dot(E1, E2) == 0
+        and dot(E1, lock_axis(E1)) == 1
+        and add(E1, (-1, 0, 0)) == ORIGIN
+        and PROBES["C"] in host
+        and add((4, 0, 0), ORIGIN) not in host,
+    )
+    checks.check(
+        "sum-letter-identity-from-neighbor-lock-vectors",
+        sum_letter_from_neighbor_locks((E1,)) == E1
+        and sum_letter_from_neighbor_locks((E1, E1, E1, E1)) == (4, 0, 0)
+        and sum_letter_from_neighbor_locks((E1, E1)) == (2, 0, 0)
+        and sum_letter_from_neighbor_locks((E1, E2)) == (1, 1, 0)
+        and sum_letter_from_neighbor_locks((E1, (-1, 0, 0))) == ORIGIN
+        and sum_letter_from_neighbor_locks((E3,)) == E3
+        and sum_letter_from_neighbor_locks(((0, 0, -1), E3, E2)) == E2
+        and sum_letter_from_neighbor_locks(()) == "UNDEFINED",
+    )
+    checks.check(
+        "not-singleton-leftover-identity",
+        sum_letter_from_neighbor_locks((E1, E1, E1, E1)) != E1
+        and sum_letter_from_neighbor_locks((E1, E2)) != "UNDEFINED"
+        and sum_letter_from_neighbor_locks(((0, 0, -1), E3, E2)) != "UNDEFINED",
+    )
+    checks.check(
+        "not-sign-lettering-identity",
+        sum_letter_from_neighbor_locks((E1, E3)) == (1, 0, 1)
+        and sum_letter_from_neighbor_locks((E2,)) != sum_letter_from_neighbor_locks(
+            (E3,)
+        )
+        and add(E1, E3) != ORIGIN,
+    )
+    checks.check(
+        "reverse-face-hold-fail-undefined",
+        reverse_report(E1, (-1, 0, 0)) == "hold"
+        and reverse_report((4, 0, 0), E3) == "fail"
+        and reverse_report((4, 0, 0), (0, 0, 1)) == "fail"
+        and reverse_report((4, 0, 0), (-4, 0, 0)) == "hold"
+        and reverse_report("UNDEFINED", E3) == "UNDEFINED"
+        and reverse_report(E1, "UNDEFINED") == "UNDEFINED"
+        and face_report(E2, (0, -1, 0)) == "hold"
+        and face_report(E2, (4, 0, 0)) == "fail"
+        and face_report("UNDEFINED", E1) == "UNDEFINED"
+        and face_report(E3, "UNDEFINED") == "UNDEFINED",
+    )
+
+    recorded = grow(host, SEED_SAME)
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    letters: dict[str, Letter] = {}
+    for name, site in PROBES.items():
+        pairs = recorded_neighbor_locks(site, recorded)
+        neighbor_lists[name] = pairs
+        letter = sum_letter_from_neighbor_locks(tuple(lock for _n, lock in pairs))
+        letters[name] = letter
+        lock_text = ", ".join(
+            f"{lock_display(lock)} at {neighbor}" for neighbor, lock in pairs
+        )
+        incoming = ",".join(lock_display(step) for step in sorted(recorded[site][1]))
+        print(
+            f"{name} recorded-neighbor-locks=[{lock_text}] "
+            f"L={letter_display(letter)} incoming={incoming}"
+        )
+
+    reverse_status = reverse_report(letters["A"], letters["B"])
+    face_status = face_report(letters["C"], letters["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+    print(
+        "per_element: letter is the vector sum of already-recorded "
+        "six-neighbor locks in Z^3, else UNDEFINED if that list is empty"
+    )
+    print(
+        "per_site: scored only at probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four sum letters plus reverse/face as hold, fail, or UNDEFINED"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    checks.check(
+        "theorem1-A-neighbor-lock-list-and-letter",
+        neighbor_lists["A"]
+        == (
+            (ORIGIN, E1),
+            ((1, -1, 0), E1),
+            ((1, 0, 1), E1),
+            ((1, 0, -1), E1),
+        )
+        and letters["A"] == (4, 0, 0),
+        str((neighbor_lists["A"], letters["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-list-and-letter",
+        neighbor_lists["B"] == (((0, 1, 1), E3),) and letters["B"] == (0, 0, 1),
+        str((neighbor_lists["B"], letters["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-list-and-letter",
+        neighbor_lists["C"]
+        == (
+            (PROBES["A"], (0, 0, -1)),
+            (PROBES["A"], E3),
+            (PROBES["A"], E2),
+        )
+        and letters["C"] == (0, 1, 0),
+        str((neighbor_lists["C"], letters["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-list-and-letter",
+        neighbor_lists["D"]
+        == (
+            (E2, E1),
+            ((1, 2, 0), E1),
+            (PROBES["B"], E1),
+            ((1, 1, -1), E1),
+        )
+        and letters["D"] == (4, 0, 0),
+        str((neighbor_lists["D"], letters["D"])),
+    )
+    checks.check(
+        "theorem1-C-defined-from-mixed-A-locks-sum",
+        letters["C"] == (0, 1, 0)
+        and letters["A"] == (4, 0, 0)
+        and recorded[PROBES["A"]][1] == frozenset({E2, E3, (0, 0, -1)})
+        and sum_letter_from_neighbor_locks(tuple(sorted(recorded[PROBES["A"]][1])))
+        == E2,
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and letters["A"] == (4, 0, 0)
+        and letters["B"] == (0, 0, 1)
+        and add((4, 0, 0), (0, 0, 1)) == (4, 0, 1)
+        and add((4, 0, 0), (0, 0, 1)) != ORIGIN
+        and reverse_status != "hold"
+        and reverse_status != "UNDEFINED",
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and letters["C"] == (0, 1, 0)
+        and letters["D"] == (4, 0, 0)
+        and add((0, 1, 0), (4, 0, 0)) == (4, 1, 0)
+        and add((0, 1, 0), (4, 0, 0)) != ORIGIN
+        and face_status != "hold"
+        and face_status != "UNDEFINED",
+        face_status,
+    )
+    checks.check(
+        "not-probe-own-incoming-lock",
+        recorded[PROBES["A"]][1] == frozenset({E2, E3, (0, 0, -1)})
+        and letters["A"] == (4, 0, 0)
+        and letters["A"] not in recorded[PROBES["A"]][1]
+        and recorded[PROBES["D"]][1] == frozenset({(0, -1, 0), E3, (0, 0, -1)})
+        and letters["D"] == (4, 0, 0)
+        and letters["D"] not in recorded[PROBES["D"]][1],
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps-not-letters",
+        all(recorded[PROBES[name]][1] <= set(STEPS) for name in ("A", "B", "C", "D"))
+        and all(
+            isinstance(letters[name], tuple) and letters[name] != "UNDEFINED"
+            for name in ("A", "B", "C", "D")
+        )
+        and letters["A"] not in AXIS_LOCKS
+        and letters["D"] not in AXIS_LOCKS,
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(recorded[PROBES["A"]][1]) == 3
+        and len(recorded[PROBES["D"]][1]) == 3
+        and letters["A"] == (4, 0, 0)
+        and letters["C"] == (0, 1, 0),
+        str(sorted(recorded[PROBES["A"]][1])),
+    )
+    checks.check(
+        "not-nsvecs-unique-leftover",
+        letters["A"] == (4, 0, 0)
+        and letters["A"] != E1
+        and letters["C"] == (0, 1, 0)
+        and letters["C"] != "UNDEFINED"
+        and letters["D"] == (4, 0, 0)
+        and letters["D"] != E1
+        and face_status == "fail"
+        and face_status != "UNDEFINED",
+    )
+    checks.check(
+        "two-site-same-lock-seed",
+        recorded[ORIGIN] == (0, frozenset({E1}))
+        and recorded[E2] == (0, frozenset({E1}))
+        and sum(time == 0 for time, _locks in recorded.values()) == 2,
+    )
+    checks.check(
+        "already-recorded-not-self-or-later",
+        all(
+            neighbor != PROBES[name]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        )
+        and all(
+            recorded[neighbor][0] < recorded[PROBES[name]][0]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(recorded) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        all(dot(site, site) <= 9 for site in recorded)
+        and "No larger host is used." in normalized_note,
+    )
+    origin_parallel_blocked = all(
+        recorded[ORIGIN][0] + 1
+        != recorded.get(add(ORIGIN, step), (None, frozenset()))[0]
+        for step in (E1, (-1, 0, 0))
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and recorded[(0, -1, 0)][0] == 1
+        and recorded[E3][0] == 1
+        and recorded[(0, 0, -1)][0] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    same_seed_locks = frozenset(SEED_SAME)
+    mixed_orbit = False
+    for matrix in proper_cubic_rotations():
+        image = frozenset(
+            (apply_matrix(matrix, site), apply_matrix(matrix, lock))
+            for site, lock in SEED_MIXED
+        )
+        if image == same_seed_locks:
+            mixed_orbit = True
+            break
+    checks.check(
+        "not-mixed-cubic-orbit",
+        (not mixed_orbit)
+        and len(proper_cubic_rotations()) == 24
+        and SEED_SAME[0][1] == SEED_SAME[1][1]
+        and SEED_MIXED[0][1] != SEED_MIXED[1][1],
+    )
+    checks.check(
+        "no-sixteen-combo-census",
+        letters["A"] == (4, 0, 0)
+        and letters["B"] == (0, 0, 1)
+        and letters["C"] == (0, 1, 0)
+        and letters["D"] == (4, 0, 0)
+        and reverse_status == "fail"
+        and face_status == "fail",
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        sum_letter_from_neighbor_locks(()) == "UNDEFINED"
+        and reverse_report("UNDEFINED", letters["B"]) == "UNDEFINED"
+        and face_report("UNDEFINED", letters["D"]) == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-mixed-neighbor-vectors-sum-defined",
+        sum_letter_from_neighbor_locks((E1, E2)) == (1, 1, 0)
+        and sum_letter_from_neighbor_locks((E1, (0, -1, 0))) == (1, -1, 0)
+        and face_report((1, 1, 0), (4, 0, 0)) == "fail"
+        and face_report((1, 1, 0), (4, 0, 0)) != "UNDEFINED",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-lists-and-letters",
+        "L(A) = (4, 0, 0)" in note
+        and "L(B) = (0, 0, 1)" in note
+        and "L(C) = (0, 1, 0)" in note
+        and "L(D) = (4, 0, 0)" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_1 at (1, -1, 0)" in note
+        and "+e_3 at (0, 1, 1)" in note
+        and "−e_3 at (1, 0, 0)" in note
+        and "+e_3 at (1, 0, 0)" in note
+        and "+e_2 at (1, 0, 0)" in note
+        and "+e_1 at (0, 1, 0)" in note
+        and "+e_1 at (1, 2, 0)" in note
+        and "+e_1 at (1, 1, 1)" in note
+        and "+e_1 at (1, 1, -1)" in note,
+    )
+    checks.check(
+        "note-reports-fail-and-fail",
+        "Report: `fail`." in note
+        and note.count("Report: `fail`.") == 2
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-not-sixteen-free-letters",
+        "not a sixteen-combination free lettering" in normalized_note
+        and "16-census" not in note
+        and "16-letter" not in note,
+    )
+    checks.check(
+        "note-not-tick-or-occupancy-reprint",
+        "3 t(" not in note
+        and "t(C)^2" not in note
+        and "n_μ" not in note
+        and "ndot" not in note
+        and "not a unique letter of occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not sign-lettering" in normalized_note
+        and "L(B) = (0, 0, 1)" in note
+        and "L(A) = (4, 0, 0)" in note,
+    )
+    checks.check(
+        "note-not-nsvecs-leftover",
+        "not the unique leftover" in normalized_note
+        and "L(A) = (4, 0, 0)" in note
+        and "L(C) = (0, 1, 0)" in note
+        and "L(C) = UNDEFINED" not in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NSSAME_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def sum_letter_from_neighbor_locks(" in source
+        and "def recorded_neighbor_locks(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def grow(" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-neighbor-locks-only",
+        "sum_letter_from_neighbor_locks" in defined_fns
+        and "recorded_neighbor_locks" in defined_fns
+        and "named_sign" not in defined_fns
+        and "unique_letter_from_neighbor_locks" not in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-tick",
+        "by_tick" in source
+        and "lock_axis" in source
+        and "arrivals" in source
+        and set(recorded) <= host,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Sum of recorded-neighbor locks on nssame. Reverse fail; face fail. Displayed, not adopted. No axiom edit.

## Runner

`scripts/nssame_neighbor_lock_sum_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.