### PR TITLE
feat(nsparex): parallel-opposite x-probe later-tick exist-opposite: reverse HOLD, face HOLD

### DIFF
--- a/docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,519 @@
+---
+claim_id: parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from existential opposite 6-NN locks at the first later tick when all four nspar x-probes are recorded are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
+---
+
+# Later-Tick Existential Opposite Neighbor-Lock Reverse And Face On Four Parallel-Opposite X-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from existential opposite six-neighbor locks at
+the first later tick in `B_3(0)` at which all four parallel-opposite x-probes
+are recorded. Let `t(q)` be the formation tick of probe `q`. Let `T` be the
+maximum of `t(A)`, `t(B)`, `t(C)`, `t(D)` among those defined in `B_3(0)`.
+At tick `T`, `S_*(q)` is the set of locks of six-neighbors of `q` that
+formed at tick `≤ T` and are not `q`. Reverse holds if and only if some
+lock in `S_*(A)` is the vector opposite of some lock in `S_*(B)`. Face
+holds if and only if some lock in `S_*(C)` is the vector opposite of some
+lock in `S_*(D)`. Empty `S_*` on either side of a comparison is
+`UNDEFINED`; nonempty with no opposite pair fails. Occupancy `n` is not
+used. The probe's own incoming lock is not used. This is not named-sign
+lettering. This is not a unique lock-vector leftover and not a sum leftover.
+This is a seed transfer of the holding readout, not leftover of later-tick
+existential opposite on the opposite-lock x-probes: that display uses the
+perp-opposite seed `{0,e_2}` with locks `+e_1/−e_1` and different nsopp lists
+at a different `T`. This is not leftover of later-tick existential opposite
+on the nnseed x-probes: that display uses the perp two-site seed `+e_1/+e_2`
+and reports reverse fail. This seed is not a proper cubic image of that
+perp-opposite two-site seed; a cubic image of that seed is `{0,e_1}` with
+locks `±e_2`. Uniqueness of incoming locks is not required. Uniqueness of
+the lock set is not required. Probe `A` is a seed site. Displayed, not
+adopted. This note does not write existential opposite into Admissibility
+and does not attach a formation member from later-tick six-neighbor locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py`](../scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse and face are scored on existence of an opposite pair in the
+later-tick six-neighbor lock sets. Named signs `{+,−}` are a coarser readout
+and are not used. A singleton unique lock-vector letter is a different
+readout and is not used. A `Z^3` sum of those locks is a different readout
+and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of later-tick six-neighbor lock sets on the four parallel-opposite x-probes at the first T with all four recorded, with reverse hold and face hold from existential opposite; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face
+target_blocker_text: "display reverse and face from existential opposite 6-NN locks at the first later tick when all four nspar x-probes are recorded, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not use occupancy n, do not identify the sets with the probe's own incoming step, and do not identify the sets with opposite-lock x-probe later-tick leftover or nnseed x-probe later-tick leftover."
+conditional_surface_status: "exact on B_3(0) for existential opposite of later-tick six-neighbor locks on the four parallel-opposite x-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose later-tick
+six-neighbor lock sets are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the two-record set `{0, (1,0,0)}` is recorded at formation tick 0 with
+opposite locks `L(0)=+e_1` and `L(1,0,0)=−e_1`. Those locks are opposite and
+parallel to the seed edge. This seed is not the perp two-site seed
+`+e_1/+e_2`. From a recorded site `p` with lock `L_in(p)=±e_i`, a
+six-neighbor step `s in NN` to `q=p+s` is allowed if and only if `s` is
+perpendicular to `e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not a member of `S_*(q)` scored below unless it appears
+as a lock of some six-neighbor of `q`.
+
+Both seed locks lie on the `e_1` axis, so the allowed-step plane at each seed
+site is the span of `{e_2,e_3}`.
+
+The parallel-opposite pair `+e_1/−e_1` on `{0,(1,0,0)}` is not a proper cubic
+image of the perp-opposite pair `+e_1/−e_1` on `{0,(0,1,0)}`. A cubic image of
+that perp-opposite seed is `{0,e_1}` with locks `±e_2`. Seed displacement
+dotted with the lock axis is `0` for the perp-opposite seed and `1` for this
+seed; proper cubic rotations preserve that inner product. This display is not
+the cubic orbit of that perp-opposite two-site seed.
+
+A leftover of the opposite-lock later-tick six-neighbor lock lists is a
+different object. This note does not reuse leftover of those nsopp lists.
+
+## Named existential opposite from later-tick six-neighbor locks
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `T` be the maximum of those four ticks. This `T` is the first
+tick in `B_3(0)` at which all four x-probes are recorded.
+
+At tick `T`, for each probe `q`, let `S_*(q)` be the set of locks of
+six-neighbors of `q` that formed at tick `≤ T` and are not `q`. Same-tick
+and later-than-formation neighbors count whenever they have formed by `T`.
+The probe itself is excluded. This display does not use occupancy `n`. It
+does not use the probe's own incoming lock. Duplicate locks at two neighbors
+collapse in the set. The construction does not require `S_*(q)` to be a
+singleton. It does not sum `S_*(q)`. It is not a unique lock-vector leftover
+and not a sum leftover. It is a seed transfer of the holding readout, not
+leftover of later-tick existential opposite on the opposite-lock x-probes.
+It is not leftover of later-tick existential opposite on the nnseed x-probes.
+It is not leftover of unique own-incoming lock-vector letters on these
+x-probes.
+
+Incoming `{±e_i}` tags of the probe itself are not `S_*(q)`. Identifying a
+named sign of those locks with reverse or face is refused: named-sign
+lettering lost the axis. Reverse and face are scored on existence of a pair
+of lock vectors that add to zero. They are not scored on `{+,−}` names and
+are not an occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in S_*(A) and some b in S_*(B) with a+b=(0,0,0)
+face     <=>  some c in S_*(C) and some d in S_*(D) with c+d=(0,0,0)
+```
+
+If `S_*(A)` or `S_*(B)` is empty, reverse is `UNDEFINED`. Else reverse fails
+if no such pair exists. If `S_*(C)` or `S_*(D)` is empty, face is
+`UNDEFINED`. Else face fails if no such pair exists. The report is one of
+`hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility.
+
+## Theorem 1 — later-tick lock sets at each x-probe
+
+Direct enumeration of the displayed parallel-opposite process on `B_3(0)`
+forms all four x-probes. The formation ticks are `t(A)=0`, `t(B)=2`,
+`t(C)=3`, `t(D)=1`. `A` is a seed. All four are defined in `B_3(0)`, so
+
+```text
+T = max{t(A), t(B), t(C), t(D)} = 3.
+```
+
+At tick `T=3` the six-neighbor lock lists and lock sets are:
+
+```text
+A: −e_2 at (2, 0, 0), −e_3 at (2, 0, 0), +e_3 at (2, 0, 0), +e_2 at (2, 0, 0),
+   +e_1 at (0, 0, 0), +e_2 at (1, 1, 0), −e_2 at (1, -1, 0), +e_3 at (1, 0, 1),
+   −e_3 at (1, 0, -1);
+   S_*(A) = {+e_1, +e_2, −e_2, +e_3, −e_3}
+B: +e_3 at (2, 1, 1), +e_2 at (2, 1, 1), +e_1 at (2, 1, 1),
+   +e_3 at (0, 1, 1), +e_2 at (0, 1, 1), +e_2 at (1, 2, 1),
+   +e_3 at (1, 0, 1), +e_3 at (1, 1, 2), +e_2 at (1, 1, 0);
+   S_*(B) = {+e_1, +e_2, +e_3}
+C: −e_1 at (1, 0, 0), +e_1 at (2, 1, 0), +e_1 at (2, -1, 0),
+   +e_1 at (2, 0, 1), +e_1 at (2, 0, -1);
+   S_*(C) = {+e_1, −e_1}
+D: +e_1 at (2, 1, 0), +e_2 at (0, 1, 0), −e_1 at (1, 0, 0),
+   +e_3 at (1, 1, 1), +e_2 at (1, 1, 1), −e_3 at (1, 1, -1), +e_2 at (1, 1, -1);
+   S_*(D) = {+e_1, −e_1, +e_2, +e_3, −e_3}
+```
+
+`A`'s later-tick neighbors include the same-tick seed origin locking `+e_1`
+and later `C` locking four perpendicular steps. `A`'s incoming set `{−e_1}`
+is not `S_*(A)`: `−e_1` is incoming at `A` and is not in `S_*(A)`, while
+`+e_1` is in `S_*(A)` and is not incoming at `A`. `D`'s later-tick neighbors
+include the seed partner `A` locking `−e_1` and `(0,1,0)` locking `+e_2`.
+Mixed remains a set.
+
+Incoming locks exist and need not be unique (`B` has two earliest incoming
+steps `+e_2` and `+e_3`; `C` has four earliest incoming steps `±e_2` and
+`±e_3`). That non-uniqueness is not a unique-lettering of later-tick neighbor
+lock vectors. The lock sets are not identified with those incoming steps.
+Uniqueness is not required.
+
+The unique own-incoming letters on these x-probes are `−e_1`, `UNDEFINED`,
+`UNDEFINED`, `+e_2`. Those are different objects: `S_*(A)` is nonempty and
+is not `{−e_1}`. Later-tick existential opposite on the opposite-lock
+x-probes reports `{+e_1, −e_2, +e_3, −e_3}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}`,
+`{+e_1, +e_2, +e_3, −e_3}`, `{+e_1, −e_1, +e_2, +e_3, −e_3}` at `T=4`. Those
+lists are not these lists: `S_*(A)` here has `+e_2` and that leftover `S_*(A)`
+does not; `S_*(C)` here is `{+e_1, −e_1}` and that leftover `S_*(C)` has no
+`−e_1`. The `S_*(D)` sets coincide as sets while the lists differ:
+`(0,1,0)` locks `+e_2` here and `−e_1` there. Later-tick existential opposite
+on the nnseed x-probes reports `{+e_1}`, `{+e_1, +e_2, +e_3}`, `{−e_2}`,
+`{+e_1, +e_2, −e_2, +e_3, −e_3}` at a different seed. Formation-time
+already-recorded neighbor locks at `A` are empty because both seed sites form
+at tick 0.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if there exist `a` in `S_*(A)` and `b` in `S_*(B)`
+with `a+b=(0,0,0)`. Both sets are nonempty:
+`S_*(A)={+e_1, +e_2, −e_2, +e_3, −e_3}` and
+`S_*(B)={+e_1, +e_2, +e_3}`. The pairs include
+`−e_2+(+e_2)=(0,0,0)` and `−e_3+(+e_3)=(0,0,0)`. Reverse holds.
+
+Reverse: hold
+
+This is not `fail` and not `UNDEFINED`. Unique lock-vector lettering of the
+same lists would assign mixed `S_*(A)` and mixed `S_*(B)` and would report
+reverse `UNDEFINED`. That readout is a different object and is not used. A
+sum leftover of the same lists would replace the sets by `+e_1` and
+`(1,1,1)` and would report reverse fail. A named-sign readout of the same
+neighbor locks would lose the axis in mixed `{+,−}` at `A`. Unique
+own-incoming letters on these x-probes report reverse `UNDEFINED` from mixed
+`B`. Later-tick existential opposite on the nnseed x-probes reports reverse
+fail on different sets. Formation-time already-recorded neighbor locks at
+`A` are empty, so that leftover reverse is `UNDEFINED`. Opposite-lock
+x-probe later-tick existential opposite also reports reverse hold, but from
+different lists at `T=4`; the holding readout transfers by seed, the nsopp
+lists do not.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if there exist `c` in `S_*(C)` and `d` in `S_*(D)`
+with `c+d=(0,0,0)`. Both sets are nonempty:
+`S_*(C)={+e_1, −e_1}` and
+`S_*(D)={+e_1, −e_1, +e_2, +e_3, −e_3}`, so `+e_1+(−e_1)=(0,0,0)`. Face
+holds.
+
+Face: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+
+This is not `fail` and not `UNDEFINED`. Unique own-incoming letters on these
+same x-probes assign `L(B)=UNDEFINED` and `L(C)=UNDEFINED` from mixed
+earliest incoming steps and report face `UNDEFINED`. Unique lock-vector
+lettering of the later-tick lists would also report face `UNDEFINED` because
+both `C` and `D` mix. A sum leftover would replace the sets by `(0,0,0)` and
+`+e_2` and would fail face, while existential opposite holds. Named-sign
+lettering lost the axis in mixed `{+,−}` at `C` and at `D`. Formation-time
+already-recorded locks at `A` are empty and report reverse `UNDEFINED` while
+later-tick reverse holds. Opposite-lock x-probe later-tick existential
+opposite reports face hold from different lists.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify lock sets with the probe's own incoming `{±e_i}`.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the later-tick lock set to be a singleton.
+- It does not sum the later-tick lock set.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from later-tick six-neighbor locks.
+- It does not census a sixteen-combination free lettering independent of
+  later-tick lock vectors.
+- It does not reprint unique own-incoming lock-vector letters on these
+  x-probes.
+- It does not reprint later-tick existential opposite on the opposite-lock
+  x-probes.
+- It does not reprint later-tick existential opposite on the nnseed x-probes.
+- It does not reprint formation-time already-recorded lock sets.
+- It does not treat the parallel-opposite seed as a proper cubic image of the
+  perp-opposite two-site seed.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+parallel-opposite process, the later-tick six-neighbor lock sets, and the
+existential-opposite reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; parallel-opposite two-site seed `+e_1/−e_1` |
+| later-tick six-neighbor lock sets at first `T` with all four x-probes recorded | Theorem 1 |
+| lock sets `S_*(A)`, `S_*(B)`, `S_*(C)`, `S_*(D)` | Theorem 1; `{+e_1, +e_2, −e_2, +e_3, −e_3}`, `{+e_1, +e_2, +e_3}`, `{+e_1, −e_1}`, `{+e_1, −e_1, +e_2, +e_3, −e_3}` |
+| reverse and face | Theorems 2–3; `hold` / `hold` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| probe's own incoming lock as the set | not used |
+| formation member from later-tick six-neighbor locks | not attached |
+| leftover of unique own-incoming letters on these x-probes | not this display |
+| leftover of opposite-lock x-probe later-tick existential opposite | not this display; seed transfer of the holding readout, not leftover of nsopp lists |
+| leftover of nnseed x-probe later-tick existential opposite | not this display |
+| leftover of formation-time already-recorded sets | not this display |
+| cubic image of the perp-opposite two-site seed | not this seed |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: existential opposite of 6-NN locks at the first later tick when all four nspar x-probes are recorded, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed later-tick existential-opposite neighbor-lock reverse/face report on these four parallel-opposite x-probes. |
+| V3 | Later-tick lock sets and the `hold`/`hold` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads six-neighbor lock vectors at a later common tick and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not reduce them to named signs, does not require a singleton lock
+vector, does not sum the lock set, does not reprint unique own-incoming
+letters, does not reprint opposite-lock x-probe later-tick leftover, does
+not reprint nnseed x-probe later-tick leftover, and does not use occupancy
+`n`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique lock-vector lettering of the same neighbor locks | require a singleton `{v}` subset `{±e_i}` | refused; leftover; reverse and face would be `UNDEFINED` while both pairs of sets are nonempty |
+| sum of the same neighbor locks | replace `S_*` by the `Z^3` sum | refused; leftover; sum of `S_*(A)` is `+e_1` and of `S_*(B)` is `(1,1,1)` and would fail reverse while `−e_2+(+e_2)=0`; sum of `S_*(C)` is `(0,0,0)` and of `S_*(D)` is `+e_2` and would fail face |
+| named-sign lettering of the same neighbor locks | map `±e_i` to `{+,−}` | refused; lost the axis; mixed `{+,−}` at `A` would hide `−e_2+(+e_2)=0` |
+| identify lock sets with the probe's own incoming `{±e_i}` | map `A`'s incoming `{−e_1}` onto `S_*(A)` | refused; `−e_1` is incoming at `A` and is not in `S_*(A)`; `S_*(A)={+e_1, +e_2, −e_2, +e_3, −e_3}` |
+| unique own-incoming lock-vector leftover on these x-probes | reuse `L(A)=−e_1`, `L(B)=UNDEFINED`, `L(C)=UNDEFINED`, `L(D)=+e_2` | refused; different object; that leftover reports reverse `UNDEFINED` and face `UNDEFINED` while later-tick `S_*(A)` and `S_*(C)` are nonempty and both bits hold |
+| leftover of opposite-lock x-probe later-tick existential opposite | reuse nsopp lists at `T=4` | refused; different seed; `S_*(A)` here has `+e_2` and that leftover has no `+e_2`; `S_*(C)` here is `{+e_1, −e_1}`; seed transfer of the holding readout, not leftover of those nsopp lists |
+| leftover of nnseed x-probe later-tick existential opposite | reuse seed `+e_1/+e_2` and x-probes with reverse fail | refused; different process; reverse holds here |
+| leftover of formation-time already-recorded sets | reuse empty locks at `A` with reverse `UNDEFINED` | refused; different set; later-tick `S_*(A)` mixes and reverse holds |
+| treat this seed as a cubic image of nsopp | map `{0,e_2}` with locks `±e_1` onto `{0,e_1}` with locks `±e_1` | refused; a cubic image is `{0,e_1}` with locks `±e_2`; the inner product of seed edge and lock axis is `1` here and `0` there |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; not this display |
+| attach a formation member from later-tick six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; both earliest incoming steps at `B` and all four at `C` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from later-tick
+six-neighbor locks, and missing Record identification of existential opposite
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `−e_1` parallel to the seed
+edge, perpendicular step rule, incoming-step lock, later-tick lock set of
+six-neighbors formed by the first `T` at which all four x-probes are recorded,
+existential opposite, four x-probes with seed `A`, and reverse/face as
+existence of a pair that sums to zero are declared. No uniqueness of incoming
+locks, no occupancy `n`, no named-sign reduction, no singleton leftover, no
+sum leftover, no unique own-incoming leftover, no opposite-lock x-probe
+leftover, no nnseed x-probe leftover, no formation attachment from later-tick
+six-neighbor locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`hold`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in a later-tick set | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four lock sets and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once a six-neighbor exists at the later common tick, the site
+should lock that unique vector as incoming content, mixed neighbor locks
+should make reverse and face `UNDEFINED`, the sets should be replaced by
+their sums, unique own-incoming letters already answered reverse
+`UNDEFINED` with face `UNDEFINED`, opposite-lock x-probe later-tick
+existential opposite already answered the later-tick question with the same
+hold/hold bits, nnseed x-probe later-tick existential opposite already
+answered the x-probe later-tick question, named signs should suffice because
+they keep orientation, occupancy `n` should track that vector, and the seed
+is a cubic image of nsopp.
+
+**Answer:** The named construction reports lock sets
+`{+e_1, +e_2, −e_2, +e_3, −e_3}`, `{+e_1, +e_2, +e_3}`,
+`{+e_1, −e_1}`, `{+e_1, −e_1, +e_2, +e_3, −e_3}` at
+`A,B,C,D` from later-tick six-neighbor locks at `T=3`. Mixed remains a set.
+The construction does not sum. Occupancy `n` is not used. Named signs lost
+the axis. Some pair from `S_*(A)` and `S_*(B)` is opposite, so reverse holds.
+Face holds. The sets are not leftover of unique own-incoming letters, not
+leftover of opposite-lock x-probe later-tick lists, and not leftover of
+nnseed x-probe later-tick existential opposite. The holding readout
+transfers by seed; the nsopp lists do not. The seed is not a proper cubic
+image of nsopp. The bits remain displayed. Incoming-lock uniqueness is not
+required.
+
+### N8 — cross-cycle echo
+
+A unique own-incoming lock-vector display on these same parallel-opposite
+x-probes assigned `L(A)=−e_1`, `L(B)=UNDEFINED`, `L(C)=UNDEFINED`,
+`L(D)=+e_2` and reported reverse `UNDEFINED` with face `UNDEFINED`. A
+unique already-recorded six-neighbor lock-vector display on these x-probes
+assigned `{+e_1}` at `A` and mixed `{+e_2,+e_3}` at `B` and reported reverse
+`UNDEFINED` with face `UNDEFINED`. Later-tick existential opposite on the
+opposite-lock x-probes reported reverse hold and face hold on different sets
+`{+e_1, −e_2, +e_3, −e_3}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}`,
+`{+e_1, +e_2, +e_3, −e_3}`, `{+e_1, −e_1, +e_2, +e_3, −e_3}` at
+`T=4`. Later-tick existential opposite on the opposite-lock y-probes and
+z-probes reported reverse hold and face hold on that same nsopp seed in the
+other two cubic frames. Later-tick existential opposite on the nnseed
+x-probes reported reverse fail and face hold on different sets `{+e_1}`,
+`{+e_1, +e_2, +e_3}`, `{−e_2}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}`. Unique
+lock-vector lettering of the later-tick lists would report reverse
+`UNDEFINED` and face `UNDEFINED` because every later-tick set mixes. A sum
+leftover of the same lists would report reverse fail and face fail because
+the sums are `+e_1` and `(1,1,1)` on reverse and `(0,0,0)` and `+e_2` on
+face. This note is not those displays: mixed remains a set, the construction
+does not sum, `−e_2+(+e_2)=(0,0,0)` so reverse holds, and
+`+e_1+(−e_1)=(0,0,0)` so face holds. The holding readout is a seed transfer;
+the lists are not leftover of the nsopp display.
+
+**Gate disposition:** PASS for the later-tick six-neighbor-lock
+existential-opposite reverse/face reports above. FAIL / DO NOT SHIP for “the
+predicate equals the named sign,” “the predicate equals the unique singleton
+lock vector,” “the predicate equals the sum of the lock set,” “the lock set
+equals the probe's own incoming step,” “bits are Admissibility,” “the letter
+is occupancy `n`,” “the sets equal unique own-incoming letters,” “the sets
+equal opposite-lock x-probe later-tick leftover,” “the sets equal nnseed
+x-probe later-tick leftover,” “reverse fails,” or “face is `UNDEFINED`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the parallel-opposite
+two-site perp-step incoming-lock process, takes `T` as the first tick at which
+all four x-probes are recorded, collects six-neighbor locks formed by `T` at
+each probe with the probe excluded, reads the lock sets at the four x-probes,
+and checks Theorems 1--3. It also checks that the construction is not
+named-sign lettering, that mixed sets remain defined, that the construction
+does not sum, that the probe's own incoming step is not the lock set, that
+occupancy `n` is not used, that a formation member from later-tick
+six-neighbor locks is not attached, that the sets are not leftover of unique
+own-incoming letters, that the sets are not leftover of opposite-lock x-probe
+later-tick existential opposite, and that the sets are not leftover of nnseed
+x-probe later-tick existential opposite. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13641,6 +13641,10 @@
   "paper_outline_2026-04-12": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "parity_operator_basis_dimension5_lv_no_go_theorem_note_2026-05-02": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
