### PR TITLE
feat(nperpin): perpnn y-probe own-lock-in exist-opposite: reverse fails, face fails

### DIFF
--- a/docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,488 @@
+---
+claim_id: perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from existential opposite in the union of strictly-earlier 6-NN locks with the probe's own incoming lock on the four perpnn y-probes are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py
+---
+
+# Own-Lock-In Existential Opposite Reverse And Face On Four Perpnn Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from existential opposite in the union of
+strictly-earlier six-neighbor locks with the probe's own incoming lock on
+the four perpnn y-probes in `B_3(0)`. Let `t(q)` be the formation tick of
+probe `q`. Let `L(q)` be `q`'s own unique incoming lock; seeds use seed
+letters. If several earliest incoming steps exist, `L(q)` is `UNDEFINED`.
+At that tick, `S^+(q)` is the set of locks of six-neighbors of `q` that
+formed at tick `< t(q)` (strictly earlier), union `{L(q)}` when `L(q)` is
+defined. Reverse holds if and only if some lock in `S^+(A)` is the vector
+opposite of some lock in `S^+(B)`. Face holds if and only if some lock in
+`S^+(C)` is the vector opposite of some lock in `S^+(D)`. Empty `S^+` on
+either side of a comparison is `UNDEFINED`; nonempty with no opposite pair
+fails. Occupancy n is not used. Occupancy `n` is not used. This is not named-sign lettering. This is
+not a unique lock-vector leftover and not a sum leftover. `A=(0,1,0)` is
+not the 1-seed; origin is. Reverse HOLD does not use `L(A)`: reverse fails.
+This is not leftover of later-tick existential opposite on these y-probes:
+that leftover waits for a global later T and reports reverse hold and face
+hold. This is not leftover of opposite-lock own-lock-in: that display holds
+reverse when A is a seed. A is not the 1-seed. This is not leftover of the unique own-incoming
+lock-vector letters on these y-probes: that readout reports reverse
+`UNDEFINED` and face `UNDEFINED` at mixed `B` and mixed `C`. This is not
+leftover of formation-tick existential opposite that excludes `q`: those
+sets omit `L(A)` and `L(D)`. Uniqueness of incoming locks is not required.
+Uniqueness of the lock set is not required. Displayed, not adopted. This
+note does not write existential opposite into Admissibility and does not
+attach a formation member from already-recorded six-neighbor locks.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py`](../scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse and face are scored on existence of an opposite pair in the
+own-lock-in union sets. Named signs `{+,−}` are a coarser readout and are
+not used. A singleton unique lock-vector letter is a different readout and
+is not used. A `Z^3` sum of those locks is a different readout and is not
+used.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of S^+ as the union of strictly-earlier six-neighbor locks with L(q) when defined, on the four perpnn y-probes, with reverse fail and face fail from existential opposite; reverse HOLD does not use L(A); uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: perpnn_yprobe_own_lock_in_existential_opposite_reverse_face
+target_blocker_text: "display reverse and face from existential opposite in the union of strictly-earlier 6-NN locks with the probe's own incoming lock on the four perpnn y-probes, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not use occupancy n, do not identify the sets with later-tick leftover, and do not identify the sets with opposite-lock own-lock-in leftover."
+conditional_surface_status: "exact on B_3(0) for existential opposite of own-lock-in union sets on the four perpnn y-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+own-lock-in union sets are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are the same y-probes as the nnseed y-probe display. They are not the
+x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`. `A` is not a
+seed.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the origin is recorded at tick `0` with lock letter `+e_1`. This is
+the perpnn 1-seed. It is not the two-site opposite-lock seed
+`{0,(0,1,0)}` with `+e_1/−e_1`, not the perp two-site seed `+e_1/+e_2`, and
+not the three-site seed `{0,(0,1,0),(1,0,0)}`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Uniqueness is not required. A later parent does not re-form
+`q`.
+
+## Named existential opposite from own-lock-in union
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `L(q)` be `q`'s own unique incoming lock in `{±e_i}`. Seeds
+use seed letters. If several earliest incoming steps exist, `L(q)` is
+`UNDEFINED`. At the own formation tick of each probe `q`, let `S^+(q)` be
+the set of locks of six-neighbors of `q` that formed at tick `< t(q)`
+(strictly earlier), union `{L(q)}` when `L(q)` is defined. Same-tick partners
+are not already recorded as neighbors. The probe itself is not a neighbor of
+itself. This display does not wait for a global later T. This display does
+not use occupancy `n`. Duplicate locks at two neighbors collapse in the set.
+The construction does not require `S^+(q)` to be a singleton. It does not
+sum `S^+(q)`. It is not a unique lock-vector leftover and not a sum leftover.
+It is not leftover of later-tick existential opposite. It is not leftover of
+opposite-lock own-lock-in. It is not leftover of unique own-incoming
+lock-vector letters on these y-probes. It is not leftover of formation-tick
+existential opposite that excludes `q`.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on existence
+of a pair of lock vectors that add to zero. They are not scored on `{+,−}`
+names and are not an occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in S^+(A) and some b in S^+(B) with a+b=(0,0,0)
+face     <=>  some c in S^+(C) and some d in S^+(D) with c+d=(0,0,0)
+```
+
+If `S^+(A)` or `S^+(B)` is empty, reverse is `UNDEFINED`. Else reverse fails
+if no such pair exists. If `S^+(C)` or `S^+(D)` is empty, face is
+`UNDEFINED`. Else face fails if no such pair exists. The report is one of
+`hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility.
+
+## Theorem 1 — formation ticks, own incoming locks, and S^+ at each y-probe
+
+Direct enumeration of the displayed perpnn 1-seed process on `B_3(0)` forms
+all four y-probes. The formation ticks are `t(A)=1`, `t(B)=3`, `t(C)=4`,
+`t(D)=2`. `A` is not a seed. The 1-seed is the origin at tick `0` with lock
+`+e_1`. Those ticks locate the already-recorded six-neighbor set. They are
+not occupancy kernels and are not a global later T.
+
+Own incoming locks and own-lock-in union sets at each probe's own formation
+tick are:
+
+```text
+A: incoming +e_2; +e_1 at (0, 0, 0);
+   t(A)=1;  L(A) = +e_2;  S^+(A) = {+e_1, +e_2}
+B: incoming +e_1, +e_2, +e_3; +e_3 at (0, 1, 1), +e_2 at (0, 1, 1),
+   +e_1 at (1, 0, 1), +e_1 at (1, 1, 0);
+   t(B)=3;  L(B) = UNDEFINED;  S^+(B) = {+e_1, +e_2, +e_3}
+C: incoming +e_1, −e_1, +e_3, −e_3; +e_2 at (1, 2, 0), +e_2 at (-1, 2, 0),
+   +e_2 at (0, 1, 0), +e_2 at (0, 2, 1), +e_2 at (0, 2, -1);
+   t(C)=4;  L(C) = UNDEFINED;  S^+(C) = {+e_2}
+D: incoming +e_1; +e_2 at (0, 1, 0);
+   t(D)=2;  L(D) = +e_1;  S^+(D) = {+e_1, +e_2}
+```
+
+`A` forms at tick 1 from the origin by the perpendicular step `+e_2`. Its
+already-recorded neighbor is the seed origin locking `+e_1`. `L(A)` is the
+unique incoming lock `+e_2`, so `S^+(A)={+e_1, +e_2}`. `B`'s already-recorded
+neighbors mix `+e_3` and `+e_2` at `(0,1,1)` with `+e_1` at `(1,0,1)` and at
+`D`. Mixed remains a set. `L(B)` is `UNDEFINED` from three earliest incoming
+steps, so `S^+(B)` is that neighbor set `{+e_1, +e_2, +e_3}`. `C`'s
+already-recorded neighbors are five copies of `+e_2`. `L(C)` is `UNDEFINED`
+from four earliest incoming steps, so `S^+(C)={+e_2}`. `D`'s already-recorded
+neighbor is `A` locking `+e_2`, and `L(D)=+e_1`, so `S^+(D)={+e_1, +e_2}`.
+
+Incoming locks exist and need not be unique (`B` has three earliest incoming
+steps `+e_1`, `+e_2`, and `+e_3`; `C` has four). That non-uniqueness leaves
+`L(B)` and `L(C)` `UNDEFINED` and does not empty `S^+(B)` or `S^+(C)`.
+Uniqueness is not required.
+
+Reverse HOLD uses L(A): no. Reverse HOLD uses `L(A)`: no. `L(A)=+e_2` is a
+member of `S^+(A)`, but `S^+(B)` contains no `−e_2`. Dropping `L(A)` leaves
+`{+e_1}` at `A`, which also finds no opposite in `S^+(B)`. Reverse fails
+with or without `L(A)`. Own lock does not recover reverse on this 1-seed
+process.
+
+The unique own-incoming letters on these same y-probes are `+e_2`,
+`UNDEFINED`, `UNDEFINED`, `+e_1`. Those are different objects: `S^+(A)` is
+not `{+e_2}`, and `S^+(D)` is not `{+e_1}`. Formation-tick existential
+opposite that excludes `q` reports `S(A)={+e_1}`, not `{+e_1, +e_2}`, and
+`S(D)={+e_2}`, not `{+e_1, +e_2}`. Later-tick existential opposite on these
+same y-probes reports `{+e_1, −e_1, +e_2, +e_3, −e_3}` at `A` after waiting
+for a global later T.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if there exist `a` in `S^+(A)` and `b` in
+`S^+(B)` with `a+b=(0,0,0)`. Both sets are nonempty: `S^+(A)={+e_1, +e_2}`
+and `S^+(B)={+e_1, +e_2, +e_3}`. No pair sums to the origin. Reverse fails.
+
+Reverse: fail
+
+This is not `hold` and not `UNDEFINED`. Reverse HOLD uses `L(A)`: no.
+This is not leftover of later-tick existential opposite on these y-probes:
+that leftover reports reverse hold from `−e_1` at a later neighbor of `A`.
+This is not leftover of opposite-lock own-lock-in: that leftover holds
+reverse when `A` is a seed with letter `−e_1`. Unique lock-vector lettering
+of the same union sets would report reverse `UNDEFINED` because `A` and `B`
+mix. A sum leftover of the same lists would replace `S^+(A)` by `(1,1,0)`
+and `S^+(B)` by `(1,1,1)`, which are not lock letters. Unique own-incoming
+letters on these y-probes report reverse `UNDEFINED` because `L(B)` is
+`UNDEFINED`. Reverse fails.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if there exist `c` in `S^+(C)` and `d` in `S^+(D)`
+with `c+d=(0,0,0)`. Both sets are nonempty: `S^+(C)={+e_2}` and
+`S^+(D)={+e_1, +e_2}`. No pair sums to the origin. Face fails.
+
+Face: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+
+This is not `hold` and not `UNDEFINED`. Unique own-incoming letters on these
+same y-probes assign `L(C)=UNDEFINED` from four earliest incoming steps and
+report face `UNDEFINED`. Unique lock-vector lettering of the union sets
+would report face `UNDEFINED` because `D` mixes. A sum leftover would
+replace `S^+(C)` by `+e_2` and `S^+(D)` by `(1,1,0)` and would also fail
+face, but those sums are a different object. Named-sign lettering lost the
+axis: every lock in the four union sets is a positive letter, so `{+,−}`
+cannot tell `+e_1` from `+e_2`. Later-tick existential opposite on these
+y-probes reports face hold from `−e_2` at a later neighbor of `D`. Face
+fails here because this display does not wait for that later neighbor.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the own-lock-in union set to be a singleton.
+- It does not sum the own-lock-in union set.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not census a sixteen-combination free lettering independent of
+  lock vectors.
+- It does not reprint unique own-incoming lock-vector letters on these
+  y-probes.
+- It does not reprint formation-tick existential opposite that excludes `q`.
+- It does not wait for a global later T.
+- It does not reprint later-tick existential opposite on these y-probes.
+- It does not reprint opposite-lock own-lock-in leftover.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+perpnn 1-seed process, the own-lock-in union sets, and the existential-opposite
+reverse/face predicates are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; perpnn 1-seed origin lock `+e_1` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `1`, `3`, `4`, `2` |
+| own incoming locks `L(A)`, `L(B)`, `L(C)`, `L(D)` | Theorem 1; `+e_2`, `UNDEFINED`, `UNDEFINED`, `+e_1` |
+| lock sets `S^+(A)`, `S^+(B)`, `S^+(C)`, `S^+(D)` | Theorem 1; `{+e_1, +e_2}`, `{+e_1, +e_2, +e_3}`, `{+e_2}`, `{+e_1, +e_2}` |
+| reverse HOLD uses `L(A)` | Theorem 1; no |
+| reverse and face | Theorems 2–3; `fail` / `fail` |
+| unique incoming lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| formation member from already-recorded six-neighbor locks | not attached |
+| leftover of unique own-incoming letters on these y-probes | not this display |
+| leftover of formation-tick existential opposite that excludes `q` | not this display |
+| leftover of later-tick existential opposite on these y-probes | not this display |
+| leftover of opposite-lock own-lock-in | not this display |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Promotion value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: existential opposite in the union of strictly-earlier 6-NN locks with the probe's own incoming lock on the four perpnn y-probes, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed own-lock-in existential-opposite reverse/face report on these four perpnn y-probes. |
+| V3 | Own-lock-in union sets and the `fail`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the union of strictly-earlier six-neighbor lock vectors with `L(q)` when defined and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+singleton lock vector, does not sum the lock set, does not reprint unique
+own-incoming letters, does not reprint formation-tick leftover that excludes
+`q`, does not reprint later-tick leftover, does not reprint opposite-lock
+own-lock-in leftover, and does not use occupancy `n`. No global impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique lock-vector lettering of the same union sets | require a singleton `{v}` subset `{±e_i}` | refused; leftover; reverse would be `UNDEFINED` while the mixed union sets are nonempty and reverse fails |
+| sum of the same union sets | replace `S^+` by the `Z^3` sum | refused; leftover; sums `(1,1,0)` and `(1,1,1)` are not lock letters |
+| named-sign lettering of the same union sets | map `±e_i` to `{+,−}` | refused; lost the axis; all four union sets are positive letters and cannot tell `+e_1` from `+e_2` |
+| unique own-incoming lock-vector leftover on these y-probes | reuse `L(A)=+e_2`, `L(B)=UNDEFINED`, `L(C)=UNDEFINED`, `L(D)=+e_1` | refused; different object; that leftover reports reverse `UNDEFINED` and face `UNDEFINED` while own-lock-in reverse fails and face fails |
+| leftover of formation-tick existential opposite that excludes `q` | reuse `S(A)={+e_1}` and `S(D)={+e_2}` | refused; different set; `S^+(A)={+e_1, +e_2}` and `S^+(D)={+e_1, +e_2}` |
+| leftover of later-tick existential opposite | reuse global later T and reverse hold | refused; different set; this display does not wait for a global later T; reverse fails here |
+| leftover of opposite-lock own-lock-in | reuse seed `{0,(0,1,0)}` with reverse hold when `A` is a seed | refused; different process; `A` is not the 1-seed and reverse fails |
+| leftover of perpnn later-tick existential opposite on x-probes | reuse reverse fail and face hold at a later common T | refused; different probes and different readout; face fails here |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; ticks locate `S^+` and are not the predicate |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted |
+| unique incoming lock required | demand one incoming step per probe | uniqueness is not required; all three earliest incoming steps at `B` and all four at `C` are kept and `L(B)`, `L(C)` are `UNDEFINED` |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from already-recorded
+six-neighbor locks, and missing Record identification of existential opposite
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, 1-seed origin lock `+e_1`, perpendicular step rule,
+incoming-step lock, formation-tick lock set of six-neighbors formed strictly
+earlier than each probe's own `t`, union with `L(q)` when defined, existential
+opposite, four y-probes with non-seed `A`, and reverse/face as existence of a
+pair that sums to zero are declared. No uniqueness of incoming locks, no
+occupancy `n`, no named-sign reduction, no singleton leftover, no sum leftover,
+no unique own-incoming leftover, no formation-tick exclude-`q` leftover, no
+later-tick leftover, no opposite-lock own-lock-in leftover, no global later T,
+no formation attachment from already-recorded six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in an own-lock-in union set | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four lock sets and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Own lock should recover reverse on the 1-seed process because
+opposite-lock own-lock-in recovered reverse when `A` is a seed, mixed
+neighbor locks should make reverse and face `UNDEFINED`, the sets should be
+replaced by their sums, later-tick existential opposite already answered the
+exist-opposite question with reverse hold and face hold, unique own-incoming
+letters already answered the own-lock question, named signs should suffice
+because every lock here is positive, and occupancy `n` should track that
+vector.
+
+**Answer:** The named construction reports lock sets `{+e_1, +e_2}`,
+`{+e_1, +e_2, +e_3}`, `{+e_2}`, `{+e_1, +e_2}` at `A,B,C,D` from
+strictly-earlier six-neighbor locks union `{L(q)}` when defined. Mixed
+remains a set. The construction does not sum. Occupancy `n` is not used.
+Named signs lost the axis. `A` is not the 1-seed; origin is. Reverse HOLD
+uses `L(A)`: no. No pair from `S^+(A)` and `S^+(B)` is opposite, so reverse
+fails. No pair from `S^+(C)` and `S^+(D)` is opposite, so face fails.
+Later-tick leftover waits for a global later T and holds reverse from
+`−e_1` at `A`. Opposite-lock own-lock-in leftover holds reverse because that
+`A` is a seed. Unique own-incoming leftover reports reverse `UNDEFINED`.
+The sets are not those leftovers. The bits remain displayed. Incoming-lock
+uniqueness is not required.
+
+### N8 — cross-cycle echo
+
+A unique own-incoming lock-vector display on these same perpnn y-probes
+assigns `L(A)=+e_2`, `L(B)=UNDEFINED`, `L(C)=UNDEFINED`, `L(D)=+e_1` and
+reports reverse `UNDEFINED` with face `UNDEFINED`. A formation-tick
+existential opposite display that excludes `q` assigns `{+e_1}` at `A` and
+`{+e_2}` at `D`. Later-tick existential opposite on these y-probes reports
+reverse hold and face hold on different later sets
+`{+e_1, −e_1, +e_2, +e_3, −e_3}` and `{+e_1, +e_2, −e_2, +e_3, −e_3}` after
+a global later T. Opposite-lock own-lock-in on these y-probes reports reverse
+hold and face hold because that `A` is a seed. Later-tick existential
+opposite on perpnn x-probes reports reverse fail and face hold. Unique
+lock-vector lettering of the union sets would report reverse `UNDEFINED`
+because `A` and `B` mix. A sum leftover of the same lists would replace the
+sets by `(1,1,0)` and `(1,1,1)`. This note is not those displays: mixed
+remains a set, the construction does not sum, `S^+(A)` includes both the
+origin lock and `L(A)`, reverse fails, and face fails. This is a 1-seed
+own-lock-in display on the four y-probes, not leftover of later-tick
+existential opposite.
+
+**Gate disposition:** PASS for the own-lock-in union existential-opposite
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals the
+named sign,” “the predicate equals the unique singleton lock vector,” “the
+predicate equals the sum of the lock set,” “bits are Admissibility,” “the
+letter is occupancy `n`,” “the sets equal unique own-incoming letters,” “the
+sets equal formation-tick leftover that excludes `q`,” “the sets equal
+later-tick leftover,” “the bits equal opposite-lock own-lock-in,” “reverse
+holds,” “face holds,” or “reverse HOLD uses `L(A)`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the perpnn 1-seed
+perp-step incoming-lock process, reads each probe's own unique incoming lock
+or `UNDEFINED`, collects six-neighbor locks formed strictly earlier than
+each probe's own formation tick, unions those locks with `{L(q)}` when
+defined, reads the union sets at the four y-probes, reports whether reverse
+HOLD uses `L(A)`, and checks Theorems 1--3. It also checks that the
+construction is not named-sign lettering, that mixed sets remain defined,
+that the construction does not sum, that occupancy `n` is not used, that a
+formation member from already-recorded six-neighbor locks is not attached,
+that the sets are not leftover of unique own-incoming letters, that the sets
+are not leftover of formation-tick existential opposite that excludes `q`,
+that the bits are not leftover of later-tick existential opposite, and that
+the bits are not leftover of opposite-lock own-lock-in. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13705,6 +13705,10 @@
   "periodic_staggered_os_circle_failure_twisted_antiperiodic_free_repair_bounded_theorem_note_2026-07-12": {
    "deps_hash": "aebdd24cfc28",
    "out_degree": 3
+  },
+  "perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "persistent_inertial_object_probe_note": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.txt
@@ -1,0 +1,96 @@
+===== runner cache v1 =====
+runner: scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py
+runner_sha256: c3de896087a9d5afa3ae7e9f0100bdc0b2e129a93371886098a101897ad0d231
+input_fingerprint_sha256: 41c1ca690b2d8da43ff9e9659cb19dcaf527c68b3e49698b54c688ef441804cb
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+own-lock-in existential opposite reverse/face on perpnn y-probes
+AUDIT_INPUT_PATHS:
+  docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from existential opposite in the union of strictly-earlier 6-NN locks with the probe's own incoming lock on the four perpnn y-probes are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: unique-own-incoming-letter-identity
+PASS: own-lock-in-set-identity
+PASS: theorem1-all-four-probes-recorded
+A t=1 L=+e_2 S+={+e_1, +e_2} incoming=+e_2
+B t=3 L=UNDEFINED S+={+e_1, +e_2, +e_3} incoming=+e_1,+e_2,+e_3
+C t=4 L=UNDEFINED S+={+e_2} incoming=+e_1,−e_1,+e_3,−e_3
+D t=2 L=+e_1 S+={+e_1, +e_2} incoming=+e_1
+t(A)=1 t(B)=3 t(C)=4 t(D)=2 leftover_T=4
+reverse=fail face=fail
+reverse_HOLD_uses_L(A)=no
+per_element: each lock vector in the union of strictly-earlier six-neighbor locks with L(q) when L(q) is defined
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four S^+ lock sets plus reverse/face as hold, fail, or UNDEFINED
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: theorem1-formation-ticks  ({'A': 1, 'B': 3, 'C': 4, 'D': 2})
+PASS: theorem1-A-own-letter-and-plus-set  (((0, 1, 0), frozenset({(1, 0, 0), (0, 1, 0)})))
+PASS: theorem1-B-own-letter-and-plus-set  (('UNDEFINED', frozenset({(1, 0, 0), (0, 0, 1), (0, 1, 0)})))
+PASS: theorem1-C-own-letter-and-plus-set  (('UNDEFINED', frozenset({(0, 1, 0)})))
+PASS: theorem1-D-own-letter-and-plus-set  (((1, 0, 0), frozenset({(1, 0, 0), (0, 1, 0)})))
+PASS: theorem1-A-is-not-the-1-seed
+PASS: theorem1-reverse-hold-does-not-use-L-A
+PASS: theorem2-reverse-fail
+PASS: theorem3-face-fail
+PASS: not-named-sign-lettering
+PASS: not-occupancy-n
+PASS: not-sum-leftover
+PASS: not-unique-vector-leftover
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required  (([(0, 0, 1), (0, 1, 0), (1, 0, 0)], [(-1, 0, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0)]))
+PASS: one-seed-origin-lock-plus-e1
+PASS: formation-tick-neighbors-strictly-earlier
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: perp-step-incoming-lock
+PASS: mutation-empty-plus-set-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: mutation-later-tick-would-hold
+PASS: mutation-own-incoming-would-be-undefined
+PASS: mutation-exclude-q-sets-differ
+PASS: mutation-opposite-lock-own-lock-in-would-hold
+PASS: mutation-sum-is-not-a-lock-letter
+PASS: note-claim-scope
+PASS: note-reports-plus-sets
+PASS: note-reports-fail-fail
+PASS: note-reports-reverse-hold-does-not-use-L-A
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-leftover
+PASS: note-not-leftover-of-own-incoming
+PASS: note-not-leftover-of-formation-tick-exclude-q
+PASS: note-not-leftover-of-later-tick
+PASS: note-not-leftover-of-opposite-lock-own-lock-in
+PASS: note-own-lock-in-union
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-own-lock-in-existential-opposite
+TOTAL: PASS=64 FAIL=0
+
+----- stderr -----
+

