### PR TITLE
feat(nscoex): same-tick y existential opposite: reverse fail, face fail

### DIFF
--- a/docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,446 @@
+---
+claim_id: nnseed_yprobe_sametick_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from existential opposite same-tick-inclusive 6-NN locks on the four nnseed y-probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py
+---
+
+# Existential Opposite Same-Tick-Inclusive Neighbor-Lock Reverse And Face On Four Nnseed Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from existential opposite same-tick-inclusive
+six-neighbor locks at the formation tick of the four nnseed y-probes
+`A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)` of the displayed two-site
+nnseed process. At a probe `q`, `S(q)` is the set of locks of six-neighbors
+of `q` that formed at tick `≤ t(q)` and are not `q`. Same-tick partner
+counts. Reverse holds if and only if some lock in `S(A)` is the vector
+opposite of some lock in `S(B)`. Face holds if and only if some lock in
+`S(C)` is the vector opposite of some lock in `S(D)`. Empty `S` on either
+side of a comparison is `UNDEFINED`; nonempty with no opposite pair fails.
+Occupancy `n` is not used. The probe's own incoming lock is not used. This
+is not named-sign lettering. This is not a unique lock-vector leftover and
+not a sum leftover. This is not the strictly-earlier leftover of already-
+recorded six-neighbor lock sets on these same four y-probes. Uniqueness of
+incoming locks is not required. Uniqueness of the lock set is not required.
+`A` is a seed (`t=0`). Displayed, not adopted. This note does not write
+existential opposite into Admissibility and does not attach a formation
+member from same-tick-inclusive six-neighbor locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py`](../scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse and face are scored on existence of an opposite pair in the
+same-tick-inclusive six-neighbor lock sets. Named signs `{+,−}` are a coarser
+readout and are not used. A singleton unique lock-vector letter is a
+different readout and is not used. A `Z^3` sum of those locks is a different
+readout and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of same-tick-inclusive six-neighbor lock sets on the four nnseed y-probes, with reverse fail and face fail from existential opposite; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_yprobe_sametick_existential_opposite_reverse_face
+target_blocker_text: "display reverse and face from existential opposite same-tick-inclusive 6-NN locks on the four nnseed y-probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not use occupancy n, and do not identify the sets with the probe's own incoming step."
+conditional_surface_status: "exact on B_3(0) for existential opposite of same-tick-inclusive six-neighbor locks on the four nnseed y-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+same-tick-inclusive six-neighbor lock sets are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`,
+`C=(0,0,2)`, `D=(0,1,1)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not a member of `S(q)` scored below.
+
+## Named existential opposite from same-tick-inclusive six-neighbor locks
+
+At the formation tick of a y-probe `q`, let `S(q)` be the set of locks of
+six-neighbors of `q` that formed at tick `≤ t(q)` and are not `q`. A
+same-tick partner counts. The probe itself is excluded. This display does
+not use occupancy `n`. It does not use the probe's own incoming lock.
+Duplicate locks at two neighbors collapse in the set. The construction does
+not require `S(q)` to be a singleton. It does not sum `S(q)`. It is not a
+unique lock-vector leftover and not a sum leftover. A leftover strictly-
+earlier collector on these same four y-probes dropped same-tick partners, so
+`A` had an empty neighbor list.
+
+Incoming `{±e_i}` tags of the probe itself are not `S(q)`. Identifying a
+named sign of those locks with reverse or face is refused: named-sign
+lettering lost the axis. Reverse and face are scored on existence of a pair
+of lock vectors that add to zero. They are not scored on `{+,−}` names and
+are not an occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in S(A) and some b in S(B) with a+b=(0,0,0)
+face     <=>  some c in S(C) and some d in S(D) with c+d=(0,0,0)
+```
+
+If `S(A)` or `S(B)` is empty, reverse is `UNDEFINED`. Else reverse fails if
+no such pair exists. If `S(C)` or `S(D)` is empty, face is `UNDEFINED`. Else
+face fails if no such pair exists. The report is one of `hold`, `fail`, or
+`UNDEFINED`. Because the scored object is a set, mixed neighbor locks remain
+defined. Unique-vector leftover of the same lists would assign `UNDEFINED`
+at `B` and would report reverse `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility.
+
+## Theorem 1 — recorded-neighbor lock sets at each y-probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+y-probes. Formation ticks are `t(A)=t(0,1,0)=0`, `t(B)=t(1,1,1)=2`,
+`t(C)=t(0,2,0)=3`, `t(D)=t(1,1,0)=1`. Those ticks locate the
+same-tick-inclusive six-neighbor set. They are not occupancy kernels and are
+not the reverse/face scoring.
+
+At each formation tick the same-tick-inclusive six-neighbor lock list and
+lock set are:
+
+```text
+A: +e_1 at (0, 0, 0);                                            S(A) = {+e_1}
+B: +e_3 at (0, 1, 1), +e_1 at (1, 0, 1), +e_1 at (1, 1, 0);       S(B) = {+e_1, +e_3}
+C: +e_2 at (1, 2, 0), +e_2 at (-1, 2, 0), +e_2 at (0, 1, 0),
+   +e_2 at (0, 2, 1), +e_2 at (0, 2, -1);                         S(C) = {+e_2}
+D: +e_2 at (0, 1, 0);                                            S(D) = {+e_2}
+```
+
+`A` is a seed at tick 0. Its same-tick partner is the origin, locking `+e_1`.
+Same-tick counts, so the recorded neighbor lock set is that origin lock and
+`S(A)={+e_1}`. `C`'s same-tick-inclusive neighbors all lock `+e_2`. `D`'s
+recorded neighbor is the seed `(0, 1, 0)` locking `+e_2`. `B`'s recorded
+neighbors lock two distinct vectors `+e_3` and `+e_1` (the same-tick site
+`(1, 0, 1)` adds another `+e_1` and does not remove the mix). Unique
+lock-vector lettering would report `UNDEFINED` at `B`. The lock set
+`S(B)={+e_1, +e_3}` remains defined. A sum leftover would replace `S(B)` by
+`(1, 0, 1)`. This display keeps the set and does not sum. They share a named
+sign `+`; reducing to named sign would hide that mix.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps `+e_1` and `+e_3`; `C` has four mixed self-incoming steps). That
+non-uniqueness is not a unique-lettering of same-tick-inclusive neighbor
+lock vectors. The lock sets are not identified with those incoming steps.
+Uniqueness is not required.
+
+`A`, `C`, and `D` each have a singleton recorded-neighbor lock set. `B` is
+mixed and remains a set.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if there exist `a` in `S(A)` and `b` in `S(B)`
+with `a+b=(0,0,0)`. Both sets are nonempty: `S(A)={+e_1}` and
+`S(B)={+e_1, +e_3}`. The pairs are `+e_1++e_1=(2,0,0)` and
+`+e_1++e_3=(1,0,1)`. No aggregation of `B`'s `{+e_1,+e_3}` is opposite `A`'s
+`+e_1`. Reverse fails.
+
+Reverse: fail
+
+This is not `hold` and not `UNDEFINED`. Unique lock-vector lettering of the
+same lists would assign `S(B)` mixed and would report reverse `UNDEFINED`
+because `B` is mixed. That readout is a different object and is not used.
+A strictly-earlier leftover of the same y-probes would leave `S(A)` empty
+and would report reverse `UNDEFINED` because `A` is empty. Here same-tick
+counts, so `S(A)` is nonempty. A sum leftover of the same lists would
+replace the sets by `(1, 0, 0)` and `(1, 0, 1)` and would report reverse
+fail for a different reason. A named-sign readout of the same neighbor
+locks would assign `+` and `+` and would report reverse fail for a different
+reason.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if there exist `c` in `S(C)` and `d` in `S(D)` with
+`c+d=(0,0,0)`. Both sets are nonempty: `S(C)={+e_2}` and `S(D)={+e_2}`, so
+`+e_2+(+e_2)=(0,2,0)`, which is not `(0,0,0)`. Face does not hold.
+
+Face: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+
+A leftover strictly-earlier existential-opposite display on the four
+x-probes reports face `hold` because those lock sets are `{−e_2}` and
+`{+e_2}`. Those probes are not these y-probes. Named-sign lettering of the
+present lists is `C+/D+`. Face as `C+` and `D−` fails on those signs, and
+the vectors are not opposites either. This note keeps the vectors.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify lock sets with the probe's own incoming `{±e_i}`.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the recorded-neighbor lock set to be a singleton.
+- It does not sum the recorded-neighbor lock set.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not reprint the strictly-earlier leftover lock sets on these four
+  y-probes.
+- It does not reprint already-recorded six-neighbor lock sets on the four
+  x-probes.
+- It does not reprint already-recorded six-neighbor lock sets on the four
+  z-probes.
+- It does not attach a formation member from same-tick-inclusive
+  six-neighbor locks.
+- It does not census a sixteen-combination free lettering independent of
+  recorded-neighbor lock vectors. Reverse and face are not a sixteen-combination
+  free lettering of the four y-probes.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+nnseed process, the same-tick-inclusive six-neighbor lock sets, and the
+existential-opposite reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| same-tick-inclusive six-neighbor lock sets at each y-probe formation tick | Theorem 1 |
+| lock sets `S(A)`, `S(B)`, `S(C)`, `S(D)` | Theorem 1; `{+e_1}`, `{+e_1, +e_3}`, `{+e_2}`, `{+e_2}` |
+| reverse and face | Theorems 2–3; `fail` / `fail` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| probe's own incoming lock as the set | not used |
+| strictly-earlier leftover on these y-probes | not this display |
+| x-probe neighbor-lock existential opposite | not this display |
+| z-probe neighbor-lock existential opposite | not this display |
+| formation member from same-tick-inclusive six-neighbor locks | not attached |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: existential opposite of same-tick-inclusive six-neighbor locks on the four nnseed y-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed existential-opposite same-tick-inclusive neighbor-lock reverse/face report on these four nnseed y-probes. |
+| V3 | Recorded-neighbor lock sets and the `fail`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads same-tick-inclusive six-neighbor lock vectors at formation and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not reduce them to named signs, does not require a singleton lock
+vector, does not sum the lock set, does not use occupancy `n`, and is not
+the strictly-earlier leftover on these y-probes. No global impossibility is
+claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique lock-vector lettering of the same neighbor locks | require a singleton `{v}` subset `{±e_i}` | refused; leftover; reverse would be `UNDEFINED` because `B` is mixed, while both sets are nonempty |
+| strictly-earlier leftover on these y-probes | drop same-tick partners | refused; leftover assigned empty `S(A)` and reverse `UNDEFINED`; here `S(A)={+e_1}` |
+| reverse/face from that leftover | reuse leftover reverse with empty `A` | different object; leftover reverse was `UNDEFINED` because `A` was empty; here reverse fails because no pair is opposite |
+| sum of the same neighbor locks | replace `S` by the `Z^3` sum | refused; leftover; no aggregation of `B`'s `{+e_1,+e_3}` is opposite `A`'s `+e_1` |
+| named-sign lettering of the same neighbor locks | map `±e_i` to `{+,−}` | refused; lost the axis; `C+/D+` fails face as `C+` and `D−` while the vectors remain `{+e_2}` |
+| identify lock sets with the probe's own incoming `{±e_i}` | map `A`'s seed lock `+e_2` into `S(A)` | refused; `S(A)={+e_1}` from the origin partner, not from `A`'s own incoming step |
+| reverse/face from self-incoming vectors | reuse mixed incoming steps at `C` | different object; `C` would be mixed |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score y-probes by formation order | different object; not this display |
+| x-probe neighbor-lock existential opposite | copy sets from the x-probes | refused; these are the y-probes `A=(0,1,0)`, `C=(0,2,0)`, `D=(1,1,0)` |
+| z-probe neighbor-lock existential opposite | copy sets from the z-probes | refused; these are the y-probes |
+| attach a formation member from same-tick-inclusive six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; both earliest incoming steps at `B` and all four at `C` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from same-tick-inclusive
+six-neighbor locks, and missing Record identification of existential opposite
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, lock set of same-tick-inclusive six-neighbors,
+existential opposite, four y-probes, seed `A` at tick 0, and reverse/face as
+existence of a pair that sums to zero are declared. No uniqueness of incoming
+locks, no occupancy `n`, no named-sign reduction, no singleton leftover, no
+sum leftover, no strictly-earlier leftover, no formation attachment from
+same-tick-inclusive six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in a recorded-neighbor set | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four lock sets and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once a same-tick seed partner exists at forming `A`, mixed
+neighbor locks at `B` should make reverse `UNDEFINED`, the sets should be
+replaced by their sums, reverse and face should copy the x-probe strictly-
+earlier leftover (`fail`/`hold`), named signs should suffice because they
+keep orientation, occupancy `n` should track that vector, and including
+same-tick should not be a new display.
+
+**Answer:** The named construction reports lock sets `{+e_1}`, `{+e_1, +e_3}`,
+`{+e_2}`, `{+e_2}` at `A,B,C,D` from same-tick-inclusive six-neighbor locks.
+Mixed remains a set. The construction does not sum. Occupancy `n` is not
+used. Named signs lost the axis. No pair from `S(A)` and `S(B)` is opposite,
+so reverse fails. Face fails. Unique-vector leftover of the same lists would
+report reverse `UNDEFINED` because `B` is mixed; that leftover is not this
+display. The bits remain displayed. Incoming-lock uniqueness is not
+required. `A` is a seed; same-tick counts. This is not the strictly-earlier
+leftover.
+
+### N8 — cross-cycle echo
+
+A leftover unique-vector same-tick-inclusive neighbor-lock display on these
+same four nnseed y-probes closed reverse/face as `UNDEFINED`/`fail` because
+`B` is mixed. This note is not that display: mixed remains a set, reverse
+fails, and face fails. A leftover strictly-earlier unique-vector display on
+these same four y-probes closed reverse/face as `UNDEFINED`/`fail` with empty
+`S(A)`. This note is not that display: same-tick counts, so `S(A)={+e_1}`.
+A leftover named-sign unique-letter display on these same four y-probes
+closed reverse/face as `UNDEFINED`/`none` with named-sign letters
+`UNDEFINED`, `+`, `+`, `+`. This note is not that display. A leftover
+formdraw occupancy-kernel display on these same four y-probes closed
+reverse/face as `UNDEFINED`/`some` because both `{+,−}` were kept at `n ≠ 0`
+on formed sites. This note does not reuse occupancy `n`. An x-probe
+strictly-earlier existential-opposite display closed reverse `fail` and face
+`hold` on `{+e_1}`, `{+e_1,+e_3}`, `{−e_2}`, `{+e_2}`. Those probes are not
+these y-probes; here face fails because `S(C)={+e_2}` and `S(D)={+e_2}`.
+
+**Gate disposition:** PASS for the same-tick-inclusive six-neighbor-lock
+existential-opposite reverse/face reports on the four nnseed y-probes above.
+FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the predicate
+equals the unique singleton lock vector,” “the predicate equals the sum of
+the lock set,” “the lock set equals the probe's own incoming step,” “the
+predicate is the strictly-earlier leftover,” “bits are Admissibility,” “the
+letter is occupancy `n`,” or “reverse holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, collects same-tick-inclusive six-neighbor locks at each
+y-probe's formation tick, reads the lock sets at the four y-probes, and checks
+Theorems 1--3. It also checks that the construction is not named-sign
+lettering, that mixed sets remain defined, that the construction does not
+sum, that the probe's own incoming step is not the lock set, that occupancy
+`n` is not used, that the scoring is not the strictly-earlier leftover, and
+that a formation member from same-tick-inclusive six-neighbor locks is not
+attached. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_yprobe_sametick_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.txt
@@ -1,0 +1,87 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py
+runner_sha256: 47118912747d267c1b32bd0627beb1d93d0477425558f19ac1410dbc24aa8be8
+input_fingerprint_sha256: c91e5e6ef6cbe737f835c9cdcd4348697b4733a6ec751341a5a5a63932736d34
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+existential opposite same-tick-inclusive 6-NN reverse/face on nnseed y-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from existential opposite same-tick-inclusive 6-NN locks on the four nnseed y-probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: y-probes-are-not-x-or-z-probes
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: duplicates-collapse-in-set
+PASS: mixed-remains-a-set
+PASS: not-named-sign-reduction
+PASS: not-unique-vector-leftover
+PASS: not-sum-leftover
+PASS: reverse-face-identity
+A t=0 recorded-neighbor-locks=[+e_1 at (0, 0, 0)] S={+e_1} incoming=+e_2
+B t=2 recorded-neighbor-locks=[+e_3 at (0, 1, 1), +e_1 at (1, 0, 1), +e_1 at (1, 1, 0)] S={+e_1, +e_3} incoming=+e_3,+e_1
+C t=3 recorded-neighbor-locks=[+e_2 at (1, 2, 0), +e_2 at (-1, 2, 0), +e_2 at (0, 1, 0), +e_2 at (0, 2, 1), +e_2 at (0, 2, -1)] S={+e_2} incoming=−e_1,−e_3,+e_3,+e_1
+D t=1 recorded-neighbor-locks=[+e_2 at (0, 1, 0)] S={+e_2} incoming=+e_1
+reverse=fail face=fail
+PASS: theorem1-A-neighbor-lock-set  (((((0, 0, 0), (1, 0, 0)),), frozenset({(1, 0, 0)})))
+PASS: theorem1-B-neighbor-lock-set  (((((0, 1, 1), (0, 0, 1)), ((1, 0, 1), (1, 0, 0)), ((1, 1, 0), (1, 0, 0))), frozenset({(1, 0, 0), (0, 0, 1)})))
+PASS: theorem1-C-neighbor-lock-set  (((((1, 2, 0), (0, 1, 0)), ((-1, 2, 0), (0, 1, 0)), ((0, 1, 0), (0, 1, 0)), ((0, 2, 1), (0, 1, 0)), ((0, 2, -1), (0, 1, 0))), frozenset({(0, 1, 0)})))
+PASS: theorem1-D-neighbor-lock-set  (((((0, 1, 0), (0, 1, 0)),), frozenset({(0, 1, 0)})))
+PASS: theorem1-B-mixed-vectors-remain-a-set
+PASS: theorem1-A-is-seed-same-tick-origin-counts
+PASS: theorem1-formation-ticks
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-fail  (fail)
+PASS: sign-lettering-loses-axis-and-also-fails-face
+PASS: not-self-incoming-nnlock
+PASS: not-probe-own-incoming-lock
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required  (([(0, 0, 1), (1, 0, 0)], [(-1, 0, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0)]))
+PASS: two-site-seed-locks
+PASS: recorded-not-self-or-later-same-tick-included
+PASS: not-strictly-earlier-leftover
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-mixed-neighbor-vectors-fail-without-opposite
+PASS: x-probe-strictly-earlier-face-hold-is-not-this-display
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-sets
+PASS: note-reports-fail-fail
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-leftover
+PASS: note-not-strictly-earlier-leftover
+PASS: note-forbids-enlargement-and-cache
+PASS: note-not-sixteen-free-letters
+PASS: note-not-x-or-z-probe-reprint
+PASS: note-a-is-seed
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-existential-opposite-only
+TOTAL: PASS=62 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py
@@ -1,0 +1,818 @@
+#!/usr/bin/env python3
+"""Existential opposite same-tick-inclusive 6-NN reverse/face on nnseed y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. At each y-probe's formation tick, S is the set of locks of 6-NN formed
+at tick <= t(q) and not equal to q (same-tick partner counts). Reverse holds
+iff some a in S(A) and some b in S(B) have a+b=(0,0,0). Face holds iff some
+c in S(C) and some d in S(D) have c+d=(0,0,0). Empty S on either side is
+UNDEFINED; nonempty with no opposite pair fails. Not unique-vector leftover.
+Not sum leftover. Not named-sign lettering. Not the strictly-earlier leftover.
+Occupancy n is not used. The probe's own incoming lock is not used.
+Uniqueness of incoming locks is not required. A is a seed (t=0).
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (0, 1, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from existential opposite same-tick-inclusive 6-NN "
+    "locks on the four nnseed y-probes are reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def recorded_lock_set(pairs: tuple[tuple[Point, Point], ...]) -> frozenset[Point]:
+    """Set of same-tick-inclusive six-neighbor locks. Duplicates collapse."""
+    return frozenset(lock for _neighbor, lock in pairs)
+
+
+def existential_opposite(left: frozenset[Point], right: frozenset[Point]) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    Empty set on either side is UNDEFINED. Nonempty with no opposite pair fails.
+    Does not sum. Does not require a singleton.
+    """
+    if not left or not right:
+        return "UNDEFINED"
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: frozenset[Point], set_b: frozenset[Point]) -> str:
+    """Reverse iff some a in S(A) and some b in S(B) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: frozenset[Point], set_d: frozenset[Point]) -> str:
+    """Face iff some c in S(C) and some d in S(D) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def recorded_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of 6-NN formed at tick <= t(q), excluding q (same-tick counts)."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if neighbor == site:
+            continue
+        if ticks[neighbor] > formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def strictly_earlier_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Strictly-earlier leftover collector, used only as a refused contrast."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("existential opposite same-tick-inclusive 6-NN reverse/face on nnseed y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites,
+    )
+    checks.check(
+        "y-probes-are-not-x-or-z-probes",
+        probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and x_probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and z_probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (0, 1, 1)),
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, E2) == (0, 2, 0)
+        and add(E1, E1) == (2, 0, 0)
+        and add(E1, E3) == (1, 0, 1)
+        and add(E1, E1) != ZERO
+        and add(E1, E3) != ZERO
+        and add(E2, E2) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(frozenset(), frozenset({E1})) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(frozenset({E1}), frozenset({NEG_E1})) == "hold"
+        and existential_opposite(frozenset({NEG_E2}), frozenset({E2})) == "hold"
+        and existential_opposite(frozenset({E2}), frozenset({NEG_E2})) == "hold"
+        and existential_opposite(frozenset({E2}), frozenset({E2})) == "fail"
+        and existential_opposite(frozenset({NEG_E2}), frozenset({NEG_E2})) == "fail"
+        and existential_opposite(frozenset({E1, E2}), frozenset({NEG_E1, E3}))
+        == "hold",
+    )
+    checks.check(
+        "duplicates-collapse-in-set",
+        recorded_lock_set(((ORIGIN, E1), (PROBES["D"], E1))) == frozenset({E1})
+        and recorded_lock_set(((ORIGIN, E1), ((0, 1, 1), E3))) == frozenset({E1, E3}),
+    )
+    checks.check(
+        "mixed-remains-a-set",
+        recorded_lock_set((((0, 1, 1), E3), (PROBES["D"], E1))) == frozenset({E1, E3})
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and len(frozenset({E1, E3})) != 1,
+    )
+    checks.check(
+        "not-named-sign-reduction",
+        named_sign(E1) == named_sign(E3) == "+"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and named_sign(E2) == named_sign(E2) == "+"
+        and existential_opposite(frozenset({E2}), frozenset({E2})) == "fail"
+        and named_sign(NEG_E2) != named_sign(E2)
+        and existential_opposite(frozenset({NEG_E2}), frozenset({E2})) == "hold",
+    )
+    checks.check(
+        "not-unique-vector-leftover",
+        existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(frozenset({E1, E2}), frozenset({NEG_E1, E3}))
+        == "hold"
+        and len(frozenset({E1, E3})) != 1
+        and len(frozenset({E1, E2})) != 1,
+    )
+    checks.check(
+        "not-sum-leftover",
+        add(E1, E1) == (2, 0, 0)
+        and add(E1, E3) == (1, 0, 1)
+        and add((1, 0, 0), (1, 0, 1)) != ZERO
+        and add(E2, E2) == (0, 2, 0)
+        and add((0, 2, 0), E2) != ZERO
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(frozenset({E2}), frozenset({E2})) == "fail"
+        and existential_opposite(frozenset({E1, E2}), frozenset({NEG_E1, E3}))
+        == "hold"
+        and add(add(E1, E2), add(NEG_E1, E3)) != ZERO,
+    )
+    checks.check(
+        "reverse-face-identity",
+        reverse_report(frozenset(), frozenset({E2})) == "UNDEFINED"
+        and reverse_report(frozenset({E1}), frozenset()) == "UNDEFINED"
+        and reverse_report(frozenset({E1}), frozenset({NEG_E1})) == "hold"
+        and reverse_report(frozenset({E1}), frozenset({E1})) == "fail"
+        and reverse_report(frozenset({E1}), frozenset({E2})) == "fail"
+        and reverse_report(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and face_report(frozenset({NEG_E2}), frozenset({E2})) == "hold"
+        and face_report(frozenset({E2}), frozenset({NEG_E2})) == "hold"
+        and face_report(frozenset({E2}), frozenset({E2})) == "fail"
+        and face_report(frozenset({NEG_E2}), frozenset({NEG_E2})) == "fail"
+        and face_report(frozenset(), frozenset({E2})) == "UNDEFINED"
+        and face_report(frozenset({NEG_E2}), frozenset()) == "UNDEFINED",
+    )
+
+    ticks, locks = form()
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    lock_sets: dict[str, frozenset[Point]] = {}
+    leftover_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    leftover_sets: dict[str, frozenset[Point]] = {}
+    for name, site in PROBES.items():
+        pairs = recorded_neighbor_locks(site, ticks, locks)
+        neighbor_lists[name] = pairs
+        lock_sets[name] = recorded_lock_set(pairs)
+        leftover = strictly_earlier_neighbor_locks(site, ticks, locks)
+        leftover_lists[name] = leftover
+        leftover_sets[name] = recorded_lock_set(leftover)
+        lock_text = ", ".join(
+            f"{lock_display(lock)} at {neighbor}" for neighbor, lock in pairs
+        )
+        incoming = ",".join(lock_display(step) for step in sorted(locks[site]))
+        print(
+            f"{name} t={ticks[site]} recorded-neighbor-locks=[{lock_text}] "
+            f"S={set_display(lock_sets[name])} incoming={incoming}"
+        )
+
+    reverse_status = reverse_report(lock_sets["A"], lock_sets["B"])
+    face_status = face_report(lock_sets["C"], lock_sets["D"])
+    leftover_reverse = reverse_report(leftover_sets["A"], leftover_sets["B"])
+    leftover_face = face_report(leftover_sets["C"], leftover_sets["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+
+    checks.check(
+        "theorem1-A-neighbor-lock-set",
+        neighbor_lists["A"] == ((ORIGIN, E1),)
+        and lock_sets["A"] == frozenset({E1}),
+        str((neighbor_lists["A"], lock_sets["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-set",
+        neighbor_lists["B"]
+        == (((0, 1, 1), E3), ((1, 0, 1), E1), (PROBES["D"], E1))
+        and lock_sets["B"] == frozenset({E1, E3}),
+        str((neighbor_lists["B"], lock_sets["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-set",
+        neighbor_lists["C"]
+        == (
+            ((1, 2, 0), E2),
+            ((-1, 2, 0), E2),
+            (E2, E2),
+            ((0, 2, 1), E2),
+            ((0, 2, -1), E2),
+        )
+        and lock_sets["C"] == frozenset({E2}),
+        str((neighbor_lists["C"], lock_sets["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-set",
+        neighbor_lists["D"] == ((E2, E2),) and lock_sets["D"] == frozenset({E2}),
+        str((neighbor_lists["D"], lock_sets["D"])),
+    )
+    checks.check(
+        "theorem1-B-mixed-vectors-remain-a-set",
+        lock_sets["B"] == frozenset({E1, E3})
+        and {lock for _n, lock in neighbor_lists["B"]} == {E1, E3}
+        and named_sign(E1) == named_sign(E3) == "+"
+        and ((1, 0, 1), E1) in neighbor_lists["B"]
+        and ticks[(1, 0, 1)] == ticks[PROBES["B"]],
+    )
+    checks.check(
+        "theorem1-A-is-seed-same-tick-origin-counts",
+        ticks[PROBES["A"]] == 0
+        and PROBES["A"] == E2
+        and ticks[ORIGIN] == 0
+        and ORIGIN in {neighbor for neighbor, _lock in neighbor_lists["A"]}
+        and neighbor_lists["A"] == ((ORIGIN, E1),)
+        and lock_sets["A"] == frozenset({E1}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 1,
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and lock_sets["A"] == frozenset({E1})
+        and lock_sets["B"] == frozenset({E1, E3})
+        and add(E1, E1) != ZERO
+        and add(E1, E3) != ZERO
+        and lock_sets["A"]
+        and lock_sets["B"],
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and lock_sets["C"] == frozenset({E2})
+        and lock_sets["D"] == frozenset({E2})
+        and add(E2, E2) == (0, 2, 0)
+        and add(E2, E2) != ZERO,
+        face_status,
+    )
+    checks.check(
+        "sign-lettering-loses-axis-and-also-fails-face",
+        named_sign(E2) == "+"
+        and named_sign(E2) == "+"
+        and not (named_sign(lock_sets["C"].__iter__().__next__()) == "+"
+                 and named_sign(lock_sets["D"].__iter__().__next__()) == "-")
+        and face_status == "fail",
+    )
+    checks.check(
+        "not-self-incoming-nnlock",
+        locks[PROBES["C"]] == {NEG_E1, E3, NEG_E3, E1}
+        and locks[PROBES["D"]] == {E1}
+        and lock_sets["C"] == frozenset({E2})
+        and lock_sets["D"] == frozenset({E2}),
+    )
+    checks.check(
+        "not-probe-own-incoming-lock",
+        locks[PROBES["A"]] == {E2}
+        and lock_sets["A"] == frozenset({E1})
+        and E2 not in lock_sets["A"]
+        and locks[PROBES["D"]] == {E1}
+        and lock_sets["D"] == frozenset({E2})
+        and E1 not in lock_sets["D"],
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 4
+        and lock_sets["B"] == frozenset({E1, E3})
+        and lock_sets["C"] == frozenset({E2}),
+        str((sorted(locks[PROBES["B"]]), sorted(locks[PROBES["C"]]))),
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2},
+    )
+    checks.check(
+        "recorded-not-self-or-later-same-tick-included",
+        all(
+            neighbor != PROBES[name]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        )
+        and all(
+            ticks[neighbor] <= ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        )
+        and any(
+            ticks[neighbor] == ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "not-strictly-earlier-leftover",
+        leftover_lists["A"] == ()
+        and leftover_sets["A"] == frozenset()
+        and leftover_reverse == "UNDEFINED"
+        and lock_sets["A"] == frozenset({E1})
+        and leftover_sets["A"] != lock_sets["A"]
+        and leftover_lists["B"] == (((0, 1, 1), E3), (PROBES["D"], E1))
+        and ((1, 0, 1), E1) not in leftover_lists["B"]
+        and leftover_sets["B"] == frozenset({E1, E3})
+        and leftover_face == "fail"
+        and reverse_status == "fail"
+        and leftover_reverse != reverse_status,
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        recorded_lock_set(()) == frozenset()
+        and reverse_report(frozenset(), lock_sets["B"]) == "UNDEFINED"
+        and face_report(lock_sets["C"], frozenset()) == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-mixed-neighbor-vectors-fail-without-opposite",
+        recorded_lock_set((((0, 1, 1), E3), (PROBES["D"], E1))) == frozenset({E1, E3})
+        and reverse_report(frozenset({E1}), frozenset({E1, E3})) == "fail",
+    )
+    checks.check(
+        "x-probe-strictly-earlier-face-hold-is-not-this-display",
+        face_report(frozenset({NEG_E2}), frozenset({E2})) == "hold"
+        and face_status == "fail"
+        and lock_sets["C"] != frozenset({NEG_E2}),
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-sets",
+        "S(A) = {+e_1}" in note
+        and "S(B) = {+e_1, +e_3}" in note
+        and "S(C) = {+e_2}" in note
+        and "S(D) = {+e_2}" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_3 at (0, 1, 1)" in note
+        and "+e_1 at (1, 0, 1)" in note
+        and "+e_1 at (1, 1, 0)" in note
+        and "+e_2 at (1, 2, 0)" in note
+        and "+e_2 at (-1, 2, 0)" in note
+        and "+e_2 at (0, 1, 0)" in note
+        and "+e_2 at (0, 2, 1)" in note
+        and "+e_2 at (0, 2, -1)" in note,
+    )
+    checks.check(
+        "note-reports-fail-fail",
+        "Reverse: fail" in note
+        and "Face: fail" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note
+        and "C+/D+" in note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from same-tick-inclusive six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "No aggregation of `B`'s `{+e_1,+e_3}` is opposite `A`'s" in note,
+    )
+    checks.check(
+        "note-not-strictly-earlier-leftover",
+        "not the strictly-earlier leftover" in normalized_note
+        and "same-tick" in note
+        and "`S(A)={+e_1}`" in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-not-sixteen-free-letters",
+        "not a sixteen-combination free lettering" in normalized_note
+        and "16-census" not in note
+        and "16-letter" not in note,
+    )
+    checks.check(
+        "note-not-x-or-z-probe-reprint",
+        "not the x-probes" in normalized_note
+        and "not the z-probes" in normalized_note
+        and "A = (0,1,0)" in note,
+    )
+    checks.check(
+        "note-a-is-seed",
+        "A` is a seed" in note or "`A` is a seed" in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_YPROBE_SAMETICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def existential_opposite(" in source
+        and "def recorded_lock_set(" in source
+        and "def recorded_neighbor_locks(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["B"]] >= 1
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-existential-opposite-only",
+        "existential_opposite" in defined_fns
+        and "recorded_lock_set" in defined_fns
+        and "recorded_neighbor_locks" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Existential opposite same-tick neighbor locks on nnseed y-probes. Reverse fail; face fail. Displayed, not adopted. No axiom edit.

## Runner

`scripts/nnseed_yprobe_sametick_existential_opposite_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.