+runner_sha256: 0615cf6319e60d9ae2eed6115b331184d42cbf0f289439e83e2007ac79eae639
+input_fingerprint_sha256: 93bfea50925a97f8c30daec45477d3d8abe4663a39f057e017cad9c3b2bb0b4c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+later-tick existential opposite 6-NN reverse/face on parallel-opposite x-probes
+AUDIT_INPUT_PATHS:
+  docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from existential opposite 6-NN locks at the first later tick when all four nspar x-probes are recorded are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: theorem1-all-four-probes-recorded
+A t=0 S_*={+e_1, +e_2, −e_2, +e_3, −e_3} incoming=−e_1
+B t=2 S_*={+e_1, +e_2, +e_3} incoming=+e_3,+e_2
+C t=3 S_*={+e_1, −e_1} incoming=−e_2,−e_3,+e_3,+e_2
+D t=1 S_*={+e_1, −e_1, +e_2, +e_3, −e_3} incoming=+e_2
+T=3 t(A)=0 t(B)=2 t(C)=3 t(D)=1
+reverse=hold face=hold
+PASS: theorem1-later-tick-T  (3)
+PASS: theorem1-A-neighbor-lock-set  (((((2, 0, 0), (0, -1, 0)), ((2, 0, 0), (0, 0, -1)), ((2, 0, 0), (0, 0, 1)), ((2, 0, 0), (0, 1, 0)), ((0, 0, 0), (1, 0, 0)), ((1, 1, 0), (0, 1, 0)), ((1, -1, 0), (0, -1, 0)), ((1, 0, 1), (0, 0, 1)), ((1, 0, -1), (0, 0, -1))), frozenset({(0, 1, 0), (0, -1, 0), (1, 0, 0), (0, 0, -1), (0, 0, 1)})))
+PASS: theorem1-B-neighbor-lock-set  (((((2, 1, 1), (0, 0, 1)), ((2, 1, 1), (0, 1, 0)), ((2, 1, 1), (1, 0, 0)), ((0, 1, 1), (0, 0, 1)), ((0, 1, 1), (0, 1, 0)), ((1, 2, 1), (0, 1, 0)), ((1, 0, 1), (0, 0, 1)), ((1, 1, 2), (0, 0, 1)), ((1, 1, 0), (0, 1, 0))), frozenset({(1, 0, 0), (0, 0, 1), (0, 1, 0)})))
+PASS: theorem1-C-neighbor-lock-set  (((((1, 0, 0), (-1, 0, 0)), ((2, 1, 0), (1, 0, 0)), ((2, -1, 0), (1, 0, 0)), ((2, 0, 1), (1, 0, 0)), ((2, 0, -1), (1, 0, 0))), frozenset({(1, 0, 0), (-1, 0, 0)})))
+PASS: theorem1-D-neighbor-lock-set  (((((2, 1, 0), (1, 0, 0)), ((0, 1, 0), (0, 1, 0)), ((1, 0, 0), (-1, 0, 0)), ((1, 1, 1), (0, 0, 1)), ((1, 1, 1), (0, 1, 0)), ((1, 1, -1), (0, 0, -1)), ((1, 1, -1), (0, 1, 0))), frozenset({(0, 1, 0), (1, 0, 0), (-1, 0, 0), (0, 0, -1), (0, 0, 1)})))
+PASS: theorem1-A-B-mixed-vectors-remain-a-set
+PASS: theorem1-C-D-mixed-vectors-remain-a-set
+PASS: theorem2-reverse-hold  (hold)
+PASS: theorem3-face-hold  (hold)
+PASS: not-leftover-of-formation-time
+PASS: not-leftover-of-nslate-nnseed-x-probes
+PASS: not-leftover-of-nsopex-nsopp-x-probe-lists
+PASS: nsopp-cubic-isotropic-later-tick-hold-hold
+PASS: not-leftover-of-unique-own-incoming
+PASS: later-tick-includes-post-formation-neighbors
+PASS: sign-lettering-loses-axis-and-would-hide-hold
+PASS: not-probe-own-incoming-lock
+PASS: not-sum-leftover
+PASS: not-unique-vector-leftover
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required  (([(0, 0, 1), (0, 1, 0)], [(0, -1, 0), (0, 0, -1), (0, 0, 1), (0, 1, 0)]))
+PASS: two-site-parallel-opposite-lock-seed
+PASS: later-tick-not-self-and-formed-by-T
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: perp-step-incoming-lock
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-sets
+PASS: note-reports-hold-hold
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-leftover
+PASS: note-not-leftover-of-own-incoming
+PASS: note-not-leftover-of-nsopp
+PASS: note-not-leftover-of-nslate
+PASS: note-not-cubic-image-of-nsopp
+PASS: note-later-tick-T-defined
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-existential-opposite-only
+TOTAL: PASS=63 FAIL=0
+
+----- stderr -----
+