--- a/scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py
+++ b/scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""Own-lock-in existential opposite reverse/face on four perpnn y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is the origin with lock +e_1. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. L(q) is q's own unique incoming lock; seeds use seed letters. If
+several earliest incoming steps exist, L(q) is UNDEFINED. At each y-probe's
+own formation tick t(q), S^+(q) is the set of locks of 6-NN of q that formed
+at tick < t(q), union {L(q)} when L(q) is defined. Reverse holds iff some a
+in S^+(A) and some b in S^+(B) have a+b=(0,0,0). Face holds iff some c in
+S^+(C) and some d in S^+(D) have c+d=(0,0,0). Empty S^+ on either side is
+UNDEFINED; nonempty with no opposite pair fails. A=(0,1,0) is not the
+1-seed; origin is. Reverse HOLD does not use L(A): reverse fails. Not
+later-tick leftover (later-tick reverse and face hold on these y-probes).
+Not leftover of opposite-lock own-lock-in (that display holds reverse when
+A is a seed). Uniqueness of incoming locks is not required. Occupancy n is
+not used. Named-sign lettering is not used. No unique P_+. No Dijkstra. No
+Gram.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Letter = Point | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+ONE_SEED: tuple[tuple[Point, Point], ...] = ((ORIGIN, E1),)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "L1",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+    "P_+",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from existential opposite in the union of "
+    "strictly-earlier 6-NN locks with the probe's own incoming lock on the "
+    "four perpnn y-probes are reported. Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def recorded_lock_set(pairs: tuple[tuple[Point, Point], ...]) -> frozenset[Point]:
+    """Set of six-neighbor locks. Duplicates collapse."""
+    return frozenset(lock for _neighbor, lock in pairs)
+
+
+def unique_own_incoming_letter(incoming: tuple[Point, ...] | set[Point]) -> Letter:
+    """Unique letter if the probe's own earliest incoming locks are a singleton in NN."""
+    unique = set(incoming)
+    if len(unique) != 1:
+        return "UNDEFINED"
+    vector = next(iter(unique))
+    if vector not in NN:
+        return "UNDEFINED"
+    return vector
+
+
+def own_lock_in_set(earlier: frozenset[Point], letter: Letter) -> frozenset[Point]:
+    """Union of strictly-earlier 6-NN locks with L(q) when L(q) is defined."""
+    if letter == "UNDEFINED":
+        return earlier
+    if not isinstance(letter, tuple):
+        raise TypeError(f"letter is not a lock vector: {letter!r}")
+    return earlier | {letter}
+
+
+def existential_opposite(left: frozenset[Point], right: frozenset[Point]) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    Empty set on either side is UNDEFINED. Nonempty with no opposite pair fails.
+    Does not sum. Does not require a singleton.
+    """
+    if not left or not right:
+        return "UNDEFINED"
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: frozenset[Point], set_b: frozenset[Point]) -> str:
+    """Reverse iff some a in S^+(A) and some b in S^+(B) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: frozenset[Point], set_d: frozenset[Point]) -> str:
+    """Face iff some c in S^+(C) and some d in S^+(D) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def letter_display(letter: Letter) -> str:
+    if letter == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter, tuple):
+        raise TypeError(f"letter is not a lock vector: {letter!r}")
+    return LOCK_NAME[letter]
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = ONE_SEED,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def formation_tick_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Locks of 6-NN of site formed at tick < t(site); site excluded."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] >= formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def later_tick_T(
+    ticks: dict[Point, int],
+    probes: dict[str, Point] = PROBES,
+) -> int | None:
+    """Leftover global T: max formation tick of the four named probes."""
+    defined = [ticks[probes[name]] for name in ("A", "B", "C", "D") if probes[name] in ticks]
+    if len(defined) != 4:
+        return None
+    return max(defined)
+
+
+def later_tick_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    common_tick: int,
+) -> tuple[tuple[Point, Point], ...]:
+    """Leftover: locks of 6-NN of site formed at tick <= common_tick, site excluded."""
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] > common_tick:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    """Z^3 sum leftover of a lock set. Contrast only; not this letter."""
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("own-lock-in existential opposite reverse/face on perpnn y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E1, E1) == (2, 0, 0)
+        and add(E2, E2) == (0, 2, 0)
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    set_a = frozenset({E1, E2})
+    set_b = frozenset({E1, E2, E3})
+    set_c = frozenset({E2})
+    set_d = frozenset({E1, E2})
+    later_mixed_a = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    later_mixed_d = frozenset({E1, E2, NEG_E2, E3, NEG_E3})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(frozenset(), frozenset({E3})) == "UNDEFINED"
+        and existential_opposite(frozenset({E3}), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(set_a, set_b) == "fail"
+        and existential_opposite(set_c, set_d) == "fail"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold"
+        and existential_opposite(later_mixed_a, set_b) == "hold"
+        and existential_opposite(set_c, later_mixed_d) == "hold",
+    )
+    checks.check(
+        "unique-own-incoming-letter-identity",
+        unique_own_incoming_letter((E1,)) == E1
+        and unique_own_incoming_letter((E1, E1)) == E1
+        and unique_own_incoming_letter((E2,)) == E2
+        and unique_own_incoming_letter((E1, E2, E3)) == "UNDEFINED"
+        and unique_own_incoming_letter((E1, NEG_E1, E3, NEG_E3)) == "UNDEFINED"
+        and unique_own_incoming_letter(()) == "UNDEFINED",
+    )
+    checks.check(
+        "own-lock-in-set-identity",
+        own_lock_in_set(frozenset({E1}), E2) == set_a
+        and own_lock_in_set(set_b, "UNDEFINED") == set_b
+        and own_lock_in_set(frozenset({E2}), "UNDEFINED") == set_c
+        and own_lock_in_set(frozenset({E2}), E1) == set_d
+        and own_lock_in_set(frozenset(), "UNDEFINED") == frozenset(),
+    )
+
+    ticks, locks = form()
+    later_common = later_tick_T(ticks)
+    opp_ticks, opp_locks = form(TWO_SITE_SEEDS)
+    checks.check(
+        "theorem1-all-four-probes-recorded",
+        all(PROBES[name] in ticks for name in ("A", "B", "C", "D"))
+        and later_common is not None,
+    )
+    assert later_common is not None
+
+    neighbor_lists: dict[str, tuple[tuple[Point, Point], ...]] = {}
+    earlier_sets: dict[str, frozenset[Point]] = {}
+    letters: dict[str, Letter] = {}
+    plus_sets: dict[str, frozenset[Point]] = {}
+    later_sets: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        pairs = formation_tick_neighbor_locks(site, ticks, locks)
+        neighbor_lists[name] = pairs
+        earlier_sets[name] = recorded_lock_set(pairs)
+        letter = unique_own_incoming_letter(locks[site])
+        letters[name] = letter
+        plus_sets[name] = own_lock_in_set(earlier_sets[name], letter)
+        later_pairs = later_tick_neighbor_locks(site, ticks, locks, later_common)
+        later_sets[name] = recorded_lock_set(later_pairs)
+        incoming = ",".join(LOCK_NAME[lock] for lock in NN if lock in locks[site])
+        print(
+            f"{name} t={ticks[site]} L={letter_display(letter)} "
+            f"S+={set_display(plus_sets[name])} incoming={incoming}"
+        )
+
+    print(
+        f"t(A)={ticks[PROBES['A']]} t(B)={ticks[PROBES['B']]} "
+        f"t(C)={ticks[PROBES['C']]} t(D)={ticks[PROBES['D']]} "
+        f"leftover_T={later_common}"
+    )
+    reverse_status = reverse_report(plus_sets["A"], plus_sets["B"])
+    face_status = face_report(plus_sets["C"], plus_sets["D"])
+    earlier_reverse = reverse_report(earlier_sets["A"], earlier_sets["B"])
+    earlier_face = face_report(earlier_sets["C"], earlier_sets["D"])
+    later_reverse = reverse_report(later_sets["A"], later_sets["B"])
+    later_face = face_report(later_sets["C"], later_sets["D"])
+    own_reverse = reverse_report(
+        own_lock_in_set(frozenset(), letters["A"]),
+        own_lock_in_set(frozenset(), letters["B"]),
+    )
+    own_face = face_report(
+        own_lock_in_set(frozenset(), letters["C"]),
+        own_lock_in_set(frozenset(), letters["D"]),
+    )
+    print(f"reverse={reverse_status} face={face_status}")
+    print(f"reverse_HOLD_uses_L(A)=no")
+    print(
+        "per_element: each lock vector in the union of strictly-earlier "
+        "six-neighbor locks with L(q) when L(q) is defined"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four S^+ lock sets plus reverse/face as hold, fail, or UNDEFINED"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    opp_plus: dict[str, frozenset[Point]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        pairs = formation_tick_neighbor_locks(site, opp_ticks, opp_locks)
+        letter = unique_own_incoming_letter(opp_locks[site])
+        opp_plus[name] = own_lock_in_set(recorded_lock_set(pairs), letter)
+    opp_reverse = reverse_report(opp_plus["A"], opp_plus["B"])
+    opp_face = face_report(opp_plus["C"], opp_plus["D"])
+
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 1
+        and ticks[PROBES["B"]] == 3
+        and ticks[PROBES["C"]] == 4
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-A-own-letter-and-plus-set",
+        letters["A"] == E2
+        and neighbor_lists["A"] == ((ORIGIN, E1),)
+        and earlier_sets["A"] == frozenset({E1})
+        and plus_sets["A"] == set_a,
+        str((letters["A"], plus_sets["A"])),
+    )
+    checks.check(
+        "theorem1-B-own-letter-and-plus-set",
+        letters["B"] == "UNDEFINED"
+        and neighbor_lists["B"]
+        == (
+            ((0, 1, 1), E3),
+            ((0, 1, 1), E2),
+            ((1, 0, 1), E1),
+            (PROBES["D"], E1),
+        )
+        and earlier_sets["B"] == set_b
+        and plus_sets["B"] == set_b,
+        str((letters["B"], plus_sets["B"])),
+    )
+    checks.check(
+        "theorem1-C-own-letter-and-plus-set",
+        letters["C"] == "UNDEFINED"
+        and neighbor_lists["C"]
+        == (
+            ((1, 2, 0), E2),
+            ((-1, 2, 0), E2),
+            (PROBES["A"], E2),
+            ((0, 2, 1), E2),
+            ((0, 2, -1), E2),
+        )
+        and earlier_sets["C"] == set_c
+        and plus_sets["C"] == set_c,
+        str((letters["C"], plus_sets["C"])),
+    )
+    checks.check(
+        "theorem1-D-own-letter-and-plus-set",
+        letters["D"] == E1
+        and neighbor_lists["D"] == ((PROBES["A"], E2),)
+        and earlier_sets["D"] == frozenset({E2})
+        and plus_sets["D"] == set_d,
+        str((letters["D"], plus_sets["D"])),
+    )
+    checks.check(
+        "theorem1-A-is-not-the-1-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[PROBES["A"]] == 1
+        and PROBES["A"] != ORIGIN
+        and letters["A"] == E2
+        and letters["A"] != E1,
+    )
+    checks.check(
+        "theorem1-reverse-hold-does-not-use-L-A",
+        letters["A"] == E2
+        and letters["A"] in plus_sets["A"]
+        and NEG_E2 not in plus_sets["B"]
+        and reverse_report(plus_sets["A"] - {E2}, plus_sets["B"]) == "fail"
+        and reverse_status == "fail",
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and plus_sets["A"]
+        and plus_sets["B"]
+        and reverse_status != "hold"
+        and reverse_status != "UNDEFINED",
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and plus_sets["C"]
+        and plus_sets["D"]
+        and face_status != "hold"
+        and face_status != "UNDEFINED",
+    )
+    checks.check(
+        "not-named-sign-lettering",
+        {named_sign(lock) for lock in plus_sets["A"]} == {"+"}
+        and {named_sign(lock) for lock in plus_sets["B"]} == {"+"}
+        and {named_sign(lock) for lock in plus_sets["C"]} == {"+"}
+        and {named_sign(lock) for lock in plus_sets["D"]} == {"+"}
+        and reverse_status == "fail"
+        and face_status == "fail",
+    )
+    checks.check(
+        "not-occupancy-n",
+        "occupancy n is not used" in normalized_note.lower()
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "not-sum-leftover",
+        sum_of_set(plus_sets["A"]) == (1, 1, 0)
+        and sum_of_set(plus_sets["B"]) == (1, 1, 1)
+        and sum_of_set(plus_sets["C"]) == E2
+        and sum_of_set(plus_sets["D"]) == (1, 1, 0)
+        and add(sum_of_set(plus_sets["A"]), sum_of_set(plus_sets["B"])) != ZERO
+        and add(sum_of_set(plus_sets["C"]), sum_of_set(plus_sets["D"])) != ZERO
+        and sum_of_set(plus_sets["A"]) not in NN
+        and reverse_status == "fail"
+        and face_status == "fail",
+    )
+    checks.check(
+        "not-unique-vector-leftover",
+        len(plus_sets["A"]) > 1
+        and len(plus_sets["B"]) > 1
+        and len(plus_sets["D"]) > 1
+        and reverse_status == "fail"
+        and reverse_status != "UNDEFINED",
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(locks[PROBES[name]] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(locks[PROBES["B"]]) == 3
+        and len(locks[PROBES["C"]]) == 4
+        and letters["B"] == "UNDEFINED"
+        and letters["C"] == "UNDEFINED"
+        and plus_sets["B"] == set_b
+        and plus_sets["C"] == set_c
+        and reverse_status == "fail"
+        and face_status == "fail",
+        str((sorted(locks[PROBES["B"]]), sorted(locks[PROBES["C"]]))),
+    )
+    checks.check(
+        "one-seed-origin-lock-plus-e1",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks.get(E2) != 0
+        and len(ONE_SEED) == 1
+        and ONE_SEED != TWO_SITE_SEEDS
+        and ONE_SEED != PERP_SEEDS,
+    )
+    checks.check(
+        "formation-tick-neighbors-strictly-earlier",
+        all(neighbor != PROBES[name] for name in PROBES for neighbor, _lock in neighbor_lists[name])
+        and all(
+            ticks[neighbor] < ticks[PROBES[name]]
+            for name in PROBES
+            for neighbor, _lock in neighbor_lists[name]
+        ),
+    )
+    checks.check(
+        "formation-stays-in-host",
+        set(ticks) <= host,
+    )
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and ticks[E2] == 1
+        and ticks[(0, -1, 0)] == 1
+        and ticks[E3] == 1
+        and ticks[(0, 0, -1)] == 1
+        and ticks[PROBES["A"]] == 1
+        and ticks[PROBES["B"]] == 3
+        and ticks[PROBES["C"]] == 4
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "mutation-empty-plus-set-undefined",
+        recorded_lock_set(()) == frozenset()
+        and reverse_report(frozenset(), plus_sets["B"]) == "UNDEFINED"
+        and face_report(plus_sets["C"], frozenset()) == "UNDEFINED",
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(set_a, set_b) == "fail"
+        and face_report(set_c, set_d) == "fail"
+        and reverse_status == "fail"
+        and face_status == "fail",
+    )
+    checks.check(
+        "mutation-later-tick-would-hold",
+        later_sets["A"] == later_mixed_a
+        and later_sets["D"] == later_mixed_d
+        and later_reverse == "hold"
+        and later_face == "hold"
+        and reverse_status == "fail"
+        and face_status == "fail"
+        and later_common == 4,
+    )
+    checks.check(
+        "mutation-own-incoming-would-be-undefined",
+        own_reverse == "UNDEFINED"
+        and own_face == "UNDEFINED"
+        and reverse_status == "fail"
+        and face_status == "fail",
+    )
+    checks.check(
+        "mutation-exclude-q-sets-differ",
+        earlier_sets["A"] == frozenset({E1})
+        and earlier_sets["D"] == frozenset({E2})
+        and earlier_sets["A"] != plus_sets["A"]
+        and earlier_sets["D"] != plus_sets["D"]
+        and earlier_reverse == "fail"
+        and earlier_face == "fail",
+    )
+    checks.check(
+        "mutation-opposite-lock-own-lock-in-would-hold",
+        opp_ticks[PROBES["A"]] == 0
+        and opp_reverse == "hold"
+        and opp_face == "hold"
+        and reverse_status == "fail",
+    )
+    checks.check(
+        "mutation-sum-is-not-a-lock-letter",
+        sum_of_set(plus_sets["A"]) not in NN
+        and sum_of_set(plus_sets["B"]) not in NN
+        and reverse_status == "fail",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-plus-sets",
+        "S^+(A) = {+e_1, +e_2}" in note
+        and "S^+(B) = {+e_1, +e_2, +e_3}" in note
+        and "S^+(C) = {+e_2}" in note
+        and "S^+(D) = {+e_1, +e_2}" in note
+        and "t(A)=1" in note
+        and "t(B)=3" in note
+        and "t(C)=4" in note
+        and "t(D)=2" in note
+        and "L(A) = +e_2" in note
+        and "L(B) = UNDEFINED" in note
+        and "L(C) = UNDEFINED" in note
+        and "L(D) = +e_1" in note
+        and "+e_1 at (0, 0, 0)" in note
+        and "+e_3 at (0, 1, 1)" in note
+        and "+e_2 at (0, 1, 1)" in note
+        and "+e_1 at (1, 0, 1)" in note
+        and "+e_1 at (1, 1, 0)" in note
+        and "+e_2 at (1, 2, 0)" in note
+        and "+e_2 at (-1, 2, 0)" in note
+        and "+e_2 at (0, 1, 0)" in note
+        and "+e_2 at (0, 2, 1)" in note
+        and "+e_2 at (0, 2, -1)" in note,
+    )
+    checks.check(
+        "note-reports-fail-fail",
+        "Reverse: fail" in note
+        and "Face: fail" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-reports-reverse-hold-does-not-use-L-A",
+        "Reverse HOLD uses L(A): no" in note
+        and "L(A)=+e_2" in note.replace(" ", "")
+        and reverse_status == "fail",
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "not written into Admissibility" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "does not use occupancy" in normalized_note
+        and "own incoming lock" in normalized_note
+        and "strictly earlier" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach" not in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "Reverse fails." in note
+        and "Face fails." in note,
+    )
+    checks.check(
+        "note-not-leftover-of-own-incoming",
+        "not leftover of the unique own-incoming lock-vector letters"
+        in normalized_note
+        and "UNDEFINED" in note
+        and "Reverse: fail" in note,
+    )
+    checks.check(
+        "note-not-leftover-of-formation-tick-exclude-q",
+        "not leftover of formation-tick existential opposite"
+        in normalized_note
+        and "S^+(A)={+e_1, +e_2}" in note.replace(" ", "").replace("`", "")
+        or "S^+(A) = {+e_1, +e_2}" in note,
+    )
+    checks.check(
+        "note-not-leftover-of-later-tick",
+        "not leftover of later-tick existential opposite" in normalized_note
+        and "later-tick" in normalized_note
+        and "Reverse: fail" in note
+        and "Face: fail" in note,
+    )
+    checks.check(
+        "note-not-leftover-of-opposite-lock-own-lock-in",
+        "not leftover of opposite-lock own-lock-in" in normalized_note
+        and "A is a seed" in note
+        and "A is not" in normalized_note,
+    )
+    checks.check(
+        "note-own-lock-in-union",
+        "union" in normalized_note
+        and "S^+(q)" in note
+        and "own incoming lock" in normalized_note
+        and "strictly earlier" in normalized_note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/PERPNN_YPROBE_OWN_LOCK_IN_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def existential_opposite(" in source
+        and "def recorded_lock_set(" in source
+        and "def formation_tick_neighbor_locks(" in source
+        and "def unique_own_incoming_letter(" in source
+        and "def own_lock_in_set(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 1
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-own-lock-in-existential-opposite",
+        "existential_opposite" in defined_fns
+        and "recorded_lock_set" in defined_fns
+        and "formation_tick_neighbor_locks" in defined_fns
+        and "unique_own_incoming_letter" in defined_fns
+        and "own_lock_in_set" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Own-lock-in S^+ on perpnn y-probes. Displayed, not adopted.

## Runner

`scripts/perpnn_yprobe_own_lock_in_existential_opposite_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.