### PR TITLE
feat(nmperpzp): forall-orthogonal M vs O at t+1 on #7186: reverse HOLD, face HOLD

### DIFF
--- a/docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,521 @@
+---
+claim_id: z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Forall-orthogonal M vs O at t+1 on the four #7186 z-probes, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+---
+
+# Forall-Orthogonal Incoming Versus Outgoing Reverse And Face At t+1 On Four #7186 Z-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** forall-orthogonal readout of own earliest incoming nearest-neighbor
+step set `M` against own outgoing dual `O` at each probe's `τ=t+1`, and
+reverse/face from that readout, on the four nszopinz #7186 z-probes in
+`B_3(0)={n:n·n<=9}`, no global T. Same process and z-probes as nszopinz
+#7186. Let `t(q)` be the formation tick of probe `q`. Let `τ(q)=t(q)+1`.
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. Seeds are a singleton seed letter.
+Unformed at `τ` is `UNDEFINED`. `O(q,τ)` is the outgoing dual of `M`: the
+set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed in `B_3(0)` and
+`e` is in `M(q+e,τ)`. Unformed `q` at `τ` is `UNDEFINED`. Empty `O` is
+empty, not `UNDEFINED`. Forall-perp HOLD if and only if every `m` in
+`M(q,τ)` and every `o` in `O(q,τ)` have integer dot `m·o=0`. Empty or
+`UNDEFINED` on either side is `UNDEFINED`. Exist-perp (some pair dots to
+0) is comparison only. Reverse HOLD if and only if forall-perp HOLDs at
+`A` and at `B`. Face likewise on `C,D`. Empty or `UNDEFINED` on either
+side of a comparison is `UNDEFINED`. This is the first forall-orthogonal
+display of `M` versus `O` at `t+1` on the nmzpin HOLDING own-incoming
+member. This is not leftover of exist-perp. This is not leftover of
+nmsimzp exist-opposite of `M` or of `O`. This is not leftover of empty
+intersection. This is not leftover of nstri forall-perp fail at B. This
+is not leftover of nmt2zp `M` two-tick HOLD/HOLD. This is not leftover of
+nmot2zp `O` two-tick. This is not leftover of unique own-incoming or
+own-outgoing letters. This is not leftover of mixed #7188 fail/fail. This
+is not leftover of a six-neighbor star. Uniqueness of incoming or outgoing
+locks is not required. Mixed remains a set. Occupancy `n` is not used. O
+is not M. Displayed, not adopted. Do not write into Admissibility. Do not
+attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py`](../scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at a per-probe cut
+`τ=t+1`. Forall-perp is scored on every integer dot of an incoming letter
+against an outgoing letter at the same probe. Reverse and face are scored
+from those four per-probe reports. Named signs `{+,−}` are a coarser readout
+and are not used. A singleton unique lock letter is a different readout
+and is not used as the object. Existential opposite of `M(A)` against
+`M(B)` is a different readout and is not used as the object. Exist-perp is
+a different leftover readout. Occupancy `n` is not used. A six-neighbor
+star is not the letter. The construction does not use occupancy.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of t, M, O, integer dots, and forall-perp of M versus O at t+1 on the four #7186 z-probes, with reverse hold and face hold from those per-probe reports; uniqueness of locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face
+target_blocker_text: "display forall-orthogonal M versus O at t+1 on the four #7186 z-probes, and reverse/face from that, no global T"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep forall-perp of M versus O at t+1 displayed; do not write the bits into Admissibility, do not reduce to exist-perp, do not reduce to exist-opposite of M or of O, do not replace orthogonality by empty intersection, do not reduce to a unique letter, do not replace O by M, do not replace either set by six-neighbor lock union, do not use occupancy n, and do not wait for a global later T."
+conditional_surface_status: "exact on B_3(0) for forall-orthogonal M versus O at t+1 on the four #7186 z-probes, no global T; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose own
+incoming sets, outgoing sets, integer dots, and forall-perp reports are
+scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (1,0,1).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`,
+`C=(0,2,0)`, `D=(1,1,0)`. `A` is a seed. Same process and z-probes as
+nszopinz #7186.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the three-record set `{0, (0,0,1), (0,0,-1)}` is recorded at formation
+tick 0 with locks `L(0)=+e_1`, `L(0,0,1)=−e_1`, and `L(0,0,-1)=−e_1`. The
+third site is the z-mirror of the two-site opposite-lock partner `(0,0,1)`.
+This seed is not the two-site opposite-lock seed `{0,(0,0,1)}` and not the
+three-site opposite-lock seed whose third site is `(1,0,0)` with lock `+e_2`.
+This seed is not the perp two-site seed `+e_1/+e_2`. This seed is not the
+y-symmetric three-site seed `{0,(0,1,0),(0,-1,0)}`. This seed is not the
+x-symmetric three-site seed `{0,(1,0,0),(-1,0,0)}`. Same process as nszmenu
+#7188 on the x-probes; the scored sites here are the z-probes.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named forall-orthogonal readout of `M` versus `O` at `t+1`
+
+Let `t(q)` be the formation tick of z-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed in B_3(0) and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate outgoing steps collapse in the set. The
+construction does not require `M` or `O` to be a singleton. It does not sum
+either set. It does not replace `O` by `M`. It does not replace either set
+by locks of six-neighbors of `q`. It does not wait for a global later T.
+Occupancy `n` is not used. O is not M.
+
+Forall-perp at a formed probe with both sets nonempty HOLDs if and only if
+every `m` in `M(q,τ)` and every `o` in `O(q,τ)` have integer dot `m·o=0`.
+Empty or `UNDEFINED` on either side is `UNDEFINED`. Nonempty with a
+nonzero pair fails. Exist-perp (some pair has integer dot 0) is a leftover
+comparison and is not the scored predicate. Empty intersection of `M` and
+`O` is a leftover comparison: `{+e_1}` and `{−e_1}` are disjoint and have
+dot `-1`. Existential opposite of `M(A)` against `M(B)`, or of `O(A)`
+against `O(B)`, is a leftover comparison across probes, not a same-site
+dot.
+
+Reverse from forall-perp at `τ` HOLDs if and only if forall-perp HOLDs at
+`A` and at `B`. Face likewise on `C,D`. Empty or `UNDEFINED` on either
+side of a comparison is `UNDEFINED`; else a fail on either side fails.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored from
+forall-perp of `M` versus `O` at the named probes. They are not an
+occupancy-kernel inner product.
+
+## Theorem 1 — ticks, `M`, `O`, dots, and forall-perp at `τ=t+1`
+
+On this process the four z-probes form. Compare to nmt2zp: that leftover
+reports `M(q,t+1)=M(q,t)` at every scored probe. Compare to nmot2zp: that
+leftover reports `O` empty or singleton at `t` and enlarged at `t+1`. Compare
+to nmsimzp: that leftover reports exist-opposite of `M` and of `O`
+separately. Here `M` and `O` are read together at `τ=t+1` and scored by
+forall-perp:
+
+```text
+t(A)=0
+t(B)=2
+t(C)=1
+t(D)=3
+M(A, τ) = {−e_1}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_3}
+M(D, τ) = {+e_2, −e_2, −e_3}
+O(A, τ) = {+e_2, −e_2, +e_3}
+O(B, τ) = {+e_2, −e_2, +e_3}
+O(C, τ) = {+e_1, −e_1, +e_2, −e_2}
+O(D, τ) = {+e_1, −e_1}
+(−e_1)·(+e_2)=0, (−e_1)·(−e_2)=0, (−e_1)·(+e_3)=0
+(+e_1)·(+e_2)=0, (+e_1)·(−e_2)=0, (+e_1)·(+e_3)=0
+(+e_3)·(+e_1)=0, (+e_3)·(−e_1)=0, (+e_3)·(+e_2)=0, (+e_3)·(−e_2)=0
+(+e_2)·(+e_1)=0, (+e_2)·(−e_1)=0, (−e_2)·(+e_1)=0, (−e_2)·(−e_1)=0, (−e_3)·(+e_1)=0, (−e_3)·(−e_1)=0
+forall-perp(A)=hold
+forall-perp(B)=hold
+forall-perp(C)=hold
+forall-perp(D)=hold
+```
+
+`A` is a seed at tick 0. Mixed remains a set: `M(D,τ)` has three incoming
+steps and `O(A,τ)` has three outgoing steps. Unique own-incoming letters
+would assign `UNDEFINED` at `D`. Unique own-outgoing letters would assign
+`UNDEFINED` at `A`, `B`, `C`, and `D`. Here uniqueness is not required.
+Every displayed integer dot is 0. Empty `O` at `t` makes forall-perp
+`UNDEFINED` at `A`, `B`, and `C` at the own-tick cut; at `τ=t+1` both
+families are nonempty. O is not M. No six-neighbor star.
+
+This is not leftover of exist-perp: some pair with integer dot 0 is a
+weaker leftover. On the nstri three-site leftover, forall-perp fails at
+`B` because `+e_1` sits in both `M(B,τ)` and `O(B,τ)` with `+e_1·+e_1=1`,
+while exist-perp still HOLDs at `B`. This is not leftover of nmsimzp
+exist-opposite: that leftover scores opposite pairs of `M` across `A,B`
+and of `O` across `A,B`. This is not leftover of empty intersection:
+`{+e_1}` and `{−e_1}` are disjoint and have integer dot `-1`. This is not
+leftover of nstri forall-perp fail at B. This is not leftover of nmt2zp
+`M` two-tick HOLD/HOLD. This is not leftover of nmot2zp `O` two-tick. This
+is not leftover of unique own-incoming or own-outgoing letters. This is
+not leftover of mixed #7188 fail/fail. This is not leftover of nmsimopp /
+nmsimsy / nmsimzx: those leftovers use other seeds and other probe
+families.
+
+## Theorem 2 — reverse from forall-perp at `τ`
+
+Reverse from forall-perp holds if and only if forall-perp HOLDs at `A` and
+at `B`. Both reports are hold. Reverse holds.
+
+Reverse from forall-perp at τ: hold
+
+Unique own-incoming letters on these z-probes report reverse hold and face
+`UNDEFINED` from mixed `M(D,τ)`. Same-tick-inclusive six-neighbor lock union
+leftover reports reverse fail from `{+e_1}` at neighbors of seed `A`.
+Exist-opposite of `M` reports reverse hold from `−e_1` at `A` against
+`+e_1` at `B`; that pair is across probes, not a same-site `M` versus `O`
+dot. Exist-perp leftover also reports reverse hold here, but fails to
+separate this member from nstri, where exist-perp reverse HOLDs and
+forall-perp reverse fails. Those are different objects. Reverse from
+forall-perp holds at `τ` because every incoming letter at `A` is orthogonal
+to every outgoing letter at `A`, and likewise at `B`.
+
+## Theorem 3 — face from forall-perp at `τ`
+
+Face from forall-perp holds if and only if forall-perp HOLDs at `C` and at
+`D`. Both reports are hold. Face holds.
+
+Face from forall-perp at τ: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1. Unique own-outgoing
+letters on these z-probes report reverse `UNDEFINED` and face `UNDEFINED`
+from mixed `O` at `τ`. nmot2zp leftover reports reverse `UNDEFINED` at `t`
+because `O` is empty at `A`, `B`, and `C`. nmsimzp leftover reports reverse
+hold and face hold from exist-opposite of `M` and of `O`. Those are
+different objects. Face from forall-perp holds at `τ` because every
+incoming letter at `C` is orthogonal to every outgoing letter at `C`, and
+likewise at `D`.
+
+At the same cut, forall-perp HOLDs at all four probes, so reverse HOLDs
+and face HOLDs. Simultaneous HOLD of exist-opposite of `M` and of `O` does
+not name this predicate. Empty intersection at a formed probe does not
+name this predicate.
+
+## What this note does not claim
+
+- It does not select a unique incoming or outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require either set to be a singleton.
+- It does not sum either set.
+- It does not replace `O` by `M`.
+- It does not replace either set by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint unique own-incoming or own-outgoing lock-vector
+  letters on these z-probes as the object.
+- It does not reprint nmt2zp `M` two-tick HOLD/HOLD.
+- It does not reprint nmot2zp `O` two-tick.
+- It does not reprint exist-perp as the scored predicate.
+- It does not reprint nmsimzp exist-opposite of `M` or of `O`.
+- It does not reprint empty intersection as orthogonality.
+- It does not reprint nstri forall-perp fail at B as this member.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not reprint nmsimopp / nmsimsy / nmsimzx simultaneous bits as
+  this member.
+- It does not use occupancy `n`.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+z-symmetric three-site process, the incoming and outgoing sets at `t+1`, the
+integer dots, the forall-perp reports, and reverse/face from those reports are
+displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; nszopinz #7186 seed `+e_1/−e_1/−e_1` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `2`, `1`, `3` |
+| `M` at `τ=t+1` | Theorem 1; frozen incoming sets |
+| `O` at `τ=t+1` | Theorem 1; enlarged outgoing duals |
+| integer dots of `M` versus `O` at `τ` | Theorem 1; every displayed pair is 0 |
+| forall-perp at `A,B,C,D` | Theorem 1; hold at each |
+| reverse from forall-perp at `τ` | Theorem 2; hold |
+| face from forall-perp at `τ` | Theorem 3; hold |
+| unique incoming or outgoing lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of exist-perp | not this display |
+| leftover of nmsimzp exist-opposite | not this display |
+| leftover of empty intersection | not this display |
+| leftover of nstri forall-perp fail at B | not this display |
+| leftover of nmt2zp `M` two-tick HOLD/HOLD | not this display |
+| leftover of nmot2zp `O` two-tick | not this display |
+| leftover of unique own-incoming or own-outgoing letters | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of nmsimopp / nmsimsy / nmsimzx | not this display |
+| global later T | not used |
+| forall-perp as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: forall-orthogonal `M` versus `O` at `t+1` on the four #7186 z-probes, and reverse/face from that. |
+| V2 | Current main has no landed forall-orthogonal incoming-versus-outgoing reverse/face at `t+1` on these four #7186 z-probes. |
+| V3 | Own incoming sets, own outgoing sets, integer dots, forall-perp reports, and the `hold`/`fail`/`UNDEFINED` reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads both duals at one cut and scores every integer dot, not existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique letter, does not replace `O` by `M`, does not replace either set by
+six-neighbor lock union, does not identify this display with exist-perp,
+does not identify the bits with nmsimzp exist-opposite, does not identify
+orthogonality with empty intersection, does not identify the bits with
+nstri forall-perp fail at B, does not identify the bits with nmt2zp `M`
+HOLD/HOLD, does not identify the bits with nmot2zp `O` two-tick, and does
+not identify the bits with mixed #7188 fail/fail. No global impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| exist-perp | score some pair with integer dot 0 | weaker leftover; nstri `B` has exist-perp hold and forall-perp fail from `+e_1·+e_1=1` | ATTEMPTED |
+| nmsimzp exist-opposite | score opposite pairs of `M` across `A,B` and of `O` across `A,B` | that leftover is cross-probe opposite, not same-site `M` versus `O` dots | ATTEMPTED |
+| empty intersection | treat `M ∩ O = {}` as the predicate | `{+e_1}` and `{−e_1}` are disjoint and have integer dot `-1` | ATTEMPTED |
+| nstri forall-perp fail at B | reuse the three-site leftover whose third seed is `(1,0,0)` with lock `+e_2` | different seed; that leftover reports reverse fail | ATTEMPTED |
+| nmt2zp `M` two-tick | reuse earliest incoming `M` at `t` versus `t+1` | that leftover is HOLD/HOLD composition of `M` alone; it does not display `O` dots | ATTEMPTED |
+| nmot2zp `O` two-tick | reuse outgoing `O` at `t` versus `t+1` | that leftover reports reverse `UNDEFINED` then hold; empty `O` at `t` makes forall-perp `UNDEFINED` | ATTEMPTED |
+| unique own letter | replace mixed `M` or `O` by a singleton or `UNDEFINED` | `M(D,τ)` has three incoming steps and `O(A,τ)` has three outgoing steps; mixed remains a set; unique-letter face from `M` is `UNDEFINED` | ATTEMPTED |
+| same-tick-inclusive six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | that leftover includes `+e_1` at `A` from the origin partner; `M(A,τ)` is `{−e_1}` and `O(A,τ)` does not contain `+e_1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail on the x-probes | different probes of this process; this member reports forall-perp hold at each z-probe | ATTEMPTED |
+| nmsimopp / nmsimsy / nmsimzx | reuse simultaneous bits on other seeds or probe families | different seeds and probes; not this member | ATTEMPTED |
+| sum of `M` or `O` | replace each set by its `Z^3` sum | the construction does not sum; forall-perp reads pairs, not a sum | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading the sets | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by forall-perp | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of forall-perp with
+exist-opposite, and missing Record identification of orthogonality are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, z-symmetric three-site seed locks `+e_1`, `−e_1`, and
+`−e_1`, perpendicular step rule, incoming-step lock, own incoming set and
+own outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+forall-perp of every integer dot, four z-probes with seed `A`, empty or
+`UNDEFINED` as `UNDEFINED`, mixed remains a set, and reverse/face from
+those reports are declared. No uniqueness of locks, no six-neighbor lock
+union as the scored object, no exist-perp as the scored predicate, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+hold reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each integer dot of an earliest incoming step against an outgoing dual step | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four incoming sets, four outgoing sets, integer dots, four forall-perp reports, reverse/face | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Because every displayed integer dot is 0, forall-perp is only
+exist-perp, or only empty intersection, or only nmsimzp exist-opposite of
+`M` and of `O`. nstri is a different seed so it cannot separate the
+predicate. Empty `O` at `t` already made reverse `UNDEFINED`, so `t+1` is
+tautological because children form. Mixed `D` incoming and mixed `A`
+outgoing should make face or reverse `UNDEFINED`. Six-neighbor lock union
+already answered reverse fail on this same process. Mixed #7188 already
+answered fail/fail. Named signs should suffice. And HOLD of forall-perp
+is only tautological because the step rule is already perpendicular.
+
+**Answer:** Forall-perp scores every pair, not some pair. On the nstri
+leftover, exist-perp HOLDs at `B` while forall-perp fails from a shared
+`+e_1`. Empty intersection is not orthogonality: `{+e_1}` and `{−e_1}`
+are disjoint with integer dot `-1`. nmsimzp exist-opposite scores
+cross-probe opposite pairs inside `M` or inside `O`; same-site `M(A)`
+versus `O(A)` has no opposite pair and still has forall-perp HOLD.
+Empty `O` at `t` makes forall-perp `UNDEFINED` at `A`, `B`, and `C`; the
+`t+1` cut is the first cut where both families are nonempty at every
+scored probe. Mixed `M(D,τ)` and mixed `O(A,τ)` remain sets; reverse and
+face hold. Six-neighbor lock union is a different object. Mixed #7188
+fail/fail is a different probe family of this process. Named signs lost
+the axis. The formation step rule is perpendicular to the parent lock;
+forall-perp here is a readout of already-formed incoming letters against
+outgoing dual letters at `t+1`, not a restatement of the step rule and
+not an Admissibility rewrite.
+
+### N8 — cross-cycle echo
+
+A unique own-incoming lock-vector display on these same z-probes assigned
+`−e_1`, `+e_1`, `+e_3`, `UNDEFINED` and reported reverse hold with face
+`UNDEFINED`. nszopinz #7186 own incoming exist-opposite reported reverse
+hold and face hold from `M`. nmt2zp `M` two-tick composition reported
+reverse hold and face hold at both cuts. nmot2zp `O` two-tick composition
+reported reverse `UNDEFINED` then hold. nmsimzp reported empty
+intersection with reverse/face hold from `M` and from `O` separately.
+nstri forall-perp fail at B is a different seed whose reverse from
+forall-perp fails. Mixed #7188 two-tick composition reported reverse fail
+and face fail. nmsimopp / nmsimsy / nmsimzx score other seeds or other
+probe families. This note is not those displays: forall-perp of `M`
+versus `O` is read at `t+1` on the four #7186 z-probes, every displayed
+integer dot is 0, reverse HOLDs, and face HOLDs.
+
+**Gate disposition:** PASS for the forall-orthogonal incoming-versus-outgoing
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals
+exist-perp,” “the predicate equals nmsimzp exist-opposite,” “the predicate
+equals empty intersection,” “the predicate equals nstri forall-perp fail
+at B,” “the predicate equals the named sign,” “the predicate equals the
+unique singleton lock vector,” “the predicate equals `M` two-tick of
+nmt2zp,” “the predicate equals nmot2zp `O` two-tick,” “the predicate
+equals six-neighbor lock union,” “the predicate equals mixed #7188
+fail/fail,” “the predicate equals nmsimopp / nmsimsy / nmsimzx,” “bits
+are Admissibility,” or “`M` equals `O`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the nszopinz #7186
+perp-step incoming-lock process, reads each probe's own incoming set and
+own outgoing dual from the record prefix at that probe's `t+1`, reports
+integer dots and forall-perp, and checks Theorems 1--3. It also checks
+that empty or `UNDEFINED` is `UNDEFINED`, that mixed sets remain sets,
+that exist-perp is a leftover, that nmsimzp exist-opposite is a leftover,
+that empty intersection is not forall-perp, that nstri forall-perp fail
+at B is a leftover, that a formation member from already-recorded
+six-neighbor locks is not attached, and that the display is not nmt2zp `M`
+two-tick HOLD/HOLD and not nmot2zp `O` two-tick. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -22233,6 +22233,10 @@
   "z_n_spectral_asymmetry_physical_identification_note_2026-05-31": {
    "deps_hash": "84609f8d3c8c",
    "out_degree": 6
+  },
+  "z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   }
  },
  "schema_version": 1

--- a/logs/runner-cache/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+runner_sha256: fa1b60311e487ff140eff5ea4040b0a0b46cea301a1e0c0ea7f78bb917cb480c
+input_fingerprint_sha256: b9ba6f9f81da80c5b6feb887118ed839b2f57ba1ac702c3b0f9dfbd447c8e0e2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+forall-orthogonal M vs O reverse/face at t+1 on #7186 z-probes
+AUDIT_INPUT_PATHS:
+  docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Forall-orthogonal M vs O at t+1 on the four #7186 z-probes, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: forall-perp-identity
+PASS: exist-perp-is-leftover-identity
+PASS: existential-opposite-is-leftover-identity
+PASS: combine-status-identity
+A t=0 tau=1 M={−e_1} O={+e_2, −e_2, +e_3} forall-perp=hold
+A dots=(('−e_1', '+e_2', 0), ('−e_1', '−e_2', 0), ('−e_1', '+e_3', 0))
+B t=2 tau=3 M={+e_1} O={+e_2, −e_2, +e_3} forall-perp=hold
+B dots=(('+e_1', '+e_2', 0), ('+e_1', '−e_2', 0), ('+e_1', '+e_3', 0))
+C t=1 tau=2 M={+e_3} O={+e_1, −e_1, +e_2, −e_2} forall-perp=hold
+C dots=(('+e_3', '+e_1', 0), ('+e_3', '−e_1', 0), ('+e_3', '+e_2', 0), ('+e_3', '−e_2', 0))
+D t=3 tau=4 M={+e_2, −e_2, −e_3} O={+e_1, −e_1} forall-perp=hold
+D dots=(('+e_2', '+e_1', 0), ('+e_2', '−e_1', 0), ('−e_2', '+e_1', 0), ('−e_2', '−e_1', 0), ('−e_3', '+e_1', 0), ('−e_3', '−e_1', 0))
+reverse=hold face=hold
+per_element: each integer dot of an earliest incoming step against an outgoing dual step at a probe, read from the record prefix at that probe's t+1
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four incoming sets, four outgoing sets, integer dots, four forall-perp reports, and reverse/face from those reports
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: unformed-at-tau-is-undefined
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 2, 'C': 1, 'D': 3})
+PASS: theorem1-M-and-O-at-tau  ({'A': ('{−e_1}', '{+e_2, −e_2, +e_3}'), 'B': ('{+e_1}', '{+e_2, −e_2, +e_3}'), 'C': ('{+e_3}', '{+e_1, −e_1, +e_2, −e_2}'), 'D': ('{+e_2, −e_2, −e_3}', '{+e_1, −e_1}')})
+PASS: theorem1-dots-all-zero
+PASS: theorem1-forall-perp-hold-at-each-probe  ({'A': 'hold', 'B': 'hold', 'C': 'hold', 'D': 'hold'})
+PASS: theorem1-A-is-seed
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem2-reverse-hold  (hold)
+PASS: theorem3-face-hold  (hold)
+PASS: empty-or-undefined-is-undefined
+PASS: disjoint-is-not-forall-perp
+PASS: O-is-not-M
+PASS: not-leftover-of-exist-perp
+PASS: not-leftover-of-exist-opposite-M-or-O
+PASS: not-leftover-of-unique-letter
+PASS: not-leftover-of-neighbor-lock-union
+PASS: not-leftover-of-M-or-O-at-t
+PASS: uniqueness-not-required
+PASS: not-leftover-of-nstri-exist-perp-hold-forall-fail  (('fail', 'fail', 'hold'))
+PASS: not-x-probes-or-y-probes-or-two-site-or-perp
+PASS: not-y-symmetric-or-x-symmetric
+PASS: z-symmetric-three-site-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-dots-and-forall
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-exist-perp-or-exist-opposite-or-simultaneous
+PASS: note-not-nstri-forall-fail
+PASS: note-does-not-use-occupancy
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+TOTAL: PASS=55 FAIL=0
+
+----- stderr -----
+

--- a/scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1094 @@
+#!/usr/bin/env python3
+"""Forall-orthogonal M vs O reverse/face at t+1 on #7186 z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,0,1), (0,0,-1)} with locks +e_1, -e_1, and -e_1 (nszopinz #7186).
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Seeds keep their seed letters as
+a singleton. t(q) is the formation tick. tau = t+1 per probe. No global T.
+M(q, tau) is the set of earliest incoming nearest-neighbor steps at q using
+only records with tick <= tau. Unformed at tau => UNDEFINED.
+O(q, tau) is the outgoing dual of M: the set of e in {+/-e_1,+/-e_2,+/-e_3}
+such that q+e is formed in B_3(0) and e is in M(q+e, tau). Unformed q at
+tau => UNDEFINED. Empty O is empty, not UNDEFINED.
+Forall-perp HOLD iff every m in M(q,tau) and o in O(q,tau) have integer
+dot m·o=0. Empty or UNDEFINED => UNDEFINED. Exist-perp (some pair dots to
+0) is comparison only. Reverse HOLD iff forall-perp at A and at B. Face
+on C,D. Empty or UNDEFINED on either side => UNDEFINED. No 6-NN star.
+Uniqueness of locks is not required. Occupancy n is not used. Named-sign
+lettering is not used. No larger host. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+BALL_SQ = 9
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+X_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, NEG_E2),
+    (NEG_E1, NEG_E2),
+)
+NSTRI_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E1, E2),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Forall-orthogonal M vs O at t+1 on the four #7186 "
+    "z-probes, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def pair_dots(left: Incoming, right: Incoming) -> tuple[tuple[str, str, int], ...] | str:
+    """Integer dots of every (m,o) pair. Unformed => UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("dot sides must be lock sets or UNDEFINED")
+    pairs: list[tuple[str, str, int]] = []
+    for m in NN:
+        if m not in left:
+            continue
+        for o in NN:
+            if o not in right:
+                continue
+            pairs.append((LOCK_NAME[m], LOCK_NAME[o], dot(m, o)))
+    return tuple(pairs)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = Z_SYMMETRIC_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def forall_perp(left: Incoming, right: Incoming) -> str:
+    """Hold iff every m in left and o in right have integer dot 0.
+
+    Empty or UNDEFINED on either side is UNDEFINED. Nonempty with a
+    nonzero pair fails. Exist-perp is a different leftover readout.
+    """
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for m in left:
+        for o in right:
+            if dot(m, o) != 0:
+                return "fail"
+    return "hold"
+
+
+def exist_perp(left: Incoming, right: Incoming) -> str:
+    """Leftover: hold iff some pair has integer dot 0."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for m in left:
+        for o in right:
+            if dot(m, o) == 0:
+                return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Leftover: hold iff some lock in left is opposite some lock in right."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def combine_status(left: str, right: str) -> str:
+    """Reverse/face from two per-probe forall-perp reports."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(status_a: str, status_b: str) -> str:
+    return combine_status(status_a, status_b)
+
+
+def face_report(status_c: str, status_d: str) -> str:
+    return combine_status(status_c, status_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def neighbor_lock_set(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    tau: int,
+) -> frozenset[Point]:
+    """Leftover contrast: locks of 6-NN formed by tau, site excluded."""
+    collected: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks or ticks[neighbor] > tau:
+            continue
+        collected.update(locks[neighbor])
+    return frozenset(collected)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("forall-orthogonal M vs O reverse/face at t+1 on #7186 z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and dot(E1, E2) == 0
+        and dot(E1, NEG_E1) == -1
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((0, 0, 4)),
+    )
+    checks.check(
+        "forall-perp-identity",
+        forall_perp(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and forall_perp(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and forall_perp(frozenset(), frozenset({E1})) == UNDEFINED
+        and forall_perp(frozenset({E1}), frozenset()) == UNDEFINED
+        and forall_perp(frozenset({E1}), frozenset({E2, NEG_E2, E3})) == "hold"
+        and forall_perp(frozenset({E1}), frozenset({NEG_E1})) == "fail"
+        and forall_perp(frozenset({E1, E2}), frozenset({E1, E3})) == "fail"
+        and forall_perp(frozenset({NEG_E1}), frozenset({E2, NEG_E2, E3})) == "hold"
+        and forall_perp(frozenset({E3}), frozenset({E1, NEG_E1, E2, NEG_E2}))
+        == "hold"
+        and forall_perp(frozenset({E2, NEG_E2, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold",
+    )
+    checks.check(
+        "exist-perp-is-leftover-identity",
+        exist_perp(frozenset({E1, E2}), frozenset({E1, E3})) == "hold"
+        and forall_perp(frozenset({E1, E2}), frozenset({E1, E3})) == "fail"
+        and exist_perp(frozenset({E1}), frozenset({NEG_E1})) == "fail"
+        and exist_perp(frozenset({E1}), frozenset({E2})) == "hold"
+        and exist_perp(frozenset(), frozenset({E1})) == UNDEFINED,
+    )
+    checks.check(
+        "existential-opposite-is-leftover-identity",
+        existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold"
+        and existential_opposite(frozenset({E1}), frozenset({E2, NEG_E2, E3}))
+        == "fail"
+        and forall_perp(frozenset({NEG_E1}), frozenset({E2, NEG_E2, E3})) == "hold",
+    )
+    checks.check(
+        "combine-status-identity",
+        reverse_report("hold", "hold") == "hold"
+        and reverse_report("hold", "fail") == "fail"
+        and reverse_report("fail", "hold") == "fail"
+        and reverse_report(UNDEFINED, "hold") == UNDEFINED
+        and face_report("hold", UNDEFINED) == UNDEFINED
+        and face_report("hold", "hold") == "hold"
+        and face_report("fail", "hold") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    two_ticks, two_locks, two_seeds = form(TWO_SITE_SEEDS)
+    ysym_ticks, ysym_locks, ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    xsym_ticks, xsym_locks, xsym_seeds = form(X_SYMMETRIC_SEEDS)
+    nstri_ticks, nstri_locks, nstri_seeds = form(NSTRI_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    fp0: dict[str, str] = {}
+    fp1: dict[str, str] = {}
+    ep1: dict[str, str] = {}
+    dots1: dict[str, tuple[tuple[str, str, int], ...] | str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        fp0[name] = forall_perp(m0[name], o0[name])
+        fp1[name] = forall_perp(m1[name], o1[name])
+        ep1[name] = exist_perp(m1[name], o1[name])
+        dots1[name] = pair_dots(m1[name], o1[name])
+        print(
+            f"{name} t={ticks[site]} tau={tau1[name]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"forall-perp={fp1[name]}"
+        )
+        print(f"{name} dots={dots1[name]}")
+
+    reverse_status = reverse_report(fp1["A"], fp1["B"])
+    face_status = face_report(fp1["C"], fp1["D"])
+    reverse0 = reverse_report(fp0["A"], fp0["B"])
+    face0 = face_report(fp0["C"], fp0["D"])
+    exist_reverse = reverse_report(ep1["A"], ep1["B"])
+    exist_face = face_report(ep1["C"], ep1["D"])
+    m_reverse = existential_opposite(m1["A"], m1["B"])
+    m_face = existential_opposite(m1["C"], m1["D"])
+    o_reverse = existential_opposite(o1["A"], o1["B"])
+    o_face = existential_opposite(o1["C"], o1["D"])
+    unique_m_reverse = existential_opposite(
+        unique_letter(m1["A"]), unique_letter(m1["B"])
+    )
+    unique_m_face = existential_opposite(
+        unique_letter(m1["C"]), unique_letter(m1["D"])
+    )
+    leftover_neighbor_reverse = existential_opposite(
+        neighbor_lock_set(PROBES["A"], ticks, locks, tau1["A"]),
+        neighbor_lock_set(PROBES["B"], ticks, locks, tau1["B"]),
+    )
+    leftover_neighbor_face = existential_opposite(
+        neighbor_lock_set(PROBES["C"], ticks, locks, tau1["C"]),
+        neighbor_lock_set(PROBES["D"], ticks, locks, tau1["D"]),
+    )
+    print(f"reverse={reverse_status} face={face_status}")
+    print(
+        "per_element: each integer dot of an earliest incoming step against "
+        "an outgoing dual step at a probe, read from the record prefix at "
+        "that probe's t+1"
+    )
+    print(
+        "per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four incoming sets, four outgoing sets, integer dots, "
+        "four forall-perp reports, and reverse/face from those reports"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E1, NEG_E1)
+    )
+    z_mirror_parallel_blocked = all(
+        ticks.get(add(NEG_E3, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and z_mirror_parallel_blocked
+        and ticks[NEG_E3] == 0
+        and ticks[E2] == 1
+        and ticks[NEG_E2] == 1
+        and ticks[(0, 0, 2)] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 3
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "unformed-at-tau-is-undefined",
+        incoming_set(PROBES["B"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 1, ticks, locks, seed_map) == UNDEFINED
+        and forall_perp(
+            incoming_set(PROBES["B"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and incoming_set(PROBES["D"], 2, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["D"], 2, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 1, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and m1["A"] == frozenset({NEG_E1}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 2
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 3,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-and-O-at-tau",
+        m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E2, NEG_E2, NEG_E3})
+        and o1["A"] == frozenset({E2, NEG_E2, E3})
+        and o1["B"] == frozenset({E2, NEG_E2, E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E2, NEG_E2})
+        and o1["D"] == frozenset({E1, NEG_E1})
+        and m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+        str({name: (lockset_display(m1[name]), lockset_display(o1[name])) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-dots-all-zero",
+        dots1["A"]
+        == (("−e_1", "+e_2", 0), ("−e_1", "−e_2", 0), ("−e_1", "+e_3", 0))
+        and dots1["B"]
+        == (("+e_1", "+e_2", 0), ("+e_1", "−e_2", 0), ("+e_1", "+e_3", 0))
+        and dots1["C"]
+        == (
+            ("+e_3", "+e_1", 0),
+            ("+e_3", "−e_1", 0),
+            ("+e_3", "+e_2", 0),
+            ("+e_3", "−e_2", 0),
+        )
+        and dots1["D"]
+        == (
+            ("+e_2", "+e_1", 0),
+            ("+e_2", "−e_1", 0),
+            ("−e_2", "+e_1", 0),
+            ("−e_2", "−e_1", 0),
+            ("−e_3", "+e_1", 0),
+            ("−e_3", "−e_1", 0),
+        )
+        and all(
+            isinstance(dots1[name], tuple)
+            and all(value == 0 for _m, _o, value in dots1[name])
+            for name in ("A", "B", "C", "D")
+        ),
+    )
+    checks.check(
+        "theorem1-forall-perp-hold-at-each-probe",
+        fp1["A"] == "hold"
+        and fp1["B"] == "hold"
+        and fp1["C"] == "hold"
+        and fp1["D"] == "hold"
+        and ep1["A"] == "hold"
+        and ep1["B"] == "hold"
+        and ep1["C"] == "hold"
+        and ep1["D"] == "hold",
+        str(fp1),
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {NEG_E1}
+        and m1["A"] == frozenset({NEG_E1})
+        and X_PROBES["A"] != PROBES["A"]
+        and Y_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 3
+        and unique_letter(m1["D"]) == UNDEFINED
+        and isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 3
+        and unique_letter(o1["A"]) == UNDEFINED
+        and fp1["D"] == "hold"
+        and fp1["A"] == "hold",
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse_status == "hold"
+        and fp1["A"] == "hold"
+        and fp1["B"] == "hold"
+        and reverse_status != "fail"
+        and reverse_status != UNDEFINED,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and fp1["C"] == "hold"
+        and fp1["D"] == "hold"
+        and face_status != "fail"
+        and face_status != UNDEFINED,
+        face_status,
+    )
+    checks.check(
+        "empty-or-undefined-is-undefined",
+        fp0["A"] == UNDEFINED
+        and fp0["B"] == UNDEFINED
+        and fp0["C"] == UNDEFINED
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and reverse0 == UNDEFINED
+        and face0 == UNDEFINED
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "disjoint-is-not-forall-perp",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and m1["A"].isdisjoint(o1["A"])
+        and forall_perp(frozenset({E1}), frozenset({NEG_E1})) == "fail"
+        and frozenset({E1}).isdisjoint(frozenset({NEG_E1}))
+        and fp1["A"] == "hold",
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E1 in m1["A"]
+        and NEG_E1 not in o1["A"]
+        and E1 in m1["B"]
+        and E1 not in o1["B"]
+        and o1["A"] != m1["A"]
+        and o1["D"] != m1["D"],
+    )
+    checks.check(
+        "not-leftover-of-exist-perp",
+        exist_reverse == "hold"
+        and exist_face == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and exist_perp(frozenset({E1, E2}), frozenset({E1, E3})) == "hold"
+        and forall_perp(frozenset({E1, E2}), frozenset({E1, E3})) == "fail",
+    )
+    checks.check(
+        "not-leftover-of-exist-opposite-M-or-O",
+        m_reverse == "hold"
+        and m_face == "hold"
+        and o_reverse == "hold"
+        and o_face == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and existential_opposite(m1["A"], o1["A"]) == "fail"
+        and forall_perp(m1["A"], o1["A"]) == "hold",
+    )
+    checks.check(
+        "not-leftover-of-unique-letter",
+        unique_m_reverse == "hold"
+        and unique_m_face == UNDEFINED
+        and unique_letter(o1["A"]) == UNDEFINED
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-leftover-of-neighbor-lock-union",
+        leftover_neighbor_reverse == "hold"
+        and leftover_neighbor_face == "hold"
+        and E1 in neighbor_lock_set(PROBES["A"], ticks, locks, tau1["A"])
+        and E1 not in m1["A"]
+        and E1 not in o1["A"]
+        and reverse_status == "hold",
+    )
+    checks.check(
+        "not-leftover-of-M-or-O-at-t",
+        m0["A"] == m1["A"]
+        and o0["A"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and fp0["D"] == "hold"
+        and reverse0 == UNDEFINED
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "uniqueness-not-required",
+        isinstance(m1["D"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and len(m1["D"]) == 3
+        and len(o1["A"]) == 3
+        and len(o1["C"]) == 4
+        and fp1["D"] == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+
+    def family_at(
+        probes: dict[str, Point],
+        ticks_map: dict[Point, int],
+        locks_map: dict[Point, set[Point]],
+        seeds: dict[Point, Point],
+    ) -> tuple[dict[str, Incoming], dict[str, Outgoing], dict[str, str]]:
+        m_map: dict[str, Incoming] = {}
+        o_map: dict[str, Outgoing] = {}
+        fp_map: dict[str, str] = {}
+        for name in ("A", "B", "C", "D"):
+            site = probes[name]
+            if site not in ticks_map:
+                m_map[name] = UNDEFINED
+                o_map[name] = UNDEFINED
+                fp_map[name] = UNDEFINED
+                continue
+            tau = ticks_map[site] + 1
+            m_map[name] = incoming_set(site, tau, ticks_map, locks_map, seeds)
+            o_map[name] = outgoing_set(site, tau, ticks_map, locks_map, seeds)
+            fp_map[name] = forall_perp(m_map[name], o_map[name])
+        return m_map, o_map, fp_map
+
+    x_m1, x_o1, x_fp = family_at(X_PROBES, ticks, locks, seed_map)
+    y_m1, y_o1, y_fp = family_at(Y_PROBES, ticks, locks, seed_map)
+    ysym_m1, ysym_o1, ysym_fp = family_at(PROBES, ysym_ticks, ysym_locks, ysym_seeds)
+    xsym_m1, xsym_o1, xsym_fp = family_at(PROBES, xsym_ticks, xsym_locks, xsym_seeds)
+    nstri_m1, nstri_o1, nstri_fp = family_at(
+        PROBES, nstri_ticks, nstri_locks, nstri_seeds
+    )
+    perp_m1, perp_o1, perp_fp = family_at(PROBES, perp_ticks, perp_locks, perp_seeds)
+    two_m1, two_o1, two_fp = family_at(PROBES, two_ticks, two_locks, two_seeds)
+    nstri_ep = {
+        name: exist_perp(nstri_m1[name], nstri_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    x_reverse = reverse_report(x_fp["A"], x_fp["B"])
+    x_face = face_report(x_fp["C"], x_fp["D"])
+    y_reverse = reverse_report(y_fp["A"], y_fp["B"])
+    y_face = face_report(y_fp["C"], y_fp["D"])
+    nstri_reverse = reverse_report(nstri_fp["A"], nstri_fp["B"])
+    nstri_face = face_report(nstri_fp["C"], nstri_fp["D"])
+    nstri_exist_reverse = reverse_report(nstri_ep["A"], nstri_ep["B"])
+    perp_reverse = reverse_report(perp_fp["A"], perp_fp["B"])
+    perp_face = face_report(perp_fp["C"], perp_fp["D"])
+    ysym_reverse = reverse_report(ysym_fp["A"], ysym_fp["B"])
+    ysym_face = face_report(ysym_fp["C"], ysym_fp["D"])
+    xsym_reverse = reverse_report(xsym_fp["A"], xsym_fp["B"])
+    xsym_face = face_report(xsym_fp["C"], xsym_fp["D"])
+    two_reverse = reverse_report(two_fp["A"], two_fp["B"])
+    two_face = face_report(two_fp["C"], two_fp["D"])
+    checks.check(
+        "not-leftover-of-nstri-exist-perp-hold-forall-fail",
+        nstri_fp["B"] == "fail"
+        and nstri_ep["B"] == "hold"
+        and nstri_reverse == "fail"
+        and nstri_exist_reverse == "hold"
+        and nstri_face == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and E1 in nstri_m1["B"]
+        and E1 in nstri_o1["B"]
+        and dot(E1, E1) == 1
+        and fp1["B"] == "hold",
+        str((nstri_fp["B"], nstri_reverse, nstri_exist_reverse)),
+    )
+    checks.check(
+        "not-x-probes-or-y-probes-or-two-site-or-perp",
+        Z_SYMMETRIC_SEEDS != TWO_SITE_SEEDS
+        and Z_SYMMETRIC_SEEDS != PERP_SEEDS
+        and ticks[NEG_E3] == 0
+        and two_ticks.get(NEG_E3) != 0
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and x_m1["A"] != m1["A"]
+        and x_o1["A"] != o1["A"]
+        and x_reverse == "hold"
+        and x_face == "hold"
+        and existential_opposite(x_m1["A"], x_m1["B"]) == "fail"
+        and y_m1["A"] != m1["A"]
+        and y_o1["A"] != o1["A"]
+        and y_reverse == "hold"
+        and y_face == "hold"
+        and existential_opposite(y_m1["A"], y_m1["B"]) == "fail"
+        and two_m1["A"] == m1["A"]
+        and two_o1["A"] == o1["A"]
+        and two_reverse == "hold"
+        and two_face == "hold"
+        and two_ticks[NEG_E3] == 1
+        and perp_fp["B"] == "fail"
+        and perp_reverse == "fail"
+        and perp_face == "hold"
+        and reverse_status == "hold",
+    )
+    checks.check(
+        "not-y-symmetric-or-x-symmetric",
+        ysym_o1["A"] != o1["A"]
+        and ysym_o1["A"] == frozenset({E1, NEG_E1})
+        and ysym_reverse == "hold"
+        and ysym_face == "hold"
+        and existential_opposite(ysym_m1["A"], ysym_m1["B"]) == "fail"
+        and xsym_o1["A"] == frozenset({E2, NEG_E2})
+        and xsym_reverse == "hold"
+        and xsym_face == "hold"
+        and ticks[PROBES["A"]] == 0
+        and ysym_ticks[PROBES["A"]] == 1
+        and xsym_ticks[PROBES["A"]] == 1,
+    )
+    checks.check(
+        "z-symmetric-three-site-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E3] == 0
+        and locks[E3] == {NEG_E1}
+        and ticks[NEG_E3] == 0
+        and locks[NEG_E3] == {NEG_E1}
+        and add(E1, NEG_E1) == ZERO
+        and Z_SYMMETRIC_SEEDS != TWO_SITE_SEEDS
+        and Z_SYMMETRIC_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "note-claim-scope",
+        CLAIM_SCOPE in note,
+    )
+    checks.check(
+        "note-reports-M-O-dots-and-forall",
+        "t(A)=0" in note
+        and "t(B)=2" in note
+        and "t(C)=1" in note
+        and "t(D)=3" in note
+        and "M(A, τ) = {−e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_3}" in note
+        and "M(D, τ) = {+e_2, −e_2, −e_3}" in note
+        and "O(A, τ) = {+e_2, −e_2, +e_3}" in note
+        and "O(B, τ) = {+e_2, −e_2, +e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_2, −e_2}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "forall-perp(A)=hold" in note
+        and "forall-perp(B)=hold" in note
+        and "forall-perp(C)=hold" in note
+        and "forall-perp(D)=hold" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse from forall-perp at τ: hold" in note
+        and "Face from forall-perp at τ: hold" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-exist-perp-or-exist-opposite-or-simultaneous",
+        "not leftover of exist-perp" in normalized_note
+        and "not leftover of nmsimzp exist-opposite" in normalized_note
+        and "not leftover of empty intersection" in normalized_note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-not-nstri-forall-fail",
+        "not leftover of nstri forall-perp fail at B" in normalized_note
+        and "Reverse from forall-perp at τ: hold" in note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "Occupancy `n` is not used" in note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/Z_SYMMETRIC_THREE_SITE_ZPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "forall_perp" in defined_fns
+        and "exist_perp" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Forall-orthogonal M vs O at t+1 HOLD at all four #7186 z-probes. Reverse HOLD, face HOLD. Displayed, not adopted.

## Runner

`scripts/z_symmetric_three_site_zprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.