### PR TITLE
feat(nsnnyex): nnseed y-probe later-tick exist-opposite: reverse HOLD, face HOLD

### DIFF
--- a/docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,448 @@
+---
+claim_id: nnseed_yprobe_later_tick_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from existential opposite 6-NN locks at the first later tick when all four nnseed y-probes are recorded are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
+---
+
+# Later-Tick Existential Opposite Neighbor-Lock Reverse And Face On Four Nnseed Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from existential opposite six-neighbor locks at
+the first later tick in `B_3(0)` at which all four nnseed y-probes are
+recorded. Let `t(q)` be the formation tick of probe `q`. Let `T` be the
+maximum of `t(A)`, `t(B)`, `t(C)`, `t(D)` among those defined in `B_3(0)`.
+At tick `T`, `S_*(q)` is the set of locks of six-neighbors of `q` that
+formed at tick `≤ T` and are not `q`. Reverse holds if and only if some
+lock in `S_*(A)` is the vector opposite of some lock in `S_*(B)`. Face
+holds if and only if some lock in `S_*(C)` is the vector opposite of some
+lock in `S_*(D)`. Empty `S_*` on either side of a comparison is
+`UNDEFINED`; nonempty with no opposite pair fails. Occupancy `n` is not
+used. The probe's own incoming lock is not used. This is not named-sign
+lettering. This is not a unique lock-vector leftover and not a sum leftover.
+This is not leftover of nslate lists: nslate reads the same later-tick
+existential-opposite construction on the four nnseed x-probes, a different
+frame. Reverse fail on those x-probes is frame-specific: it does not hold
+on these y-probes. Uniqueness of incoming locks is not required. Uniqueness
+of the lock set is not required. Displayed, not adopted. This note does not
+write existential opposite into Admissibility and does not attach a
+formation member from later-tick six-neighbor locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py`](../scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse and face are scored on existence of an opposite pair in the
+later-tick six-neighbor lock sets. Named signs `{+,−}` are a coarser readout
+and are not used. A singleton unique lock-vector letter is a different
+readout and is not used. A `Z^3` sum of those locks is a different readout
+and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of later-tick six-neighbor lock sets on the four nnseed y-probes at the first T with all four recorded, with reverse hold and face hold from existential opposite; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: nnseed_yprobe_later_tick_existential_opposite_reverse_face
+target_blocker_text: "display reverse and face from existential opposite 6-NN locks at the first later tick when all four nnseed y-probes are recorded, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not use occupancy n, do not identify the sets with the probe's own incoming step, and do not identify the sets with nslate x-probe later-tick leftover."
+conditional_surface_status: "exact on B_3(0) for existential opposite of later-tick six-neighbor locks on the four nnseed y-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose later-tick
+six-neighbor lock sets are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_1, ±e_2, ±e_3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+perp-consistent locks `L(0)=+e_1` and `L(0,1,0)=+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not a member of `S_*(q)` scored below unless it appears
+as a lock of some six-neighbor of `q`.
+
+## Named existential opposite from later-tick six-neighbor locks
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `T` be the maximum of those four ticks. This `T` is the first
+tick in `B_3(0)` at which all four y-probes are recorded.
+
+At tick `T`, for each probe `q`, let `S_*(q)` be the set of locks of
+six-neighbors of `q` that formed at tick `≤ T` and are not `q`. Same-tick
+and later-than-formation neighbors count whenever they have formed by `T`.
+The probe itself is excluded. This display does not use occupancy `n`. It
+does not use the probe's own incoming lock. Duplicate locks at two neighbors
+collapse in the set. The construction does not require `S_*(q)` to be a
+singleton. It does not sum `S_*(q)`. It is not a unique lock-vector leftover
+and not a sum leftover. It is not leftover of nslate lists.
+
+Incoming `{±e_i}` tags of the probe itself are not `S_*(q)`. Identifying a
+named sign of those locks with reverse or face is refused: named-sign
+lettering lost the axis. Reverse and face are scored on existence of a pair
+of lock vectors that add to zero. They are not scored on `{+,−}` names and
+are not an occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in S_*(A) and some b in S_*(B) with a+b=(0,0,0)
+face     <=>  some c in S_*(C) and some d in S_*(D) with c+d=(0,0,0)
+```
+
+If `S_*(A)` or `S_*(B)` is empty, reverse is `UNDEFINED`. Else reverse fails
+if no such pair exists. If `S_*(C)` or `S_*(D)` is empty, face is
+`UNDEFINED`. Else face fails if no such pair exists. The report is one of
+`hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility.
+
+## Theorem 1 — later-tick lock sets at each y-probe
+
+Direct enumeration of the displayed nnseed process on `B_3(0)` forms all four
+y-probes. The formation ticks are `t(A)=0`, `t(B)=2`, `t(C)=3`, `t(D)=1`.
+`A` is a seed. All four are defined in `B_3(0)`, so
+
+```text
+T = max{t(A), t(B), t(C), t(D)} = 3.
+```
+
+At tick `T=3` the six-neighbor lock lists and lock sets are:
+
+```text
+A: +e_1 at (1, 1, 0), −e_1 at (-1, 1, 0), −e_1 at (0, 2, 0),
+   −e_3 at (0, 2, 0), +e_3 at (0, 2, 0), +e_1 at (0, 2, 0),
+   +e_1 at (0, 0, 0), +e_3 at (0, 1, 1), −e_3 at (0, 1, -1);
+   S_*(A) = {+e_1, −e_1, +e_3, −e_3}
+B: +e_1 at (2, 1, 1), +e_3 at (0, 1, 1), +e_3 at (1, 2, 1),
+   +e_2 at (1, 2, 1), +e_1 at (1, 2, 1), +e_1 at (1, 0, 1),
+   +e_3 at (1, 1, 2), +e_1 at (1, 1, 0);
+   S_*(B) = {+e_1, +e_2, +e_3}
+C: +e_2 at (1, 2, 0), +e_2 at (-1, 2, 0), +e_2 at (0, 1, 0),
+   +e_2 at (0, 2, 1), +e_2 at (0, 2, -1);
+   S_*(C) = {+e_2}
+D: +e_2 at (0, 1, 0), +e_2 at (1, 2, 0), −e_2 at (1, 0, 0),
+   +e_3 at (1, 1, 1), +e_1 at (1, 1, 1), −e_3 at (1, 1, -1),
+   +e_1 at (1, 1, -1);
+   S_*(D) = {+e_1, +e_2, −e_2, +e_3, −e_3}
+```
+
+`A`'s later-tick neighbors include the same-tick seed partner at the origin
+locking `+e_1` and later `C` mixing `±e_1` and `±e_3`. `A`'s own seed letter
+`+e_2` is not in `S_*(A)`: the probe is excluded, and no six-neighbor of `A`
+formed by `T` locks `+e_2`. `C`'s later-tick neighbors are five copies of
+`+e_2`, including the seed `A`. Mixed remains a set at `A`, `B`, and `D`.
+
+Incoming locks exist and need not be unique (`C` has four earliest incoming
+steps `±e_1` and `±e_3`; `B` has two). That non-uniqueness is not a
+unique-lettering of later-tick neighbor lock vectors. The lock sets are not
+identified with those incoming steps. Uniqueness is not required.
+
+The nslate x-probe later-tick lists are `{+e_1}`, `{+e_1, +e_2, +e_3}`,
+`{−e_2}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}`. Those are different lists:
+`S_*(A)` here is not `{+e_1}` and `S_*(C)` here is not `{−e_2}`. Shared
+probes `B` and `D` keep the same later-tick sets as nslate because they are
+the same sites at the same `T`. The frame still differs at `A` and at `C`.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if there exist `a` in `S_*(A)` and `b` in `S_*(B)`
+with `a+b=(0,0,0)`. Both sets are nonempty: `S_*(A)={+e_1, −e_1, +e_3, −e_3}`
+and `S_*(B)={+e_1, +e_2, +e_3}`. The pairs include `−e_1+(+e_1)=(0,0,0)` and
+`−e_3+(+e_3)=(0,0,0)`. Reverse holds.
+
+Reverse: hold
+
+This is not `fail` and not `UNDEFINED`. Unique lock-vector lettering of the
+same lists would assign mixed `S_*(A)` and mixed `S_*(B)` and would report
+reverse `UNDEFINED`. That readout is a different object and is not used. A
+sum leftover of the same lists would replace the sets by `(0,0,0)` and
+`(1,1,1)` and would report reverse fail. A named-sign readout of the same
+neighbor locks would lose the axis in mixed `{+,−}` at `A` against `+` at
+`B`. The nslate x-probe later-tick lists report reverse fail on different
+sets `{+e_1}` and `{+e_1, +e_2, +e_3}`. Reverse fail on those x-probes is
+frame-specific. Formation-time already-recorded neighbor locks at seed `A`
+are empty, so that leftover reverse is `UNDEFINED`.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if there exist `c` in `S_*(C)` and `d` in `S_*(D)`
+with `c+d=(0,0,0)`. Both sets are nonempty: `S_*(C)={+e_2}` and
+`S_*(D)={+e_1, +e_2, −e_2, +e_3, −e_3}`, so `+e_2+(−e_2)=(0,0,0)`. Face
+holds.
+
+Face: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+
+Named-sign lettering of the same lists is `C+` against a mixed `D`. Face as
+`C+` and `D−` fails on those signs. The vectors remain opposites. This note
+keeps the vectors. A sum leftover of `S_*(D)` would replace the set by
+`+e_1` and would fail face, while existential opposite holds. Unique
+lock-vector lettering of `S_*(D)` is mixed and would report face
+`UNDEFINED`. Formation-time already-recorded sets at `C` and `D` are both
+`{+e_2}` and fail face. The nslate x-probe later-tick lists also hold face,
+but from `{−e_2}` at x-probe `C`, a different list.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify lock sets with the probe's own incoming `{±e_i}`.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the later-tick lock set to be a singleton.
+- It does not sum the later-tick lock set.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from later-tick six-neighbor locks.
+- It does not census a sixteen-combination free lettering independent of
+  later-tick lock vectors.
+- It does not reprint nslate x-probe later-tick lock sets.
+- It does not reprint formation-time already-recorded lock sets.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+nnseed process, the later-tick six-neighbor lock sets, and the
+existential-opposite reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-site seed `+e_1/+e_2` |
+| later-tick six-neighbor lock sets at first `T` with all four y-probes recorded | Theorem 1 |
+| lock sets `S_*(A)`, `S_*(B)`, `S_*(C)`, `S_*(D)` | Theorem 1; `{+e_1, −e_1, +e_3, −e_3}`, `{+e_1, +e_2, +e_3}`, `{+e_2}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}` |
+| reverse and face | Theorems 2–3; `hold` / `hold` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| probe's own incoming lock as the set | not used |
+| formation member from later-tick six-neighbor locks | not attached |
+| leftover of nslate x-probe later-tick lists | not this display |
+| leftover of formation-time already-recorded sets | not this display |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: existential opposite of 6-NN locks at the first later tick when all four nnseed y-probes are recorded, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed later-tick existential-opposite neighbor-lock reverse/face report on these four nnseed y-probes. |
+| V3 | Later-tick lock sets and the `hold`/`hold` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads six-neighbor lock vectors at a later common tick and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not reduce them to named signs, does not require a singleton lock
+vector, does not sum the lock set, does not reprint nslate lists, and does
+not use occupancy `n`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique lock-vector lettering of the same neighbor locks | require a singleton `{v}` subset `{±e_i}` | refused; leftover; reverse and face would be `UNDEFINED` while both pairs of sets are nonempty |
+| sum of the same neighbor locks | replace `S_*` by the `Z^3` sum | refused; leftover; sum of `S_*(A)` is `(0,0,0)` and of `S_*(B)` is `(1,1,1)` and would fail reverse while `−e_1+(+e_1)=0`; sum of `S_*(D)` is `+e_1` and would fail face while `+e_2+(−e_2)=0` |
+| named-sign lettering of the same neighbor locks | map `±e_i` to `{+,−}` | refused; lost the axis; mixed `{+,−}` at `A` against `+` at `B` would hide `−e_1+(+e_1)=0`; `C+` against mixed `D` fails face while `+e_2+(−e_2)=0` |
+| identify lock sets with the probe's own incoming `{±e_i}` | map `A`'s seed letter `+e_2` into `S_*(A)` | refused; `S_*(A)` has no `+e_2`; `S_*(A)={+e_1, −e_1, +e_3, −e_3}` |
+| leftover of nslate x-probe later-tick lists | reuse `{+e_1}`, `{+e_1, +e_2, +e_3}`, `{−e_2}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}` with reverse fail | refused; different frame; `S_*(A)` and `S_*(C)` differ and reverse holds here |
+| leftover of formation-time already-recorded sets | reuse empty `A` and reverse `UNDEFINED` | refused; different set; later-tick `S_*(A)` is nonempty |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; not this display |
+| attach a formation member from later-tick six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; all four earliest incoming steps at `C` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from later-tick
+six-neighbor locks, and missing Record identification of existential opposite
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `+e_2`, perpendicular step
+rule, incoming-step lock, later-tick lock set of six-neighbors formed by the
+first `T` at which all four y-probes are recorded, existential opposite, four
+y-probes with seed `A`, and reverse/face as existence of a pair that sums to
+zero are declared. No uniqueness of incoming locks, no occupancy `n`, no
+named-sign reduction, no singleton leftover, no sum leftover, no nslate
+leftover, no formation attachment from later-tick six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`hold`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in a later-tick set | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four lock sets and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once a six-neighbor exists at the later common tick, the site
+should lock that unique vector as incoming content, mixed neighbor locks
+should make reverse `UNDEFINED`, the sets should be replaced by their sums,
+reverse should fail as it did on the nslate x-probes, named signs should
+suffice because they keep orientation, occupancy `n` should track that
+vector, and the formation-time already-recorded sets already answered the
+question.
+
+**Answer:** The named construction reports lock sets `{+e_1, −e_1, +e_3, −e_3}`,
+`{+e_1, +e_2, +e_3}`, `{+e_2}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}` at
+`A,B,C,D` from later-tick six-neighbor locks at `T=3`. Mixed remains a set.
+The construction does not sum. Occupancy `n` is not used. Named signs lost
+the axis. Some pair from `S_*(A)` and `S_*(B)` is opposite, so reverse holds.
+Face holds. Reverse fail on the nslate x-probes is frame-specific. The sets
+are not leftover of nslate lists. The bits remain displayed. Incoming-lock
+uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+Later-tick existential opposite on the nnseed x-probes reported reverse fail
+and face hold on different lists `{+e_1}`, `{+e_1, +e_2, +e_3}`, `{−e_2}`,
+`{+e_1, +e_2, −e_2, +e_3, −e_3}`. Unique lock-vector lettering of the
+later-tick y-probe lists would report reverse `UNDEFINED` because `S_*(A)`
+and `S_*(B)` mix, and face `UNDEFINED` because `S_*(D)` mixes. A sum leftover
+of the same lists would report reverse fail and face fail because the sums
+are `(0,0,0)` with `(1,1,1)` and `+e_2` with `+e_1`. Formation-time
+already-recorded sets at seed `A` are empty, so that leftover reverse is
+`UNDEFINED`, and the formation-time sets at `C` and `D` are both `{+e_2}` so
+that leftover face fails. Named-sign lettering of the later-tick lists
+reports mixed `{+,−}` at `A` against `+` at `B` and `C+` against mixed `D`.
+This note is not those displays: mixed remains a set, the construction does
+not sum, `−e_1+(+e_1)=(0,0,0)` so reverse holds, and `+e_2+(−e_2)=(0,0,0)`
+so face holds. Reverse fail on nnseed x-probes is frame-specific.
+
+**Gate disposition:** PASS for the later-tick six-neighbor-lock
+existential-opposite reverse/face reports above. FAIL / DO NOT SHIP for “the
+predicate equals the named sign,” “the predicate equals the unique singleton
+lock vector,” “the predicate equals the sum of the lock set,” “the lock set
+equals the probe's own incoming step,” “bits are Admissibility,” “the letter
+is occupancy `n`,” “the sets equal nslate lists,” or “reverse fails.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-site perp-step
+incoming-lock process, takes `T` as the first tick at which all four y-probes
+are recorded, collects six-neighbor locks formed by `T` at each probe with
+the probe excluded, reads the lock sets at the four y-probes, and checks
+Theorems 1--3. It also checks that the construction is not named-sign
+lettering, that mixed sets remain defined, that the construction does not
+sum, that the probe's own incoming step is not the lock set, that occupancy
+`n` is not used, that a formation member from later-tick six-neighbor locks
+is not attached, and that the sets are not leftover of nslate lists. No
+runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13221,6 +13221,10 @@
   "nn_lattice_rescaled_universal_parameter_theorem_note_2026-05-10": {
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
+  },
+  "nnseed_yprobe_later_tick_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.txt
@@ -1,0 +1,83 @@
+===== runner cache v1 =====
+runner: scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
+runner_sha256: 68d297db1ee31703c46366891c351002396a4a63cdb93bd55ce65442cfa8ee82
+input_fingerprint_sha256: d392efdbfbcee8d677b466275a6ff1d378d8ca24d85c15724385dbfc566f0446
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.07
+status: ok
+----- stdout -----
+later-tick existential opposite 6-NN reverse/face on nnseed y-probes
+AUDIT_INPUT_PATHS:
+  docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from existential opposite 6-NN locks at the first later tick when all four nnseed y-probes are recorded are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: theorem1-all-four-probes-recorded
+A t=0 S_*={+e_1, −e_1, +e_3, −e_3} incoming=+e_2
+B t=2 S_*={+e_1, +e_2, +e_3} incoming=+e_3,+e_1
+C t=3 S_*={+e_2} incoming=−e_1,−e_3,+e_3,+e_1
+D t=1 S_*={+e_1, +e_2, −e_2, +e_3, −e_3} incoming=+e_1
+T=3 t(A)=0 t(B)=2 t(C)=3 t(D)=1
+reverse=hold face=hold
+PASS: theorem1-later-tick-T  (3)
+PASS: theorem1-A-neighbor-lock-set  (((((1, 1, 0), (1, 0, 0)), ((-1, 1, 0), (-1, 0, 0)), ((0, 2, 0), (-1, 0, 0)), ((0, 2, 0), (0, 0, -1)), ((0, 2, 0), (0, 0, 1)), ((0, 2, 0), (1, 0, 0)), ((0, 0, 0), (1, 0, 0)), ((0, 1, 1), (0, 0, 1)), ((0, 1, -1), (0, 0, -1))), frozenset({(1, 0, 0), (-1, 0, 0), (0, 0, 1), (0, 0, -1)})))
+PASS: theorem1-B-neighbor-lock-set  (((((2, 1, 1), (1, 0, 0)), ((0, 1, 1), (0, 0, 1)), ((1, 2, 1), (0, 0, 1)), ((1, 2, 1), (0, 1, 0)), ((1, 2, 1), (1, 0, 0)), ((1, 0, 1), (1, 0, 0)), ((1, 1, 2), (0, 0, 1)), ((1, 1, 0), (1, 0, 0))), frozenset({(1, 0, 0), (0, 0, 1), (0, 1, 0)})))
+PASS: theorem1-C-neighbor-lock-set  (((((1, 2, 0), (0, 1, 0)), ((-1, 2, 0), (0, 1, 0)), ((0, 1, 0), (0, 1, 0)), ((0, 2, 1), (0, 1, 0)), ((0, 2, -1), (0, 1, 0))), frozenset({(0, 1, 0)})))
+PASS: theorem1-D-neighbor-lock-set  (((((0, 1, 0), (0, 1, 0)), ((1, 2, 0), (0, 1, 0)), ((1, 0, 0), (0, -1, 0)), ((1, 1, 1), (0, 0, 1)), ((1, 1, 1), (1, 0, 0)), ((1, 1, -1), (0, 0, -1)), ((1, 1, -1), (1, 0, 0))), frozenset({(0, 1, 0), (0, -1, 0), (1, 0, 0), (0, 0, -1), (0, 0, 1)})))
+PASS: theorem1-A-B-mixed-vectors-remain-a-set
+PASS: theorem1-D-mixed-vectors-remain-a-set
+PASS: theorem2-reverse-hold  (hold)
+PASS: theorem3-face-hold  (hold)
+PASS: not-leftover-of-formation-time
+PASS: not-leftover-of-nslate-lists
+PASS: later-tick-includes-post-formation-neighbors
+PASS: sign-lettering-loses-axis-and-would-hide-hold
+PASS: not-probe-own-incoming-lock
+PASS: not-sum-leftover
+PASS: not-unique-vector-leftover
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required  ([(-1, 0, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0)])
+PASS: two-site-seed-locks
+PASS: later-tick-not-self-and-formed-by-T
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: perp-step-incoming-lock
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: note-claim-scope
+PASS: note-reports-neighbor-lock-sets
+PASS: note-reports-hold-hold
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-leftover
+PASS: note-not-leftover-of-nslate
+PASS: note-later-tick-T-defined
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-existential-opposite-only
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
+++ b/scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py
@@ -1,0 +1,871 @@
+#!/usr/bin/env python3
+"""Later-tick existential opposite 6-NN reverse/face on four nnseed y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and +e_2. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. Let T be the max of t(A), t(B), t(C), t(D) among those defined in
+B_3(0): the first later tick at which all four y-probes are recorded. At
+tick T, S_*(q) is the set of locks of 6-NN of q that formed at tick <= T
+and are not q. Reverse holds iff some a in S_*(A) and some b in S_*(B) have
+a+b=(0,0,0). Face holds iff some c in S_*(C) and some d in S_*(D) have
+c+d=(0,0,0). Empty S_* on either side is UNDEFINED; nonempty with no
+opposite pair fails. Not leftover of nslate lists (different frame). Not
+unique-vector leftover. Not sum leftover. Not named-sign lettering.
+Occupancy n is not used. The probe's own incoming lock is not used.
+Uniqueness of incoming locks is not required.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+    "P_+",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from existential opposite 6-NN locks at "
+    "the first later tick when all four nnseed y-probes are recorded are "
+    "reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def recorded_lock_set(pairs: tuple[tuple[Point, Point], ...]) -> frozenset[Point]:
+    """Set of later-tick six-neighbor locks. Duplicates collapse."""
+    return frozenset(lock for _neighbor, lock in pairs)
+
+
+def existential_opposite(left: frozenset[Point], right: frozenset[Point]) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    Empty set on either side is UNDEFINED. Nonempty with no opposite pair fails.
+    Does not sum. Does not require a singleton.
+    """
+    if not left or not right:
+        return "UNDEFINED"
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: frozenset[Point], set_b: frozenset[Point]) -> str:
+    """Reverse iff some a in S_*(A) and some b in S_*(B) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: frozenset[Point], set_d: frozenset[Point]) -> str:
+    """Face iff some c in S_*(C) and some d in S_*(D) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def later_tick_T(
+    ticks: dict[Point, int],
+    probes: dict[str, Point] = PROBES,
+) -> int | None:
+    """First later tick at which all named probes are recorded, or None."""
+    defined = [ticks[probes[name]] for name in ("A", "B", "C", "D") if probes[name] in ticks]
+    if len(defined) != 4:
+        return None
+    return max(defined)
+
+
+def later_tick_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    common_tick: int,
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of 6-NN of site formed at tick <= common_tick, site excluded."""
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] > common_tick:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def strictly_earlier_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Formation-time leftover: already-recorded 6-NN locks at formation of site."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    """Z^3 sum leftover of a lock set. Contrast only; not this letter."""
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("later-tick existential opposite 6-NN reverse/face on nnseed y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(NEG_E3, E3) == ZERO
+        and add(E1, E1) != ZERO
+        and add(E1, E2) != ZERO
+        and add(E1, E3) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    set_a = frozenset({E1, NEG_E1, E3, NEG_E3})
+    set_b = frozenset({E1, E2, E3})
+    set_c = frozenset({E2})
+    set_d = frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(frozenset(), frozenset({E1})) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and existential_opposite(set_a, set_b) == "hold"
+        and existential_opposite(set_c, set_d) == "hold"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold",
+    )
+
+    ticks, locks = form()
+    common_tick = later_tick_T(ticks)
+    checks.check(
+        "theorem1-all-four-probes-recorded",
+        all(PROBES[name] in ticks for name in ("A", "B", "C", "D"))
+        and common_tick is not None,
+    )
+    assert common_tick is not None
+
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    lock_sets: dict[str, frozenset[Point]] = {}
+    leftover_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    leftover_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        pairs = later_tick_neighbor_locks(site, ticks, locks, common_tick)
+        neighbor_lists[name] = pairs
+        lock_sets[name] = recorded_lock_set(pairs)
+        leftover = strictly_earlier_neighbor_locks(site, ticks, locks)
+        leftover_lists[name] = leftover
+        leftover_sets[name] = recorded_lock_set(leftover)
+        incoming = ",".join(LOCK_NAME[lock] for lock in sorted(locks[site]))
+        print(
+            f"{name} t={ticks[site]} S_*={set_display(lock_sets[name])} "
+            f"incoming={incoming}"
+        )
+
+    print(
+        f"T={common_tick} "
+        f"t(A)={ticks[PROBES['A']]} t(B)={ticks[PROBES['B']]} "
+        f"t(C)={ticks[PROBES['C']]} t(D)={ticks[PROBES['D']]}"
+    )
+    reverse_status = reverse_report(lock_sets["A"], lock_sets["B"])
+    face_status = face_report(lock_sets["C"], lock_sets["D"])
+    leftover_reverse = reverse_report(leftover_sets["A"], leftover_sets["B"])
+    leftover_face = face_report(leftover_sets["C"], leftover_sets["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+
+    nslate_common = later_tick_T(ticks, X_PROBES)
+    nslate_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    nslate_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = X_PROBES[name]
+        pairs = later_tick_neighbor_locks(site, ticks, locks, nslate_common or 0)
+        nslate_lists[name] = pairs
+        nslate_sets[name] = recorded_lock_set(pairs)
+    nslate_reverse = reverse_report(nslate_sets["A"], nslate_sets["B"])
+    nslate_face = face_report(nslate_sets["C"], nslate_sets["D"])
+
+    checks.check(
+        "theorem1-later-tick-T",
+        common_tick == 3
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 1
+        and common_tick
+        == max(
+            ticks[PROBES["A"]],
+            ticks[PROBES["B"]],
+            ticks[PROBES["C"]],
+            ticks[PROBES["D"]],
+        ),
+        str(common_tick),
+    )
+    checks.check(
+        "theorem1-A-neighbor-lock-set",
+        neighbor_lists["A"]
+        == (
+            (PROBES["D"], E1),
+            ((-1, 1, 0), NEG_E1),
+            (PROBES["C"], NEG_E1),
+            (PROBES["C"], NEG_E3),
+            (PROBES["C"], E3),
+            (PROBES["C"], E1),
+            (ORIGIN, E1),
+            ((0, 1, 1), E3),
+            ((0, 1, -1), NEG_E3),
+        )
+        and lock_sets["A"] == set_a,
+        str((neighbor_lists["A"], lock_sets["A"])),
+    )
+    checks.check(
+        "theorem1-B-neighbor-lock-set",
+        neighbor_lists["B"]
+        == (
+            ((2, 1, 1), E1),
+            ((0, 1, 1), E3),
+            ((1, 2, 1), E3),
+            ((1, 2, 1), E2),
+            ((1, 2, 1), E1),
+            ((1, 0, 1), E1),
+            ((1, 1, 2), E3),
+            (PROBES["D"], E1),
+        )
+        and lock_sets["B"] == set_b,
+        str((neighbor_lists["B"], lock_sets["B"])),
+    )
+    checks.check(
+        "theorem1-C-neighbor-lock-set",
+        neighbor_lists["C"]
+        == (
+            ((1, 2, 0), E2),
+            ((-1, 2, 0), E2),
+            (PROBES["A"], E2),
+            ((0, 2, 1), E2),
+            ((0, 2, -1), E2),
+        )
+        and lock_sets["C"] == set_c
+        and ticks.get((0, 3, 0)) == 4,
+        str((neighbor_lists["C"], lock_sets["C"])),
+    )
+    checks.check(
+        "theorem1-D-neighbor-lock-set",
+        neighbor_lists["D"]
+        == (
+            (E2, E2),
+            ((1, 2, 0), E2),
+            ((1, 0, 0), NEG_E2),
+            (PROBES["B"], E3),
+            (PROBES["B"], E1),
+            ((1, 1, -1), NEG_E3),
+            ((1, 1, -1), E1),
+        )
+        and lock_sets["D"] == set_d,
+        str((neighbor_lists["D"], lock_sets["D"])),
+    )
+    checks.check(
+        "theorem1-A-B-mixed-vectors-remain-a-set",
+        lock_sets["A"] == set_a
+        and lock_sets["B"] == set_b
+        and len(lock_sets["A"]) == 4
+        and len(lock_sets["B"]) == 3
+        and named_sign(E1) == named_sign(E2) == named_sign(E3) == "+",
+    )
+    checks.check(
+        "theorem1-D-mixed-vectors-remain-a-set",
+        lock_sets["D"] == set_d
+        and len(lock_sets["D"]) == 5
+        and lock_sets["C"] == set_c,
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse_status == "hold"
+        and lock_sets["A"] == set_a
+        and lock_sets["B"] == set_b
+        and NEG_E1 in lock_sets["A"]
+        and E1 in lock_sets["B"]
+        and add(NEG_E1, E1) == ZERO
+        and NEG_E3 in lock_sets["A"]
+        and E3 in lock_sets["B"]
+        and add(NEG_E3, E3) == ZERO
+        and lock_sets["A"]
+        and lock_sets["B"],
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and lock_sets["C"] == set_c
+        and E2 in lock_sets["C"]
+        and NEG_E2 in lock_sets["D"]
+        and add(E2, NEG_E2) == ZERO,
+        face_status,
+    )
+    checks.check(
+        "not-leftover-of-formation-time",
+        leftover_sets["A"] == frozenset()
+        and leftover_sets["B"] == frozenset({E1, E3})
+        and leftover_sets["C"] == frozenset({E2})
+        and leftover_sets["D"] == frozenset({E2})
+        and leftover_sets["A"] != lock_sets["A"]
+        and leftover_sets["B"] != lock_sets["B"]
+        and leftover_sets["D"] != lock_sets["D"]
+        and leftover_reverse == "UNDEFINED"
+        and leftover_face == "fail"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-leftover-of-nslate-lists",
+        probe_sites != x_probe_sites
+        and nslate_common == 3
+        and nslate_sets["A"] == frozenset({E1})
+        and nslate_sets["B"] == frozenset({E1, E2, E3})
+        and nslate_sets["C"] == frozenset({NEG_E2})
+        and nslate_sets["D"] == frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+        and nslate_reverse == "fail"
+        and nslate_face == "hold"
+        and reverse_status == "hold"
+        and reverse_status != nslate_reverse
+        and lock_sets["A"] != nslate_sets["A"]
+        and lock_sets["C"] != nslate_sets["C"]
+        and nslate_lists["A"] != neighbor_lists["A"]
+        and nslate_lists["C"] != neighbor_lists["C"],
+    )
+    checks.check(
+        "later-tick-includes-post-formation-neighbors",
+        any(ticks[neighbor] > ticks[PROBES["A"]] for neighbor, _lock in neighbor_lists["A"])
+        and any(ticks[neighbor] > ticks[PROBES["B"]] for neighbor, _lock in neighbor_lists["B"])
+        and any(ticks[neighbor] > ticks[PROBES["D"]] for neighbor, _lock in neighbor_lists["D"])
+        and all(
+            ticks[neighbor] <= ticks[PROBES["C"]] for neighbor, _lock in neighbor_lists["C"]
+        ),
+    )
+    checks.check(
+        "sign-lettering-loses-axis-and-would-hide-hold",
+        named_sign(NEG_E1) == "-"
+        and named_sign(E1) == "+"
+        and named_sign(E2) == "+"
+        and named_sign(NEG_E2) == "-"
+        and not (named_sign(E2) == "+" and named_sign(NEG_E2) == "-" and False)
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-probe-own-incoming-lock",
+        locks[PROBES["A"]] == {E2}
+        and lock_sets["A"] == set_a
+        and E2 not in lock_sets["A"]
+        and locks[PROBES["C"]] == {E1, NEG_E1, E3, NEG_E3}
+        and lock_sets["C"] == set_c
+        and lock_sets["C"] != locks[PROBES["C"]],
+    )
+    checks.check(
+        "not-sum-leftover",
+        sum_of_set(lock_sets["A"]) == ZERO
+        and sum_of_set(lock_sets["B"]) == (1, 1, 1)
+        and sum_of_set(lock_sets["C"]) == E2
+        and sum_of_set(lock_sets["D"]) == E1
+        and add(sum_of_set(lock_sets["A"]), sum_of_set(lock_sets["B"])) != ZERO
+        and add(sum_of_set(lock_sets["C"]), sum_of_set(lock_sets["D"])) != ZERO
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-unique-vector-leftover",
+        len(lock_sets["A"]) > 1
+        and len(lock_sets["B"]) > 1
+        and len(lock_sets["D"]) > 1
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 2
+        and len(locks[PROBES["C"]]) == 4
+        and lock_sets["B"] == set_b
+        and lock_sets["C"] == set_c,
+        str(sorted(locks[PROBES["C"]])),
+    )
+    checks.check(
+        "two-site-seed-locks",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E2}
+        and PROBES["A"] == E2,
+    )
+    checks.check(
+        "later-tick-not-self-and-formed-by-T",
+        all(neighbor != PROBES[name] for name in PROBES for neighbor, _lock in neighbor_lists[name])
+        and all(
+            ticks[neighbor] <= common_tick
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E2, NEG_E2)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[(0, -1, 0)] == 1
+        and ticks[E3] == 1
+        and ticks[(0, 0, -1)] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        recorded_lock_set(()) == frozenset()
+        and reverse_report(frozenset(), lock_sets["B"]) == "UNDEFINED"
+        and face_report(lock_sets["C"], frozenset()) == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and reverse_status == "hold",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-neighbor-lock-sets",
+        "S_*(A) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "S_*(B) = {+e_1, +e_2, +e_3}" in note
+        and "S_*(C) = {+e_2}" in note
+        and "S_*(D) = {+e_1, +e_2, −e_2, +e_3, −e_3}" in note
+        and "T = max{t(A), t(B), t(C), t(D)} = 3." in note
+        and "+e_1 at (1, 1, 0)" in note
+        and "−e_1 at (-1, 1, 0)" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_2 at (1, 2, 0)" in note
+        and "+e_2 at (0, 1, 0)" in note
+        and "−e_2 at (1, 0, 0)" in note
+        and "−e_3 at (1, 1, -1)" in note,
+    )
+    checks.check(
+        "note-reports-hold-hold",
+        "Reverse: hold" in note
+        and "Face: hold" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note
+        and "C+" in note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note
+        and "S_*(A)` has no `+e_2`" in note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from later-tick six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "Reverse holds." in note,
+    )
+    checks.check(
+        "note-not-leftover-of-nslate",
+        "not leftover of nslate lists" in normalized_note
+        and "different frame" in normalized_note
+        and "frame-specific" in normalized_note,
+    )
+    checks.check(
+        "note-later-tick-T-defined",
+        "first later tick" in normalized_note
+        and "all four" in normalized_note
+        and "tick `≤ T`" in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/NNSEED_YPROBE_LATER_TICK_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def existential_opposite(" in source
+        and "def recorded_lock_set(" in source
+        and "def later_tick_neighbor_locks(" in source
+        and "def later_tick_T(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-existential-opposite-only",
+        "existential_opposite" in defined_fns
+        and "recorded_lock_set" in defined_fns
+        and "later_tick_neighbor_locks" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Later-tick existential opposite on nnseed y-probes. Reverse HOLD and face HOLD. HOLDING_MEMBER (displayed, not adopted). nslate #7096 x-probe reverse-fail is frame-specific.

## Runner

`scripts/nnseed_yprobe_later_tick_existential_opposite_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.