### PR TITLE
feat(nmperpx2): forall-orthogonal M vs O at t+1 on #7214: reverse HOLD, face HOLD

### DIFF
--- a/docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,466 @@
+---
+claim_id: x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Forall-orthogonal M vs O at t+1 on the four #7214 x-probes, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+---
+
+# Forall-Orthogonal Incoming Versus Outgoing At t+1 On Four #7214 X-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** forall-orthogonal `M` versus `O` at each probe's `τ=t+1` on the
+four nmxe2x #7214 x-probes in `B_3(0)={n:n·n<=9}`. Same process as nmxe2x
+#7214. Same x-probes as nsopp. Let `t(q)` be the formation tick of probe
+`q`. Let `τ(q)=t(q)+1`. There is no global T. `M(q,τ)` is the set of
+earliest incoming nearest-neighbor steps at `q` using only records with
+tick `<= τ`. Seeds are a singleton seed letter. `O(q,τ)` is the outgoing
+dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is
+formed and `e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty
+`O` is empty, not `UNDEFINED`. For formed `q` with both `M` and `O`
+defined and nonempty, forall-perp HOLD if and only if every `m` in
+`M(q,τ)` and every `o` in `O(q,τ)` have integer dot `m·o=0`. Empty or
+`UNDEFINED` is `UNDEFINED`. Exist-perp (some pair dots to 0) is comparison
+only. Reverse HOLD if and only if forall-perp at `A` and at `B`. Face
+likewise on `C,D`. Mixed remains a set. Uniqueness of incoming or outgoing
+locks is not required. Occupancy `n` is not used. This is not named-sign
+lettering. This is not leftover of exist-perp. This is not leftover of
+exist-opposite of M. This is not leftover of exist-opposite of O. This
+display does not use a six-neighbor star. Displayed, not adopted. Do not
+write into Admissibility. Do not attach L1. This note does not write
+forall-perp into Admissibility and does not attach a formation member from
+already-recorded six-neighbor locks. This display does not use occupancy.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py`](../scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Reverse and face are scored on forall-perp of `M` versus `O` at
+that same cut. Named signs `{+,−}` are a coarser readout and are not used.
+A singleton unique lock letter is a different readout and is not used as
+the object. A `Z^3` sum of those locks is a different readout and is not
+used. Occupancy `n` is not used. A six-neighbor star is not the letter.
+O is not M.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of forall-orthogonal M vs O at t+1 on the four #7214 x-probes, integer dots, reverse hold and face hold from forall-perp at A,B and at C,D; uniqueness of locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face
+target_blocker_text: "display forall-orthogonal M vs O at t+1 on the four #7214 x-probes, and reverse/face from that, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep forall-orthogonal M vs O at t+1 displayed; do not write forall-perp into Admissibility, do not reduce to exist-perp, do not replace forall-perp by exist-opposite of M or of O, do not reduce to a unique letter, do not use occupancy n, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for forall-orthogonal M vs O at t+1 on the four #7214 x-probes, reverse hold and face hold; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose own
+incoming and outgoing sets are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are the nsopp x-probes. These are not the y-probes `A=(0,1,0)`,
+`B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`. These are not the z-probes
+`A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(1,0,1)`. `A` is a seed. Same
+process and x-probes as nmxe2x #7214.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the two-record set `{0, (1,0,0)}` is recorded at formation tick 0 with
+opposite locks `L(0)=+e_2` and `L(1,0,0)=−e_2`. This seed is not the
+same-lock two-site seed `+e_2/+e_2`. This seed is not the nspar two-site
+seed `+e_1/−e_1`. This seed is not the x-axis opposite ±e_3 two-site seed
+`+e_3/−e_3`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named incoming set `M` and outgoing set `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter. Own incoming sets are the scored incoming
+object.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy `n` is not used. O is not M.
+
+Forall-perp at a formed probe with both sets nonempty HOLD if and only if
+every `m` in `M(q,τ)` and every `o` in `O(q,τ)` have integer dot
+`m·o=0`. Empty or `UNDEFINED` on either side is `UNDEFINED`. Nonempty with
+some pair of nonzero dot fails. Exist-perp (some pair dots to 0) is
+comparison only.
+
+Reverse HOLD if and only if forall-perp at `A` and at `B`. Face HOLD if
+and only if forall-perp at `C` and at `D`. If either side of that pair is
+`UNDEFINED`, the report is `UNDEFINED`. Else if either fails, the report
+is `fail`. The report is one of `hold`, `fail`, or `UNDEFINED`.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on
+forall-perp of incoming versus outgoing at the same cut. They are not
+scored on `{+,−}` names and are not an occupancy-kernel inner product.
+
+## Theorem 1 — ticks, `M`, `O`, dots, and forall-perp at `A,B,C,D`
+
+On this process the four x-probes form. Incoming is frozen at formation:
+`M(q,t+1)=M(q,t)` at every scored probe. Outgoing is empty at `t` for
+`A`, `B`, and `C`, then filled at `t+1`. This display reads `M` and `O`
+together at the same cut `τ=t+1` and scores integer dots and forall-perp:
+
+```text
+t(A)=0
+t(B)=2
+t(C)=1
+t(D)=3
+M(A, τ) = {−e_2}
+M(B, τ) = {+e_2}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_1, +e_3, −e_3}
+O(A, τ) = {+e_1, +e_3, −e_3}
+O(B, τ) = {+e_1, +e_3, −e_3}
+O(C, τ) = {+e_2, −e_2, +e_3, −e_3}
+O(D, τ) = {+e_2, −e_2}
+(−e_2)·(+e_1)=0, (−e_2)·(+e_3)=0, (−e_2)·(−e_3)=0
+(+e_2)·(+e_1)=0, (+e_2)·(+e_3)=0, (+e_2)·(−e_3)=0
+(+e_1)·(+e_2)=0, (+e_1)·(−e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0
+(−e_1)·(+e_2)=0, (−e_1)·(−e_2)=0, (+e_3)·(+e_2)=0, (+e_3)·(−e_2)=0, (−e_3)·(+e_2)=0, (−e_3)·(−e_2)=0
+forall-perp(A): hold
+forall-perp(B): hold
+forall-perp(C): hold
+forall-perp(D): hold
+```
+
+`A` is a seed at tick 0. Mixed remains a set: `M(D,τ)` has three earliest
+incoming steps and `O(A,τ)` has three outgoing steps. Unique letters would
+assign `UNDEFINED` at mixed probes and would leave reverse and face
+`UNDEFINED`. Here uniqueness is not required. `M` and `O` are disjoint at
+each of the four probes at `τ`. O is not M. Every pair at each probe dots
+to zero, so forall-perp holds at each probe.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0), (1, 0, 1), (1, 0, -1)
+new 6-NN of B at t(B)+1: (2, 1, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, 1, 0), (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (1, 2, 0)
+```
+
+At `t`, `O(A,t)`, `O(B,t)`, and `O(C,t)` are empty, so forall-perp at those
+probes is `UNDEFINED` at `t`. That empty-at-`t` leftover is not this
+display. Exist-perp also holds at each probe on this member; exist-perp is
+comparison only. On the nspar leftover, exist-perp HOLDs at `B` while
+forall-perp FAILs at `B`. Exist-opposite of `M(A)` against `O(A)` fails
+because `{−e_2}` is not opposite `{+e_1, +e_3, −e_3}` while forall-perp at
+`A` holds.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse HOLD if and only if forall-perp at `A` and at `B`. Both bits are
+`hold`. Reverse holds. Both sides are nonempty and defined, so this is not
+`UNDEFINED`. This is not `fail`.
+
+Reverse: hold
+
+Reverse holds. Unique-letter leftover reports reverse `UNDEFINED` from mixed
+`O(A,τ)`. Exist-opposite of `M` leftover also reports reverse hold from
+`{−e_2}` against `{+e_2}`, but that leftover never reads `O`. Exist-opposite
+of `O` leftover reports reverse hold from `{+e_3}` against `{−e_3}` inside
+outgoing sets, not forall-perp of `M` versus `O`. Reverse HOLD uses
+forall-perp at `A` and at `B`.
+
+Reverse holds.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face HOLD if and only if forall-perp at `C` and at `D`. Both bits are
+`hold`. Face holds. Mixed `M(D,τ)` remains a three-element set and every
+pair against `O(D,τ)` dots to zero.
+
+Face: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `fail` and not `UNDEFINED`. Face holds. Unique-letter leftover
+reports face `UNDEFINED` from mixed `M(D,τ)`. Exist-opposite of `M` leftover
+reports face hold from `{+e_1}` against `{−e_1}` inside incoming sets, not
+forall-perp of `M` versus `O`. Face already holds at `τ=t+1` from
+forall-perp at `C` and at `D`.
+
+Face holds.
+
+## What this note does not claim
+
+- It does not select a unique incoming or outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require either set to be a singleton.
+- It does not sum either set.
+- It does not replace `O` by `M`.
+- It does not replace either set by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint exist-perp as the scored predicate.
+- It does not reprint exist-opposite of `M` as this display.
+- It does not reprint exist-opposite of `O` as this display.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+x-axis opposite ±e_2 two-site process, the own incoming and outgoing sets
+at `t+1`, the integer dots, and the forall-perp reverse/face bits are
+displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; x-axis opposite ±e_2 seed `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `2`, `1`, `3` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; outgoing dual |
+| integer dots `m·o` at each probe | Theorem 1; all zero |
+| forall-perp at `A,B,C,D` | Theorem 1; `hold` at each |
+| reverse and face from forall-perp | Theorems 2–3; `hold` / `hold` |
+| unique incoming or outgoing lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| leftover of exist-perp | not this display; comparison only |
+| leftover of exist-opposite of M | not this display |
+| leftover of exist-opposite of O | not this display |
+| six-neighbor star as the letter | not used |
+| forall-perp as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: forall-orthogonal `M` vs `O` at `t+1` on the four #7214 x-probes, and reverse/face from that. |
+| V2 | Current main has no landed forall-orthogonal `M` vs `O` reverse/face report on these four #7214 x-probes. |
+| V3 | Incoming sets, outgoing sets, integer dots, forall-perp bits, and the `hold`/`hold` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads own incoming and own outgoing at the same `t+1` cut and scores forall integer orthogonality. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique letter, does not replace `O` by `M`, does not replace forall-perp by
+exist-perp, does not replace forall-perp by exist-opposite of `M` or of
+`O`, does not use a six-neighbor star, and does not use occupancy `n`. No
+global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| exist-perp | score some pair with `m·o=0` | exist-perp is comparison only; nspar `B` exist-perp HOLDs while forall-perp FAILs | ATTEMPTED |
+| exist-opposite of M | score `a+b=0` inside `M(A)` and `M(B)` | leftover; that readout never reads `O`; exist-opposite of `M(A)` against `O(A)` fails while forall-perp at `A` holds | ATTEMPTED |
+| exist-opposite of O | score `a+b=0` inside `O(A)` and `O(B)` | leftover; that readout never reads `M`; reverse of `O` HOLDs from `{+e_3,−e_3}` inside outgoing | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `M(D,τ)` and mixed `O(A,τ)` remain sets; unique-letter reverse and face are `UNDEFINED` | ATTEMPTED |
+| empty `O` at `t` | score forall-perp at formation tick | `O(A,t)` is empty so reverse at `t` is `UNDEFINED`; this cut is `τ=t+1` | ATTEMPTED |
+| y-probes on the same process | score `A=(0,1,0)`, `C=(0,2,0)` | leftover; `M(A)` and `O(A)` differ from the x-probe sets | ATTEMPTED |
+| z-probes on the same process | score `A=(0,0,1)`, `C=(0,0,2)` | leftover; `M(A)` is `{+e_3}`, not `{−e_2}` | ATTEMPTED |
+| same-lock `+e_2/+e_2` on these x-probes | replace the opposite seed | leftover; `M(A)` is `{+e_2}`, not `{−e_2}` | ATTEMPTED |
+| nspar `+e_1/−e_1` on these x-probes | replace the opposite seed | leftover; forall-perp FAILs at `B` and reverse fails | ATTEMPTED |
+| x-axis opposite ±e_3 on these x-probes | replace the seed axis | leftover; `M(A)` is `{−e_3}`, not `{−e_2}` | ATTEMPTED |
+| sum of a set | replace each set by its `Z^3` sum | the construction does not sum; sum of mixed `M(D,τ)` cancels to `−e_1` while the set stays three-element | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` | different object; not an occupancy-kernel inner product | ATTEMPTED |
+| six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | this display does not use a six-neighbor star | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by forall-perp | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of forall-perp with
+exist-perp, missing identification of forall-perp with exist-opposite of
+`M` or of `O`, and missing Record identification of forall-perp are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-site seed locks `+e_2` and `−e_2`, perpendicular step
+rule, incoming-step lock, own incoming set and own outgoing dual from
+records with tick `<= τ`, per-probe `τ=t+1`, forall-perp of every pair,
+four x-probes with seed `A`, empty or `UNDEFINED` as `UNDEFINED`, and mixed
+remains a set are declared. No uniqueness of locks, no six-neighbor star as
+the scored object, no exist-perp as the scored predicate, no exist-opposite
+of `M` or of `O` as the scored predicate, no global later T, no formation
+attachment from already-recorded six-neighbor locks, and no Admissibility
+rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+forall-perp `hold`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each earliest incoming or outgoing nearest-neighbor step | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four incoming sets, four outgoing sets, integer dots, forall-perp, reverse/face | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for forall-perp reverse/face,
+a formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Forall-perp of `M` versus `O` is only exist-perp because every
+pair here already dots to zero; it is only exist-opposite of `M` because
+nmxe2x already HOLDs reverse and face from incoming sets; it is only
+exist-opposite of `O` because outgoing opposite pairs exist at `A` and `B`;
+mixed `D` should make face `UNDEFINED`; empty `O` at `t` should make reverse
+`UNDEFINED`; and y-probes on the same process already HOLD.
+
+**Answer:** Exist-perp is comparison only. On nspar `B`, exist-perp HOLDs
+while forall-perp FAILs, so the predicates differ. Exist-opposite of `M`
+never reads `O`; exist-opposite of `M(A)` against `O(A)` fails while
+forall-perp at `A` holds. Exist-opposite of `O` never reads `M`. Mixed
+`M(D,τ)` remains `{−e_1, +e_3, −e_3}` and face holds. Empty `O` at `t`
+makes reverse `UNDEFINED` at that leftover cut; this display scores
+`τ=t+1`. Y-probes are a different four-tuple; `M(A)` there is not `{−e_2}`.
+
+### N8 — cross-cycle echo
+
+nmxe2x #7214 reported reverse hold and face hold from own incoming `M` by
+exist-opposite. That leftover is not leftover of exist-perp and not this
+forall-perp of `M` versus `O`. This note is not those displays: it reports
+forall-orthogonal `M` versus `O` at `τ=t+1` on the four #7214 x-probes,
+integer dots all zero, reverse hold, and face hold.
+
+**Gate disposition:** PASS for the forall-orthogonal `M` vs `O` at `t+1`
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals the
+named sign,” “the predicate equals the unique singleton lock vector,” “the
+predicate equals exist-perp,” “the predicate equals exist-opposite of `M`,”
+“the predicate equals exist-opposite of `O`,” “bits are Admissibility,”
+“forall-perp fails at `A`,” “reverse fails,” “face is `UNDEFINED`,” or
+“`O` is `M`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the x-axis opposite ±e_2
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports integer dots and forall-perp at `A,B,C,D`, lists new records in
+`B_3(0)` between `t` and `t+1` that meet a probe's six-neighbors, and
+checks Theorems 1--3. It also checks that `M` is frozen from `t` to `t+1`,
+that `O` is empty at `t` for `A`, `B`, and `C`, that mixed sets remain
+sets, that unique-letter reverse and face are `UNDEFINED`, that exist-perp
+is comparison only, that exist-opposite of `M` against `O` fails at `A`
+while forall-perp holds, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not attached,
+and that nspar reverse fails. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -21656,6 +21656,10 @@
   },
   "writing_voice_guide_2026-04-25": {
    "deps_hash": "8990b3713089",
+   "out_degree": 1
+  },
+  "x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
    "out_degree": 1
   },
   "yang_mills_coupling_marginality_forces_d_four_narrow_theorem_note_2026-05-26": {

--- a/logs/runner-cache/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,88 @@
+===== runner cache v1 =====
+runner: scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 8b9785f60ac346cbe1f85eb2a28f50fba8879aaf48783957cf406f4ca2a4f796
+input_fingerprint_sha256: edb4e9a08485030a0982f11f782a77b1d438de361a21474fb8000617c4bfe480
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+forall-orthogonal M vs O at t+1 on #7214 x-probes
+AUDIT_INPUT_PATHS:
+  docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Forall-orthogonal M vs O at t+1 on the four #7214 x-probes, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: forall-perp-identity
+PASS: exist-perp-is-comparison-only
+PASS: pair-status-identity
+A t=0 M={−e_2} O={+e_1, +e_3, −e_3} forall-perp=hold
+B t=2 M={+e_2} O={+e_1, +e_3, −e_3} forall-perp=hold
+C t=1 M={+e_1} O={+e_2, −e_2, +e_3, −e_3} forall-perp=hold
+D t=3 M={−e_1, +e_3, −e_3} O={+e_2, −e_2} forall-perp=hold
+reverse=hold face=hold
+per_element: each earliest incoming or outgoing nearest-neighbor step at a probe, read from the record prefix at that probe's t+1
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four incoming sets, four outgoing sets, integer dots, forall-perp at each probe, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 2, 'C': 1, 'D': 3})
+PASS: theorem1-M-at-tau  ({'A': '{−e_2}', 'B': '{+e_2}', 'C': '{+e_1}', 'D': '{−e_1, +e_3, −e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_1, +e_3, −e_3}', 'B': '{+e_1, +e_3, −e_3}', 'C': '{+e_2, −e_2, +e_3, −e_3}', 'D': '{+e_2, −e_2}'})
+PASS: theorem1-dots-all-zero
+PASS: theorem1-forall-perp-hold-at-all-four  ({'A': 'hold', 'B': 'hold', 'C': 'hold', 'D': 'hold'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-O-empty-at-t-then-filled
+PASS: theorem1-new-records-meet-6nn  ({'A': ((2, 0, 0), (1, 0, 1), (1, 0, -1)), 'B': ((2, 1, 1), (1, 1, 2), (1, 1, 0)), 'C': ((2, 1, 0), (2, -1, 0), (2, 0, 1), (2, 0, -1)), 'D': ((1, 2, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-hold  (hold)
+PASS: theorem3-face-hold  (hold)
+PASS: O-is-not-M
+PASS: mutation-unique-letter-face-undefined
+PASS: mutation-exist-perp-same-hold-not-this-predicate
+PASS: mutation-exist-opposite-of-M-or-O-not-this-predicate
+PASS: mutation-empty-or-undefined-is-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: not-nnlock-named-sign
+PASS: not-y-or-z-probes-or-same-lock-or-nspar-or-opp-e3
+PASS: uniqueness-not-required
+PASS: two-site-opposite-lock-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-ticks-M-O-dots-forall-perp
+PASS: note-reports-new-neighbors
+PASS: note-reports-hold-hold
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-attach-formation-member
+PASS: note-not-exist-perp-or-exist-opposite-leftover
+PASS: note-no-six-neighbor-star-as-letter
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+TOTAL: PASS=58 FAIL=0
+
+----- stderr -----
+

--- a/scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1041 @@
+#!/usr/bin/env python3
+"""Forall-orthogonal M vs O at t+1 on four #7214 x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (1,0,0)} with locks +e_2 and -e_2 (x-axis opposite ±e_2; same
+process and x-probes as nmxe2x #7214). A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. Seeds keep their seed letters as a singleton. t(q) is the formation
+tick. tau = t+1. M(q, tau) is the set of earliest incoming nearest-neighbor
+steps at q using only records with tick <= tau. Unformed at tau =>
+UNDEFINED. O(q, tau) is the outgoing dual of M: the set of e in
+{±e_1,±e_2,±e_3} such that q+e is formed and e is in M(q+e, tau). Unformed
+q at tau => UNDEFINED. Empty O is empty, not UNDEFINED. O is not M.
+Forall-perp HOLD iff every m in M(q, tau) and o in O(q, tau) have integer
+dot m·o = 0. Empty or UNDEFINED => UNDEFINED. Exist-perp (some pair dots
+to 0) is comparison only. Reverse HOLD iff forall-perp at A and at B.
+Face likewise on C, D. Uniqueness of locks is not required. No unique P_+.
+Occupancy n is not used. Named-sign lettering is not used. No larger host.
+No six-neighbor star. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+BALL_SQ = 9
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, NEG_E2),
+)
+SAME_E2_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, E2),
+)
+NSPAR_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E1, NEG_E1),
+)
+OPPOSITE_E3_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E3),
+    (E1, NEG_E3),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Forall-orthogonal M vs O at t+1 on the four #7214 "
+    "x-probes, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def pair_dots(left: Incoming, right: Incoming) -> tuple[tuple[Point, Point, int], ...] | str:
+    """Integer dots m·o for every pair. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    return tuple((m, o, dot(m, o)) for m in NN if m in left for o in NN if o in right)
+
+
+def forall_perp(left: Incoming, right: Incoming) -> str:
+    """HOLD iff every m in M and o in O have integer dot m·o = 0.
+
+    UNDEFINED if either side is UNDEFINED or empty. FAIL if some pair is
+    not orthogonal. Exist-perp is not this predicate.
+    """
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for m in left:
+        for o in right:
+            if dot(m, o) != 0:
+                return "fail"
+    return "hold"
+
+
+def exist_perp(left: Incoming, right: Incoming) -> str:
+    """Comparison only: HOLD iff some pair dots to 0. Not the scored predicate."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for m in left:
+        for o in right:
+            if dot(m, o) == 0:
+                return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Leftover: HOLD iff some lock in left is the vector opposite of some in right."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def pair_status(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(status_a: str, status_b: str) -> str:
+    """Reverse HOLD iff forall-perp at A and at B."""
+    return pair_status(status_a, status_b)
+
+
+def face_report(status_c: str, status_d: str) -> str:
+    """Face HOLD iff forall-perp at C and at D."""
+    return pair_status(status_c, status_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def named_sign(lock: Point) -> str:
+    if lock in (E1, E2, E3):
+        return "+"
+    if lock in (NEG_E1, NEG_E2, NEG_E3):
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("forall-orthogonal M vs O at t+1 on #7214 x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and dot(E2, E1) == 0
+        and perpendicular(E2, E1)
+        and not perpendicular(E2, E2)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    mixed_nspar_b_m = frozenset({E2, E3})
+    mixed_nspar_b_o = frozenset({E1, E2, E3})
+    set_a = frozenset({NEG_E2})
+    set_a_o = frozenset({E1, E3, NEG_E3})
+    checks.check(
+        "forall-perp-identity",
+        forall_perp(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and forall_perp(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and forall_perp(frozenset(), frozenset({E1})) == UNDEFINED
+        and forall_perp(frozenset({E1}), frozenset()) == UNDEFINED
+        and forall_perp(frozenset(), frozenset()) == UNDEFINED
+        and forall_perp(set_a, set_a_o) == "hold"
+        and forall_perp(mixed_nspar_b_m, mixed_nspar_b_o) == "fail"
+        and forall_perp(frozenset({E1}), frozenset({E1})) == "fail"
+        and forall_perp(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == "hold",
+    )
+    checks.check(
+        "exist-perp-is-comparison-only",
+        exist_perp(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and exist_perp(frozenset(), frozenset({E1})) == UNDEFINED
+        and exist_perp(set_a, set_a_o) == "hold"
+        and exist_perp(mixed_nspar_b_m, mixed_nspar_b_o) == "hold"
+        and exist_perp(frozenset({E1}), frozenset({E1})) == "fail"
+        and exist_perp(mixed_nspar_b_m, mixed_nspar_b_o)
+        != forall_perp(mixed_nspar_b_m, mixed_nspar_b_o),
+    )
+    checks.check(
+        "pair-status-identity",
+        pair_status(UNDEFINED, "hold") == UNDEFINED
+        and pair_status("hold", UNDEFINED) == UNDEFINED
+        and pair_status("hold", "hold") == "hold"
+        and pair_status("hold", "fail") == "fail"
+        and pair_status("fail", "hold") == "fail"
+        and pair_status("fail", "fail") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    same_e2_ticks, same_e2_locks, same_e2_seeds = form(SAME_E2_SEEDS)
+    nspar_ticks, nspar_locks, nspar_seeds = form(NSPAR_SEEDS)
+    opp_e3_ticks, opp_e3_locks, opp_e3_seeds = form(OPPOSITE_E3_SEEDS)
+
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    fp0: dict[str, str] = {}
+    fp1: dict[str, str] = {}
+    ep1: dict[str, str] = {}
+    dots1: dict[str, tuple[tuple[Point, Point, int], ...] | str] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        fp0[name] = forall_perp(m0[name], o0[name])
+        fp1[name] = forall_perp(m1[name], o1[name])
+        ep1[name] = exist_perp(m1[name], o1[name])
+        dots1[name] = pair_dots(m1[name], o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"forall-perp={fp1[name]}"
+        )
+
+    reverse_status = reverse_report(fp1["A"], fp1["B"])
+    face_status = face_report(fp1["C"], fp1["D"])
+    reverse0 = reverse_report(fp0["A"], fp0["B"])
+    face0 = face_report(fp0["C"], fp0["D"])
+    exist_perp_reverse = pair_status(ep1["A"], ep1["B"])
+    exist_perp_face = pair_status(ep1["C"], ep1["D"])
+    m_opp_reverse = existential_opposite(m1["A"], m1["B"])
+    m_opp_face = existential_opposite(m1["C"], m1["D"])
+    o_opp_reverse = existential_opposite(o1["A"], o1["B"])
+    o_opp_face = existential_opposite(o1["C"], o1["D"])
+    unique_fp_reverse = reverse_report(
+        forall_perp(unique_letter(m1["A"]), unique_letter(o1["A"])),
+        forall_perp(unique_letter(m1["B"]), unique_letter(o1["B"])),
+    )
+    unique_fp_face = face_report(
+        forall_perp(unique_letter(m1["C"]), unique_letter(o1["C"])),
+        forall_perp(unique_letter(m1["D"]), unique_letter(o1["D"])),
+    )
+    print(f"reverse={reverse_status} face={face_status}")
+    print(
+        "per_element: each earliest incoming or outgoing nearest-neighbor step "
+        "at a probe, read from the record prefix at that probe's t+1"
+    )
+    print(
+        "per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four incoming sets, four outgoing sets, integer dots, "
+        "forall-perp at each probe, reverse/face from those bits"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E2, NEG_E2)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E1, step)) != 1 for step in (E2, NEG_E2)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[NEG_E1] == 1
+        and ticks[E3] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 3
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 1, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["D"], 2, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["D"], 2, ticks, locks, seed_map) == UNDEFINED
+        and forall_perp(
+            incoming_set(PROBES["B"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 3,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E2})
+        and m1["B"] == frozenset({E2})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({NEG_E1, E3, NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E1, E3, NEG_E3})
+        and o1["B"] == frozenset({E1, E3, NEG_E3})
+        and o1["C"] == frozenset({E2, NEG_E2, E3, NEG_E3})
+        and o1["D"] == frozenset({E2, NEG_E2}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-dots-all-zero",
+        all(
+            isinstance(dots1[name], tuple)
+            and dots1[name]
+            and all(value == 0 for _m, _o, value in dots1[name])
+            for name in ("A", "B", "C", "D")
+        )
+        and isinstance(dots1["A"], tuple)
+        and len(dots1["A"]) == 3
+        and isinstance(dots1["B"], tuple)
+        and len(dots1["B"]) == 3
+        and isinstance(dots1["C"], tuple)
+        and len(dots1["C"]) == 4
+        and isinstance(dots1["D"], tuple)
+        and len(dots1["D"]) == 6,
+    )
+    checks.check(
+        "theorem1-forall-perp-hold-at-all-four",
+        fp1["A"] == "hold"
+        and fp1["B"] == "hold"
+        and fp1["C"] == "hold"
+        and fp1["D"] == "hold",
+        str(fp1),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-O-empty-at-t-then-filled",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E2})
+        and fp0["A"] == UNDEFINED
+        and fp0["B"] == UNDEFINED
+        and fp0["C"] == UNDEFINED
+        and fp0["D"] == "hold"
+        and reverse0 == UNDEFINED
+        and face0 == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0), (1, 0, 1), (1, 0, -1))
+        and new_meet["B"] == ((2, 1, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, 1, 0), (2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((1, 2, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 3
+        and unique_letter(m1["D"]) == UNDEFINED
+        and isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 3
+        and unique_letter(o1["A"]) == UNDEFINED
+        and m1["D"] != UNDEFINED
+        and o1["A"] != UNDEFINED
+        and fp1["D"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E1
+        and ticks[E1] == 0
+        and locks[E1] == {NEG_E2}
+        and m1["A"] == frozenset({NEG_E2})
+        and Y_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse_status == "hold"
+        and fp1["A"] == "hold"
+        and fp1["B"] == "hold"
+        and reverse_status != "fail"
+        and reverse_status != UNDEFINED,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and fp1["C"] == "hold"
+        and fp1["D"] == "hold"
+        and face_status != "fail"
+        and face_status != UNDEFINED,
+        face_status,
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E2 in m1["A"]
+        and NEG_E2 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and m1["A"].isdisjoint(o1["A"])
+        and m1["B"].isdisjoint(o1["B"])
+        and m1["C"].isdisjoint(o1["C"])
+        and m1["D"].isdisjoint(o1["D"]),
+    )
+    checks.check(
+        "mutation-unique-letter-face-undefined",
+        unique_fp_reverse == UNDEFINED
+        and unique_fp_face == UNDEFINED
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["D"]) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-exist-perp-same-hold-not-this-predicate",
+        exist_perp_reverse == "hold"
+        and exist_perp_face == "hold"
+        and exist_perp(mixed_nspar_b_m, mixed_nspar_b_o) == "hold"
+        and forall_perp(mixed_nspar_b_m, mixed_nspar_b_o) == "fail"
+        and reverse_status == "hold",
+    )
+    checks.check(
+        "mutation-exist-opposite-of-M-or-O-not-this-predicate",
+        m_opp_reverse == "hold"
+        and m_opp_face == "hold"
+        and o_opp_reverse == "hold"
+        and o_opp_face == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and forall_perp(m1["A"], o1["A"]) == "hold"
+        and existential_opposite(m1["A"], o1["A"]) == "fail",
+    )
+    checks.check(
+        "mutation-empty-or-undefined-is-undefined",
+        forall_perp(frozenset(), o1["A"]) == UNDEFINED
+        and forall_perp(m1["A"], frozenset()) == UNDEFINED
+        and reverse_report(UNDEFINED, "hold") == UNDEFINED
+        and reverse0 == UNDEFINED
+        and reverse_status == "hold",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(m1["D"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E2
+        and sum_of_set(m1["B"]) == E2
+        and sum_of_set(m1["C"]) == E1
+        and sum_of_set(m1["D"]) == NEG_E1
+        and sum_of_set(o1["A"]) == E1
+        and sum_of_set(o1["D"]) == ZERO
+        and m1["D"] != frozenset({NEG_E1})
+        and o1["A"] != frozenset({E1}),
+    )
+    checks.check(
+        "not-nnlock-named-sign",
+        m1["A"] == frozenset({NEG_E2})
+        and named_sign(NEG_E2) == "-"
+        and named_sign(E2) == "+"
+        and m1["C"] == frozenset({E1})
+        and named_sign(E1) == "+"
+        and m1["A"] != named_sign(NEG_E2)
+        and forall_perp(m1["A"], o1["A"]) != named_sign(NEG_E2),
+    )
+
+    def probe_fp(
+        probe_map: dict[str, Point],
+        ticks_map: dict[Point, int],
+        locks_map: dict[Point, set[Point]],
+        seed_map_local: dict[Point, Point],
+    ) -> tuple[dict[str, Incoming], dict[str, Outgoing], dict[str, str]]:
+        incoming: dict[str, Incoming] = {}
+        outgoing: dict[str, Outgoing] = {}
+        status: dict[str, str] = {}
+        for name in ("A", "B", "C", "D"):
+            site = probe_map[name]
+            tau = ticks_map[site] + 1
+            incoming[name] = incoming_set(site, tau, ticks_map, locks_map, seed_map_local)
+            outgoing[name] = outgoing_set(site, tau, ticks_map, locks_map, seed_map_local)
+            status[name] = forall_perp(incoming[name], outgoing[name])
+        return incoming, outgoing, status
+
+    y_m, y_o, y_fp = probe_fp(Y_PROBES, ticks, locks, seed_map)
+    z_m, z_o, z_fp = probe_fp(Z_PROBES, ticks, locks, seed_map)
+    same_m, same_o, same_fp = probe_fp(
+        PROBES, same_e2_ticks, same_e2_locks, same_e2_seeds
+    )
+    nspar_m, nspar_o, nspar_fp = probe_fp(PROBES, nspar_ticks, nspar_locks, nspar_seeds)
+    opp_m, opp_o, opp_fp = probe_fp(PROBES, opp_e3_ticks, opp_e3_locks, opp_e3_seeds)
+    y_reverse = reverse_report(y_fp["A"], y_fp["B"])
+    nspar_reverse = reverse_report(nspar_fp["A"], nspar_fp["B"])
+    nspar_face = face_report(nspar_fp["C"], nspar_fp["D"])
+    checks.check(
+        "not-y-or-z-probes-or-same-lock-or-nspar-or-opp-e3",
+        TWO_SITE_SEEDS != SAME_E2_SEEDS
+        and TWO_SITE_SEEDS != NSPAR_SEEDS
+        and TWO_SITE_SEEDS != OPPOSITE_E3_SEEDS
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites
+        and y_m["A"] != m1["A"]
+        and y_o["A"] != o1["A"]
+        and z_m["A"] != m1["A"]
+        and same_m["A"] != m1["A"]
+        and nspar_m["A"] != m1["A"]
+        and opp_m["A"] != m1["A"]
+        and nspar_fp["B"] == "fail"
+        and nspar_reverse == "fail"
+        and nspar_face == "hold"
+        and exist_perp(nspar_m["B"], nspar_o["B"]) == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and y_reverse == "hold"
+        and same_fp["A"] == "hold"
+        and opp_fp["A"] == "hold",
+    )
+    checks.check(
+        "uniqueness-not-required",
+        isinstance(m1["A"], frozenset)
+        and len(m1["A"]) == 1
+        and isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 3
+        and isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 3
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "two-site-opposite-lock-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E2}
+        and ticks[E1] == 0
+        and locks[E1] == {NEG_E2}
+        and add(E2, NEG_E2) == ZERO
+        and TWO_SITE_SEEDS != SAME_E2_SEEDS
+        and TWO_SITE_SEEDS != NSPAR_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 2,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-M-O-dots-forall-perp",
+        "t(A)=0" in note
+        and "t(B)=2" in note
+        and "t(C)=1" in note
+        and "t(D)=3" in note
+        and "M(A, τ) = {−e_2}" in note
+        and "M(B, τ) = {+e_2}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_1, +e_3, −e_3}" in note
+        and "O(A, τ) = {+e_1, +e_3, −e_3}" in note
+        and "O(B, τ) = {+e_1, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_2, −e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_2, −e_2}" in note
+        and "forall-perp(A): hold" in note
+        and "forall-perp(B): hold" in note
+        and "forall-perp(C): hold" in note
+        and "forall-perp(D): hold" in note
+        and "(−e_2)·(+e_1)=0" in note
+        and "(+e_2)·(+e_1)=0" in note
+        and "(+e_1)·(+e_2)=0" in note
+        and "(−e_1)·(+e_2)=0" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (2, 0, 0), (1, 0, 1), (1, 0, -1)" in note
+        and "new 6-NN of B at t(B)+1: (2, 1, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (2, 1, 0), (2, -1, 0), (2, 0, 1), (2, 0, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, 2, 0)" in note,
+    )
+    checks.check(
+        "note-reports-hold-hold",
+        "Reverse: hold" in note
+        and "Face: hold" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "does not use occupancy" in normalized_note
+        and "mixed remains a set" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-exist-perp-or-exist-opposite-leftover",
+        "not leftover of exist-perp" in normalized_note
+        and "not leftover of exist-opposite of M" in normalized_note
+        and "not leftover of exist-opposite of O" in normalized_note
+        and "exist-perp is comparison only" in normalized_note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-no-six-neighbor-star-as-letter",
+        "does not use a six-neighbor star" in normalized_note
+        and "own incoming" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/X_AXIS_OPPOSITE_E2_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "forall_perp" in defined_fns
+        and "exist_perp" in defined_fns
+        and "pair_dots" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Forall-orthogonal M vs O at t+1 holds on all four #7214 x-probes. Reverse HOLD, face HOLD. Displayed, not adopted.

## Runner

`scripts/x_axis_opposite_e2_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.