### PR TITLE
feat(nm2axx): axis-cover of M and O at t+1 on two-axis opposite x-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,519 @@
+---
+claim_id: two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Axis-cover of M and O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
+---
+
+# Axis-Cover Of Incoming Versus Outgoing At t+1 On Four X-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** axis-cover of `M` versus `O` at each probe's `τ=t+1` on the
+four x-probes of the two-axis opposite seed in `B_3(0)={n:n·n<=9}`. Same
+process as nm2ax, x-probes. Let `t(q)` be the formation tick of probe
+`q`. Let `τ(q)=t(q)+1`. There is no global T. `M(q,τ)` is the set of
+earliest incoming nearest-neighbor steps at `q` using only records with
+tick `<= τ`. Seeds are a singleton seed letter. `O(q,τ)` is the outgoing
+dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is
+formed and `e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty
+`O` is empty, not `UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLD at formed `q` if and only if
+`Axis(M)∩Axis(O)` is empty and `Axis(M)∪Axis(O)` equals `{e_1,e_2,e_3}`.
+Unformed at `τ` is `UNDEFINED`. Empty `O` fails cover unless `Axis(M)`
+already equals `{e_1,e_2,e_3}`. Reverse HOLD if and only if cover at `A`
+and at `B`. Face likewise on `C,D`. Mixed remains a set. Uniqueness of
+incoming or outgoing locks is not required. Occupancy `n` is not used.
+This is not named-sign lettering. This is not leftover of leftover-axis.
+This is not leftover of forall-perp. This is not leftover of
+exist-opposite of M. This is not leftover of exist-opposite of O. This
+display does not use a six-neighbor star. Displayed, not adopted. Do not
+write into Admissibility. Do not attach L1. This note does not write
+axis-cover into Admissibility and does not attach a formation member from
+already-recorded six-neighbor locks. This display does not use occupancy.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Reverse and face are scored on axis-cover of `M` versus `O` at
+that same cut. Named signs `{+,−}` are a coarser readout and are not used.
+A singleton unique lock letter is a different readout and is not used as
+the object. A `Z^3` sum of those locks is a different readout and is not
+used. Occupancy `n` is not used. A six-neighbor star is not the letter.
+O is not M.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of Axis-cover of M and O at t+1 on the four x-probes of the two-axis opposite seed, reverse fail and face fail from cover at A,B and at C,D; uniqueness of locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face
+target_blocker_text: "display Axis-cover of M and O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep Axis-cover of M and O at t+1 displayed; do not write axis-cover into Admissibility, do not reduce to leftover-axis, do not replace cover by forall-perp, do not replace cover by exist-opposite of M or of O, do not reduce to a unique letter, do not use occupancy n, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for Axis-cover of M and O at t+1 on the four x-probes of the two-axis opposite seed, reverse fail and face fail; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose own
+incoming and outgoing sets are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are the nsopp x-probes. These are not the y-probes `A=(0,1,0)`,
+`B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`. These are not the z-probes
+`A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(1,0,1)`. `A` is not a seed.
+Same process as nm2ax, x-probes.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: four records at formation tick 0, two disjoint opposite pairs.
+`L(0)=+e_1`, `L(0,1,0)=−e_1`, `L(0,0,1)=+e_2`, and `L(0,1,1)=−e_2`. The
+second pair is a new seed, not a formed child of the first pair. On the
+one-axis nsopp leftover, `(0,0,1)` forms at tick 1 and locks `+e_3`. This
+seed is not the same-lock four-site seed. This seed is not the nspar
+two-site seed `+e_1/−e_1`. This seed is not the x-axis opposite ±e_2
+two-site seed. This seed is not the x-axis opposite ±e_3 two-site seed.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named incoming set `M`, outgoing set `O`, Axis, and cover at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter. Own incoming sets are the scored incoming
+object.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy `n` is not used. O is not M.
+
+Axis of a defined lock set is the unsigned lattice direction:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover HOLD at formed `q` if and only if
+
+```text
+Axis(M(q,τ)) ∩ Axis(O(q,τ)) = empty
+Axis(M(q,τ)) ∪ Axis(O(q,τ)) = {e_1,e_2,e_3}.
+```
+
+Unformed at `τ` is `UNDEFINED`. Empty `O` fails cover unless `Axis(M)`
+already equals `{e_1,e_2,e_3}`. Overlap of axes fails even when the union
+is full. Leftover-axis `{e_1,e_2,e_3}` minus that union is comparison only:
+empty leftover with overlapping axes is not cover.
+
+Reverse HOLD if and only if cover at `A` and at `B`. Face HOLD if and only
+if cover at `C` and at `D`. If either side of that pair is `UNDEFINED`, the
+report is `UNDEFINED`. Else if either fails, the report is `fail`. The
+report is one of `hold`, `fail`, or `UNDEFINED`.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on
+axis-cover of incoming versus outgoing at the same cut. They are not
+scored on `{+,−}` names and are not an occupancy-kernel inner product.
+
+## Theorem 1 — ticks, `M`, `O`, Axis, and cover at `A,B,C,D`
+
+On this process the four x-probes form. Incoming is frozen at formation:
+`M(q,t+1)=M(q,t)` at every scored probe. Outgoing is empty at `t` for
+`A`, `B`, and `C`, then filled at `t+1`. At `D`, `O` is already `{−e_1}`
+at `t` and becomes `{+e_1, −e_1}` at `t+1`. This display reads `M` and
+`O` together at the same cut `τ=t+1` and scores Axis and cover:
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {−e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_1}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {−e_2, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+Axis(M(A, τ)) = {e_3}
+Axis(O(A, τ)) = {e_1}
+Axis(M(B, τ)) = {e_1}
+Axis(O(B, τ)) = {e_2, e_3}
+Axis(M(C, τ)) = {e_1}
+Axis(O(C, τ)) = {e_2, e_3}
+Axis(M(D, τ)) = {e_3}
+Axis(O(D, τ)) = {e_1}
+cover(A): fail
+cover(B): hold
+cover(C): hold
+cover(D): fail
+```
+
+`A` is not a seed. `A` is the site `(1,0,0)` forming at tick 2 with
+incoming `{−e_3}`. Mixed remains a set: `O(B,τ)` has three outgoing
+steps, `O(C,τ)` has three outgoing steps, and `O(D,τ)` has two outgoing
+steps on one axis. Unique letters would assign `UNDEFINED` at those mixed
+outgoing sets and would leave reverse and face `UNDEFINED`. Here
+uniqueness is not required. `M` and `O` are disjoint at each of the four
+probes at `τ`. O is not M. Cover holds at `B` and at `C` because the Axis
+sets are complementary partitions of `{e_1,e_2,e_3}`. Cover fails at `A`
+and at `D` because `Axis(M)∪Axis(O)={e_1,e_3}` misses `e_2`.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+At `t`, `O(A,t)`, `O(B,t)`, and `O(C,t)` are empty, so cover at those
+probes fails at `t` because the union is not `{e_1,e_2,e_3}`. Reverse at
+`t` is `fail`. That empty-at-`t` leftover is not this display. Forall-perp
+at those probes is `UNDEFINED` at `t` from empty `O`, so empty-at-`t`
+already splits cover from forall-perp. At `τ`, forall-perp HOLDs at `A`
+because `{−e_3}` is orthogonal to `{+e_1}`, while cover FAILs at `A`
+because leftover-axis is `{e_2}`. Leftover-axis leftover of `M` and `O`
+at `τ` is `{e_2}` at `A` and empty at `B`; leftover-axis reverse fails
+from empty leftover at `B` while cover HOLDs at `B`. On the nspar leftover,
+Axis of `M(B)` and `O(B)` overlap, leftover is empty, and cover FAILs at
+`B`. Exist-opposite of `M(B)` against `O(B)` fails while cover at `B`
+holds. Y-probes on this same seed report reverse hold and face fail; this
+display scores the x-probes.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse HOLD if and only if cover at `A` and at `B`. Cover fails at `A`
+and HOLDs at `B`. Reverse fails. Both sides are nonempty and defined, so
+this is not `UNDEFINED`. This is not `hold`.
+
+Reverse: fail
+
+Reverse fails. Unique-letter leftover reports reverse `UNDEFINED` from
+mixed `O(B,τ)`. Leftover-axis leftover reports reverse `fail` from empty
+leftover at `B`, but cover HOLDs at `B`; reverse fails here because cover
+fails at `A`. Forall-perp leftover reports reverse hold from orthogonal
+pairs at `A` and at `B` while cover reverse fails. Exist-opposite of `M`
+leftover reports reverse fail from `{−e_3}` against `{+e_1}` and never
+reads `O`. Exist-opposite of `O` leftover reports reverse fail from
+`{+e_1}` against `{+e_2, +e_3, −e_3}`. Reverse HOLD uses cover at `A` and
+at `B`.
+
+Reverse fails.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face HOLD if and only if cover at `C` and at `D`. Cover HOLDs at `C` and
+fails at `D`. Face fails. Mixed `O(D,τ)` remains a two-element set and
+`Axis(M(D,τ))={e_3}` against `Axis(O(D,τ))={e_1}` misses `e_2`.
+
+Face: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `hold` and not `UNDEFINED`. Face fails. Unique-letter leftover
+reports face `UNDEFINED` from mixed `O(C,τ)` and mixed `O(D,τ)`.
+Leftover-axis leftover reports face `fail` from empty leftover at `C`
+while cover HOLDs at `C`; face fails here because cover fails at `D`.
+Forall-perp leftover reports face hold. Exist-opposite of `M` leftover
+reports face fail from `{+e_1}` against `{−e_3}` inside incoming sets, not
+axis-cover of `M` versus `O`. Face already fails at `τ=t+1` from cover at
+`C` and at `D`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming or outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require either set to be a singleton.
+- It does not sum either set.
+- It does not replace `O` by `M`.
+- It does not replace either set by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint leftover-axis as the scored predicate.
+- It does not reprint forall-perp as the scored predicate.
+- It does not reprint exist-opposite of `M` as this display.
+- It does not reprint exist-opposite of `O` as this display.
+- It does not use occupancy `n`.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite four-site process, the own incoming and outgoing sets
+at `t+1`, the Axis sets, and the axis-cover reverse/face bits are
+displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; outgoing dual |
+| `Axis(M)` and `Axis(O)` at each probe | Theorem 1; complementary at `B,C`; leftover `{e_2}` at `A,D` |
+| cover at `A,B,C,D` | Theorem 1; `fail`, `hold`, `hold`, `fail` |
+| reverse and face from cover | Theorems 2–3; `fail` / `fail` |
+| unique incoming or outgoing lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| occupancy-kernel inner product | not used |
+| leftover of leftover-axis | not this display; empty leftover at `B` fails leftover-axis reverse while cover HOLDs at `B` |
+| leftover of forall-perp | not this display; forall-perp reverse HOLDs while cover reverse fails |
+| leftover of exist-opposite of M | not this display |
+| leftover of exist-opposite of O | not this display |
+| six-neighbor star as the letter | not used |
+| axis-cover as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the probe-direction discriminator: Axis-cover of `M` and `O` at `t+1` on the four x-probes of the two-axis opposite seed, and reverse/face from that. |
+| V2 | Current main has no landed Axis-cover of `M` and `O` reverse/face report on these four x-probes of the two-axis opposite seed. |
+| V3 | Incoming sets, outgoing sets, Axis sets, cover bits, and the `fail`/`fail` reports are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads own incoming and own outgoing at the same `t+1` cut and scores disjoint full Axis cover. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique letter, does not replace `O` by `M`, does not replace cover by
+leftover-axis, does not replace cover by forall-perp, does not replace
+cover by exist-opposite of `M` or of `O`, does not use a six-neighbor
+star, and does not use occupancy `n`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| leftover-axis | score equality of nonempty `{e_1,e_2,e_3}` minus `Axis(M)∪Axis(O)` | leftover is empty at `B` so leftover-axis reverse fails while cover HOLDs at `B`; reverse fails here from cover fail at `A` | ATTEMPTED |
+| union-only leftover | score leftover empty, ignore `Axis(M)∩Axis(O)` | nspar `B` leftover is empty while axes overlap, so cover FAILs at `B` | ATTEMPTED |
+| forall-perp | score every pair `m·o=0` | leftover; forall-perp reverse HOLDs while cover reverse fails because leftover at `A` is `{e_2}` | ATTEMPTED |
+| exist-opposite of M | score `a+b=0` inside `M(A)` and `M(B)` | leftover; that readout never reads `O`; exist-opposite of `M(B)` against `O(B)` fails while cover at `B` holds | ATTEMPTED |
+| exist-opposite of O | score `a+b=0` inside `O(A)` and `O(B)` | leftover; that readout never reads `M` | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(B,τ)`, `O(C,τ)`, and `O(D,τ)` remain sets; unique-letter reverse and face are `UNDEFINED` | ATTEMPTED |
+| empty `O` at `t` | score cover at formation tick | `O(A,t)` is empty so reverse at `t` is `fail`; this cut is `τ=t+1` | ATTEMPTED |
+| y-probes on the same process | score `A=(0,1,0)`, `C=(0,2,0)` | leftover; y-probe reverse HOLDs while x-probe reverse fails; `M(A)` there is `{−e_1}`, not `{−e_3}` | ATTEMPTED |
+| z-probes on the same process | score `A=(0,0,1)`, `C=(0,0,2)` | leftover; z-probe reverse and face HOLD; `M(A)` is `{+e_2}`, not `{−e_3}` | ATTEMPTED |
+| one-axis nsopp on these x-probes | drop the second opposite pair | leftover; nsopp reverse HOLDs and face HOLDs; `M(A)` is mixed `{+e_2, +e_3, −e_3}`, not `{−e_3}` | ATTEMPTED |
+| same-lock four-site on these x-probes | replace opposite second letters | leftover; `O(D)` is `{+e_1}`, not `{+e_1, −e_1}` | ATTEMPTED |
+| nspar `+e_1/−e_1` on these x-probes | replace the opposite seed | leftover; cover FAILs at `B` and reverse fails | ATTEMPTED |
+| x-axis opposite ±e_2 on these x-probes | replace the seed | leftover; `M(A)` is `{−e_2}`, not `{−e_3}`; reverse HOLDs | ATTEMPTED |
+| x-axis opposite ±e_3 on these x-probes | replace the seed | leftover; `A` is a seed and reverse HOLDs | ATTEMPTED |
+| sum of a set | replace each set by its `Z^3` sum | the construction does not sum; sum of mixed `O(D,τ)` cancels to `0` while the set stays two-element | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| occupancy-kernel inner product | score `n(A)·n(B)<0` | different object; not an occupancy-kernel inner product | ATTEMPTED |
+| six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | this display does not use a six-neighbor star | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by axis-cover | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of cover with leftover-axis,
+missing identification of cover with forall-perp, missing identification of
+cover with exist-opposite of `M` or of `O`, and missing Record identification
+of axis-cover are distinct open premises. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, four-site two-axis opposite seed locks `+e_1`, `−e_1`,
+`+e_2`, and `−e_2`, perpendicular step rule, incoming-step lock, own
+incoming set and own outgoing dual from records with tick `<= τ`,
+per-probe `τ=t+1`, Axis of signed locks, cover as disjoint full union of
+`{e_1,e_2,e_3}`, four x-probes with `A` not a seed, empty or `UNDEFINED`
+as declared, and mixed remains a set are declared. No uniqueness of
+locks, no six-neighbor star as the scored object, no leftover-axis as the
+scored predicate, no forall-perp as the scored predicate, no
+exist-opposite of `M` or of `O` as the scored predicate, no global later T,
+no formation attachment from already-recorded six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+cover `fail`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each earliest incoming or outgoing nearest-neighbor step | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four incoming sets, four outgoing sets, Axis, cover, reverse/face | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for axis-cover reverse/face,
+a formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Axis-cover of `M` versus `O` is only leftover-axis because
+leftover at `A` is `{e_2}`; it is only forall-perp because every pair at
+`τ` dots to zero and forall-perp reverse HOLDs; it is only the y-probe
+cover because the seed is the same; mixed `O(B)` should make reverse
+`UNDEFINED`; empty `O` at `t` should make reverse `UNDEFINED`; and one-axis
+nsopp x-probes already HOLD.
+
+**Answer:** Leftover-axis reverse fails from empty leftover at `B` while
+cover HOLDs at `B`. Reverse fails here because cover fails at `A`, where
+the union misses `e_2`. Union-only leftover is not cover: nspar `B`
+leftover is empty while `Axis(M)` and `Axis(O)` overlap, so cover FAILs at
+`B`. Forall-perp is comparison only. Forall-perp HOLDs at `A` from
+`{−e_3}·{+e_1}=0` while cover FAILs at `A`. Y-probes are a different
+four-tuple; reverse HOLDs there and fails here. Mixed `O(B,τ)` remains
+`{+e_2, +e_3, −e_3}` and reverse is `fail`, not `UNDEFINED`. Empty `O` at
+`t` makes reverse `fail` at that leftover cut; this display scores
+`τ=t+1`. One-axis nsopp is a different seed: `(0,0,1)` is a formed child
+locking `+e_3`, not a seed locking `+e_2`.
+
+### N8 — cross-cycle echo
+
+nm2ax reported axis-cover of `M` versus `O` on the four y-probes of this
+same two-axis opposite seed. That leftover is not this x-probe display:
+y-probe reverse HOLDs and face fails, while these x-probes report reverse
+fail and face fail. One-axis nsopp x-probe axis-cover reverse HOLDs. This
+note is the probe-direction discriminator: Axis-cover of `M` versus `O` at
+`τ=t+1` on the four x-probes of the two-axis opposite seed, leftover
+`{e_2}` at `A` and at `D`, reverse fail, and face fail.
+
+**Gate disposition:** PASS for the Axis-cover of `M` vs `O` at `t+1`
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals the
+named sign,” “the predicate equals the unique singleton lock vector,” “the
+predicate equals leftover-axis,” “the predicate equals forall-perp,” “the
+predicate equals exist-opposite of `M`,” “the predicate equals exist-opposite
+of `O`,” “bits are Admissibility,” “cover holds at `A`,” “reverse holds,”
+“face is `UNDEFINED`,” or “`O` is `M`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports Axis sets and cover at `A,B,C,D`, lists new records in `B_3(0)`
+between `t` and `t+1` that meet a probe's six-neighbors, and checks
+Theorems 1--3. It also checks that `M` is frozen from `t` to `t+1`, that
+`O` is empty at `t` for `A`, `B`, and `C` so cover fails at that leftover
+cut, that mixed sets remain sets, that unique-letter reverse and face are
+`UNDEFINED`, that leftover-axis reverse fails from empty leftover at `B`
+while cover HOLDs at `B`, that forall-perp reverse HOLDs while cover
+reverse fails, that exist-opposite of `M` against `O` fails at `B` while
+cover holds, that the construction does not sum, that a formation member
+from already-recorded six-neighbor locks is not attached, that y-probe
+reverse HOLDs on this same seed, and that nsopp reverse HOLDs. No runner
+cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18641,6 +18641,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
+runner_sha256: d8b0b3c217b721cba4df2858e27e35750def7edb75820307761db31779dc1fbc
+input_fingerprint_sha256: d1f0ddeda63ec616ed1f3ba30782ff0e20695a1ecf7453c1ccda34c8595b862b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+axis-cover of M and O at t+1 on two-axis opposite x-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Axis-cover of M and O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: axis-cover-identity
+PASS: axis-set-identity
+PASS: pair-status-identity
+A t=2 M={−e_3} O={+e_1} Axis(M)={e_3} Axis(O)={e_1} cover=fail
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} cover=hold
+C t=3 M={+e_1} O={−e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} cover=hold
+D t=2 M={−e_3} O={+e_1, −e_1} Axis(M)={e_3} Axis(O)={e_1} cover=fail
+reverse=fail face=fail
+per_element: each earliest incoming or outgoing nearest-neighbor step at a probe, read from the record prefix at that probe's t+1
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four incoming sets, four outgoing sets, Axis of each, cover at each probe, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_3}', 'B': '{+e_1}', 'C': '{+e_1}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_1}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{−e_2, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-Axis-M-and-O  ({'A': ('{e_3}', '{e_1}'), 'B': ('{e_1}', '{e_2, e_3}'), 'C': ('{e_1}', '{e_2, e_3}'), 'D': ('{e_3}', '{e_1}')})
+PASS: theorem1-cover-bits  ({'A': 'fail', 'B': 'hold', 'C': 'hold', 'D': 'fail'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-O-empty-at-t-then-filled
+PASS: theorem1-new-records-meet-6nn  ({'A': ((2, 0, 0),), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((2, -1, 0), (2, 0, 1), (2, 0, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-not-seed
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-fail  (fail)
+PASS: O-is-not-M
+PASS: mutation-unique-letter-undefined
+PASS: mutation-leftover-axis-empty-fails
+PASS: mutation-forall-perp-hold-not-this-predicate
+PASS: mutation-exist-opposite-of-M-or-O-not-this-predicate
+PASS: mutation-empty-or-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: not-nnlock-named-sign
+PASS: not-y-or-z-probes-or-nsopp-or-same-lock-or-nspar-or-opp-e3
+PASS: uniqueness-not-required
+PASS: four-site-two-axis-opposite-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-ticks-M-O-Axis-cover
+PASS: note-reports-new-neighbors
+PASS: note-reports-fail-fail
+PASS: note-displayed-not-adopted
+PASS: note-does-not-use-occupancy
+PASS: note-not-sign-lettering
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-attach-formation-member
+PASS: note-not-leftover-axis-or-forall-perp-or-exist-opposite
+PASS: note-no-six-neighbor-star-as-letter
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+TOTAL: PASS=59 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1193 @@
+#!/usr/bin/env python3
+"""Axis-cover of M and O at t+1 on four x-probes of the two-axis opposite seed.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites, two disjoint opposite pairs: origin locks +e_1, (0,1,0)
+locks -e_1, (0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process as nm2ax,
+x-probes. The second pair is a new seed, not a formed child of the first
+pair. A 6-NN step is allowed iff it is perpendicular to the parent lock
+axis. Newly formed sites lock the incoming step. Seeds keep their seed
+letters as a singleton. t(q) is the formation tick. tau = t+1. M(q, tau)
+is the set of earliest incoming nearest-neighbor steps at q using only
+records with tick <= tau. Unformed at tau => UNDEFINED. O(q, tau) is the
+outgoing dual of M: the set of e in {±e_1,±e_2,±e_3} such that q+e is
+formed and e is in M(q+e, tau). Unformed q at tau => UNDEFINED. Empty O is
+empty, not UNDEFINED. O is not M. Axis(S) = {e_i | some ±e_i in S}. Cover
+HOLD at q iff Axis(M) intersect Axis(O) is empty and Axis(M) union Axis(O)
+equals {e_1,e_2,e_3}. Unformed at tau => UNDEFINED. Empty O fails cover
+unless Axis(M) already equals {e_1,e_2,e_3}. Reverse HOLD iff cover at A
+and at B. Face likewise on C, D. Uniqueness of locks is not required. No
+unique P_+. Occupancy n is not used. Named-sign lettering is not used. No
+larger host. No six-neighbor star. Displayed, not adopted. Do not attach
+L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+FOUR_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    ((0, 1, 1), NEG_E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    ((0, 1, 1), E2),
+)
+NSOPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+XE2_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, NEG_E2),
+)
+NSPAR_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E1, NEG_E1),
+)
+OPPOSITE_E3_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E3),
+    (E1, NEG_E3),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Axis-cover of M and O at t+1 on the four x-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = FOUR_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Lx = {e_1,e_2,e_3} minus (Axis(M) union Axis(O)). Unformed => UNDEFINED."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff Axis(M) and Axis(O) are disjoint and their union is {e_1,e_2,e_3}.
+
+    Unformed => UNDEFINED. Empty leftover with overlapping axes fails.
+    Empty O fails unless Axis(M) already equals {e_1,e_2,e_3}.
+    """
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if (axes_m | axes_o) == frozenset(AXES):
+        return "hold"
+    return "fail"
+
+
+def leftover_equal(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-axis leftover: HOLD iff both defined, nonempty, and equal."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    return "hold" if left == right else "fail"
+
+
+def forall_perp(left: Incoming, right: Incoming) -> str:
+    """Comparison leftover: HOLD iff every m in M and o in O have m·o = 0."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for m in left:
+        for o in right:
+            if dot(m, o) != 0:
+                return "fail"
+    return "hold"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Leftover: HOLD iff some lock in left is the vector opposite of some in right."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def pair_status(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(status_a: str, status_b: str) -> str:
+    """Reverse HOLD iff cover at A and at B."""
+    return pair_status(status_a, status_b)
+
+
+def face_report(status_c: str, status_d: str) -> str:
+    """Face HOLD iff cover at C and at D."""
+    return pair_status(status_c, status_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def named_sign(lock: Point) -> str:
+    if lock in (E1, E2, E3):
+        return "+"
+    if lock in (NEG_E1, NEG_E2, NEG_E3):
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("axis-cover of M and O at t+1 on two-axis opposite x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E1, E1) != ZERO
+        and add(E2, E2) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    set_a = frozenset({NEG_E3})
+    set_a_o = frozenset({E1})
+    set_b = frozenset({E1})
+    set_b_o = frozenset({E2, E3, NEG_E3})
+    mixed_nspar_b_m = frozenset({E2, E3})
+    mixed_nspar_b_o = frozenset({E1, E2, E3})
+    missing_axis = frozenset({E1})
+    checks.check(
+        "axis-cover-identity",
+        axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_cover(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_cover(frozenset(), frozenset({E1})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset()) == "fail"
+        and axis_cover(frozenset(), frozenset()) == "fail"
+        and axis_cover(set_a, set_a_o) == "fail"
+        and axis_cover(set_b, set_b_o) == "hold"
+        and axis_cover(mixed_nspar_b_m, mixed_nspar_b_o) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1})) == "fail"
+        and axis_cover(frozenset({E2}), missing_axis) == "fail"
+        and leftover_axis(set_a, set_a_o) == frozenset({E2})
+        and leftover_axis(set_b, set_b_o) == frozenset()
+        and leftover_axis(mixed_nspar_b_m, mixed_nspar_b_o) == frozenset()
+        and leftover_axis(frozenset({E2}), missing_axis) == frozenset({E3}),
+    )
+    checks.check(
+        "axis-set-identity",
+        axis_set(UNDEFINED) == UNDEFINED
+        and axis_set(frozenset()) == frozenset()
+        and axis_set(frozenset({NEG_E3})) == frozenset({E3})
+        and axis_set(frozenset({E1, NEG_E1, E3})) == frozenset({E1, E3})
+        and axis_set(frozenset({E2, NEG_E2})) == frozenset({E2}),
+    )
+    checks.check(
+        "pair-status-identity",
+        pair_status(UNDEFINED, "hold") == UNDEFINED
+        and pair_status("hold", UNDEFINED) == UNDEFINED
+        and pair_status("hold", "hold") == "hold"
+        and pair_status("hold", "fail") == "fail"
+        and pair_status("fail", "hold") == "fail"
+        and pair_status("fail", "fail") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    nsopp_ticks, nsopp_locks, nsopp_seeds = form(NSOPP_SEEDS)
+    xe2_ticks, xe2_locks, xe2_seeds = form(XE2_SEEDS)
+    nspar_ticks, nspar_locks, nspar_seeds = form(NSPAR_SEEDS)
+    opp_e3_ticks, opp_e3_locks, opp_e3_seeds = form(OPPOSITE_E3_SEEDS)
+
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    ax_m: dict[str, AxisSet] = {}
+    ax_o: dict[str, AxisSet] = {}
+    cover0: dict[str, str] = {}
+    cover1: dict[str, str] = {}
+    leftover1: dict[str, AxisSet] = {}
+    fp0: dict[str, str] = {}
+    fp1: dict[str, str] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        ax_m[name] = axis_set(m1[name])
+        ax_o[name] = axis_set(o1[name])
+        cover0[name] = axis_cover(m0[name], o0[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        leftover1[name] = leftover_axis(m1[name], o1[name])
+        fp0[name] = forall_perp(m0[name], o0[name])
+        fp1[name] = forall_perp(m1[name], o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"Axis(M)={axis_display(ax_m[name])} "
+            f"Axis(O)={axis_display(ax_o[name])} "
+            f"cover={cover1[name]}"
+        )
+
+    reverse_status = reverse_report(cover1["A"], cover1["B"])
+    face_status = face_report(cover1["C"], cover1["D"])
+    reverse0 = reverse_report(cover0["A"], cover0["B"])
+    face0 = face_report(cover0["C"], cover0["D"])
+    leftover_reverse = leftover_equal(leftover1["A"], leftover1["B"])
+    leftover_face = leftover_equal(leftover1["C"], leftover1["D"])
+    fp_reverse = reverse_report(fp1["A"], fp1["B"])
+    fp_face = face_report(fp1["C"], fp1["D"])
+    m_opp_reverse = existential_opposite(m1["A"], m1["B"])
+    m_opp_face = existential_opposite(m1["C"], m1["D"])
+    o_opp_reverse = existential_opposite(o1["A"], o1["B"])
+    o_opp_face = existential_opposite(o1["C"], o1["D"])
+    unique_cover_reverse = reverse_report(
+        axis_cover(unique_letter(m1["A"]), unique_letter(o1["A"])),
+        axis_cover(unique_letter(m1["B"]), unique_letter(o1["B"])),
+    )
+    unique_cover_face = face_report(
+        axis_cover(unique_letter(m1["C"]), unique_letter(o1["C"])),
+        axis_cover(unique_letter(m1["D"]), unique_letter(o1["D"])),
+    )
+    print(f"reverse={reverse_status} face={face_status}")
+    print(
+        "per_element: each earliest incoming or outgoing nearest-neighbor step "
+        "at a probe, read from the record prefix at that probe's t+1"
+    )
+    print(
+        "per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four incoming sets, four outgoing sets, Axis of each, "
+        "cover at each probe, reverse/face from those bits"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["C"], 2, ticks, locks, seed_map) == UNDEFINED
+        and axis_cover(
+            incoming_set(PROBES["A"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["A"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E3})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E1})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({NEG_E2, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Axis-M-and-O",
+        ax_m["A"] == frozenset({E3})
+        and ax_o["A"] == frozenset({E1})
+        and ax_m["B"] == frozenset({E1})
+        and ax_o["B"] == frozenset({E2, E3})
+        and ax_m["C"] == frozenset({E1})
+        and ax_o["C"] == frozenset({E2, E3})
+        and ax_m["D"] == frozenset({E3})
+        and ax_o["D"] == frozenset({E1})
+        and leftover1["A"] == frozenset({E2})
+        and leftover1["B"] == frozenset()
+        and leftover1["C"] == frozenset()
+        and leftover1["D"] == frozenset({E2}),
+        str(
+            {
+                name: (axis_display(ax_m[name]), axis_display(ax_o[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-cover-bits",
+        cover1["A"] == "fail"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "fail",
+        str(cover1),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-O-empty-at-t-then-filled",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and cover0["A"] == "fail"
+        and cover0["B"] == "fail"
+        and cover0["C"] == "fail"
+        and cover0["D"] == "fail"
+        and reverse0 == "fail"
+        and face0 == "fail"
+        and fp0["A"] == UNDEFINED
+        and fp0["B"] == UNDEFINED
+        and fp0["C"] == UNDEFINED
+        and fp0["D"] == "hold",
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0),)
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(o1["D"], frozenset)
+        and len(o1["D"]) == 2
+        and unique_letter(o1["D"]) == UNDEFINED
+        and isinstance(o1["C"], frozenset)
+        and len(o1["C"]) == 3
+        and o1["B"] != UNDEFINED
+        and cover1["B"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and E1 not in seed_map
+        and ticks[E1] == 2
+        and locks[E1] == {NEG_E3}
+        and m1["A"] == frozenset({NEG_E3})
+        and Y_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse_status == "fail"
+        and cover1["A"] == "fail"
+        and cover1["B"] == "hold"
+        and reverse_status != "hold"
+        and reverse_status != UNDEFINED,
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face_status == "fail"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "fail"
+        and face_status != "hold"
+        and face_status != UNDEFINED,
+        face_status,
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E3 in m1["A"]
+        and NEG_E3 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and m1["A"].isdisjoint(o1["A"])
+        and m1["B"].isdisjoint(o1["B"])
+        and m1["C"].isdisjoint(o1["C"])
+        and m1["D"].isdisjoint(o1["D"]),
+    )
+    checks.check(
+        "mutation-unique-letter-undefined",
+        unique_cover_reverse == UNDEFINED
+        and unique_cover_face == UNDEFINED
+        and reverse_status == "fail"
+        and face_status == "fail"
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-leftover-axis-empty-fails",
+        leftover1["A"] == frozenset({E2})
+        and leftover1["B"] == frozenset()
+        and leftover1["C"] == frozenset()
+        and leftover1["D"] == frozenset({E2})
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and reverse_status == "fail",
+    )
+    checks.check(
+        "mutation-forall-perp-hold-not-this-predicate",
+        fp_reverse == "hold"
+        and fp_face == "hold"
+        and fp0["A"] == UNDEFINED
+        and cover0["A"] == "fail"
+        and reverse0 == "fail"
+        and reverse_status == "fail"
+        and cover1["A"] == "fail"
+        and fp1["A"] == "hold",
+    )
+    checks.check(
+        "mutation-exist-opposite-of-M-or-O-not-this-predicate",
+        m_opp_reverse == "fail"
+        and m_opp_face == "fail"
+        and o_opp_reverse == "fail"
+        and o_opp_face == "fail"
+        and reverse_status == "fail"
+        and face_status == "fail"
+        and axis_cover(m1["B"], o1["B"]) == "hold"
+        and existential_opposite(m1["B"], o1["B"]) == "fail",
+    )
+    checks.check(
+        "mutation-empty-or-undefined",
+        axis_cover(frozenset(), o1["A"]) == "fail"
+        and axis_cover(m1["A"], frozenset()) == "fail"
+        and reverse_report(UNDEFINED, "hold") == UNDEFINED
+        and reverse0 == "fail"
+        and reverse_status == "fail",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["D"], frozenset)
+        and isinstance(o1["B"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E3
+        and sum_of_set(m1["B"]) == E1
+        and sum_of_set(m1["C"]) == E1
+        and sum_of_set(m1["D"]) == NEG_E3
+        and sum_of_set(o1["A"]) == E1
+        and sum_of_set(o1["D"]) == ZERO
+        and o1["D"] != frozenset()
+        and o1["B"] != frozenset({E2}),
+    )
+    checks.check(
+        "not-nnlock-named-sign",
+        m1["A"] == frozenset({NEG_E3})
+        and named_sign(NEG_E3) == "-"
+        and named_sign(E1) == "+"
+        and m1["B"] == frozenset({E1})
+        and m1["A"] != named_sign(NEG_E3)
+        and axis_cover(m1["A"], o1["A"]) != named_sign(NEG_E3),
+    )
+
+    def probe_cover(
+        probe_map: dict[str, Point],
+        ticks_map: dict[Point, int],
+        locks_map: dict[Point, set[Point]],
+        seed_map_local: dict[Point, Point],
+    ) -> tuple[dict[str, Incoming], dict[str, Outgoing], dict[str, str]]:
+        incoming: dict[str, Incoming] = {}
+        outgoing: dict[str, Outgoing] = {}
+        status: dict[str, str] = {}
+        for name in ("A", "B", "C", "D"):
+            site = probe_map[name]
+            tau = ticks_map[site] + 1
+            incoming[name] = incoming_set(
+                site, tau, ticks_map, locks_map, seed_map_local
+            )
+            outgoing[name] = outgoing_set(
+                site, tau, ticks_map, locks_map, seed_map_local
+            )
+            status[name] = axis_cover(incoming[name], outgoing[name])
+        return incoming, outgoing, status
+
+    y_m, y_o, y_cover = probe_cover(Y_PROBES, ticks, locks, seed_map)
+    z_m, z_o, z_cover = probe_cover(Z_PROBES, ticks, locks, seed_map)
+    same_m, same_o, same_cover = probe_cover(
+        PROBES, same_ticks, same_locks, same_seeds
+    )
+    nsopp_m, nsopp_o, nsopp_cover = probe_cover(
+        PROBES, nsopp_ticks, nsopp_locks, nsopp_seeds
+    )
+    xe2_m, xe2_o, xe2_cover = probe_cover(PROBES, xe2_ticks, xe2_locks, xe2_seeds)
+    nspar_m, nspar_o, nspar_cover = probe_cover(
+        PROBES, nspar_ticks, nspar_locks, nspar_seeds
+    )
+    opp_m, opp_o, opp_cover = probe_cover(
+        PROBES, opp_e3_ticks, opp_e3_locks, opp_e3_seeds
+    )
+    y_reverse = reverse_report(y_cover["A"], y_cover["B"])
+    y_face = face_report(y_cover["C"], y_cover["D"])
+    z_reverse = reverse_report(z_cover["A"], z_cover["B"])
+    z_face = face_report(z_cover["C"], z_cover["D"])
+    nsopp_reverse = reverse_report(nsopp_cover["A"], nsopp_cover["B"])
+    nsopp_face = face_report(nsopp_cover["C"], nsopp_cover["D"])
+    nspar_reverse = reverse_report(nspar_cover["A"], nspar_cover["B"])
+    nspar_face = face_report(nspar_cover["C"], nspar_cover["D"])
+    checks.check(
+        "not-y-or-z-probes-or-nsopp-or-same-lock-or-nspar-or-opp-e3",
+        FOUR_SITE_SEEDS != SAME_LOCK_SEEDS
+        and FOUR_SITE_SEEDS != NSOPP_SEEDS
+        and FOUR_SITE_SEEDS != XE2_SEEDS
+        and FOUR_SITE_SEEDS != NSPAR_SEEDS
+        and FOUR_SITE_SEEDS != OPPOSITE_E3_SEEDS
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites
+        and y_m["A"] != m1["A"]
+        and y_o["A"] != o1["A"]
+        and z_m["A"] != m1["A"]
+        and same_o["D"] != o1["D"]
+        and nsopp_m["A"] != m1["A"]
+        and xe2_m["A"] != m1["A"]
+        and nspar_m["A"] != m1["A"]
+        and opp_o["A"] != o1["A"]
+        and y_reverse == "hold"
+        and y_face == "fail"
+        and z_reverse == "hold"
+        and z_face == "hold"
+        and nsopp_reverse == "hold"
+        and nsopp_face == "hold"
+        and nspar_cover["B"] == "fail"
+        and leftover_axis(nspar_m["B"], nspar_o["B"]) == frozenset()
+        and nspar_reverse == "fail"
+        and nspar_face == "hold"
+        and reverse_status == "fail"
+        and face_status == "fail"
+        and same_cover["A"] == "fail"
+        and xe2_cover["A"] == "hold"
+        and opp_cover["A"] == "hold",
+    )
+    checks.check(
+        "uniqueness-not-required",
+        isinstance(m1["A"], frozenset)
+        and len(m1["A"]) == 1
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and isinstance(o1["D"], frozenset)
+        and len(o1["D"]) == 2
+        and reverse_status == "fail"
+        and face_status == "fail",
+    )
+    checks.check(
+        "four-site-two-axis-opposite-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and ticks[(0, 1, 1)] == 0
+        and locks[(0, 1, 1)] == {NEG_E2}
+        and add(E1, NEG_E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and nsopp_ticks[E3] == 1
+        and nsopp_locks[E3] == {E3}
+        and FOUR_SITE_SEEDS != NSOPP_SEEDS
+        and FOUR_SITE_SEEDS != SAME_LOCK_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-M-O-Axis-cover",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_1}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {−e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "Axis(M(A, τ)) = {e_3}" in note
+        and "Axis(O(A, τ)) = {e_1}" in note
+        and "Axis(M(B, τ)) = {e_1}" in note
+        and "Axis(O(B, τ)) = {e_2, e_3}" in note
+        and "Axis(M(C, τ)) = {e_1}" in note
+        and "Axis(O(C, τ)) = {e_2, e_3}" in note
+        and "Axis(M(D, τ)) = {e_3}" in note
+        and "Axis(O(D, τ)) = {e_1}" in note
+        and "cover(A): fail" in note
+        and "cover(B): hold" in note
+        and "cover(C): hold" in note
+        and "cover(D): fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (2, 0, 0)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-fail-fail",
+        "Reverse: fail" in note
+        and "Face: fail" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "does not use occupancy" in normalized_note
+        and "mixed remains a set" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-leftover-axis-or-forall-perp-or-exist-opposite",
+        "not leftover of leftover-axis" in normalized_note
+        and "not leftover of forall-perp" in normalized_note
+        and "not leftover of exist-opposite of M" in normalized_note
+        and "not leftover of exist-opposite of O" in normalized_note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-no-six-neighbor-star-as-letter",
+        "does not use a six-neighbor star" in normalized_note
+        and "own incoming" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_AXIS_COVER_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "axis_cover" in defined_fns
+        and "leftover_axis" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two-axis opposite x-probe cover reverse fails face fails. Probe-direction discriminator. Displayed, not adopted.

## Runner

`scripts/two_axis_opposite_xprobe_incoming_outgoing_axis_cover_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.