### PR TITLE
feat(nscosum): y-probe same-tick neighbor-lock sum: reverse fail, face fail

### DIFF
--- a/docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,397 @@
+---
+claim_id: nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the same-tick-inclusive sum of 6-NN locks on the four nnseed y-probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py
+---
+
+# Same-Tick-Inclusive Sum Of Six-Neighbor Locks On Four Nnseed Y-Probes: Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the vector sum in `Z^3` of six-neighbor incoming locks formed at
+tick `<= t(q)`, with the probe `q` excluded, at the formation tick of the four
+nnseed y-probes `A_y=(0,1,0)`, `B=(1,1,1)`, `C_y=(0,2,0)`, `D_y=(1,1,0)` of
+the displayed two-site nnseed process, scored as reverse and face. Same-tick
+neighbors count. If the list of those locks is empty, the letter is
+`UNDEFINED`. Reverse holds if and only if both letters are defined and sum to
+`(0,0,0)`. Face holds if and only if both letters are defined and sum to
+`(0,0,0)`. Uniqueness is not required. This is not the strictly-earlier
+six-neighbor lock-sum display, not a unique leftover vector, not
+occupancy-kernel `n`, and not a named `{+,−}` PVM letter. Displayed, not
+adopted. This note does not write the sum letter into Admissibility and does
+not add a formation member beyond the displayed perp-step incoming-lock
+process.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py`](../scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. The scored letter at a probe is the vector sum of same-tick-inclusive
+six-neighbor locks, or `UNDEFINED`.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of the same-tick-inclusive sum of 6-NN locks on the four nnseed y-probes, with reverse fail because L(A_y)+L(B)=(3,0,1) and face fail because L(C_y)+L(D_y)=(0,6,0); uniqueness is not claimed and the letters are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face
+target_blocker_text: "display reverse and face from the same-tick-inclusive sum of 6-NN locks on the four nnseed y-probes"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write the sum letter into Admissibility, and do not replace it by strictly-earlier lock-sum, leftover unique vector, occupancy-kernel n, or PVM letters."
+conditional_surface_status: "exact on B_3(0) for the same-tick-inclusive sum of 6-NN locks on the four nnseed y-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+same-tick-inclusive six-neighbor lock sums are scored:
+
+```text
+A_y = (0,1,0),  B = (1,1,1),  C_y = (0,2,0),  D_y = (1,1,0).
+```
+
+These are the nsiso y-probe sites. Formation ticks of those sites locate the
+same-tick-inclusive six-neighbor set. The ticks are not the reverse/face
+scoring.
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+`A_y` is the seed site `(0,1,0)`. It is already formed at tick 0. It is not
+re-formed by a later incoming step.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`. A seed site is already formed, so it is not re-formed.
+
+## Named sum letter
+
+At the formation tick of a probe `q`, let `S` be the list of incoming locks
+of six-neighbors of `q` that formed at tick `<= t(q)` and are not `q`.
+Same-tick neighbors count. The same-tick partner counts. The probe itself is
+excluded. In particular, at
+`t(A_y)=0` the origin is the same-tick partner of `A_y` and contributes its
+lock to `S`.
+
+Walk the six steps in the order `+e_1,-e_1,+e_2,-e_2,+e_3,-e_3`. For each
+included neighbor, append that neighbor's incoming lock vectors, in sorted
+coordinate order, to `S`. If a neighbor carries several earliest incoming
+locks, every such lock is appended. Uniqueness is not required.
+
+If `S` is empty, the letter is `UNDEFINED`. Else the letter is the vector
+sum of `S` in `Z^3`.
+
+That sum is not occupancy-kernel `n`. It is not a unique leftover vector of
+an unrecorded six-neighbor step. It is not a named rank-1 PVM letter in
+`{+,−}`. It is not the strictly-earlier six-neighbor lock-sum letter. Incoming
+`{±e_i}` tags of the probe itself are not that assignment.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  L(A_y) and L(B) are defined and L(A_y)+L(B)=(0,0,0)
+face     <=>  L(C_y) and L(D_y) are defined and L(C_y)+L(D_y)=(0,0,0)
+```
+
+If a letter needed by a comparison is `UNDEFINED`, that comparison is
+`UNDEFINED`. Otherwise the report is `hold` or `fail`.
+
+Admissibility is not edited. The sum letters are not written into
+Admissibility.
+
+## Theorem 1 — lock list and sum letter at each y-probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+y-probes. Formation ticks are `t(A_y)=t(0,1,0)=0`, `t(B)=t(1,1,1)=2`,
+`t(C_y)=t(0,2,0)=3`, `t(D_y)=t(1,1,0)=1`. Those ticks match the nsiso y-probe
+formation order and locate the same-tick-inclusive neighbor set. They are not
+the reverse/face letter.
+
+At the seed tick of `A_y` the same-tick-inclusive six-neighbor lock list is
+nonempty: the origin partner is included. At the formation ticks of `B`,
+`C_y`, and `D_y` the list is also nonempty. Every letter is the vector sum:
+
+```text
+S(A_y) = (+e_1),                                     L(A_y) = (1, 0, 0)
+S(B)   = (+e_3, +e_1, +e_1),                         L(B)   = (2, 0, 1)
+S(C_y) = (+e_2, +e_2, +e_2, +e_2, +e_2),             L(C_y) = (0, 5, 0)
+S(D_y) = (+e_2),                                     L(D_y) = (0, 1, 0)
+```
+
+Same-tick-inclusive six-neighbors at those formation ticks:
+
+- `A_y`: origin `(0,0,0)` locks `+e_1` at tick 0;
+- `B`: `(0,1,1)` locks `+e_3` at tick 1, `(1,0,1)` locks `+e_1` at tick 2, and
+  `(1,1,0)` locks `+e_1` at tick 1;
+- `C_y`: `(1,2,0)`, `(-1,2,0)`, `(0,1,0)`, `(0,2,1)`, and `(0,2,-1)` all lock
+  `+e_2`;
+- `D_y`: `(0,1,0)` locks `+e_2`.
+
+`A_y` carries the seed lock `+e_2`. Incoming locks of the grown sites exist
+and need not be unique (`B` has two earliest incoming steps; `C_y` has four).
+That non-uniqueness is not the sum letter. The sum letter is read from
+included neighbors, not from the probe's own incoming steps.
+
+On `C_y` there is a unique unrecorded six-neighbor step `+e_2`. That leftover
+vector is not `L(C_y)=(0,5,0)`. This display is not the unique-vector leftover
+construction.
+
+The strictly-earlier six-neighbor lock list at `A_y` is empty, and the
+strictly-earlier list at `B` omits the same-tick neighbor `(1,0,1)`. Those
+strictly-earlier sums are a different display: they assign `L(A_y)` as
+`UNDEFINED` and `L(B)=(1,0,1)`. They are not this letter.
+
+## Theorem 2 — reverse report
+
+Reverse is `L(A_y)+L(B)=(0,0,0)` with both letters defined. Both letters are
+defined: `L(A_y)=(1,0,0)` and `L(B)=(2,0,1)`, so
+
+```text
+L(A_y)+L(B) = (3, 0, 1) ≠ (0, 0, 0).
+```
+
+Report: `fail`.
+
+This is not `hold` and not `UNDEFINED`. A unique leftover vector, an
+occupancy-kernel letter, a named `{+,−}` PVM letter, a named-sign readout of
+the probe's own incoming steps, a strictly-earlier lock-sum letter, and a
+formation-tick inequality are different objects and are not used.
+
+## Theorem 3 — face report
+
+Face is `L(C_y)+L(D_y)=(0,0,0)` with both letters defined. Both letters are
+defined: `L(C_y)=(0,5,0)` and `L(D_y)=(0,1,0)`, so
+
+```text
+L(C_y)+L(D_y) = (0, 6, 0) ≠ (0, 0, 0).
+```
+
+Report: `fail`.
+
+This is not `hold` and not `UNDEFINED`. Displayed, not adopted. The letters
+are not written into Admissibility.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock of the probe itself.
+- It is not a unique leftover vector.
+- It is not occupancy-kernel `n`.
+- It is not a named `{+,−}` PVM letter.
+- It is not the strictly-earlier six-neighbor lock-sum display.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the quoted one-site algebra. It uses Record only as a boundary: a
+present lock is content. It does not rewrite Admissibility. The nnseed
+process, the same-tick-inclusive six-neighbor lock list, the vector-sum letter,
+and the reverse/face predicates are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| same-tick-inclusive 6-NN lock list `S` and vector-sum letter at each y-probe | Theorem 1; `L(A_y)=(1,0,0)`, `L(B)=(2,0,1)`, `L(C_y)=(0,5,0)`, `L(D_y)=(0,1,0)` |
+| reverse and face | Theorems 2–3; `fail` / `fail` |
+| unique incoming lock of the probe | not required |
+| unique leftover vector | not this display |
+| occupancy-kernel `n` | not this display |
+| named `{+,−}` PVM letter | not this display |
+| strictly-earlier 6-NN lock-sum letter | not this display |
+| sum letters as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: same-tick-inclusive sum of 6-NN locks on the four nnseed y-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed same-tick-inclusive 6-NN lock-sum reverse/face report on these four nnseed y-probes. |
+| V3 | Lock lists, vector sums, and the `fail`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it sums same-tick-inclusive neighbor locks at formation. |
+| V5 | It is not an adopted content rule: the letters remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those letters into
+Admissibility, does not replace them by a unique leftover vector, does not
+read occupancy-kernel `n`, does not assign `{+,−}` PVM letters, and does not
+replace the same-tick-inclusive list by the strictly-earlier list. No global
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique leftover vector | take the unique unrecorded six-neighbor step | different object; leftover at `C_y` is `+e_2`, not `(0,5,0)` |
+| occupancy-kernel `n` | score `n_μ=(o_{+μ}−o_{−μ})/3` | different object; not this display |
+| named `{+,−}` PVM letter | assign both `P_±` whenever `n≠0` | different object; the letter here is a vector in `Z^3` |
+| reverse/face from the probe's own incoming steps | reuse the probe lock as the letter | different object; `S` is neighbor locks |
+| reverse/face from formation-tick inequalities | score y-probes by nsiso tick order | different object; ticks locate `S` only |
+| strictly-earlier 6-NN lock-sum | drop neighbors with tick `= t(q)` | different object; `S(A_y)` empty and `L(B)=(1,0,1)` |
+| adopt letters into Admissibility | rewrite the local rule by the sum | refused; displayed, not adopted |
+| unique incoming lock required | demand one lock per grown site | uniqueness is not required |
+
+### N2 — wall independence
+
+Missing physical adoption, missing leftover identification, and missing Record
+identification of the sum bits are distinct open premises. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, same-tick-inclusive neighbor lock list with `q`
+excluded, vector-sum letter, four y-probes, and reverse/face definitions are
+declared. No uniqueness, no leftover identification, no occupancy-kernel
+letter, no PVM letter, no strictly-earlier replacement, and no Admissibility
+rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each incoming lock in `S` and each coordinate of the sum | no continuum alphabet |
+| per site | `A_y,B,C_y,D_y` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four letters and `fail`/`fail` comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among possible incoming locks.
+None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Same-tick inclusion is only the strictly-earlier leftover with
+the origin glued on, so reverse should remain `UNDEFINED`, `S(B)` should stay
+`(+e_3,+e_1)`, `C_y` should lock the unique leftover `+e_2`, and face should
+hold or be adopted as Admissibility content.
+
+**Answer:** Same-tick-inclusive neighbors are a different recorded set. The
+origin partner is in `S(A_y)`, so `L(A_y)=(1,0,0)` and reverse is defined.
+`S(B)` also includes the same-tick neighbor `(1,0,1)` locking `+e_1`, so
+`L(B)=(2,0,1)` and `L(A_y)+L(B)=(3,0,1)`. Reverse fails. The letter at `C_y`
+is the sum of five `+e_2` locks, namely `(0,5,0)`, not the leftover step
+`+e_2`. Face fails because `(0,5,0)+(0,1,0)=(0,6,0)`. The bits remain
+displayed. Uniqueness is not required. This is not a unique leftover vector,
+not occupancy-kernel `n`, and not a `{+,−}` PVM letter. Tick reverse FAIL /
+face HOLD is a different object.
+
+### N8 — cross-cycle echo
+
+A prior display scored named rank-1 PVM letters from occupancy-kernel `n` on
+the four nnseed y-probes and reported reverse `UNDEFINED` / face `some`,
+because `n(A_y)=0`. A second prior display scored formation-tick inequalities
+on the same y-probes and reported reverse FAIL / face HOLD. A third prior
+display summed strictly-earlier 6-NN locks on the four y-probes and reported
+reverse `UNDEFINED` / face `fail`, because `S(A_y)` was empty. A fourth prior
+display summed already-recorded 6-NN locks on the four nnseed x-probes and
+reported reverse fail / face hold. This note is not those displays: it sums
+same-tick-inclusive 6-NN locks on the four y-probes, where `L(A_y)=(1,0,0)`,
+`L(B)=(2,0,1)`, and `L(C_y)+L(D_y)=(0,6,0)`. Unique leftover vectors on those
+y-probes are not used.
+
+**Gate disposition:** PASS for the same-tick-inclusive 6-NN lock-sum
+reverse/face reports on the four nnseed y-probes above. FAIL / DO NOT SHIP
+for “the sum letter equals the leftover unique vector,” “letters are
+Admissibility,” “this is the strictly-earlier leftover,” “occupancy-kernel
+`n` is the letter,” “reverse is `UNDEFINED`,” or “face holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, lists six-neighbor incoming locks formed at tick
+`<= t(q)` with `q` excluded at each y-probe's formation tick, sums those
+locks in `Z^3` or reports `UNDEFINED`, and checks Theorems 1--3. It also
+checks that the probe's own incoming steps are not the sum letter, that the
+unique leftover vector at `C_y` is not `L(C_y)`, that the same-tick partner
+is included, that the strictly-earlier list is a different object, that
+reverse is `fail` and face is `fail`, and that formation ticks match the
+nsiso y-probe order. No runner cache is written.

--- a/logs/runner-cache/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.txt
@@ -1,0 +1,71 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py
+runner_sha256: a5508f0695441d560edeeae9abb0f88d8fd0772f5ebcec82e80bdb9443b1b535
+input_fingerprint_sha256: c040293bf33a37679c8a0c030b92154738354a635e87ff56e55f1fa5acea2da4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+same-tick-inclusive 6-NN lock-sum reverse/face on four nnseed y-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the same-tick-inclusive sum of 6-NN locks on the four nnseed y-probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-euclidean-b3
+PASS: y-probes-in-host
+PASS: perp-step-blocks-parallel
+A S=[(1, 0, 0)] L=(1, 0, 0) t=0 incoming=[(0, 1, 0)] leftover=None
+B S=[(0, 0, 1), (1, 0, 0), (1, 0, 0)] L=(2, 0, 1) t=2 incoming=[(0, 0, 1), (1, 0, 0)] leftover=None
+C S=[(0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0)] L=(0, 5, 0) t=3 incoming=[(-1, 0, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0)] leftover=(0, 1, 0)
+D S=[(0, 1, 0)] L=(0, 1, 0) t=1 incoming=[(1, 0, 0)] leftover=None
+PASS: theorem1-A-sum  ((1, 0, 0))
+PASS: theorem1-B-sum  ((2, 0, 1))
+PASS: theorem1-C-sum  ((0, 5, 0))
+PASS: theorem1-D-sum  ((0, 1, 0))
+PASS: theorem1-y-ticks-match-nsiso  ({'A': 0, 'B': 2, 'C': 3, 'D': 1})
+PASS: uniqueness-not-required  (B=[(0, 0, 1), (1, 0, 0)] C=[(-1, 0, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0)])
+PASS: two-site-seed-locks
+PASS: seed-includes-same-tick-partner
+reverse=fail reverse_sum=(3, 0, 1) face=fail face_sum=(0, 6, 0)
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-fail  (fail)
+PASS: not-leftover-unique-vector  ((0, 1, 0))
+PASS: letter-is-not-probe-incoming
+PASS: empty-S-is-undefined
+PASS: not-strictly-earlier-leftover  (strict_reverse=UNDEFINED strict_B=(1, 0, 1))
+PASS: mutation-including-q-changes-A  ((1, 1, 0))
+PASS: mutation-leftover-changes-letter  (leftover_sum=(0, 2, 0) face_sum=(0, 6, 0))
+PASS: mutation-one-site-seed-changes-S  ([(0, 0, 1), (0, 1, 0), (1, 0, 0), (1, 0, 0)])
+PASS: x-probe-sum-is-fail-hold-not-this-display  (x_reverse=fail x_face=hold)
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: not-t-as-comparator
+PASS: a-is-seed-not-grown-incoming
+PASS: note-claim-scope
+PASS: note-reports-S-and-letters
+PASS: note-reports-fail-fail
+PASS: note-reverse-sum-not-zero
+PASS: note-face-sum-not-zero
+PASS: note-not-leftover-or-occupancy-or-pvm
+PASS: note-y-ticks-nsiso
+PASS: note-displayed-not-adopted
+PASS: note-same-tick-inclusive-rule
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+TOTAL: PASS=46 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Same-tick-inclusive sum of 6-NN locks on four nnseed y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each y-probe's formation tick, S is the list of incoming locks of
+six-neighbors formed at tick <= t(q), q excluded. Same-tick partner counts.
+If S is empty the letter is UNDEFINED; else the letter is the vector sum of
+S in Z^3. Reverse iff L(A)+L(B)=(0,0,0). Face iff L(C)+L(D)=(0,0,0).
+Uniqueness is not required. Not strictly-earlier leftover. Not leftover
+unique vector. Not occupancy-kernel n. Not named {+,−} PVM letters.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+ZERO: Point = (0, 0, 0)
+NN: tuple[Point, ...] = (
+    E1,
+    (-1, 0, 0),
+    E2,
+    (0, -1, 0),
+    E3,
+    (0, 0, -1),
+)
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "L1",
+    "Runner cache",
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def vector_sum(locks: list[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def letter_from_S(locks: list[Point]) -> Point | None:
+    if not locks:
+        return None
+    return vector_sum(locks)
+
+
+def letter_report(letter: Point | None) -> str:
+    if letter is None:
+        return "UNDEFINED"
+    return str(letter)
+
+
+def comparison_report(left: Point | None, right: Point | None) -> str:
+    if left is None or right is None:
+        return "UNDEFINED"
+    if add(left, right) == ZERO:
+        return "hold"
+    return "fail"
+
+
+def leftover_unique_vector(site: Point, ticks: dict[Point, int]) -> Point | None:
+    """Refused unique leftover: the unique unrecorded 6-NN step."""
+    formation = ticks[site]
+    unrecorded: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks or ticks[neighbor] >= formation:
+            unrecorded.append(step)
+    if len(unrecorded) != 1:
+        return None
+    return unrecorded[0]
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def recorded_inclusive(site: Point, ticks: dict[Point, int]) -> frozenset[Point]:
+    """Sites formed at tick <= t(site), site excluded."""
+    formation = ticks[site]
+    return frozenset(
+        other
+        for other, tick in ticks.items()
+        if tick <= formation and other != site
+    )
+
+
+def recorded_strict(site: Point, ticks: dict[Point, int]) -> frozenset[Point]:
+    formation = ticks[site]
+    return frozenset(other for other, tick in ticks.items() if tick < formation)
+
+
+def neighbor_lock_list(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    *,
+    inclusive: bool = True,
+) -> list[Point]:
+    """Incoming locks of included 6-NN, walked in NN order."""
+    recorded = (
+        recorded_inclusive(site, ticks)
+        if inclusive
+        else recorded_strict(site, ticks)
+    )
+    collected: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor in recorded:
+            collected.extend(sorted(locks[neighbor]))
+    return collected
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("same-tick-inclusive 6-NN lock-sum reverse/face on four nnseed y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(
+        "claim_scope: Reverse and face from the same-tick-inclusive sum of 6-NN "
+        "locks on the four nnseed y-probes are reported. Displayed, not adopted."
+    )
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    checks.check(
+        "host-is-euclidean-b3",
+        ORIGIN in host and len(host) == 123 and BALL_SQ == 9,
+    )
+    checks.check(
+        "y-probes-in-host",
+        {PROBES["A"], PROBES["B"], PROBES["C"], PROBES["D"]} <= host,
+    )
+    checks.check(
+        "perp-step-blocks-parallel",
+        perpendicular(E1, E2)
+        and not perpendicular(E2, E2)
+        and in_ball(PROBES["C"])
+        and not in_ball((0, 4, 0)),
+    )
+
+    ticks, locks = form()
+    lists: dict[str, list[Point]] = {}
+    letters: dict[str, Point | None] = {}
+    leftovers: dict[str, Point | None] = {}
+    strict_lists: dict[str, list[Point]] = {}
+    for name, site in PROBES.items():
+        collected = neighbor_lock_list(site, ticks, locks, inclusive=True)
+        lists[name] = collected
+        letters[name] = letter_from_S(collected)
+        leftovers[name] = leftover_unique_vector(site, ticks)
+        strict_lists[name] = neighbor_lock_list(
+            site, ticks, locks, inclusive=False
+        )
+        print(
+            f"{name} S={collected} L={letter_report(letters[name])} "
+            f"t={ticks[site]} incoming={sorted(locks.get(site, ()))} "
+            f"leftover={leftovers[name]}"
+        )
+
+    checks.check(
+        "theorem1-A-sum",
+        lists["A"] == [E1]
+        and letters["A"] == (1, 0, 0)
+        and letters["A"] == vector_sum(lists["A"])
+        and ticks[PROBES["A"]] == 0,
+        letter_report(letters["A"]),
+    )
+    checks.check(
+        "theorem1-B-sum",
+        lists["B"] == [E3, E1, E1]
+        and letters["B"] == (2, 0, 1)
+        and letters["B"] == vector_sum(lists["B"])
+        and ticks[PROBES["B"]] == 2,
+        str(letters["B"]),
+    )
+    checks.check(
+        "theorem1-C-sum",
+        lists["C"] == [E2, E2, E2, E2, E2]
+        and letters["C"] == (0, 5, 0)
+        and letters["C"] == vector_sum(lists["C"])
+        and ticks[PROBES["C"]] == 3,
+        str(letters["C"]),
+    )
+    checks.check(
+        "theorem1-D-sum",
+        lists["D"] == [E2]
+        and letters["D"] == (0, 1, 0)
+        and letters["D"] == vector_sum(lists["D"])
+        and ticks[PROBES["D"]] == 1,
+        str(letters["D"]),
+    )
+    checks.check(
+        "theorem1-y-ticks-match-nsiso",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 4
+        and len(locks[PROBES["D"]]) == 1,
+        f"B={sorted(locks[PROBES['B']])} C={sorted(locks[PROBES['C']])}",
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2}
+        and PROBES["A"] == E2,
+    )
+
+    formed_inclusive_a = recorded_inclusive(PROBES["A"], ticks)
+    checks.check(
+        "seed-includes-same-tick-partner",
+        ORIGIN in formed_inclusive_a
+        and PROBES["A"] not in formed_inclusive_a
+        and ticks[ORIGIN] == ticks[PROBES["A"]] == 0
+        and lists["A"] == [E1],
+    )
+
+    reverse_status = comparison_report(letters["A"], letters["B"])
+    face_status = comparison_report(letters["C"], letters["D"])
+    reverse_sum = (
+        add(letters["A"], letters["B"])
+        if letters["A"] is not None and letters["B"] is not None
+        else None
+    )
+    face_sum = (
+        add(letters["C"], letters["D"])
+        if letters["C"] is not None and letters["D"] is not None
+        else None
+    )
+    print(
+        f"reverse={reverse_status} reverse_sum={reverse_sum} "
+        f"face={face_status} face_sum={face_sum}"
+    )
+
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and letters["A"] == (1, 0, 0)
+        and letters["B"] == (2, 0, 1)
+        and reverse_sum == (3, 0, 1)
+        and reverse_sum != ZERO,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and letters["C"] == (0, 5, 0)
+        and letters["D"] == (0, 1, 0)
+        and face_sum == (0, 6, 0)
+        and face_sum != ZERO,
+        face_status,
+    )
+    checks.check(
+        "not-leftover-unique-vector",
+        leftovers["A"] is None
+        and leftovers["B"] is None
+        and leftovers["C"] == E2
+        and leftovers["D"] is None
+        and leftovers["C"] != letters["C"]
+        and letters["C"] == (0, 5, 0),
+        str(leftovers["C"]),
+    )
+    checks.check(
+        "letter-is-not-probe-incoming",
+        letters["A"] not in locks[PROBES["A"]]
+        and letters["B"] not in locks[PROBES["B"]]
+        and letters["C"] not in locks[PROBES["C"]]
+        and letters["D"] not in locks[PROBES["D"]],
+    )
+    checks.check(
+        "empty-S-is-undefined",
+        letter_from_S([]) is None
+        and letter_from_S([E1]) == E1
+        and vector_sum([E3, E1, E1]) == (2, 0, 1)
+        and vector_sum([E2, E2, E2, E2, E2]) == (0, 5, 0),
+    )
+
+    strict_letters = {
+        name: letter_from_S(strict_lists[name]) for name in ("A", "B", "C", "D")
+    }
+    strict_reverse = comparison_report(strict_letters["A"], strict_letters["B"])
+    strict_face = comparison_report(strict_letters["C"], strict_letters["D"])
+    checks.check(
+        "not-strictly-earlier-leftover",
+        strict_lists["A"] == []
+        and strict_letters["A"] is None
+        and strict_lists["B"] == [E3, E1]
+        and strict_letters["B"] == (1, 0, 1)
+        and strict_reverse == "UNDEFINED"
+        and strict_face == "fail"
+        and lists["A"] != strict_lists["A"]
+        and lists["B"] != strict_lists["B"]
+        and letters["B"] != strict_letters["B"]
+        and reverse_status == "fail",
+        f"strict_reverse={strict_reverse} strict_B={strict_letters['B']}",
+    )
+    included_probe = lists["A"] + sorted(locks[PROBES["A"]])
+    included_probe_letter = letter_from_S(included_probe)
+    checks.check(
+        "mutation-including-q-changes-A",
+        included_probe_letter == (1, 1, 0)
+        and letters["A"] == (1, 0, 0)
+        and included_probe_letter != letters["A"],
+        str(included_probe_letter),
+    )
+    leftover_face = comparison_report(leftovers["C"], letters["D"])
+    leftover_sum = (
+        add(leftovers["C"], letters["D"])
+        if leftovers["C"] is not None and letters["D"] is not None
+        else None
+    )
+    checks.check(
+        "mutation-leftover-changes-letter",
+        leftovers["C"] == E2
+        and leftovers["C"] != letters["C"]
+        and leftover_sum == (0, 2, 0)
+        and leftover_sum != face_sum
+        and leftover_face == "fail"
+        and face_status == "fail",
+        f"leftover_sum={leftover_sum} face_sum={face_sum}",
+    )
+    one_site_ticks, one_site_locks = form(seeds=((ORIGIN, E1),))
+    one_site_lists = {
+        name: neighbor_lock_list(
+            PROBES[name], one_site_ticks, one_site_locks, inclusive=True
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in one_site_ticks
+    }
+    checks.check(
+        "mutation-one-site-seed-changes-S",
+        one_site_ticks[PROBES["A"]] != 0
+        and one_site_lists["B"] != lists["B"]
+        and letter_from_S(one_site_lists["B"]) != letters["B"]
+        and letter_from_S(one_site_lists["A"]) is not None,
+        str(one_site_lists.get("B")),
+    )
+
+    x_letters = {
+        name: letter_from_S(
+            neighbor_lock_list(site, ticks, locks, inclusive=True)
+        )
+        for name, site in X_PROBES.items()
+    }
+    x_reverse = comparison_report(x_letters["A"], x_letters["B"])
+    x_face = comparison_report(x_letters["C"], x_letters["D"])
+    checks.check(
+        "x-probe-sum-is-fail-hold-not-this-display",
+        x_reverse == "fail"
+        and x_face == "hold"
+        and add(x_letters["C"], x_letters["D"]) == ZERO
+        and reverse_status == "fail"
+        and face_status == "fail"
+        and x_letters["C"] != letters["C"],
+        f"x_reverse={x_reverse} x_face={x_face}",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "not-t-as-comparator",
+        reverse_status == "fail"
+        and face_status == "fail"
+        and "3 t(" not in note,
+    )
+    checks.check(
+        "a-is-seed-not-grown-incoming",
+        ticks[PROBES["A"]] == 0
+        and locks[PROBES["A"]] == {E2}
+        and letters["A"] == E1
+        and letters["A"] != E2,
+    )
+
+    claim_scope = (
+        "Reverse and face from the same-tick-inclusive sum of 6-NN "
+        "locks on the four nnseed y-probes are reported. Displayed, not adopted."
+    )
+    checks.check("note-claim-scope", claim_scope in note)
+    checks.check(
+        "note-reports-S-and-letters",
+        "S(A_y) = (+e_1)" in note
+        and "L(A_y) = (1, 0, 0)" in note
+        and "L(B)   = (2, 0, 1)" in note
+        and "L(C_y) = (0, 5, 0)" in note
+        and "L(D_y) = (0, 1, 0)" in note
+        and "S(B)   = (+e_3, +e_1, +e_1)" in note
+        and "S(D_y) = (+e_2)" in note,
+    )
+    checks.check(
+        "note-reports-fail-fail",
+        note.count("Report: `fail`.") == 2
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-reverse-sum-not-zero",
+        "L(A_y)+L(B) = (3, 0, 1) ≠ (0, 0, 0)." in note,
+    )
+    checks.check(
+        "note-face-sum-not-zero",
+        "L(C_y)+L(D_y) = (0, 6, 0) ≠ (0, 0, 0)." in note,
+    )
+    checks.check(
+        "note-not-leftover-or-occupancy-or-pvm",
+        "not a unique leftover vector" in normalized_note
+        and "not occupancy-kernel `n`" in normalized_note
+        and "not a named `{+,−}` PVM letter" in normalized_note
+        and "not the strictly-earlier six-neighbor lock-sum display"
+        in normalized_note,
+    )
+    checks.check(
+        "note-y-ticks-nsiso",
+        "t(A_y)=t(0,1,0)=0" in note
+        and "t(B)=t(1,1,1)=2" in note
+        and "t(C_y)=t(0,2,0)=3" in note
+        and "t(D_y)=t(1,1,0)=1" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-same-tick-inclusive-rule",
+        "Same-tick neighbors count." in note
+        and "tick `<= t(q)`" in note
+        and "probe `q` excluded" in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS)
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_YPROBE_SAMETICK_NEIGHBOR_LOCK_SUM_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def form(" in source
+        and "def recorded_inclusive(" in source
+        and "def neighbor_lock_list(" in source
+        and "def vector_sum(" in source
+        and "def letter_from_S(" in source
+        and "def leftover_unique_vector(" in source,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Same-tick-inclusive sum of 6-NN locks on nnseed y-probes. Reverse fail; face fail. Strictly-earlier leftover reverse was UNDEFINED because A was empty. Displayed, not adopted. No axiom edit.

## Runner

`scripts/nnseed_yprobe_sametick_neighbor_lock_sum_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.