### PR TITLE
feat(nsopytmin): nsopp y-probe later-tick exist-opposite: reverse HOLD, face HOLD first at T=2

### DIFF
--- a/docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,529 @@
+---
+claim_id: opposite_lock_yprobe_minimal_t_existential_opposite_holding_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "The later-tick exist-opposite reverse/face bits on nsopp y-probes at each T, and the smallest T at which both HOLD, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py
+---
+
+# Minimal T Later-Tick Existential Opposite Holding On Four Opposite-Lock Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** the later-tick exist-opposite reverse/face bits on the four
+opposite-lock y-probes at each integer T from 0 through the max formation
+tick of those probes in `B_3(0)`, and the smallest T at which reverse_T
+HOLD and face_T HOLD. Let `t(q)` be the formation tick of probe `q`. Let
+`T_max` be the maximum of `t(A)`, `t(B)`, `t(C)`, `t(D)` among those defined
+in `B_3(0)`. For each integer T from 0 through `T_max`, at tick T let
+`S_T(q)` be the set of locks of six-neighbors of `q` that formed at tick
+`≤ T` and are not `q`. Reverse_T holds if and only if some lock in `S_T(A)`
+is the vector opposite of some lock in `S_T(B)`. Face_T holds if and only
+if some lock in `S_T(C)` is the vector opposite of some lock in `S_T(D)`.
+Empty `S_T` on either side of a comparison is `UNDEFINED`; nonempty with no
+opposite pair fails. Occupancy `n` is not used. The probe's own incoming
+lock is not used. This is not named-sign lettering. This is not a unique
+lock-vector leftover and not a sum leftover. This is not leftover of the
+global-T=3 later-tick lists on these same y-probes: that display waits for
+the first T at which all four probes are recorded and reports different
+lock sets. This is not leftover of formation-tick already-recorded sets:
+that readout takes strictly earlier neighbors at each probe's own `t` and
+finds empty `S(A)`, so reverse is `UNDEFINED`. Uniqueness of incoming locks
+is not required. Uniqueness of the lock set is not required. Displayed, not
+adopted. This note does not write existential opposite into Admissibility
+and does not attach a formation member from later-tick six-neighbor locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py`](../scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse_T and face_T are scored on existence of an opposite pair in
+the later-tick six-neighbor lock sets at that T. Named signs `{+,−}` are a
+coarser readout and are not used. A singleton unique lock-vector letter is a
+different readout and is not used. A `Z^3` sum of those locks is a different
+readout and is not used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of later-tick six-neighbor lock reverse/face bits on the four opposite-lock y-probes at each T through T_max, and of the smallest T at which both HOLD; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: opposite_lock_yprobe_minimal_t_existential_opposite_holding
+target_blocker_text: "for T=0,1,2,... up to max formation tick of the four nsopp y-probes, score later-tick exist-opposite reverse and face at that T; report the smallest T with reverse AND face HOLD, or none"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse_T and face_T displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not use occupancy n, do not identify the sets with the probe's own incoming step, and do not identify the T=2 sets with the global-T=3 later-tick lists."
+conditional_surface_status: "exact on B_3(0) for existential opposite of later-tick six-neighbor locks on the four opposite-lock y-probes at each T through T_max; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose later-tick
+six-neighbor lock sets are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+opposite locks `L(0)=+e_1` and `L(0,1,0)=−e_1`. This seed is not the perp
+two-site seed `+e_1/+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+That incoming lock is not a member of `S_T(q)` scored below unless it appears
+as a lock of some six-neighbor of `q`.
+
+## Named existential opposite from later-tick six-neighbor locks at each T
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `T_max` be the maximum of those four ticks. Direct enumeration
+gives `t(A)=0`, `t(B)=2`, `t(C)=1`, `t(D)=3`, so `T_max=3`. The display
+scans T=0,1,2,3. It does not scan a larger ball and does not use formation
+ticks of sites other than the four y-probes to set the upper bound.
+
+The scan is for each integer T from 0 through `T_max`. At that T, for each
+probe `q`, let `S_T(q)`
+be the set of locks of six-neighbors of `q` that formed at tick `≤ T` and
+are not `q`. Same-tick and later-than-formation neighbors count whenever they
+have formed by T. The probe itself is excluded. This display does not use
+occupancy `n`. It does not use the probe's own incoming lock. Duplicate locks
+at two neighbors collapse in the set. The construction does not require
+`S_T(q)` to be a singleton. It does not sum `S_T(q)`. It is not a unique
+lock-vector leftover and not a sum leftover. It is not leftover of the
+global-T=3 later-tick lists. It is not leftover of formation-tick
+already-recorded lock sets.
+
+Incoming `{±e_i}` tags of the probe itself are not `S_T(q)`. Identifying a
+named sign of those locks with reverse or face is refused: named-sign
+lettering lost the axis. Reverse and face are scored on existence of a pair
+of lock vectors that add to zero. They are not scored on `{+,−}` names and
+are not an occupancy-kernel inner product.
+
+Reverse_T and face_T (displayed):
+
+```text
+reverse_T  <=>  some a in S_T(A) and some b in S_T(B) with a+b=(0,0,0)
+face_T     <=>  some c in S_T(C) and some d in S_T(D) with c+d=(0,0,0)
+```
+
+If `S_T(A)` or `S_T(B)` is empty, reverse_T is `UNDEFINED`. Else reverse_T
+fails if no such pair exists. If `S_T(C)` or `S_T(D)` is empty, face_T is
+`UNDEFINED`. Else face_T fails if no such pair exists. The report is one of
+`hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility.
+
+## Theorem 1 — reverse_T and face_T for each T
+
+Direct enumeration of the displayed opposite-lock process on `B_3(0)` forms
+all four y-probes. The formation ticks are `t(A)=0`, `t(B)=2`, `t(C)=1`,
+`t(D)=3`. `A` is a seed. All four are defined in `B_3(0)`, so
+
+```text
+T_max = max{t(A), t(B), t(C), t(D)} = 3.
+```
+
+At each T the six-neighbor lock lists, lock sets, and bits are as follows.
+
+### T=0
+
+```text
+A: +e_1 at (0, 0, 0);
+   S_0(A) = {+e_1}
+B: (empty);
+   S_0(B) = {}
+C: −e_1 at (0, 1, 0);
+   S_0(C) = {−e_1}
+D: −e_1 at (0, 1, 0);
+   S_0(D) = {−e_1}
+```
+
+`S_0(B)` is empty, so reverse_0 is `UNDEFINED`. Both `S_0(C)` and `S_0(D)`
+equal `{−e_1}` and `−e_1+(−e_1)≠(0,0,0)`, so face_0 fails.
+
+T=0: reverse UNDEFINED, face fail
+
+### T=1
+
+```text
+A: +e_2 at (0, 2, 0), +e_1 at (0, 0, 0), +e_3 at (0, 1, 1),
+   −e_3 at (0, 1, -1);
+   S_1(A) = {+e_1, +e_2, +e_3, −e_3}
+B: +e_3 at (0, 1, 1);
+   S_1(B) = {+e_3}
+C: −e_1 at (0, 1, 0);
+   S_1(C) = {−e_1}
+D: −e_1 at (0, 1, 0);
+   S_1(D) = {−e_1}
+```
+
+Both reverse sides are nonempty. The pair `−e_3` in `S_1(A)` with `+e_3` in
+`S_1(B)` sums to zero, so reverse_1 holds. Face_1 still sees `{−e_1}` on
+both sides, so face_1 fails.
+
+T=1: reverse hold, face fail
+
+### T=2
+
+```text
+A: +e_2 at (0, 2, 0), +e_1 at (0, 0, 0), +e_3 at (0, 1, 1),
+   −e_3 at (0, 1, -1);
+   S_2(A) = {+e_1, +e_2, +e_3, −e_3}
+B: +e_3 at (0, 1, 1), +e_1 at (1, 0, 1);
+   S_2(B) = {+e_1, +e_3}
+C: +e_1 at (1, 2, 0), −e_1 at (-1, 2, 0), −e_1 at (0, 1, 0),
+   +e_3 at (0, 2, 1), +e_2 at (0, 2, 1), −e_3 at (0, 2, -1),
+   +e_2 at (0, 2, -1);
+   S_2(C) = {+e_1, −e_1, +e_2, +e_3, −e_3}
+D: −e_1 at (0, 1, 0), +e_1 at (1, 2, 0), +e_1 at (1, 1, 1),
+   +e_1 at (1, 1, -1);
+   S_2(D) = {+e_1, −e_1}
+```
+
+Both reverse sides are nonempty. The pair `−e_3` in `S_2(A)` with `+e_3` in
+`S_2(B)` sums to zero, so reverse_2 holds. Both face sides are nonempty.
+The pair `−e_1` in `S_2(C)` with `+e_1` in `S_2(D)` sums to zero, so face_2
+holds. Mixed remains a set. `S_2(A)` has no `−e_1`: the probe is excluded,
+and no six-neighbor of `A` formed by T=2 locks `−e_1`.
+
+T=2: reverse hold, face hold
+
+These T=2 sets are not the global-T=3 later-tick lists:
+`S_2(A)` lacks `−e_2`, `S_2(B)={+e_1, +e_3}` is not the T=3 five-letter
+set, and `S_2(D)={+e_1, −e_1}` is not the T=3 five-letter set.
+
+### T=3
+
+```text
+A: −e_2 at (1, 1, 0), −e_3 at (1, 1, 0), +e_3 at (1, 1, 0),
+   −e_2 at (-1, 1, 0), −e_3 at (-1, 1, 0), +e_3 at (-1, 1, 0),
+   +e_2 at (0, 2, 0), +e_1 at (0, 0, 0), +e_3 at (0, 1, 1),
+   −e_3 at (0, 1, -1);
+   S_3(A) = {+e_1, +e_2, −e_2, +e_3, −e_3}
+B: +e_3 at (0, 1, 1), +e_3 at (1, 2, 1), +e_2 at (1, 2, 1),
+   +e_1 at (1, 2, 1), +e_1 at (1, 0, 1), +e_3 at (1, 1, 2),
+   −e_2 at (1, 1, 0), −e_3 at (1, 1, 0), +e_3 at (1, 1, 0);
+   S_3(B) = {+e_1, +e_2, −e_2, +e_3, −e_3}
+C: +e_1 at (1, 2, 0), −e_1 at (-1, 2, 0), −e_1 at (0, 1, 0),
+   +e_3 at (0, 2, 1), +e_2 at (0, 2, 1), −e_3 at (0, 2, -1),
+   +e_2 at (0, 2, -1);
+   S_3(C) = {+e_1, −e_1, +e_2, +e_3, −e_3}
+D: −e_1 at (0, 1, 0), +e_1 at (1, 2, 0), −e_3 at (1, 0, 0),
+   +e_3 at (1, 0, 0), +e_2 at (1, 0, 0), +e_1 at (1, 1, 1),
+   +e_1 at (1, 1, -1);
+   S_3(D) = {+e_1, −e_1, +e_2, +e_3, −e_3}
+```
+
+Both pairs of sets are nonempty. Reverse_3 holds by `+e_2+(−e_2)=(0,0,0)`.
+Face_3 holds by `−e_1+(+e_1)=(0,0,0)`. This T=3 row is the global later-tick
+display; it is recorded here only as the last row of the T-scan. The
+minimal-T answer below is not this row.
+
+T=3: reverse hold, face hold
+
+Incoming locks exist and need not be unique (`D` has three earliest incoming
+steps `−e_2`, `−e_3`, and `+e_3`). That non-uniqueness is not a
+unique-lettering of later-tick neighbor lock vectors. The lock sets are not
+identified with those incoming steps. Uniqueness is not required.
+
+## Theorem 2 — smallest T with reverse_T HOLD and face_T HOLD
+
+Scan T=0,1,2,3 from Theorem 1. Both bits HOLD first at T=2. No smaller T in
+the scan has reverse_T hold and face_T hold: T=0 has reverse `UNDEFINED` and
+face fail; T=1 has reverse hold and face fail. T=3 also has both hold, but
+it is later.
+
+Smallest T: 2
+
+The T=2 lock sets are not leftover of the global-T=3 later-tick lists, as
+recorded in Theorem 1. They are not leftover of formation-tick
+already-recorded sets: formation-tick `S(A)` is empty, so that leftover
+reverse is `UNDEFINED`, while `S_2(A)` is nonempty and reverse_2 holds.
+
+## Theorem 3 — displayed, not adopted
+
+Displayed, not adopted. The bits are not written into Admissibility.
+
+The T-scan and the smallest T=2 are theorem-domain data. This note does not
+rewrite the local rule by existential opposite. It does not attach a
+formation member from later-tick six-neighbor locks.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not identify lock sets with the probe's own incoming `{±e_i}`.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the later-tick lock set to be a singleton.
+- It does not sum the later-tick lock set.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from later-tick six-neighbor locks.
+- It does not census a sixteen-combination free lettering independent of
+  later-tick lock vectors.
+- It does not reprint unique own-incoming lock-vector letters on these
+  y-probes.
+- It does not reprint later-tick existential opposite on the nnseed x-probes.
+- It does not reprint formation-tick already-recorded lock sets as the
+  scored object.
+- It does not take the global-T=3 later-tick lists as the scored object for
+  the smallest-T answer.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+opposite-lock process, the later-tick six-neighbor lock sets at each T, the
+existential-opposite reverse_T/face_T predicates, and the smallest T at which
+both HOLD are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; opposite-lock two-site seed `+e_1/−e_1` |
+| later-tick six-neighbor lock sets at each T through `T_max=3` | Theorem 1 |
+| reverse_T and face_T at T=0,1,2,3 | Theorem 1; `UNDEFINED`/`fail`, `hold`/`fail`, `hold`/`hold`, `hold`/`hold` |
+| smallest T with both HOLD | Theorem 2; `2` |
+| displayed, not adopted | Theorem 3 |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| probe's own incoming lock as the set | not used |
+| formation member from later-tick six-neighbor locks | not attached |
+| leftover of unique own-incoming letters on these y-probes | not this display |
+| leftover of nnseed x-probe later-tick existential opposite | not this display |
+| leftover of formation-tick already-recorded sets | not this display |
+| leftover of the global-T=3 later-tick lists | not this display |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: later-tick exist-opposite reverse/face on nsopp y-probes at each T through T_max, and the smallest T at which both HOLD, or none. |
+| V2 | Current main has no landed per-T later-tick existential-opposite reverse/face scan on these four opposite-lock y-probes, and no smallest-T HOLD report. |
+| V3 | The per-T lock sets, the `UNDEFINED`/`fail`/`hold` reports, and smallest T=2 are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads six-neighbor lock vectors at each later tick T and scores existence of an opposite pair, then takes the first T at which both bits HOLD. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not identify them with the probe's own incoming steps,
+does not reduce them to named signs, does not require a singleton lock
+vector, does not sum the lock set, does not reprint unique own-incoming
+letters, does not reprint nnseed x-probe later-tick leftover, does not
+reprint formation-tick leftover, does not take the global-T=3 lists as the
+minimal-T object, and does not use occupancy `n`. No global impossibility is
+claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique lock-vector lettering of the same neighbor locks | require a singleton `{v}` subset `{±e_i}` | refused; leftover; reverse and face would be `UNDEFINED` while both pairs of sets at T=2 are nonempty |
+| sum of the same neighbor locks | replace `S_T` by the `Z^3` sum | refused; leftover; sum of `S_2(A)` is `+e_1++e_2` and sum of `S_2(B)` is `+e_1++e_3`, which do not cancel, while `−e_3++e_3=0` |
+| named-sign lettering of the same neighbor locks | map `±e_i` to `{+,−}` | refused; lost the axis; mixed `{+,−}` at `A` would hide `−e_3++e_3=0` |
+| identify lock sets with the probe's own incoming `{±e_i}` | map `A`'s seed letter `−e_1` into `S_2(A)` | refused; `S_2(A)` has no `−e_1`; `S_2(A)={+e_1, +e_2, +e_3, −e_3}` |
+| unique own-incoming lock-vector leftover on these y-probes | reuse `L(A)=−e_1`, `L(B)=+e_1`, `L(C)=+e_2`, `L(D)=UNDEFINED` | refused; different object; that leftover reports face `UNDEFINED` while later-tick `S_2(D)` is nonempty and face_2 holds |
+| leftover of nnseed x-probe later-tick existential opposite | reuse seed `+e_1/+e_2` and x-probes with reverse fail | refused; different process and different frame; reverse_2 holds here |
+| leftover of formation-tick already-recorded sets | reuse empty `A` and reverse `UNDEFINED` | refused; different set; later-tick `S_2(A)` is nonempty and reverse_2 holds |
+| leftover of the global-T=3 later-tick lists | reuse `S_3` as the scored object for the smallest T | refused; `S_2` differs from `S_3`; smallest T is 2, not 3 |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; not this display |
+| attach a formation member from later-tick six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; all three earliest incoming steps at `D` are kept |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from later-tick
+six-neighbor locks, and missing Record identification of existential opposite
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `−e_1`, perpendicular step
+rule, incoming-step lock, later-tick lock set of six-neighbors formed by each
+integer T through the max formation tick of the four y-probes, existential
+opposite, four y-probes with seed `A`, reverse_T/face_T as existence of a
+pair that sums to zero, and smallest T with both HOLD are declared. No
+uniqueness of incoming locks, no occupancy `n`, no named-sign reduction, no
+singleton leftover, no sum leftover, no unique own-incoming leftover, no
+nnseed x-probe leftover, no formation-tick leftover, no global-T=3 list
+leftover, no formation attachment from later-tick six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+smallest-T HOLD report does not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in a later-tick set | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four lock sets at each T and two reverse/face comparisons, then smallest T | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Once a six-neighbor exists at a later tick, the site should
+lock that unique vector as incoming content, mixed neighbor locks should
+make reverse and face `UNDEFINED`, the sets should be replaced by their
+sums, unique own-incoming letters already answered reverse hold with face
+`UNDEFINED`, nnseed x-probe later-tick existential opposite already answered
+the later-tick question, the global-T=3 lists already answered HOLD so the
+smallest T is 3, formation-tick already-recorded sets already answered the
+per-probe question, named signs should suffice because they keep
+orientation, and occupancy `n` should track that vector.
+
+**Answer:** The named construction reports, at each T through `T_max=3`, the
+later-tick six-neighbor lock sets and the reverse_T/face_T bits. Mixed
+remains a set. The construction does not sum. Occupancy `n` is not used.
+Named signs lost the axis. Both bits HOLD first at T=2 on sets
+`S_2(A)={+e_1, +e_2, +e_3, −e_3}`, `S_2(B)={+e_1, +e_3}`,
+`S_2(C)={+e_1, −e_1, +e_2, +e_3, −e_3}`, `S_2(D)={+e_1, −e_1}`, which are
+not the global-T=3 lists and not the formation-tick empty-`A` leftover. The
+bits remain displayed. Incoming-lock uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+A unique own-incoming lock-vector display on these same opposite-lock
+y-probes assigned `L(A)=−e_1`, `L(B)=+e_1`, `L(C)=+e_2`, `L(D)=UNDEFINED` and
+reported reverse hold with face `UNDEFINED`. Formation-tick already-recorded
+six-neighbor locks on these y-probes found empty `S(A)` and reported reverse
+`UNDEFINED`. Later-tick existential opposite on the nnseed x-probes reported
+reverse fail and face hold on different sets `{+e_1}`, `{+e_1, +e_2, +e_3}`,
+`{−e_2}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}`. The global-T=3 later-tick lists
+on these y-probes are
+`{+e_1, +e_2, −e_2, +e_3, −e_3}`, `{+e_1, +e_2, −e_2, +e_3, −e_3}`,
+`{+e_1, −e_1, +e_2, +e_3, −e_3}`, `{+e_1, −e_1, +e_2, +e_3, −e_3}` with both
+bits hold. Unique lock-vector lettering of the T=2 lists would report reverse
+`UNDEFINED` and face `UNDEFINED` because every T=2 set mixes. A sum leftover
+of the T=2 lists would miss `−e_3++e_3=0`. This note is not those displays:
+it scans each T, mixed remains a set, the construction does not sum, both
+bits HOLD first at T=2, and the T=2 sets are not the T=3 lists.
+
+**Gate disposition:** PASS for the per-T later-tick six-neighbor-lock
+existential-opposite reverse/face reports and for smallest T=2 above.
+FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the predicate
+equals the unique singleton lock vector,” “the predicate equals the sum of
+the lock set,” “the lock set equals the probe's own incoming step,” “bits
+are Admissibility,” “the letter is occupancy `n`,” “the sets equal unique
+own-incoming letters,” “the sets equal nnseed x-probe later-tick leftover,”
+“the sets equal formation-tick leftover,” “the smallest T is the global T=3
+lists,” “reverse fails at T=2,” or “face is `UNDEFINED` at T=2.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the opposite-lock two-site
+perp-step incoming-lock process, takes `T_max` as the max formation tick of
+the four y-probes, collects six-neighbor locks formed by each T at each
+probe with the probe excluded, reads reverse_T and face_T, and checks
+Theorems 1--3 including that the smallest T with both HOLD is 2. It also
+checks that the construction is not named-sign lettering, that mixed sets
+remain defined, that the construction does not sum, that the probe's own
+incoming step is not the lock set, that occupancy `n` is not used, that a
+formation member from later-tick six-neighbor locks is not attached, that
+the T=2 sets are not leftover of unique own-incoming letters, that they are
+not leftover of nnseed x-probe later-tick existential opposite, that they
+are not leftover of formation-tick already-recorded sets, and that they are
+not leftover of the global-T=3 later-tick lists. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13537,6 +13537,10 @@
   "openreference_patchgraph_four_rail_signed_clifford_equivalence_cycle706_note_2026-07-26": {
    "deps_hash": "a9cb5a27b029",
    "out_degree": 4
+  },
+  "opposite_lock_yprobe_minimal_t_existential_opposite_holding_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "orbit_constant_mass_dimension_cycle906_support_note_2026-08-09": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.txt
+++ b/logs/runner-cache/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.txt
@@ -1,0 +1,82 @@
+===== runner cache v1 =====
+runner: scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py
+runner_sha256: 866d59b1fa9b0d06a6be58d760eedbda90353a7831c9c513b2617f75b1fedde1
+input_fingerprint_sha256: e41edf3ad95861e23185970555d22620e72f673542aaf9db0326abd9802b13d0
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+minimal T later-tick exist-opposite HOLD on opposite-lock y-probes
+AUDIT_INPUT_PATHS:
+  docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: The later-tick exist-opposite reverse/face bits on nsopp y-probes at each T, and the smallest T at which both HOLD, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: theorem1-all-four-probes-recorded
+T=0 S_T(A)={+e_1} S_T(B)={} S_T(C)={−e_1} S_T(D)={−e_1} reverse=UNDEFINED face=fail
+T=1 S_T(A)={+e_1, +e_2, +e_3, −e_3} S_T(B)={+e_3} S_T(C)={−e_1} S_T(D)={−e_1} reverse=hold face=fail
+T=2 S_T(A)={+e_1, +e_2, +e_3, −e_3} S_T(B)={+e_1, +e_3} S_T(C)={+e_1, −e_1, +e_2, +e_3, −e_3} S_T(D)={+e_1, −e_1} reverse=hold face=hold
+T=3 S_T(A)={+e_1, +e_2, −e_2, +e_3, −e_3} S_T(B)={+e_1, +e_2, −e_2, +e_3, −e_3} S_T(C)={+e_1, −e_1, +e_2, +e_3, −e_3} S_T(D)={+e_1, −e_1, +e_2, +e_3, −e_3} reverse=hold face=hold
+T_max=3 t(A)=0 t(B)=2 t(C)=1 t(D)=3 smallest_holding_T=2
+PASS: theorem1-max-probe-tick  (3)
+PASS: theorem1-T0-sets-and-bits  (reverse=UNDEFINED face=fail)
+PASS: theorem1-T1-sets-and-bits  (reverse=hold face=fail)
+PASS: theorem1-T2-sets-and-bits  (reverse=hold face=hold)
+PASS: theorem1-T3-sets-and-bits  (reverse=hold face=hold)
+PASS: theorem2-smallest-T-both-hold  (2)
+PASS: not-leftover-of-global-T3-lists
+PASS: not-leftover-of-formation-time
+PASS: not-leftover-of-nslate-nnseed-x-probes
+PASS: not-leftover-of-unique-own-incoming
+PASS: sign-lettering-loses-axis-and-would-hide-hold
+PASS: not-probe-own-incoming-lock
+PASS: not-sum-leftover
+PASS: not-unique-vector-leftover
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required  ([(0, -1, 0), (0, 0, -1), (0, 0, 1)])
+PASS: two-site-opposite-lock-seed
+PASS: later-tick-not-self-and-formed-by-T
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: perp-step-incoming-lock
+PASS: mutation-empty-neighbor-locks-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: note-claim-scope
+PASS: note-reports-each-T-bits
+PASS: note-reports-smallest-T
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy-or-incoming
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-identify-incoming
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-leftover
+PASS: note-not-leftover-of-T3-lists
+PASS: note-not-leftover-of-formation-tick
+PASS: note-later-tick-T-defined
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-existential-opposite-only
+PASS: theorem3-displayed-not-adopted
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py
+++ b/scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py
@@ -1,0 +1,983 @@
+#!/usr/bin/env python3
+"""Minimal T with later-tick exist-opposite HOLD on four opposite-lock y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and -e_1. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. Let t(q) be the formation tick of probe q. Let T_max be the max of
+t(A), t(B), t(C), t(D) among those defined in B_3(0). For each integer T from
+0 through T_max, S_T(q) is the set of locks of 6-NN of q that formed at tick
+<= T and are not q. Reverse_T holds iff some a in S_T(A) and some b in
+S_T(B) have a+b=(0,0,0). Face_T holds iff some c in S_T(C) and some d in
+S_T(D) have c+d=(0,0,0). Empty S_T on either side is UNDEFINED; nonempty
+with no opposite pair fails. Report reverse_T and face_T at each T, and the
+smallest T at which reverse_T HOLD and face_T HOLD, or none. Uniqueness is
+not required. Occupancy n is not used. The probe's own incoming lock is not
+used. Not leftover of the global-T=3 later-tick lists. Not leftover of
+formation-tick already-recorded sets. Not named-sign lettering. Not unique
+P_+. Not a Dijkstra search. Not a Gram readout.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+    "P_+",
+)
+CLAIM_SCOPE = (
+    "The later-tick exist-opposite reverse/face bits on nsopp y-probes at "
+    "each T, and the smallest T at which both HOLD, are reported. "
+    "Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def recorded_lock_set(pairs: tuple[tuple[Point, Point], ...]) -> frozenset[Point]:
+    """Set of later-tick six-neighbor locks. Duplicates collapse."""
+    return frozenset(lock for _neighbor, lock in pairs)
+
+
+def existential_opposite(left: frozenset[Point], right: frozenset[Point]) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    Empty set on either side is UNDEFINED. Nonempty with no opposite pair fails.
+    Does not sum. Does not require a singleton.
+    """
+    if not left or not right:
+        return "UNDEFINED"
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: frozenset[Point], set_b: frozenset[Point]) -> str:
+    """Reverse_T iff some a in S_T(A) and some b in S_T(B) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: frozenset[Point], set_d: frozenset[Point]) -> str:
+    """Face_T iff some c in S_T(C) and some d in S_T(D) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def max_probe_tick(
+    ticks: dict[Point, int],
+    probes: dict[str, Point] = PROBES,
+) -> int | None:
+    """Max formation tick of the four named probes, or None if any is missing."""
+    defined = [
+        ticks[probes[name]] for name in ("A", "B", "C", "D") if probes[name] in ticks
+    ]
+    if len(defined) != 4:
+        return None
+    return max(defined)
+
+
+def later_tick_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    common_tick: int,
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of 6-NN of site formed at tick <= common_tick, site excluded."""
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] > common_tick:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def strictly_earlier_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Formation-time leftover: already-recorded 6-NN locks at formation of site."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    """Z^3 sum leftover of a lock set. Contrast only; not this letter."""
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def smallest_holding_t(
+    reverse_by_t: dict[int, str],
+    face_by_t: dict[int, str],
+) -> int | None:
+    """Smallest T with reverse_T hold and face_T hold, or None."""
+    for tick in sorted(reverse_by_t):
+        if reverse_by_t[tick] == "hold" and face_by_t[tick] == "hold":
+            return tick
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("minimal T later-tick exist-opposite HOLD on opposite-lock y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E1, E1) == (2, 0, 0)
+        and add(E2, E2) == (0, 2, 0)
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    mixed_ab_t3 = frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+    mixed_cd_t3 = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    set_a_t2 = frozenset({E1, E2, E3, NEG_E3})
+    set_b_t2 = frozenset({E1, E3})
+    set_c_t2 = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    set_d_t2 = frozenset({E1, NEG_E1})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(frozenset(), frozenset({E1})) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({NEG_E1})) == "fail"
+        and existential_opposite(set_a_t2, set_b_t2) == "hold"
+        and existential_opposite(set_c_t2, set_d_t2) == "hold"
+        and existential_opposite(mixed_ab_t3, mixed_ab_t3) == "hold"
+        and existential_opposite(mixed_cd_t3, mixed_cd_t3) == "hold"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold",
+    )
+
+    ticks, locks = form()
+    t_max = max_probe_tick(ticks)
+    perp_ticks, perp_locks = form(PERP_SEEDS)
+    checks.check(
+        "theorem1-all-four-probes-recorded",
+        all(PROBES[name] in ticks for name in ("A", "B", "C", "D"))
+        and t_max is not None,
+    )
+    assert t_max is not None
+
+    neighbor_by_t: dict[int, dict[str, tuple[tuple[Point, Point], ...]]] = {}
+    sets_by_t: dict[int, dict[str, frozenset[Point]]] = {}
+    reverse_by_t: dict[int, str] = {}
+    face_by_t: dict[int, str] = {}
+    for tick in range(0, t_max + 1):
+        neighbor_by_t[tick] = {}
+        sets_by_t[tick] = {}
+        for name in ("A", "B", "C", "D"):
+            pairs = later_tick_neighbor_locks(PROBES[name], ticks, locks, tick)
+            neighbor_by_t[tick][name] = pairs
+            sets_by_t[tick][name] = recorded_lock_set(pairs)
+        reverse_by_t[tick] = reverse_report(
+            sets_by_t[tick]["A"], sets_by_t[tick]["B"]
+        )
+        face_by_t[tick] = face_report(sets_by_t[tick]["C"], sets_by_t[tick]["D"])
+        print(
+            f"T={tick} "
+            f"S_T(A)={set_display(sets_by_t[tick]['A'])} "
+            f"S_T(B)={set_display(sets_by_t[tick]['B'])} "
+            f"S_T(C)={set_display(sets_by_t[tick]['C'])} "
+            f"S_T(D)={set_display(sets_by_t[tick]['D'])} "
+            f"reverse={reverse_by_t[tick]} face={face_by_t[tick]}"
+        )
+
+    holding_t = smallest_holding_t(reverse_by_t, face_by_t)
+    leftover_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    leftover_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        leftover = strictly_earlier_neighbor_locks(PROBES[name], ticks, locks)
+        leftover_lists[name] = leftover
+        leftover_sets[name] = recorded_lock_set(leftover)
+    leftover_reverse = reverse_report(leftover_sets["A"], leftover_sets["B"])
+    leftover_face = face_report(leftover_sets["C"], leftover_sets["D"])
+    print(
+        f"T_max={t_max} "
+        f"t(A)={ticks[PROBES['A']]} t(B)={ticks[PROBES['B']]} "
+        f"t(C)={ticks[PROBES['C']]} t(D)={ticks[PROBES['D']]} "
+        f"smallest_holding_T={holding_t}"
+    )
+
+    nslate_sets: dict[str, frozenset[Point]] = {}
+    perp_common = max_probe_tick(perp_ticks, X_PROBES)
+    assert perp_common is not None
+    for name in ("A", "B", "C", "D"):
+        pairs = later_tick_neighbor_locks(
+            X_PROBES[name], perp_ticks, perp_locks, perp_common
+        )
+        nslate_sets[name] = recorded_lock_set(pairs)
+    nslate_reverse = reverse_report(nslate_sets["A"], nslate_sets["B"])
+    nslate_face = face_report(nslate_sets["C"], nslate_sets["D"])
+
+    checks.check(
+        "theorem1-max-probe-tick",
+        t_max == 3
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 3
+        and list(range(0, t_max + 1)) == [0, 1, 2, 3],
+        str(t_max),
+    )
+    checks.check(
+        "theorem1-T0-sets-and-bits",
+        neighbor_by_t[0]["A"] == ((ORIGIN, E1),)
+        and neighbor_by_t[0]["B"] == ()
+        and neighbor_by_t[0]["C"] == ((PROBES["A"], NEG_E1),)
+        and neighbor_by_t[0]["D"] == ((PROBES["A"], NEG_E1),)
+        and sets_by_t[0]["A"] == frozenset({E1})
+        and sets_by_t[0]["B"] == frozenset()
+        and sets_by_t[0]["C"] == frozenset({NEG_E1})
+        and sets_by_t[0]["D"] == frozenset({NEG_E1})
+        and reverse_by_t[0] == "UNDEFINED"
+        and face_by_t[0] == "fail",
+        f"reverse={reverse_by_t[0]} face={face_by_t[0]}",
+    )
+    checks.check(
+        "theorem1-T1-sets-and-bits",
+        neighbor_by_t[1]["A"]
+        == (
+            (PROBES["C"], E2),
+            (ORIGIN, E1),
+            ((0, 1, 1), E3),
+            ((0, 1, -1), NEG_E3),
+        )
+        and neighbor_by_t[1]["B"] == (((0, 1, 1), E3),)
+        and neighbor_by_t[1]["C"] == ((PROBES["A"], NEG_E1),)
+        and neighbor_by_t[1]["D"] == ((PROBES["A"], NEG_E1),)
+        and sets_by_t[1]["A"] == frozenset({E1, E2, E3, NEG_E3})
+        and sets_by_t[1]["B"] == frozenset({E3})
+        and sets_by_t[1]["C"] == frozenset({NEG_E1})
+        and sets_by_t[1]["D"] == frozenset({NEG_E1})
+        and reverse_by_t[1] == "hold"
+        and face_by_t[1] == "fail"
+        and NEG_E3 in sets_by_t[1]["A"]
+        and E3 in sets_by_t[1]["B"]
+        and add(NEG_E3, E3) == ZERO,
+        f"reverse={reverse_by_t[1]} face={face_by_t[1]}",
+    )
+    checks.check(
+        "theorem1-T2-sets-and-bits",
+        neighbor_by_t[2]["A"]
+        == (
+            (PROBES["C"], E2),
+            (ORIGIN, E1),
+            ((0, 1, 1), E3),
+            ((0, 1, -1), NEG_E3),
+        )
+        and neighbor_by_t[2]["B"]
+        == (
+            ((0, 1, 1), E3),
+            ((1, 0, 1), E1),
+        )
+        and neighbor_by_t[2]["C"]
+        == (
+            ((1, 2, 0), E1),
+            ((-1, 2, 0), NEG_E1),
+            (PROBES["A"], NEG_E1),
+            ((0, 2, 1), E3),
+            ((0, 2, 1), E2),
+            ((0, 2, -1), NEG_E3),
+            ((0, 2, -1), E2),
+        )
+        and neighbor_by_t[2]["D"]
+        == (
+            (PROBES["A"], NEG_E1),
+            ((1, 2, 0), E1),
+            (PROBES["B"], E1),
+            ((1, 1, -1), E1),
+        )
+        and sets_by_t[2]["A"] == set_a_t2
+        and sets_by_t[2]["B"] == set_b_t2
+        and sets_by_t[2]["C"] == set_c_t2
+        and sets_by_t[2]["D"] == set_d_t2
+        and reverse_by_t[2] == "hold"
+        and face_by_t[2] == "hold"
+        and NEG_E3 in sets_by_t[2]["A"]
+        and E3 in sets_by_t[2]["B"]
+        and NEG_E1 in sets_by_t[2]["C"]
+        and E1 in sets_by_t[2]["D"],
+        f"reverse={reverse_by_t[2]} face={face_by_t[2]}",
+    )
+    checks.check(
+        "theorem1-T3-sets-and-bits",
+        neighbor_by_t[3]["A"]
+        == (
+            (PROBES["D"], NEG_E2),
+            (PROBES["D"], NEG_E3),
+            (PROBES["D"], E3),
+            ((-1, 1, 0), NEG_E2),
+            ((-1, 1, 0), NEG_E3),
+            ((-1, 1, 0), E3),
+            (PROBES["C"], E2),
+            (ORIGIN, E1),
+            ((0, 1, 1), E3),
+            ((0, 1, -1), NEG_E3),
+        )
+        and neighbor_by_t[3]["B"]
+        == (
+            ((0, 1, 1), E3),
+            ((1, 2, 1), E3),
+            ((1, 2, 1), E2),
+            ((1, 2, 1), E1),
+            ((1, 0, 1), E1),
+            ((1, 1, 2), E3),
+            (PROBES["D"], NEG_E2),
+            (PROBES["D"], NEG_E3),
+            (PROBES["D"], E3),
+        )
+        and neighbor_by_t[3]["C"]
+        == (
+            ((1, 2, 0), E1),
+            ((-1, 2, 0), NEG_E1),
+            (PROBES["A"], NEG_E1),
+            ((0, 2, 1), E3),
+            ((0, 2, 1), E2),
+            ((0, 2, -1), NEG_E3),
+            ((0, 2, -1), E2),
+        )
+        and neighbor_by_t[3]["D"]
+        == (
+            (PROBES["A"], NEG_E1),
+            ((1, 2, 0), E1),
+            ((1, 0, 0), NEG_E3),
+            ((1, 0, 0), E3),
+            ((1, 0, 0), E2),
+            (PROBES["B"], E1),
+            ((1, 1, -1), E1),
+        )
+        and sets_by_t[3]["A"] == mixed_ab_t3
+        and sets_by_t[3]["B"] == mixed_ab_t3
+        and sets_by_t[3]["C"] == mixed_cd_t3
+        and sets_by_t[3]["D"] == mixed_cd_t3
+        and reverse_by_t[3] == "hold"
+        and face_by_t[3] == "hold",
+        f"reverse={reverse_by_t[3]} face={face_by_t[3]}",
+    )
+    checks.check(
+        "theorem2-smallest-T-both-hold",
+        holding_t == 2
+        and reverse_by_t[2] == "hold"
+        and face_by_t[2] == "hold"
+        and reverse_by_t[0] != "hold"
+        and face_by_t[0] != "hold"
+        and face_by_t[1] != "hold"
+        and all(
+            not (
+                reverse_by_t[tick] == "hold" and face_by_t[tick] == "hold"
+            )
+            for tick in range(0, 2)
+        ),
+        str(holding_t),
+    )
+    checks.check(
+        "not-leftover-of-global-T3-lists",
+        sets_by_t[2]["A"] != sets_by_t[3]["A"]
+        and sets_by_t[2]["B"] != sets_by_t[3]["B"]
+        and sets_by_t[2]["D"] != sets_by_t[3]["D"]
+        and NEG_E2 not in sets_by_t[2]["A"]
+        and NEG_E2 in sets_by_t[3]["A"]
+        and sets_by_t[2]["B"] == frozenset({E1, E3})
+        and sets_by_t[3]["B"] == mixed_ab_t3
+        and sets_by_t[2]["D"] == frozenset({E1, NEG_E1})
+        and sets_by_t[3]["D"] == mixed_cd_t3
+        and holding_t == 2
+        and holding_t != 3,
+    )
+    checks.check(
+        "not-leftover-of-formation-time",
+        leftover_sets["A"] == frozenset()
+        and leftover_sets["B"] == frozenset({E3})
+        and leftover_sets["C"] == frozenset({NEG_E1})
+        and leftover_sets["D"] == frozenset({NEG_E1, E1})
+        and leftover_reverse == "UNDEFINED"
+        and leftover_face == "hold"
+        and leftover_sets["A"] != sets_by_t[2]["A"]
+        and reverse_by_t[2] == "hold"
+        and leftover_reverse != reverse_by_t[2],
+    )
+    checks.check(
+        "not-leftover-of-nslate-nnseed-x-probes",
+        TWO_SITE_SEEDS != PERP_SEEDS
+        and probe_sites != x_probe_sites
+        and nslate_sets["A"] == frozenset({E1})
+        and nslate_sets["B"] == frozenset({E1, E2, E3})
+        and nslate_sets["C"] == frozenset({NEG_E2})
+        and nslate_sets["D"] == frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+        and nslate_reverse == "fail"
+        and nslate_face == "hold"
+        and reverse_by_t[2] == "hold"
+        and reverse_by_t[2] != nslate_reverse
+        and sets_by_t[2]["A"] != nslate_sets["A"],
+    )
+    checks.check(
+        "not-leftover-of-unique-own-incoming",
+        locks[PROBES["A"]] == {NEG_E1}
+        and locks[PROBES["B"]] == {E1}
+        and locks[PROBES["C"]] == {E2}
+        and locks[PROBES["D"]] == {NEG_E2, NEG_E3, E3}
+        and NEG_E1 not in sets_by_t[2]["A"]
+        and sets_by_t[2]["A"] != frozenset({NEG_E1})
+        and sets_by_t[2]["C"] != frozenset({E2})
+        and sets_by_t[2]["D"] != frozenset()
+        and face_by_t[2] == "hold"
+        and face_by_t[2] != "UNDEFINED",
+    )
+    checks.check(
+        "sign-lettering-loses-axis-and-would-hide-hold",
+        named_sign(E2) == "+"
+        and named_sign(NEG_E2) == "-"
+        and named_sign(NEG_E1) == "-"
+        and named_sign(E1) == "+"
+        and reverse_by_t[2] == "hold"
+        and face_by_t[2] == "hold",
+    )
+    checks.check(
+        "not-probe-own-incoming-lock",
+        locks[PROBES["A"]] == {NEG_E1}
+        and NEG_E1 not in sets_by_t[2]["A"]
+        and locks[PROBES["C"]] == {E2}
+        and sets_by_t[2]["C"] != frozenset({E2}),
+    )
+    checks.check(
+        "not-sum-leftover",
+        sum_of_set(sets_by_t[2]["A"]) == add(E1, E2)
+        and sum_of_set(sets_by_t[2]["B"]) == add(E1, E3)
+        and add(sum_of_set(sets_by_t[2]["A"]), sum_of_set(sets_by_t[2]["B"])) != ZERO
+        and reverse_by_t[2] == "hold"
+        and face_by_t[2] == "hold",
+    )
+    checks.check(
+        "not-unique-vector-leftover",
+        len(sets_by_t[2]["A"]) > 1
+        and len(sets_by_t[2]["B"]) > 1
+        and len(sets_by_t[2]["C"]) > 1
+        and len(sets_by_t[2]["D"]) > 1
+        and reverse_by_t[2] == "hold"
+        and face_by_t[2] == "hold",
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["D"]]) == 3
+        and sets_by_t[2]["D"] == set_d_t2
+        and face_by_t[2] == "hold",
+        str(sorted(locks[PROBES["D"]])),
+    )
+    checks.check(
+        "two-site-opposite-lock-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and add(E1, NEG_E1) == ZERO
+        and TWO_SITE_SEEDS != PERP_SEEDS,
+    )
+    checks.check(
+        "later-tick-not-self-and-formed-by-T",
+        all(
+            neighbor != PROBES[name]
+            for tick in range(0, t_max + 1)
+            for name in PROBES
+            for neighbor, _lock in neighbor_by_t[tick][name]
+        )
+        and all(
+            ticks[neighbor] <= tick
+            for tick in range(0, t_max + 1)
+            for name in PROBES
+            for neighbor, _lock in neighbor_by_t[tick][name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[(0, -1, 0)] == 1
+        and ticks[E3] == 1
+        and ticks[(0, 0, -1)] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["D"]] == 3
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "mutation-empty-neighbor-locks-undefined",
+        recorded_lock_set(()) == frozenset()
+        and reverse_report(frozenset(), sets_by_t[2]["B"]) == "UNDEFINED"
+        and face_report(sets_by_t[2]["C"], frozenset()) == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and reverse_by_t[2] == "hold",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-each-T-bits",
+        "T=0: reverse UNDEFINED, face fail" in note
+        and "T=1: reverse hold, face fail" in note
+        and "T=2: reverse hold, face hold" in note
+        and "T=3: reverse hold, face hold" in note
+        and "S_0(A) = {+e_1}" in note
+        and "S_0(B) = {}" in note
+        and "S_1(A) = {+e_1, +e_2, +e_3, −e_3}" in note
+        and "S_1(B) = {+e_3}" in note
+        and "S_2(A) = {+e_1, +e_2, +e_3, −e_3}" in note
+        and "S_2(B) = {+e_1, +e_3}" in note
+        and "S_2(C) = {+e_1, −e_1, +e_2, +e_3, −e_3}" in note
+        and "S_2(D) = {+e_1, −e_1}" in note
+        and "S_3(A) = {+e_1, +e_2, −e_2, +e_3, −e_3}" in note
+        and "S_3(D) = {+e_1, −e_1, +e_2, +e_3, −e_3}" in note,
+    )
+    checks.check(
+        "note-reports-smallest-T",
+        "Smallest T: 2" in note
+        and "smallest T" in normalized_note
+        and "T=2" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy-or-incoming",
+        "does not use occupancy" in normalized_note
+        and "does not use the probe" in normalized_note
+        and "own incoming lock" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-identify-incoming",
+        "not identified" in normalized_note
+        and "incoming step" in normalized_note
+        and "S_2(A)` has no `−e_1`" in note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from later-tick six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "uniqueness is not required" in normalized_note.lower(),
+    )
+    checks.check(
+        "note-not-leftover-of-T3-lists",
+        "not leftover of the global-T=3 later-tick lists" in normalized_note
+        and "S_2(A)" in note
+        and "S_3(A)" in note,
+    )
+    checks.check(
+        "note-not-leftover-of-formation-tick",
+        "not leftover of formation-tick" in normalized_note
+        and "empty" in normalized_note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-later-tick-T-defined",
+        "for each integer T" in normalized_note
+        and "tick `≤ T`" in note
+        and "max" in normalized_note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/OPPOSITE_LOCK_YPROBE_MINIMAL_T_EXISTENTIAL_OPPOSITE_HOLDING_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def existential_opposite(" in source
+        and "def recorded_lock_set(" in source
+        and "def later_tick_neighbor_locks(" in source
+        and "def max_probe_tick(" in source
+        and "def smallest_holding_t(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-existential-opposite-only",
+        "existential_opposite" in defined_fns
+        and "recorded_lock_set" in defined_fns
+        and "later_tick_neighbor_locks" in defined_fns
+        and "smallest_holding_t" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns
+        and "dijkstra" not in {name.lower() for name in defined_fns}
+        and "gram" not in {name.lower() for name in defined_fns},
+    )
+    checks.check(
+        "theorem3-displayed-not-adopted",
+        reverse_by_t[2] == "hold"
+        and face_by_t[2] == "hold"
+        and holding_t == 2
+        and "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Smallest T with reverse HOLD and face HOLD on nsopp y-probes is T=2. Lists at T=2 differ from #7128 T=3. Displayed, not adopted. HOLDING_MEMBER. Formation-tick leftover still empty S(A).

## Runner

`scripts/opposite_lock_yprobe_minimal_t_existential_opposite_holding_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.