### PR TITLE
physics: encode NN Record programs and expose self-hosting gap

### DIFF
--- a/docs/NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-22.md
+++ b/docs/NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-22.md
@@ -1,0 +1,561 @@
+---
+claim_id: nn_record_program_preparation_quotient_trace_compiler_bounded_theorem_note_2026-08-22
+claim_type: bounded_theorem
+claim_scope: "For supplied six-neighbour candidate-carrier shells, an explicit opposite-pair encoding places any binary or ternary scaled-projector program and positive labels in the anti-Hermitian parts of existing M_2(C) contents while all six Hermitian parts retain one common qubit density matrix. An orientation-free decoder recovers the program under all 24 proper cubic rotations. One fixed selected downstream rule is total on all shells; when the common Hermitian part is a density matrix and the program is valid, it assigns Tr(C E_j), writes literal projector contents on the selected binary projective subdomain, and otherwise writes injective effect-label contents, while all other shells receive a deterministic covariant fallback. Exact fixtures establish a cross-program preparation quotient, the parent one-site marginal formula on supplied shells, same-effect mass, content-only decoding, repeated-effect separation, refinement addition, and a pure-state zero/one endpoint. The same rule cannot form its own active carrier inputs: every rule output has scalar anti-Hermitian coefficient, whereas active projective carrier inputs require a nonscalar one. Thus this is a conditional capacity/encoding theorem, not a self-hosting physical Record carrier. Density-matrix preparation calibration, trace-Law selection from the four axioms, program genesis, formation site/rate, histories, and composite Bell carrier are not derived. No axiom, primitive, audit verdict, formal obligation, or TOE percentage is changed."
+depends_on:
+  - minimal_axioms
+  - record_projective_history_local_append_downstream_law_candidate_bounded_theorem_note_2026-08-21
+runner: scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py
+runner_cache: logs/runner-cache/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Nearest-Neighbor Record Program, Preparation Quotient, And Trace Compiler
+
+**Date:** 2026-08-22
+
+**Claim type:** bounded_theorem
+
+**Role:** constructive downstream-Law realization
+
+**Stacking boundary:** this source is stacked on the owner-selected but still
+open and unaudited
+[`Record projective-history candidate`](RECORD_PROJECTIVE_HISTORY_LOCAL_APPEND_DOWNSTREAM_LAW_CANDIDATE_BOUNDED_THEOREM_NOTE_2026-08-21.md).
+That parent is a provisional campaign benchmark, not retained authority. The
+only effective foundation used here is the
+[`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md). Independent audit owns every
+scientific verdict.
+
+**Primary runner:**
+[`scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py`](../scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py)
+
+**Cached receipt:**
+[`logs/runner-cache/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.txt`](../logs/runner-cache/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.txt)
+
+## Result Up Front
+
+There is enough room in six supplied nearest-neighbor `M_2(C)`
+candidate-carrier matrices to keep a preparation fixed while changing a
+complete binary or ternary quantum program. No new site type or auxiliary
+register is needed for that algebraic representation. Formation of those
+matrices as physical Records is not supplied.
+
+For each of the three unoriented opposite-neighbor pairs, put one effect
+`E_j` and one positive label `ell_j` into the anti-Hermitian part, while every
+neighbor has the same Hermitian part `C`:
+
+```text
+R_(+a_j) = C + i(E_j + ell_j I),
+R_(-a_j) = C + i(E_j - ell_j I).                 (1)
+```
+
+The pair average recovers `E_j`; the magnitude of the pair difference
+recovers `ell_j`. A proper cubic rotation may permute pairs or reverse their
+orientations, but it cannot change either decoded object. The Hermitian
+average of all six neighbors remains exactly `C`, independent of the menu.
+This gives an explicit **Preparation quotient**: shells with the same `C`
+are the same preparation for this selected rule even when their program
+parts differ.
+
+The note then executes one total downstream rule. When `C` is a density
+matrix and the program is valid, it receives
+
+```text
+rho_C = C,
+p(j|C,M) = Tr(C E_j).                             (2)
+```
+
+On the owner-selected binary rank-one projective subdomain, the output Record
+content is literally `E_j`, matching the parent candidate's event map. On the
+larger scaled-projector test domain, the output content is the injective code
+`E_j+i ell_j I`; this keeps repeated equal effects distinguishable. Invalid
+programs receive the covariant deterministic fallback `delta_C`, making the
+rule defined on every shell.
+
+The exact runner verifies two different ternary programs with the same
+preparation and shared effect, a repeated-effect binary program, the literal
+binary projective sublaw, all 24 proper cubic rotations, a simultaneous
+internal basis change, three deletion tests, and a refinement identity. The
+shared effect-label Record has probability `3/10` in both ternary programs.
+
+This is real constructive progress on the representational subproblem inside
+the parent's missing local-carrier and cross-program calibration surface. It
+is not a derivation selecting equation
+(2) or physically calibrating the common matrix as a preparation. That
+identification and the trace functional are downstream Law content. Program genesis,
+Record formation site or rate, repeated trials, finite-history reset,
+two-wing Bell composition, and a realized member remain separate. The axiom
+memo is unchanged, and there is **no TOE-percentage movement** from this
+source packet before landing and independent audit.
+
+An independent cold check found the decisive physical boundary. Every output
+of the displayed rule has a scalar anti-Hermitian coefficient, but every
+active carrier pair for a non-scalar projector needs a nonscalar one. The rule
+therefore cannot form the supplied carrier Records that it later reads. The
+theorem is a correct conditional encoding/capacity result, not a self-hosting
+physical carrier for the parent Law.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The opposite-pair encoding, syntactic preparation quotient, decoder, covariance, total-shell fallback, selected trace-law realization for every encoded qubit density matrix, exact contents, finite deletion controls, and same-law self-hosting failure are proved on the declared supplied-shell class. Preparation calibration, a physical carrier writer, trace-Law selection from the four axioms, and occurrence/history interfaces are selected or open rather than derived."
+trace_class: direct_blocker_composition
+target_claim_id: record_projective_history_nn_carrier_capacity_and_self_hosting_gap
+target_blocker_text: "construct a self-hosting target-local carrier whose complete nearest-neighbor Record condition determines the selected one-site event marginal while keeping preparation fixed across programs"
+source_of_blocker_text: "record_projective_history_local_append_downstream_law_candidate_bounded_theorem_note_2026-08-21"
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "construct and deletion-test a same-law writer/history in which the six active carrier contents are themselves supported outputs at fresh sites; do not claim the parent physical carrier until that self-hosting step closes"
+conditional_surface_status: "exact selected one-site low-arity encoding and marginal on supplied boundary shells; the law cannot generate its own active carrier contents, and no physical program genesis, occurrence, history reset, or composite Bell-local realization is supplied"
+hypothetical_axiom_status: "no core-axiom edit proposed or justified"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target Contract
+
+| Field | Contract |
+|---|---|
+| target statement | construct one translation/proper-cubic-covariant radius-one rule whose full neighbor shell contains a preparation and a binary/ternary program, and whose valid-program marginal realizes the selected one-site trace Law |
+| quantifiers/domain | every supplied qubit density center `C` on the selected trace branch; every two- or three-member nonzero scaled-projector resolution with distinct positive labels; all 24 proper cubic rotations; the explicit total fallback on every other Hermitian-center shell |
+| allowed premises | `Z^3` nearest-neighbor structure, one-site `M_2(C)` possibility domain, one fixed local probability rule, and the parent owner-selected finite projective Law as a provisional downstream benchmark |
+| forbidden weakenings | a host-side program not present in the six matrices; a menu-dependent preparation center; a signed pair label that changes under an allowed rotation; calling equation (2) derived from the four axioms; calling supplied boundary matrices physically formed Records; calling conditional formation a formation process |
+| required edges | reversed opposite pairs, binary unused pair, repeated effects, malformed shell, exact endpoints/normalization, internal basis transport, shared effects across distinct menus, and same-law self-hosting |
+| completion witness | explicit encode/decode equations, exact law, all-rotation certificate, exact shared-effect fixtures, and deletion controls in the primary runner |
+| outcomes not counted as closure | program genesis, law selection, arbitrary POVMs, histories, frequency typicality, composite Bell localization, formation site/rate, gravity, or TOE score movement |
+
+The theorem is intentionally one-site and conditional on formation. The
+Admissibility reading says which possibility a forming Record locks; it does
+not say that the target forms now, how often it forms, or what forms next.
+
+## 1. Objects And Program Encoding
+
+Let the three unoriented neighbor pairs at a target `x` be
+
+```text
+{x+e_x,x-e_x}, {x+e_y,x-e_y}, {x+e_z,x-e_z}.
+```
+
+For any matrix `R`, define its Hermitian and anti-Hermitian coefficients
+
+```text
+H(R) = (R+R^dagger)/2,
+K(R) = (R-R^dagger)/(2i).
+```
+
+Let `C=C^dagger`, `C>=0`, and `Tr(C)=1`; it is the supplied normalized
+preparation matrix for the selected Law. A program item is a nonzero member `E_j` of
+
+```text
+S = {cP: 0<c<=1, P rank one} union {cI: 0<c<=1}
+```
+
+together with a positive scalar label `ell_j`. A valid program has two or
+three items, distinct labels, and `sum_j E_j=I`. Unused pairs carry `R_+=R_-=C`.
+Active pairs use equation (1).
+
+Every encoded `R` lies in the already supplied one-site domain `M_2(C)`.
+Equation (1) is a downstream content choice, not a new one-site ontology.
+Calling its common Hermitian part the physical preparation is a calibration
+choice. The parent Law already accepts a supplied normalized preparation;
+this theorem gives that matrix an exact nearest-neighbor encoding but does not
+derive its genesis, Record formation, or interpretation.
+
+### Exact decoder
+
+For either orientation of one pair, define
+
+```text
+E_pair = (K(R_+) + K(R_-))/2,
+D_pair = (K(R_+) - K(R_-))/2.
+```
+
+On an encoded pair, `D_pair=+ell I` or `-ell I`. The decoder accepts a pair
+only when `D_pair` is scalar and reads
+
+```text
+ell_pair = sqrt(Tr(D_pair^dagger D_pair)/2)=ell.
+```
+
+The executed rational fixtures equivalently use the absolute scalar entry.
+Thus reversing `+a` and `-a` changes the sign of `D_pair` but not the decoded
+label. The effect average is also unchanged.
+
+The preparation decoder is
+
+```text
+C(eta) = (1/6) sum_(d in {+/-e_x,+/-e_y,+/-e_z}) H(R_d).   (3)
+```
+
+Every term equals `C`, so equation (3) returns `C` exactly. Changing the
+program changes only the `K` data. This is an explicit quotient chosen by the
+rule; it is not a claim that arbitrary microscopic shells with equal
+Hermitian averages are experimentally equivalent under every possible Law.
+
+## 2. Covariance And Totality
+
+A proper cubic rotation permutes the three unoriented pairs and may reverse
+some pair orientations. The decoder is invariant under both operations.
+Consequently the decoded program is transported as an unordered set of
+effect-label items, and equation (3) is unchanged. The runner enumerates all
+24 proper signed-permutation rotations rather than sampling them.
+
+The same formula is used at every translated site. Under simultaneous
+internal re-presentation `R_d -> V R_d V^dagger`, one has
+
+```text
+C -> V C V^dagger,
+E_j -> V E_j V^dagger,
+ell_j -> ell_j.
+```
+
+The runner executes Pauli-`X` conjugation as an exact hostile control. The
+algebraic proof covers every unitary because conjugation commutes with
+`H`, `K`, matrix sums, squares, and trace.
+
+The validity predicate is also invariant: it checks that `C` is a density
+matrix, item count, positive distinct labels, membership in `S`, and
+`sum E_j=I`. If the pair decoder encounters a nonscalar difference, or if
+any later validity check fails, the fixed rule returns `delta_C`. Hence this
+is not a partial program evaluator silently
+called an Admissibility law; it gives one normalized answer at every shell.
+
+## 3. Selected One-Site Law
+
+For a valid program define equation (2). Because `C` is positive with trace
+one, every mass is nonnegative, and
+
+```text
+sum_j p(j|C,M) = Tr(C sum_j E_j) = Tr(C)=1.               (4)
+```
+
+The same `C` and same effect give the same value even when the other menu
+items differ. This equality is a property of the selected rule, not a
+consequence of content-only Record readout. A pure `C` can give an orthogonal
+branch mass zero; that output is absent from the measure support and cannot
+be locked, reproducing the parent's exact no-fabrication endpoint.
+
+There are two content branches inside the one fixed validity rule:
+
+1. For a binary pair of distinct rank-one projectors, write the literal
+   content `R_out=E_j`. This exactly realizes the parent candidate's selected
+   finite projective event content.
+2. Otherwise write `R_out=E_j+i ell_j I`. The fixed maps
+   `Q(R)=H(R)` and `L(R)=Tr(K(R))/2` recover the effect and label. Repeated
+   equal effects therefore remain distinct Record outcomes.
+
+The branch test is algebraic and invariant. It does not privilege a spatial
+axis or refer to host insertion order.
+
+### Exact composition with the selected parent prefix law
+
+Let `sigma_h>=0` be any supported one-qubit parent prefix with
+`Tr(sigma_h)>0`, and encode
+
+```text
+C_h = sigma_h / Tr(sigma_h)
+```
+
+as the common Hermitian part of the six neighbors. Encode the next binary
+projective program `{P_e^0,P_e^1}` by equation (1). The target-local rule then
+gives
+
+```text
+p(a|eta_h,e) = Tr(C_h P_e^a)
+               = Tr(P_e^a sigma_h P_e^a) / Tr(sigma_h).  (5)
+```
+
+The second equality uses projector idempotence and cyclicity of trace.
+Equation (5) is exactly the parent candidate's selected conditional mass, and
+the output content is literally `P_e^a`. Thus the complete supplied six-site
+neighbor condition determines the selected one-site marginal for every
+positive-trace qubit prefix. The runner executes a non-diagonal unnormalized
+prefix and an `X` program, obtaining `(3/4,1/4)` by both formulas. A separate
+genuinely complex `Y`-coherent preparation/program fixture gives
+`(1/4,3/4)` exactly.
+
+This reproduces the parent's one-site carrier **formula** on supplied encoded
+shells. It does not close the parent's physical carrier requirement: the six
+preparation/program matrices have not yet been formed as Records by the same
+law. It also does not refresh them after an outcome, so recurrent history
+realization remains open.
+
+### Same-law self-hosting test
+
+The displayed total rule has only three output shapes:
+
+```text
+invalid shell:                 R_out=C,
+binary projective program:     R_out=E,
+other valid program:           R_out=E+i ell I.
+```
+
+Their anti-Hermitian coefficients are respectively `0`, `0`, and `ell I`,
+all scalar. An active input carrier from equation (1) instead has
+
+```text
+K(R_(+a))=E+ell I,
+K(R_(-a))=E-ell I.                                  (6)
+```
+
+For a rank-one projector `E`, both matrices in equation (6) are nonscalar.
+Therefore no output of this fixed rule at any site can equal an active
+projective carrier input. In the executed binary fixture, four of the six
+input matrices have nonscalar anti-Hermitian coefficients, while every output
+of every executed rule branch has a scalar coefficient.
+
+This is an exact same-law failure, not a capacity failure of `M_2(C)`. A
+different writer branch, a full-support law, or a supplied boundary can place
+the matrices in the one-site domain. The present rule does not physically
+form them. A full-support continuous escape would also need an honest account
+of exact zero-singleton-mass program calibration and history; it is not
+silently adopted here.
+
+### Relation to trace-form forcing
+
+Equation (2) is the executed concrete Law. A weaker structural composition is
+also visible. Suppose a rule on these physically encoded programs assigned a
+single value `w_C(E)` to an effect at fixed `C`, independent of the other menu
+items, and normalized every valid binary and ternary program. The landed but
+currently unaudited
+[`binary/ternary frame-lift source`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+then gives a unique density matrix with `w_C(E)=Tr(rho E)` on `S`.
+
+The present carrier supplies a concrete program domain and preparation
+quotient for that implication. It does **not** derive the single-effect
+probability property. The exact deletion control assigns one shared effect
+`1/4` in one normalized ternary law and `1/3` in another. Thus menu
+normalization alone is insufficient.
+
+## 4. Exact Fixtures
+
+Take
+
+```text
+C = diag(3/5,2/5).
+```
+
+Use the shared scaled effect `E_0=(1/2)P_z` and the two exact ternary
+resolutions from the August 10 compiler source. The runner reconstructs their
+matrices from exact `sqrt(2)` coordinates and obtains
+
+```text
+p(M_A)=(3/10,19/50,8/25),
+p(M_B)=(3/10,7/20,7/20).
+```
+
+Both encoded shells have precisely the same `C`. With label one, both write
+the same codeword `E_0+iI` with mass `3/10`.
+
+For the repeated-effect binary menu `{I/2,I/2}`, labels one and two give two
+different contents and masses `(1/2,1/2)`. For the projective menu
+`{P_z,P_-z}`, the literal contents have masses `(3/5,2/5)`. Replacing
+the common preparation by the pure matrix `P_z` gives exact endpoint masses
+`(1,0)` and leaves the same program carrier intact.
+
+### Refinement is addition, not identity
+
+For the coarse effect `E=I/2` and refinement `F=G=I/4`, equation (2) gives
+
+```text
+p(E)=1/2,
+p(F)=p(G)=1/4,
+p(E)=p(F)+p(G).
+```
+
+The events are not declared to be the same microscopic set. The runner also
+uses a six-point uniform space with two disjoint two-point cells. They have
+equal probability `1/3` while remaining disjoint. Operational event
+equivalence is therefore a probability/content quotient, not literal equality
+of microscopic subsets. This directly preserves the distinction raised in
+the owner discussion: refined alternatives can have different individual
+probabilities, and their probabilities add to the coarse event.
+
+## 5. What This Closes And What It Does Not
+
+| Interface | Disposition |
+|---|---|
+| algebraic capacity for preparation plus a two/three-outcome program | constructed in six supplied `M_2(C)` matrices |
+| syntactic preparation value unchanged across different programs | constructed by the Hermitian-average quotient |
+| orientation/proper-cubic-safe decoding | proved and exhaustively checked on 24 rotations |
+| literal event content for the selected binary projective parent sector | constructed |
+| labels for repeated scaled effects | constructed in output content |
+| one normalized target-local marginal from the supplied complete shell | constructed for the selected equation-(2) Law and equal to the parent prefix formula |
+| same-law formation of the six active carrier contents | fails for this rule: its outputs have scalar `K`, while active inputs require nonscalar `K` |
+| preparation-matrix calibration and trace-Law selection from the four axioms | not derived; equation (2) is downstream Law content |
+| physical program/preparation Record genesis | not constructed; shells are supplied |
+| Record formation site, probability, rate, or cadence | not constructed; all outcome statements are conditional on formation |
+| reset, repeated trials, exchangeability, frequencies, or typicality | not constructed |
+| the parent's composite two-wing Bell cylinder as two nearest-neighbor marginals | not constructed; Bell locality is a separate high-risk interface |
+| axiom or primitive update | none |
+| retained claim or TOE score change | none; independent audit is required |
+
+The significant positive result is representational and formula-compositional:
+the `M_2(C)`/nearest-neighbor substrate is not too small to encode the missing
+one-site program and preparation quotient, and the supplied-shell marginal
+equals the parent formula. The significant negative result is equally local:
+this particular rule is not self-hosting. The next constructive obligation is
+a same-law carrier writer/history, not more finite menu enumeration.
+
+## 6. Deletion Tests
+
+| Deleted ingredient | Exact result |
+|---|---|
+| orientation-free label magnitude | a proper half-turn changes a signed label from `+1` to `-1`; covariance fails |
+| output label on a repeated-effect menu | `{I/2,I/2}` collapses to one Record content even though the program has two outcomes |
+| same-effect probability descent | two normalized ternary assignments give a shared effect masses `1/4` and `1/3`; normalization survives |
+| complete-program validity | an incomplete effect family need not normalize under equation (4) |
+| fallback on invalid shells | the proposed nearest-neighbor rule becomes undefined on part of its axiom domain |
+| a self-hosting writer branch | active projective carrier contents are absent from every output support of the displayed atomic/fallback rule |
+
+The first three and the same-law support mismatch are executed as named
+controls. The remaining definition checks are not inflated into
+runner-exhausted no-go claims.
+
+## No-Go Discipline Gate
+
+The no-go-discipline skill is applied because this positive construction also
+ships narrow deletion negatives and names open interfaces. The gate status is
+**PASS for the finite deletion statements and scope boundary**. No broad
+Born, Record, compiler, or axiom-necessity no-go is claimed.
+
+### N1 — Alternative route enumeration
+
+| Family | Attack on the narrow boundary | Disposition and honesty marker |
+|---|---|---|
+| intrinsic effect grade plus frame lift | restore one menu-independent `w_C` and use the dimension-three representation theorem | **ATTEMPTED**: this succeeds conditionally and is recorded in section 3; it changes the deletion premises by restoring the omitted descent property, so it does not refute the contextual finite witness |
+| deterministic measurable partitions on the original possibility law | identify each event with a fixed measurable subset and read its `mu_eta` mass | **ATTEMPTED**: the current exact construction instead uses atomic output contents; the prior [registered-partition source](ADMISSIBILITY_REGISTERED_PARTITION_BARYCENTER_PUSHFORWARD_BOUNDED_THEOREM_NOTE_2026-08-12.md) shows product/atom-splitting routes remain live, so no universal partition no-go is asserted |
+| Gaussian quantile compiler | derive a uniform scalar from a full-support law and cut it at effect weights | **ATTEMPTED**: the [Gaussian source](ADMISSIBILITY_GAUSSIAN_SECOND_MOMENT_QUANTILE_DECODER_EFFECT_QUOTIENT_BOUNDED_THEOREM_NOTE_2026-08-10.md) is a positive mathematical realization; this note adds an algebraic neighbor encoding on supplied matrices and a cross-program center quotient but still does not derive physical formation or selector adoption |
+| content-only Record descent | make equal operational effects equal because their formed contents are equal | **ATTEMPTED**: literal projectors close this on the selected binary subdomain, while labelled contents close it through fixed `Q`; content equality still does not by itself constrain formation probabilities across different shells |
+| affine preparation duality | require randomized preparations to push forward affinely, then represent each fixed Record cell by a POVM effect | **ATTEMPTED**: finite-dimensional affine duality is a viable distinct route, but it imports a density-preparation chart, decomposition-independent randomization, and fixed cells; those additions are not premises of the deletion witness |
+| explicit downstream Law | select trace/Lueders weights as a falsifiable sector Law rather than derive them | **ATTEMPTED**: the parent does exactly this; the present construction reproduces its one-site marginal on supplied shells but is not a self-hosting physical carrier |
+| contact/pointer dynamics | derive the quotient, carrier writer, and weights from a physical interaction | **ATTEMPTED** as a source search and left live: no source used here supplies the terminal self-hosting/occurrence theorem; because the mechanism is unclosed, the note makes no broad impossibility claim |
+
+The families differ in primary object, mechanism, and terminal obligation.
+They are not multiple names for the same frame-theorem route.
+
+### N2 — Wall-independence audit
+
+The raw list collapses to three downstream interfaces.
+
+| Pair | closing first closes second? | closing second closes first? | independent? |
+|---|---:|---:|---:|
+| program representation/preparation quotient vs preparation calibration/trace-Law selection | no | no | yes |
+| program representation/preparation quotient vs program/Record occurrence and history | no | no | yes |
+| preparation calibration/trace-Law selection vs program/Record occurrence and history | no | no | yes |
+
+This theorem constructs the algebraic part of the first on supplied shells
+and explicitly selects a member for the second. Same-law formation of those
+shells remains inside the third and fails for the displayed rule. Program
+storage, pair orientation, and output labels are sub-obligations of the first,
+not inflated as independent physics walls.
+
+### N3 — Hidden-wall scan
+
+| Phrase | Classification |
+|---|---|
+| `registered` | defined here as the output content of the displayed conditional local law; no pre-existing physical registration is inferred |
+| `standard` | appears only in the proper-cubic/lattice names fixed by the Minimal Axioms; no standard-QFT result is imported |
+| `by construction` variants | refer only to equations (1)--(4), whose objects are explicit downstream inputs |
+| `framework provides` | not used to supply weights, programs, formation, histories, or calibration |
+| `canonical`, `naturally`, `obviously`, `bridge context`, `background` | not load-bearing proof phrases |
+
+The selected preparation calibration/trace map and supplied encoded shells are exposed in the
+claim scope and target contract rather than hidden behind those words.
+
+### N4 — Residual matching
+
+| Source | Source residual | Residual used here | Match? |
+|---|---|---|---:|
+| [August 9 frame lift](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md) | physical grade and binary/ternary menu registration absent | conditional structural trace-form composition after this carrier | yes, source evidence only; unaudited |
+| [August 10 type separation](ADMISSIBILITY_GLOBAL_MEASURE_MENU_KERNEL_TYPE_SEPARATION_BOUNDED_THEOREM_NOTE_2026-08-10.md) | global point measure is not automatically an effect-menu kernel | same-effect probability property is not obtained by retyping `mu_eta` | yes, source evidence only; unaudited |
+| [Gaussian compiler](ADMISSIBILITY_GAUSSIAN_SECOND_MOMENT_QUANTILE_DECODER_EFFECT_QUOTIENT_BOUNDED_THEOREM_NOTE_2026-08-10.md) | program storage and cross-condition preparation quotient open | construct an algebraic version of those two objects on supplied shells | yes for capacity, not physical genesis; unaudited |
+| [effect-label carrier](ADMISSIBILITY_M2_EFFECT_LABEL_RECORD_CARRIER_ATOMIC_BORN_LAW_FACTORIZATION_BOUNDED_THEOREM_NOTE_2026-08-10.md) | physical neighbor program and Record selection open | embed its output fiber in a complete NN program rule | partial match; used as algebraic precedent, not as closure authority |
+| [parent Record-history candidate](RECORD_PROJECTIVE_HISTORY_LOCAL_APPEND_DOWNSTREAM_LAW_CANDIDATE_BOUNDED_THEOREM_NOTE_2026-08-21.md) | target-local NN carrier absent | literal one-site binary projective marginal on a supplied shell | partial: formula matches, but physical arrival/self-hosting and the composite Bell carrier remain unmatched |
+
+No nonmatching citation is used to support a negative conclusion.
+
+### N5 — Rhetoric audit
+
+The cached primary runner lands five substantive execution-certificate lines:
+
+```text
+per_element: exact effect-label encoding, decoding, trace mass, and two deletion controls are checked for every displayed item
+per_site: one complete six-neighbour shell, its valid-program law, fallback, and same-law self-hosting support mismatch are executed
+per_mode: checked and not executed — no spectral, momentum, transfer, or continuum mode claim belongs to this local compiler
+per_block: binary and ternary program blocks, repeated effects, refinement, and all 24 proper-cubic transports are checked
+lattice_wide: checked and not executed — translation uses the same radius-one formula, but no global occurrence history is claimed
+```
+
+Accordingly the negative language is limited to the displayed element/site/
+program-block deletions. No per-mode or lattice-wide impossibility is stated.
+
+### N6 — Partial-closure path scan
+
+The primitive registry supplies scale reference, kinetic isotropy, and
+realized-state evaluation only. None supplies a probability rule, selector,
+readout bridge, or dynamics. They are not counted as walls and are not enlarged.
+
+Live partial-closure paths are:
+
+| Path | Status | What it can close |
+|---|---|---|
+| this opposite-pair encoding | current stacked source | local capacity, a syntactic preparation quotient, and the selected one-site marginal on supplied shells; not carrier genesis |
+| frame-lift composition | landed source, unaudited | trace representation after low-arity grade/descent is supplied |
+| Gaussian quantile/compiler | landed source, unaudited | mathematical atom splitting and event partition on one selected law |
+| parent downstream Law | open owner-selected PR, unaudited | explicit finite projective trace/history kernel without claiming derivation |
+| a future affine preparation chart | live theorem route | construct POVM effects from preparation mixing rather than assume effect labels |
+
+These paths show why “a new core axiom is required” would be an overclaim.
+No core-axiom edit is proposed.
+
+### N7 — Steelman
+
+A hostile reviewer should reject any claim that the existing substrate cannot
+carry the missing calibration. The full `M_2(C)` contents of six neighbors
+have ample real capacity, and equation (1) gives a concrete covariant use of
+that capacity: a program can vary entirely in anti-Hermitian data while the
+Hermitian preparation center stays fixed. The Gaussian and product-register
+sources further show exact atom-splitting mechanisms. A contact law or a
+full-support writer branch could make the encoding self-hosting, and an affine
+preparation theorem could construct a POVM without beginning from named
+effects. The actionable terminal obligations are a physical writer,
+selector/calibration, and occurrence/history—not a substrate-capacity
+impossibility. This steelman succeeds, so every broad no-go is withheld; the
+note ships only the positive capacity result and the exact current-rule
+self-hosting/deletion boundaries.
+
+### N8 — Cross-cycle echo
+
+Repository searches for `program`, `compiler`, `Record content`, `no retained
+primitive`, and `requires new axiom` recover repeated cases where a broad
+compiler wall was narrowed by an explicit carrier rather than a foundation
+edit. The closest echoes are the August 10 Gaussian compiler, the August 10
+effect-label carrier, the August 12 product registration, and the parent
+August 21 downstream Law. Their mechanism—take an explicit bounded import,
+construct it, then leave adoption/retirement to review and audit—is applied
+here. None has since become retained authority, so this note does not borrow a
+retired wall or claim their open selection residual is closed.
+
+## Review And Axiom Decision
+
+The construction changes the decision in one useful way: a new ontology axiom
+is not needed merely to store a preparation and a low-arity program locally.
+The current one-site domain and six-neighbor shell suffice. What remains is a
+constructive Law problem: make the encoding self-hosting, then decide whether
+equation (2), an affine-preparation alternative, or a dynamics-derived
+selector is the physical rule, followed by independent audit.
+
+The canonical
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) is therefore
+left unchanged. The next high-leverage positive campaign is a same-law writer
+that forms these six carrier contents at fresh sites. Only after that works
+should the campaign compose recurrent formation/history and confront the
+parent's two-wing correlation carrier. Re-running more finite menus without a
+new writer, selector, or occurrence mechanism should not be counted as TOE
+progress.

--- a/logs/runner-cache/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.txt
+++ b/logs/runner-cache/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py
+runner_sha256: 8f998e9713e21a9c042261d9c4f808753297388ce6f3beaf54b8a8e355b60a67
+input_fingerprint_sha256: d0e59241db72883c77996b147db47372af575b10ce831124ddbcba6f8c308718
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.73
+status: ok
+----- stdout -----
+PASS menu-domain: two ternary menus, a repeated-effect binary menu, and a projective binary menu are valid
+PASS preparation-quotient: four distinct programs have exactly the same six-neighbour Hermitian preparation center
+PASS proper-cubic-decode: all 24 proper cubic rotations only permute or reverse unoriented program pairs
+PASS preparation-density: the common Hermitian center is itself the exact normalized preparation diag(3/5,2/5)
+PASS exact-menu-weights: both ternary laws reproduce the exact shared-effect compiler weights
+PASS probability-normalization: every executed valid program has positive weights summing exactly to one
+PASS shared-record-event: the same effect-label Record code has mass 3/10 across two different neighbour programs
+PASS content-only-readout: fixed Hermitian and imaginary-trace maps recover every effect and label from Record content
+PASS selected-projective-content: the selected binary projective sublaw writes literal projector contents with exact 3/5 and 2/5 masses
+PASS pure-state-endpoint: a pure preparation gives the exact selected-projective endpoint masses one and zero
+PASS parent-prefix-composition: encoding sigma_h/Tr(sigma_h) reproduces the selected trace-Lueders parent masses 3/4 and 1/4
+PASS complex-qubit-prefix: a genuinely complex Y-coherent preparation and Y program give exact masses one quarter and three quarters
+PASS repeated-effect-labels: two equal effects remain distinct registered outcomes and each receives probability one half
+PASS internal-basis-covariance: simultaneous Pauli-X conjugation transports every output code and preserves every weight
+PASS total-rule-fallback: empty and non-scalar malformed programs receive a normalized fallback rather than an undefined decoder
+PASS self-hosting-gap: four projective carrier inputs need nonscalar anti-Hermitian data, while every current-law output has scalar such data
+PASS deletion-orientation: a signed label decoder breaks under a proper half-turn while the absolute pair decoder survives
+PASS deletion-label: deleting the scalar labels would collapse the repeated-effect binary menu to one Record content
+PASS deletion-effect-descent: menu normalization alone permits one shared effect to have contextual masses 1/4 and 1/3
+PASS registered-refinement: distinct refined Record events have separate probabilities whose ordinary sum equals the coarse event
+PASS probability-not-set-identity: two disjoint microscopic cells can represent equal-probability operational events without being one set
+PASS source-contract: the source binds the constructive claim, negative-claim gate, formation boundary, and score boundary
+per_element: exact effect-label encoding, decoding, trace mass, and two deletion controls are checked for every displayed item
+per_site: one complete six-neighbour shell, its valid-program law, fallback, and same-law self-hosting support mismatch are executed
+per_mode: checked and not executed — no spectral, momentum, transfer, or continuum mode claim belongs to this local compiler
+per_block: binary and ternary program blocks, repeated effects, refinement, and all 24 proper-cubic transports are checked
+lattice_wide: checked and not executed — translation uses the same radius-one formula, but no global occurrence history is claimed
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py
+++ b/scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Exact checks for the NN Record-program/preparation-quotient compiler.
+
+The executed fixtures use exact SymPy arithmetic.  A local possibility is an
+actual 2x2 complex matrix.  Three unoriented opposite-neighbour pairs carry
+up to three effect/label program items while all six Hermitian parts carry one
+common preparation center.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import permutations, product
+from pathlib import Path
+
+from sympy import Abs, I, Matrix, Rational as Q, sqrt, simplify
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md"
+)
+
+I2 = Matrix.eye(2)
+ZERO2 = Matrix.zeros(2)
+SX = Matrix([[0, 1], [1, 0]])
+SY = Matrix([[0, -I], [I, 0]])
+SZ = Matrix([[1, 0], [0, -1]])
+
+DIRECTIONS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+AXES = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+
+@dataclass(frozen=True)
+class Item:
+    effect: Matrix
+    label: object
+
+
+def matrix_equal(left: Matrix, right: Matrix) -> bool:
+    return left.shape == right.shape and all(
+        simplify(left[r, c] - right[r, c]) == 0
+        for r in range(left.rows)
+        for c in range(left.cols)
+    )
+
+
+def scalar_matrix(value: Matrix) -> bool:
+    return matrix_equal(value, value[0, 0] * I2)
+
+
+def hermitian_part(value: Matrix) -> Matrix:
+    return (value + value.conjugate().T) / 2
+
+
+def antihermitian_coefficient(value: Matrix) -> Matrix:
+    return (value - value.conjugate().T) / (2 * I)
+
+
+def p(nx, nz) -> Matrix:
+    return (I2 + nx * SX + nz * SZ) / 2
+
+
+def encode_pair(center: Matrix, item: Item | None) -> tuple[Matrix, Matrix]:
+    if item is None:
+        return center, center
+    plus = center + I * (item.effect + item.label * I2)
+    minus = center + I * (item.effect - item.label * I2)
+    return plus, minus
+
+
+def neg(direction: tuple[int, int, int]) -> tuple[int, int, int]:
+    return tuple(-value for value in direction)
+
+
+def encode_shell(center: Matrix, items: tuple[Item, ...]) -> dict[tuple[int, int, int], Matrix]:
+    if len(items) > 3:
+        raise ValueError("only three opposite-neighbour pairs are available")
+    shell: dict[tuple[int, int, int], Matrix] = {}
+    padded: tuple[Item | None, ...] = items + (None,) * (3 - len(items))
+    for axis, item in zip(AXES, padded, strict=True):
+        plus, minus = encode_pair(center, item)
+        shell[axis] = plus
+        shell[neg(axis)] = minus
+    return shell
+
+
+def preparation_center(shell: dict[tuple[int, int, int], Matrix]) -> Matrix:
+    return simplify(sum((hermitian_part(shell[d]) for d in DIRECTIONS), ZERO2) / 6)
+
+
+def decode_pair(plus: Matrix, minus: Matrix) -> Item | None:
+    k_plus = antihermitian_coefficient(plus)
+    k_minus = antihermitian_coefficient(minus)
+    effect = simplify((k_plus + k_minus) / 2)
+    signed_label_matrix = simplify((k_plus - k_minus) / 2)
+    if not scalar_matrix(signed_label_matrix):
+        raise ValueError("pair difference is not a scalar label")
+    label = Abs(simplify(signed_label_matrix[0, 0]))
+    if label == 0 and matrix_equal(effect, ZERO2):
+        return None
+    return Item(effect, label)
+
+
+def decode_program(shell: dict[tuple[int, int, int], Matrix]) -> tuple[Item, ...]:
+    items = []
+    for axis in AXES:
+        item = decode_pair(shell[axis], shell[neg(axis)])
+        if item is not None:
+            items.append(item)
+    return tuple(sorted(items, key=lambda item: str(item.label)))
+
+
+def positive_truth(expr) -> bool:
+    expr = simplify(expr)
+    return bool(expr.is_positive)
+
+
+def nonnegative_truth(expr) -> bool:
+    expr = simplify(expr)
+    return bool(expr.is_nonnegative)
+
+
+def is_scaled_projector_effect(effect: Matrix) -> bool:
+    if not matrix_equal(effect, effect.conjugate().T):
+        return False
+    scalar = matrix_equal(effect, effect[0, 0] * I2)
+    if scalar:
+        value = simplify(effect[0, 0])
+        return positive_truth(value) and nonnegative_truth(1 - value)
+    determinant = simplify(effect.det())
+    coefficient = simplify(effect.trace())
+    return (
+        determinant == 0
+        and positive_truth(coefficient)
+        and nonnegative_truth(1 - coefficient)
+        and nonnegative_truth(effect[0, 0])
+        and nonnegative_truth(effect[1, 1])
+    )
+
+
+def valid_program(items: tuple[Item, ...]) -> bool:
+    return (
+        len(items) in (2, 3)
+        and len({simplify(item.label) for item in items}) == len(items)
+        and all(positive_truth(item.label) for item in items)
+        and all(is_scaled_projector_effect(item.effect) for item in items)
+        and matrix_equal(sum((item.effect for item in items), ZERO2), I2)
+    )
+
+
+def is_density(center: Matrix) -> bool:
+    return (
+        matrix_equal(center, center.conjugate().T)
+        and simplify(center.trace()) == 1
+        and nonnegative_truth(center[0, 0])
+        and nonnegative_truth(center[1, 1])
+        and nonnegative_truth(center.det())
+    )
+
+
+def weight(center: Matrix, effect: Matrix):
+    return simplify((center * effect).trace())
+
+
+def codeword(item: Item) -> Matrix:
+    return item.effect + I * item.label * I2
+
+
+def literal_projective_program(items: tuple[Item, ...]) -> bool:
+    return (
+        len(items) == 2
+        and all(
+            simplify(item.effect.det()) == 0
+            and simplify(item.effect.trace()) == 1
+            for item in items
+        )
+        and not matrix_equal(items[0].effect, items[1].effect)
+    )
+
+
+def read_effect(code: Matrix) -> Matrix:
+    return hermitian_part(code)
+
+
+def read_label(code: Matrix):
+    return simplify(antihermitian_coefficient(code).trace() / 2)
+
+
+def local_law(shell: dict[tuple[int, int, int], Matrix]):
+    center = preparation_center(shell)
+    try:
+        items = decode_program(shell)
+    except ValueError:
+        return ((center, Q(1)),)
+    if not is_density(center) or not valid_program(items):
+        return ((center, Q(1)),)
+    literal = literal_projective_program(items)
+    return tuple(
+        (item.effect if literal else codeword(item), weight(center, item.effect))
+        for item in items
+    )
+
+
+def permutation_sign(perm: tuple[int, int, int]) -> int:
+    inversions = sum(
+        1 for i in range(3) for j in range(i + 1, 3) if perm[i] > perm[j]
+    )
+    return -1 if inversions % 2 else 1
+
+
+def proper_cubic_rotations() -> tuple[Matrix, ...]:
+    rotations = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            if permutation_sign(perm) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            rotation = Matrix.zeros(3)
+            for row, column in enumerate(perm):
+                rotation[row, column] = signs[row]
+            rotations.append(rotation)
+    return tuple(rotations)
+
+
+def rotate_direction(rotation: Matrix, direction: tuple[int, int, int]):
+    vector = rotation * Matrix(direction)
+    return tuple(int(vector[index]) for index in range(3))
+
+
+def rotate_shell(shell: dict[tuple[int, int, int], Matrix], rotation: Matrix):
+    return {rotate_direction(rotation, d): value for d, value in shell.items()}
+
+
+def conjugate_shell(shell, unitary: Matrix):
+    return {d: simplify(unitary * value * unitary.conjugate().T) for d, value in shell.items()}
+
+
+def item_equal(left: Item, right: Item) -> bool:
+    return simplify(left.label - right.label) == 0 and matrix_equal(left.effect, right.effect)
+
+
+def program_equal(left: tuple[Item, ...], right: tuple[Item, ...]) -> bool:
+    return len(left) == len(right) and all(item_equal(a, b) for a, b in zip(left, right))
+
+
+def law_equal(left, right) -> bool:
+    return len(left) == len(right) and all(
+        matrix_equal(a_code, b_code) and simplify(a_p - b_p) == 0
+        for (a_code, a_p), (b_code, b_p) in zip(left, right)
+    )
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    root2 = sqrt(2)
+    center = Matrix([[Q(3, 5), 0], [0, Q(2, 5)]])
+    shared = Q(1, 2) * p(0, 1)
+    menu_a = (
+        Item(shared, Q(1)),
+        Item(Q(9, 10) * p(4 * root2 / 9, Q(-7, 9)), Q(2)),
+        Item(Q(3, 5) * p(-2 * root2 / 3, Q(1, 3)), Q(3)),
+    )
+    menu_b = (
+        Item(shared, Q(1)),
+        Item(Q(3, 4) * p(2 * root2 / 3, Q(-1, 3)), Q(2)),
+        Item(Q(3, 4) * p(-2 * root2 / 3, Q(-1, 3)), Q(3)),
+    )
+    duplicate_binary = (
+        Item(Q(1, 2) * I2, Q(1)),
+        Item(Q(1, 2) * I2, Q(2)),
+    )
+    projective_binary = (
+        Item(p(0, 1), Q(1)),
+        Item(p(0, -1), Q(2)),
+    )
+
+    shell_a = encode_shell(center, menu_a)
+    shell_b = encode_shell(center, menu_b)
+    shell_d = encode_shell(center, duplicate_binary)
+    shell_p = encode_shell(center, projective_binary)
+
+    check(
+        "menu-domain",
+        all(valid_program(menu) for menu in (menu_a, menu_b, duplicate_binary, projective_binary)),
+        "two ternary menus, a repeated-effect binary menu, and a projective binary menu are valid",
+    )
+    check(
+        "preparation-quotient",
+        all(matrix_equal(preparation_center(shell), center) for shell in (shell_a, shell_b, shell_d, shell_p)),
+        "four distinct programs have exactly the same six-neighbour Hermitian preparation center",
+    )
+
+    rotations = proper_cubic_rotations()
+    rotation_ok = len(rotations) == 24
+    for shell, menu in (
+        (shell_a, menu_a),
+        (shell_b, menu_b),
+        (shell_d, duplicate_binary),
+        (shell_p, projective_binary),
+    ):
+        rotation_ok = rotation_ok and all(
+            program_equal(decode_program(rotate_shell(shell, rotation)), menu)
+            and matrix_equal(preparation_center(rotate_shell(shell, rotation)), center)
+            for rotation in rotations
+        )
+    check(
+        "proper-cubic-decode",
+        rotation_ok,
+        "all 24 proper cubic rotations only permute or reverse unoriented program pairs",
+    )
+
+    check(
+        "preparation-density",
+        is_density(center),
+        "the common Hermitian center is itself the exact normalized preparation diag(3/5,2/5)",
+    )
+    weights_a = tuple(weight(center, item.effect) for item in menu_a)
+    weights_b = tuple(weight(center, item.effect) for item in menu_b)
+    check(
+        "exact-menu-weights",
+        weights_a == (Q(3, 10), Q(19, 50), Q(8, 25))
+        and weights_b == (Q(3, 10), Q(7, 20), Q(7, 20)),
+        "both ternary laws reproduce the exact shared-effect compiler weights",
+    )
+    check(
+        "probability-normalization",
+        all(simplify(sum(weights)) == 1 for weights in (weights_a, weights_b, (Q(1, 2), Q(1, 2)))),
+        "every executed valid program has positive weights summing exactly to one",
+    )
+
+    law_a = local_law(shell_a)
+    law_b = local_law(shell_b)
+    law_d = local_law(shell_d)
+    law_p = local_law(shell_p)
+    check(
+        "shared-record-event",
+        matrix_equal(law_a[0][0], law_b[0][0])
+        and simplify(law_a[0][1] - law_b[0][1]) == 0
+        and law_a[0][1] == Q(3, 10),
+        "the same effect-label Record code has mass 3/10 across two different neighbour programs",
+    )
+    check(
+        "content-only-readout",
+        all(
+            matrix_equal(read_effect(code), item.effect) and read_label(code) == item.label
+            for menu, law in ((menu_a, law_a), (menu_b, law_b), (duplicate_binary, law_d))
+            for item, (code, _) in zip(menu, law)
+        ),
+        "fixed Hermitian and imaginary-trace maps recover every effect and label from Record content",
+    )
+    check(
+        "selected-projective-content",
+        matrix_equal(law_p[0][0], projective_binary[0].effect)
+        and matrix_equal(law_p[1][0], projective_binary[1].effect)
+        and (law_p[0][1], law_p[1][1]) == (Q(3, 5), Q(2, 5)),
+        "the selected binary projective sublaw writes literal projector contents with exact 3/5 and 2/5 masses",
+    )
+    pure_shell = encode_shell(p(0, 1), projective_binary)
+    pure_law = local_law(pure_shell)
+    check(
+        "pure-state-endpoint",
+        matrix_equal(pure_law[0][0], projective_binary[0].effect)
+        and matrix_equal(pure_law[1][0], projective_binary[1].effect)
+        and (pure_law[0][1], pure_law[1][1]) == (1, 0),
+        "a pure preparation gives the exact selected-projective endpoint masses one and zero",
+    )
+    sigma_h = Matrix([[2, 1], [1, 2]])
+    conditional_h = simplify(sigma_h / sigma_h.trace())
+    x_projective_binary = (
+        Item(p(1, 0), Q(1)),
+        Item(p(-1, 0), Q(2)),
+    )
+    parent_shell = encode_shell(conditional_h, x_projective_binary)
+    parent_law = local_law(parent_shell)
+    parent_masses = tuple(
+        simplify((item.effect * sigma_h * item.effect).trace() / sigma_h.trace())
+        for item in x_projective_binary
+    )
+    check(
+        "parent-prefix-composition",
+        tuple(probability for _, probability in parent_law) == parent_masses == (Q(3, 4), Q(1, 4)),
+        "encoding sigma_h/Tr(sigma_h) reproduces the selected trace-Lueders parent masses 3/4 and 1/4",
+    )
+    y_preparation = simplify((I2 - Q(1, 2) * SY) / 2)
+    y_projective_binary = (
+        Item(simplify((I2 + SY) / 2), Q(1)),
+        Item(simplify((I2 - SY) / 2), Q(2)),
+    )
+    y_law = local_law(encode_shell(y_preparation, y_projective_binary))
+    check(
+        "complex-qubit-prefix",
+        tuple(probability for _, probability in y_law) == (Q(1, 4), Q(3, 4)),
+        "a genuinely complex Y-coherent preparation and Y program give exact masses one quarter and three quarters",
+    )
+    check(
+        "repeated-effect-labels",
+        not matrix_equal(law_d[0][0], law_d[1][0])
+        and law_d[0][1] == law_d[1][1] == Q(1, 2),
+        "two equal effects remain distinct registered outcomes and each receives probability one half",
+    )
+
+    x_shell = conjugate_shell(shell_a, SX)
+    expected_x_law = tuple(
+        (simplify(SX * code * SX), probability) for code, probability in law_a
+    )
+    check(
+        "internal-basis-covariance",
+        law_equal(local_law(x_shell), expected_x_law),
+        "simultaneous Pauli-X conjugation transports every output code and preserves every weight",
+    )
+
+    invalid_shell = {direction: center for direction in DIRECTIONS}
+    fallback = local_law(invalid_shell)
+    fallback_rotated = local_law(rotate_shell(invalid_shell, rotations[7]))
+    malformed_shell = dict(invalid_shell)
+    malformed_shell[AXES[0]] = center + I * SX
+    malformed_fallback = local_law(malformed_shell)
+    check(
+        "total-rule-fallback",
+        len(fallback) == 1
+        and matrix_equal(fallback[0][0], center)
+        and fallback[0][1] == 1
+        and law_equal(fallback, fallback_rotated)
+        and len(malformed_fallback) == 1
+        and malformed_fallback[0][1] == 1
+        and all(
+            law_equal(malformed_fallback, local_law(rotate_shell(malformed_shell, rotation)))
+            for rotation in rotations
+        ),
+        "empty and non-scalar malformed programs receive a normalized fallback rather than an undefined decoder",
+    )
+    required_projective_carriers = tuple(shell_p[direction] for direction in DIRECTIONS)
+    nonscalar_input_count = sum(
+        not scalar_matrix(antihermitian_coefficient(value))
+        for value in required_projective_carriers
+    )
+    executed_outputs = tuple(
+        code
+        for law in (law_a, law_b, law_d, law_p, pure_law, parent_law, y_law, fallback, malformed_fallback)
+        for code, _ in law
+    )
+    check(
+        "self-hosting-gap",
+        nonscalar_input_count == 4
+        and all(scalar_matrix(antihermitian_coefficient(code)) for code in executed_outputs),
+        "four projective carrier inputs need nonscalar anti-Hermitian data, while every current-law output has scalar such data",
+    )
+
+    signed_before = simplify(
+        ((antihermitian_coefficient(shell_a[AXES[0]]) - antihermitian_coefficient(shell_a[neg(AXES[0])])) / 2)[0, 0]
+    )
+    half_turn = Matrix.diag(-1, -1, 1)
+    half_shell = rotate_shell(shell_a, half_turn)
+    signed_after = simplify(
+        ((antihermitian_coefficient(half_shell[AXES[0]]) - antihermitian_coefficient(half_shell[neg(AXES[0])])) / 2)[0, 0]
+    )
+    check(
+        "deletion-orientation",
+        signed_before == 1 and signed_after == -1 and decode_program(half_shell)[0].label == 1,
+        "a signed label decoder breaks under a proper half-turn while the absolute pair decoder survives",
+    )
+    check(
+        "deletion-label",
+        matrix_equal(duplicate_binary[0].effect, duplicate_binary[1].effect)
+        and len({str(code) for code, _ in law_d}) == 2,
+        "deleting the scalar labels would collapse the repeated-effect binary menu to one Record content",
+    )
+    contextual_a = (Q(1, 4), Q(1, 4), Q(1, 2))
+    contextual_b = (Q(1, 3), Q(1, 3), Q(1, 3))
+    check(
+        "deletion-effect-descent",
+        sum(contextual_a) == sum(contextual_b) == 1 and contextual_a[0] != contextual_b[0],
+        "menu normalization alone permits one shared effect to have contextual masses 1/4 and 1/3",
+    )
+
+    coarse = weight(center, Q(1, 2) * I2)
+    fine_left = weight(center, Q(1, 4) * I2)
+    fine_right = weight(center, Q(1, 4) * I2)
+    check(
+        "registered-refinement",
+        coarse == Q(1, 2) and fine_left == fine_right == Q(1, 4) and coarse == fine_left + fine_right,
+        "distinct refined Record events have separate probabilities whose ordinary sum equals the coarse event",
+    )
+    event_a = {0, 1}
+    event_b = {2, 3}
+    check(
+        "probability-not-set-identity",
+        event_a.isdisjoint(event_b) and Q(len(event_a), 6) == Q(len(event_b), 6),
+        "two disjoint microscopic cells can represent equal-probability operational events without being one set",
+    )
+
+    note_text = NOTE.read_text() if NOTE.exists() else ""
+    check(
+        "source-contract",
+        all(
+            token in note_text
+            for token in (
+                "Preparation quotient",
+                "No-Go Discipline Gate",
+                "N1 — Alternative route enumeration",
+                "N8 — Cross-cycle echo",
+                "conditional on formation",
+                "no TOE-percentage movement",
+                "self-hosting",
+            )
+        ),
+        "the source binds the constructive claim, negative-claim gate, formation boundary, and score boundary",
+    )
+
+    print(
+        "per_element: exact effect-label encoding, decoding, trace mass, and two deletion controls are checked for every displayed item"
+    )
+    print(
+        "per_site: one complete six-neighbour shell, its valid-program law, fallback, and same-law self-hosting support mismatch are executed"
+    )
+    print(
+        "per_mode: checked and not executed — no spectral, momentum, transfer, or continuum mode claim belongs to this local compiler"
+    )
+    print(
+        "per_block: binary and ternary program blocks, repeated effects, refinement, and all 24 proper-cubic transports are checked"
+    )
+    print(
+        "lattice_wide: checked and not executed — translation uses the same radius-one formula, but no global occurrence history is claimed"
+    )
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Gives an exact opposite-neighbor M2 encoding that separates a supplied density preparation from a binary or ternary scaled-projector program under all 24 proper cubic rotations.
- Shows that the selected trace law reproduces the parent one-site prefix marginal, literal projective contents, pure endpoints, repeated-effect menus, and additive refinements.
- Adds an exact self-hosting check: the current Record rule outputs only scalar anti-Hermitian coefficients, while active carrier inputs require nonscalar coefficients. This is therefore a conditional capacity theorem, not physical Record-carrier closure.

## Scientific status

This is stacked on #7210. It is source-level bounded evidence only: no axiom or primitive change, no audit verdict, no formal obligation retired, and no TOE-percentage movement.

Still open are a same-law physical writer/genesis mechanism, physical calibration or trace-law selection, multi-site formation/history, and a Bell-capable composite carrier.

The note includes the N1-N8 no-go stress test, including the five required N5 resolution lines.

## Verification

- Block 32 primary runner: TOTAL: PASS=22 FAIL=0
- Canonical cache is runner-SHA and input-fingerprint pinned; cached stdout is below 6000 characters
- Both parent #7210 runners: TOTAL: PASS=12 FAIL=0
- Python compile, vocabulary lint, staged diff check, and audit-runner freshness checks pass
- Independent cold check: packaging PASS after narrowing the original carrier-closure overclaim