### PR TITLE
feat(nm2ax12): 1-in 2-out split on two-axis opposite: reverse HOLD, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,597 @@
+---
+claim_id: two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
+---
+
+# One-In Two-Out Axis Split Of Own-Incoming And Own-Outgoing At t+1 Reverse And Face On Four Y-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** 1-in 2-out axis split of simultaneous earliest incoming set `M` and
+outgoing dual `O` at each probe's `τ=t+1`, and reverse/face from that split,
+on the four y-probes of the two-axis opposite seed in `B_3(0)={n:n·n<=9}`.
+Same process and y-probes as nm2ax. Let `t(q)` be the formation tick of
+probe `q`. Let `τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest incoming
+nearest-neighbor steps at `q` using only records with tick `<= τ`. Seeds
+are a singleton seed letter. `O(q,τ)` is the outgoing dual of `M`: the set
+of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in
+`M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not
+`UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals
+`{e_1,e_2,e_3}`. `UNDEFINED` if `M` or `O` is `UNDEFINED`. Else fail. Split
+HOLDs at `q` if and only if cover HOLDs and `|Axis(M)|=1` (hence
+`|Axis(O)|=2`). 2-in 1-out is fail of this object, not UNDEFINED. Reverse
+HOLDs if and only if split HOLDs at `A` and at `B`. Face HOLDs if and only
+if split HOLDs at `C` and at `D`. This is not leftover of the 1-axis
+opposite two-site seed. This is not leftover of nmcover axis-cover. This is
+not leftover of leftover-of-`M` alone. This is not leftover of
+leftover-of-`O` alone. This is not leftover-empty fail of leftover axis.
+This is not leftover of nmunopp union. This is not leftover of nmt2opp `M`
+frozen at `t`. This is not leftover of nmot2opp two-tick composition. This
+is not leftover of nmoutopp untimed eventual-`O`. This is not leftover of
+mixed #7188 fail/fail. This is not leftover of the same-lock two-site seed.
+The second pair is a new seed, not a formed child. Uniqueness is not
+required. Mixed remains a set. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. Reverse and face are scored on
+split HOLD at the paired probes. Named signs `{+,−}` are a coarser readout
+and are not used. A singleton unique lock letter is a different readout and
+is not used as the object. Existential opposite of signed locks is a
+different readout and is not used as the split reverse. Axis-cover without
+the one-axis incoming cardinality is a different readout and is not used.
+Leftover-empty fail of unsigned leftover axis sets is a different readout
+and is not used. A `Z^3` sum of those locks is a different readout and is
+not used. Occupancy of sites is not used. A six-neighbor star is not the
+letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis opposite seed, split hold at A,B,C, split fail at D from cover fail with leftover e_2, reverse hold and face fail from that split; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face
+target_blocker_text: "display 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that split, not cover, not exist-opposite"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep 1-in 2-out axis split of M and O at t+1 displayed; do not write split into Admissibility, do not reduce to cover, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace split by existential opposite of signed locks, do not replace split by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis opposite seed and reverse/face from that split; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose 1-in
+2-out axis split of `M` and `O` is scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed. Same process and y-probes as nm2ax.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named 1-in 2-out axis split of `M` and `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy of sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+If `q` is unformed at `τ`, then cover is `UNDEFINED`. Overlapping axes fail.
+Incomplete union fails. Axis is unsigned: `+e_i` and `−e_i` occupy the same
+axis.
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of this object, not UNDEFINED: cover HOLD with
+`|Axis(M)|=2` (hence `|Axis(O)|=1`) is split fail. Cover without the
+one-axis incoming cardinality is not this object. Unique letters are not
+this object. One-in one-out with leftover axis is cover fail and therefore
+split fail.
+
+Reverse 1-in 2-out holds if and only if split HOLDs at `A` and at `B`. Face
+1-in 2-out holds if and only if split HOLDs at `C` and at `D`. Either side
+`UNDEFINED` is `UNDEFINED`. Else if both sides HOLD, reverse or face HOLDs.
+Else fail.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Identifying leftover-empty fail with
+split reverse is refused: leftover-empty fail scores empty leftover as
+fail. Identifying axis-cover reverse/face of the 1-axis opposite two-site
+seed with this reverse/face is refused: that 1-axis cover HOLDs at every
+probe, including 2-in 1-out `D`.
+
+## Theorem 1 — ticks, `M`, `O`, `Axis`, cover, `|Axis(M)|`, and split at `τ=t+1`
+
+On this process the four y-probes form. Compare to the 1-axis opposite
+two-site seed: that member forms `B` at tick 2 and `D` at tick 3, has
+`M(D,τ)` mixed of three steps, has cover HOLD at `D` from 2-in 1-out, and
+has `O(A,τ)` include `+e_3` because `(0,1,1)` is a formed child at tick 1.
+Here the second pair is a new seed, not a formed child, so `(0,1,1)` is
+already recorded at tick 0 with lock `−e_2`. This display reads the 1-in
+2-out split of timed `M` and `O` on that new seed:
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=2
+M(A, τ) = {−e_1}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_2}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_2, −e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+Axis(M)(A, τ) = {e_1}
+Axis(O)(A, τ) = {e_2, e_3}
+Axis(M)(B, τ) = {e_1}
+Axis(O)(B, τ) = {e_2, e_3}
+Axis(M)(C, τ) = {e_2}
+Axis(O)(C, τ) = {e_1, e_3}
+Axis(M)(D, τ) = {e_3}
+Axis(O)(D, τ) = {e_1}
+|Axis(M)|(A, τ) = 1
+|Axis(O)|(A, τ) = 2
+|Axis(M)|(B, τ) = 1
+|Axis(O)|(B, τ) = 2
+|Axis(M)|(C, τ) = 1
+|Axis(O)|(C, τ) = 2
+|Axis(M)|(D, τ) = 1
+|Axis(O)|(D, τ) = 1
+cover(A) = hold
+cover(B) = hold
+cover(C) = hold
+cover(D) = fail
+split(A) = hold
+split(B) = hold
+split(C) = hold
+split(D) = fail
+```
+
+`A` is a seed at tick 0. Mixed remains a set: `O(A,τ)` has two outgoing
+steps and `O(B,τ)` has three outgoing steps. Unique letters would assign
+`UNDEFINED` at mixed `O`. Here uniqueness is not required. At `A`, `B`, and
+`C`, `Axis(M)` and `Axis(O)` are complementary: their union is
+`{e_1,e_2,e_3}` and their intersection is empty. Cover therefore HOLDs at
+those three probes, and split HOLDs because `|Axis(M)|=1`. At `D`,
+`Axis(M)={e_3}` and `Axis(O)={e_1}`, so leftover of the union is `{e_2}`.
+Cover fails at `D` from 1-in 1-out, not from 2-in 1-out. Split therefore
+fails at `D`. 2-in 1-out is fail of this object, not UNDEFINED; that
+identity remains, and it is not the `D` report on this seed. Leftover of
+the union is empty at `A`, `B`, and `C`; leftover-empty fail of that
+leftover is not this object.
+O is not M.
+
+Investment nmcover on the 1-axis opposite two-site seed: cover HOLDs at
+every probe, so cover reverse and cover face HOLD. Cover is cheap on that
+seed. On this two-axis opposite seed, cover fails at `D`, so cover face
+fails with split face. Split is still the stricter object: 2-in 1-out is
+cover HOLD with split fail. Leftover of `M` alone at `A` and `B` is
+`{e_2,e_3}`, nonempty and equal. Leftover of `O` alone at `A` and `B` is
+`{e_1}`, nonempty and equal. Those one-sided leftovers are not this
+object.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`:
+
+```text
+new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+## Theorem 2 — reverse from 1-in 2-out split at `τ`
+
+Reverse 1-in 2-out holds if and only if split HOLDs at `A` and at `B`.
+Both splits HOLD. Reverse HOLDs. This is HOLD iff split, not leftover of
+nmcover axis-cover, not leftover-empty fail, and not exist-opposite.
+
+Reverse 1-in 2-out at τ: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Leftover-empty reverse
+fails because leftover of the union is empty at `A` and at `B`. Cover
+reverse HOLDs from complementary occupation of all three axes at `A` and at
+`B`. Split reverse HOLDs because `A` and `B` are both 1-in 2-out. Leftover
+of `M` reverse would hold because leftover of `M` at `A` and at `B` is
+`{e_2, e_3}`. Leftover of `O` reverse would hold because leftover of `O` at
+`A` and at `B` is `{e_1}`. Exist-opposite reverse of signed `M` holds.
+Those leftovers are not this display.
+
+Reverse holds.
+
+## Theorem 3 — face from 1-in 2-out split at `τ`
+
+Face 1-in 2-out holds if and only if split HOLDs at `C` and at `D`. Split
+HOLDs at `C` and fails at `D`. Face fails. The `D` failure is cover fail
+from leftover `{e_2}` (1-in 1-out), which is fail of this object, not
+UNDEFINED. 2-in 1-out is also fail of this object, not UNDEFINED; that
+identity is not the `D` report here.
+
+Face 1-in 2-out at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Cover face fails because cover fails at `D`. Split face fails because
+split fails at `D`. On this seed those two face bits agree. They remain
+different predicates: 2-in 1-out is cover HOLD and split fail. On the
+1-axis opposite two-site seed, cover face HOLDs while split face fails.
+This two-axis member is not leftover of that 1-axis cover face hold.
+Leftover-empty face fails because leftover of the union is empty at `C`.
+Leftover of `M` at `C` is `{e_1, e_3}` and leftover of `M` at `D` is
+`{e_1, e_2}`: nonempty and unequal. Leftover of `O` at `C` is `{e_2}` and
+leftover of `O` at `D` is `{e_2, e_3}`: nonempty and unequal. Exist-opposite
+face of signed `M` fails. Exist-opposite face of signed `O` holds, so that
+face is not this split face.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover fails at `D` while 2-in 1-out also fails at `D`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming, outgoing, or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require split sides to be singletons.
+- It does not sum either set.
+- It does not replace split by leftover-empty fail.
+- It does not replace split by leftover of `M` alone.
+- It does not replace split by leftover of `O` alone.
+- It does not replace split by existential opposite of signed locks.
+- It does not replace split by axis-cover without `|Axis(M)|=1`.
+- It does not treat 2-in 1-out as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace split by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  split display.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this split display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite seed process, 1-in 2-out axis split of `M` and `O` at `t+1`,
+and the reverse/face bits from that split are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual |
+| `Axis(M)` and `Axis(O)` at `τ` | Theorem 1; complementary at `A,B,C`; leftover `{e_2}` at `D` |
+| cover at `τ` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| `|Axis(M)|` at `τ` | Theorem 1; `1,1,1,1` |
+| split at `τ` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| reverse from 1-in 2-out at `τ` | Theorem 2; `hold` |
+| face from 1-in 2-out at `τ` | Theorem 3; `fail` |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this split display |
+| leftover of exist-opposite HOLD | not this split display |
+| leftover of nmcover axis-cover HOLD | not this split display |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display |
+| 2-in 1-out scored as `UNDEFINED` | refused; fail of this object |
+| global later T | not used |
+| 1-in 2-out split as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: 1-in 2-out axis split of `M` and `O` at `t+1` on the four y-probes of the two-axis opposite seed, and reverse/face from that split. |
+| V2 | Current main has no landed 1-in 2-out reverse/face of timed `M` and `O` on these four y-probes of the two-axis opposite seed. |
+| V3 | Split reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads unsigned 1-in 2-out split of own incoming and own outgoing at the same `t+1` cut and scores HOLD iff cover and `|Axis(M)|=1`. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace split by leftover-empty fail, does not
+replace split by leftover of `M` alone or leftover of `O` alone, does not
+replace split by existential opposite of signed locks, does not replace
+split by nmcover axis-cover, does not identify this display with the 1-axis
+opposite two-site seed, and does not identify it with nmunopp union. No
+global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nmcover axis-cover | score reverse/face as cover HOLD | on the 1-axis opposite two-site seed cover HOLDs at every probe so cover face HOLDs, while this two-axis cover fails at `D`; 2-in 1-out is still cover HOLD and split fail | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover of the union is empty at `A` and at `B`, leftover reverse fails, while split reverse HOLDs | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` and `B` is `{e_2,e_3}`, nonempty equal, reverse would hold, but that leftover is not `|Axis(M)|=1` cover | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` and `B` is `{e_1}`, nonempty equal, reverse would hold, but that leftover is not this split | ATTEMPTED |
+| exist-opposite | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite face of signed `O` HOLDs while split face fails | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; split is unsigned 1-in 2-out of `M` and `O` | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(A,τ)` and mixed `O(B,τ)` remain sets; split still reports hold at `A` and fail at `D` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | 2-in 1-out is fail of this object, not UNDEFINED; `D` here is 1-in 1-out cover fail, also not UNDEFINED | ATTEMPTED |
+| letter intersection as split | score reverse/face inside `M ∩ O` | letter intersection empty is not 1-in 2-out; opposite signs can share an axis | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(B)=2`, `t(D)=3`, mixed `M(D)`, cover HOLD at `D` | different seed; second pair is a new seed, not a formed child | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores 1-in 2-out of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports split reverse hold and split face fail | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace split by a `Z^3` sum | the construction does not sum; split is cover plus `|Axis(M)|=1` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by 1-in 2-out split | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of split with leftover of
+`M` alone, missing identification of split with leftover-empty fail, missing
+identification of split with existential opposite of signed locks, missing
+identification of split with nmcover axis-cover, missing identification of
+this seed with the 1-axis opposite two-site seed, and missing Record
+identification of split reverse are distinct open premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, 2-in 1-out as fail not `UNDEFINED`, four
+y-probes with seed `A`, second pair as a new seed not a formed child, and
+mixed remains a set are declared. No uniqueness of incoming locks, no
+six-neighbor lock union as the scored object, no lock-count clock, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+split `hold`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each unsigned lattice axis among `{e_1,e_2,e_3}` | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four split reports, reverse/face from 1-in 2-out HOLD | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for split reverse/face, a
+formation-rate rule, and a physical selector among 1-in 2-out axes. None
+is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Split HOLD is only cover HOLD; on this seed cover reverse and
+cover face already match split reverse and split face; leftover of `M`
+alone already gives `{e_2,e_3}` at `A`; leftover of `O` alone already gives
+`{e_1}`; complementary occupation is only letter intersection empty; 1-in
+1-out at `D` should be `UNDEFINED` like unformed; the second pair is only
+the formed child `(0,1,1)` of the 1-axis seed; and exist-opposite already
+answers reverse.
+
+**Answer:** Cover HOLDs at `A`, `B`, and `C` and fails at `D` from leftover
+`{e_2}`. Split requires `|Axis(M)|=1` in addition to cover, so 2-in 1-out
+is cover HOLD and split fail even when those bits agree on this seed. On
+the 1-axis opposite two-site seed, cover face HOLDs while split face fails.
+Letter intersection empty is signed-letter disjointness. Opposite signs on
+one axis are letter-disjoint and occupy that axis, so they are not cover
+and not 1-in 2-out. Leftover of `M` alone and leftover of `O` alone are
+nonempty one-sided leftovers; they are not complementary 1-in 2-out of the
+pair. `D` is formed at tick 2; 1-in 1-out is cover fail and split fail, not
+UNDEFINED. The second pair is a new seed, not a formed child: `(0,1,1)` is
+recorded at tick 0 with lock `−e_2`, whereas the 1-axis child forms at tick
+1 with lock `+e_3`. Exist-opposite face of signed `O` HOLDs while split
+face fails. Reverse 1-in 2-out is HOLD iff split at `A` and at `B`, not
+leftover of nmcover axis-cover.
+
+### N8 — cross-cycle echo
+
+nsmopp #7208 reported reverse hold and face hold from own incoming `M` on
+the 1-axis opposite two-site seed. nmcover axis-cover on that seed reported
+cover HOLD at each of the four y-probes, reverse hold, and face hold. The
+1-axis 1-in 2-out split reported split HOLD at `A`, `B`, and `C`, split
+fail at `D` from 2-in 1-out, reverse hold, and face fail, with `t(B)=2` and
+`t(D)=3`. This note is not those displays: it reports 1-in 2-out axis split
+of `M` and `O` at `τ=t+1` on the two-axis opposite seed, with `t(B)=1` and
+`t(D)=2`, split HOLD at `A`, `B`, and `C`, split fail at `D` from cover
+fail with leftover `{e_2}`, reverse hold, and face fail.
+
+**Gate disposition:** PASS for the 1-in 2-out `t+1` reverse/face reports
+above. FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the
+predicate equals the unique singleton lock vector,” “the predicate equals
+six-neighbor lock union,” “the predicate equals leftover-empty fail,” “the
+predicate equals leftover of `M` alone,” “the predicate equals leftover of
+`O` alone,” “the predicate equals exist-opposite HOLD,” “the predicate
+equals nmcover axis-cover HOLD,” “the predicate equals the 1-axis opposite
+two-site seed,” “the predicate equals nmunopp union,” “bits are
+Admissibility,” “2-in 1-out is UNDEFINED,” “reverse 1-in 2-out fails,” or
+“face 1-in 2-out holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports unsigned axis of each, reports cover of the pair, reports
+`|Axis(M)|` and the 1-in 2-out split, lists new records in `B_3(0)` between
+`t` and `t+1` that meet a probe's six-neighbors, and checks Theorems 1--3.
+It also checks that split HOLDs at `A`, `B`, and `C` and fails at `D`, that
+2-in 1-out is fail not `UNDEFINED`, that the 1-axis opposite two-site seed
+is a different member, that leftover-empty fail is a different reverse and
+face, that leftover of `M` alone and leftover of `O` alone are different
+objects, that mixed sets remain sets, that unique-letter split is
+`UNDEFINED` at mixed `O`, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not attached,
+that the second pair is a new seed not a formed child, and that the display
+is not the two-tick lock-count clock composition. No runner cache is
+written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18641,6 +18641,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,97 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
+runner_sha256: dac7b39d458efe3825ec0ab47f4a7ca52edd03f979132743d525c640ec9c806d
+input_fingerprint_sha256: aa717e2c0ce7315d3f5e37351a9556c9930de9a2256eb2fcbddead8db1ed08dd
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+1-in 2-out axis split of M and O reverse/face at t+1 on two-axis opposite
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: axis-identity
+PASS: cover-identity
+PASS: split-identity
+PASS: pair-bit-identity
+PASS: leftover-empty-fail-contrast
+A t=0 M={−e_1} O={+e_2, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} |Axis(M)|=1 |Axis(O)|=2 cover=hold split=hold
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} |Axis(M)|=1 |Axis(O)|=2 cover=hold split=hold
+C t=1 M={+e_2} O={+e_1, −e_1, +e_3, −e_3} Axis(M)={e_2} Axis(O)={e_1, e_3} |Axis(M)|=1 |Axis(O)|=2 cover=hold split=hold
+D t=2 M={−e_3} O={+e_1, −e_1} Axis(M)={e_3} Axis(O)={e_1} |Axis(M)|=1 |Axis(O)|=1 cover=fail split=fail
+split reverse=hold face=fail
+cover reverse=hold face=fail
+leftover-empty reverse=fail face=fail
+per_element: each unsigned lattice axis among {e_1,e_2,e_3} occupied by M or by O at a probe's t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four split reports, reverse/face from 1-in 2-out HOLD
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_1}', 'B': '{+e_1}', 'C': '{+e_2}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_2, −e_3}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{+e_1, −e_1, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-Axis-M-and-O  ({'A': ('{e_1}', '{e_2, e_3}'), 'B': ('{e_1}', '{e_2, e_3}'), 'C': ('{e_2}', '{e_1, e_3}'), 'D': ('{e_3}', '{e_1}')})
+PASS: theorem1-cover-and-axis-card  ({'A': ('hold', '1', '2'), 'B': ('hold', '1', '2'), 'C': ('hold', '1', '2'), 'D': ('fail', '1', '1')})
+PASS: theorem1-split-hold-fail  ({'A': 'hold', 'B': 'hold', 'C': 'hold', 'D': 'fail'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((0, 2, 0), (0, 1, -1)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-split-hold
+PASS: theorem3-face-split-fail
+PASS: two-in-one-out-is-fail-not-undefined
+PASS: d-is-one-in-one-out-not-cover
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-alone-differs
+PASS: mutation-leftover-of-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-empty-plus-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-two-site-seed
+PASS: not-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-Axis-cover-split
+PASS: note-reports-new-neighbors
+PASS: note-reports-split-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-exist-opposite
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: split-hold-not-leftover-empty
+TOTAL: PASS=65 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1304 @@
+#!/usr/bin/env python3
+"""1-in 2-out axis split of M and O at t+1 reverse/face on two-axis opposite.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites: origin locks +e_1, (0,1,0) locks -e_1, (0,0,1) locks +e_2,
+and (0,1,1) locks -e_2. Two disjoint opposite pairs. Same process and
+y-probes as nm2ax. The second pair is a new seed, not a formed child of the
+first pair. A 6-NN step is allowed iff it is perpendicular to the parent
+lock axis. Newly formed sites lock the incoming step. Seeds keep their seed
+letters as a singleton. M(q, tau) is the set of earliest incoming
+nearest-neighbor steps at q using only records with tick <= tau. Unformed
+at tau => UNDEFINED. O(q, tau) is the outgoing dual of M: the set of e in
+{±e_1,±e_2,±e_3} such that q+e is formed and e is in M(q+e, tau). Unformed
+q at tau => UNDEFINED. Empty O is empty, not UNDEFINED. Axis(S) is the
+unsigned lattice directions of signed locks in S. Cover HOLDs at q iff
+Axis(M) intersect Axis(O) is empty and Axis(M) union Axis(O) equals
+{e_1,e_2,e_3}. UNDEFINED if M or O UNDEFINED. Else fail. Split HOLDs at q
+iff cover HOLDs and |Axis(M)|=1 (hence |Axis(O)|=2). 2-in 1-out is fail of
+this object, not UNDEFINED. Reverse HOLDs iff split at A and at B. Face
+likewise on C, D. Uniqueness is not required. Occupancy of sites is not
+used. Named-sign lettering is not used. No larger host.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "1-in 2-out axis split of M and O at t+1 on the four y-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast: {e_1,e_2,e_3} minus Axis(S). Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2).
+
+    2-in 1-out (cover HOLD with |Axis(M)|=2) is fail of this object, not
+    UNDEFINED.
+    """
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2, hence |Axis(O)|=1. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(split_a: str, split_b: str) -> str:
+    """Reverse HOLDs iff split at A and split at B."""
+    return pair_bit(split_a, split_b)
+
+
+def face_report(split_c: str, split_d: str) -> str:
+    """Face HOLDs iff split at C and split at D."""
+    return pair_bit(split_c, split_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("1-in 2-out axis split of M and O reverse/face at t+1 on two-axis opposite")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E2, E3) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "axis-identity",
+        axis_set(UNDEFINED) == UNDEFINED
+        and axis_set(frozenset({NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E1, NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E2, E3, NEG_E3})) == frozenset({E2, E3})
+        and axis_set(frozenset({E1, NEG_E1, E3, NEG_E3})) == frozenset({E1, E3}),
+    )
+    checks.check(
+        "cover-identity",
+        axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_cover(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_cover(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset()) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "hold"
+        and axis_cover(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1})) == "fail",
+    )
+    checks.check(
+        "split-identity",
+        axis_split(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_split(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_split(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_split(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_split(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == "hold"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_split(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_in_one_out(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "fail"
+        and two_in_one_out(UNDEFINED, frozenset({E1})) == UNDEFINED,
+    )
+    checks.check(
+        "pair-bit-identity",
+        pair_bit(UNDEFINED, "hold") == UNDEFINED
+        and pair_bit("hold", UNDEFINED) == UNDEFINED
+        and pair_bit("hold", "hold") == "hold"
+        and pair_bit("hold", "fail") == "fail"
+        and pair_bit("fail", "hold") == "fail"
+        and pair_bit("fail", "fail") == "fail",
+    )
+    checks.check(
+        "leftover-empty-fail-contrast",
+        leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and leftover_axis(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3}))
+        == frozenset()
+        and leftover_axis(frozenset({NEG_E3}), frozenset({E1, NEG_E1}))
+        == frozenset({E2})
+        and leftover_axis(frozenset({E2}), frozenset({E1})) == frozenset({E3}),
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"Axis(M)={axis_display(axis_m[name])} "
+            f"Axis(O)={axis_display(axis_o[name])} "
+            f"|Axis(M)|={axis_card(axis_m[name])} "
+            f"|Axis(O)|={axis_card(axis_o[name])} "
+            f"cover={cover[name]} split={split[name]}"
+        )
+
+    reverse = reverse_report(split["A"], split["B"])
+    face = face_report(split["C"], split["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unique_split_a = axis_split(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    one_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_o1 = {
+        name: outgoing_set(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    print(f"split reverse={reverse} face={face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(f"leftover-empty reverse={leftover_reverse} face={leftover_face}")
+    print(
+        "per_element: each unsigned lattice axis among {e_1,e_2,e_3} "
+        "occupied by M or by O at a probe's t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four split reports, reverse/face from 1-in 2-out HOLD")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PAIR2] == 0
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["D"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(PAIR2, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and m1["A"] == frozenset({NEG_E1}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Axis-M-and-O",
+        axis_m["A"] == frozenset({E1})
+        and axis_o["A"] == frozenset({E2, E3})
+        and axis_m["B"] == frozenset({E1})
+        and axis_o["B"] == frozenset({E2, E3})
+        and axis_m["C"] == frozenset({E2})
+        and axis_o["C"] == frozenset({E1, E3})
+        and axis_m["D"] == frozenset({E3})
+        and axis_o["D"] == frozenset({E1}),
+        str(
+            {
+                name: (axis_display(axis_m[name]), axis_display(axis_o[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-cover-and-axis-card",
+        cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and axis_card(axis_m["A"]) == "1"
+        and axis_card(axis_m["B"]) == "1"
+        and axis_card(axis_m["C"]) == "1"
+        and axis_card(axis_m["D"]) == "1"
+        and axis_card(axis_o["A"]) == "2"
+        and axis_card(axis_o["B"]) == "2"
+        and axis_card(axis_o["C"]) == "2"
+        and axis_card(axis_o["D"]) == "1"
+        and lx["D"] == frozenset({E2})
+        and all(lx[name] == frozenset() for name in ("A", "B", "C")),
+        str(
+            {
+                name: (
+                    cover[name],
+                    axis_card(axis_m[name]),
+                    axis_card(axis_o[name]),
+                )
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-split-hold-fail",
+        split["A"] == "hold"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and two_one["A"] == "fail"
+        and two_one["B"] == "fail"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and split["D"] != UNDEFINED,
+        str({name: split[name] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((0, 2, 0), (0, 1, -1))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 2
+        and unique_letter(o1["A"]) == UNDEFINED
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 1
+        and split["D"] == "fail"
+        and split["A"] == "hold"
+        and cover["D"] == "fail",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and m1["A"] == frozenset({NEG_E1}),
+    )
+    checks.check(
+        "theorem2-reverse-split-hold",
+        reverse == "hold"
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail",
+    )
+    checks.check(
+        "theorem3-face-split-fail",
+        face == "fail"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold",
+    )
+    checks.check(
+        "two-in-one-out-is-fail-not-undefined",
+        two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and two_one["D"] == "fail"
+        and cover["D"] == "fail"
+        and split["D"] == "fail"
+        and split["D"] != UNDEFINED
+        and face == "fail"
+        and face != UNDEFINED,
+    )
+    checks.check(
+        "d-is-one-in-one-out-not-cover",
+        cover["D"] == "fail"
+        and two_one["D"] == "fail"
+        and split["D"] == "fail"
+        and axis_card(axis_m["D"]) == "1"
+        and axis_card(axis_o["D"]) == "1"
+        and lx["D"] == frozenset({E2}),
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and one_cover["D"] == "hold"
+        and one_cover_face == "hold"
+        and one_split["D"] == "fail"
+        and one_split_face == "fail"
+        and cover["D"] == "fail"
+        and cover_face == "fail"
+        and face == "fail"
+        and one_cover_face != cover_face
+        and one_m1["D"] != m1["D"]
+        and one_o1["A"] != o1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset()
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and reverse == "hold"
+        and face == "fail"
+        and leftover_reverse != reverse,
+    )
+    checks.check(
+        "mutation-leftover-of-M-alone-differs",
+        lx_m["A"] == frozenset({E2, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_m["C"] == frozenset({E1, E3})
+        and lx_m["D"] == frozenset({E1, E2})
+        and reverse_m_alone == "hold"
+        and face_m_alone == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-O-alone-differs",
+        lx_o["A"] == frozenset({E1})
+        and lx_o["B"] == frozenset({E1})
+        and lx_o["C"] == frozenset({E2})
+        and lx_o["D"] == frozenset({E2, E3})
+        and reverse_o_alone == "hold"
+        and face_o_alone == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "hold"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and reverse == "hold"
+        and face == "fail"
+        and o_exist_face != face
+        and axis_split(m1["A"], m1["B"]) == "fail"
+        and axis_split(m1["C"], m1["D"]) == "fail",
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["D"]) == frozenset({NEG_E3})
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_split_a == UNDEFINED
+        and split["A"] == "hold"
+        and split["D"] == "fail",
+    )
+    checks.check(
+        "mutation-empty-plus-undefined",
+        axis_split(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_split(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and reverse == "hold",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(m1["D"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E1
+        and sum_of_set(m1["D"]) == NEG_E3
+        and sum_of_set(o1["A"]) == add(E2, NEG_E3)
+        and sum_of_set(o1["D"]) == ZERO
+        and axis_m["D"] == frozenset({E3}),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E1 in m1["A"]
+        and NEG_E1 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and axis_m["A"] != axis_o["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2}
+        and PAIR2 not in one_seeds
+        and one_ticks[PAIR2] == 1
+        and one_locks[PAIR2] == {E3}
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    x_m1 = {
+        name: incoming_set(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if X_PROBES[name] in ticks
+    }
+    perp_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            perp_ticks[PROBES[name]] + 1,
+            perp_ticks,
+            perp_locks,
+            perp_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in perp_ticks
+    }
+    same_m_a = incoming_set(
+        PROBES["A"],
+        same_ticks[PROBES["A"]] + 1,
+        same_ticks,
+        same_locks,
+        same_seeds,
+    )
+    zsym_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            zsym_ticks[PROBES[name]] + 1,
+            zsym_ticks,
+            zsym_locks,
+            zsym_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in zsym_ticks
+    }
+    ysym_ticks_count0 = sum(time == 0 for time in ysym_ticks.values())
+    checks.check(
+        "not-x-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and x_m1["A"] != m1["A"]
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse == "hold",
+    )
+    checks.check(
+        "not-same-lock-two-site-seed",
+        TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and same_m_a == frozenset({E1})
+        and m1["A"] == frozenset({NEG_E1})
+        and same_m_a != m1["A"],
+    )
+    checks.check(
+        "not-one-axis-or-y-symmetric-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and ysym_ticks_count0 == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Axis-cover-split",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_2, −e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "Axis(M)(A, τ) = {e_1}" in note
+        and "Axis(O)(A, τ) = {e_2, e_3}" in note
+        and "Axis(M)(B, τ) = {e_1}" in note
+        and "Axis(O)(B, τ) = {e_2, e_3}" in note
+        and "Axis(M)(C, τ) = {e_2}" in note
+        and "Axis(O)(C, τ) = {e_1, e_3}" in note
+        and "Axis(M)(D, τ) = {e_3}" in note
+        and "Axis(O)(D, τ) = {e_1}" in note
+        and "|Axis(M)|(A, τ) = 1" in note
+        and "|Axis(M)|(B, τ) = 1" in note
+        and "|Axis(M)|(C, τ) = 1" in note
+        and "|Axis(M)|(D, τ) = 1" in note
+        and "|Axis(O)|(A, τ) = 2" in note
+        and "|Axis(O)|(B, τ) = 2" in note
+        and "|Axis(O)|(C, τ) = 2" in note
+        and "|Axis(O)|(D, τ) = 1" in note
+        and "cover(A) = hold" in note
+        and "cover(B) = hold" in note
+        and "cover(C) = hold" in note
+        and "cover(D) = fail" in note
+        and "split(A) = hold" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-split-reverse-face",
+        "Reverse 1-in 2-out at τ: hold" in note
+        and "Face 1-in 2-out at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-exist-opposite",
+        "not leftover of nmcover axis-cover" in normalized_note
+        and "not leftover of the 1-axis opposite two-site seed" in normalized_note
+        and "2-in 1-out is fail of this object, not UNDEFINED" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse 1-in 2-out at τ: hold" in note
+        and "Face 1-in 2-out at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "axis_cover" in defined_fns
+        and "axis_split" in defined_fns
+        and "two_in_one_out" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "split-hold-not-leftover-empty",
+        reverse == "hold"
+        and face == "fail"
+        and cover_reverse == "hold"
+        and cover_face == "fail"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and split["A"] == "hold"
+        and split["D"] == "fail"
+        and cover["D"] == "fail"
+        and two_one["D"] == "fail"
+        and o_exist_face == "hold",
+    )
+    _ = (
+        o0,
+        unique_split_a,
+        one_cover_face,
+        one_split_face,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

1-in 2-out reverse HOLD face fails on two-axis opposite y-probes. Displayed, not adopted.

## Runner

`scripts/two_axis_opposite_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.