### PR TITLE
feat(nmoread): neighbor-read of O on #7167: reverse HOLD, face HOLD

### DIFF
--- a/docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,526 @@
+---
+claim_id: opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read R_O of own outgoing on the four #7208 y-probes, equality to O, and reverse/face from R_O are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py
+---
+
+# Neighbor-Read Of Own Outgoing Reverse And Face On Four #7208 Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** neighbor-read `R_O(q)` of own outgoing on the four nsmopp #7208
+y-probes in `B_3(0)={n:n·n<=9}`, equality of `R_O` to `O`, and reverse/face
+from `R_O`. Same process as nsopp #7093. Let `t(q)` be the formation tick of
+probe `q`. `M(q)` is the set of earliest incoming nearest-neighbor steps at
+`q`. Seeds use their seed letter as a singleton. Mixed stays a set. Unformed
+is `UNDEFINED`. `O(q)` is the outgoing dual of `M`: the set of `e` in
+`{±e_1,±e_2,±e_3}` such that `q+e` is formed in `B_3(0)` and `e` is in
+`M(q+e)`. Unformed `q` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`.
+For formed `q`, `Nbr(q)` is the set of 6-NN of `q` that are formed in
+`B_3(0)` and are not `q`. `R_O(q)` is the neighbor-read of own outgoing:
+
+```text
+R_O(q) = { e in {±e_1,±e_2,±e_3} | q+e in Nbr(q) and (−e) in O(q+e) }.
+```
+
+Unformed `q` is `UNDEFINED`. Empty `R_O` is empty, not `UNDEFINED`. `R_O`
+is not `O` and is not `R(M)`. Read-HOLD at `q` iff `R_O(q)=O(q)` as sets
+(both defined, possibly mixed). Read-fail if both defined and unequal.
+`UNDEFINED` if either is `UNDEFINED`. Reverse holds if and only if some lock
+in `R_O(A)` is the vector opposite of some lock in `R_O(B)`. Face holds if
+and only if some lock in `R_O(C)` is the vector opposite of some lock in
+`R_O(D)`. Empty or `UNDEFINED` on either side of a comparison is
+`UNDEFINED`; nonempty with no opposite pair fails. Unique `L` is not the
+object. The six-neighbor star `S^+` is not the letter. Occupancy `n` is not
+used. This is not named-sign lettering. This is not a unique lock-vector
+leftover and not a sum leftover. This is not leftover of unique-L. This is
+not leftover of #7208 `M` exist-opposite, which HOLDs reverse from singleton
+`M(A)={−e_1}` against `M(B)={+e_1}`. This is not leftover of own outgoing
+`O`, which HOLDs reverse from `±e_3` in `O(A)` and `O(B)`. This is not
+leftover of neighbor-read `R(M)` of own incoming, which is `UNDEFINED` on
+#7167 reverse/face from empty `R(A)` and empty `R(C)`. The letter is
+neighbor-read of outgoing, not own outgoing. This is not leftover of #7167
+`S^+`. The six-NN star excluding `q` does not recover `O(q)`. Uniqueness is
+not required. This is not the sister kernel. This is not the sister #7210 kernel. Displayed, not adopted.
+Do not write into Admissibility. Do not attach L1. This note does not write
+existential opposite into Admissibility and does not attach a formation
+member from already-recorded six-neighbor locks. This display does not use
+occupancy. Mixed stays a set. No S⁺. Not Cl.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py`](../scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets. `R_O` is the
+neighbor-read of those outgoing sets. Reverse and face are scored on
+existence of an opposite pair in the neighbor-reads of outgoing. Named signs
+`{+,−}` are a coarser readout and are not used. A singleton unique lock-vector
+letter is a different readout and is not used as the object: report `R_O`.
+A `Z^3` sum of those locks is a different readout and is not used. The
+construction does not sum. No S⁺. R_O is not O. R_O is not R(M). R_O is not
+M.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of R_O(q) as neighbor-read of own outgoing on the four #7208 y-probes, mixed stays a set, with equality R_O=O as Read-fail at each probe and reverse hold plus face hold from existential opposite; uniqueness of neighbor-read locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face
+target_blocker_text: "display neighbor-read R_O of own outgoing on the four #7208 y-probes, equality to O, and reverse/face from R_O, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not use occupancy n, do not identify the sets with unique-L leftover, do not identify the sets with #7208 M leftover, do not identify the sets with outgoing O leftover, and do not identify the sets with R(M) leftover."
+conditional_surface_status: "exact on B_3(0) for neighbor-read of own outgoing on the four #7208 y-probes; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+neighbor-reads of outgoing are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed. Same process and y-probes as nsmopp #7208.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the two-record set `{0, (0,1,0)}` is recorded at formation tick 0 with
+opposite locks `L(0)=+e_1` and `L(0,1,0)=−e_1`. This seed is not the perp
+two-site seed `+e_1/+e_2`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept as a
+possible lock. Mixed stays a set. Uniqueness is not required. A later parent
+does not re-form `q`.
+
+## Named neighbor-read of own outgoing
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `M(q)` be the set of earliest incoming nearest-neighbor steps
+at `q`. Seeds use their seed letter as a singleton. Mixed stays a set.
+Unformed is `UNDEFINED`. Let `O(q)` be the outgoing dual of `M`:
+
+```text
+O(q) = { e in {±e_1,±e_2,±e_3} | q+e is formed in B_3(0) and e is in M(q+e) }.
+```
+
+Unformed `q` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. For formed
+`q`, `Nbr(q)` is the set of 6-NN of `q` that are formed in `B_3(0)` and are
+not `q`. Let `R_O(q)` be the neighbor-read of own outgoing:
+
+```text
+R_O(q) = { e in {±e_1,±e_2,±e_3} | q+e in Nbr(q) and (−e) in O(q+e) }.
+```
+
+Unformed `q` is `UNDEFINED`. Empty `R_O` is empty, not `UNDEFINED`. Unique
+`L(q)` is not used as the letter. This display does not use a six-neighbor
+star as the letter. Occupancy `n` is not used. Duplicate neighbor-read steps
+collapse in the set. The construction does not require `R_O(q)` to be a
+singleton. It does not sum `R_O(q)`. It is not a unique lock-vector leftover
+and not a sum leftover. It is not leftover of unique-L. It is not leftover
+of #7208 own incoming `M`. It is not leftover of own outgoing `O`. It is not
+leftover of neighbor-read `R(M)` of own incoming. R_O is not O. R_O is not
+R(M). R_O is not M. The six-NN star excluding `q` does not recover `O(q)`.
+Uniqueness is not required. This is not the sister #7210 kernel.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on existence
+of a pair of lock vectors that add to zero. They are not scored on `{+,−}`
+names and are not an occupancy-kernel inner product.
+
+Read equality, reverse, and face (displayed):
+
+```text
+read(q)  <=>  R_O(q) = O(q) as sets, both defined
+reverse  <=>  some a in R_O(A) and some b in R_O(B) with a+b=(0,0,0)
+face     <=>  some c in R_O(C) and some d in R_O(D) with c+d=(0,0,0)
+```
+
+If `R_O(q)` or `O(q)` is `UNDEFINED`, read is `UNDEFINED`. Else Read-HOLD if
+the sets are equal and Read-fail if they are unequal. If `R_O(A)` or
+`R_O(B)` is empty or `UNDEFINED`, reverse is `UNDEFINED`. Else reverse fails
+if no such pair exists. If `R_O(C)` or `R_O(D)` is empty or `UNDEFINED`,
+face is `UNDEFINED`. Else face fails if no such pair exists. The report is
+one of `hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility. Do not write into Admissibility. Do not attach L1.
+
+## Theorem 1 — formation ticks, O, and R_O at each y-probe
+
+Direct enumeration of the displayed nsopp #7093 process on `B_3(0)` forms
+all four y-probes. The formation ticks are `t(A)=0`, `t(B)=2`, `t(C)=1`,
+`t(D)=3`. `A` is a seed. Those ticks locate the earliest incoming set, the
+outgoing dual, and the neighbor-read of outgoing. They are not occupancy
+kernels and are not a global later T.
+
+Own outgoing duals of #7167 and neighbor-reads of outgoing at each probe
+are:
+
+```text
+A: seed letter −e_1;
+   t(A)=0;  O(A) = {+e_2, +e_3, −e_3};  R_O(A) = {+e_1}
+B: incoming +e_1;
+   t(B)=2;  O(B) = {+e_2, +e_3, −e_3};  R_O(B) = {−e_1}
+C: incoming +e_2;
+   t(C)=1;  O(C) = {+e_1, −e_1, +e_3, −e_3};  R_O(C) = {−e_2}
+D: incoming −e_2, −e_3, +e_3;
+   t(D)=3;  O(D) = {+e_1, −e_1};  R_O(D) = {+e_2, +e_3, −e_3}
+```
+
+`A` is a seed at tick 0. Mixed stays a set: `R_O(D)` has three neighbor-read
+steps `+e_2`, `+e_3`, and `−e_3`, and `O(A)` has three outgoing steps
+`+e_2`, `+e_3`, and `−e_3`. Unique-L leftover of `R_O` would assign
+`UNDEFINED` at mixed `D` and would leave face `UNDEFINED`. Uniqueness is not
+required.
+
+Equality `R_O=O` at each probe is Read-fail: both sides are defined and
+unequal. The six-NN star excluding `q` does not recover `O(q)`. `Nbr(A)` has
+six formed neighbors and omits `A`; `R_O(A)={+e_1}` while
+`O(A)={+e_2, +e_3, −e_3}`.
+
+Compare R_O to O, to M of #7208, and to R(M) of #7167. Same process reports
+
+```text
+M(A) = {−e_1},  M(B) = {+e_1},  M(C) = {+e_2},  M(D) = {−e_2, +e_3, −e_3}
+O(A) = {+e_2, +e_3, −e_3},  O(B) = {+e_2, +e_3, −e_3},
+O(C) = {+e_1, −e_1, +e_3, −e_3},  O(D) = {+e_1, −e_1}
+R(A) = {},  R(B) = {−e_3},  R(C) = {},  R(D) = {−e_2}
+```
+
+and Reverse HOLD of #7208 uses `−e_1` in `M(A)` against `+e_1` in `M(B)`.
+Own outgoing leftover uses `±e_3` in `O(A)` and `O(B)`. Neighbor-read
+`R(M)` of own incoming is empty at `A` and at `C`. Those letters are not
+the neighbor-read of outgoing. R_O is not O. R_O is not M. R_O is not R(M).
+`M` and `O` are disjoint at each of the four probes. No S⁺. Not Cl.
+
+Outgoing locks exist and need not be unique. Neighbor-read locks of outgoing
+need not be unique (`D` has three steps). That non-uniqueness does not empty
+`R_O(D)`. Uniqueness is not required.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if there exist `a` in `R_O(A)` and `b` in
+`R_O(B)` with `a+b=(0,0,0)`. Both sets are nonempty: `R_O(A)={+e_1}` and
+`R_O(B)={−e_1}`, so `+e_1+(−e_1)=(0,0,0)`. Reverse holds.
+
+Reverse: hold
+
+This is not `fail` and not `UNDEFINED`. Reverse holds. Unique-L leftover of
+`O` reports reverse `UNDEFINED` because every outgoing set is mixed.
+Unique-L leftover of `M` reports reverse hold from unique `L(A)=−e_1` and
+`L(B)=+e_1`. #7208 `M` leftover reports reverse hold from `−e_1` in `M(A)`
+against `+e_1` in `M(B)`. Own outgoing leftover reports reverse hold from
+`±e_3` in `O(A)` and `O(B)`. Neighbor-read `R(M)` leftover reports reverse
+`UNDEFINED` from empty `R(A)`. Reverse HOLD of neighbor-read of outgoing
+uses `+e_1` in `R_O(A)` against `−e_1` in `R_O(B)`, which is not the
+outgoing pair `±e_3` and is not leftover of the #7167 `R(M)` kill-gate.
+Neighbor-read is not only an `M` kill-gate. Reverse holds.
+
+Reverse holds.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if there exist `c` in `R_O(C)` and `d` in `R_O(D)`
+with `c+d=(0,0,0)`. Both sets are nonempty: `R_O(C)={−e_2}` and
+`R_O(D)={+e_2, +e_3, −e_3}`, so `−e_2+(+e_2)=(0,0,0)`. Face holds.
+
+Face: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `fail` and not `UNDEFINED`. Face holds. Unique-L leftover of
+`R_O` reports face `UNDEFINED` from mixed `D`. Unique-L leftover of `O`
+reports face `UNDEFINED` from mixed outgoing sets. Unique-L leftover of `M`
+reports face `UNDEFINED` from mixed `D`. #7208 `M` leftover reports face
+hold from `+e_2` in `M(C)` against `−e_2` in `M(D)`. Own outgoing leftover
+reports face hold from `±e_1` in `O(C)` and `O(D)`. Neighbor-read `R(M)`
+leftover reports face `UNDEFINED` from empty `R(C)`. Hold of face from the
+neighbor-read of outgoing uses `±e_2` and is not leftover of the outgoing
+`±e_1` HOLD. Named-sign lettering lost the axis. Face already holds at each
+probe's own formation tick from the neighbor-read of outgoing.
+
+Face holds.
+
+## What this note does not claim
+
+- It does not select a unique neighbor-read lock of outgoing.
+- It does not recover `O(q)` from the six-NN star excluding `q`.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the neighbor-read of outgoing to be a singleton.
+- It does not sum the neighbor-read of outgoing.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not census a sixteen-combination free lettering independent of
+  lock vectors.
+- It does not reprint unique-L letters on these y-probes as the object.
+- It does not reprint #7208 `M` as the letter.
+- It does not reprint own outgoing `O` as the letter.
+- It does not reprint neighbor-read `R(M)` of own incoming as the letter.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+- It is not the sister kernel.
+- It is not the sister #7210 kernel.
+- It is not leftover of `R(M)`.
+- It is not Cl.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+opposite-lock two-site process, the neighbor-reads of own outgoing, and the
+existential-opposite reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; nsopp #7093 seed `+e_1/−e_1` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `2`, `1`, `3` |
+| own incoming sets `M(A)`, `M(B)`, `M(C)`, `M(D)` of #7208 | Theorem 1; `{−e_1}`, `{+e_1}`, `{+e_2}`, `{−e_2, +e_3, −e_3}` |
+| own outgoing sets `O(A)`, `O(B)`, `O(C)`, `O(D)` of #7167 | Theorem 1; `{+e_2, +e_3, −e_3}`, `{+e_2, +e_3, −e_3}`, `{+e_1, −e_1, +e_3, −e_3}`, `{+e_1, −e_1}` |
+| neighbor-reads `R_O(A)`, `R_O(B)`, `R_O(C)`, `R_O(D)` | Theorem 1; `{+e_1}`, `{−e_1}`, `{−e_2}`, `{+e_2, +e_3, −e_3}` |
+| equality `R_O=O` at each probe | Theorem 1; Read-fail at each |
+| six-NN star excluding `q` recovers `O(q)` | no; uniqueness is not required |
+| reverse and face from `R_O` | Theorems 2–3; `hold` / `hold` |
+| unique neighbor-read lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed stays a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| formation member from already-recorded six-neighbor locks | not attached |
+| leftover of unique-L | not this display |
+| leftover of #7208 `M` exist-opposite | not this display |
+| leftover of own outgoing `O` | not this display |
+| leftover of neighbor-read `R(M)` | not this display |
+| leftover of `R(M)` | not this display |
+| sister #7210 kernel | not this display |
+| six-neighbor star as the letter | not used |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: neighbor-read of own outgoing on the four #7208 y-probes, equality to `O`, reverse/face from `R_O` or `UNDEFINED`. |
+| V2 | Current main has no landed neighbor-read of own outgoing reverse/face report on these four #7208 y-probes. |
+| V3 | Neighbor-reads of outgoing, Read-fail, and the `hold`/`hold` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads neighbor outgoing whose reverse step is from the probe and scores equality to `O` plus existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+singleton lock vector, does not sum the lock set, does not reprint unique-L,
+does not reprint #7208 `M` as the letter, does not reprint outgoing `O`, does
+not reprint neighbor-read `R(M)`, does not use a six-neighbor star, does not
+recover `O(q)` from six-NN excluding `q`, and does not use occupancy `n`. No
+global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attack | Result |
+|---|---|---|
+| unique-L leftover | require a singleton `{v}` subset `{±e_i}` else `UNDEFINED` | refused; leftover; unique-L of mixed `R_O(D)` is `UNDEFINED` while face from `R_O` holds |
+| #7208 `M` exist-opposite | reuse the own incoming set as the letter | refused; leftover; that readout HOLDs reverse from `−e_1` in `M(A)` against `+e_1` in `M(B)` while neighbor-read of outgoing uses `+e_1` in `R_O(A)` against `−e_1` in `R_O(B)` |
+| own outgoing `O` exist-opposite | reuse `e in M(q+e)` as the letter | refused; leftover; `O` HOLDs reverse from `±e_3` while `R_O` HOLDs reverse from `±e_1`; Read-fail `R_O≠O` |
+| neighbor-read `R(M)` of own incoming | reuse `(−e) in M(q+e)` as the letter | refused; leftover of `R(M)`; that readout is `UNDEFINED` reverse/face on #7167 from empty `R(A)` and empty `R(C)` while `R_O` HOLDs reverse and face |
+| six-NN star excluding `q` as a unique kernel for `O(q)` | demand recovery of `O(q)` | refused; the star does not recover `O(q)`; uniqueness is not required; this is not the sister #7210 kernel |
+| sum of the same neighbor-reads | replace `R_O` by the `Z^3` sum | refused; leftover; the construction does not sum; sum of mixed `R_O(D)` cancels to `+e_2` while `R_O(D)` stays a three-element set |
+| unique letter of occupancy `n` | assign one letter from occupancy `n` | different object; occupancy `n` is not used |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` and `n(C)·n(D)<0` | different object; not an occupancy-kernel inner product |
+| reverse/face from formation-tick inequalities | score probes by formation order | different object; ticks locate `O` and `R_O` and are not the predicate |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted |
+| unique neighbor-read lock required | demand one neighbor-read step per probe | uniqueness is not required; mixed `R_O(D)` stays a set |
+
+### N2 — wall independence
+
+Missing physical adoption, missing formation attachment from already-recorded
+six-neighbor locks, and missing Record identification of existential opposite
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_1` and `−e_1`, perpendicular step
+rule, incoming-step lock, own outgoing dual, neighbor-read of own outgoing,
+mixed stays a set, existential opposite, four y-probes with seed `A`,
+Read-fail when `R_O≠O`, and reverse/face as existence of a pair that sums to
+zero are declared. No uniqueness of neighbor-read locks, no occupancy `n`, no
+named-sign reduction, no singleton leftover as the object, no sum leftover,
+no unique-L leftover, no #7208 `M` leftover, no outgoing leftover, no `R(M)`
+leftover, no six-neighbor star as the letter, no sister #7210 kernel, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`hold`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in a neighbor-read of own outgoing | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four neighbor-reads, equality to `O`, and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Neighbor-read of own outgoing is leftover of unique-L or of
+#7208 `M` because reverse already HOLDs from singleton `M(A)={−e_1}`, or it
+is leftover of outgoing `O` because both HOLD reverse and face, or it is
+leftover of neighbor-read `R(M)` because both read 6-NN excluding `q`, or
+the six-NN star excluding `q` recovers `O(q)`, or mixed `R_O(D)` should be
+`UNDEFINED`, or occupancy `n` should track that vector, or neighbor-read is
+only an `M` kill-gate.
+
+**Answer:** The named construction reports neighbor-reads of outgoing
+`{+e_1}`, `{−e_1}`, `{−e_2}`, `{+e_2, +e_3, −e_3}` at `A,B,C,D`. Empty
+`R_O` is empty. Mixed stays a set. The construction does not sum. Occupancy
+`n` is not used. Named signs lost the axis. Equality `R_O=O` is Read-fail at
+each probe. The six-NN star excluding `q` does not recover `O(q)`. Reverse
+holds because `+e_1` in `R_O(A)` is opposite `−e_1` in `R_O(B)`. Face holds
+because `−e_2` in `R_O(C)` is opposite `+e_2` in `R_O(D)`. Unique-L leftover
+of `R_O` reports face `UNDEFINED` from mixed `D`. Unique-L leftover of `O`
+reports reverse `UNDEFINED` and face `UNDEFINED`. #7208 `M` leftover reports
+reverse hold from `−e_1` in `M(A)` against `+e_1` in `M(B)`. Outgoing
+leftover reports reverse hold from `±e_3`, not from `±e_1`. Neighbor-read
+`R(M)` leftover reports reverse `UNDEFINED` and face `UNDEFINED` on #7167.
+Neighbor-read is not only an `M` kill-gate. R_O is not O. R_O is not M. R_O
+is not R(M). This is not leftover of `R(M)`. This is not the sister kernel. This is not the sister #7210
+kernel. Uniqueness is not required. The bits remain displayed.
+
+### N8 — cross-cycle echo
+
+A unique-L display on these same #7208 y-probes would assign
+`L(A)=−e_1`, `L(B)=+e_1`, `L(C)=+e_2`, `L(D)=UNDEFINED` and report reverse
+hold with face `UNDEFINED`. A #7208 own incoming display reports
+`M(A) = {−e_1}` with reverse hold and face hold. An own outgoing display
+reports `O(A) = {+e_2, +e_3, −e_3}` with reverse hold and face hold from
+`±e_3` / `±e_1`. A neighbor-read `R(M)` display on #7167 reports empty
+`R(A)` and empty `R(C)` with reverse `UNDEFINED` and face `UNDEFINED`. Unique
+lock-vector lettering of the neighbor-reads of outgoing would report reverse
+hold with face `UNDEFINED` because `R_O(D)` is mixed. A sum leftover of the
+same lists would replace mixed `R_O(D)` by `+e_2` after cancelling `+e_3`
+and `−e_3`. This note is not those displays: mixed stays a set, the
+construction does not sum, the letter is the neighbor-read of own outgoing,
+R_O is not O, R_O is not M, R_O is not R(M), reverse holds, and face holds.
+
+**Gate disposition:** PASS for the neighbor-read of own outgoing reverse/face
+reports above. FAIL / DO NOT SHIP for “the predicate equals the named sign,”
+“the predicate equals the unique singleton lock vector,” “the predicate
+equals the sum of the lock set,” “bits are Admissibility,” “the letter is
+occupancy `n`,” “the sets equal unique-L leftover,” “the sets equal #7208
+`M` leftover,” “the sets equal outgoing leftover,” “the sets equal `R(M)`
+leftover,” “R_O equals O,” “the six-NN star excluding `q` recovers `O(q)`,”
+“reverse fails,” or “face is `UNDEFINED`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the nsopp #7093 perp-step
+incoming-lock process, reads each probe's neighbor-read of own outgoing,
+scores equality of `R_O` to `O`, scores reverse and face by existential
+opposite, reports that the six-NN star excluding `q` does not recover
+`O(q)`, and checks Theorems 1--3. It also checks that the construction is
+not named-sign lettering, that mixed stays a set, that the construction does
+not sum, that occupancy `n` is not used, that a formation member from
+already-recorded six-neighbor locks is not attached, that the sets are not
+leftover of unique-L, that the sets are not leftover of #7208 `M`, that the
+sets are not leftover of outgoing `O`, and that the sets are not leftover of
+neighbor-read `R(M)`. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13537,6 +13537,10 @@
   "openreference_patchgraph_four_rail_signed_clifford_equivalence_cycle706_note_2026-07-26": {
    "deps_hash": "a9cb5a27b029",
    "out_degree": 4
+  },
+  "opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "orbit_constant_mass_dimension_cycle906_support_note_2026-08-09": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.txt
@@ -1,0 +1,94 @@
+===== runner cache v1 =====
+runner: scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py
+runner_sha256: 3948e5775a62f35abae529b17110796d01e02a9c0c43eb29c45374747fc70f30
+input_fingerprint_sha256: 43252f31f741bd8e0835e6f4f5d34c9dc04fe94bff82e73159637d803f32cbbd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+neighbor-read of own outgoing reverse/face on #7208 y-probes
+AUDIT_INPUT_PATHS:
+  docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read R_O of own outgoing on the four #7208 y-probes, equality to O, and reverse/face from R_O are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: neighbor-read-identity
+PASS: theorem1-all-four-probes-recorded
+A t=0 M={−e_1} O={+e_2, +e_3, −e_3} R_O={+e_1} R={} read=fail L=−e_1 S+={+e_1, −e_1}
+B t=2 M={+e_1} O={+e_2, +e_3, −e_3} R_O={−e_1} R={−e_3} read=fail L=+e_1 S+={+e_1, +e_3}
+C t=1 M={+e_2} O={+e_1, −e_1, +e_3, −e_3} R_O={−e_2} R={} read=fail L=+e_2 S+={−e_1, +e_2}
+D t=3 M={−e_2, +e_3, −e_3} O={+e_1, −e_1} R_O={+e_2, +e_3, −e_3} R={−e_2} read=fail L=UNDEFINED S+={+e_1, −e_1, +e_2, +e_3, −e_3}
+reverse=hold face=hold
+M_reverse=hold M_face=hold O_reverse=hold O_face=hold R_reverse=UNDEFINED R_face=UNDEFINED S+_reverse=hold S+_face=hold
+unique_L_reverse=hold unique_L_face=UNDEFINED
+unique_R_O_reverse=hold unique_R_O_face=UNDEFINED
+per_element: each lock vector in the neighbor-read R_O(q) of own outgoing
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-reads plus equality to O and reverse/face as hold, fail, or UNDEFINED
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 2, 'C': 1, 'D': 3})
+PASS: theorem1-incoming-sets-of-7208  ({'A': '{−e_1}', 'B': '{+e_1}', 'C': '{+e_2}', 'D': '{−e_2, +e_3, −e_3}'})
+PASS: theorem1-outgoing-sets  ({'A': '{+e_2, +e_3, −e_3}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{+e_1, −e_1, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-neighbor-reads  ({'A': '{+e_1}', 'B': '{−e_1}', 'C': '{−e_2}', 'D': '{+e_2, +e_3, −e_3}'})
+PASS: theorem1-equality-R-O-to-O-is-read-fail  ({'A': 'fail', 'B': 'fail', 'C': 'fail', 'D': 'fail'})
+PASS: theorem1-R-O-is-not-O-and-not-M-and-not-R-M  (('{+e_1}', '{+e_2, +e_3, −e_3}', '{}'))
+PASS: theorem1-star-excluding-q-does-not-recover-O
+PASS: theorem1-A-is-seed
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-empty-R-O-is-empty-unformed-undefined
+PASS: theorem2-reverse-hold  (hold)
+PASS: theorem3-face-hold  (hold)
+PASS: discriminator-hold-from-R-O-not-M-or-O-or-R-M-or-S-plus
+PASS: not-unique-L-leftover
+PASS: not-leftover-of-M-or-O-or-R-M-or-S-plus-7208
+PASS: not-x-probes-or-z-symmetric-or-perp
+PASS: not-nnlock-named-sign
+PASS: neighbor-read-locks-are-nn-steps
+PASS: uniqueness-not-required
+PASS: two-site-opposite-lock-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: perp-step-incoming-lock
+PASS: mutation-empty-or-undefined-is-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: mutation-unique-L-of-R-O-face-undefined
+PASS: mutation-R-M-undefined-while-R-O-holds
+PASS: mutation-sum-of-R-O-is-not-the-letter
+PASS: note-claim-scope
+PASS: note-reports-ticks-and-neighbor-reads
+PASS: note-reports-equality-read-fail
+PASS: note-reports-hold-hold
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-or-star-leftover
+PASS: note-no-six-neighbor-star-as-letter
+PASS: note-not-sister-kernel-or-R-M
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-neighbor-read-existential-opposite
+TOTAL: PASS=61 FAIL=0
+
+----- stderr -----
+

--- a/scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py
+++ b/scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py
@@ -1,0 +1,1248 @@
+#!/usr/bin/env python3
+"""Neighbor-read of own outgoing reverse/face on four #7208 y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0)} with locks +e_1 and -e_1 (nsopp #7093; same process and
+y-probes as nsmopp #7208). A 6-NN step is allowed iff it is perpendicular
+to the parent lock axis. Newly formed sites lock the incoming step. Seeds
+keep their seed letters as a singleton. M(q) is the set of earliest incoming
+NN steps at q. Mixed stays a set. Unformed is UNDEFINED. For formed q, Nbr(q)
+is the set of 6-NN of q that are formed in B_3(0) and are not q. O(q) is the
+outgoing dual of M. R_O(q) is the neighbor-read of own outgoing:
+
+    R_O(q) = { e in {±e_1,±e_2,±e_3} | q+e in Nbr(q) and (-e) in O(q+e) }.
+
+Unformed q is UNDEFINED. Empty R_O is empty, not UNDEFINED. R_O is not O and
+is not R(M). Unique L is not the object. Read-HOLD at q iff R_O(q)=O(q) as
+sets (both defined, possibly mixed). Read-fail if both defined and unequal.
+UNDEFINED if either is UNDEFINED. Reverse holds iff some a in R_O(A) and
+some b in R_O(B) have a+b=(0,0,0). Face holds iff some c in R_O(C) and some
+d in R_O(D) have c+d=(0,0,0). Empty or UNDEFINED on either side is UNDEFINED;
+nonempty with no opposite pair fails. This is not leftover of #7167 O bits:
+the letter is neighbor-read of outgoing, not own outgoing. Occupancy n is not used.
+Named-sign lettering is not used. No unique P_+. Uniqueness of neighbor-read
+locks is not required. No larger ball. No sister kernel. No Cl.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Letter = Point | str
+Incoming = frozenset[Point] | str
+NeighborRead = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "16-census",
+    "16-letter",
+    "Runner cache",
+    "f(n)",
+    "ndot",
+    "P_+",
+    "CHSH",
+    "W9",
+    "mu*",
+    "Dirac-Kähler",
+    "Cl(3,0)",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read R_O of own outgoing on the four #7208 y-probes, "
+    "equality to O, and reverse/face from R_O are reported. "
+    "Displayed, not adopted."
+)
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def neg(step: Point) -> Point:
+    return (-step[0], -step[1], -step[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def own_incoming_set(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> Incoming:
+    """Earliest incoming NN steps at site. Seeds are a singleton. Unformed is UNDEFINED."""
+    if site not in ticks:
+        return "UNDEFINED"
+    return frozenset(locks[site])
+
+
+def own_outgoing_set(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> Incoming:
+    """Outgoing dual of M. Leftover comparator only. Empty O is empty, not UNDEFINED."""
+    if site not in ticks:
+        return "UNDEFINED"
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        if step in locks[neighbor]:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def formed_neighbors(
+    site: Point,
+    ticks: dict[Point, int],
+) -> frozenset[Point] | str:
+    """6-NN of site that are formed in B_3(0) and are not site. Unformed is UNDEFINED."""
+    if site not in ticks:
+        return "UNDEFINED"
+    neighbors: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if not in_ball(neighbor):
+            continue
+        neighbors.add(neighbor)
+    return frozenset(neighbors)
+
+
+def neighbor_read_own_incoming(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> NeighborRead:
+    """Neighbor-read R of own incoming. Leftover comparator only. Empty R is empty."""
+    if site not in ticks:
+        return "UNDEFINED"
+    neighbors = formed_neighbors(site, ticks)
+    if neighbors == "UNDEFINED":
+        return "UNDEFINED"
+    assert isinstance(neighbors, frozenset)
+    result: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in neighbors:
+            continue
+        if neg(step) in locks[neighbor]:
+            result.add(step)
+    return frozenset(result)
+
+
+def neighbor_read_own_outgoing(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> NeighborRead:
+    """Neighbor-read R_O of own outgoing. Unformed is UNDEFINED. Empty R_O is empty."""
+    if site not in ticks:
+        return "UNDEFINED"
+    neighbors = formed_neighbors(site, ticks)
+    if neighbors == "UNDEFINED":
+        return "UNDEFINED"
+    assert isinstance(neighbors, frozenset)
+    result: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in neighbors:
+            continue
+        outgoing = own_outgoing_set(neighbor, ticks, locks)
+        if outgoing == "UNDEFINED":
+            continue
+        if neg(step) in outgoing:
+            result.add(step)
+    return frozenset(result)
+
+
+def unique_own_incoming_letter(incoming: tuple[Point, ...] | set[Point] | Incoming) -> Letter:
+    """Unique-L leftover: UNDEFINED when mixed or empty. Not this letter."""
+    if incoming == "UNDEFINED":
+        return "UNDEFINED"
+    unique = set(incoming)
+    if len(unique) != 1:
+        return "UNDEFINED"
+    vector = next(iter(unique))
+    if vector not in NN:
+        return "UNDEFINED"
+    return vector
+
+
+def recorded_lock_set(pairs: tuple[tuple[Point, Point], ...]) -> frozenset[Point]:
+    """Set of six-neighbor locks. Leftover comparator only."""
+    return frozenset(lock for _neighbor, lock in pairs)
+
+
+def own_lock_in_set(neighbors: frozenset[Point], letter: Letter) -> Incoming:
+    """S^+ leftover: neighbor locks union L(q) when defined. Not this letter."""
+    if letter == "UNDEFINED":
+        return neighbors
+    if not isinstance(letter, tuple):
+        raise TypeError(f"letter is not a lock vector: {letter!r}")
+    return neighbors | {letter}
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    UNDEFINED or empty on either side is UNDEFINED. Nonempty with no opposite
+    pair fails. Mixed stays a set. Does not sum. Does not require a singleton.
+    """
+    if left == "UNDEFINED" or right == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        return "UNDEFINED"
+    if not left or not right:
+        return "UNDEFINED"
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: Incoming, set_b: Incoming) -> str:
+    """Reverse iff some a in R_O(A) and some b in R_O(B) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: Incoming, set_d: Incoming) -> str:
+    """Face iff some c in R_O(C) and some d in R_O(D) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def read_report(neighbor_read: NeighborRead, outgoing: Incoming) -> str:
+    """Read-HOLD iff R_O=O as sets. Read-fail if both defined and unequal."""
+    if neighbor_read == "UNDEFINED" or outgoing == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(neighbor_read, frozenset) or not isinstance(outgoing, frozenset):
+        return "UNDEFINED"
+    if neighbor_read == outgoing:
+        return "hold"
+    return "fail"
+
+
+def lock_display(lock: Point) -> str:
+    return LOCK_NAME[lock]
+
+
+def set_display(locks: Incoming) -> str:
+    if locks == "UNDEFINED":
+        return "UNDEFINED"
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def letter_display(letter: Letter) -> str:
+    if letter == "UNDEFINED":
+        return "UNDEFINED"
+    if not isinstance(letter, tuple):
+        raise TypeError(f"letter is not a lock vector: {letter!r}")
+    return LOCK_NAME[letter]
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks
+
+
+def own_tick_neighbor_locks(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+) -> tuple[tuple[Point, Point], ...]:
+    """Leftover S^+ neighbor list: 6-NN locks formed at tick <= t(site)."""
+    formation = ticks[site]
+    pairs: list[tuple[Point, Point]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor == site:
+            continue
+        if neighbor not in ticks:
+            continue
+        if ticks[neighbor] > formation:
+            continue
+        for lock in sorted(locks[neighbor]):
+            pairs.append((neighbor, lock))
+    return tuple(pairs)
+
+
+def sum_of_set(locks: Incoming) -> Point | str:
+    """Z^3 sum leftover of a lock set. Contrast only; not this letter."""
+    if locks == "UNDEFINED":
+        return "UNDEFINED"
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("neighbor-read of own outgoing reverse/face on #7208 y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and neg(E1) == NEG_E1
+        and neg(NEG_E3) == E3
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    plus_a = frozenset({E1, NEG_E1})
+    plus_b = frozenset({E1, E3})
+    plus_c = frozenset({NEG_E1, E2})
+    plus_d = frozenset({E1, NEG_E1, E2, E3, NEG_E3})
+    set_a = frozenset({NEG_E1})
+    set_b = frozenset({E1})
+    set_c = frozenset({E2})
+    set_d = frozenset({NEG_E2, E3, NEG_E3})
+    out_a = frozenset({E2, E3, NEG_E3})
+    out_b = frozenset({E2, E3, NEG_E3})
+    out_c = frozenset({E1, NEG_E1, E3, NEG_E3})
+    out_d = frozenset({E1, NEG_E1})
+    incoming_read_a = frozenset()
+    incoming_read_b = frozenset({NEG_E3})
+    incoming_read_c = frozenset()
+    incoming_read_d = frozenset({NEG_E2})
+    read_a = frozenset({E1})
+    read_b = frozenset({NEG_E1})
+    read_c = frozenset({NEG_E2})
+    read_d = frozenset({E2, E3, NEG_E3})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite("UNDEFINED", frozenset({E1})) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), "UNDEFINED") == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset({E3})) == "UNDEFINED"
+        and existential_opposite(frozenset({E3}), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset(), frozenset()) == "UNDEFINED"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(set_a, set_b) == "hold"
+        and existential_opposite(set_c, set_d) == "hold"
+        and existential_opposite(out_a, out_b) == "hold"
+        and existential_opposite(incoming_read_a, incoming_read_b) == "UNDEFINED"
+        and existential_opposite(incoming_read_c, incoming_read_d) == "UNDEFINED"
+        and existential_opposite(read_a, read_b) == "hold"
+        and existential_opposite(read_c, read_d) == "hold"
+        and existential_opposite(frozenset({NEG_E2}), frozenset({E2})) == "hold",
+    )
+    checks.check(
+        "neighbor-read-identity",
+        unique_own_incoming_letter(frozenset({NEG_E1})) == NEG_E1
+        and unique_own_incoming_letter(frozenset()) == "UNDEFINED"
+        and unique_own_incoming_letter(frozenset({NEG_E2, E3, NEG_E3})) == "UNDEFINED"
+        and unique_own_incoming_letter(frozenset({E2, E3, NEG_E3})) == "UNDEFINED"
+        and unique_own_incoming_letter(frozenset({E1})) == E1
+        and unique_own_incoming_letter((E1, E2)) == "UNDEFINED"
+        and unique_own_incoming_letter(()) == "UNDEFINED"
+        and unique_own_incoming_letter("UNDEFINED") == "UNDEFINED"
+        and read_report("UNDEFINED", out_a) == "UNDEFINED"
+        and read_report(read_a, "UNDEFINED") == "UNDEFINED"
+        and read_report(read_a, out_a) == "fail"
+        and read_report(out_a, out_a) == "hold"
+        and read_report(read_d, out_d) == "fail",
+    )
+
+    ticks, locks = form()
+    perp_ticks, perp_locks = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, ysym_locks = form(Y_SYMMETRIC_SEEDS)
+    checks.check(
+        "theorem1-all-four-probes-recorded",
+        all(PROBES[name] in ticks for name in ("A", "B", "C", "D")),
+    )
+
+    incoming_sets: dict[str, Incoming] = {}
+    outgoing_sets: dict[str, Incoming] = {}
+    incoming_reads: dict[str, NeighborRead] = {}
+    neighbor_reads: dict[str, NeighborRead] = {}
+    neighbor_sets: dict[str, frozenset[Point] | str] = {}
+    letters: dict[str, Letter] = {}
+    outgoing_letters: dict[str, Letter] = {}
+    read_letters: dict[str, Letter] = {}
+    plus_sets: dict[str, Incoming] = {}
+    read_status: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        incoming_sets[name] = own_incoming_set(site, ticks, locks)
+        outgoing_sets[name] = own_outgoing_set(site, ticks, locks)
+        incoming_reads[name] = neighbor_read_own_incoming(site, ticks, locks)
+        neighbor_reads[name] = neighbor_read_own_outgoing(site, ticks, locks)
+        neighbor_sets[name] = formed_neighbors(site, ticks)
+        letters[name] = unique_own_incoming_letter(incoming_sets[name])
+        outgoing_letters[name] = unique_own_incoming_letter(outgoing_sets[name])
+        read_letters[name] = unique_own_incoming_letter(neighbor_reads[name])
+        pairs = own_tick_neighbor_locks(site, ticks, locks)
+        plus_sets[name] = own_lock_in_set(recorded_lock_set(pairs), letters[name])
+        read_status[name] = read_report(neighbor_reads[name], outgoing_sets[name])
+        print(
+            f"{name} t={ticks[site]} M={set_display(incoming_sets[name])} "
+            f"O={set_display(outgoing_sets[name])} "
+            f"R_O={set_display(neighbor_reads[name])} "
+            f"R={set_display(incoming_reads[name])} "
+            f"read={read_status[name]} "
+            f"L={letter_display(letters[name])} "
+            f"S+={set_display(plus_sets[name])}"
+        )
+
+    reverse_status = reverse_report(neighbor_reads["A"], neighbor_reads["B"])
+    face_status = face_report(neighbor_reads["C"], neighbor_reads["D"])
+    reverse_m = reverse_report(incoming_sets["A"], incoming_sets["B"])
+    face_m = face_report(incoming_sets["C"], incoming_sets["D"])
+    reverse_o = reverse_report(outgoing_sets["A"], outgoing_sets["B"])
+    face_o = face_report(outgoing_sets["C"], outgoing_sets["D"])
+    plus_reverse = reverse_report(plus_sets["A"], plus_sets["B"])
+    plus_face = face_report(plus_sets["C"], plus_sets["D"])
+    unique_reverse = reverse_report(
+        own_lock_in_set(frozenset(), letters["A"]),
+        own_lock_in_set(frozenset(), letters["B"]),
+    )
+    unique_face = face_report(
+        own_lock_in_set(frozenset(), letters["C"]),
+        own_lock_in_set(frozenset(), letters["D"]),
+    )
+    unique_read_reverse = reverse_report(
+        own_lock_in_set(frozenset(), read_letters["A"]),
+        own_lock_in_set(frozenset(), read_letters["B"]),
+    )
+    unique_read_face = face_report(
+        own_lock_in_set(frozenset(), read_letters["C"]),
+        own_lock_in_set(frozenset(), read_letters["D"]),
+    )
+    unique_out_reverse = reverse_report(
+        own_lock_in_set(frozenset(), outgoing_letters["A"]),
+        own_lock_in_set(frozenset(), outgoing_letters["B"]),
+    )
+    unique_out_face = face_report(
+        own_lock_in_set(frozenset(), outgoing_letters["C"]),
+        own_lock_in_set(frozenset(), outgoing_letters["D"]),
+    )
+    reverse_r = reverse_report(incoming_reads["A"], incoming_reads["B"])
+    face_r = face_report(incoming_reads["C"], incoming_reads["D"])
+    print(f"reverse={reverse_status} face={face_status}")
+    print(
+        f"M_reverse={reverse_m} M_face={face_m} "
+        f"O_reverse={reverse_o} O_face={face_o} "
+        f"R_reverse={reverse_r} R_face={face_r} "
+        f"S+_reverse={plus_reverse} S+_face={plus_face}"
+    )
+    print(f"unique_L_reverse={unique_reverse} unique_L_face={unique_face}")
+    print(
+        f"unique_R_O_reverse={unique_read_reverse} unique_R_O_face={unique_read_face}"
+    )
+    print(
+        "per_element: each lock vector in the neighbor-read R_O(q) of own outgoing"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four neighbor-reads plus equality to O and reverse/face as hold, fail, or UNDEFINED"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    perp_reads: dict[str, NeighborRead] = {}
+    for name in ("A", "B", "C", "D"):
+        perp_reads[name] = neighbor_read_own_outgoing(PROBES[name], perp_ticks, perp_locks)
+    perp_reverse = reverse_report(perp_reads["A"], perp_reads["B"])
+    perp_face = face_report(perp_reads["C"], perp_reads["D"])
+
+    zsym_reads: dict[str, NeighborRead] = {}
+    for name in ("A", "B", "C", "D"):
+        zsym_reads[name] = neighbor_read_own_outgoing(PROBES[name], zsym_ticks, zsym_locks)
+    zsym_reverse = reverse_report(zsym_reads["A"], zsym_reads["B"])
+
+    ysym_reads: dict[str, NeighborRead] = {}
+    for name in ("A", "B", "C", "D"):
+        ysym_reads[name] = neighbor_read_own_outgoing(PROBES[name], ysym_ticks, ysym_locks)
+
+    x_reads: dict[str, NeighborRead] = {}
+    x_incoming: dict[str, Incoming] = {}
+    x_outgoing: dict[str, Incoming] = {}
+    for name in ("A", "B", "C", "D"):
+        x_reads[name] = neighbor_read_own_outgoing(X_PROBES[name], ticks, locks)
+        x_incoming[name] = own_incoming_set(X_PROBES[name], ticks, locks)
+        x_outgoing[name] = own_outgoing_set(X_PROBES[name], ticks, locks)
+    x_reverse = reverse_report(x_reads["A"], x_reads["B"])
+    x_face = face_report(x_reads["C"], x_reads["D"])
+
+    unformed = (0, 3, 0)
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 3,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-incoming-sets-of-7208",
+        incoming_sets["A"] == set_a
+        and incoming_sets["B"] == set_b
+        and incoming_sets["C"] == set_c
+        and incoming_sets["D"] == set_d
+        and incoming_sets["A"] != "UNDEFINED"
+        and incoming_sets["D"] != "UNDEFINED"
+        and len(incoming_sets["A"]) == 1
+        and len(incoming_sets["D"]) == 3,
+        str({name: set_display(incoming_sets[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-outgoing-sets",
+        outgoing_sets["A"] == out_a
+        and outgoing_sets["B"] == out_b
+        and outgoing_sets["C"] == out_c
+        and outgoing_sets["D"] == out_d
+        and outgoing_sets["A"] != "UNDEFINED"
+        and outgoing_sets["D"] != "UNDEFINED"
+        and len(outgoing_sets["A"]) == 3
+        and len(outgoing_sets["D"]) == 2,
+        str({name: set_display(outgoing_sets[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-neighbor-reads",
+        neighbor_reads["A"] == read_a
+        and neighbor_reads["B"] == read_b
+        and neighbor_reads["C"] == read_c
+        and neighbor_reads["D"] == read_d
+        and neighbor_reads["A"] != "UNDEFINED"
+        and neighbor_reads["C"] != "UNDEFINED"
+        and isinstance(neighbor_reads["A"], frozenset)
+        and len(neighbor_reads["A"]) == 1
+        and len(neighbor_reads["B"]) == 1
+        and len(neighbor_reads["C"]) == 1
+        and len(neighbor_reads["D"]) == 3,
+        str({name: set_display(neighbor_reads[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-equality-R-O-to-O-is-read-fail",
+        read_status["A"] == "fail"
+        and read_status["B"] == "fail"
+        and read_status["C"] == "fail"
+        and read_status["D"] == "fail"
+        and neighbor_reads["A"] != outgoing_sets["A"]
+        and neighbor_reads["B"] != outgoing_sets["B"]
+        and neighbor_reads["C"] != outgoing_sets["C"]
+        and neighbor_reads["D"] != outgoing_sets["D"]
+        and all(status != "UNDEFINED" for status in read_status.values())
+        and all(status != "hold" for status in read_status.values()),
+        str(read_status),
+    )
+    checks.check(
+        "theorem1-R-O-is-not-O-and-not-M-and-not-R-M",
+        neighbor_reads["A"] != incoming_sets["A"]
+        and neighbor_reads["B"] != incoming_sets["B"]
+        and neighbor_reads["C"] != incoming_sets["C"]
+        and neighbor_reads["D"] != incoming_sets["D"]
+        and neighbor_reads["A"] != outgoing_sets["A"]
+        and neighbor_reads["B"] != outgoing_sets["B"]
+        and neighbor_reads["C"] != outgoing_sets["C"]
+        and neighbor_reads["D"] != outgoing_sets["D"]
+        and neighbor_reads["A"] != incoming_reads["A"]
+        and neighbor_reads["B"] != incoming_reads["B"]
+        and neighbor_reads["C"] != incoming_reads["C"]
+        and neighbor_reads["D"] != incoming_reads["D"]
+        and incoming_reads["A"] == incoming_read_a
+        and incoming_reads["B"] == incoming_read_b
+        and incoming_reads["C"] == incoming_read_c
+        and incoming_reads["D"] == incoming_read_d
+        and outgoing_sets["A"] == out_a
+        and outgoing_sets["B"] == out_b
+        and outgoing_sets["C"] == out_c
+        and outgoing_sets["D"] == out_d
+        and E1 in neighbor_reads["A"]
+        and E1 not in outgoing_sets["A"]
+        and NEG_E1 in incoming_sets["A"]
+        and NEG_E1 not in neighbor_reads["A"],
+        str(
+            (
+                set_display(neighbor_reads["A"]),
+                set_display(outgoing_sets["A"]),
+                set_display(incoming_reads["A"]),
+            )
+        ),
+    )
+    checks.check(
+        "theorem1-star-excluding-q-does-not-recover-O",
+        PROBES["A"] not in neighbor_sets["A"]
+        and isinstance(neighbor_sets["A"], frozenset)
+        and len(neighbor_sets["A"]) == 6
+        and neighbor_reads["A"] != outgoing_sets["A"]
+        and outgoing_sets["A"] == out_a
+        and E2 not in neighbor_reads["A"]
+        and unique_own_incoming_letter(neighbor_reads["D"]) == "UNDEFINED",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and incoming_sets["A"] == frozenset({NEG_E1})
+        and X_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        len(neighbor_reads["D"]) == 3
+        and read_letters["D"] == "UNDEFINED"
+        and neighbor_reads["D"] != "UNDEFINED"
+        and unique_own_incoming_letter(neighbor_reads["D"]) == "UNDEFINED"
+        and unique_own_incoming_letter(outgoing_sets["A"]) == "UNDEFINED"
+        and E2 in neighbor_reads["D"]
+        and E3 in neighbor_reads["D"]
+        and NEG_E3 in neighbor_reads["D"]
+        and neighbor_reads["D"] != outgoing_sets["D"],
+    )
+    checks.check(
+        "theorem1-empty-R-O-is-empty-unformed-undefined",
+        neighbor_reads["A"] != frozenset()
+        and neighbor_reads["A"] != "UNDEFINED"
+        and neighbor_read_own_outgoing(unformed, ticks, locks) == "UNDEFINED"
+        and unformed not in ticks,
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse_status == "hold"
+        and neighbor_reads["A"] == read_a
+        and neighbor_reads["B"] == read_b
+        and reverse_status != "fail"
+        and reverse_status != "UNDEFINED"
+        and reverse_m == "hold"
+        and reverse_o == "hold"
+        and reverse_r == "UNDEFINED"
+        and E1 in neighbor_reads["A"]
+        and NEG_E1 in neighbor_reads["B"],
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and neighbor_reads["C"] == read_c
+        and neighbor_reads["D"] == read_d
+        and face_status != "fail"
+        and face_status != "UNDEFINED"
+        and face_m == "hold"
+        and face_o == "hold"
+        and face_r == "UNDEFINED"
+        and NEG_E2 in neighbor_reads["C"]
+        and E2 in neighbor_reads["D"],
+        face_status,
+    )
+    checks.check(
+        "discriminator-hold-from-R-O-not-M-or-O-or-R-M-or-S-plus",
+        reverse_status == "hold"
+        and face_status == "hold"
+        and reverse_m == "hold"
+        and face_m == "hold"
+        and reverse_o == "hold"
+        and face_o == "hold"
+        and reverse_r == "UNDEFINED"
+        and face_r == "UNDEFINED"
+        and plus_reverse == "hold"
+        and plus_face == "hold"
+        and neighbor_reads["A"] != incoming_sets["A"]
+        and neighbor_reads["A"] != outgoing_sets["A"]
+        and neighbor_reads["A"] != incoming_reads["A"]
+        and neighbor_reads["A"] != plus_sets["A"]
+        and E1 in neighbor_reads["A"]
+        and E3 in outgoing_sets["A"]
+        and NEG_E1 in incoming_sets["A"]
+        and letters["A"] == NEG_E1,
+    )
+    checks.check(
+        "not-unique-L-leftover",
+        unique_reverse == "hold"
+        and unique_face == "UNDEFINED"
+        and unique_read_reverse == "hold"
+        and unique_read_face == "UNDEFINED"
+        and unique_out_reverse == "UNDEFINED"
+        and unique_out_face == "UNDEFINED"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and face_status != unique_read_face
+        and letters["A"] == NEG_E1
+        and letters["B"] == E1
+        and letters["C"] == E2
+        and letters["D"] == "UNDEFINED"
+        and outgoing_letters["A"] == "UNDEFINED"
+        and outgoing_letters["D"] == "UNDEFINED"
+        and read_letters["A"] == E1
+        and read_letters["B"] == NEG_E1
+        and read_letters["C"] == NEG_E2
+        and read_letters["D"] == "UNDEFINED"
+        and neighbor_reads["D"] != "UNDEFINED",
+    )
+    checks.check(
+        "not-leftover-of-M-or-O-or-R-M-or-S-plus-7208",
+        incoming_sets["A"] == set_a
+        and outgoing_sets["A"] == out_a
+        and plus_sets["A"] == plus_a
+        and incoming_reads["A"] == incoming_read_a
+        and reverse_m == "hold"
+        and face_m == "hold"
+        and reverse_o == "hold"
+        and reverse_r == "UNDEFINED"
+        and plus_reverse == "hold"
+        and neighbor_reads["A"] != incoming_sets["A"]
+        and neighbor_reads["B"] != incoming_sets["B"]
+        and neighbor_reads["C"] != incoming_sets["C"]
+        and neighbor_reads["D"] != incoming_sets["D"]
+        and neighbor_reads["A"] != outgoing_sets["A"]
+        and neighbor_reads["A"] != incoming_reads["A"]
+        and neighbor_reads["A"] != plus_sets["A"]
+        and E1 in neighbor_reads["A"]
+        and NEG_E1 in incoming_sets["A"]
+        and E3 in outgoing_sets["A"]
+        and E1 in plus_sets["A"],
+    )
+    checks.check(
+        "not-x-probes-or-z-symmetric-or-perp",
+        TWO_SITE_SEEDS != PERP_SEEDS
+        and TWO_SITE_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and x_incoming["A"] != incoming_sets["A"]
+        and x_outgoing["A"] != outgoing_sets["A"]
+        and zsym_reads["A"] != neighbor_reads["A"]
+        and perp_reads["C"] != neighbor_reads["C"]
+        and zsym_reads["C"] != neighbor_reads["C"]
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and zsym_reverse == "fail"
+        and perp_reverse == "fail"
+        and perp_face == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-nnlock-named-sign",
+        incoming_sets["A"] == frozenset({NEG_E1})
+        and named_sign(NEG_E1) == "-"
+        and named_sign(E1) == "+"
+        and named_sign(NEG_E3) == "-"
+        and neighbor_reads["B"] != named_sign(NEG_E3)
+        and incoming_sets["A"] != named_sign(NEG_E1),
+    )
+    checks.check(
+        "neighbor-read-locks-are-nn-steps",
+        all(
+            neighbor_reads[name] <= set(NN)
+            for name in ("A", "B", "C", "D")
+        ),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(neighbor_reads["A"]) == 1
+        and len(neighbor_reads["B"]) == 1
+        and len(neighbor_reads["C"]) == 1
+        and len(neighbor_reads["D"]) == 3
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and read_status["A"] == "fail",
+    )
+    checks.check(
+        "two-site-opposite-lock-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and add(E1, NEG_E1) == ZERO
+        and TWO_SITE_SEEDS != PERP_SEEDS
+        and TWO_SITE_SEEDS != Y_SYMMETRIC_SEEDS
+        and ysym_reads["A"] == neighbor_reads["A"]
+        and sum(time == 0 for time in ticks.values()) == 2,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[E3] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["D"]] == 3
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "mutation-empty-or-undefined-is-undefined",
+        reverse_report(frozenset(), neighbor_reads["B"]) == "UNDEFINED"
+        and face_report(neighbor_reads["C"], frozenset()) == "UNDEFINED"
+        and reverse_report("UNDEFINED", neighbor_reads["B"]) == "UNDEFINED"
+        and face_report(neighbor_reads["C"], "UNDEFINED") == "UNDEFINED"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "mutation-unique-L-of-R-O-face-undefined",
+        unique_read_reverse == "hold"
+        and unique_read_face == "UNDEFINED"
+        and unique_face == "UNDEFINED"
+        and unique_reverse == "hold"
+        and unique_out_reverse == "UNDEFINED"
+        and unique_out_face == "UNDEFINED"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and face_status != unique_read_face,
+    )
+    checks.check(
+        "mutation-R-M-undefined-while-R-O-holds",
+        reverse_m == "hold"
+        and face_m == "hold"
+        and reverse_o == "hold"
+        and face_o == "hold"
+        and reverse_r == "UNDEFINED"
+        and face_r == "UNDEFINED"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and incoming_sets["A"] != neighbor_reads["A"]
+        and outgoing_sets["A"] != neighbor_reads["A"]
+        and incoming_reads["A"] != neighbor_reads["A"],
+    )
+    checks.check(
+        "mutation-sum-of-R-O-is-not-the-letter",
+        sum_of_set(neighbor_reads["A"]) == E1
+        and sum_of_set(neighbor_reads["B"]) == NEG_E1
+        and sum_of_set(neighbor_reads["C"]) == NEG_E2
+        and sum_of_set(neighbor_reads["D"]) == E2
+        and neighbor_reads["D"] != frozenset({E2})
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-and-neighbor-reads",
+        "R_O(A) = {+e_1}" in note
+        and "R_O(B) = {−e_1}" in note
+        and "R_O(C) = {−e_2}" in note
+        and "R_O(D) = {+e_2, +e_3, −e_3}" in note
+        and "O(A) = {+e_2, +e_3, −e_3}" in note
+        and "O(B) = {+e_2, +e_3, −e_3}" in note
+        and "O(C) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D) = {+e_1, −e_1}" in note
+        and "t(A)=0" in note
+        and "t(B)=2" in note
+        and "t(C)=1" in note
+        and "t(D)=3" in note,
+    )
+    checks.check(
+        "note-reports-equality-read-fail",
+        "Read-fail" in note
+        and "R_O is not O" in note
+        and "R_O is not R(M)" in note
+        and "does not recover `O(q)`" in note,
+    )
+    checks.check(
+        "note-reports-hold-hold",
+        "Reverse: hold" in note
+        and "Face: hold" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "does not use occupancy" in normalized_note
+        and "neighbor-read" in normalized_note
+        and "mixed stays a set" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-or-star-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "not leftover of #7208" in normalized_note
+        and "not leftover of unique-L" in normalized_note
+        and "Face holds." in note
+        and "Reverse holds." in note,
+    )
+    checks.check(
+        "note-no-six-neighbor-star-as-letter",
+        "does not use a six-neighbor star" in normalized_note
+        and "No S⁺." in note
+        and "R_O is not O" in note
+        and "neighbor-read" in normalized_note,
+    )
+    checks.check(
+        "note-not-sister-kernel-or-R-M",
+        "not the sister kernel" in normalized_note
+        and "R_O is not R(M)" in note
+        and "R_O is not O" in note
+        and "Uniqueness is not required." in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/OPPOSITE_LOCK_YPROBE_OWN_OUTGOING_SET_NEIGHBOR_READ_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    checks.check(
+        "identity-gates-present",
+        "def neighbor_read_own_outgoing(" in source
+        and "def neighbor_read_own_incoming(" in source
+        and "def formed_neighbors(" in source
+        and "def own_outgoing_set(" in source
+        and "def read_report(" in source
+        and "def existential_opposite(" in source
+        and "def reverse_report(" in source
+        and "def face_report(" in source
+        and "def form(" in source,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "source-letter-from-neighbor-read-existential-opposite",
+        "neighbor_read_own_outgoing" in defined_fns
+        and "neighbor_read_own_incoming" in defined_fns
+        and "formed_neighbors" in defined_fns
+        and "read_report" in defined_fns
+        and "existential_opposite" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Neighbor-read R_O of outgoing on #7167. R_O\neq O at every probe (Read-fail) but reverse HOLD and face HOLD from R_O. Outgoing neighbor-read does not recover O, unlike empty-R of M. Displayed, not adopted.

## Runner

`scripts/opposite_lock_yprobe_own_outgoing_set_neighbor_read_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.