### PR TITLE
feat(nm2sl12): 1-in 2-out split on two-axis same-lock: reverse HOLD, face fails

### DIFF
--- a/docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,574 @@
+---
+claim_id: two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
+---
+
+# Incoming And Outgoing 1-In 2-Out Axis Split At t+1 Reverse And Face On Four Y-Probes Of The Two-Axis Same-Lock Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** 1-in 2-out axis split of simultaneous earliest incoming set `M`
+and outgoing dual `O` at each probe's `τ=t+1`, and reverse/face from that
+split, on the four y-probes of the two-axis same-lock seed in
+`B_3(0)={n:n·n<=9}`. Same process and y-probes as nm2sl. Let `t(q)` be the
+formation tick of probe `q`. Let `τ(q)=t(q)+1`. `M(q,τ)` is the set of
+earliest incoming nearest-neighbor steps at `q` using only records with
+tick `<= τ`. Seeds are a singleton seed letter. `O(q,τ)` is the outgoing
+dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed
+and `e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is
+empty, not `UNDEFINED`. Axis of a defined lock set `S` is `Axis(S)={e_i |
+some ±e_i in S}`. Cover holds at `q` if and only if `Axis(M)` intersect
+`Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals `{e_1,e_2,e_3}`.
+Split holds at `q` if and only if cover holds and `|Axis(M)|=1`. 2-in 1-out
+is fail of this object, not `UNDEFINED`. Unformed at `τ` is `UNDEFINED`.
+Else fail. Reverse holds if and only if split holds at `A` and at `B`. Face
+holds if and only if split holds at `C` and at `D`. Either side
+`UNDEFINED` is `UNDEFINED`. Discriminator versus the two-axis opposite
+seed: seed letters at `(0,1,0)` and `(0,1,1)` are same-lock, not opposite.
+This is not leftover of cover reverse. This is not leftover-axis reverse.
+This is not leftover of leftover-of-`M` alone. This is not leftover of
+leftover-of-`O` alone. This is not leftover of the two-axis opposite seed.
+This is not leftover of one-axis same-lock `+e_1/+e_1`. This is not leftover
+of nsopp `+e_1/−e_1`. This is not leftover of nnseed `+e_1/+e_2`.
+Uniqueness of incoming or outgoing locks is not required. Mixed remains a
+set. Occupancy of sites is not used. Named-sign lettering is not used. The
+construction does not use a six-neighbor star. A is a seed. Displayed, not
+adopted. Do not write into Admissibility. Do not attach L1. This note does
+not write the 1-in 2-out split into Admissibility and does not attach a
+formation member from already-recorded six-neighbor locks. This display
+does not use occupancy. Mixed stays a set.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`, so `|Axis(O)|=2`. Reverse and
+face are scored on split at the paired probes. 2-in 1-out is fail. Named
+signs `{+,−}` are a coarser readout and are not used. A singleton unique
+lock letter is a different readout and is not used as the object.
+Existential opposite of signed locks is a different readout and is not used
+as the split reverse: exist-opposite of signed M fails reverse here, while
+split reverse holds. Cover reverse holds here while leftover reverse fails.
+On this member `|Axis(M)|=1` at each of the four y-probes, so split equals
+cover at each probe; D fails cover by missing `e_2`, not by 2-in 1-out. A
+`Z^3` sum of those locks is a different readout and is not used. Occupancy
+of sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis same-lock seed, cover hold at A,B,C and cover fail at D from missing e_2, split hold at A,B,C and split fail at D, reverse hold and face fail from split; uniqueness of locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face
+target_blocker_text: "display 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis same-lock seed, and reverse/face from that split, discriminator versus two-axis opposite"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep 1-in 2-out axis split of M and O at t+1 displayed; do not write split into Admissibility, do not reduce to cover reverse, do not reduce to leftover-axis reverse, do not reduce to leftover of M alone or leftover of O alone, do not replace split by existential opposite of signed locks, do not identify the display with the two-axis opposite seed, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis same-lock seed and reverse/face from that split; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose 1-in
+2-out axis split of `M` and `O` is scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`,
+`C=(0,0,2)`, `D=(1,0,1)`. A is a seed. Same process and y-probes as nm2sl.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: the four-record set `{0, (0,1,0), (0,0,1), (0,1,1)}` is recorded at
+formation tick 0 with two disjoint same-lock pairs `L(0)=+e_1`,
+`L(0,1,0)=+e_1`, `L(0,0,1)=+e_2`, and `L(0,1,1)=+e_2`. This seed is not the
+two-axis opposite seed `{0,(0,1,0),(0,0,1),(0,1,1)}` with locks
+`+e_1/−e_1` and `+e_2/−e_2`. This seed is not the one-axis same-lock
+two-site seed `{0,(0,1,0)}` with locks `+e_1/+e_1`. This seed is not the
+nnseed two-site seed `+e_1/+e_2`. This seed is not the opposite two-site
+seed `+e_1/−e_1`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named 1-in 2-out axis split of `M` and `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy of sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover of `M` and `O` at the same cut:
+
+```text
+cover(q) HOLD iff Axis(M(q,τ)) intersect Axis(O(q,τ)) is empty
+and Axis(M(q,τ)) union Axis(O(q,τ)) equals {e_1,e_2,e_3}.
+```
+
+Split of `M` and `O` at the same cut:
+
+```text
+split(q) HOLD iff cover(q) HOLD and |Axis(M(q,τ))|=1.
+```
+
+If `q` is unformed at `τ`, then cover and split are `UNDEFINED`. Else fail.
+2-in 1-out is fail of this object, not `UNDEFINED`: cover can HOLD with
+`|Axis(M)|=2` and `|Axis(O)|=1`, and that is split fail. Axis is unsigned:
+`+e_i` and `−e_i` occupy the same axis. Cover is complementary occupation
+of the three lattice axes. Leftover of the union `{e_1,e_2,e_3}` minus
+`(Axis(M) union Axis(O))` empty is weaker: two sides that both occupy all
+three axes have empty leftover and fail cover because the intersection is
+nonempty. Leftover of `M` alone is a different object. Leftover of `O`
+alone is a different object. Cover without the `|Axis(M)|=1` cut is a
+different object.
+
+Reverse 1-in 2-out holds if and only if split at `A` and split at `B` both
+HOLD. Face 1-in 2-out holds if and only if split at `C` and split at `D`
+both HOLD. Either side `UNDEFINED` is `UNDEFINED`. Else fail.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Identifying leftover-axis reverse with
+this reverse is refused: leftover reverse fails when leftover is empty at
+`A` and at `B`. Identifying cover reverse with this reverse is refused:
+cover without `|Axis(M)|=1` is a different object, even when the two bits
+coincide on this member. Identifying existential opposite of signed locks
+with split reverse is refused: exist-opposite of signed M fails reverse
+here.
+
+## Theorem 1 — ticks, `M`, `O`, `Axis`, cover, `|Axis(M)|`, and split at `τ=t+1`
+
+On this process the four y-probes form. Compare to one-axis same-lock
+cover-HOLD: that two-site seed `{0,(0,1,0)}` both locking `+e_1` has
+`t(B)=2`, `t(D)=3`, cover hold at each of the four y-probes, and split fail
+at `D` from 2-in 1-out. This four-site two-axis same-lock seed has earlier
+`B` and `D`, cover fail at `D` from missing `e_2`, and `|Axis(M)|=1` at
+`D`. Discriminator versus two-axis opposite: that seed locks `−e_1` at
+`(0,1,0)` and `−e_2` at `(0,1,1)`; timed `M(A)` there is `{−e_1}` and
+`O(D)` there is `{+e_1, −e_1}`. This display reads the 1-in 2-out axis
+split of timed `M` and `O` on the same-lock four-site seed:
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=2
+M(A, τ) = {+e_1}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_2}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_2, −e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ) = {+e_1}
+Axis(M)(A, τ) = {e_1}
+Axis(O)(A, τ) = {e_2, e_3}
+Axis(M)(B, τ) = {e_1}
+Axis(O)(B, τ) = {e_2, e_3}
+Axis(M)(C, τ) = {e_2}
+Axis(O)(C, τ) = {e_1, e_3}
+Axis(M)(D, τ) = {e_3}
+Axis(O)(D, τ) = {e_1}
+cover(A) = hold
+cover(B) = hold
+cover(C) = hold
+cover(D) = fail
+|Axis(M)|(A, τ) = 1
+|Axis(M)|(B, τ) = 1
+|Axis(M)|(C, τ) = 1
+|Axis(M)|(D, τ) = 1
+split(A) = hold
+split(B) = hold
+split(C) = hold
+split(D) = fail
+```
+
+A is a seed at tick 0. Mixed remains a set: `O(A,τ)` has two outgoing
+steps, `O(B,τ)` has three, and `O(C,τ)` has four. Unique letters would
+assign `UNDEFINED` at mixed `O(A)`. Here uniqueness is not required.
+At `A`, `B`, and `C`, `Axis(M)` and `Axis(O)` are complementary: their
+union is `{e_1,e_2,e_3}` and their intersection is empty, and
+`|Axis(M)|=1`, so cover holds and split holds. At `D`, `|Axis(M)|=1` and
+`Axis(O)={e_1}`, so the union is `{e_1,e_3}` and leftover of the union is
+`{e_2}`. Cover fails at `D` from missing `e_2`. Split fails at `D` because
+cover fails. That fail is not 2-in 1-out: `|Axis(M)|=1` at `D`. O is not
+M. `M` at `τ` is frozen equal to `M` at `t`. `O` at `t` is empty at each of
+the four y-probes, so cover at `t` fails and split at `t` fails; new
+records at `t+1` fill `O` and cover holds at `A`, `B`, and `C`, while cover
+still fails at `D`.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+The seed site `(0,1,1)` is a six-neighbor of `A` already recorded at tick
+0, so it is not a new record at `t(A)+1`.
+
+## Theorem 2 — reverse from 1-in 2-out at `τ`
+
+Reverse 1-in 2-out holds if and only if split at `A` and split at `B` both
+HOLD. Split holds at `A` and at `B`: each is 1-in 2-out. Reverse holds.
+Cover reverse holds. Leftover reverse fails because leftover is empty at
+`A` and at `B`. Exist-opposite of signed M fails reverse.
+
+Reverse 1-in 2-out at τ: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Leftover-axis reverse
+fails because leftover is empty at `A` and at `B`. Leftover-of-`M`
+reverse would hold because leftover of `M` at `A` and at `B` is
+`{e_2, e_3}`. Leftover-of-`O` reverse would hold because leftover of `O`
+at `A` and at `B` is `{e_1}`. Exist-opposite of signed M fails reverse:
+`{+e_1}` against `{+e_1}` has no pair summing to zero. On the two-axis
+opposite seed, exist-opposite of signed M holds reverse from `{−e_1}`
+against `{+e_1}`. Cover reverse holds from cover at `A` and at `B`. Those
+leftovers are not this display. Reverse holds.
+
+## Theorem 3 — face from 1-in 2-out at `τ`
+
+Face 1-in 2-out holds if and only if split at `C` and split at `D` both
+HOLD. Split holds at `C`. Split fails at `D` because cover fails from
+missing `e_2`. Face fails.
+
+Face 1-in 2-out at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Leftover-axis face fails because leftover is empty at `C` while leftover
+at `D` is `{e_2}`. Leftover-of-`M` face would fail because leftover of `M`
+at `C` is `{e_1, e_3}` and leftover of `M` at `D` is `{e_1, e_2}`. Leftover
+of `O` at `C` is `{e_2}` and leftover of `O` at `D` is `{e_2, e_3}`:
+leftover-of-`O` face would fail. Exist-opposite of signed M fails face:
+`{+e_2}` against `{−e_3}` has no opposite pair. Exist-opposite of signed
+`O` holds face. Cover face fails from cover fail at `D`. On one-axis
+same-lock, cover face holds while split face fails from 2-in 1-out at `D`.
+This display scores 1-in 2-out of `Axis(M)` and `Axis(O)`, which fails at
+`D` from missing `e_2`, so face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming, outgoing, or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require `M` or `O` to be a singleton of signed letters.
+- It does not sum either set.
+- It does not replace split by cover reverse.
+- It does not replace split by leftover of `M` alone.
+- It does not replace split by leftover of `O` alone.
+- It does not replace split by leftover-axis equality of nonempty leftovers.
+- It does not replace split by existential opposite of signed locks.
+- It does not replace `O` by `M`.
+- It does not replace split by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint leftover of cover reverse.
+- It does not reprint leftover-axis reverse.
+- It does not reprint leftover of leftover-of-`M` alone.
+- It does not reprint leftover of leftover-of-`O` alone.
+- It does not reprint leftover of the two-axis opposite process.
+- It does not reprint leftover of one-axis same-lock cover-HOLD.
+- It does not reprint leftover of nsopp `+e_1/−e_1`.
+- It does not reprint leftover of nnseed `+e_1/+e_2`.
+- It does not reprint mixed unique-letter `UNDEFINED` as this split.
+- It does not treat 2-in 1-out as `UNDEFINED`.
+- It does not treat missing-axis cover fail as 2-in 1-out.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis same-lock process, 1-in 2-out axis split of `M` and `O` at
+`t+1`, and the reverse/face bits from that split are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis same-lock four-site seed `+e_1/+e_1` and `+e_2/+e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual at `A,B,C`; singleton at `D` |
+| `Axis(M)` and `Axis(O)` at `τ` | Theorem 1; complementary at `A,B,C`; missing `e_2` at `D` |
+| cover at `τ` | Theorem 1; hold at `A,B,C`; fail at `D` from missing `e_2` |
+| `|Axis(M)|` at `τ` | Theorem 1; `1`, `1`, `1`, `1` |
+| split at `τ` | Theorem 1; hold at `A,B,C`; fail at `D` from cover fail, not 2-in 1-out |
+| reverse from split at `τ` | Theorem 2; `hold` |
+| face from split at `τ` | Theorem 3; `fail` |
+| unique lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of cover reverse | not this split display |
+| leftover-axis reverse | not this split display |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of two-axis opposite y-probes | not this display |
+| leftover of one-axis same-lock cover-HOLD | not this display |
+| leftover of nsopp exist-opposite | not this display |
+| global later T | not used |
+| 1-in 2-out split as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: 1-in 2-out axis split of `M` and `O` at `t+1` on the four y-probes of the two-axis same-lock seed, and reverse/face from that split, discriminator versus two-axis opposite. |
+| V2 | Current main has no landed 1-in 2-out reverse/face of timed `M` and `O` on these four y-probes of the two-axis same-lock seed. |
+| V3 | Split bits at one cut and the two split reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads unsigned 1-in 2-out of own incoming and own outgoing at the same `t+1` cut and scores reverse/face from that split, not from opposite seed letters. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace split by cover reverse, does not replace
+split by leftover of `M` alone or leftover of `O` alone, does not replace
+split by leftover-axis reverse, does not replace split by existential
+opposite of signed locks, and does not identify this display with the
+two-axis opposite seed. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| leftover of cover reverse | score reverse/face as cover at `A,B` and `C,D` | on this member cover equals split at each y-probe because `|Axis(M)|=1`; one-axis same-lock has cover face hold and split face fail from 2-in 1-out at `D` | ATTEMPTED |
+| leftover-axis reverse | score nonempty leftover-axis equality | leftover empty at `A` and at `B`, leftover reverse fail, while split reverse hold | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` and at `B` is `{e_2,e_3}`, nonempty equal; reverse of leftover of `M` holds, which is not a discriminator of this split | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` and at `B` is `{e_1}`, nonempty equal; reverse of leftover of `O` holds | ATTEMPTED |
+| leftover of two-axis opposite | reuse seed `{0,(0,1,0),(0,0,1),(0,1,1)}` with locks `+e_1/−e_1` and `+e_2/−e_2` | this seed locks `+e_1/+e_1` and `+e_2/+e_2`; `M(A,τ)` is `{+e_1}` here and `{−e_1}` there; `O(D,τ)` is `{+e_1}` here and `{+e_1, −e_1}` there; exist-opposite of signed M reverse fails here and holds there | ATTEMPTED |
+| leftover of one-axis same-lock | reuse seed `{0,(0,1,0)}` with locks `+e_1/+e_1` | `t(B)=2` and `t(D)=3` there versus `1` and `2` here; cover holds at `D` there as 2-in 1-out; cover fails at `D` here from missing `e_2` | ATTEMPTED |
+| leftover of nsopp `+e_1/−e_1` | reuse opposite two-site seed | two-site seed; cover at `D` holds as 2-in 1-out; this seed has four sites | ATTEMPTED |
+| leftover of nnseed `+e_1/+e_2` | reuse nnseed two-site seed | cover at `B` fails so reverse fails from cover fail; cover at `C` holds while split at `C` fails | ATTEMPTED |
+| leftover of x-probes on this seed | reuse `A=(1,0,0)` | x-probe `A` forms at tick 2 with cover fail; y-probe `A` is a seed with split hold | ATTEMPTED |
+| leftover of z-probes on this seed | reuse `A=(0,0,1)` | z-probe `A` is the `+e_2` seed, a different frame | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; unique-letter split at `A` is `UNDEFINED`; this split is hold, not `UNDEFINED` | ATTEMPTED |
+| shared-axis leftover empty | both sides occupy all three axes | leftover empty, cover fails, split fails; here cover holds at `A,B,C` | ATTEMPTED |
+| exist-opposite of signed locks | score `a+b=(0,0,0)` inside `M` or `O` | exist-opposite of signed M fails reverse; split reverse holds from 1-in 2-out at `A` and at `B` | ATTEMPTED |
+| same-tick-inclusive six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | that leftover includes partner locks; split is unsigned 1-in 2-out of `M` and `O` | ATTEMPTED |
+| sum of a set | replace split by a `Z^3` sum | the construction does not sum; `O(A,τ)` sums to `+e_2−e_3` while `Axis(O)(A)` is `{e_2,e_3}` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by 1-in 2-out | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of split with cover reverse,
+missing identification of split with leftover-axis reverse, missing
+identification of split with leftover of `M` alone, missing identification
+of split with exist-opposite of signed `M`, missing identification with the
+two-axis opposite seed, and missing Record identification of split reverse
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-axis same-lock four-site seed locks `+e_1`, `+e_1`,
+`+e_2`, and `+e_2`, perpendicular step rule, incoming-step lock, own
+incoming set and own outgoing dual from records with tick `<= τ`,
+per-probe `τ=t+1`, unsigned axis, cover as empty intersection and
+three-axis union, split as cover together with `|Axis(M)|=1`, 2-in 1-out as
+fail, four y-probes with `A` a seed, and mixed remains a set are declared.
+No uniqueness of lock, no six-neighbor lock union as the scored object, no
+leftover-axis equality as the scored reverse, no cover reverse as the
+scored reverse, no global later T, no formation attachment from
+already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+split reverse `hold` and face `fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each unsigned lattice axis among `{e_1,e_2,e_3}` | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four split bits, reverse/face from 1-in 2-out | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for 1-in 2-out reverse/face, a
+formation-rate rule, and a physical selector among complementary axis
+splits. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Split HOLD is only cover HOLD; reverse HOLD is only leftover
+of `M` alone or only two-axis opposite; face FAIL is only leftover empty
+or only exist-opposite of signed `M`; one-axis same-lock already gives
+reverse hold and face fail; and missing `e_2` at `D` is only 2-in 1-out.
+
+**Answer:** Cover holds at `A`, `B`, and `C` and fails at `D` from missing
+`e_2`. Split requires cover and `|Axis(M)|=1`. At each of the four
+y-probes `|Axis(M)|=1`, so split equals cover on this member. That
+coincidence is not identity of the objects: one-axis same-lock has cover
+hold at `D` with `|Axis(M)|=2`, which is 2-in 1-out, so cover face holds
+and split face fails. Here `D` is 1-in 1-out with leftover `{e_2}`, so
+cover fails and split fails. 2-in 1-out is fail of this object, not
+`UNDEFINED`. Unique-letter split at mixed `O(A)` is `UNDEFINED`; this
+split is hold. Leftover reverse fails on empty leftover at `A` and at `B`.
+Exist-opposite of signed M fails reverse here and holds on two-axis
+opposite. Two-axis opposite locks `−e_1` at seed `A`; this seed locks
+`+e_1`. Split reverse is HOLD of split at `A` and at `B`, not exist-opposite
+of signed locks and not leftover of `M` alone.
+
+### N8 — cross-cycle echo
+
+One-axis same-lock on these y-probes has cover hold at each probe and split
+fail at `D` from 2-in 1-out. Two-axis opposite on these y-probes has the
+same split reverse hold and face fail pattern, with `M(A)={−e_1}` and
+exist-opposite of signed M reverse hold. Leftover-axis reverse fails
+because leftover is empty at `A` and at `B`. This note is not those
+displays: it reports 1-in 2-out axis split of `M` and `O` at `τ=t+1` on
+the two-axis same-lock seed, split hold at `A,B,C`, split fail at `D` from
+missing `e_2`, reverse hold, and face fail.
+
+**Gate disposition:** PASS for the 1-in 2-out `t+1` reverse/face reports
+above. FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the
+predicate equals the unique singleton lock vector,” “the predicate equals
+six-neighbor lock union,” “the predicate equals leftover of `M` alone,”
+“the predicate equals leftover of `O` alone,” “the predicate equals
+leftover-axis reverse,” “the predicate equals cover reverse,” “the
+predicate equals two-axis opposite,” “the predicate equals exist-opposite
+of signed M,” “bits are Admissibility,” “2-in 1-out is `UNDEFINED`,”
+“split fails at `A`,” “reverse 1-in 2-out fails,” “face 1-in 2-out holds,”
+“cover holds at `D`,” or “empty leftover is this reverse.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis same-lock
+four-site perp-step incoming-lock process, reads each probe's own earliest
+incoming set and own outgoing dual from the record prefix at that probe's
+`t+1`, reports unsigned axis of each, reports cover, reports `|Axis(M)|`,
+reports 1-in 2-out split, lists new records in `B_3(0)` between `t` and
+`t+1` that meet a probe's six-neighbors, and checks Theorems 1--3. It also
+checks that cover holds at `A,B,C` and fails at `D` from missing `e_2`,
+that split holds at `A,B,C` and fails at `D`, that leftover empty fails
+leftover reverse while split reverse holds, that leftover of `M` alone and
+leftover of `O` alone are different objects, that exist-opposite of signed
+M fails reverse, that mixed sets remain sets, that unique-letter split is
+`UNDEFINED` at mixed `O(A)` while this split is hold, that shared-axis
+leftover empty fails cover, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not attached,
+and that the display is not the two-axis opposite leftover process.
+No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18641,6 +18641,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,93 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
+runner_sha256: fded42aa0bcfaa21a455384fe57d6f5681b31bd6f92dd39ff011aaa0e2215d9b
+input_fingerprint_sha256: e6cc43b8fa089feb0d5b2c18ca4b4dfa711912d9dae3bb8e8b02cfb1a14f0010
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+1-in 2-out axis split of M and O reverse/face at t+1 on y-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: 1-in 2-out axis split of M and O at t+1 on the four y-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: axis-identity
+PASS: cover-identity
+PASS: both-hold-identity
+PASS: split-identity
+A t=0 M={+e_1} O={+e_2, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} |Axis(M)|=1 cover=hold split=hold
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} |Axis(M)|=1 cover=hold split=hold
+C t=1 M={+e_2} O={+e_1, −e_1, +e_3, −e_3} Axis(M)={e_2} Axis(O)={e_1, e_3} |Axis(M)|=1 cover=hold split=hold
+D t=2 M={−e_3} O={+e_1} Axis(M)={e_3} Axis(O)={e_1} |Axis(M)|=1 cover=fail split=fail
+split reverse=hold face=fail cover reverse=hold face=fail
+per_element: each unsigned lattice axis among {e_1,e_2,e_3} occupied by M or by O at a probe's t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four split bits, reverse/face from 1-in 2-out at A,B and at C,D
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{+e_1}', 'B': '{+e_1}', 'C': '{+e_2}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_2, −e_3}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{+e_1, −e_1, +e_3, −e_3}', 'D': '{+e_1}'})
+PASS: theorem1-Axis-M-and-O  ({'A': ('{e_1}', '{e_2, e_3}'), 'B': ('{e_1}', '{e_2, e_3}'), 'C': ('{e_2}', '{e_1, e_3}'), 'D': ('{e_3}', '{e_1}')})
+PASS: theorem1-cover-and-split  ({'A': ('hold', 'hold', 1), 'B': ('hold', 'hold', 1), 'C': ('hold', 'hold', 1), 'D': ('fail', 'fail', 1)})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-O-empty-at-t-fills-at-tplus1
+PASS: theorem1-new-records-meet-6nn  ({'A': ((0, 2, 0), (0, 1, -1)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-split-hold  (hold)
+PASS: theorem3-face-split-fail  (fail)
+PASS: mutation-leftover-empty-fails-leftover-reverse
+PASS: mutation-leftover-of-M-alone-differs
+PASS: mutation-leftover-of-O-alone-differs
+PASS: mutation-exist-opposite-of-M-fails-reverse
+PASS: mutation-exist-opposite-of-O-is-not-split
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-2in1out-is-fail-not-undefined
+PASS: mutation-shared-axis-fails-even-if-leftover-empty
+PASS: mutation-sum-is-not-axis
+PASS: O-is-not-M
+PASS: not-x-probes  (({'A': 'fail', 'B': 'hold', 'C': 'hold', 'D': 'fail'}, 'fail', 'fail'))
+PASS: not-one-axis-same-lock
+PASS: not-nsopp-or-nnseed
+PASS: discriminator-vs-two-axis-opposite  ((frozenset({(-1, 0, 0)}), frozenset({(1, 0, 0), (-1, 0, 0)}), 'hold'))
+PASS: two-axis-same-lock-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: uniqueness-not-required
+PASS: note-claim-scope
+PASS: note-reports-M-O-Axis-cover-split
+PASS: note-reports-new-neighbors
+PASS: note-reports-split-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-leftover-or-exist-opposite
+PASS: note-not-star-or-occupancy
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-axis-split
+TOTAL: PASS=63 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1325 @@
+#!/usr/bin/env python3
+"""1-in 2-out axis split of M and O at t+1 reverse/face on four y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is {0, (0,1,0), (0,0,1), (0,1,1)} with locks +e_1, +e_1, +e_2, +e_2 (two
+disjoint same-lock pairs; same process and y-probes as nm2sl). A 6-NN step
+is allowed iff it is perpendicular to the parent lock axis. Newly formed
+sites lock the incoming step. Seeds keep their seed letters as a singleton.
+t(q) is the formation tick. tau = t+1 is per-probe. M(q, tau) is the set of
+earliest incoming nearest-neighbor steps at q using only records with tick
+<= tau. Unformed at tau => UNDEFINED. O(q, tau) is the outgoing dual of M:
+the set of e in {±e_1,±e_2,±e_3} such that q+e is formed and e is in
+M(q+e, tau). Unformed q at tau => UNDEFINED. Empty O is empty, not
+UNDEFINED. Axis(S) is the unsigned lattice directions of signed locks in S.
+Cover HOLD at q iff Axis(M) intersect Axis(O) is empty and Axis(M) union
+Axis(O) equals {e_1,e_2,e_3}. Split HOLD at q iff cover HOLD and
+|Axis(M)|=1. 2-in 1-out is fail of this object, not UNDEFINED. UNDEFINED if
+M or O is UNDEFINED. Else fail. Reverse HOLD iff split at A and at B. Face
+HOLD iff split at C and at D. Either side UNDEFINED is UNDEFINED.
+Discriminator versus the two-axis opposite seed. Uniqueness of locks is
+not required. Occupancy of sites is not used. Named-sign lettering is not
+used. No six-neighbor star. No larger host. Not leftover of cover reverse.
+Not leftover-axis reverse. Not exist-opposite of signed locks. Displayed,
+not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SAME_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    ((0, 1, 1), E2),
+)
+TWO_AXIS_OPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    ((0, 1, 1), NEG_E2),
+)
+ONE_AXIS_SAME_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+NSOPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+NNSEED_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "1-in 2-out axis split of M and O at t+1 on the four y-probes "
+    "of the two-axis same-lock seed, and reverse/face from that, are "
+    "reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SAME_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover reverse contrast: nonempty equal leftovers. Empty => fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def cover_report(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff Axis(M) intersect Axis(O) empty and union equals {e_1,e_2,e_3}."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("cover sides must be axis sets or UNDEFINED")
+    if axes_m.isdisjoint(axes_o) and (axes_m | axes_o) == frozenset(AXES):
+        return "hold"
+    return "fail"
+
+
+def axis_count(value: AxisSet) -> int | str:
+    """Cardinality of an unsigned axis set. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return len(value)
+
+
+def split_report(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1. 2-in 1-out is fail, not UNDEFINED."""
+    cover = cover_report(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    if axes_m == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset):
+        raise TypeError("split needs an Axis(M) set or UNDEFINED")
+    if cover == "hold" and len(axes_m) == 1:
+        return "hold"
+    return "fail"
+
+
+def both_hold(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. Either UNDEFINED is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(split_a: str, split_b: str) -> str:
+    """Reverse HOLD iff split at A and split at B."""
+    return both_hold(split_a, split_b)
+
+
+def face_report(split_c: str, split_d: str) -> str:
+    """Face HOLD iff split at C and split at D."""
+    return both_hold(split_c, split_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_cover(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = cover_report(
+            incoming_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+            outgoing_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+        )
+    return out
+
+
+def probe_split(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = split_report(
+            incoming_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+            outgoing_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+        )
+    return out
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("1-in 2-out axis split of M and O reverse/face at t+1 on y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E1, E1) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and perpendicular(E1, E3)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((0, 4, 0)),
+    )
+    checks.check(
+        "axis-identity",
+        axis_set(UNDEFINED) == UNDEFINED
+        and axis_set(frozenset({NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E1, NEG_E1, E2})) == frozenset({E1, E2})
+        and axis_set(frozenset({E3})) == frozenset({E3})
+        and axis_set(frozenset({E2, E3, NEG_E3})) == frozenset({E2, E3}),
+    )
+    checks.check(
+        "cover-identity",
+        cover_report(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and cover_report(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and cover_report(frozenset({E1}), frozenset({E2, NEG_E3})) == "hold"
+        and cover_report(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3}))
+        == "hold"
+        and cover_report(frozenset({NEG_E3}), frozenset({E1})) == "fail"
+        and cover_report(frozenset({E1}), frozenset({E1})) == "fail"
+        and cover_report(frozenset({E1, E2}), frozenset({E3})) == "hold"
+        and cover_report(frozenset({E1, E2, E3}), frozenset({E1, E2, E3})) == "fail"
+        and leftover_axis(frozenset({E1, E2, E3}), frozenset({E1, E2, E3}))
+        == frozenset()
+        and cover_report(frozenset({E1, E2}), frozenset()) == "fail",
+    )
+    checks.check(
+        "both-hold-identity",
+        both_hold(UNDEFINED, "hold") == UNDEFINED
+        and both_hold("hold", UNDEFINED) == UNDEFINED
+        and both_hold("hold", "hold") == "hold"
+        and both_hold("hold", "fail") == "fail"
+        and both_hold("fail", "fail") == "fail"
+        and leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(frozenset({E1}), frozenset({E1})) == "hold"
+        and leftover_match(frozenset({E3}), frozenset({E1, E2})) == "fail",
+    )
+    checks.check(
+        "split-identity",
+        split_report(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and split_report(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and split_report(frozenset({E1}), frozenset({E2, NEG_E3})) == "hold"
+        and split_report(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3}))
+        == "hold"
+        and split_report(frozenset({NEG_E3}), frozenset({E1})) == "fail"
+        and split_report(frozenset({E1, E2}), frozenset({E3})) == "fail"
+        and cover_report(frozenset({E1, E2}), frozenset({E3})) == "hold"
+        and split_report(frozenset({E1}), frozenset({E2})) == "fail"
+        and split_report(frozenset({E1, E2}), frozenset()) == "fail"
+        and axis_count(frozenset({E1, E2})) == 2
+        and axis_count(frozenset({E3})) == 1
+        and axis_count(UNDEFINED) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    opp_ticks, opp_locks, opp_seeds = form(TWO_AXIS_OPP_SEEDS)
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SAME_SEEDS)
+    nsopp_ticks, nsopp_locks, nsopp_seeds = form(NSOPP_SEEDS)
+    nnseed_ticks, nnseed_locks, nnseed_seeds = form(NNSEED_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    n_axis_m: dict[str, int | str] = {}
+    split: dict[str, str] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = cover_report(m1[name], o1[name])
+        n_axis_m[name] = axis_count(axis_m[name])
+        split[name] = split_report(m1[name], o1[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"Axis(M)={axis_display(axis_m[name])} "
+            f"Axis(O)={axis_display(axis_o[name])} "
+            f"|Axis(M)|={n_axis_m[name]} "
+            f"cover={cover[name]} "
+            f"split={split[name]}"
+        )
+
+    cover_reverse = both_hold(cover["A"], cover["B"])
+    cover_face = both_hold(cover["C"], cover["D"])
+    reverse = reverse_report(split["A"], split["B"])
+    face = face_report(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unique_cover_a = cover_report(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    unique_split_a = split_report(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    cover_at_t = {
+        name: cover_report(m0[name], o0[name]) for name in ("A", "B", "C", "D")
+    }
+    split_at_t = {
+        name: split_report(m0[name], o0[name]) for name in ("A", "B", "C", "D")
+    }
+    print(
+        f"split reverse={reverse} face={face} "
+        f"cover reverse={cover_reverse} face={cover_face}"
+    )
+    print(
+        "per_element: each unsigned lattice axis among {e_1,e_2,e_3} "
+        "occupied by M or by O at a probe's t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four split bits, reverse/face from 1-in 2-out at A,B and at C,D"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[ORIGIN] == 0
+        and ticks[E2] == 0
+        and ticks[E3] == 0
+        and ticks[(0, 1, 1)] == 0
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and cover_report(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and split_report(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and split_report(
+            incoming_set(PROBES["D"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and split_report(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set((0, 1, 1), 1, ticks, locks, seed_map) == frozenset({E2})
+        and PROBES["A"] in seed_map
+        and m1["A"] == frozenset({E1}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Axis-M-and-O",
+        axis_m["A"] == frozenset({E1})
+        and axis_o["A"] == frozenset({E2, E3})
+        and axis_m["B"] == frozenset({E1})
+        and axis_o["B"] == frozenset({E2, E3})
+        and axis_m["C"] == frozenset({E2})
+        and axis_o["C"] == frozenset({E1, E3})
+        and axis_m["D"] == frozenset({E3})
+        and axis_o["D"] == frozenset({E1}),
+        str(
+            {
+                name: (axis_display(axis_m[name]), axis_display(axis_o[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-cover-and-split",
+        cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and n_axis_m["A"] == 1
+        and n_axis_m["B"] == 1
+        and n_axis_m["C"] == 1
+        and n_axis_m["D"] == 1
+        and axis_count(axis_o["A"]) == 2
+        and axis_count(axis_o["D"]) == 1
+        and lx["D"] == frozenset({E2})
+        and split["D"] != UNDEFINED,
+        str({name: (cover[name], split[name], n_axis_m[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-O-empty-at-t-fills-at-tplus1",
+        all(o0[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(cover_at_t[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(split_at_t[name] == "fail" for name in ("A", "B", "C", "D"))
+        and cover["A"] == "hold"
+        and cover["D"] == "fail",
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((0, 2, 0), (0, 1, -1))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 2
+        and unique_letter(o1["A"]) == UNDEFINED
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(m1["A"], frozenset)
+        and len(m1["A"]) == 1
+        and cover["A"] == "hold"
+        and split["A"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and PROBES["A"] in seed_map
+        and ticks[E2] == 0
+        and locks[E2] == {E1}
+        and m1["A"] == frozenset({E1})
+        and X_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem2-reverse-split-hold",
+        reverse == "hold"
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover_reverse == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail",
+        reverse,
+    )
+    checks.check(
+        "theorem3-face-split-fail",
+        face == "fail"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and cover_face == "fail"
+        and face != UNDEFINED
+        and n_axis_m["D"] == 1
+        and cover["D"] == "fail",
+        face,
+    )
+    checks.check(
+        "mutation-leftover-empty-fails-leftover-reverse",
+        lx["A"] == frozenset()
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-M-alone-differs",
+        lx_m["A"] == frozenset({E2, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_m["C"] == frozenset({E1, E3})
+        and lx_m["D"] == frozenset({E1, E2})
+        and reverse_m_alone == "hold"
+        and face_m_alone == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-O-alone-differs",
+        lx_o["A"] == frozenset({E1})
+        and lx_o["B"] == frozenset({E1})
+        and lx_o["C"] == frozenset({E2})
+        and lx_o["D"] == frozenset({E2, E3})
+        and reverse_o_alone == "hold"
+        and face_o_alone == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-exist-opposite-of-M-fails-reverse",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and reverse == "hold"
+        and face == "fail"
+        and existential_opposite(frozenset({E1}), frozenset({E1})) == "fail"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold"
+        and existential_opposite(frozenset({E2}), frozenset({NEG_E3})) == "fail",
+    )
+    checks.check(
+        "mutation-exist-opposite-of-O-is-not-split",
+        o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and reverse == "hold"
+        and face == "fail"
+        and face != o_exist_face,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({E1})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_cover_a == UNDEFINED
+        and unique_split_a == UNDEFINED
+        and cover["A"] == "hold"
+        and split["A"] == "hold",
+    )
+    checks.check(
+        "mutation-2in1out-is-fail-not-undefined",
+        cover_report(frozenset({E1, E2}), frozenset({E3})) == "hold"
+        and split_report(frozenset({E1, E2}), frozenset({E3})) == "fail"
+        and split_report(frozenset({E1, E2}), frozenset({E3})) != UNDEFINED
+        and cover["D"] == "fail"
+        and n_axis_m["D"] == 1
+        and split["D"] == "fail",
+    )
+    checks.check(
+        "mutation-shared-axis-fails-even-if-leftover-empty",
+        leftover_axis(frozenset({E1, E2, E3}), frozenset({E1, E2, E3}))
+        == frozenset()
+        and cover_report(frozenset({E1, E2, E3}), frozenset({E1, E2, E3})) == "fail"
+        and cover["A"] == "hold",
+    )
+    checks.check(
+        "mutation-sum-is-not-axis",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == E1
+        and sum_of_set(o1["A"]) == add(E2, NEG_E3)
+        and axis_o["A"] == frozenset({E2, E3})
+        and axis_o["A"] != frozenset({add(E2, NEG_E3)}),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and E1 in m1["A"]
+        and E1 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and axis_m["A"] != axis_o["A"]
+        and o1["D"] != m1["D"],
+    )
+
+    x_cover = probe_cover(X_PROBES, ticks, locks, seed_map)
+    x_split = probe_split(X_PROBES, ticks, locks, seed_map)
+    opp_cover = probe_cover(PROBES, opp_ticks, opp_locks, opp_seeds)
+    opp_split = probe_split(PROBES, opp_ticks, opp_locks, opp_seeds)
+    one_cover = probe_cover(PROBES, one_ticks, one_locks, one_seeds)
+    one_split = probe_split(PROBES, one_ticks, one_locks, one_seeds)
+    nsopp_cover = probe_cover(PROBES, nsopp_ticks, nsopp_locks, nsopp_seeds)
+    nsopp_split = probe_split(PROBES, nsopp_ticks, nsopp_locks, nsopp_seeds)
+    nnseed_cover = probe_cover(PROBES, nnseed_ticks, nnseed_locks, nnseed_seeds)
+    nnseed_split = probe_split(PROBES, nnseed_ticks, nnseed_locks, nnseed_seeds)
+    x_reverse = reverse_report(x_split["A"], x_split["B"])
+    x_face = face_report(x_split["C"], x_split["D"])
+    opp_reverse = reverse_report(opp_split["A"], opp_split["B"])
+    opp_face = face_report(opp_split["C"], opp_split["D"])
+    one_reverse = reverse_report(one_split["A"], one_split["B"])
+    one_face = face_report(one_split["C"], one_split["D"])
+    nnseed_reverse = reverse_report(nnseed_split["A"], nnseed_split["B"])
+    nnseed_face = face_report(nnseed_split["C"], nnseed_split["D"])
+    opp_m_a = incoming_set(
+        PROBES["A"],
+        opp_ticks[PROBES["A"]] + 1,
+        opp_ticks,
+        opp_locks,
+        opp_seeds,
+    )
+    opp_o_d = outgoing_set(
+        PROBES["D"],
+        opp_ticks[PROBES["D"]] + 1,
+        opp_ticks,
+        opp_locks,
+        opp_seeds,
+    )
+    opp_m_exist_reverse = existential_opposite(
+        opp_m_a,
+        incoming_set(
+            PROBES["B"],
+            opp_ticks[PROBES["B"]] + 1,
+            opp_ticks,
+            opp_locks,
+            opp_seeds,
+        ),
+    )
+    checks.check(
+        "not-x-probes",
+        probe_sites != x_probe_sites
+        and X_PROBES["A"] == E1
+        and ticks[X_PROBES["A"]] == 2
+        and x_cover["A"] == "fail"
+        and x_split["A"] == "fail"
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and reverse == "hold"
+        and face == "fail",
+        str((x_split, x_reverse, x_face)),
+    )
+    checks.check(
+        "not-one-axis-same-lock",
+        TWO_AXIS_SAME_SEEDS != ONE_AXIS_SAME_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and one_cover["D"] == "hold"
+        and one_split["D"] == "fail"
+        and cover["D"] == "fail"
+        and split["D"] == "fail"
+        and one_reverse == "hold"
+        and one_face == "fail"
+        and n_axis_m["D"] == 1,
+    )
+    checks.check(
+        "not-nsopp-or-nnseed",
+        TWO_AXIS_SAME_SEEDS != NSOPP_SEEDS
+        and TWO_AXIS_SAME_SEEDS != NNSEED_SEEDS
+        and nsopp_cover["D"] == "hold"
+        and nsopp_split["D"] == "fail"
+        and nnseed_cover["B"] == "fail"
+        and nnseed_split["B"] == "fail"
+        and nnseed_reverse == "fail"
+        and nnseed_cover["C"] == "hold"
+        and nnseed_split["C"] == "fail"
+        and nnseed_face == "fail"
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "discriminator-vs-two-axis-opposite",
+        TWO_AXIS_SAME_SEEDS != TWO_AXIS_OPP_SEEDS
+        and seed_map[E2] == E1
+        and opp_seeds[E2] == NEG_E1
+        and seed_map[(0, 1, 1)] == E2
+        and opp_seeds[(0, 1, 1)] == NEG_E2
+        and m1["A"] == frozenset({E1})
+        and opp_m_a == frozenset({NEG_E1})
+        and o1["D"] == frozenset({E1})
+        and opp_o_d == frozenset({E1, NEG_E1})
+        and m_exist_reverse == "fail"
+        and opp_m_exist_reverse == "hold"
+        and opp_cover["D"] == "fail"
+        and opp_split["D"] == "fail"
+        and opp_reverse == "hold"
+        and opp_face == "fail"
+        and reverse == "hold"
+        and face == "fail",
+        str((opp_m_a, opp_o_d, opp_m_exist_reverse)),
+    )
+    checks.check(
+        "two-axis-same-lock-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {E1}
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and ticks[(0, 1, 1)] == 0
+        and locks[(0, 1, 1)] == {E2}
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and TWO_AXIS_SAME_SEEDS != TWO_AXIS_OPP_SEEDS
+        and TWO_AXIS_SAME_SEEDS != ONE_AXIS_SAME_SEEDS
+        and TWO_AXIS_SAME_SEEDS != NSOPP_SEEDS
+        and TWO_AXIS_SAME_SEEDS != NNSEED_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(m1["A"]) == 1
+        and len(o1["A"]) == 2
+        and len(o1["B"]) == 3
+        and len(o1["C"]) == 4
+        and reverse == "hold"
+        and face == "fail",
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Axis-cover-split",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {+e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_2, −e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1}" in note
+        and "Axis(M)(A, τ) = {e_1}" in note
+        and "Axis(O)(A, τ) = {e_2, e_3}" in note
+        and "Axis(M)(B, τ) = {e_1}" in note
+        and "Axis(O)(B, τ) = {e_2, e_3}" in note
+        and "Axis(M)(C, τ) = {e_2}" in note
+        and "Axis(O)(C, τ) = {e_1, e_3}" in note
+        and "Axis(M)(D, τ) = {e_3}" in note
+        and "Axis(O)(D, τ) = {e_1}" in note
+        and "cover(A) = hold" in note
+        and "cover(B) = hold" in note
+        and "cover(C) = hold" in note
+        and "cover(D) = fail" in note
+        and "|Axis(M)|(A, τ) = 1" in note
+        and "|Axis(M)|(B, τ) = 1" in note
+        and "|Axis(M)|(C, τ) = 1" in note
+        and "|Axis(M)|(D, τ) = 1" in note
+        and "split(A) = hold" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-split-reverse-face",
+        "Reverse 1-in 2-out at τ: hold" in note
+        and "Face 1-in 2-out at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-leftover-or-exist-opposite",
+        "not leftover-axis reverse" in normalized_note
+        and "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover of cover reverse" in normalized_note
+        and "O is not M" in note
+        and "exist-opposite of signed M fails reverse" in normalized_note
+        and "2-in 1-out is fail" in normalized_note
+        and "missing e_2" in normalized_note,
+    )
+    checks.check(
+        "note-not-star-or-occupancy",
+        "does not use a six-neighbor star" in normalized_note
+        and "does not use occupancy" in normalized_note
+        and "A is a seed" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_SAME_LOCK_YPROBE_INCOMING_OUTGOING_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "cover_report" in defined_fns
+        and "split_report" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "source-letter-from-axis-split",
+        "cover_report" in defined_fns
+        and "split_report" in defined_fns
+        and "both_hold" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and "inner_product" not in defined_fns,
+    )
+    _ = (
+        o0,
+        unique_cover_a,
+        unique_split_a,
+        nsopp_cover,
+        x_reverse,
+        one_reverse,
+        opp_reverse,
+        opp_face,
+        cover_face,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

1-in 2-out reverse HOLD face fails on two-axis same-lock y-probes. Displayed, not adopted.

## Runner

`scripts/two_axis_same_lock_yprobe_incoming_outgoing_one_two_split_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.