--- a/scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
+++ b/scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
@@ -1,0 +1,1023 @@
+#!/usr/bin/env python3
+"""Later-tick existential opposite 6-NN reverse/face on four parallel-opposite x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (1,0,0)} with locks +e_1 and -e_1 (opposite and parallel to the seed
+edge). A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Probe A is a seed site. Let T be
+the max of t(A), t(B), t(C), t(D) among those defined in B_3(0): the first
+later tick at which all four x-probes are recorded. At tick T, S_*(q) is the
+set of locks of 6-NN of q that formed at tick <= T and are not q. Reverse
+holds iff some a in S_*(A) and some b in S_*(B) have a+b=(0,0,0). Face holds
+iff some c in S_*(C) and some d in S_*(D) have c+d=(0,0,0). Empty S_* on
+either side is UNDEFINED; nonempty with no opposite pair fails. Seed transfer
+of the holding readout, not leftover of nsopp later-tick lists. This seed is
+not a cubic image of the perp-opposite two-site seed {0,e_2} with locks ±e_1.
+Not leftover of nnseed x-probe later-tick existential opposite (different
+process). Not leftover of unique own-incoming letters on these x-probes. Not
+unique-vector leftover. Not sum leftover. Not named-sign lettering. Occupancy
+n is not used. The probe's own incoming lock is not used. Uniqueness of
+incoming locks is not required.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E1, NEG_E1),
+)
+NSOPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+NSOPP_CUBIC_IMAGE_EXAMPLE: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, NEG_E2),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+    "P_+",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from existential opposite 6-NN locks at "
+    "the first later tick when all four nspar x-probes are recorded are "
+    "reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def recorded_lock_set(pairs: tuple[tuple[Point, Point], ...]) -> frozenset[Point]:
+    """Set of later-tick six-neighbor locks. Duplicates collapse."""
+    return frozenset(lock for _neighbor, lock in pairs)
+
+
+def existential_opposite(left: frozenset[Point], right: frozenset[Point]) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    Empty set on either side is UNDEFINED. Nonempty with no opposite pair fails.
+    Does not sum. Does not require a singleton.
+    """
+    if not left or not right:
+        return "UNDEFINED"
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: frozenset[Point], set_b: frozenset[Point]) -> str:
+    """Reverse iff some a in S_*(A) and some b in S_*(B) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: frozenset[Point], set_d: frozenset[Point]) -> str:
+    """Face iff some c in S_*(C) and some d in S_*(D) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def later_tick_T(
+    ticks: dict[Point, int],
+    probes: dict[str, Point] = PROBES,
+) -> int | None:
+    """First later tick at which all named probes are recorded, or None."""
+    defined = [ticks[probes[name]] for name in ("A", "B", "C", "D") if probes[name] in ticks]
+    if len(defined) != 4:
+        return None
+    return max(defined)
+
+
+def later_tick_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    common_tick: int,
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of 6-NN of site formed at tick <= common_tick, site excluded."""
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] > common_tick:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def strictly_earlier_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Formation-time leftover: already-recorded 6-NN locks at formation of site."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    """Z^3 sum leftover of a lock set. Contrast only; not this letter."""
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("later-tick existential opposite 6-NN reverse/face on parallel-opposite x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E1, E1) == (2, 0, 0)
+        and add(E2, E2) == (0, 2, 0)
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    mixed_a = frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+    mixed_b = frozenset({E1, E2, E3})
+    mixed_c = frozenset({E1, NEG_E1})
+    mixed_d = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    nsopex_a = frozenset({E1, NEG_E2, E3, NEG_E3})
+    nsopex_b = frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+    nsopex_c = frozenset({E1, E2, E3, NEG_E3})
+    nsopex_d = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    nsopyex_a = frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+    nsopyex_c = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(frozenset(), frozenset({E1})) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and existential_opposite(mixed_a, mixed_b) == "hold"
+        and existential_opposite(mixed_c, mixed_d) == "hold"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold",
+    )
+
+    ticks, locks = form()
+    common_tick = later_tick_T(ticks)
+    nsopp_ticks, nsopp_locks = form(NSOPP_SEEDS)
+    nsopp_common = later_tick_T(nsopp_ticks, PROBES)
+    y_common = later_tick_T(nsopp_ticks, Y_PROBES)
+    z_common = later_tick_T(nsopp_ticks, Z_PROBES)
+    perp_ticks, perp_locks = form(PERP_SEEDS)
+    perp_common = later_tick_T(perp_ticks, PROBES)
+    checks.check(
+        "theorem1-all-four-probes-recorded",
+        all(PROBES[name] in ticks for name in ("A", "B", "C", "D"))
+        and common_tick is not None,
+    )
+    assert common_tick is not None
+    assert nsopp_common is not None
+    assert y_common is not None
+    assert z_common is not None
+    assert perp_common is not None
+
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    lock_sets: dict[str, frozenset[Point]] = {}
+    leftover_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    leftover_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        pairs = later_tick_neighbor_locks(site, ticks, locks, common_tick)
+        neighbor_lists[name] = pairs
+        lock_sets[name] = recorded_lock_set(pairs)
+        leftover = strictly_earlier_neighbor_locks(site, ticks, locks)
+        leftover_lists[name] = leftover
+        leftover_sets[name] = recorded_lock_set(leftover)
+        incoming = ",".join(LOCK_NAME[lock] for lock in sorted(locks[site]))
+        print(
+            f"{name} t={ticks[site]} S_*={set_display(lock_sets[name])} "
+            f"incoming={incoming}"
+        )
+
+    print(
+        f"T={common_tick} "
+        f"t(A)={ticks[PROBES['A']]} t(B)={ticks[PROBES['B']]} "
+        f"t(C)={ticks[PROBES['C']]} t(D)={ticks[PROBES['D']]}"
+    )
+    reverse_status = reverse_report(lock_sets["A"], lock_sets["B"])
+    face_status = face_report(lock_sets["C"], lock_sets["D"])
+    leftover_reverse = reverse_report(leftover_sets["A"], leftover_sets["B"])
+    leftover_face = face_report(leftover_sets["C"], leftover_sets["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+
+    nsopex_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    nsopex_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        pairs = later_tick_neighbor_locks(site, nsopp_ticks, nsopp_locks, nsopp_common)
+        nsopex_lists[name] = pairs
+        nsopex_sets[name] = recorded_lock_set(pairs)
+    nsopex_reverse = reverse_report(nsopex_sets["A"], nsopex_sets["B"])
+    nsopex_face = face_report(nsopex_sets["C"], nsopex_sets["D"])
+
+    nsopyex_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    nsopyex_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = Y_PROBES[name]
+        pairs = later_tick_neighbor_locks(site, nsopp_ticks, nsopp_locks, y_common)
+        nsopyex_lists[name] = pairs
+        nsopyex_sets[name] = recorded_lock_set(pairs)
+    nsopyex_reverse = reverse_report(nsopyex_sets["A"], nsopyex_sets["B"])
+    nsopyex_face = face_report(nsopyex_sets["C"], nsopyex_sets["D"])
+
+    nsopzex_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = Z_PROBES[name]
+        pairs = later_tick_neighbor_locks(site, nsopp_ticks, nsopp_locks, z_common)
+        nsopzex_sets[name] = recorded_lock_set(pairs)
+    nsopzex_reverse = reverse_report(nsopzex_sets["A"], nsopzex_sets["B"])
+    nsopzex_face = face_report(nsopzex_sets["C"], nsopzex_sets["D"])
+
+    nslate_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        pairs = later_tick_neighbor_locks(site, perp_ticks, perp_locks, perp_common)
+        nslate_sets[name] = recorded_lock_set(pairs)
+    nslate_reverse = reverse_report(nslate_sets["A"], nslate_sets["B"])
+    nslate_face = face_report(nslate_sets["C"], nslate_sets["D"])
+
+    checks.check(
+        "theorem1-later-tick-T",
+        common_tick == 3
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 1
+        and common_tick
+        == max(
+            ticks[PROBES["A"]],
+            ticks[PROBES["B"]],
+            ticks[PROBES["C"]],
+            ticks[PROBES["D"]],
+        ),
+        str(common_tick),
+    )
+    checks.check(
+        "theorem1-A-neighbor-lock-set",
+        neighbor_lists["A"]
+        == (
+            (PROBES["C"], NEG_E2),
+            (PROBES["C"], NEG_E3),
+            (PROBES["C"], E3),
+            (PROBES["C"], E2),
+            (ORIGIN, E1),
+            (PROBES["D"], E2),
+            ((1, -1, 0), NEG_E2),
+            ((1, 0, 1), E3),
+            ((1, 0, -1), NEG_E3),
+        )
+        and lock_sets["A"] == mixed_a,
+        str((neighbor_lists["A"], lock_sets["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-set",
+        neighbor_lists["B"]
+        == (
+            ((2, 1, 1), E3),
+            ((2, 1, 1), E2),
+            ((2, 1, 1), E1),
+            ((0, 1, 1), E3),
+            ((0, 1, 1), E2),
+            ((1, 2, 1), E2),
+            ((1, 0, 1), E3),
+            ((1, 1, 2), E3),
+            (PROBES["D"], E2),
+        )
+        and lock_sets["B"] == mixed_b,
+        str((neighbor_lists["B"], lock_sets["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-set",
+        neighbor_lists["C"]
+        == (
+            (PROBES["A"], NEG_E1),
+            ((2, 1, 0), E1),
+            ((2, -1, 0), E1),
+            ((2, 0, 1), E1),
+            ((2, 0, -1), E1),
+        )
+        and lock_sets["C"] == mixed_c,
+        str((neighbor_lists["C"], lock_sets["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-set",
+        neighbor_lists["D"]
+        == (
+            ((2, 1, 0), E1),
+            ((0, 1, 0), E2),
+            (PROBES["A"], NEG_E1),
+            (PROBES["B"], E3),
+            (PROBES["B"], E2),
+            ((1, 1, -1), NEG_E3),
+            ((1, 1, -1), E2),
+        )
+        and lock_sets["D"] == mixed_d,
+        str((neighbor_lists["D"], lock_sets["D"])),
+    )
+    checks.check(
+        "theorem1-A-B-mixed-vectors-remain-a-set",
+        lock_sets["A"] == mixed_a
+        and lock_sets["B"] == mixed_b
+        and len(lock_sets["A"]) == 5
+        and len(lock_sets["B"]) == 3,
+    )
+    checks.check(
+        "theorem1-C-D-mixed-vectors-remain-a-set",
+        lock_sets["C"] == mixed_c
+        and lock_sets["D"] == mixed_d
+        and len(lock_sets["C"]) == 2
+        and len(lock_sets["D"]) == 5,
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse_status == "hold"
+        and lock_sets["A"] == mixed_a
+        and lock_sets["B"] == mixed_b
+        and add(NEG_E2, E2) == ZERO
+        and add(NEG_E3, E3) == ZERO
+        and NEG_E2 in lock_sets["A"]
+        and E2 in lock_sets["B"]
+        and NEG_E3 in lock_sets["A"]
+        and E3 in lock_sets["B"]
+        and lock_sets["A"]
+        and lock_sets["B"],
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and lock_sets["C"] == mixed_c
+        and lock_sets["D"] == mixed_d
+        and E1 in lock_sets["C"]
+        and NEG_E1 in lock_sets["D"]
+        and add(E1, NEG_E1) == ZERO,
+        face_status,
+    )
+    checks.check(
+        "not-leftover-of-formation-time",
+        leftover_sets["A"] == frozenset()
+        and leftover_sets["B"] == frozenset({E2, E3})
+        and leftover_sets["C"] == mixed_c
+        and leftover_sets["D"] == frozenset({NEG_E1})
+        and leftover_sets["A"] != lock_sets["A"]
+        and leftover_sets["B"] != lock_sets["B"]
+        and leftover_sets["D"] != lock_sets["D"]
+        and leftover_reverse == "UNDEFINED"
+        and leftover_face == "hold"
+        and reverse_status == "hold"
+        and reverse_status != leftover_reverse
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-leftover-of-nslate-nnseed-x-probes",
+        TWO_SITE_SEEDS != PERP_SEEDS
+        and nslate_sets["A"] == frozenset({E1})
+        and nslate_sets["B"] == frozenset({E1, E2, E3})
+        and nslate_sets["C"] == frozenset({NEG_E2})
+        and nslate_sets["D"] == frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+        and nslate_reverse == "fail"
+        and nslate_face == "hold"
+        and reverse_status == "hold"
+        and reverse_status != nslate_reverse
+        and lock_sets["A"] != nslate_sets["A"],
+    )
+    checks.check(
+        "not-leftover-of-nsopex-nsopp-x-probe-lists",
+        TWO_SITE_SEEDS != NSOPP_SEEDS
+        and TWO_SITE_SEEDS != NSOPP_CUBIC_IMAGE_EXAMPLE
+        and nsopp_common == 4
+        and common_tick == 3
+        and nsopex_sets["A"] == nsopex_a
+        and nsopex_sets["B"] == nsopex_b
+        and nsopex_sets["C"] == nsopex_c
+        and nsopex_sets["D"] == nsopex_d
+        and lock_sets["D"] == nsopex_sets["D"]
+        and neighbor_lists["D"] != nsopex_lists["D"]
+        and E2 in lock_sets["A"]
+        and E2 not in nsopex_sets["A"]
+        and NEG_E1 in lock_sets["C"]
+        and NEG_E1 not in nsopex_sets["C"]
+        and nsopex_reverse == "hold"
+        and nsopex_face == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and lock_sets["A"] != nsopex_sets["A"]
+        and lock_sets["B"] != nsopex_sets["B"]
+        and lock_sets["C"] != nsopex_sets["C"],
+    )
+    checks.check(
+        "nsopp-cubic-isotropic-later-tick-hold-hold",
+        nsopyex_sets["A"] == nsopyex_a
+        and nsopyex_sets["B"] == nsopyex_a
+        and nsopyex_sets["C"] == nsopyex_c
+        and nsopyex_sets["D"] == nsopyex_c
+        and nsopyex_reverse == "hold"
+        and nsopyex_face == "hold"
+        and nsopzex_reverse == "hold"
+        and nsopzex_face == "hold"
+        and nsopex_reverse == "hold"
+        and nsopex_face == "hold"
+        and y_common == 3
+        and z_common == 4,
+    )
+    checks.check(
+        "not-leftover-of-unique-own-incoming",
+        locks[PROBES["A"]] == {NEG_E1}
+        and locks[PROBES["B"]] == {E2, E3}
+        and locks[PROBES["C"]] == {E2, NEG_E2, E3, NEG_E3}
+        and locks[PROBES["D"]] == {E2}
+        and lock_sets["A"] != frozenset({NEG_E1})
+        and lock_sets["C"] != frozenset({E2, NEG_E2, E3, NEG_E3})
+        and lock_sets["D"] != frozenset({E2})
+        and face_status == "hold"
+        and face_status != "UNDEFINED"
+        and reverse_status == "hold"
+        and reverse_status != "UNDEFINED",
+    )
+    checks.check(
+        "later-tick-includes-post-formation-neighbors",
+        any(ticks[neighbor] > ticks[PROBES["A"]] for neighbor, _lock in neighbor_lists["A"])
+        and any(ticks[neighbor] > ticks[PROBES["B"]] for neighbor, _lock in neighbor_lists["B"])
+        and all(
+            ticks[neighbor] <= ticks[PROBES["C"]] for neighbor, _lock in neighbor_lists["C"]
+        )
+        and any(ticks[neighbor] > ticks[PROBES["D"]] for neighbor, _lock in neighbor_lists["D"])
+        and any(
+            neighbor == ORIGIN and ticks[neighbor] == ticks[PROBES["A"]]
+            for neighbor, _lock in neighbor_lists["A"]
+        ),
+    )
+    checks.check(
+        "sign-lettering-loses-axis-and-would-hide-hold",
+        named_sign(NEG_E2) == "-"
+        and named_sign(E2) == "+"
+        and named_sign(E1) == "+"
+        and named_sign(NEG_E1) == "-"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-probe-own-incoming-lock",
+        locks[PROBES["A"]] == {NEG_E1}
+        and lock_sets["A"] == mixed_a
+        and NEG_E1 in locks[PROBES["A"]]
+        and NEG_E1 not in lock_sets["A"]
+        and E1 in lock_sets["A"]
+        and E1 not in locks[PROBES["A"]]
+        and locks[PROBES["D"]] == {E2}
+        and lock_sets["D"] != frozenset({E2}),
+    )
+    checks.check(
+        "not-sum-leftover",
+        sum_of_set(lock_sets["A"]) == E1
+        and sum_of_set(lock_sets["B"]) == (1, 1, 1)
+        and sum_of_set(lock_sets["C"]) == ZERO
+        and sum_of_set(lock_sets["D"]) == E2
+        and add(sum_of_set(lock_sets["A"]), sum_of_set(lock_sets["B"])) != ZERO
+        and add(sum_of_set(lock_sets["C"]), sum_of_set(lock_sets["D"])) != ZERO
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-unique-vector-leftover",
+        len(lock_sets["A"]) > 1
+        and len(lock_sets["B"]) > 1
+        and len(lock_sets["C"]) > 1
+        and len(lock_sets["D"]) > 1
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["A"]]) == 1
+        and len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 4
+        and len(locks[PROBES["D"]]) == 1
+        and lock_sets["A"] == mixed_a
+        and lock_sets["C"] == mixed_c
+        and reverse_status == "hold"
+        and face_status == "hold",
+        str((sorted(locks[PROBES["B"]]), sorted(locks[PROBES["C"]]))),
+    )
+    checks.check(
+        "two-site-parallel-opposite-lock-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E1] == 0
+        and locks[E1] == {NEG_E1}
+        and add(E1, NEG_E1) == ZERO
+        and PROBES["A"] == E1
+        and TWO_SITE_SEEDS != NSOPP_SEEDS
+        and TWO_SITE_SEEDS != NSOPP_CUBIC_IMAGE_EXAMPLE
+        and TWO_SITE_SEEDS != PERP_SEEDS
+        and dot(E1, E1) == 1
+        and dot(E2, E1) == 0,
+    )
+    checks.check(
+        "later-tick-not-self-and-formed-by-T",
+        all(neighbor != PROBES[name] for name in PROBES for neighbor, _lock in neighbor_lists[name])
+        and all(
+            ticks[neighbor] <= common_tick
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E1, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[(0, -1, 0)] == 1
+        and ticks[E3] == 1
+        and ticks[(0, 0, -1)] == 1
+        and ticks[(0, 1, 0)] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        recorded_lock_set(()) == frozenset()
+        and reverse_report(frozenset(), lock_sets["B"]) == "UNDEFINED"
+        and face_report(lock_sets["C"], frozenset()) == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and reverse_status == "hold",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-sets",
+        "S_*(A) = {+e_1, +e_2, −e_2, +e_3, −e_3}" in note
+        and "S_*(B) = {+e_1, +e_2, +e_3}" in note
+        and "S_*(C) = {+e_1, −e_1}" in note
+        and "S_*(D) = {+e_1, −e_1, +e_2, +e_3, −e_3}" in note
+        and "T = max{t(A), t(B), t(C), t(D)} = 3." in note
+        and "−e_2 at (2, 0, 0)" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_2 at (1, 1, 0)" in note
+        and "+e_3 at (2, 1, 1)" in note
+        and "−e_1 at (1, 0, 0)" in note
+        and "+e_2 at (0, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-hold-hold",
+        "Reverse: hold" in note
+        and "Face: hold" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note
+        and "`−e_1` is incoming at `A` and is not in `S_*(A)`" in note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from later-tick six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "Reverse holds." in note,
+    )
+    checks.check(
+        "note-not-leftover-of-own-incoming",
+        "not leftover of unique own-incoming lock-vector letters"
+        in normalized_note
+        and "face `UNDEFINED`" in note
+        and "Face: hold" in note,
+    )
+    checks.check(
+        "note-not-leftover-of-nsopp",
+        "not leftover of later-tick existential opposite on the opposite-lock"
+        in normalized_note
+        and "seed transfer of the holding readout" in normalized_note
+        and "nsopp lists" in normalized_note,
+    )
+    checks.check(
+        "note-not-leftover-of-nslate",
+        "not leftover of later-tick existential opposite on the nnseed"
+        in normalized_note
+        and "perp two-site seed" in normalized_note
+        and "reverse fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-cubic-image-of-nsopp",
+        "not a proper cubic image" in normalized_note
+        and "locks `±e_2`" in note
+        and "inner product" in normalized_note,
+    )
+    checks.check(
+        "note-later-tick-T-defined",
+        "first later tick" in normalized_note
+        and "all four" in normalized_note
+        and "tick `≤ T`" in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/PARALLEL_OPPOSITE_XPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def existential_opposite(" in source
+        and "def recorded_lock_set(" in source
+        and "def later_tick_neighbor_locks(" in source
+        and "def later_tick_T(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-existential-opposite-only",
+        "existential_opposite" in defined_fns
+        and "recorded_lock_set" in defined_fns
+        and "later_tick_neighbor_locks" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Later-tick existential opposite on nspar x-probes. Reverse HOLD and face HOLD. HOLDING_MEMBER (displayed, not adopted). Seed-transfer of nsopp #7128/#7134/#7135 readout.

## Runner

`scripts/parallel_opposite_xprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.