### PR TITLE
physics: remove the four nsimplify sites from the committed chain

### DIFF
--- a/scripts/admissibility_dirac_kahler_adm_seam_two_history_gram_2026_08_15.py
+++ b/scripts/admissibility_dirac_kahler_adm_seam_two_history_gram_2026_08_15.py
@@ -858,7 +858,7 @@ def stage_h_local_dressing_rank(gram: sp.Matrix, mutation: str) -> dict[str, obj
     certificate_invertible = sp.expand(pinned_dressing.det()) != 0
     if certificate_equation:
         certificate_minors = [
-            sp.nsimplify(sp.det(dressed[:size, :size])) for size in range(1, 9)
+            sp.det(dressed[:size, :size]) for size in range(1, 9)
         ]
         certificate_positive = all(minor > 0 for minor in certificate_minors)
     else:

--- a/scripts/admissibility_dirac_kahler_quotient_gate_2026_08_20.py
+++ b/scripts/admissibility_dirac_kahler_quotient_gate_2026_08_20.py
@@ -630,7 +630,7 @@ def principal_cosines(left: sp.Matrix, right: sp.Matrix) -> tuple:
     product = sp.expand(gl.inv() * cross * gr.inv() * cross.T)
     out: list = []
     for eigenvalue, multiplicity in product.eigenvals().items():
-        out.extend([sp.nsimplify(sp.simplify(eigenvalue))] * multiplicity)
+        out.extend([sp.Rational(sp.simplify(eigenvalue))] * multiplicity)
     return tuple(sorted(out, key=lambda v: -sp.Rational(v)))
 
 
@@ -1618,9 +1618,10 @@ def measure(deep: bool) -> Facts:
         ("cone", a_point, a_tau),
         ("typeB", b_point, b_tau),
     ):
+        tau = sp.Rational(tau)
         substitution = {
-            SHEAR_X: sp.numer(sp.nsimplify(tau)),
-            SHEAR_T: sp.denom(sp.nsimplify(tau)),
+            SHEAR_X: sp.numer(tau),
+            SHEAR_T: sp.denom(tau),
         }
         K = {
             key: sp.expand(residue[key].xreplace(substitution).xreplace(point))

--- a/scripts/admissibility_dirac_kahler_shear_gauge_classification_2026_08_20.py
+++ b/scripts/admissibility_dirac_kahler_shear_gauge_classification_2026_08_20.py
@@ -508,7 +508,7 @@ def cover_action(differential: sp.Matrix, hodge: sp.Matrix, mass) -> sp.Matrix:
 def charpoly(matrix: sp.MatrixBase) -> tuple:
     """Exact characteristic polynomial coefficients, root-free (H5)."""
     return tuple(
-        sp.nsimplify(value)
+        value
         for value in sp.Poly(
             sp.expand(sp.Matrix(matrix).charpoly(LAMBDA).as_expr()), LAMBDA
         ).all_coeffs()


### PR DESCRIPTION
## Hygiene: the four nsimplify repair sites (queued since the 2026-08-21 hygiene batch)

Mechanical repairs to the four `sympy.nsimplify` sites identified by the hygiene audit (handoff item 8): the ADM-seam Sylvester minors (exact determinant direct), the shear-gauge charpoly coefficients (exact `all_coeffs`), the quotient-gate principal cosines (explicit `sp.Rational` construction — the undeclared rationality assumption now fails loud), and the quotient-gate tau substitution (the one fail-quiet site — single coercion then numer/denom).

- Verification: per-site self-tests pass (full stage results and complete gate dictionaries unchanged before/after); science gates B–H pass before and after on the affected runners; strict audit lint clean. Measured in passing: at the shear-gauge site, current `nsimplify` silently rewrites at least one exact rational charpoly coefficient into an algebraic radical — the exact corruption class this repair removes. No verdict changes anywhere.
- Worker profile: codex `gpt-5.6-sol` (xhigh) mechanical repair worker; supervisor review and landing. Patches authored against the chain tip e7078f7a; stacked on block 173's branch because the affected runners are chain-landed, not on main.

### Status discipline
No science content changed; no axiom movement; nothing registered or adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
