### PR TITLE
feat(nm2axpx): forall-orthogonal M vs O at t+1 on two-axis opposite x-probes: reverse HOLD, face HOLD

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,548 @@
+---
+claim_id: two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Forall-orthogonal M vs O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+---
+
+# Forall-Orthogonal Incoming Versus Outgoing Reverse And Face At t+1 On Four X-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** forall-orthogonal of earliest incoming set `M` versus outgoing dual
+`O` at each probe's `τ=t+1`, and reverse/face from that predicate, on the
+four x-probes of the two-axis opposite seed in `B_3(0)={n:n·n<=9}`, no
+global T. Same process and x-probes as nm2axx. Let `t(q)` be the formation
+tick of probe `q`. Let `τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest
+incoming nearest-neighbor steps at `q` using only records with tick `<= τ`.
+Seeds are a singleton seed letter. `O(q,τ)` is the outgoing dual of `M`:
+the set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is
+in `M(q+e,τ)`. Unformed is `UNDEFINED`. Forall-perp HOLD if and only if
+every `m` in `M` and every `o` in `O` have integer dot `m·o=0`. Empty or
+`UNDEFINED` is `UNDEFINED`. Exist-perp (some pair dots to 0) is comparison
+only. Reverse HOLD if and only if forall-perp holds at `A` and at `B`. Face
+on `C,D`. This is the first forall-orthogonal display of `M` versus `O` at
+`t+1` on the nm2axx cover-FAIL x-probe direction of the two-axis opposite
+seed. nm2axx cover reverse FAIL face FAIL (union misses e_2 at `A` and at
+`D`; axes still disjoint). Same split as nmpfail on the one-axis member:
+cover reverse FAIL face FAIL, forall-perp reverse HOLD face HOLD. This is
+not leftover of nm2axx cover. This is not leftover of exist-perp. This is
+not leftover of empty intersection. This is not leftover of exist-opposite.
+Uniqueness of incoming or outgoing locks is not required. Mixed remains a
+set. Occupancy `n` is not used. O is not M. Displayed, not adopted. Do not
+write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Reverse and face are scored on forall-orthogonal of `M` versus `O`
+at that same cut. Named signs `{+,−}` are a coarser readout and are not
+used. A singleton unique lock letter is a different readout and is not used
+as the object. A `Z^3` sum of those locks is a different readout and is not
+used. Occupancy `n` is not used. This display does not use occupancy. A
+six-neighbor star is not the letter. Exist-opposite of `M` with `M` or of
+`O` with `O` is a different predicate and is leftover. nm2axx axis-cover is
+a different leftover readout.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of forall-orthogonal M versus O at t+1 on the four x-probes of the two-axis opposite seed, integer dots all zero, reverse hold from forall-perp at A and B, face hold from forall-perp at C and D; uniqueness of locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face
+target_blocker_text: "display forall m in M, o in O have m·o=0 at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, not nm2axx cover leftover"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep forall-orthogonal M versus O at t+1 displayed; do not write forall-perp into Admissibility, do not reduce to nm2axx cover leftover, do not reduce to exist-opposite leftover, do not reduce to exist-perp leftover, do not require a unique letter, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for forall-orthogonal M versus O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose
+incoming-versus-outgoing dots are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. `A` is not a seed. Same process and x-probes as nm2axx.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. The first
+pair is `{0, (0,1,0)}` with opposite locks `L(0)=+e_1` and `L(0,1,0)=−e_1`.
+The second pair is `{(0,0,1), (0,1,1)}` with opposite locks `L(0,0,1)=+e_2`
+and `L(0,1,1)=−e_2`. The second pair is a new seed, not a formed child of
+the first pair. On the one-axis opposite two-site process the sites
+`(0,0,1)` and `(0,1,1)` form at tick 1 locking `+e_3`; here they are seeds
+at tick 0 locking `+e_2` and `−e_2`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named incoming set `M`, outgoing set `O`, and forall-perp at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. Occupancy `n` is not used.
+
+Forall-perp HOLD if and only if every `m` in `M` and every `o` in `O` have
+integer dot `m·o=0`. Empty or `UNDEFINED` on either side is `UNDEFINED`.
+Nonempty with some pair of nonzero dot fails.
+
+Exist-perp holds if and only if some pair has integer dot zero. Exist-perp
+is comparison only. It is not the scored predicate. A pair with
+`m={+e_1,+e_2}` and `o={+e_2}` has exist-perp hold and forall-perp fail.
+
+Reverse holds if and only if forall-perp holds at `A` and at `B`. Face
+holds if and only if forall-perp holds at `C` and at `D`. If either side of
+a reverse or face comparison is `UNDEFINED`, the comparison is
+`UNDEFINED`. If either side fails, the comparison fails.
+
+nm2axx cover leftover scores complementary occupation of `{e_1,e_2,e_3}`
+by `Axis(M)` and `Axis(O)`. Cover HOLD at a probe if and only if the Axis
+sets are disjoint and their union equals `{e_1,e_2,e_3}`. That leftover is
+not this display. On these x-probes cover fails at `A` and at `D` because
+the union misses e_2; axes still disjoint. Forall-perp HOLDs at those
+probes because every incoming letter is orthogonal to every outgoing
+letter.
+
+Exist-opposite leftover scores some pair that sums to zero inside `M` or
+inside `O` across reverse or face. That leftover is not this display. On
+this seed leftover M reverse, O reverse, M face, and O face all fail,
+while forall-perp at `A`, `B`, `C`, and `D` all hold. Forall-perp scores
+every incoming-versus-outgoing integer dot at one probe, not an opposite
+pair inside one named set.
+
+## Theorem 1 — ticks, `M`, `O`, integer dots, and forall-perp at `τ=t+1`
+
+On this process the four x-probes form. Incoming is frozen at formation:
+`M(q,t+1)=M(q,t)` at every scored probe. Outgoing is empty at `t` for
+`A`, `B`, and `C`, then filled at `t+1`. At `D`, `O` is already `{−e_1}`
+at `t` and becomes `{+e_1, −e_1}` at `t+1`. Compare to nm2axx cover: that
+leftover reports reverse fail and face fail. Here `M` and `O` are read
+together at the same cut `τ=t+1` and scored by forall-perp:
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {−e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_1}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {−e_2, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+cover(A) = fail
+cover(B) = hold
+cover(C) = hold
+cover(D) = fail
+forall-perp(A)=hold
+forall-perp(B)=hold
+forall-perp(C)=hold
+forall-perp(D)=hold
+```
+
+`A` is not a seed. `A` is the site `(1,0,0)` forming at tick 2 with
+incoming `{−e_3}`. Mixed remains a set: `O(B,τ)` has three outgoing
+steps, `O(C,τ)` has three outgoing steps, and `O(D,τ)` has two outgoing
+steps on one axis. Unique letters would assign `UNDEFINED` at those mixed
+outgoing sets and would leave reverse and face `UNDEFINED`. Here
+uniqueness is not required. `M` and `O` are disjoint at each of the four
+probes at `τ`. O is not M.
+
+Integer dots `m·o` at each probe, in six-neighbor order:
+
+```text
+A: (−e_3)·(+e_1)=0
+   forall-perp at A: hold
+B: (+e_1)·(+e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0
+   forall-perp at B: hold
+C: (+e_1)·(−e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0
+   forall-perp at C: hold
+D: (−e_3)·(+e_1)=0, (−e_3)·(−e_1)=0
+   forall-perp at D: hold
+```
+
+Every scored integer dot is `0`. Forall-perp holds at `A`, `B`, `C`, and
+`D`. Exist-perp also holds at each probe on this process because every pair
+already dots to zero; that coincidence is comparison only. The predicates
+are not the same: exist-perp can hold while forall-perp fails.
+
+Empty `O` at `t` makes forall-perp `UNDEFINED` at `A`, `B`, and `C`, while
+nm2axx cover fails on empty `O`. At `D`, nonempty `O(D,t)={−e_1}` already
+makes forall-perp hold at the own-tick cut, while cover still fails because
+the union misses e_2. At `τ=t+1` both families are nonempty at every scored
+probe. Reverse at `t` is `UNDEFINED` from empty `O` at `A`. That
+empty-at-`t` leftover is not this display.
+
+At `A` and at `D`, nm2axx cover fails because the unsigned union misses
+e_2; axes still disjoint. Forall-perp HOLDs at those probes because
+`{−e_3}` is orthogonal to `{+e_1}` at `A` and to `{+e_1, −e_1}` at `D`.
+Does forall `m·o=0` HOLD where cover fails? Yes. At `B` and at `C` both
+cover and forall-perp HOLD. Perp versus cover split. Same split as nmpfail
+on the one-axis member.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+This is not leftover of exist-perp: some pair with integer dot 0 is a
+weaker leftover. This is not leftover of empty intersection: `{+e_1}` and
+`{−e_1}` are disjoint and have integer dot `-1`. This is not leftover of
+nm2axx cover. This is not leftover of exist-opposite. This is not leftover
+of unique own-incoming or own-outgoing letters. This is not leftover of the
+y-probe forall-perp display on this same seed.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if forall-perp holds at `A` and at `B`. Both
+sides hold. Both sides are nonempty and defined, so this is not
+`UNDEFINED`. Reverse is not exist-opposite leftover of `M(A,τ)` against
+`M(B,τ)`. Reverse is not nm2axx cover leftover.
+
+Reverse: hold
+
+Reverse from forall-perp at τ: hold
+
+This is not `fail` and not `UNDEFINED`. Reverse holds.
+
+nm2axx cover reverse fails because cover fails at `A` (union misses e_2;
+axes still disjoint). Forall-perp reverse HOLDs because every pair at `A`
+and at `B` has integer dot 0. Unique own-outgoing letters on these
+x-probes report reverse `UNDEFINED` from mixed `O(B,τ)`. Exist-opposite of
+`M` reports reverse fail from `{−e_3}` against `{+e_1}`. Exist-opposite of
+`O` reports reverse fail from `{+e_1}` against `{+e_2, +e_3, −e_3}`.
+Exist-perp leftover also reports reverse hold here, but exist-perp is
+weaker: `{+e_1,+e_2}` versus `{+e_2}` has exist-perp hold and forall-perp
+fail. Those are different objects. Reverse from forall-perp holds at `τ`
+because every incoming letter at `A` is orthogonal to every outgoing
+letter at `A`, and likewise at `B`.
+
+Reverse holds.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if forall-perp holds at `C` and at `D`. Both sides
+hold. Both sides are nonempty and defined, so this is not `UNDEFINED`. Face
+is not exist-opposite leftover of `M(C,τ)` against `M(D,τ)`.
+
+Face: hold
+
+Face from forall-perp at τ: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `fail` and not `UNDEFINED`. Face holds.
+
+nm2axx cover face fails because cover fails at `D` (union misses e_2; axes
+still disjoint) while cover HOLDs at `C`. Unique own-outgoing letters on
+these x-probes report face `UNDEFINED` from mixed `O(C,τ)` and mixed
+`O(D,τ)`. Exist-opposite leftover of `M` reports face fail from `{+e_1}`
+against `{−e_3}`. Exist-opposite leftover of `O` reports face fail from
+`{−e_2, +e_3, −e_3}` against `{+e_1, −e_1}`. Those are different objects.
+Face from forall-perp holds at `τ` because every incoming letter at `C` is
+orthogonal to every outgoing letter at `C`, and likewise at `D`.
+
+At the same cut, forall-perp HOLDs at all four probes, so reverse HOLDs
+and face HOLDs. nm2axx cover reverse FAIL face FAIL. Simultaneous HOLD
+of exist-perp does not name this predicate. Empty intersection at a
+formed probe does not name this predicate. Cover fail at `A` and at `D`
+does not name this predicate.
+
+Face holds.
+
+## What this note does not claim
+
+- It does not select a unique incoming or outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require either set to be a singleton.
+- It does not sum either set.
+- It does not replace `O` by `M`.
+- It does not replace forall-perp by exist-perp.
+- It does not reprint exist-opposite reverse/face as this predicate.
+- It does not score reverse as an opposite pair inside `M` or inside `O`.
+- It does not reprint nm2axx cover reverse fail and face fail as this
+  predicate.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not use occupancy `n`.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite process, the incoming and outgoing sets at `t+1`, the
+integer dots, and the forall-perp reverse/face bits are displayed
+theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; `{−e_3}`, `{+e_1}`, `{+e_1}`, `{−e_3}` |
+| `O` at `τ=t+1` | Theorem 1; outgoing dual |
+| integer dots `m·o` at `A,B,C,D` | Theorem 1; all `0` |
+| forall-perp at `A,B,C,D` | Theorem 1; `hold` / `hold` / `hold` / `hold` |
+| compare to nm2axx cover fail | Theorem 1; cover fail, hold, hold, fail; forall-perp hold at each |
+| reverse from forall-perp at `A` and `B` | Theorem 2; `hold` |
+| face from forall-perp at `C` and `D` | Theorem 3; `hold` |
+| unique incoming or outgoing lock | not required |
+| occupancy `n` as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of exist-opposite | not this display; M reverse, O reverse, M face, and O face all fail |
+| leftover of exist-perp | comparison only |
+| leftover of nm2axx cover | not this display; cover reverse FAIL face FAIL; union misses e_2 |
+| leftover of empty intersection | not this display |
+| leftover of unique own-incoming or own-outgoing letters | not this display |
+| leftover of y-probe forall-perp on this seed | not this display |
+| global later T | not used |
+| forall-perp as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: forall `m` in `M`, `o` in `O` have `m·o=0` at `t+1` on the four x-probes of the two-axis opposite seed, and reverse/face from that, on the nm2axx cover-FAIL probe direction. |
+| V2 | Current main has no landed forall-orthogonal `M` versus `O` at `t+1` reverse/face on these four x-probes of the two-axis opposite seed. |
+| V3 | Integer dots, forall-perp at four probes, and reverse/face are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads every incoming-versus-outgoing integer dot at `t+1` and scores the universal zero-dot predicate. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique letter, does not replace forall-perp by exist-perp, does not
+identify this display with exist-opposite leftover, and does not identify
+the bits with nm2axx cover. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| exist-opposite leftover | score some pair in `M` or in `O` that sums to zero | leftover M reverse, O reverse, M face, and O face all fail while forall-perp reverse HOLD face HOLD | ATTEMPTED |
+| exist-perp leftover | score some pair with `m·o=0` | comparison only; `{+e_1,+e_2}` versus `{+e_2}` exist-perp HOLDs and forall-perp fails | ATTEMPTED |
+| nm2axx cover | score complementary occupation of `{e_1,e_2,e_3}` | cover reverse FAIL face FAIL because the union misses e_2 at `A` and at `D`; forall-perp reverse HOLD face HOLD; axes still disjoint | ATTEMPTED |
+| empty intersection | treat `M ∩ O = {}` as the predicate | `{+e_1}` and `{−e_1}` are disjoint and have integer dot `-1` | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(B,τ)`, `O(C,τ)`, and `O(D,τ)` remain sets; uniqueness is not required; unique-letter reverse is `UNDEFINED` | ATTEMPTED |
+| y-probes | score `A=(0,1,0)` | different probes; this member scores the x-probes; y-probe forall-perp reverse HOLD face HOLD is a different display | ATTEMPTED |
+| one-axis leftover seed | treat `(0,0,1)` and `(0,1,1)` as formed children locking `+e_3` | those sites are a new second pair at tick 0 locking `+e_2` and `−e_2` | ATTEMPTED |
+| sum of a set | replace each set by its `Z^3` sum | the construction does not sum | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by forall-perp | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of forall-perp with
+nm2axx cover, missing identification of forall-perp with exist-perp, and
+missing Record identification of the bits are distinct open premises. This
+note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite pairs with locks `+e_1`, `−e_1`,
+`+e_2`, and `−e_2`, perpendicular step rule, incoming-step lock, own
+incoming set and own outgoing dual from records with tick `<= τ`, per-probe
+`τ=t+1`, integer dots, forall-perp, four x-probes with non-seed `A`, reverse as
+forall-perp at `A` and `B`, face as forall-perp at `C` and `D`, and mixed
+remains a set are declared. No uniqueness of locks, no exist-opposite as
+the scored object, no exist-perp as the scored object, no nm2axx cover as
+the scored object, no global later T, no formation attachment from
+already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`hold`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each integer dot `m·o` of earliest incoming or outgoing nearest-neighbor step | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four `M`/`O` pairs, integer dots, forall-perp, reverse/face | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Forall-perp is only empty intersection, because disjoint
+axis-aligned `M` and `O` already force `m·o=0`; reverse/face are only
+nm2axx cover with the union demand dropped; mixed `O` should make the
+predicate `UNDEFINED`; exist-perp already answers some pair dots to zero;
+HOLD of forall-perp is tautological because the step rule is already
+perpendicular.
+
+**Answer:** Empty intersection is a set-theoretic report. Forall-perp is
+the universal integer-dot report at the same cut. `{+e_1}` and `{−e_1}`
+are disjoint with integer dot `-1`. Exist-opposite leftover pairs locks
+inside `M` or inside `O`; this display pairs every incoming lock with
+every outgoing lock at one probe. On this seed leftover exist-opposite
+reverse and face fail while forall-perp reverse and face hold, so the
+predicates split. Mixed `O(B,τ)` remains `{+e_2, +e_3, −e_3}` and
+forall-perp at `B` holds. Exist-perp is comparison only and is a weaker
+predicate. nm2axx cover demands complementary occupation of all three
+axes; the union misses e_2 at `A` and at `D` so cover reverse FAIL face
+FAIL, while forall-perp HOLDs because axes still disjoint. The formation
+step rule is perpendicular to the parent lock; forall-perp here is a
+readout of already-formed incoming letters against outgoing dual letters
+at `t+1`, not a restatement of the step rule and not an Admissibility
+rewrite. Same split as nmpfail on the one-axis member.
+
+### N8 — cross-cycle echo
+
+nm2ax reported forall-orthogonal `M` versus `O` on the four y-probes of
+this same seed with reverse hold and face hold. nm2axx reported axis-cover
+of `M` versus `O` on these four x-probes with reverse fail and face fail
+because the union misses e_2; axes still disjoint. nmpfail reported the
+same perp-versus-cover split on the one-axis z-symmetric x-probes. This
+note is not those displays: forall-perp of `M` versus `O` is read at `t+1`
+on the four x-probes of the two-axis opposite seed, every displayed integer
+dot is 0, reverse HOLDs, and face HOLDs, including where nm2axx cover
+fails.
+
+**Gate disposition:** PASS for the forall-orthogonal `M` versus `O` at `t+1`
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals
+exist-opposite leftover,” “the predicate equals exist-perp,” “the predicate
+equals nm2axx cover,” “the predicate equals empty intersection,” “the
+predicate equals the unique singleton lock vector,” “bits are Admissibility,”
+“reverse fails,” or “face is `UNDEFINED`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+lists every integer dot `m·o`, scores forall-perp at `A,B,C,D`, compares
+those reports to nm2axx cover, and checks Theorems 1--3. It also checks
+that exist-perp is comparison only, that exist-opposite leftover of `M`
+and of `O` fails on reverse and on face, that mixed sets remain sets, that
+uniqueness is not required, that occupancy `n` is not used, that a
+formation member from already-recorded six-neighbor locks is not attached,
+and that forall-perp HOLDs where cover fails. No runner cache is written.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15753,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18641,6 +18641,10 @@
   "trysquared_proof_walk_lattice_independence_bounded_note_2026-05-08": {
    "deps_hash": "3f7cd343351a",
    "out_degree": 7
+  },
+  "two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_bounded_theorem_note_2026-08-15": {
+   "deps_hash": "c8eee4235fc9",
+   "out_degree": 1
   },
   "two_band_bdg_strict_time_flat_spectrum_and_cubic_scalar_boundary_bounded_theorem_note_2026-07-12": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 4c0a11e1b850450474e0eabdd2c0751a625990d32d411803847face28181596e
+input_fingerprint_sha256: 8677ead7565620173ea215066a318060ac828fbba3c7e74dfd87d45b73efe4a1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+forall-orthogonal M vs O at t+1 reverse/face on two-axis opposite x-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Forall-orthogonal M vs O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: forall-orthogonal-identity
+PASS: exist-perp-comparison-identity
+PASS: cover-is-leftover-identity
+A t=2 M={−e_3} O={+e_1} dots=(−e_3)·(+e_1)=0 forall-perp=hold cover=fail
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} dots=(+e_1)·(+e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0 forall-perp=hold cover=hold
+C t=3 M={+e_1} O={−e_2, +e_3, −e_3} dots=(+e_1)·(−e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0 forall-perp=hold cover=hold
+D t=2 M={−e_3} O={+e_1, −e_1} dots=(−e_3)·(+e_1)=0, (−e_3)·(−e_1)=0 forall-perp=hold cover=fail
+reverse=hold face=hold
+nm2axx cover reverse=fail face=fail
+leftover exist-opposite M reverse=fail O reverse=fail M face=fail O face=fail
+per_element: each integer dot m·o of earliest incoming M and outgoing O
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four M/O pairs, integer dots, forall-perp, reverse/face
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_3}', 'B': '{+e_1}', 'C': '{+e_1}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_1}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{−e_2, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-dots-and-forall-perp  ({'A': ('(−e_3)·(+e_1)=0', 'hold'), 'B': ('(+e_1)·(+e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0', 'hold'), 'C': ('(+e_1)·(−e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0', 'hold'), 'D': ('(−e_3)·(+e_1)=0, (−e_3)·(−e_1)=0', 'hold')})
+PASS: theorem1-A-is-not-seed
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-compare-nm2axx-cover  ({'A': ('hold', 'fail', '{e_2}'), 'B': ('hold', 'hold', '{}'), 'C': ('hold', 'hold', '{}'), 'D': ('hold', 'fail', '{e_2}')})
+PASS: theorem1-new-records-meet-6nn
+PASS: theorem2-reverse-hold  (hold)
+PASS: theorem3-face-hold  (hold)
+PASS: empty-or-undefined-is-undefined
+PASS: not-leftover-of-nm2axx-cover
+PASS: not-exist-opposite-leftover
+PASS: exist-perp-is-comparison-only
+PASS: disjoint-is-not-forall-perp
+PASS: O-is-not-M
+PASS: mutation-empty-or-undefined-is-undefined
+PASS: uniqueness-not-required
+PASS: two-axis-opposite-seed
+PASS: second-pair-is-new-seed-not-formed-child
+PASS: not-y-probes-or-z-probes
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-ticks-M-O
+PASS: note-reports-dots-and-forall-perp
+PASS: note-reports-reverse-face
+PASS: note-compare-nm2axx-cover-fail
+PASS: note-displayed-not-adopted
+PASS: note-not-exist-opposite-leftover
+PASS: note-not-exist-perp-or-cover-or-empty-intersection
+PASS: note-uniqueness-not-required
+PASS: note-does-not-use-occupancy
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: perp-hold-where-cover-fails
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1194 @@
+#!/usr/bin/env python3
+"""Forall-orthogonal M vs O at t+1 reverse/face on two-axis opposite x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and x-probes as nm2axx.
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Seeds keep their seed letters as
+a singleton. The second pair is a new seed, not a formed child of the first
+pair. t(q) is the formation tick. tau = t+1. M(q, tau) is the set of
+earliest incoming nearest-neighbor steps at q using only records with tick
+<= tau. O(q, tau) is the outgoing dual of M: the set of e in
+{+/-e_1,+/-e_2,+/-e_3} such that q+e is formed and e is in M(q+e, tau).
+Unformed => UNDEFINED. Forall-perp HOLD iff every m in M and o in O have
+integer dot m·o=0. Empty or UNDEFINED => UNDEFINED. Exist-perp (some pair
+dots to 0) is comparison only. nm2axx cover reverse FAIL face FAIL on these
+x-probes (union misses e_2 at A and at D; axes still disjoint). Reverse
+HOLD iff forall-perp at A and B. Face on C,D. Uniqueness of locks is not
+required. Occupancy n is not used. Named-sign lettering is not used. No
+unique P_+. No larger host. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+YZ: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_OPPOSITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (YZ, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+NSPAR_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E1, NEG_E1),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Forall-orthogonal M vs O at t+1 on the four x-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def dots_display(pairs: tuple[tuple[Point, Point, int], ...]) -> str:
+    if not pairs:
+        return ""
+    parts = [
+        f"({LOCK_NAME[a]})·({LOCK_NAME[b]})={value}" for a, b, value in pairs
+    ]
+    return ", ".join(parts)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_OPPOSITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def integer_dots(left: Incoming, right: Incoming) -> tuple[tuple[Point, Point, int], ...]:
+    """All integer dots m·o in NN order. Empty if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return ()
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("dot sides must be lock sets or UNDEFINED")
+    pairs: list[tuple[Point, Point, int]] = []
+    for a in NN:
+        if a not in left:
+            continue
+        for b in NN:
+            if b not in right:
+                continue
+            pairs.append((a, b, dot(a, b)))
+    return tuple(pairs)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """nm2axx leftover: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """nm2axx leftover: HOLD iff Axis(M) and Axis(O) disjoint and union is all three.
+
+    Unformed => UNDEFINED. Empty leftover with overlapping axes fails.
+    Empty O fails unless Axis(M) already equals {e_1,e_2,e_3}.
+    """
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if (axes_m | axes_o) == frozenset(AXES):
+        return "hold"
+    return "fail"
+
+
+def forall_orthogonal(left: Incoming, right: Incoming) -> str:
+    """Hold iff every m in left and o in right have integer dot m·o=0."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if dot(a, b) != 0:
+                return "fail"
+    return "hold"
+
+
+def forall_perp(left: Incoming, right: Incoming) -> str:
+    return forall_orthogonal(left, right)
+
+
+def exist_perp(left: Incoming, right: Incoming) -> str:
+    """Comparison only: hold iff some pair has integer dot 0."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if dot(a, b) == 0:
+                return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Exist-opposite leftover: hold iff some lock in left is vector opposite of some in right."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(status_a: str, status_b: str) -> str:
+    """Reverse holds iff forall-perp at A and at B."""
+    if status_a == UNDEFINED or status_b == UNDEFINED:
+        return UNDEFINED
+    if status_a == "hold" and status_b == "hold":
+        return "hold"
+    return "fail"
+
+
+def face_report(status_c: str, status_d: str) -> str:
+    """Face holds iff forall-perp at C and at D."""
+    if status_c == UNDEFINED or status_d == UNDEFINED:
+        return UNDEFINED
+    if status_c == "hold" and status_d == "hold":
+        return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def family_at(
+    probes: dict[str, Point],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing], dict[str, str]]:
+    m1: dict[str, Incoming] = {}
+    o1: dict[str, Outgoing] = {}
+    fp: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in ticks:
+            m1[name] = UNDEFINED
+            o1[name] = UNDEFINED
+            fp[name] = UNDEFINED
+            continue
+        tau = ticks[site] + 1
+        m1[name] = incoming_set(site, tau, ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau, ticks, locks, seed_map)
+        fp[name] = forall_orthogonal(m1[name], o1[name])
+    return m1, o1, fp
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("forall-orthogonal M vs O at t+1 reverse/face on two-axis opposite x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E2, E3) == YZ
+        and dot(E1, E2) == 0
+        and dot(E1, E1) == 1
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and in_ball(YZ)
+        and not in_ball((4, 0, 0)),
+    )
+    mixed_exist = frozenset({E1, E2})
+    mixed_axis = frozenset({E2})
+    checks.check(
+        "forall-orthogonal-identity",
+        forall_orthogonal(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and forall_orthogonal(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and forall_orthogonal(frozenset(), frozenset({E1})) == UNDEFINED
+        and forall_orthogonal(frozenset({E1}), frozenset()) == UNDEFINED
+        and forall_orthogonal(frozenset({E1}), frozenset({E1})) == "fail"
+        and forall_orthogonal(frozenset({E1}), frozenset({E2})) == "hold"
+        and forall_orthogonal(mixed_exist, mixed_axis) == "fail"
+        and forall_orthogonal(frozenset({NEG_E3}), frozenset({E1})) == "hold"
+        and forall_perp(frozenset({E1}), frozenset({NEG_E1})) == "fail",
+    )
+    checks.check(
+        "exist-perp-comparison-identity",
+        exist_perp(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and exist_perp(frozenset(), frozenset({E1})) == UNDEFINED
+        and exist_perp(frozenset({E1}), frozenset({E1})) == "fail"
+        and exist_perp(frozenset({E1}), frozenset({E2})) == "hold"
+        and exist_perp(mixed_exist, mixed_axis) == "hold"
+        and exist_perp(mixed_exist, mixed_axis)
+        != forall_orthogonal(mixed_exist, mixed_axis),
+    )
+    set_a = frozenset({NEG_E3})
+    set_a_o = frozenset({E1})
+    set_b = frozenset({E1})
+    set_b_o = frozenset({E2, E3, NEG_E3})
+    checks.check(
+        "cover-is-leftover-identity",
+        axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_cover(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_cover(set_a, set_a_o) == "fail"
+        and axis_cover(set_b, set_b_o) == "hold"
+        and leftover_axis(set_a, set_a_o) == frozenset({E2})
+        and leftover_axis(set_b, set_b_o) == frozenset()
+        and axis_cover(frozenset({E1}), frozenset({E1})) == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    one_axis_ticks, one_axis_locks, one_axis_seeds = form(TWO_SITE_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    dots1: dict[str, tuple[tuple[Point, Point, int], ...]] = {}
+    forall1: dict[str, str] = {}
+    exist1: dict[str, str] = {}
+    cover0: dict[str, str] = {}
+    cover1: dict[str, str] = {}
+    fp0: dict[str, str] = {}
+    lx: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        dots1[name] = integer_dots(m1[name], o1[name])
+        forall1[name] = forall_orthogonal(m1[name], o1[name])
+        exist1[name] = exist_perp(m1[name], o1[name])
+        cover0[name] = axis_cover(m0[name], o0[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        fp0[name] = forall_orthogonal(m0[name], o0[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"dots={dots_display(dots1[name])} "
+            f"forall-perp={forall1[name]} cover={cover1[name]}"
+        )
+
+    reverse_status = reverse_report(forall1["A"], forall1["B"])
+    face_status = face_report(forall1["C"], forall1["D"])
+    reverse0 = reverse_report(fp0["A"], fp0["B"])
+    face0 = face_report(fp0["C"], fp0["D"])
+    cover_reverse = reverse_report(cover1["A"], cover1["B"])
+    cover_face = face_report(cover1["C"], cover1["D"])
+    leftover_m_reverse = existential_opposite(m1["A"], m1["B"])
+    leftover_o_reverse = existential_opposite(o1["A"], o1["B"])
+    leftover_m_face = existential_opposite(m1["C"], m1["D"])
+    leftover_o_face = existential_opposite(o1["C"], o1["D"])
+    unique_reverse = reverse_report(
+        forall_orthogonal(unique_letter(m1["A"]), unique_letter(o1["A"])),
+        forall_orthogonal(unique_letter(m1["B"]), unique_letter(o1["B"])),
+    )
+    unique_face = face_report(
+        forall_orthogonal(unique_letter(m1["C"]), unique_letter(o1["C"])),
+        forall_orthogonal(unique_letter(m1["D"]), unique_letter(o1["D"])),
+    )
+    print(f"reverse={reverse_status} face={face_status}")
+    print(f"nm2axx cover reverse={cover_reverse} face={cover_face}")
+    print(
+        f"leftover exist-opposite M reverse={leftover_m_reverse} "
+        f"O reverse={leftover_o_reverse} "
+        f"M face={leftover_m_face} O face={leftover_o_face}"
+    )
+    print(
+        "per_element: each integer dot m·o of earliest incoming M and outgoing O"
+    )
+    print(
+        "per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four M/O pairs, integer dots, forall-perp, reverse/face"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and locks[PROBES["A"]] == {NEG_E3}
+        and locks[PROBES["B"]] == {E1}
+        and locks[PROBES["C"]] == {E1}
+        and locks[PROBES["D"]] == {NEG_E3}
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["C"], 2, ticks, locks, seed_map) == UNDEFINED
+        and forall_orthogonal(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E3})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({NEG_E3})
+        and m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E1})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({NEG_E2, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    expected_dots = {
+        "A": ((NEG_E3, E1, 0),),
+        "B": (
+            (E1, E2, 0),
+            (E1, E3, 0),
+            (E1, NEG_E3, 0),
+        ),
+        "C": (
+            (E1, NEG_E2, 0),
+            (E1, E3, 0),
+            (E1, NEG_E3, 0),
+        ),
+        "D": (
+            (NEG_E3, E1, 0),
+            (NEG_E3, NEG_E1, 0),
+        ),
+    }
+    checks.check(
+        "theorem1-dots-and-forall-perp",
+        all(dots1[name] == expected_dots[name] for name in ("A", "B", "C", "D"))
+        and all(value == 0 for name in ("A", "B", "C", "D") for _a, _b, value in dots1[name])
+        and all(forall1[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(exist1[name] == "hold" for name in ("A", "B", "C", "D")),
+        str({name: (dots_display(dots1[name]), forall1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and ticks[E1] == 2
+        and locks[E1] == {NEG_E3}
+        and m1["A"] == frozenset({NEG_E3})
+        and PROBES["A"] not in seed_map
+        and Y_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(o1["C"], frozenset)
+        and len(o1["C"]) == 3
+        and unique_letter(o1["C"]) == UNDEFINED
+        and isinstance(o1["D"], frozenset)
+        and len(o1["D"]) == 2
+        and unique_letter(o1["D"]) == UNDEFINED
+        and forall1["B"] == "hold"
+        and forall1["C"] == "hold"
+        and forall1["D"] == "hold",
+    )
+    checks.check(
+        "theorem1-compare-nm2axx-cover",
+        cover1["A"] == "fail"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "fail"
+        and lx["A"] == frozenset({E2})
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and forall1["A"] == "hold"
+        and forall1["D"] == "hold",
+        str({name: (forall1[name], cover1[name], axis_display(lx[name])) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0),)
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse_status == "hold"
+        and forall1["A"] == "hold"
+        and forall1["B"] == "hold"
+        and reverse_status != "fail"
+        and reverse_status != UNDEFINED
+        and cover_reverse == "fail",
+        reverse_status,
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face_status == "hold"
+        and forall1["C"] == "hold"
+        and forall1["D"] == "hold"
+        and face_status != "fail"
+        and face_status != UNDEFINED
+        and cover_face == "fail",
+        face_status,
+    )
+    checks.check(
+        "empty-or-undefined-is-undefined",
+        fp0["A"] == UNDEFINED
+        and fp0["B"] == UNDEFINED
+        and fp0["C"] == UNDEFINED
+        and fp0["D"] == "hold"
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and reverse0 == UNDEFINED
+        and face0 == UNDEFINED
+        and cover0["A"] == "fail"
+        and cover0["D"] == "fail"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "not-leftover-of-nm2axx-cover",
+        cover_reverse == "fail"
+        and cover_face == "fail"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and cover1["A"] == "fail"
+        and forall1["A"] == "hold"
+        and cover1["D"] == "fail"
+        and forall1["D"] == "hold"
+        and cover_reverse != reverse_status
+        and cover_face != face_status,
+    )
+    checks.check(
+        "not-exist-opposite-leftover",
+        leftover_m_reverse == "fail"
+        and leftover_o_reverse == "fail"
+        and leftover_m_face == "fail"
+        and leftover_o_face == "fail"
+        and reverse_status == "hold"
+        and face_status == "hold"
+        and forall_orthogonal is not existential_opposite,
+    )
+    checks.check(
+        "exist-perp-is-comparison-only",
+        exist1["A"] == "hold"
+        and exist1["B"] == "hold"
+        and exist1["C"] == "hold"
+        and exist1["D"] == "hold"
+        and exist_perp(mixed_exist, mixed_axis) == "hold"
+        and forall_orthogonal(mixed_exist, mixed_axis) == "fail"
+        and reverse_report("hold", "fail") == "fail"
+        and reverse_status == "hold",
+    )
+    checks.check(
+        "disjoint-is-not-forall-perp",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and m1["A"].isdisjoint(o1["A"])
+        and forall_orthogonal(frozenset({E1}), frozenset({NEG_E1})) == "fail"
+        and frozenset({E1}).isdisjoint(frozenset({NEG_E1}))
+        and forall1["A"] == "hold",
+    )
+    checks.check(
+        "O-is-not-M",
+        o1["A"] != m1["A"]
+        and o1["B"] != m1["B"]
+        and o1["C"] != m1["C"]
+        and o1["D"] != m1["D"]
+        and o0["A"] == frozenset()
+        and o1["A"] == frozenset({E1}),
+    )
+    checks.check(
+        "mutation-empty-or-undefined-is-undefined",
+        forall_orthogonal(frozenset(), m1["A"]) == UNDEFINED
+        and forall_orthogonal(UNDEFINED, o1["A"]) == UNDEFINED
+        and reverse_report(UNDEFINED, "hold") == UNDEFINED
+        and face_report("hold", UNDEFINED) == UNDEFINED
+        and reverse_report("hold", "fail") == "fail"
+        and face_report("fail", "hold") == "fail",
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(m1["A"]) == 1
+        and len(m1["D"]) == 1
+        and len(o1["B"]) == 3
+        and len(o1["C"]) == 3
+        and len(o1["D"]) == 2
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_reverse == UNDEFINED
+        and unique_face == UNDEFINED
+        and forall1["A"] == "hold"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "two-axis-opposite-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and ticks[YZ] == 0
+        and locks[YZ] == {NEG_E2}
+        and TWO_AXIS_OPPOSITE_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != PERP_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != Y_SYMMETRIC_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != Z_SYMMETRIC_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != NSPAR_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and len({site for site, _lock in TWO_AXIS_OPPOSITE_SEEDS}) == 4,
+    )
+    checks.check(
+        "second-pair-is-new-seed-not-formed-child",
+        one_axis_ticks[E3] == 1
+        and one_axis_locks[E3] == {E3}
+        and one_axis_ticks[YZ] == 1
+        and one_axis_locks[YZ] == {E3}
+        and one_axis_ticks[PROBES["B"]] == 2
+        and one_axis_ticks[PROBES["D"]] == 3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and ticks[YZ] == 0
+        and locks[YZ] == {NEG_E2}
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and E3 not in one_axis_seeds
+        and YZ not in one_axis_seeds
+        and E3 in seed_map
+        and YZ in seed_map,
+    )
+    y_m1, y_o1, y_fp = family_at(Y_PROBES, ticks, locks, seed_map)
+    z_m1, z_o1, z_fp = family_at(Z_PROBES, ticks, locks, seed_map)
+    y_reverse = reverse_report(y_fp["A"], y_fp["B"])
+    y_face = face_report(y_fp["C"], y_fp["D"])
+    z_reverse = reverse_report(z_fp["A"], z_fp["B"])
+    z_face = face_report(z_fp["C"], z_fp["D"])
+    checks.check(
+        "not-y-probes-or-z-probes",
+        probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites
+        and y_m1["A"] != m1["A"]
+        and y_m1["A"] == frozenset({NEG_E1})
+        and y_reverse == "hold"
+        and y_face == "hold"
+        and z_m1["A"] != m1["A"]
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-M-O",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_1}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {−e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note,
+    )
+    checks.check(
+        "note-reports-dots-and-forall-perp",
+        "(−e_3)·(+e_1)=0" in note
+        and "(+e_1)·(+e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0" in note
+        and "(+e_1)·(−e_2)=0, (+e_1)·(+e_3)=0, (+e_1)·(−e_3)=0" in note
+        and "(−e_3)·(+e_1)=0, (−e_3)·(−e_1)=0" in note
+        and "forall-perp at A: hold" in note
+        and "forall-perp at B: hold" in note
+        and "forall-perp at C: hold" in note
+        and "forall-perp at D: hold" in note
+        and "forall-perp(A)=hold" in note
+        and "forall-perp(B)=hold" in note
+        and "forall-perp(C)=hold" in note
+        and "forall-perp(D)=hold" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse: hold" in note
+        and "Face: hold" in note
+        and "Reverse holds." in note
+        and "Face holds." in note
+        and "Reverse from forall-perp at τ: hold" in note
+        and "Face from forall-perp at τ: hold" in note,
+    )
+    checks.check(
+        "note-compare-nm2axx-cover-fail",
+        "nm2axx" in note
+        and "union misses e_2" in normalized_note
+        and "axes still disjoint" in normalized_note
+        and "cover(A) = fail" in note
+        and "cover(B) = hold" in note
+        and "cover(C) = hold" in note
+        and "cover(D) = fail" in note
+        and cover_reverse == "fail"
+        and cover_face == "fail"
+        and reverse_status == "hold"
+        and face_status == "hold",
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-exist-opposite-leftover",
+        "not leftover of exist-opposite" in normalized_note
+        or "not exist-opposite leftover" in normalized_note,
+    )
+    checks.check(
+        "note-not-exist-perp-or-cover-or-empty-intersection",
+        "not leftover of exist-perp" in normalized_note
+        and "not leftover of nm2axx cover" in normalized_note
+        and "not leftover of empty intersection" in normalized_note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-uniqueness-not-required",
+        "Uniqueness of incoming or outgoing locks is not required."
+        in normalized_note
+        and "Mixed remains a set." in note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "does not use occupancy" in normalized_note
+        and "Occupancy `n` is not used" in note
+        and "forall-perp" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_XPROBE_INCOMING_OUTGOING_FORALL_ORTHOGONAL_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "integer_dots" in defined_fns
+        and "forall_orthogonal" in defined_fns
+        and "forall_perp" in defined_fns
+        and "exist_perp" in defined_fns
+        and "axis_cover" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "perp-hold-where-cover-fails",
+        reverse_status == "hold"
+        and face_status == "hold"
+        and cover_reverse == "fail"
+        and cover_face == "fail"
+        and forall1["A"] == "hold"
+        and cover1["A"] == "fail"
+        and forall1["D"] == "hold"
+        and cover1["D"] == "fail"
+        and forall1["C"] == "hold"
+        and cover1["C"] == "hold",
+    )
+    _ = (y_o1, z_o1, z_reverse, z_face)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Forall-perp HOLDING where two-axis x-probe cover fails. Displayed, not adopted.

## Runner

`scripts/two_axis_opposite_xprobe_incoming_outgoing_forall_orthogonal_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.