### PR TITLE
science: isolate AC determinant-power selector boundary

### DIFF
--- a/docs/ACPHILAMBDA_RECORD_POSITIVITY_DETERMINANT_POWER_SELECTOR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-22.md
+++ b/docs/ACPHILAMBDA_RECORD_POSITIVITY_DETERMINANT_POWER_SELECTOR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-22.md
@@ -1,0 +1,440 @@
+---
+claim_id: acphilambda_record_positivity_determinant_power_selector_boundary_bounded_theorem_note_2026-08-22
+claim_type: bounded_theorem
+claim_scope: "On the declared phase-complete scalar-determinant surface, a real-linear map from C into positive Hermitian blocks is zero. An entrywise-holomorphic F:Omega->M_d(C) on a connected open complex domain whose image is Hermitian is constant, and is zero if 0 is in Omega and F(0)=0. For fixed rho>=0 and nonzero A_0 with Tr(A_0 rho A_0^dagger)>0, the branch-operator typing A_z=zA_0 gives sigma_z=|z|^2 sigma_1 and squared-modulus trace ratios. A nonzero positive modulus-power-one construction must leave at least one of those direct-map or scalar-amplitude hypotheses; named examples are explicitly non-exhaustive. For separately supplied additive positive blocks, coarse addition preserves the supplied fine-block calibration, while event-label cardinality alone fixes no factor. These finite facts expose independent physical typing, trace/probability, and event-calibration bridges; they do not select the charged-lepton action, measure, event carrier, determinant horn, r value, or a universal no-go."
+depends_on:
+  - minimal_axioms
+runner: scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py
+runner_cache: logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Positive Blocks and the AC Determinant-Power Selector Boundary
+
+**Date:** 2026-08-22
+
+**Role:** bounded action/measure typing probe after the provisional finite
+Record-law candidate
+
+**Claim type:** bounded theorem; source proposal requiring independent audit
+
+**Type:** bounded_theorem
+
+**Primary runner:**
+[`scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py`](../scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py)
+
+**Cached receipt:**
+[`logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt`](../logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt)
+
+## Result up front
+
+This probe narrows, but does not retire, the charged-lepton
+count-once/count-twice fork. Let
+
+```text
+z = det_C(K).
+```
+
+Three determinant typings must be kept distinct.
+
+1. **Direct positive block.** A nonzero real-linear map from a
+   phase-complete complex `z` domain into positive Hermitian blocks is
+   impossible. More generally, an entrywise-holomorphic matrix map on a
+   connected open complex domain whose image is Hermitian is constant. It is
+   zero when the domain contains zero and the zero determinant must map to the
+   zero block.
+2. **Scalar branch amplitude.** If `A_z=z A_0`, then branch-operator algebra
+   gives
+
+   ```text
+   sigma_z = A_z rho A_z^dagger = |z|^2 sigma_1,
+   Tr(sigma_z) = |z|^2 Tr(sigma_1).
+   ```
+
+   This establishes a squared-modulus branch-block and trace factor. It does
+   not by itself identify that factor with physical probability or with the
+   realified/conjugate-paired AC action horn.
+3. **Positive modulus-power-one construction.** A supplied positive
+   determinant ray, a direct modulus weight, or a square-root writer
+   `A_z=sqrt(|z|)A_0` can produce modulus power one. These routes leave the
+   real-linear/holomorphic direct-map or standard scalar-amplitude hypotheses.
+   They are examples, not an exhaustive list of physical constructions.
+
+Supplied event calibration is a separate axis. If two fine positive blocks
+are assigned traces `w,w`, their sum has trace `2w`. If a coarse block of
+trace `w` is instead refined into calibrated blocks with traces `w/2,w/2`,
+their sum remains `w`. Thus coarse addition preserves the calibration already
+supplied; the number of event labels does not create a factor. In particular,
+an event quotient or rescaling can change a multiplicity factor but cannot by
+itself turn the determinant exponent `|z|^2` into `|z|`.
+
+The AC residual therefore has three independent physical interfaces:
+
+- `W_T`: which action/measure or amplitude **typing** the determinant has;
+- `W_P`: which downstream law, if any, turns a branch trace or statistical
+  measure into physical probability;
+- `W_E`: which K/CPT alternatives are physical events and how their fine
+  blocks are calibrated.
+
+The current Minimal Axioms supply none of these choices. This packet makes no
+minimal-axiom edit and retires no TOE obligation.
+
+## 1. Exact supplied surface
+
+The theorem uses only the following finite objects and assumptions.
+
+- `K` is a finite complex matrix and `z=det_C(K)`.
+- The exact real-linear test surface contains the rank-one kernels `[1]`,
+  `[-1]`, `[i]`, and `[-i]`; `det([z])=z`.
+- A supplied branch block is a positive semidefinite finite matrix `sigma`.
+  Its trace is a candidate mathematical weight, not an axiomatically supplied
+  probability.
+- For the amplitude identity, `rho>=0`, `A_0` is nonzero, and
+  `A_z=zA_0`. Ratios require `Tr(sigma_1)>0`.
+- For the holomorphic identity, `Omega` is connected and open and
+  `F:Omega->M_d(C)` is entrywise holomorphic with Hermitian image. The zero
+  conclusion additionally requires `0 in Omega` and `F(0)=0`.
+- For the coarse-block identity, positive fine blocks and their additive
+  coarse block are supplied theorem-domain data. Their physical event meaning
+  and normalization are not inferred from label cardinality.
+
+The branch identity itself does not assert that an arbitrary `A_z` family is
+a complete or trace-nonincreasing instrument. The runner also supplies one
+exact `c=1/9` fixture with positive completion so the displayed conditional
+ratios occur inside a valid finite instrument.
+
+The only determinant identity consumed is `det([z])=z`, reproved by the
+runner. Two older sources are non-load-bearing consistency context:
+`ACPHILAMBDA_OCCUPANCY_DETERMINANT_POWER_SPLIT_EXACT_SUPPORT_NOTE_2026-07-04.md`
+and
+`ACPHILAMBDA_FERMIONIC_REALIFICATION_PFAFFIAN_POWER_IDENTITY_NARROW_THEOREM_NOTE_2026-07-12.md`.
+The latter warns that a complex-to-Majorana coordinate rewrite does not itself
+add an independent conjugate physical carrier. Neither source proves the
+present lemmas and neither is a dependency edge.
+
+The current [Minimal Axioms](MINIMAL_AXIOMS_2026-06-29.md) supply a local
+probability-distribution slot and fixed Records while leaving distribution
+values, source/action, measurement/event calibration, Born weights, and
+physical-observable identification downstream. The August 13 revision also
+removed finite additivity from Record. Therefore positive blocks, trace
+weighting, and coarse additivity below are explicit theorem hypotheses, not
+Record content.
+
+## 2. Phase-complete linear and holomorphic maps
+
+Let `B:C->Herm(H)` be real-linear and suppose `B(z)>=0` at both `z` and `-z`.
+Real linearity gives `B(-z)=-B(z)`. Both `B(z)` and `-B(z)` are positive
+semidefinite, so for every vector `v`,
+
+```text
+0 <= v^dagger B(z) v <= 0.
+```
+
+Every quadratic form vanishes and polarization gives `B(z)=0`. Applying this
+at the `+/-1` and `+/-i` fixtures makes `B` zero on their real span, all of
+`C`. The runner supplies an exact rank-four `Herm(2)` polarization
+certificate and directly checks that multiplying a positive block by `i`
+does not leave it Hermitian or real-trace positive.
+
+For the holomorphic result, let `F:Omega->M_d(C)` be entrywise holomorphic on
+a connected open complex domain and suppose every `F(z)` is Hermitian. For
+every vector `v`,
+
+```text
+f_v(z) = v^dagger F(z) v
+```
+
+is holomorphic and real-valued. Writing `f_v=u+i v_im`, Hermiticity gives
+`v_im=0`; the Cauchy--Riemann equations then force both derivatives of `u` to
+vanish. Thus each `f_v` is constant, and polarization makes `F` constant. If
+`0 in Omega` and `F(0)=0`, then `F` is zero. The runner checks the exact
+rank-four Cauchy--Riemann certificate.
+
+These statements do not cover nonholomorphic positive maps, affine
+normalizations, or a physically restricted positive determinant domain.
+
+## 3. Scalar-amplitude typing gives a squared-modulus trace factor
+
+For supplied `rho>=0` and fixed nonzero `A_0`, set
+
+```text
+A_z = z A_0,
+sigma_z = A_z rho A_z^dagger.
+```
+
+Then exactly
+
+```text
+sigma_z
+  = z A_0 rho conjugate(z) A_0^dagger
+  = |z|^2 sigma_1.
+```
+
+Taking the trace preserves that factor. When `Tr(sigma_1)>0`, a finite menu
+with the same underlying nonzero block has conditional trace ratios
+
+```text
+q_j = |z_j|^2 / sum_k |z_k|^2,
+```
+
+conditional on landing in one of those displayed determinant branches. In
+the runner's completed instrument, the menu `{1,2i}` has unconditional branch
+probabilities `(1/45,4/45)` and completion probability `8/9`; only after
+conditioning on the determinant branches are the ratios `(1/5,4/5)`. The
+single `z=3+4i` fixture has branch probability `5/9`, completion probability
+`4/9`, and trace ratio `25` relative to `z=1`.
+
+The trace-to-probability interpretation in that fixture comes from the
+separately supplied instrument semantics. The general algebraic identity
+supplies only branch blocks and their traces. Current Record supplies neither
+a trace/Born law nor finite additivity. A separate provisional Record-law
+source proposal is not a dependency and is not yet effective retained
+science.
+
+Finally, `|z|^2 sigma_1` is only a squared-modulus branch factor. Showing that
+the actual charged-lepton determinant is this amplitude, and showing that its
+carrier is the physical realified/conjugate-paired horn, remain `W_T`.
+
+## 4. Coarse addition preserves supplied calibration
+
+For supplied orthogonal rank-one blocks with traces `w,w`, where `w>0`,
+
+```text
+sigma_0 = w P_0,
+sigma_1 = w P_1,
+sigma_coarse = sigma_0 + sigma_1,
+Tr(sigma_coarse) = 2w != w.
+```
+
+That is one valid calibration. A different valid calibration starts from a
+coarse operation `A` and refines it using orthogonal-output isometries:
+
+```text
+A_0 = V_0 A / sqrt(2),
+A_1 = V_1 A / sqrt(2),
+A_0^dagger A_0 + A_1^dagger A_1 = A^dagger A.
+```
+
+The fine traces are then `w/2,w/2` and the coarse trace stays `w`. The runner
+checks the corresponding exact positive-block fixtures. Therefore addition
+preserves a supplied calibration, while one versus two labels selects no
+normalization. Coherent combination before positive blocks form, an affine
+reference-arm instrument, and an indivisible K/CPT event are also outside the
+equal-`w` fixture.
+
+This finite sum is a theorem-domain assumption. It is not derived from Record
+or the Minimal Axioms. It constrains neither determinant exponent nor the
+physical event map without `W_T`, `W_P`, and `W_E`.
+
+## 5. Non-exhaustive routes that remain live
+
+| Axis | Example mechanism | Missing physical supplier |
+|---|---|---|
+| `W_T` | positive determinant ray, `sigma_z=z sigma_1` for `z>=0` | prove the actual action stays positive and enters as a direct weight |
+| `W_T` | nonholomorphic modulus, `sigma_z=|z| sigma_1` | derive phase erasure and its carrier |
+| `W_T` | square-root writer, `A_z=sqrt(|z|)A_0` | derive this nonlinear amplitude map |
+| `W_T` | Euclidean positive determinant as path-measure weight | connect the finite positive determinant sector to the actual AC generation carrier |
+| `W_T/W_E` | phase-sensitive positive homogeneous or coherent/affine instrument | derive the map and its physical event interpretation |
+| `W_E` | one indivisible K/CPT event | prove the conjugate labels are not independent events |
+| `W_E` | normalized two-event refinement with fine weights `w/2,w/2` | derive the event instrument and calibration |
+| `W_P` | downstream trace/Born or normalized path-measure law | derive probabilities from the chosen physical carrier |
+
+These are constructive targets, not a complete classification. The runner
+checks only the positive-ray, square-root, amplitude, and two displayed
+calibration mechanisms.
+
+## 6. AC occupancy consequence
+
+The standing AC obligation asks for a physical matter action and measure that
+distinguish the count-once `det_C` realization from a count-twice
+`|det_C|^2`/conjugate-paired realization without inserting the desired value.
+This packet turns that residual into three explicit questions:
+
+1. **`W_T`, carrier typing:** Is the determinant an amplitude, a direct
+   statistical weight, or input to another derived map?
+2. **`W_P`, probability bridge:** What physical law maps that carrier to
+   outcome probabilities and normalization?
+3. **`W_E`, event calibration:** Which K/CPT alternatives are registrable
+   events, and what fine-block normalization does the instrument supply?
+
+Standard scalar-amplitude typing answers only the algebraic exponent question:
+it gives a squared-modulus branch factor. With a separately established
+trace-as-probability law, conditional outcome ratios inherit that factor. A
+separate physical-carrier theorem is still needed to identify this with the
+AC count-twice horn. Conversely, a positive first-power path remains
+mathematically open, and event calibration can change a multiplicity without
+changing the determinant exponent.
+
+This is useful route reduction, but no formal obligation is retired. The
+physical charged-lepton action, probability bridge, and event carrier are
+still missing. The observed charged-lepton `r` value is not used in any proof.
+
+## 7. Axiom decision
+
+There is no minimal-axiom edit in this packet. The memo already puts
+source/action, measurement, probability values, and observable identification
+downstream. The three open interfaces sit exactly there.
+
+An axiom update would become scientifically warranted only if independent
+work showed that one of these interfaces is genuinely foundational and cannot
+be derived from retained physics. The present finite lemmas establish neither
+necessity nor uniqueness. Editing the axioms now would choose the AC answer
+rather than derive it.
+
+## 8. Scope and non-claims
+
+- This is not a universal no-go against count-once physics.
+- It is not a classification of all positive nonlinear determinant maps.
+- It does not derive the physical charged-lepton matter action, measure,
+  determinant typing, K/CPT carrier, physical event map, or calibration.
+- It does not derive a universal Born/trace law, Record process, gravity
+  coupling, continuum theory, or charged-lepton mass formula.
+- It does not equate a coordinate presentation with an independent conjugate
+  physical sector.
+- It does not edit an axiom, primitive, audit verdict, obligation status, or
+  TOE percentage.
+- It does not claim that the routes in section 5 are exhaustive.
+
+## 9. No-Go Discipline Gate
+
+The packet contains negative-flavored subclaims, so the current N1--N8
+protocol is applied to the exact bounded statements. The broad claim “no
+count-once theory can work” fails this gate and is not shipped.
+
+### N1 — alternative-route enumeration
+
+| Family | Test against the narrow result | Disposition |
+|---|---|---|
+| Restricted positive determinant ray | Direct positive weight on `z>=0`; runner also tests failure at `z=-1`. | **ATTEMPTED; live outside scope.** It changes the phase-complete hypothesis. |
+| Direct modulus weight | `z->|z|sigma` is positive and first-power. | **ATTEMPTED algebraically; live.** It is nonholomorphic and nonlinear. |
+| Square-root writer | `A_z=sqrt(|z|)A_0`; exact runner fixture. | **ATTEMPTED; live.** It changes scalar-amplitude typing. |
+| Euclidean determinant measure | [`STAGGERED_ONLY_DET_POSITIVITY_CASE_A_NOTE_2026-05-17.md`](STAGGERED_ONLY_DET_POSITIVITY_CASE_A_NOTE_2026-05-17.md) gives a finite positive staggered-determinant source candidate used as path-weight context. | **ATTEMPTED as boundary context; live and currently unaudited.** The cited source is not retained authority here and requires an actual AC carrier bridge. |
+| Phase-sensitive positive homogeneous map | For `sigma>=0`, `B(z)=(|z|+Re z)sigma>=0`. | **ATTEMPTED analytically; live.** It is neither real-linear nor holomorphic. |
+| Coherent/affine pre-block construction | Combine K/CPT paths coherently or with a reference arm before positive fine blocks form. | **ATTEMPTED as a premise-boundary construction; unresolved.** It lies outside the supplied fine-block premise, so it does not falsify the additive identity and is not physically ruled out. |
+| One-event quotient | Form one indivisible event before refinement. | **ATTEMPTED as a premise-boundary construction; live.** The two-block sum is then undefined, so it changes `W_E` rather than the determinant exponent. |
+| Calibrated normalized split | `A_j=V_jA/sqrt(2)` gives fine weights `w/2,w/2`. | **ATTEMPTED exactly; live.** It disproves any cardinality-only factor rule. |
+
+The named families are non-exhaustive. They leave intact only the exact
+real-linear, holomorphic, scalar-amplitude, and supplied-addition statements.
+
+### N2 — wall-independence audit
+
+| Pair | Why the first does not close the second | Why the second does not close the first | Verdict |
+|---|---|---|---|
+| `W_T` / `W_P` | Choosing an amplitude or path weight does not derive its probability law. | A trace/Born law does not identify which AC object enters it. | independent absent a linking theorem |
+| `W_T` / `W_E` | Determinant exponent does not decide whether K/CPT labels are physical events. | Event identity does not decide amplitude versus direct-weight typing. | independent absent a linking theorem |
+| `W_P` / `W_E` | A probability functional does not calibrate the event partition it acts on. | An event partition and instrument do not derive a universal trace/Born rule. | independent absent a linking theorem |
+
+Positive ray, modulus, square-root, and Euclidean-measure routes are candidate
+closures of `W_T`, not extra walls. One-event and calibrated-split routes are
+candidate closures of `W_E`.
+
+### N3 — hidden-condition scan
+
+| Phrase/class | Classification |
+|---|---|
+| positive branch block | supplied finite operator data; not called Record content |
+| trace weight | candidate mathematical quantity; physical probability requires `W_P` |
+| standard amplitude typing | exact conditional equation `A_z=zA_0`; load-bearing `W_T` premise |
+| coarse addition | supplied finite block-sum convention; not a Minimal-Axiom or Record theorem |
+| current Minimal Axioms | authority only for the explicit non-supply boundary |
+| physical event map/calibration | open `W_E`, never inferred from labels |
+
+The scan found no unnamed bridge beyond `W_T`, `W_P`, and `W_E`. In
+particular, “standard instrument” is not used to smuggle completeness or a
+universal probability law into the general branch identity.
+
+### N4 — residual matching
+
+The finite lemmas prove map-typing facts; the AC obligation asks for the actual
+physical matter carrier. A squared-modulus trace factor is not itself the
+realified/conjugate-paired AC horn, and an additive factor of two is not a
+determinant-power result. No prior no-go, contextual determinant note, or
+desired mass ratio is used as a witness. The result therefore ships as bounded
+route reduction with the three mismatched physical residuals explicit.
+
+### N5 — rhetoric audit and execution certificate
+
+| Resolution | Tested? | Exact scope |
+|---|---:|---|
+| per-element | Yes | scalar fixtures `z in {1,-1,i,-i}` and determinant typings |
+| per-site | No | no site action or site-to-event lift |
+| per-mode | No | no fermion-mode or K/CPT independence theorem |
+| per-block | Yes | `Herm(2)` positivity, Kraus blocks, and two calibration fixtures |
+| lattice-wide | No | no lattice action, continuum lift, or charged-lepton theory |
+
+The runner prints substantive `per_element:`, `per_site:`, `per_mode:`,
+`per_block:`, and `lattice_wide:` lines. The cached stdout must match the
+landed runner exactly. Every broader physical phrase is excluded.
+
+### N6 — partial-closure path and primitive scan
+
+The approved primitive registry and relevant source memos were checked.
+
+- `scale_reference_primitive` supplies units only.
+- `kinetic_isotropy_primitive` supplies kinetic-form graining only.
+- `realized_state_primitive` supplies pointwise evaluation, not weighting or
+  probability.
+- `minimal_axioms` supplies the probability-distribution slot and fixed
+  Records while leaving the values, source/action, and calibration downstream.
+
+No primitive is relabeled as a wall. Positive partial closures remain
+available without an axiom edit: derive a positive AC action (`W_T`), derive a
+trace or normalized-measure law (`W_P`), or derive the physical instrument and
+its normalized refinement (`W_E`). The exact `w/2,w/2` split is a concrete
+partial-closure construction, not a rhetorical escape.
+
+### N7 — strongest steelman
+
+The strongest positive critic combines all three missing interfaces.
+[`STAGGERED_ONLY_DET_POSITIVITY_CASE_A_NOTE_2026-05-17.md`](STAGGERED_ONLY_DET_POSITIVITY_CASE_A_NOTE_2026-05-17.md)
+is the exact repository source candidate for a configuration-wise positive
+first-power staggered determinant that may enter the path measure directly
+(`W_T`); a derived normalized-measure-to-outcome rule may connect that measure
+to observable records (`W_P`); and an independently calibrated one-event or
+normalized two-event instrument may avoid artificial K/CPT double counting
+(`W_E`). The cited source is currently unaudited, is non-load-bearing here,
+and does not establish the AC carrier.
+Executing these three links could positively close count-once without
+contradicting any lemma here. This is why no broad no-go or axiom selection is
+allowed.
+
+### N8 — cross-cycle echo
+
+Repository ledgers and the relevant August 13 correction were checked.
+
+- The block-28 determinant-power ledger says determinant algebra does not
+  select the physical horn. The later Pfaffian note reinforces that a
+  coordinate rewrite is not a new physical carrier.
+- The block-29 Record-orbit ledger says outcome labels do not select
+  determinant power. The calibrated split here strengthens that boundary.
+- `MINIMAL_AXIOMS_2026-06-29.md` records the August 13 removal of scalar
+  intensity and finite additivity from Record.
+- `FINITE_DYADIC_PRODUCT_REGISTRATION_TRUNCATED_BARYCENTER_BOUNDED_THEOREM_NOTE_2026-08-13.md`
+  records the corresponding prior repair: a supplied finite-product
+  construction must not be advertised as a Record-bit theorem.
+
+This packet follows that retirement mechanism by saying “supplied positive
+block/trace convention,” never “Record trace law” or “Record additivity.” No
+convention-only repair closes `W_T`, `W_P`, and `W_E` together.
+
+**Gate result:** PASS for the exact bounded finite lemmas and corrected
+three-interface residual. FAIL for a universal count-once no-go, a physical AC
+horn selection, or a framework-wide probability theorem; none is shipped.
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py
+```
+
+Expected result:
+
+```text
+TOTAL: PASS=12 FAIL=0
+```
+
+Every named hostile mutation must produce exactly one failed check.

--- a/docs/ACPHILAMBDA_RECORD_POSITIVITY_DETERMINANT_POWER_SELECTOR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-22.md
+++ b/docs/ACPHILAMBDA_RECORD_POSITIVITY_DETERMINANT_POWER_SELECTOR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-22.md
@@ -17,9 +17,7 @@ bare_retained_allowed: false
 **Role:** bounded action/measure typing probe after the provisional finite
 Record-law candidate
 
-**Claim type:** bounded theorem; source proposal requiring independent audit
-
-**Type:** bounded_theorem
+**Claim type:** bounded_theorem
 
 **Primary runner:**
 [`scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py`](../scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py)

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15754,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -264,6 +264,10 @@
   },
   "acphilambda_record_outcome_orbit_occupancy_non_supply_no_go_note_2026-07-04": {
    "deps_hash": "7b707271a9a8",
+   "out_degree": 2
+  },
+  "acphilambda_record_positivity_determinant_power_selector_boundary_bounded_theorem_note_2026-08-22": {
+   "deps_hash": "7795e949cc13",
    "out_degree": 2
   },
   "acphilambda_registrable_cycle_holonomy_normal_form_2026-07-01": {

--- a/logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt
+++ b/logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt
@@ -1,10 +1,10 @@
 ===== runner cache v1 =====
 runner: scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py
 runner_sha256: 6f1ad13fd87aa2bb2e8fffa9efdee6b5ab2e8e6aba95123412001c2766a9b2b9
-input_fingerprint_sha256: aa3f09fbd03caf78b81e9e11717a54b0c53aa2ffdf6399c1939ec8f8fc05c940
+input_fingerprint_sha256: 13f4268386196efdee004cc27131207e0bb9c82e8df247b2c3d12eeb7db39f14
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 0.55
+elapsed_sec: 0.45
 status: ok
 ----- stdout -----
 [PASS] phase-complete determinant witness: det([z]) values=(1, -1, I, -I)

--- a/logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt
+++ b/logs/runner-cache/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.txt
@@ -1,0 +1,30 @@
+===== runner cache v1 =====
+runner: scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py
+runner_sha256: 6f1ad13fd87aa2bb2e8fffa9efdee6b5ab2e8e6aba95123412001c2766a9b2b9
+input_fingerprint_sha256: aa3f09fbd03caf78b81e9e11717a54b0c53aa2ffdf6399c1939ec8f8fc05c940
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.55
+status: ok
+----- stdout -----
+[PASS] phase-complete determinant witness: det([z]) values=(1, -1, I, -I)
+[PASS] real-linear phase-complete positive map is zero: polarization rank=4 det=-4
+[PASS] holomorphic Hermitian branch-block map is constant: Cauchy-Riemann rank=4 det=1
+[PASS] raw holomorphic determinant is not a positive branch block: z=I hermitian=False trace=I
+[PASS] Kraus amplitude gives a squared-modulus branch-trace factor: trace ratio=25 branch_probability=5/9 completion_probability=4/9
+[PASS] scalar amplitude phase leaves its positive branch block invariant: phase=I invariant=True
+[PASS] conditional determinant-branch menu uses squared-modulus ratios: branch_probabilities=[1/45, 4/45] conditional=[1/5, 4/5] completion=8/9
+[PASS] first-power direct weight needs a supplied positive domain: domain=(0, 2, 5, -1) traces=(0, 2, 5, -1)
+[PASS] modulus-power-one square-root writer is a separate nonlinear bridge: trace ratio=5 complex_linear=False
+[PASS] coarse addition preserves supplied fine-block calibration: equal_fine=(3/7,3/7) equal_coarse=6/7 calibrated_split=3/7
+[PASS] squared-modulus amplitude factors compose multiplicatively: composite=25 factors=25
+[PASS] source preserves action, event-map, escape, and axiom boundaries: needles=7 present=7
+per_element: checked — phase-complete scalar determinant fixtures and their positive-weight typings are exercised exactly
+per_site: checked and not executed — no site-local matter action, site calibration, or site-to-event lift is claimed
+per_mode: checked and not executed — no fermion-mode carrier or K/CPT mode independence is selected by this theorem
+per_block: checked — Hermitian positivity, Kraus branch blocks, and a two-fine-event coarse sum are exercised exactly
+lattice_wide: checked and not executed — no lattice dynamics, continuum lift, or full charged-lepton action is claimed
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py
+++ b/scripts/acphilambda_record_positivity_determinant_power_selector_boundary_2026_08_22.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Exact checks for a positive-block/determinant-power typing boundary.
+
+The runner separates three typings of a complex determinant z:
+
+1. a phase-complete real-linear positive branch block (only the zero map);
+2. a quantum amplitude z A (branch trace proportional to |z|^2);
+3. a separately supplied positive first-power weight or square-root writer.
+
+It also checks that supplied positive blocks add while their cardinality does
+not fix their calibration.  The calculation is a bounded finite theorem.  It
+does not derive a probability law, physical matter action, determinant typing,
+charged-lepton event map, or an axiom update.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import sympy as sp
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/ACPHILAMBDA_RECORD_POSITIVITY_DETERMINANT_POWER_SELECTOR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-22.md",
+)
+
+
+MUTATIONS = (
+    "phase_domain",
+    "positivity_certificate",
+    "holomorphic_hermitian",
+    "direct_weight",
+    "kraus_power",
+    "phase_invariance",
+    "normalization",
+    "positive_ray",
+    "sqrt_escape",
+    "coarse_additivity",
+    "multiplicativity",
+    "source_scope",
+)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--mutation", choices=MUTATIONS)
+args = parser.parse_args()
+mutation = args.mutation
+
+
+@dataclass
+class Check:
+    name: str
+    passed: bool
+    detail: str
+
+
+checks: list[Check] = []
+
+
+def check(name: str, passed: bool, detail: str) -> None:
+    checks.append(Check(name=name, passed=bool(passed), detail=detail))
+
+
+def matrix_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return left.shape == right.shape and all(
+        sp.simplify(value) == 0 for value in left - right
+    )
+
+
+def scalar_equal(left: sp.Expr, right: sp.Expr) -> bool:
+    return sp.simplify(left - right) == 0
+
+
+def branch(amplitude: sp.Matrix, state: sp.Matrix) -> sp.Matrix:
+    return sp.simplify(amplitude * state * amplitude.H)
+
+
+def weight(block: sp.Matrix) -> sp.Expr:
+    return sp.simplify(sp.trace(block))
+
+
+def psd_2x2(block: sp.Matrix) -> bool:
+    """Exact Sylvester check for a Hermitian 2x2 positive-semidefinite block."""
+    return (
+        block.shape == (2, 2)
+        and matrix_equal(block, block.H)
+        and sp.simplify(block[0, 0]).is_nonnegative is True
+        and sp.simplify(block[1, 1]).is_nonnegative is True
+        and sp.simplify(block.det()).is_nonnegative is True
+    )
+
+
+# A. The determinant of the 1x1 complex kernel [z] reaches every complex
+# phase.  The four displayed points provide both additive inverses and a real
+# basis for C.  Removing one inverse is the hostile phase-domain mutation.
+phase_points = (1, -1, sp.I, -sp.I)
+if mutation == "phase_domain":
+    phase_points = (1, 1, sp.I, -sp.I)
+det_values = tuple(sp.det(sp.Matrix([[z]])) for z in phase_points)
+check(
+    "phase-complete determinant witness",
+    det_values == (1, -1, sp.I, -sp.I),
+    f"det([z]) values={det_values}",
+)
+
+
+# B. Let B:C->Herm(2) be real-linear and suppose B(z), B(-z) are positive.
+# Then every quadratic form q_v(B(z)) is both >=0 and <=0, hence zero.  Four
+# polarization probes reconstruct all four real Hermitian coordinates.  Their
+# coefficient matrix is invertible, certifying B(z)=0 for every z.  A repeated
+# probe destroys the certificate under mutation.
+probe_matrix = sp.Matrix(
+    [
+        [1, 0, 0, 0],       # q(e1) = a
+        [0, 1, 0, 0],       # q(e2) = b
+        [1, 1, 2, 0],       # q(e1+e2) = a+b+2c
+        [1, 1, 0, -2],      # q(e1+i e2) = a+b-2d
+    ]
+)
+if mutation == "positivity_certificate":
+    probe_matrix[3, :] = probe_matrix[2, :]
+check(
+    "real-linear phase-complete positive map is zero",
+    probe_matrix.rank() == 4 and probe_matrix.det() != 0,
+    f"polarization rank={probe_matrix.rank()} det={probe_matrix.det()}",
+)
+
+
+# C. More generally, an entrywise-holomorphic F:Omega->M_d(C) on a connected
+# open complex domain whose image is Hermitian is constant.  For each quadratic
+# probe its scalar value is real-valued and holomorphic.  Writing that scalar as
+# u+i v, v=0 together with the Cauchy-Riemann equations forces both derivatives
+# of u to vanish.  The exact constraint matrix below has full rank.  The
+# polarization probes then reconstruct a constant matrix; if 0 is in Omega and
+# F(0)=0, it is the zero map.
+cr_matrix = sp.Matrix(
+    [
+        [0, 0, 1, 0],   # v_x = 0
+        [0, 0, 0, 1],   # v_y = 0
+        [1, 0, 0, -1],  # u_x - v_y = 0
+        [0, 1, 1, 0],   # u_y + v_x = 0
+    ]
+)
+if mutation == "holomorphic_hermitian":
+    cr_matrix[3, :] = cr_matrix[2, :]
+check(
+    "holomorphic Hermitian branch-block map is constant",
+    cr_matrix.rank() == 4 and cr_matrix.det() != 0,
+    f"Cauchy-Riemann rank={cr_matrix.rank()} det={cr_matrix.det()}",
+)
+
+
+# D. A raw complex determinant is not itself a positive branch weight on the
+# phase-complete domain.  The i fixture is neither Hermitian nor real-valued.
+rho = sp.Matrix([[sp.Rational(3, 5), sp.Rational(1, 5)],
+                 [sp.Rational(1, 5), sp.Rational(2, 5)]])
+raw_z = sp.Integer(1) if mutation == "direct_weight" else sp.I
+raw_block = sp.simplify(raw_z * rho)
+check(
+    "raw holomorphic determinant is not a positive branch block",
+    not matrix_equal(raw_block, raw_block.H) and not weight(raw_block).is_real,
+    f"z={raw_z} hermitian={matrix_equal(raw_block, raw_block.H)} trace={weight(raw_block)}",
+)
+
+
+# E. Standard amplitude typing.  If A_z=c z A_0, complete positivity supplies
+# sigma_z=A_z rho A_z^dag=|z|^2 sigma_1.  The exact c=1/9 fixture also makes
+# A_z a trace-nonincreasing branch with a positive completion.  The mutation
+# drops the adjoint phase from the expected power.
+a0 = sp.Matrix([[1, 1], [0, 1]])
+z = 3 + 4 * sp.I
+instrument_scale = sp.Rational(1, 9)
+sigma_1 = branch(instrument_scale * a0, rho)
+az = instrument_scale * z * a0
+sigma_z = branch(az, rho)
+expected_power = z**2 if mutation == "kraus_power" else z * sp.conjugate(z)
+single_completion_effect = sp.simplify(sp.eye(2) - az.H * az)
+single_branch_probability = weight(sigma_z)
+single_completion_probability = sp.simplify(sp.trace(rho * single_completion_effect))
+check(
+    "Kraus amplitude gives a squared-modulus branch-trace factor",
+    matrix_equal(sigma_z, sp.simplify(expected_power * sigma_1))
+    and scalar_equal(weight(sigma_z), 25 * weight(sigma_1))
+    and psd_2x2(single_completion_effect)
+    and scalar_equal(single_branch_probability, sp.Rational(5, 9))
+    and scalar_equal(single_completion_probability, sp.Rational(4, 9))
+    and scalar_equal(single_branch_probability + single_completion_probability, 1),
+    f"trace ratio={sp.simplify(weight(sigma_z)/weight(sigma_1))} "
+    f"branch_probability={single_branch_probability} "
+    f"completion_probability={single_completion_probability}",
+)
+
+
+# F. The standard branch weight is phase blind, as positivity requires for a
+# scalar rephasing of the same amplitude.
+phase = 2 if mutation == "phase_invariance" else sp.I
+sigma_phase = branch(instrument_scale * phase * z * a0, rho)
+check(
+    "scalar amplitude phase leaves its positive branch block invariant",
+    matrix_equal(sigma_phase, sigma_z),
+    f"phase={phase} invariant={matrix_equal(sigma_phase, sigma_z)}",
+)
+
+
+# G. Competing amplitude branches inherit |z_j|^2 trace ratios.  The exact
+# instrument includes a completion outcome, so 1/5 and 4/5 are conditional on
+# landing in the displayed determinant branches rather than unconditional.
+menu = (sp.Integer(1), 2 * sp.I)
+menu_weights = [sp.simplify(v * sp.conjugate(v)) for v in menu]
+denominator = sum(menu_weights)
+conditional_probabilities = [sp.simplify(v / denominator) for v in menu_weights]
+expected_conditionals = [sp.Rational(1, 2), sp.Rational(1, 2)] if mutation == "normalization" else [sp.Rational(1, 5), sp.Rational(4, 5)]
+menu_effect = sp.zeros(2)
+menu_branch_probabilities = []
+for menu_value in menu:
+    menu_amplitude = instrument_scale * menu_value * a0
+    menu_effect += sp.simplify(menu_amplitude.H * menu_amplitude)
+    menu_branch_probabilities.append(weight(branch(menu_amplitude, rho)))
+menu_completion_effect = sp.simplify(sp.eye(2) - menu_effect)
+menu_completion_probability = sp.simplify(sp.trace(rho * menu_completion_effect))
+check(
+    "conditional determinant-branch menu uses squared-modulus ratios",
+    conditional_probabilities == expected_conditionals
+    and menu_branch_probabilities == [sp.Rational(1, 45), sp.Rational(4, 45)]
+    and scalar_equal(sum(conditional_probabilities), 1)
+    and psd_2x2(menu_completion_effect)
+    and scalar_equal(menu_completion_probability, sp.Rational(8, 9))
+    and scalar_equal(sum(menu_branch_probabilities) + menu_completion_probability, 1),
+    f"branch_probabilities={menu_branch_probabilities} "
+    f"conditional={conditional_probabilities} completion={menu_completion_probability}",
+)
+
+
+# H. A determinant may instead scale a positive block directly on an
+# independently supplied positive ray.  Extending that typing to a negative
+# point immediately violates positivity; the mutation falsely omits it.
+positive_ray_points = (sp.Integer(0), sp.Integer(2), sp.Integer(5))
+if mutation != "positive_ray":
+    positive_ray_points += (-sp.Integer(1),)
+direct_traces = tuple(weight(sp.simplify(v * rho)) for v in positive_ray_points)
+positive_prefix = all(value >= 0 for value in direct_traces[:3])
+negative_escape = direct_traces[-1] < 0 if len(direct_traces) == 4 else False
+check(
+    "first-power direct weight needs a supplied positive domain",
+    positive_prefix and negative_escape,
+    f"domain={positive_ray_points} traces={direct_traces}",
+)
+
+
+# I. A first-power modulus weight can be realized by a square-root Kraus
+# amplitude sqrt(|z|) A_0.  It is positive and has exponent one, but is not
+# complex-linear in z.  Mutation uses |z| and loses the first-power receipt.
+sqrt_scale = instrument_scale * (
+    sp.Abs(z) if mutation == "sqrt_escape" else sp.sqrt(sp.Abs(z))
+)
+sqrt_sigma = branch(sqrt_scale * a0, rho)
+sqrt_ratio = sp.simplify(weight(sqrt_sigma) / weight(sigma_1))
+not_complex_linear = not matrix_equal(
+    instrument_scale * sp.sqrt(sp.Abs(sp.I)) * a0,
+    sp.I * instrument_scale * a0,
+)
+check(
+    "modulus-power-one square-root writer is a separate nonlinear bridge",
+    scalar_equal(sqrt_ratio, sp.Abs(z)) and not_complex_linear,
+    f"trace ratio={sqrt_ratio} complex_linear={not not_complex_linear}",
+)
+
+
+# J. Coarse positive blocks inherit the sum of their supplied fine positive
+# blocks.  Two equal-weight-w blocks sum to 2w, while a calibrated split into
+# two weight-w/2 blocks sums back to w.  Cardinality alone fixes no factor.
+p0 = sp.diag(1, 0)
+p1 = sp.diag(0, 1)
+w = sp.Rational(3, 7)
+fine_0 = w * p0
+fine_1 = w * p1
+coarse = (fine_0 + fine_1) / 2 if mutation == "coarse_additivity" else fine_0 + fine_1
+split_0 = (w / 2) * p0
+split_1 = (w / 2) * p1
+split_coarse = split_0 + split_1
+check(
+    "coarse addition preserves supplied fine-block calibration",
+    scalar_equal(weight(coarse), 2 * w)
+    and scalar_equal(weight(fine_0), w)
+    and scalar_equal(weight(fine_1), w)
+    and scalar_equal(weight(split_coarse), w),
+    f"equal_fine=({weight(fine_0)},{weight(fine_1)}) equal_coarse={weight(coarse)} calibrated_split={weight(split_coarse)}",
+)
+
+
+# K. Independent amplitude composition preserves the second-power law.
+z1 = 2 + sp.I
+z2 = 1 - 2 * sp.I
+composite_weight = sp.simplify((z1 * z2) * sp.conjugate(z1 * z2))
+factor_weight = sp.simplify(
+    (z1 * sp.conjugate(z1)) * (z2 * sp.conjugate(z2))
+)
+if mutation == "multiplicativity":
+    factor_weight += 1
+check(
+    "squared-modulus amplitude factors compose multiplicatively",
+    scalar_equal(composite_weight, factor_weight),
+    f"composite={composite_weight} factors={factor_weight}",
+)
+
+
+# L. Source guards keep the theorem at the physical-selector boundary.
+root = Path(__file__).resolve().parents[1]
+note = root / "docs" / "ACPHILAMBDA_RECORD_POSITIVITY_DETERMINANT_POWER_SELECTOR_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-22.md"
+note_text = note.read_text(encoding="utf-8") if note.exists() else ""
+needles = (
+    "not a universal no-go",
+    "does not derive the physical charged-lepton matter action",
+    "no minimal-axiom edit",
+    "routes that remain live",
+    "physical event map",
+    "standard amplitude typing",
+    "W_P",
+)
+if mutation == "source_scope":
+    needles += ("THIS_MARKER_MUST_NOT_EXIST",)
+check(
+    "source preserves action, event-map, escape, and axiom boundaries",
+    all(needle in note_text for needle in needles),
+    f"needles={len(needles)} present={sum(needle in note_text for needle in needles)}",
+)
+
+
+for result in checks:
+    label = "PASS" if result.passed else "FAIL"
+    print(f"[{label}] {result.name}: {result.detail}")
+
+print("per_element: checked — phase-complete scalar determinant fixtures and their positive-weight typings are exercised exactly")
+print("per_site: checked and not executed — no site-local matter action, site calibration, or site-to-event lift is claimed")
+print("per_mode: checked and not executed — no fermion-mode carrier or K/CPT mode independence is selected by this theorem")
+print("per_block: checked — Hermitian positivity, Kraus branch blocks, and a two-fine-event coarse sum are exercised exactly")
+print("lattice_wide: checked and not executed — no lattice dynamics, continuum lift, or full charged-lepton action is claimed")
+
+passed = sum(result.passed for result in checks)
+failed = len(checks) - passed
+print(f"TOTAL: PASS={passed} FAIL={failed}")
+raise SystemExit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Result

This source packet proves four bounded finite facts: phase-complete real-linear positive determinant maps vanish; entrywise-holomorphic matrix maps with Hermitian image are constant; scalar branch-amplitude typing gives a squared-modulus branch-trace factor; and supplied coarse addition preserves supplied calibration while label cardinality fixes no factor.

It decomposes the remaining physical AC choice into three independent interfaces: action/measure typing W_T, trace/probability law W_P, and event/instrument calibration W_E. It does not identify the physical charged-lepton carrier, retire an obligation, change a TOE percentage, or edit the Minimal Axioms.

## Verification

- Primary runner: TOTAL: PASS=12 FAIL=0
- All 12 named hostile mutations: exactly PASS=11 FAIL=1
- Cached stdout is SHA/input bound and byte-identical to live stdout
- No-Go Discipline N1-N8: independent hostile recheck PASS after route citations and attempt markers
- Independent source review: no remaining load-bearing defect on the final hashes
- Full audit-compatible pipeline: PASS
- Changed-audit-evidence readiness: 1 checked, 0 failures
- Strict audit lint: 0 errors; 8 pre-existing warnings
- Vocabulary lint: 0 violations

Audit status remains owned by the independent audit lane; this PR applies no verdict.