### PR TITLE
feat(nm2sl): axis-cover of M and O at t+1 on two-axis same-lock: reverse HOLD, face fails

### DIFF
--- a/docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,531 @@
+---
+claim_id: two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Axis-cover of M and O at t+1 on the four y-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
+---
+
+# Axis-Cover Of Own-Incoming And Own-Outgoing At t+1 Reverse And Face On Four Two-Axis Same-Lock Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** axis-cover of simultaneous earliest incoming set `M` and outgoing
+dual `O` at each probe's `τ=t+1`, and reverse/face from that cover, on the
+four y-probes of the two-axis same-lock seed in `B_3(0)={n:n·n<=9}`. Let
+`t(q)` be the formation tick of probe `q`. Let `τ(q)=t(q)+1`.
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. Seeds are a singleton seed letter.
+`O(q,τ)` is the outgoing dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}`
+such that `q+e` is formed and `e` is in `M(q+e,τ)`. Unformed at `τ` is
+`UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Axis of a defined lock
+set `S` is `Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and
+only if `Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union
+`Axis(O)` equals `{e_1,e_2,e_3}`. `UNDEFINED` if `M` or `O` is
+`UNDEFINED`. Else fail. Reverse HOLDs if and only if cover HOLDs at `A`
+and at `B`. Face HOLDs if and only if cover HOLDs at `C` and at `D`. This
+is HOLD iff cover, not leftover-empty fail. This is not leftover of
+exist-opposite of `M`. This is not leftover of leftover-of-`M` alone.
+This is not leftover of leftover-of-`O` alone. This is not leftover of
+1-axis same-lock cover-HOLD. This is not leftover of two-axis opposite.
+Neither pair is opposite. Uniqueness is not required. Mixed remains a
+set. Displayed, not adopted. Do not write into Admissibility. Do not
+attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Reverse and face are scored on cover HOLD at the paired probes. Named signs
+`{+,−}` are a coarser readout and are not used. A singleton unique lock
+letter is a different readout and is not used as the object. Existential
+opposite of signed locks is a different readout and is not used as the
+cover reverse. Leftover-empty fail of unsigned leftover axis sets is a
+different readout and is not used. A `Z^3` sum of those locks is a
+different readout and is not used. Occupancy of sites is not used. A
+six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of axis-cover of M and O at t+1 on the four y-probes of the two-axis same-lock seed, complementary cover at A,B,C, cover fail at D, reverse hold and face fail from cover; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face
+target_blocker_text: "display axis-cover of M and O at t+1 on the four y-probes of the two-axis same-lock seed, compare to 1-axis same-lock cover-HOLD, HOLD iff cover, not leftover-empty fail"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep axis-cover of M and O at t+1 displayed; do not write cover into Admissibility, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace cover by 1-axis same-lock cover-HOLD, do not replace cover by two-axis opposite, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for axis-cover of M and O at t+1 on the four y-probes of the two-axis same-lock seed and reverse/face from that cover; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose axis-cover
+of `M` and `O` is scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint same-lock pairs recorded at formation tick 0. Origin
+locks `+e_1` and `(0,1,0)` locks `+e_1`. `(0,0,1)` locks `+e_2` and
+`(0,1,1)` locks `+e_2`. The second pair is a new seed, not a formed child
+of the first pair, and neither pair is opposite. This seed is not the 1-axis
+same-lock two-site seed `{0,(0,1,0)}` with `+e_1/+e_1` alone. This seed is
+not the two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2`. This seed is
+not the y-symmetric three-site seed that also records `(0,-1,0)` at tick 0.
+This seed is not the x-axis same-lock seed `{0,(1,0,0)}` with `+e_2/+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named axis-cover of `M` and `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy of sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+If `q` is unformed at `τ`, then cover is `UNDEFINED`. Empty `M` or empty
+`O` fails because the union misses an axis. Overlapping axes fail.
+Incomplete union fails. Axis is unsigned: `+e_i` and `−e_i` occupy the
+same axis. Leftover of the union is `{e_1,e_2,e_3}` minus `(Axis(M)
+union Axis(O))`. Empty leftover is leftover fail of leftover-empty scoring;
+this display is HOLD iff cover, not leftover-empty fail. Leftover of `M`
+alone is `{e_1,e_2,e_3}` minus `Axis(M)`, a different object. Leftover of
+`O` alone is a different object.
+
+Reverse axis-cover holds if and only if cover HOLDs at `A` and at `B`. Face
+axis-cover holds if and only if cover HOLDs at `C` and at `D`. Either side
+`UNDEFINED` is `UNDEFINED`. Else if both sides HOLD, reverse or face HOLDs.
+Else fail.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Identifying leftover-empty fail with
+cover reverse is refused: leftover-empty fail scores empty leftover as
+fail, while cover reverse HOLDs from complementary occupation at `A` and
+at `B`. Identifying 1-axis same-lock cover-HOLD with this reverse/face is
+refused: 1-axis same-lock HOLDs at `D` and HOLDs face; this member fails
+at `D` and fails face.
+
+## Theorem 1 — ticks, `M`, `O`, `Axis`, and cover at `τ=t+1`
+
+On this process the four y-probes form. Compare to 1-axis same-lock
+cover-HOLD: the two-site seed `{0,(0,1,0)}` with locks `+e_1/+e_1` reports
+cover HOLD at each of the four y-probes, reverse hold, and face hold, with
+`t(D)=3` and mixed `M(D,τ)={−e_2,+e_3,−e_3}`. This two-axis same-lock
+member adds a second same-lock pair as a new seed. Cover HOLDs at `A`, at
+`B`, and at `C`, and fails at `D`: `Axis(M)(D,τ)={e_3}` and
+`Axis(O)(D,τ)={e_1}`, so their union misses `e_2`. Reverse still HOLDs.
+Face fails.
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=2
+M(A, τ) = {+e_1}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_2}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_2, −e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ) = {+e_1}
+Axis(M)(A, τ) = {e_1}
+Axis(O)(A, τ) = {e_2, e_3}
+Axis(M)(B, τ) = {e_1}
+Axis(O)(B, τ) = {e_2, e_3}
+Axis(M)(C, τ) = {e_2}
+Axis(O)(C, τ) = {e_1, e_3}
+Axis(M)(D, τ) = {e_3}
+Axis(O)(D, τ) = {e_1}
+cover(A) = hold
+cover(B) = hold
+cover(C) = hold
+cover(D) = fail
+```
+
+`A` is a seed at tick 0. Mixed remains a set: `O(A,τ)` has two outgoing
+steps and `O(B,τ)` has three outgoing steps. Unique letters would assign
+`UNDEFINED` at mixed `O(A)`. Here uniqueness is not required. At `A`, `B`,
+and `C`, `Axis(M)` and `Axis(O)` are complementary: their union is
+`{e_1,e_2,e_3}` and their intersection is empty. At `D` the intersection
+is empty and the union is `{e_1,e_3}`, so cover fails. Leftover of the
+union is empty at `A`, `B`, and `C`, and is `{e_2}` at `D`. Leftover-empty
+fail of that leftover is not this object. O is not M. At formation tick
+`t` itself, `O` is empty at each probe and cover fails; the `t+1` cut is
+required.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+Leftover of `M` alone at `A` and at `B` is `{e_2, e_3}`, nonempty and
+equal. Leftover of `O` alone at `A` and at `B` is `{e_1}`, nonempty and
+equal. Those one-sided leftovers are not this object. M exist-opposite
+reverse fail: both `M(A,τ)` and `M(B,τ)` are `{+e_1}`.
+
+## Theorem 2 — reverse from axis-cover at `τ`
+
+Reverse axis-cover holds if and only if cover HOLDs at `A` and at `B`.
+Both covers HOLD. Reverse HOLDs. This is HOLD iff cover, not leftover-empty
+fail.
+
+Reverse axis-cover at τ: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Leftover-empty reverse
+fails because leftover of the union is empty at `A` and at `B`. Cover
+reverse HOLDs from complementary occupation of all three axes. Leftover-of-
+`M` reverse would hold because leftover of `M` at `A` and at `B` is
+`{e_2, e_3}`. Leftover-of-`O` reverse would hold because leftover of `O`
+at `A` and at `B` is `{e_1}`. Exist-opposite reverse of signed `M` fails.
+Exist-opposite reverse of signed `O` holds. Those leftovers are not this
+display.
+
+Reverse holds.
+
+## Theorem 3 — face from axis-cover at `τ`
+
+Face axis-cover holds if and only if cover HOLDs at `C` and at `D`. Cover
+HOLDs at `C` and fails at `D`. Face fails. Face is not `UNDEFINED`.
+
+Face axis-cover at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Leftover-empty face fails because leftover of the union is empty at `C`
+while leftover at `D` is `{e_2}`. Cover face fails because `Axis(M)` and
+`Axis(O)` at `D` miss `e_2`. Leftover-of-`M` face would fail because
+leftover of `M` at `C` is `{e_1, e_3}` and leftover of `M` at `D` is
+`{e_1, e_2}`: nonempty and unequal. Leftover of `O` at `C` is `{e_2}` and
+leftover of `O` at `D` is `{e_2, e_3}`: nonempty and unequal.
+Exist-opposite face of signed `M` fails. Exist-opposite face of signed
+`O` holds. This display scores cover of `M` and `O`, which HOLDs at `C`
+and fails at `D`, so face fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover reverse HOLDs. Cover face fails.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming, outgoing, or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require cover sides to be singletons.
+- It does not sum either set.
+- It does not replace cover by leftover-empty fail.
+- It does not replace cover by leftover of `M` alone.
+- It does not replace cover by leftover of `O` alone.
+- It does not replace cover by existential opposite of signed locks.
+- It does not replace `O` by `M`.
+- It does not replace cover by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint 1-axis same-lock cover-HOLD as this member.
+- It does not reprint two-axis opposite axis-cover.
+- It does not reprint x-axis same-lock y-probe axis-cover.
+- It does not reprint nsopp exist-opposite HOLD.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis same-lock four-site process, axis-cover of `M` and `O` at `t+1`, and
+the reverse/face bits from cover are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two disjoint same-lock pairs `+e_1/+e_1` and `+e_2/+e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; outgoing dual nonempty at `τ` |
+| `Axis(M)` and `Axis(O)` at `τ` | Theorem 1; complementary at `A`,`B`,`C`; incomplete at `D` |
+| cover at `τ` | Theorem 1; HOLD at `A`,`B`,`C`; fail at `D` |
+| reverse from axis-cover at `τ` | Theorem 2; `hold` |
+| face from axis-cover at `τ` | Theorem 3; `fail` |
+| compare to 1-axis same-lock cover-HOLD | Theorem 1; 1-axis HOLDs at `D` and HOLDs face; this member fails `D` and fails face |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail | not this cover display |
+| leftover of exist-opposite of `M` | not this cover display |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of 1-axis same-lock cover-HOLD | not this display |
+| leftover of two-axis opposite | not this display |
+| leftover of x-axis same-lock y-probe axis-cover | not this display |
+| leftover of nsopp exist-opposite HOLD | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| global later T | not used |
+| axis-cover as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: axis-cover of `M` and `O` at `t+1` on the four y-probes of the two-axis same-lock seed, compared to 1-axis same-lock cover-HOLD, and reverse/face from that cover. |
+| V2 | Current main has no landed axis-cover reverse/face of timed `M` and `O` on these four two-axis same-lock y-probes. |
+| V3 | Cover reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads unsigned axis-cover of own incoming and own outgoing at the same `t+1` cut and scores HOLD iff cover. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace cover by leftover-empty fail, does not
+replace cover by leftover of `M` alone or leftover of `O` alone, does not
+replace cover by existential opposite of signed locks, and does not
+identify this display with 1-axis same-lock cover-HOLD or with two-axis
+opposite. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover of the union is empty at `A` and at `B`, leftover reverse fails, while cover reverse HOLDs | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` and `B` is `{e_2,e_3}`, nonempty equal, reverse would hold, but that is not cover of the pair | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` and `B` is `{e_1}`, nonempty equal, reverse would hold, but that is not cover of the pair | ATTEMPTED |
+| exist-opposite of `M` | reuse signed reverse and face of `M` | M exist-opposite reverse fail and face fail; cover reverse HOLDs from unsigned complementary axes at `A` and `B` | ATTEMPTED |
+| exist-opposite of `O` | reuse signed reverse and face of `O` | O exist-opposite reverse hold and face hold; cover face fails | ATTEMPTED |
+| 1-axis same-lock cover-HOLD | reuse seed `{0,(0,1,0)}` with `+e_1/+e_1` | 1-axis HOLDs at `D` with `t(D)=3`; here `t(D)=2`, `M(D)={−e_3}`, cover fails at `D`, face fails | ATTEMPTED |
+| two-axis opposite | reuse seed `+e_1/−e_1` and `+e_2/−e_2` | `M(A)` there is `{−e_1}` and `O(D)` includes `−e_1`; here `M(A)={+e_1}` and `O(D)={+e_1}` | ATTEMPTED |
+| x-axis same-lock y-probe | reuse seed `{0,(1,0,0)}` with `+e_2/+e_2` | that leftover HOLDs cover at each probe including `D`; this member fails at `D` | ATTEMPTED |
+| nsopp exist-opposite HOLD | reuse opposite `+e_1/−e_1` y-probes | that leftover has M exist-opposite reverse hold; this member has M exist-opposite reverse fail | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; unique-letter cover at `A` is `UNDEFINED` while cover HOLDs | ATTEMPTED |
+| letter intersection as cover | score reverse/face inside `M ∩ O` | letter intersection empty is not axis-cover; opposite signs can share an axis | ATTEMPTED |
+| same-tick-inclusive six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | that leftover is a signed exist-opposite readout; cover is unsigned complementary axes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores axis-cover of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports reverse hold and face fail from cover | ATTEMPTED |
+| sum of a set | replace cover by a `Z^3` sum | the construction does not sum; cover is a complementary pair of unsigned axis sets | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by axis-cover | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of cover with leftover of
+`M` alone, missing identification of cover with leftover-empty fail, missing
+identification of cover with existential opposite of signed locks, missing
+identification of this member with 1-axis same-lock cover-HOLD, and missing
+Record identification of cover reverse are distinct open premises. This note
+claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, four-site two-axis same-lock seed, perpendicular step
+rule, incoming-step lock, own incoming set and own outgoing dual from
+records with tick `<= τ`, per-probe `τ=t+1`, unsigned axis, cover as
+complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`, HOLD
+iff cover not leftover-empty fail, four y-probes with seed `A`, and mixed
+remains a set are declared. No uniqueness of incoming locks, no six-neighbor
+lock union as the scored object, no lock-count clock, no global later T, no
+formation attachment from already-recorded six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+cover reverse hold and face fail reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each unsigned lattice axis among `{e_1,e_2,e_3}` | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four cover reports, reverse/face from cover HOLD | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for cover reverse/face, a
+formation-rate rule, and a physical selector among complementary axes. None
+is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Two-axis same-lock is still cover HOLD because 1-axis
+same-lock HOLDs and two-axis opposite also HOLDs reverse; same-lock is
+only a sign flip of opposite; leftover empty already answered three-axis
+occupation; leftover of `M` alone already gives `{e_2,e_3}` at `A`; and
+signed exist-opposite of `O` already answered reverse/face.
+
+**Answer:** Cover fails at `D` because `Axis(M)={e_3}` and `Axis(O)={e_1}`
+miss `e_2`. 1-axis same-lock HOLDs at `D` and HOLDs face. Two-axis opposite
+has `M(A)={−e_1}` and `O(D)` including `−e_1`; this member has
+`M(A)={+e_1}` and `O(D)={+e_1}`. Leftover empty at `A` and `B` is leftover
+reverse fail, while cover reverse HOLDs. Leftover of `M` alone reverse
+would hold and is not complementary cover of the pair. Signed
+exist-opposite of `O` reverse-holds and face-holds, while cover face
+fails. Reverse axis-cover is HOLD iff cover at `A` and at `B`, not
+leftover-empty fail and not 1-axis same-lock cover-HOLD.
+
+### N8 — cross-cycle echo
+
+1-axis same-lock cover-HOLD on `{0,(0,1,0)}` with `+e_1/+e_1` reports cover
+HOLD at each of the four y-probes, reverse hold, and face hold. Two-axis
+opposite reports reverse hold and face fail with opposite seed letters.
+This note is not those displays: it reports axis-cover of `M` and `O` at
+`τ=t+1` on two disjoint same-lock pairs, cover HOLD at `A`,`B`,`C`, cover
+fail at `D`, reverse hold, and face fail. HOLD iff cover, not leftover-empty
+fail, and not leftover of 1-axis same-lock cover-HOLD.
+
+**Gate disposition:** PASS for the axis-cover `t+1` reverse/face reports
+above. FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the
+predicate equals the unique singleton lock vector,” “the predicate equals
+six-neighbor lock union,” “the predicate equals leftover-empty fail,” “the
+predicate equals leftover of `M` alone,” “the predicate equals leftover of
+`O` alone,” “the predicate equals exist-opposite of `M`,” “the predicate
+equals 1-axis same-lock cover-HOLD,” “the predicate equals two-axis
+opposite,” “bits are Admissibility,” “cover fails at `A`,” “cover HOLDs at
+`D`,” “reverse axis-cover fails,” or “face axis-cover HOLDs.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis same-lock
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports unsigned axis of each, reports cover of the pair, lists new records
+in `B_3(0)` between `t` and `t+1` that meet a probe's six-neighbors, compares
+to 1-axis same-lock cover-HOLD, and checks Theorems 1--3. It also checks that
+cover HOLDs at `A`,`B`,`C` and fails at `D`, that leftover-empty fail is a
+different reverse, that leftover of `M` alone and leftover of `O` alone are
+different objects, that signed exist-opposite of `M` fails reverse, that
+mixed sets remain sets, that unique-letter cover is `UNDEFINED` at mixed
+`O(A)`, that the construction does not sum, that a formation member from
+already-recorded six-neighbor locks is not attached, and that the display is
+not the two-tick lock-count clock composition. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18641,6 +18641,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,94 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
+runner_sha256: efcd2bff2a057d430b91cc1088c86d69416d6c63ac2b0f6ae7d6b9de7b7f12f4
+input_fingerprint_sha256: da8d85293d62abccb0b6b2d727a384f305388e39346a47fe092513c532545d9d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+axis-cover of M and O reverse/face at t+1
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Axis-cover of M and O at t+1 on the four y-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: axis-identity
+PASS: cover-identity
+PASS: pair-cover-identity
+PASS: leftover-empty-fail-contrast
+A t=0 M={+e_1} O={+e_2, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} cover=hold
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} cover=hold
+C t=1 M={+e_2} O={+e_1, −e_1, +e_3, −e_3} Axis(M)={e_2} Axis(O)={e_1, e_3} cover=hold
+D t=2 M={−e_3} O={+e_1} Axis(M)={e_3} Axis(O)={e_1} cover=fail
+cover reverse=hold face=fail
+leftover-empty reverse=fail face=fail
+1-axis same-lock cover reverse=hold face=hold D=hold
+per_element: each unsigned lattice axis among {e_1,e_2,e_3} occupied by M or by O at a probe's t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four cover reports, reverse/face from cover HOLD
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: neither-pair-is-opposite
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{+e_1}', 'B': '{+e_1}', 'C': '{+e_2}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_2, −e_3}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{+e_1, −e_1, +e_3, −e_3}', 'D': '{+e_1}'})
+PASS: theorem1-Axis-M-and-O  ({'A': ('{e_1}', '{e_2, e_3}'), 'B': ('{e_1}', '{e_2, e_3}'), 'C': ('{e_2}', '{e_1, e_3}'), 'D': ('{e_3}', '{e_1}')})
+PASS: theorem1-cover-hold-fail  ({'A': 'hold', 'B': 'hold', 'C': 'hold', 'D': 'fail'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-O-empty-at-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((0, 2, 0), (0, 1, -1)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: compare-1-axis-same-lock-cover-hold
+PASS: theorem2-reverse-cover-hold
+PASS: theorem3-face-cover-fail
+PASS: not-leftover-empty-fail
+PASS: not-leftover-of-M-alone
+PASS: not-leftover-of-O-alone
+PASS: not-exist-opposite-of-M
+PASS: not-exist-opposite-of-O
+PASS: mutation-empty-plus-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: not-x-probes-or-x-axis-same-or-ysym
+PASS: not-two-axis-opposite
+PASS: not-nsopp-exist-opposite-hold
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-Axis-cover
+PASS: note-reports-new-neighbors
+PASS: note-reports-cover-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-leftover-empty-fail
+PASS: note-not-one-sided-or-exist-opposite-leftover
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-1-axis-same-lock-or-two-axis-opposite
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: cover-not-leftover-empty-fail
+TOTAL: PASS=62 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1165 @@
+#!/usr/bin/env python3
+"""Axis-cover of M and O at t+1 reverse/face on two-axis same-lock y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites in two disjoint same-lock pairs: origin and (0,1,0) lock
++e_1; (0,0,1) and (0,1,1) lock +e_2. Neither pair is opposite. A 6-NN step
+is allowed iff it is perpendicular to the parent lock axis. Newly formed
+sites lock the incoming step. Seeds keep their seed letters as a singleton.
+M(q, tau) is the set of earliest incoming nearest-neighbor steps at q using
+only records with tick <= tau. Unformed at tau => UNDEFINED. O(q, tau) is
+the outgoing dual of M: the set of e in {±e_1,±e_2,±e_3} such that q+e is
+formed and e is in M(q+e, tau). Unformed q at tau => UNDEFINED. Empty O is
+empty, not UNDEFINED. Axis(S) is the unsigned lattice directions of signed
+locks in S. Cover HOLDs at q iff Axis(M) intersect Axis(O) is empty and
+Axis(M) union Axis(O) equals {e_1,e_2,e_3}. UNDEFINED if M or O UNDEFINED.
+Else fail. Reverse HOLDs iff cover at A and at B. Face likewise on C, D.
+Compare to 1-axis same-lock cover-HOLD. Uniqueness is not required.
+Occupancy of sites is not used. Named-sign lettering is not used. No larger
+host. Not leftover of M alone or of O alone. Not exist-opposite of signed
+locks. Not leftover of two-axis opposite. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+FOUR_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    ((0, 1, 1), E2),
+)
+ONE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+TWO_AXIS_OPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    ((0, 1, 1), NEG_E2),
+)
+NSOPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+X_AXIS_SAME_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, E2),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Axis-cover of M and O at t+1 on the four y-probes of the "
+    "two-axis same-lock seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = FOUR_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast: {e_1,e_2,e_3} minus Axis(S). Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def pair_cover(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(cover_a: str, cover_b: str) -> str:
+    """Reverse HOLDs iff cover at A and cover at B."""
+    return pair_cover(cover_a, cover_b)
+
+
+def face_report(cover_c: str, cover_d: str) -> str:
+    """Face HOLDs iff cover at C and cover at D."""
+    return pair_cover(cover_c, cover_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def neighbor_lock_set(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    tau: int,
+) -> frozenset[Point]:
+    """Leftover contrast: locks of 6-NN formed by tau, site excluded."""
+    collected: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks or ticks[neighbor] > tau:
+            continue
+        collected.update(locks[neighbor])
+    return frozenset(collected)
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def probe_cover(
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> dict[str, str]:
+    report: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau = ticks[site] + 1
+        report[name] = axis_cover(
+            incoming_set(site, tau, ticks, locks, seed_map),
+            outgoing_set(site, tau, ticks, locks, seed_map),
+        )
+    return report
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("axis-cover of M and O reverse/face at t+1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "axis-identity",
+        axis_set(UNDEFINED) == UNDEFINED
+        and axis_set(frozenset({NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E1, NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E2, E3, NEG_E3})) == frozenset({E2, E3})
+        and axis_set(frozenset({E1, E3})) == frozenset({E1, E3}),
+    )
+    checks.check(
+        "cover-identity",
+        axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_cover(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_cover(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset()) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E3}), frozenset({E1})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and axis_cover(frozenset({E1, E2, E3}), frozenset({E1, E2, E3})) == "fail",
+    )
+    checks.check(
+        "pair-cover-identity",
+        pair_cover(UNDEFINED, "hold") == UNDEFINED
+        and pair_cover("hold", UNDEFINED) == UNDEFINED
+        and pair_cover("hold", "hold") == "hold"
+        and pair_cover("hold", "fail") == "fail"
+        and pair_cover("fail", "hold") == "fail"
+        and pair_cover("fail", "fail") == "fail",
+    )
+    checks.check(
+        "leftover-empty-fail-contrast",
+        leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and leftover_axis(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3}))
+        == frozenset()
+        and leftover_axis(frozenset({E3}), frozenset({E1})) == frozenset({E2}),
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SEEDS)
+    opp_ticks, opp_locks, opp_seeds = form(TWO_AXIS_OPP_SEEDS)
+    nsopp_ticks, nsopp_locks, nsopp_seeds = form(NSOPP_SEEDS)
+    xsame_ticks, xsame_locks, xsame_seeds = form(X_AXIS_SAME_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"Axis(M)={axis_display(axis_m[name])} "
+            f"Axis(O)={axis_display(axis_o[name])} "
+            f"cover={cover[name]}"
+        )
+
+    reverse = reverse_report(cover["A"], cover["B"])
+    face = face_report(cover["C"], cover["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unique_cover_a = axis_cover(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    leftover_neighbor_reverse = leftover_match(
+        leftover_of_one(
+            neighbor_lock_set(PROBES["A"], ticks, locks, ticks[PROBES["A"]])
+        ),
+        leftover_of_one(
+            neighbor_lock_set(PROBES["B"], ticks, locks, ticks[PROBES["B"]])
+        ),
+    )
+    one_cover = probe_cover(one_ticks, one_locks, one_seeds)
+    one_reverse = reverse_report(one_cover["A"], one_cover["B"])
+    one_face = face_report(one_cover["C"], one_cover["D"])
+    opp_m_a = incoming_set(
+        PROBES["A"],
+        opp_ticks[PROBES["A"]] + 1,
+        opp_ticks,
+        opp_locks,
+        opp_seeds,
+    )
+    opp_o_d = outgoing_set(
+        PROBES["D"],
+        opp_ticks[PROBES["D"]] + 1,
+        opp_ticks,
+        opp_locks,
+        opp_seeds,
+    )
+    opp_cover = probe_cover(opp_ticks, opp_locks, opp_seeds)
+    print(f"cover reverse={reverse} face={face}")
+    print(f"leftover-empty reverse={leftover_reverse} face={leftover_face}")
+    print(
+        f"1-axis same-lock cover reverse={one_reverse} face={one_face} "
+        f"D={one_cover['D']}"
+    )
+    print(
+        "per_element: each unsigned lattice axis among {e_1,e_2,e_3} "
+        "occupied by M or by O at a probe's t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four cover reports, reverse/face from cover HOLD")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and axis_cover(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and axis_cover(
+            incoming_set(PROBES["D"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set((0, 1, 1), 1, ticks, locks, seed_map) == frozenset({E2})
+        and FOUR_SITE_SEEDS
+        == ((ORIGIN, E1), (E2, E1), (E3, E2), ((0, 1, 1), E2)),
+    )
+    checks.check(
+        "neither-pair-is-opposite",
+        seed_map[ORIGIN] == seed_map[E2] == E1
+        and seed_map[E3] == seed_map[(0, 1, 1)] == E2
+        and add(seed_map[ORIGIN], seed_map[E2]) != ZERO
+        and add(seed_map[E3], seed_map[(0, 1, 1)]) != ZERO
+        and FOUR_SITE_SEEDS != TWO_AXIS_OPP_SEEDS,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Axis-M-and-O",
+        axis_m["A"] == frozenset({E1})
+        and axis_o["A"] == frozenset({E2, E3})
+        and axis_m["B"] == frozenset({E1})
+        and axis_o["B"] == frozenset({E2, E3})
+        and axis_m["C"] == frozenset({E2})
+        and axis_o["C"] == frozenset({E1, E3})
+        and axis_m["D"] == frozenset({E3})
+        and axis_o["D"] == frozenset({E1}),
+        str(
+            {
+                name: (axis_display(axis_m[name]), axis_display(axis_o[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-cover-hold-fail",
+        cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and isinstance(axis_m["D"], frozenset)
+        and isinstance(axis_o["D"], frozenset)
+        and axis_m["D"].isdisjoint(axis_o["D"])
+        and axis_m["D"] | axis_o["D"] == frozenset({E1, E3}),
+        str({name: cover[name] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-O-empty-at-t",
+        all(o0[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(axis_cover(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((0, 2, 0), (0, 1, -1))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 2
+        and unique_letter(o1["A"]) == UNDEFINED
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_cover_a == UNDEFINED
+        and cover["A"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and E2 in seed_map
+        and seed_map[E2] == E1
+        and m1["A"] == frozenset({E1}),
+    )
+    checks.check(
+        "compare-1-axis-same-lock-cover-hold",
+        all(one_cover[name] == "hold" for name in ("A", "B", "C", "D"))
+        and one_reverse == "hold"
+        and one_face == "hold"
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and cover["D"] == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "theorem2-reverse-cover-hold",
+        reverse == "hold"
+        and cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail",
+    )
+    checks.check(
+        "theorem3-face-cover-fail",
+        face == "fail"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold",
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset()
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and reverse == "hold"
+        and face == "fail"
+        and leftover_reverse != reverse,
+    )
+    checks.check(
+        "not-leftover-of-M-alone",
+        reverse_m_alone == "hold"
+        and face_m_alone == "fail"
+        and lx_m["A"] == frozenset({E2, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_m["C"] == frozenset({E1, E3})
+        and lx_m["D"] == frozenset({E1, E2})
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "not-leftover-of-O-alone",
+        reverse_o_alone == "hold"
+        and face_o_alone == "fail"
+        and lx_o["A"] == frozenset({E1})
+        and lx_o["B"] == frozenset({E1})
+        and lx_o["C"] == frozenset({E2})
+        and lx_o["D"] == frozenset({E2, E3})
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "not-exist-opposite-of-M",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "not-exist-opposite-of-O",
+        o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-empty-plus-undefined",
+        axis_cover(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and reverse == "hold",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["A"], frozenset)
+        and isinstance(o1["B"], frozenset)
+        and sum_of_set(m1["A"]) == E1
+        and sum_of_set(o1["A"]) == add(E2, NEG_E3)
+        and axis_o["A"] != frozenset({E2})
+        and axis_o["A"] == frozenset({E2, E3}),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and E1 in m1["A"]
+        and E1 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and axis_m["A"] != axis_o["A"],
+    )
+    x_m1 = {
+        name: incoming_set(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if X_PROBES[name] in ticks
+    }
+    xsame_cover = probe_cover(xsame_ticks, xsame_locks, xsame_seeds)
+    nsopp_m_exist = existential_opposite(
+        incoming_set(
+            PROBES["A"],
+            nsopp_ticks[PROBES["A"]] + 1,
+            nsopp_ticks,
+            nsopp_locks,
+            nsopp_seeds,
+        ),
+        incoming_set(
+            PROBES["B"],
+            nsopp_ticks[PROBES["B"]] + 1,
+            nsopp_ticks,
+            nsopp_locks,
+            nsopp_seeds,
+        ),
+    )
+    checks.check(
+        "not-x-probes-or-x-axis-same-or-ysym",
+        FOUR_SITE_SEEDS != X_AXIS_SAME_SEEDS
+        and FOUR_SITE_SEEDS != Y_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and x_m1["A"] != m1["A"]
+        and all(xsame_cover[name] == "hold" for name in ("A", "B", "C", "D"))
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check(
+        "not-two-axis-opposite",
+        FOUR_SITE_SEEDS != TWO_AXIS_OPP_SEEDS
+        and opp_m_a == frozenset({NEG_E1})
+        and m1["A"] == frozenset({E1})
+        and isinstance(opp_o_d, frozenset)
+        and NEG_E1 in opp_o_d
+        and isinstance(o1["D"], frozenset)
+        and NEG_E1 not in o1["D"]
+        and opp_cover["D"] == "fail"
+        and cover["D"] == "fail",
+    )
+    checks.check(
+        "not-nsopp-exist-opposite-hold",
+        FOUR_SITE_SEEDS != NSOPP_SEEDS
+        and nsopp_m_exist == "hold"
+        and m_exist_reverse == "fail",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Axis-cover",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {+e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_2, −e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1}" in note
+        and "Axis(M)(A, τ) = {e_1}" in note
+        and "Axis(O)(A, τ) = {e_2, e_3}" in note
+        and "Axis(M)(B, τ) = {e_1}" in note
+        and "Axis(O)(B, τ) = {e_2, e_3}" in note
+        and "Axis(M)(C, τ) = {e_2}" in note
+        and "Axis(O)(C, τ) = {e_1, e_3}" in note
+        and "Axis(M)(D, τ) = {e_3}" in note
+        and "Axis(O)(D, τ) = {e_1}" in note
+        and "cover(A) = hold" in note
+        and "cover(B) = hold" in note
+        and "cover(C) = hold" in note
+        and "cover(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-cover-reverse-face",
+        "Reverse axis-cover at τ: hold" in note
+        and "Face axis-cover at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-leftover-empty-fail",
+        "not leftover-empty fail" in normalized_note
+        and "HOLD iff cover" in note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-not-one-sided-or-exist-opposite-leftover",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover of exist-opposite of `M`" in normalized_note
+        and "M exist-opposite reverse fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-1-axis-same-lock-or-two-axis-opposite",
+        "not leftover of 1-axis same-lock cover-HOLD" in normalized_note
+        and "not leftover of two-axis opposite" in normalized_note
+        and "neither pair is opposite" in normalized_note
+        and "Face axis-cover at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained and line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "axis_cover" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "cover-not-leftover-empty-fail",
+        reverse == "hold"
+        and face == "fail"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and cover["D"] == "fail"
+        and lx["D"] == frozenset({E2})
+        and one_cover["D"] == "hold",
+    )
+    _ = (
+        leftover_neighbor_reverse,
+        unique_cover_a,
+        o0,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two-axis same-lock y-probe cover reverse HOLD face fails. Displayed, not adopted.

## Runner

`scripts/two_axis_same_lock_yprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.