### PR TITLE
feat(nscovec): y-probe same-tick neighbor-lock vector: reverse UNDEFINED, face fail

### DIFF
--- a/docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,428 @@
+---
+claim_id: nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from unique same-tick-inclusive 6-NN lock vectors on the four nnseed y-probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py
+---
+
+# Unique Lock Vector From Same-Tick-Inclusive Six-Neighbor Locks On Four Nnseed Y-Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** unique lock vector in `{±e_i}` or `UNDEFINED` read from same-tick-inclusive
+six-neighbor locks at the formation tick of the four nnseed y-probes
+`A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)` of the displayed two-site
+nnseed process, scored as reverse and face. The unique vector is the singleton
+lock in `{±e_i}` of those neighbors formed at tick `≤ t(q)` and not equal to
+`q`, or `UNDEFINED` if the lock list is empty or mixed. Same-tick partner
+counts. Reverse holds iff `L(A)` and `L(B)` are defined and
+`L(A)+L(B)=(0,0,0)`. Face holds iff `L(C)` and `L(D)` are defined and
+`L(C)+L(D)=(0,0,0)`. Occupancy `n` is not used. The probe's own incoming lock
+is not used. Uniqueness of incoming locks is not required. `A` is a seed
+(`t=0`). This is not the strictly-earlier leftover of unique already-recorded
+six-neighbor lock vectors on these same four y-probes. This is not unique
+`f(n)` and is not ndot. Displayed, not adopted. This note does not write the
+unique vector into Admissibility and does not attach a formation member from
+same-tick-inclusive six-neighbor lock vectors. This is not a sixteen-combination
+free lettering.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py`](../scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming locks are unit nearest-neighbor steps.
+The unique letter scored here is a unique *vector* in `{±e_i}`, or
+`UNDEFINED`. Named signs `{+,−}` of those locks are a different alphabet and
+are not identified with the unique vector.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of same-tick-inclusive six-neighbor lock lists and the unique lock vector on the four nnseed y-probes, with reverse UNDEFINED and face fail; uniqueness of incoming locks is not claimed and the vectors are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face
+target_blocker_text: "display reverse and face from the unique same-tick-inclusive 6-NN lock vector on the four nnseed y-probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write the unique vector into Admissibility, do not use occupancy n, and do not identify the vector with the probe's own incoming step."
+conditional_surface_status: "exact on B_3(0) for unique lock vectors from same-tick-inclusive six-neighbor locks on the four nnseed y-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+same-tick-inclusive six-neighbor lock lists and unique vectors are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`,
+`C=(0,0,2)`, `D=(0,1,1)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not the unique vector scored below.
+
+## Unique lock vector from same-tick-inclusive six-neighbor locks
+
+At the formation tick of a y-probe `q`, collect the locks of six-neighbors of
+`q` that formed at tick `≤ t(q)` and are not `q`. A same-tick partner counts.
+The probe itself is excluded. This display does not use occupancy `n`. It does
+not use the probe's own incoming lock.
+
+If the set of those lock vectors is a singleton `{v}` subset `{±e_i}`, the
+unique letter is `v`. Else (empty, mixed, or no recorded neighbor) the unique
+letter is `UNDEFINED`.
+
+A process-determined unique vector at a probe is a value in `{±e_i}` assigned
+by that named construction from same-tick-inclusive six-neighbor locks, or
+`UNDEFINED`. Incoming `{±e_i}` tags of the probe itself are not that
+assignment. Identifying a named sign of those locks, or of the probe's own
+incoming step, with the unique vector is refused. Reverse and face are scored
+on that unique vector. They are not scored on a sixteen-combination free
+lettering of the four y-probes. Uniqueness of incoming locks is not required.
+
+This is not a unique letter of occupancy `n`. It is not unique `f(n)` and is
+not ndot. A leftover strictly-earlier unique-vector display on these same four
+y-probes dropped same-tick partners, so `A` had an empty neighbor list and
+`L(A)` was `UNDEFINED`. Here the origin lock at tick 0 counts, so `L(A)` is
+`+e_1`. Named-sign collapse of `{±e_i}` is a different alphabet and is not
+used.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A) and L(B) are defined and L(A)+L(B)=(0,0,0)
+face     <=>  L(C) and L(D) are defined and L(C)+L(D)=(0,0,0)
+```
+
+If a vector needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. The report is one of `hold`, `fail`, or `UNDEFINED`. Because the
+unique letter is a single vector per probe, the scored comparisons are not a
+sixteen-combination free lettering, and `some` is not produced. Leftover
+named-sign reports used `all` / `some` / `none`; those are not this display.
+
+Admissibility is not edited. Unique vectors are not written into
+Admissibility.
+
+## Theorem 1 — recorded-neighbor lock list and unique vector at each y-probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+y-probes. Formation ticks are `t(A)=t(0,1,0)=0`, `t(B)=t(1,1,1)=2`,
+`t(C)=t(0,2,0)=3`, `t(D)=t(1,1,0)=1`. Those ticks locate the
+same-tick-inclusive six-neighbor set. They are not occupancy kernels and are
+not the reverse/face scoring.
+
+At each formation tick the same-tick-inclusive six-neighbor lock list and
+unique vector are:
+
+```text
+A: +e_1 at (0, 0, 0);                                            L(A) = +e_1
+B: +e_3 at (0, 1, 1), +e_1 at (1, 0, 1), +e_1 at (1, 1, 0);       L(B) = UNDEFINED
+C: +e_2 at (1, 2, 0), +e_2 at (-1, 2, 0), +e_2 at (0, 1, 0),
+   +e_2 at (0, 2, 1), +e_2 at (0, 2, -1);                         L(C) = +e_2
+D: +e_2 at (0, 1, 0);                                            L(D) = +e_2
+```
+
+`A` is a seed at tick 0. Its same-tick partner is the origin, locking `+e_1`.
+Same-tick counts, so the recorded neighbor lock list is that origin lock and
+`L(A)` is `+e_1`. `C`'s same-tick-inclusive neighbors all lock `+e_2`. `D`'s
+recorded neighbor is the seed `(0, 1, 0)` locking `+e_2`. `B`'s recorded
+neighbors lock two distinct vectors `+e_3` and `+e_1` (the same-tick site
+`(1, 0, 1)` adds another `+e_1` and does not remove the mix), so `L(B)` is
+`UNDEFINED`.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps `+e_1` and `+e_3`; `C` has four mixed self-incoming steps). That
+non-uniqueness is not a unique-vectoring of same-tick-inclusive neighbor
+locks. The unique vectors are not identified with those incoming steps.
+Uniqueness is not required.
+
+`A`, `C`, and `D` each have a singleton recorded-neighbor lock set. `B` is
+`UNDEFINED`.
+
+## Theorem 2 — reverse report
+
+Reverse holds iff `L(A)` and `L(B)` are defined and `L(A)+L(B)=(0,0,0)`.
+The unique vectors are `L(A)=+e_1` and `L(B)=UNDEFINED`. Reverse is
+`UNDEFINED`.
+
+Report: `UNDEFINED`.
+
+This is not `hold` and not `fail`. The strictly-earlier leftover also scored
+reverse as `UNDEFINED`, but from an empty list at `A`. Here `A` is defined;
+reverse remains `UNDEFINED` because `B` is mixed. Unique `f(n)`, ndot,
+occupancy-kernel `{+,−}` pairs, and a sixteen-combination free lettering are
+different objects and are not used.
+
+## Theorem 3 — face report
+
+Face holds iff `L(C)` and `L(D)` are defined and `L(C)+L(D)=(0,0,0)`. The
+unique vectors are `L(C)=+e_2` and `L(D)=+e_2`. Their sum is `(0,2,0)`, which
+is not `(0,0,0)`. Face does not hold.
+
+Report: `fail`.
+
+Displayed, not adopted. The vectors are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify unique vectors with the probe's own incoming `{±e_i}`.
+- It does not use occupancy `n`.
+- It is not unique `f(n)`.
+- It is not ndot.
+- It does not reprint the named-sign unique letters on these four y-probes.
+- It does not reprint the strictly-earlier leftover unique vectors on these
+  four y-probes.
+- It does not reprint already-recorded six-neighbor unique vectors on the
+  four x-probes.
+- It does not reprint already-recorded six-neighbor unique vectors on the
+  four z-probes.
+- It does not attach a formation member from same-tick-inclusive six-neighbor
+  lock vectors.
+- It does not census a sixteen-combination free lettering independent of
+  recorded-neighbor lock vectors.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+nnseed process, the same-tick-inclusive six-neighbor lock lists, the unique
+vector from those locks, and the reverse/face predicates are displayed
+theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| same-tick-inclusive six-neighbor lock lists at each y-probe formation tick | Theorem 1 |
+| unique vector from those locks | Theorem 1; `+e_1`, `UNDEFINED`, `+e_2`, `+e_2` |
+| reverse and face | Theorems 2–3; `UNDEFINED` and `fail` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| unique `f(n)` | not this display |
+| ndot contraction letter | not this display |
+| probe's own incoming lock as the letter | not used |
+| strictly-earlier unique-vector leftover on these y-probes | not this display |
+| named-sign unique letter leftover on these y-probes | not this display |
+| x-probe neighbor-lock unique vectors | not this display |
+| z-probe neighbor-lock unique vectors | not this display |
+| formation member from same-tick-inclusive six-neighbor lock vectors | not attached |
+| sixteen-combination free lettering independent of neighbor-lock vectors | not enumerated |
+| unique vectors as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: unique lock vector from same-tick-inclusive six-neighbor locks on the four nnseed y-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed unique-vector same-tick-inclusive neighbor-lock reverse/face report on these four nnseed y-probes. |
+| V3 | Recorded-neighbor lock lists, unique vectors, and the `UNDEFINED`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads same-tick-inclusive six-neighbor locks at formation and names their common vector in `{±e_i}`. |
+| V5 | It is not an adopted content rule: the vectors remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those vectors into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not use occupancy `n`, is not unique `f(n)`, is not ndot, and is not the
+strictly-earlier leftover on these y-probes. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| strictly-earlier unique-vector leftover on these y-probes | drop same-tick partners | refused; leftover assigned `UNDEFINED` at `A` from an empty list; here `L(A)=+e_1` |
+| reverse/face from that leftover | reuse leftover reverse with empty `A` | different object; leftover reverse was `UNDEFINED` because `A` was empty; here reverse is `UNDEFINED` because `B` is mixed |
+| named-sign unique letter on these y-probes | map each lock `±e_i` to `{+,−}` | refused; unique vector at `B` is `UNDEFINED` because `+e_3` and `+e_1` are distinct |
+| reverse/face from named signs | reuse leftover reverse `L(A)=+` and `L(B)=−` | different object; named-sign reverse was `UNDEFINED` and face was `none`; vector reverse is `UNDEFINED` and face fails |
+| identify unique vector with the probe's own incoming `{±e_i}` | map `A`'s seed lock `+e_2` to `+e_2` | refused; `L(A)=+e_1` from the origin partner, not from `A`'s own incoming step |
+| reverse/face from self-incoming vectors | reuse mixed incoming steps at `C` | different object; `C` would be `UNDEFINED` |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| unique `f(n)` | assign one letter as a function of occupancy `n` | different object; not unique `f(n)` |
+| ndot contraction letter | unique letter `sign(n·v)` | different object; not ndot |
+| reverse/face from formation-tick inequalities | score y-probes by formation order | different object; not this display |
+| formdraw occupancy-kernel `{+,−}` pairs | keep both letters whenever occupancy `n ≠ 0` | different object; unique vector is a singleton or `UNDEFINED` |
+| sixteen-combination free letters on the four y-probes | ignore neighbor-lock vectors and letter independently | different object; not enumerated |
+| x-probe neighbor-lock unique vectors | copy vectors from the x-probes | refused; these are the y-probes `A=(0,1,0)`, `C=(0,2,0)`, `D=(1,1,0)` |
+| z-probe neighbor-lock unique vectors | copy vectors from the z-probes | refused; these are the y-probes |
+| attach a formation member from same-tick-inclusive six-neighbor lock vectors | form the probes by a neighbor-lock vector instead of perp-step | refused; not attached |
+| adopt vectors into Admissibility | rewrite the local rule by `{±e_i}` | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; both earliest incoming steps at `B` and all four at `C` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from same-tick-inclusive
+six-neighbor lock vectors, and missing Record identification of the unique
+vector bits are distinct open premises. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, unique vector from same-tick-inclusive six-neighbor
+locks, four y-probes, seed `A` at tick 0, and reverse/face definitions are
+declared. No uniqueness of incoming locks, no occupancy `n`, no unique
+`f(n)`, no ndot, no named-sign collapse of `{±e_i}`, no formation attachment
+from same-tick-inclusive six-neighbor lock vectors, and no Admissibility rewrite
+are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`UNDEFINED` and `fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each unique vector from recorded-neighbor locks | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four unique vectors and two hold/fail/`UNDEFINED` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide vectoring rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once a same-tick seed partner exists at forming `A`, the site
+should lock that unique vector as incoming content, reverse should hold
+against `B`, named signs at `B` should collapse `+e_1` and `+e_3` to one
+letter, and occupancy `n` or unique `f(n)` or ndot should track that sign.
+Including same-tick should copy the strictly-earlier leftover at `C` and `D`
+and therefore should not be a new display.
+
+**Answer:** The named construction assigns unique vectors `+e_1`,
+`UNDEFINED`, `+e_2`, `+e_2` at `A,B,C,D` from same-tick-inclusive
+six-neighbor locks. Occupancy `n` is not used. This is not unique `f(n)` and
+is not ndot. Named signs at `B` would agree and are not used. Reverse is
+`UNDEFINED` because `B` is mixed. Face fails. The bits remain displayed.
+Incoming-lock uniqueness is not required. `A` is a seed; same-tick counts.
+This is not the strictly-earlier leftover.
+
+### N8 — cross-cycle echo
+
+A leftover unique-vector neighbor-lock display on these same four nnseed
+y-probes closed reverse/face as `UNDEFINED`/`fail` with strictly-earlier
+vectors `UNDEFINED`, `UNDEFINED`, `+e_2`, `+e_2` because `A` had an empty
+already-recorded list. This note is not that display: same-tick counts, so
+`L(A)` is `+e_1`, `L(B)` remains `UNDEFINED` from mixed `+e_3` and `+e_1`,
+reverse is `UNDEFINED`, and face fails. A leftover unique-letter neighbor-lock
+display on these same four y-probes closed reverse/face as `UNDEFINED`/`none`
+with named-sign letters `UNDEFINED`, `+`, `+`, `+`. This note is not that
+display. A leftover formdraw occupancy-kernel display on these same four
+y-probes closed reverse/face as `UNDEFINED`/`some` because both `{+,−}` were
+kept at `n ≠ 0` on formed sites. This note does not reuse occupancy `n`.
+Unique `f(n)` and ndot letterings are different objects and are not used. An
+x-probe unique-vector display closed reverse `UNDEFINED` and face `hold`;
+those probes are not these y-probes.
+
+**Gate disposition:** PASS for the unique-vector same-tick-inclusive
+six-neighbor-lock reverse/face reports on the four nnseed y-probes above.
+FAIL / DO NOT SHIP for “the unique vector equals the probe's own incoming
+step,” “the unique vector is the strictly-earlier leftover,” “vectors are
+Admissibility,” “the letter is occupancy `n`,” “unique `f(n)`,” “ndot,” or
+“reverse/face holds on all combinations.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, collects same-tick-inclusive six-neighbor locks at each
+y-probe's formation tick, reads the unique lock vector at the four y-probes,
+and checks Theorems 1--3. It also checks that the probe's own incoming step is
+not the unique vector, that occupancy `n` is not used, that the scoring is not
+unique `f(n)` and not ndot, that the scoring is not named-sign lettering, that
+the scoring is not the strictly-earlier leftover, and that a formation member
+from same-tick-inclusive six-neighbor lock vectors is not attached. No runner
+cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.txt
@@ -1,0 +1,83 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py
+runner_sha256: 02c8720f242cf9924a42d154f475acb439bdaa34d8361bdcd2bfa3a1eda77a4d
+input_fingerprint_sha256: 886f4ad7263c3191bf35bd566ce57e97be2c7ff96fcaed26cea4307beb645d23
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+unique lock vector from same-tick-inclusive 6-NN locks on nnseed y-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from unique same-tick-inclusive 6-NN lock vectors on the four nnseed y-probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: y-probes-are-not-x-or-z-probes
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: unique-vector-identity-from-neighbor-locks
+PASS: named-sign-same-plus-is-not-unique-vector
+PASS: reverse-face-undefined-when-vector-undefined
+A t=0 recorded-neighbor-locks=[+e_1 at (0, 0, 0)] L=+e_1 incoming=+e_2
+B t=2 recorded-neighbor-locks=[+e_3 at (0, 1, 1), +e_1 at (1, 0, 1), +e_1 at (1, 1, 0)] L=UNDEFINED incoming=+e_3,+e_1
+C t=3 recorded-neighbor-locks=[+e_2 at (1, 2, 0), +e_2 at (-1, 2, 0), +e_2 at (0, 1, 0), +e_2 at (0, 2, 1), +e_2 at (0, 2, -1)] L=+e_2 incoming=−e_1,−e_3,+e_3,+e_1
+D t=1 recorded-neighbor-locks=[+e_2 at (0, 1, 0)] L=+e_2 incoming=+e_1
+reverse=UNDEFINED face=fail
+PASS: theorem1-A-neighbor-lock-list-and-vector  (((((0, 0, 0), (1, 0, 0)),), (1, 0, 0)))
+PASS: theorem1-B-neighbor-lock-list-and-vector  (((((0, 1, 1), (0, 0, 1)), ((1, 0, 1), (1, 0, 0)), ((1, 1, 0), (1, 0, 0))), 'UNDEFINED'))
+PASS: theorem1-C-neighbor-lock-list-and-vector  (((((1, 2, 0), (0, 1, 0)), ((-1, 2, 0), (0, 1, 0)), ((0, 1, 0), (0, 1, 0)), ((0, 2, 1), (0, 1, 0)), ((0, 2, -1), (0, 1, 0))), (0, 1, 0)))
+PASS: theorem1-D-neighbor-lock-list-and-vector  (((((0, 1, 0), (0, 1, 0)),), (0, 1, 0)))
+PASS: theorem1-vectors-e1-undefined-e2-e2
+PASS: theorem1-A-is-seed-same-tick-origin-counts
+PASS: theorem1-formation-ticks
+PASS: theorem1-B-mixed-vectors-include-same-tick
+PASS: theorem2-reverse-undefined  (UNDEFINED)
+PASS: theorem3-face-fail  (fail)
+PASS: not-self-incoming-at-C  (UNDEFINED)
+PASS: not-probe-own-incoming-as-unique-vector-source
+PASS: incoming-locks-are-nn-steps-not-sign-letters
+PASS: uniqueness-not-required  (([(0, 0, 1), (1, 0, 0)], [(-1, 0, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0)]))
+PASS: two-site-seed-locks
+PASS: recorded-not-self-or-later-same-tick-included
+PASS: not-strictly-earlier-leftover
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: no-sixteen-combo-census
+PASS: not-named-sign-collapse-at-B
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-mixed-neighbor-vectors-undefined
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-lists-and-vectors
+PASS: note-reports-undefined-fail
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-does-not-identify-incoming
+PASS: note-not-unique-fn-or-ndot
+PASS: note-not-strictly-earlier-leftover
+PASS: note-does-not-attach-formation-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-not-sixteen-free-letters
+PASS: note-not-occupancy-letter-or-self-incoming
+PASS: note-not-x-or-z-probe-reprint
+PASS: note-a-is-seed
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-vector-from-neighbor-locks-only
+TOTAL: PASS=58 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Unique lock vector from same-tick-inclusive 6-NN locks on four nnseed y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each y-probe's formation tick, collect locks of 6-NN that formed at
+tick <= t(q) and are not q (same-tick partner counts). If that set of lock
+vectors is a singleton {v} subset {±e_i}, the unique letter is v; otherwise
+UNDEFINED. Reverse holds iff L(A) and L(B) are defined and L(A)+L(B)=(0,0,0).
+Face holds iff L(C) and L(D) are defined and L(C)+L(D)=(0,0,0). Occupancy n
+is not used. The probe's own incoming lock is not used. Uniqueness of
+incoming locks is not required. A is a seed (t=0). Not unique f(n). Not ndot.
+Not the strictly-earlier leftover of unique already-recorded 6-NN lock
+vectors on these y-probes.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Letter = Point | str
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (0, 1, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    (-1, 0, 0): "−e_1",
+    E2: "+e_2",
+    (0, -1, 0): "−e_2",
+    E3: "+e_3",
+    (0, 0, -1): "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from unique same-tick-inclusive 6-NN lock "
+    "vectors on the four nnseed y-probes are reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def unique_vector_from_neighbor_locks(locks: tuple[Point, ...]) -> Letter:
+    """Unique vector if all recorded-neighbor locks equal one {±e_i} step."""
+    if not locks:
+        return "UNDEFINED"
+    distinct = set(locks)
+    if len(distinct) == 1:
+        vector = next(iter(distinct))
+        if vector in NN:
+            return vector
+    return "UNDEFINED"
+
+
+def reverse_report(letter_a: Letter, letter_b: Letter) -> str:
+    """Reverse iff L(A)+L(B)=(0,0,0). UNDEFINED if a needed vector is UNDEFINED."""
+    if letter_a == "UNDEFINED" or letter_b == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter_a, tuple) or not isinstance(letter_b, tuple):
+        return "UNDEFINED"
+    holds = add(letter_a, letter_b) == ORIGIN
+    return "hold" if holds else "fail"
+
+
+def face_report(letter_c: Letter, letter_d: Letter) -> str:
+    """Face iff L(C)+L(D)=(0,0,0). UNDEFINED if a needed vector is UNDEFINED."""
+    if letter_c == "UNDEFINED" or letter_d == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter_c, tuple) or not isinstance(letter_d, tuple):
+        return "UNDEFINED"
+    holds = add(letter_c, letter_d) == ORIGIN
+    return "hold" if holds else "fail"
+
+
+def letter_display(letter: Letter) -> str:
+    if letter == "UNDEFINED":
+        return "UNDEFINED"
+    if isinstance(letter, tuple):
+        return LOCK_NAME[letter]
+    return str(letter)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def recorded_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of 6-NN formed at tick <= t(q), excluding q (same-tick counts)."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if neighbor == site:
+            continue
+        if ticks[neighbor] > formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def strictly_earlier_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Strictly-earlier leftover collector, used only as a refused contrast."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("unique lock vector from same-tick-inclusive 6-NN locks on nnseed y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "y-probes-are-not-x-or-z-probes",
+        probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and x_probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and z_probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (0, 1, 1)),
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(E2, E2) == (0, 2, 0)
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "unique-vector-identity-from-neighbor-locks",
+        unique_vector_from_neighbor_locks((E1,)) == E1
+        and unique_vector_from_neighbor_locks((E1, E1)) == E1
+        and unique_vector_from_neighbor_locks((E2,)) == E2
+        and unique_vector_from_neighbor_locks(((0, -1, 0),)) == (0, -1, 0)
+        and unique_vector_from_neighbor_locks((E1, E2)) == "UNDEFINED"
+        and unique_vector_from_neighbor_locks((E1, E3)) == "UNDEFINED"
+        and unique_vector_from_neighbor_locks((E1, (-1, 0, 0))) == "UNDEFINED"
+        and unique_vector_from_neighbor_locks((E2, E2, E2)) == E2
+        and unique_vector_from_neighbor_locks(()) == "UNDEFINED",
+    )
+    checks.check(
+        "named-sign-same-plus-is-not-unique-vector",
+        unique_vector_from_neighbor_locks((E1, E3)) == "UNDEFINED"
+        and unique_vector_from_neighbor_locks((E1,)) == E1
+        and unique_vector_from_neighbor_locks((E3,)) == E3,
+    )
+    checks.check(
+        "reverse-face-undefined-when-vector-undefined",
+        reverse_report("UNDEFINED", E2) == "UNDEFINED"
+        and reverse_report(E1, "UNDEFINED") == "UNDEFINED"
+        and face_report("UNDEFINED", E2) == "UNDEFINED"
+        and face_report(E2, "UNDEFINED") == "UNDEFINED"
+        and reverse_report(E1, (-1, 0, 0)) == "hold"
+        and reverse_report(E1, E2) == "fail"
+        and reverse_report(E2, E2) == "fail"
+        and face_report((0, -1, 0), E2) == "hold"
+        and face_report(E2, E2) == "fail"
+        and face_report(E3, E2) == "fail",
+    )
+
+    ticks, locks = form()
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    letters: dict[str, Letter] = {}
+    leftover_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    leftover_letters: dict[str, Letter] = {}
+    for name, site in PROBES.items():
+        pairs = recorded_neighbor_locks(site, ticks, locks)
+        neighbor_lists[name] = pairs
+        letter = unique_vector_from_neighbor_locks(tuple(lock for _n, lock in pairs))
+        letters[name] = letter
+        leftover = strictly_earlier_neighbor_locks(site, ticks, locks)
+        leftover_lists[name] = leftover
+        leftover_letters[name] = unique_vector_from_neighbor_locks(
+            tuple(lock for _n, lock in leftover)
+        )
+        lock_text = ", ".join(
+            f"{lock_display(lock)} at {neighbor}" for neighbor, lock in pairs
+        )
+        incoming = ",".join(lock_display(step) for step in sorted(locks[site]))
+        print(
+            f"{name} t={ticks[site]} recorded-neighbor-locks=[{lock_text}] "
+            f"L={letter_display(letter)} incoming={incoming}"
+        )
+
+    reverse_status = reverse_report(letters["A"], letters["B"])
+    face_status = face_report(letters["C"], letters["D"])
+    leftover_reverse = reverse_report(leftover_letters["A"], leftover_letters["B"])
+    print(f"reverse={reverse_status} face={face_status}")
+
+    incoming_c_vector = unique_vector_from_neighbor_locks(tuple(locks[PROBES["C"]]))
+
+    checks.check(
+        "theorem1-A-neighbor-lock-list-and-vector",
+        neighbor_lists["A"] == ((ORIGIN, E1),) and letters["A"] == E1,
+        str((neighbor_lists["A"], letters["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-list-and-vector",
+        neighbor_lists["B"]
+        == (((0, 1, 1), E3), ((1, 0, 1), E1), (PROBES["D"], E1))
+        and letters["B"] == "UNDEFINED",
+        str((neighbor_lists["B"], letters["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-list-and-vector",
+        neighbor_lists["C"]
+        == (
+            ((1, 2, 0), E2),
+            ((-1, 2, 0), E2),
+            (E2, E2),
+            ((0, 2, 1), E2),
+            ((0, 2, -1), E2),
+        )
+        and letters["C"] == E2,
+        str((neighbor_lists["C"], letters["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-list-and-vector",
+        neighbor_lists["D"] == ((E2, E2),) and letters["D"] == E2,
+        str((neighbor_lists["D"], letters["D"])),
+    )
+    checks.check(
+        "theorem1-vectors-e1-undefined-e2-e2",
+        letters["A"] == E1
+        and letters["B"] == "UNDEFINED"
+        and letters["C"] == E2
+        and letters["D"] == E2,
+    )
+    checks.check(
+        "theorem1-A-is-seed-same-tick-origin-counts",
+        ticks[PROBES["A"]] == 0
+        and PROBES["A"] == E2
+        and ticks[ORIGIN] == 0
+        and ORIGIN in {neighbor for neighbor, _lock in neighbor_lists["A"]}
+        and neighbor_lists["A"] == ((ORIGIN, E1),)
+        and letters["A"] == E1,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 1,
+    )
+    checks.check(
+        "theorem1-B-mixed-vectors-include-same-tick",
+        letters["B"] == "UNDEFINED"
+        and {lock for _n, lock in neighbor_lists["B"]} == {E1, E3}
+        and ((1, 0, 1), E1) in neighbor_lists["B"]
+        and ticks[(1, 0, 1)] == ticks[PROBES["B"]],
+    )
+    checks.check(
+        "theorem2-reverse-undefined",
+        reverse_status == "UNDEFINED"
+        and letters["A"] == E1
+        and letters["B"] == "UNDEFINED",
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and letters["C"] == E2
+        and letters["D"] == E2
+        and add(E2, E2) == (0, 2, 0)
+        and add(E2, E2) != ORIGIN,
+        face_status,
+    )
+    checks.check(
+        "not-self-incoming-at-C",
+        locks[PROBES["C"]] == {(-1, 0, 0), E3, (0, 0, -1), E1}
+        and incoming_c_vector == "UNDEFINED"
+        and letters["C"] == E2,
+        incoming_c_vector,
+    )
+    checks.check(
+        "not-probe-own-incoming-as-unique-vector-source",
+        locks[PROBES["A"]] == {E2}
+        and letters["A"] == E1
+        and letters["A"] != next(iter(locks[PROBES["A"]]))
+        and locks[PROBES["D"]] == {E1}
+        and letters["D"] == E2
+        and letters["D"] != next(iter(locks[PROBES["D"]]))
+        and incoming_c_vector != letters["C"],
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps-not-sign-letters",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 4
+        and letters["B"] == "UNDEFINED"
+        and letters["C"] == E2,
+        str((sorted(locks[PROBES["B"]]), sorted(locks[PROBES["C"]]))),
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2},
+    )
+    checks.check(
+        "recorded-not-self-or-later-same-tick-included",
+        all(
+            neighbor != PROBES[name]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        )
+        and all(
+            ticks[neighbor] <= ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        )
+        and any(
+            ticks[neighbor] == ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "not-strictly-earlier-leftover",
+        leftover_lists["A"] == ()
+        and leftover_letters["A"] == "UNDEFINED"
+        and leftover_reverse == "UNDEFINED"
+        and letters["A"] == E1
+        and leftover_letters["A"] != letters["A"]
+        and leftover_lists["B"] == (((0, 1, 1), E3), (PROBES["D"], E1))
+        and ((1, 0, 1), E1) not in leftover_lists["B"]
+        and leftover_letters["B"] == "UNDEFINED",
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "no-sixteen-combo-census",
+        reverse_status == "UNDEFINED"
+        and face_status == "fail"
+        and reverse_status != "some"
+        and face_status != "some",
+    )
+    checks.check(
+        "not-named-sign-collapse-at-B",
+        letters["B"] == "UNDEFINED"
+        and letters["A"] == E1
+        and letters["C"] == E2
+        and letters["D"] == E2
+        and {lock for _n, lock in neighbor_lists["B"]} == {E1, E3},
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        unique_vector_from_neighbor_locks(()) == "UNDEFINED"
+        and reverse_report("UNDEFINED", letters["D"] if isinstance(letters["D"], tuple) else E2)
+        == "UNDEFINED"
+        and face_report(letters["C"], "UNDEFINED") == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-mixed-neighbor-vectors-undefined",
+        unique_vector_from_neighbor_locks((E1, E3)) == "UNDEFINED"
+        and reverse_report(E1, "UNDEFINED") == "UNDEFINED",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-lists-and-vectors",
+        "L(A) = +e_1" in note
+        and "L(B) = UNDEFINED" in note
+        and "L(C) = +e_2" in note
+        and "L(D) = +e_2" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_3 at (0, 1, 1)" in note
+        and "+e_1 at (1, 0, 1)" in note
+        and "+e_1 at (1, 1, 0)" in note
+        and "+e_2 at (1, 2, 0)" in note
+        and "+e_2 at (-1, 2, 0)" in note
+        and "+e_2 at (0, 1, 0)" in note
+        and "+e_2 at (0, 2, 1)" in note
+        and "+e_2 at (0, 2, -1)" in note,
+    )
+    checks.check(
+        "note-reports-undefined-fail",
+        "Report: `UNDEFINED`." in note
+        and "Report: `fail`." in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note,
+    )
+    checks.check(
+        "note-not-unique-fn-or-ndot",
+        "not unique `f(n)`" in note and "not ndot" in note,
+    )
+    checks.check(
+        "note-not-strictly-earlier-leftover",
+        "not the strictly-earlier leftover" in normalized_note
+        and "unique *vector*" in note
+        and "same-tick" in note
+        and "L(A)` is `+e_1`" in note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from same-tick-inclusive six-neighbor lock vectors"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-not-sixteen-free-letters",
+        "not a sixteen-combination free lettering" in normalized_note
+        and "16-census" not in note
+        and "16-letter" not in note,
+    )
+    checks.check(
+        "note-not-occupancy-letter-or-self-incoming",
+        "not a unique letter of occupancy" in normalized_note
+        and "self-incoming" in normalized_note
+        and "mixed" in normalized_note,
+    )
+    checks.check(
+        "note-not-x-or-z-probe-reprint",
+        "not the x-probes" in normalized_note
+        and "not the z-probes" in normalized_note
+        and "A = (0,1,0)" in note,
+    )
+    checks.check(
+        "note-a-is-seed",
+        "A` is a seed" in note or "`A` is a seed" in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_VECTOR_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def unique_vector_from_neighbor_locks(" in source
+        and "def recorded_neighbor_locks(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["B"]] >= 1
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-vector-from-neighbor-locks-only",
+        "unique_vector_from_neighbor_locks" in defined_fns
+        and "recorded_neighbor_locks" in defined_fns
+        and "named_sign" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and not any("ndot" in name for name in defined_fns),
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-tick-inclusive unique neighbor-lock vector on nnseed y-probes. Reverse UNDEFINED (B mixed); face fail (C and D both +e2). Strictly-earlier leftover was UNDEFINED because A was empty. Displayed, not adopted. No axiom edit.

## Runner

`scripts/nnseed_yprobe_sametick_neighbor_lock_vector_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.