### PR TITLE
physics: construct self-hosting homogeneous Record carrier

### DIFF
--- a/docs/NN_RECORD_HOMOGENEOUS_PAYLOAD_SELF_HOSTING_WRITER_BOUNDED_THEOREM_NOTE_2026-08-22.md
+++ b/docs/NN_RECORD_HOMOGENEOUS_PAYLOAD_SELF_HOSTING_WRITER_BOUNDED_THEOREM_NOTE_2026-08-22.md
@@ -1,0 +1,682 @@
+---
+claim_id: nn_record_homogeneous_payload_self_hosting_writer_bounded_theorem_note_2026-08-22
+claim_type: bounded_theorem
+claim_scope: "For the owner-selected but open binary-projective Record sector Law, one explicit total nearest-neighbor kernel uses a normalized full-support Gaussian seed measure on M_2(C), a content-symmetric copy branch, and a six-equal-payload trace-read branch. A generic payload A decodes covariantly to a density C(A) and complementary rank-one projectors P(A),I-P(A). One exact seed-plus-ten-copy append order leaves the origin fresh while forming six identical nearest-neighbor payload Records; conditional on that supplied fresh-site order, the Gaussian root is generic almost surely, each of ten later copies has conditional mass one, and the target writes literal projectors with masses Tr(CP), reproducing the parent's one-site trace/Lueders prefix marginal. Exact fixtures cover real, complex, and pure endpoint payloads, all 24 proper cubic rotations, internal basis transport, total fallbacks, permanence, an atomless-independent deletion, and premature-target failure. This is an alternative binary-projective carrier, not a repair of Block 32's opposite-pair carrier and not a retention of its ternary/scaled/repeated-label domain. The payload calibration, trace-Law selection, formation site/rate/order, fresh-resource guarantee, recurrent history, composite four-arm/Bell carrier, PR #7317 amplitude calibration, audit status, obligations, and TOE percentages remain unchanged."
+depends_on:
+  - minimal_axioms
+  - realized_state_primitive
+  - record_projective_history_local_append_downstream_law_candidate_bounded_theorem_note_2026-08-21
+  - nn_record_program_preparation_quotient_trace_compiler_bounded_theorem_note_2026-08-22
+runner: scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py
+independent_runner: scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py
+runner_cache: logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.txt
+independent_runner_cache: logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Nearest-Neighbor Record Homogeneous-Payload Self-Hosting Writer
+
+**Date:** 2026-08-22
+
+**Claim type:** bounded theorem
+
+**Role:** alternative binary-projective carrier and finite append witness
+
+**Authority boundary:** the only effective premise used as framework authority
+is the current
+[`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md). The
+[`realized-state primitive`](REALIZED_STATE_PRIMITIVE_NOTE_2026-06-11.md)
+permits pointwise reference to the law-admissible realized history; it supplies
+no seed, draw, probability rule, or selected state. The selected
+[`Record projective-history candidate`](RECORD_PROJECTIVE_HISTORY_LOCAL_APPEND_DOWNSTREAM_LAW_CANDIDATE_BOUNDED_THEOREM_NOTE_2026-08-21.md)
+and the preceding
+[`six-neighbor program compiler`](NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-22.md)
+are open source proposals, not retained premises. Independent audit owns every
+scientific verdict.
+
+**Primary runner:**
+[`scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py`](../scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py)
+
+**Independent runner:**
+[`scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py`](../scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py)
+
+**Cached receipts:**
+[`primary`](../logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.txt),
+[`independent`](../logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.txt)
+
+## Result Up Front
+
+The one-site binary-projective carrier can be made output-closed under one
+fixed nearest-neighbor Law. The mechanism is a **shared payload**, not six
+independent continuous draws.
+
+A generic Record content `A in M_2(C)` carries both a preparation and a binary
+projective program. Its Hermitian and centered anti-Hermitian parts decode
+
+```text
+C(A) = H(A)^2 / Tr(H(A)^2),
+P(A) = (I + K_0(A)/r(A))/2,
+Q(A) = I-P(A).                                           (1)
+```
+
+The empty-neighbor branch draws `A` from a normalized, conjugation-invariant
+Gaussian with full support. Outside the complete homogeneous read predicate, a
+copy branch gives positive atomic mass to every generic payload already present
+in the neighboring Records. When all six neighbors of a fresh site carry one
+common generic `A`, the read branch writes
+the literal contents `P(A)` and `Q(A)` with masses
+
+```text
+Tr(C(A)P(A)),  Tr(C(A)Q(A)).                             (2)
+```
+
+An explicit eleven-Record scaffold starts with one Gaussian seed and makes ten
+exact copies around a still-fresh origin. Every copy is an output of the same
+kernel. The completed target shell therefore satisfies the read predicate and
+equation (2) exactly. No carrier matrix is inserted by the host.
+
+This closes the **output-shape/self-hosting gap** for this alternative
+binary-projective carrier. It does not repair the exact opposite-pair matrices
+of Block 32, and it deliberately gives up that source's ternary scaled-effect
+and repeated-label coverage. More importantly, the content kernel is still
+conditional on where formation occurs. The axioms do not protect the origin
+from forming too early or select the eleven-site order. The exact deletion test
+shows that an early target permanently locks the payload and can never become
+the intended outcome Record.
+
+Thus the significant advance is real but bounded: the carrier-content problem
+has a constructive solution; the terminal physics problem is now a joint
+formation-site/history rule with freshness and resource accounting.
+
+There is no axiom edit, no primitive proposal, no audit verdict, no formal
+obligation retirement, and **no TOE-percentage movement** in this source.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The payload quotient, one total content kernel, exact seed/copy scaffold, output closure, covariance, parent one-site marginal, and formation-order deletion are proved. The realized formation-site order, program calibration/control, trace-Law selection, recurrent history, and composite carrier are conditional or open."
+trace_class: direct_blocker_composition
+target_claim_id: record_projective_history_nn_homogeneous_payload_self_hosting_writer
+target_blocker_text: "construct a self-hosting target-local carrier whose complete nearest-neighbor Record condition determines the selected one-site event marginal"
+source_of_blocker_text: "record_projective_history_local_append_downstream_law_candidate_bounded_theorem_note_2026-08-21"
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "construct an equivariant append eligibility/rate kernel that grows the payload scaffold while keeping the target ineligible until all six carrier Records exist; in parallel, test whether PR #7318's marginal is an exact in-framework average of its formation conditional across held-out fixtures"
+conditional_surface_status: "same-content-law output closure and exact one-site trace readout conditional on one finite fresh-site formation order; autonomous site/rate/cadence, calibration, recurrence, and composite coupling remain open"
+hypothetical_axiom_status: "no core-axiom edit proposed or justified"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target Contract
+
+| Field | Contract |
+|---|---|
+| target statement | construct one translation/proper-cubic-covariant nearest-neighbor content kernel whose own outputs form an exact local preparation/program carrier at fresh sites and whose completed carrier realizes the selected binary-projective trace marginal |
+| quantifiers/domain | every generic payload in the declared open set; every qubit density and rank-one projector through a supported canonical representative; every translation; all 24 proper cubic rotations; every partial or malformed neighboring Record condition |
+| allowed premises | `Z^3`, the one-site `M_2(C)` possibility domain, one fixed local probability rule, Record locking/permanence, pointwise realized-history reference, and the open parent trace Law as a provisional downstream benchmark |
+| forbidden weakenings | six host-inserted carrier matrices; independent atomless draws called a positive exact shell; zero singleton mass called impossibility; a supplied formation order called derived; the payload quotient or trace functional called axiom content |
+| required edges | generic and degenerate payloads, mixed and pure preparations, genuinely complex projectors, exact zero/one endpoint, all rotations, internal basis transport, total fallback, no overwrite, and premature target formation |
+| completion witness | explicit kernel, exact seed decoder, seed-plus-ten-copy append certificate, output-support inclusion, and equality with the parent prefix formula |
+| outcomes not counted as closure | program control, formation-site/rate derivation, recurrent reset, arbitrary POVMs, ternary labels, Bell/four-arm composition, determinant-amplitude calibration, audit retention, gravity, or TOE score movement |
+
+The theorem is conditional on formation at the displayed fresh sites. That is
+not cosmetic: Admissibility fixes content odds conditional on formation, while
+the Minimal Axioms expressly leave the formation site, probability, and rate
+outside the content rule.
+
+## 1. Payload Quotient
+
+For `A in M_2(C)`, put
+
+```text
+H(A)   = (A+A^dagger)/2,
+K(A)   = (A-A^dagger)/(2i),
+K_0(A) = K(A) - Tr(K(A)) I/2,
+d(A)   = Tr(H(A)^2),
+r(A)   = sqrt(Tr(K_0(A)^2)/2).                          (3)
+```
+
+Call `A` **generic for this downstream Law** when `d(A)>0` and `r(A)>0`.
+Equation (1) then has the following elementary properties.
+
+1. `H(A)^2` is positive and has trace `d(A)`, so `C(A)` is a density
+   matrix.
+2. A nonzero traceless Hermitian `2x2` matrix `K_0` has eigenvalues
+   `+r,-r`; hence `P(A)` and `Q(A)` are complementary rank-one projectors.
+3. Under `A -> U A U^dagger`, all three decoded matrices conjugate by `U`.
+4. Every prescribed pair `(C,P)` has a supported representative
+
+```text
+A_(C,P) = sqrt(C) + iP.                                 (4)
+```
+
+Indeed `d=Tr(C)=1`, while the centered part of `P` has radius `1/2`, so
+equation (1) returns exactly `C` and `P`.
+
+Equation (4) is a **canonical representative of a quotient fiber**. It is not
+an assertion that a smooth Gaussian seed almost surely has that literal form.
+A generic Gaussian seed is decoded by equation (1); the many matrices with the
+same `H^2` and upper `K` eigenspace intentionally represent the same selected
+preparation/program pair. This wording matters because the canonical-code
+submanifold has zero Gaussian measure even though every one of its points lies
+in support.
+
+The identification of `C(A)` as a physical preparation and `P(A)` as a
+physical program is downstream calibration content. The algebra proves that
+the quotient exists and is covariant; it does not make that calibration a
+consequence of Qubit or Record.
+
+## 2. One Fixed Total Content Kernel
+
+Write a fresh site's nearest-neighbor condition as six slots, each either
+blank or occupied by one permanent Record content. Blank is an occupancy
+condition, not a matrix readout value.
+
+Let `D(eta)` be the set of distinct generic payload contents among the occupied
+neighbor slots. Define the one fixed kernel `K_eta` in this order:
+
+```text
+R. if all six slots contain one common generic A:
+       K_eta = Tr(C(A)P(A)) delta_(P(A))
+             + Tr(C(A)Q(A)) delta_(Q(A));
+
+C. otherwise, if D(eta) is nonempty:
+       K_eta = (1/|D(eta)|) sum_(B in D(eta)) delta_B;
+
+G. otherwise:
+       K_eta = nu.                                      (5)
+```
+
+Here `nu` is the standard complex matrix Gaussian
+
+```text
+d nu(A) = pi^(-4) exp[-Tr(A^dagger A)] d^8 A.           (6)
+```
+
+The product of eight normalized real Gaussian integrals proves that equation
+(6) has mass one. Its density is strictly positive at every finite matrix, so
+its support is all of `M_2(C)`. The nongeneric sets `H=0` and `K_0=0` are
+proper real-linear subspaces and therefore have `nu`-measure zero. A seed is
+generic almost surely.
+
+Rule R is tested before Rule C. Degenerate homogeneous shells, conditions with
+only nongeneric contents, and the empty shell receive Rule G. Conditions with
+several distinct generic neighbors receive their symmetric uniform copy law.
+Therefore equation (5) gives one normalized probability measure on every
+condition; it is not a partial decoder.
+
+It is also a Borel Markov kernel, not merely a pointwise recipe. Genericity is
+an open condition, the decoder is continuous on that open set, and the finite
+occupancy/genericity/equality patterns of six slots form a Borel partition.
+On each stratum, equation (5) is either a fixed Gaussian, a finite sum of
+Dirac kernels at coordinate projections, or a two-Dirac kernel with continuous
+decoded locations and weights.
+
+Translations do not change relative neighbor contents. Proper cubic rotations
+only permute the six slots. Rules R--G use equality, occupancy, the unordered
+set `D`, adjoint, trace, and spectrum, so all 24 proper cubic rotations preserve
+the answer. Equation (6) is invariant under unitary conjugation, and equations
+(1)--(3) are equivariant, giving the stronger internal-representation check as
+well.
+
+The kernel genuinely varies with its neighbor condition: an empty or
+nongeneric shell receives a continuous full-support law, a partial generic
+condition receives copy atoms, and a complete homogeneous payload receives the
+binary trace law.
+
+## 3. Exact Append Scaffold
+
+Put the intended read target at the origin. Form payload Records in this order:
+
+```text
+( 1, 1, 0)      seed
+( 1, 0, 0)      copy
+( 0, 1, 0)      copy
+(-1, 1, 0)      copy
+(-1, 0, 0)      copy
+( 1, 0, 1)      copy
+( 0, 0, 1)      copy
+( 1, 0,-1)      copy
+( 0, 0,-1)      copy
+( 1,-1, 0)      copy
+( 0,-1, 0)      copy                               (7)
+```
+
+For this finite witness, every undeclared site in the nearest-neighbor buffer
+of the displayed sites is initially blank. That fresh-buffer condition and the
+site order are supplied realized-history data; the content matrices are not.
+
+The first site has no earlier recorded neighbor and draws `A` from `nu`. On the
+`nu`-probability-one event that `A` is generic, every later site has exactly one
+earlier payload neighbor in the displayed finite history, so Rule C copies that
+exact `A` with mass one. The runner checks the predecessor census
+
+```text
+(0,1,1,1,1,1,1,1,1,1,1).
+```
+
+The six sites at `+/-e_x,+/-e_y,+/-e_z` are among the eleven Records. The
+origin is never written during equation (7), and after the last append its full
+nearest-neighbor shell is `(A,A,A,A,A,A)`. Rule R then applies.
+
+This avoids a subtle atomless error. If six carrier matrices were drawn
+independently from equation (6), the five equalities `A_j=A_1` impose forty
+independent real constraints in forty-eight dimensions. The exact homogeneous
+shell would have probability zero. The shared-seed joint law instead has form
+
+```text
+nu(dA) delta_A(dA_2) ... delta_A(dA_11).                (8)
+```
+
+Under equation (8), the root is generic with probability one and every copy
+equals that realized root with probability one. Every preselected exact `A`
+still has `nu({A})=0`; there is no contradiction. Continuous variables have
+zero-mass exact points, while content-conditioned Dirac branches correlate
+later Records with the realized seed.
+
+The history is append-only. Each site is written once, no old Record changes,
+and the target writes exactly one supported projector. At an endpoint, the
+orthogonal projector has mass zero and is absent from support, matching the
+parent's no-fabrication behavior.
+
+### Formation-site boundary
+
+Equation (7) is a legal externally supplied formation order whose content
+trajectory is supported by `K`, not a formation-site Law. The distinction is
+exact. Once the first `+e_x` carrier exists, the still-blank origin has a generic
+payload neighbor. If the origin forms at that moment,
+Rule C writes `A` there. Permanence then rejects the later projector write even
+after the other five carriers appear. The primary runner executes this
+premature-target deletion.
+
+Consequently content-level self-hosting is closed on the displayed finite
+history, while autonomous genesis is not. A positive completion must add a
+joint append or eligibility/rate rule that:
+
+1. makes scaffold sites eligible in a covariant local order;
+2. holds the origin ineligible while its payload shell is incomplete;
+3. makes the origin eligible after all six copies exist;
+4. preserves old Records and controls overlapping fronts; and
+5. accounts for fresh sites, recurrence, and any fuel or exported resource.
+
+Those are process requirements, not reasons to rewrite the four axioms. The
+current Admissibility clause is explicitly a content distribution conditional
+on formation.
+
+## 4. Parent One-Site Composition
+
+For any supported one-qubit parent prefix
+`0 <= sigma_h in M_2(C)` with `Tr(sigma_h)>0`, set
+
+```text
+C = sigma_h / Tr(sigma_h).
+```
+
+Choose any rank-one program projector `P`, and use any payload in the quotient
+fiber `(C,P)`, including equation (4). At the completed shell, Rule R gives
+
+```text
+p(P | A) = Tr(CP)
+         = Tr(P sigma_h P) / Tr(sigma_h).                (9)
+```
+
+The second equality is projector idempotence plus trace cyclicity. Equation
+(9) is exactly the selected parent candidate's one-site prefix marginal. The
+output contents are literally `P` and `I-P`, so its provisional event map also
+matches.
+
+The exact runner obtains `13/14,1/14` on a real coherent payload, `1/14,13/14`
+on a genuinely complex `Y` payload, `3/4,1/4` on an unnormalized parent prefix,
+and `1,0` at a pure endpoint. It changes only the anti-Hermitian payload data to
+hold the preparation fixed while changing the program.
+
+This is a selected downstream Law realization, not a derivation of equation
+(9) from the four axioms. A specified laboratory `(C,P)` also needs controlled
+preparation of a payload in the relevant quotient fiber. A spontaneous
+Gaussian seed produces a random decoded pair; support of every prescribed
+representative is not the same as operational control of that representative.
+
+## 5. Relation To Block 32
+
+Block 32 used six different active matrices
+
+```text
+C + i(E_j +/- ell_j I)
+```
+
+to carry binary or ternary scaled-projector menus with repeated-effect labels.
+Its displayed read rule outputs only matrices with scalar anti-Hermitian
+coefficient, so it cannot output those active inputs.
+
+This note changes the carrier. It places the complete binary preparation and
+program quotient in one generic payload `A` and copies that same content to all
+six neighbors. Since Rule C outputs `A` itself, the input/output alphabet is
+closed. That is a genuine solution for the narrower parent binary-projective
+sector, but it is not a literal repair of Block 32 equation (1). Arbitrary
+ternary scaled effects and repeated labels are not claimed here.
+
+The change is scientifically useful because the selected parent Law is binary
+projective. It should not be counted as retaining every generalization explored
+by the earlier compiler.
+
+## 6. The PR #7317/#7318 Pincer
+
+The independently developed open
+[`PR #7317`](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/7317)
+isolates a complementary high-value question. On its finite Dirac--Kahler
+fixtures, a complex Gaussian gives four menu amplitudes
+
+```text
+Z_a = pi^N / det Q_a,
+```
+
+but does not select a positive readout map. Squared modulus, unsquared modulus,
+a Hermitian surrogate, and positive-real variants survive the advertised
+fixtures with the same pass/fail pattern.
+
+There is an exact conditional algebraic route. Fix a bijection between the four
+menu labels `a` and pairs `(i,j) in {0,1}^2`, and put
+
+```text
+Pi_ij = |i><i| tensor |j><j|.
+```
+
+For raw amplitudes `z_ij=pi^N/det Q_ij`, assume a common finite `N` and a
+fixture on which every Gaussian integral converges (in particular, the
+relevant Hermitian part of each `Q_ij` is positive definite, hence every
+determinant is nonzero) and `0 < sum_ij |z_ij|^2 < infinity`. If those four
+complex numbers are physically calibrated **jointly**, up to one common
+nonzero gain, as the components of a normalized two-qubit amplitude state
+
+```text
+|psi_Z> = (sum_ij z_ij |ij>) / sqrt(sum_ij |z_ij|^2),
+rho_Z = |psi_Z><psi_Z|,
+```
+
+then the parent composite projective trace Law, supplied with the possibly
+entangled two-qubit preparation `rho_Z` and commuting local product projectors
+`Pi_ij`, assigns
+
+```text
+p(i,j) = Tr(Pi_ij rho_Z Pi_ij)
+       = |det Q_ij|^(-2) / sum_kl |det Q_kl|^(-2).       (10)
+```
+
+The common factor `pi^N` cancels. Arm-dependent magnitude gains or basis mixing
+would change the answer. Relative phases do not affect this one product-basis
+measurement, but a physical calibration must still fix them consistently
+because other projective programs can detect them. Equation (10) therefore
+returns the `|det Q|^-2` member *conditional on imposing that amplitude-state
+calibration*. The parent Law permits the supplied, possibly entangled,
+two-qubit preparation and these commuting local product projectors
+algebraically, but its runner does not
+execute PR #7317's determinant fixtures. Conversely, this note's independent
+four-arm test uses arbitrary nonzero determinant values and checks only that
+conditional trace algebra; it does not test those matrices, convergence, or
+packet formation.
+
+The subsequently opened
+[`PR #7318`](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/7318)
+measures the missing distinction on one exact fixture. Its inherited W9
+record-slice block is exactly diagonal, so its normalized diagonal is a
+classical density `C`; `Tr(C E_j)` then equals that lane's measured **marginal**
+entry for entry. But its normalized `|det Q_j|^-2` law is a
+**formation-conditional** distribution, and it differs from the marginal in
+all four entries. Thus the existing W9 density is not the imposed `rho_Z` above.
+The two laws are different probability objects, not rival evaluations of one
+already calibrated object.
+
+This is therefore algebra, not yet a physical bridge. The shear-menu label
+`0` must not be confused with `det Q=0`: PR #7317's sampled `Q_0` is
+nonsingular. At `m=0` its determinants remain nonzero while the Hermitian part
+loses the positivity needed by the Gaussian integral, so that limit diverges.
+Open interfaces include
+calibrating four separately computed Gaussian numbers into one coherent state,
+fixing the tensor factorization and basis, preserving relative phases, carrying
+the packet, and registering the corresponding event. The present writer
+carries only one binary qubit marginal. The parent benchmark serializes a
+`4x4` supplied preparation through one anchor plus four `M_2(C)` block Records;
+it does not already construct a genuine two-site carrier. A local composite
+carrier or exact sequential binary compiler is still required. Selecting the
+readout also does not repair PR #7317's separate exact finite-width
+blanket-locality failure, its level-indexed construction, its sampled-only
+`m>0` positivity evidence, or the `m=0` divergence.
+
+Thus the pincer is promising but not closed by either open block. It converts a
+vague readout ambiguity into two concrete successor tests: derive one object
+from the other by an in-framework conditioning/averaging rule, or supply a
+principle that selects which object Admissibility names. If an amplitude-state
+bridge remains live, it must physically carry the four-component packet into
+the parent two-qubit Record cylinder and recover its full joint four-valued
+event. The two one-wing marginals do not determine the coupling. A valid bridge
+must therefore either collocate or encode the joint cylinder in one site's
+complete nearest-neighbor Record condition, or provide an exact
+sequential/block compiler whose pushforward is the original four-valued site
+event. The parent explicitly leaves that global coupling separate from its
+per-wing local kernels.
+
+## 7. What Is Closed And What Remains
+
+| Interface | Disposition |
+|---|---|
+| one `M_2(C)` payload capacity for arbitrary qubit density plus binary projector | constructed as the quotient (1), with supported representatives (4) |
+| one total translation/proper-cubic-covariant content kernel | constructed in equation (5) |
+| same-law output closure of the active carrier contents | constructed: Rule C outputs the exact payload copied into Rule R's shell |
+| finite append-only physical-content witness | constructed with one seed and ten copies; all old Records remain fixed |
+| parent one-site trace/Lueders marginal and literal contents | reproduced exactly on every completed generic payload shell |
+| joint exact-homogeneity event after a continuous seed | probability one through conditional atoms; every preselected diagonal point remains zero-mass |
+| preparation/program physical calibration and control | open downstream interface |
+| trace-Law selection from the four axioms | not derived; owner-selected candidate only |
+| formation site, rate, order, target readiness, and collision handling | not supplied by the content kernel; premature-target failure executed |
+| recurrent resource renewal and arbitrary histories | not constructed |
+| Block 32 ternary/scaled/repeated-label carrier | not retained by this alternative encoding |
+| PR #7317/#7318 four-arm readout pincer | conditional amplitude-state algebra identified, while one exact fixture separates the trace marginal from the determinant formation conditional; selection/relation, physical calibration, full-coupling carrier/pushforward, and blanket locality remain open |
+| axiom/primitive change | none |
+| retained claim or TOE score | none; landing and independent audit are required |
+
+## 8. Deletion And Hostile Controls
+
+| Deleted or altered ingredient | Exact result |
+|---|---|
+| shared realized seed plus conditional copy atoms | six independent Gaussian payloads hit the exact homogeneous shell only on a codimension-40 null set |
+| nonzero Hermitian payload part | `C(A)` is undefined; the rule sends the condition to fallback |
+| nonscalar anti-Hermitian payload part | the program eigenspace is undefined; the rule sends the condition to fallback |
+| full six-copy read predicate | a partial shell uses the copy branch and does not pretend to be an outcome measurement |
+| fresh-target order | the origin copies `A` early and permanence rejects the later outcome write |
+| literal projector output | the parent candidate's provisional event-content map no longer composes |
+| complete projector frame | trace normalization does not follow |
+| quotient calibration | the matrices remain a valid algebraic code but have no established physical preparation/program meaning |
+
+The primary runner executes the first five, the parent content/marginal
+composition, malformed totality, exact complex and endpoint cases, and all 24
+proper cubic rotations. It does not inflate the process or four-arm questions
+into executed no-go claims.
+
+## No-Go Discipline Gate
+
+The no-go-discipline skill applies because this positive theorem names a
+formation-site boundary and contains narrow deletion negatives. The gate status
+is **PASS for the stated content-level theorem, atomless deletion, and exact
+premature-target boundary**. No broad self-hosting, Record, Born, formation, or
+axiom-necessity no-go is claimed.
+
+### N1 — Alternative route enumeration
+
+| Family | Distinct attack route | Disposition and honesty marker |
+|---|---|---|
+| shared continuous payload plus conditional atoms | sample one generic payload, copy the realized content through atomic neighbor-conditioned branches, then read six equal copies | **ATTEMPTED — SUCCEEDS** at content level in equations (5)--(8); this is why every broad self-hosting no-go is withheld |
+| six independent atomless carriers | draw each active carrier independently from a full-support Gaussian | **ATTEMPTED — FAILS FOR POSITIVE EXACT SHELL MASS**: the runner finds forty independent equality constraints; this does not deny topological support |
+| universal purely atomic seed law | assign positive singleton mass to a representative for every exact `(C,P)` | **ATTEMPTED — FAILS AT THE DECLARED CONTINUUM**: the atoms of a probability measure are countable, while the preparation/program family is uncountable; a continuous shared seed avoids this |
+| literal Block 32 radius-two copier | supply the six distinct equation-(1) payloads one layer outward and copy them inward | **ATTEMPTED — PARTIAL**: it repairs the immediate output-shape mismatch but moves six program/preparation Records to supplied boundary data rather than generating a shared payload |
+| coherent cq/instrument writer | use Stinespring pointer copies and a nondemolition carrier | **ATTEMPTED — LIVE CONDITIONAL ROUTE**: open PRs #7031, #7036, and #7037 give finite channel/carrier algebra, while their own scopes leave framework Record formation, fresh fragments, calibration, and scheduling open |
+| content-phase cellular front | encode readiness in Record content and grow an append-only compiler front | **ATTEMPTED — LIVE**: it can change the formation obligation and is the next positive target; the Minimal Axioms do not themselves supply a site/rate process |
+| joint pure-birth generator | supplement the content kernel by local eligibility/rates and prove a nonexplosive append history | **ATTEMPTED AS A FORMAL TARGET — LIVE**: it directly attacks the surviving formation-site boundary and prevents any claim that a new core axiom is already necessary |
+| four-arm composite amplitude carrier | calibrate PR #7317's four amplitudes as a two-qubit state and use the selected composite trace cylinder | **ATTEMPTED ALGEBRAICALLY — LIVE PHYSICALLY**: squared modulus follows conditionally, but amplitude calibration, a local composite carrier, and finite-width locality remain open |
+
+These families differ in primary object, mechanism, and terminal obligation;
+they are not multiple names for one carrier encoding.
+
+The two finite-measure statements used in the table are elementary. For an
+atomless Gaussian, the forty independent equality constraints define a
+Lebesgue-null linear subspace. For any probability measure, the atoms of mass
+at least `1/n` form a finite set; the union over positive integers `n` contains
+every positive-mass atom and is countable. Hence one fixed purely atomic seed
+law cannot give positive singleton mass to every member of an uncountable
+exact `(C,P)` family.
+
+### N2 — Wall-independence audit
+
+The raw issue list collapses to three physics interfaces. Program control is
+part of calibration; target freshness, site/rate, recurrence, and resources are
+parts of one autonomous append/history interface; the four-arm and Bell cases
+share the composite-carrier interface.
+
+| Pair | closing first closes second? | closing second closes first? | independent? |
+|---|---:|---:|---:|
+| payload/trace calibration vs autonomous append/history | no | no | yes |
+| payload/trace calibration vs composite carrier/coupling | no | no | yes |
+| autonomous append/history vs composite carrier/coupling | no | no | yes |
+
+Landing and audit are governance gates, not additional physics walls. Block 32
+generality is outside this note's narrower target, not a fourth wall.
+
+### N3 — Hidden-wall scan
+
+| Phrase or risk | Classification |
+|---|---|
+| `canonical representative` | explicitly means equation (4), a supported point in a quotient fiber; it is not claimed to be a generic Gaussian draw |
+| `registered` | used only for already formed Record contents under the provisional parent event map; no pointer is silently registered by algebra |
+| `by construction` variants | refer only to displayed downstream definitions and the executed append list, never to axiom-supplied dynamics |
+| `fresh` / `formation order` | promoted to the explicit autonomous append/history wall and deletion-tested |
+| `framework provides` | limited to the four axiom clauses and approved realized-state reference; neither supplies the seed, trace weights, calibration, or schedule |
+| `standard`, `naturally`, `obviously`, `background`, `bridge context` | not used as load-bearing proof steps |
+
+### N4 — Residual matching
+
+| Source | Source residual | Residual used here | Match? |
+|---|---|---|---:|
+| [Minimal Axioms](MINIMAL_AXIOMS_2026-06-29.md) | content distribution is conditional on formation; distribution values, formation site/rate, dynamics, and context selection remain downstream | formation-site/order boundary and selected trace/payload calibration | yes |
+| [parent finite projective candidate](RECORD_PROJECTIVE_HISTORY_LOCAL_APPEND_DOWNSTREAM_LAW_CANDIDATE_BOUNDED_THEOREM_NOTE_2026-08-21.md) | target-local nearest-neighbor carrier absent; preparation, formation, and composite carrier remain open | reproduce its one-site marginal while constructing an alternative local carrier | partial match: one-site formula/carrier advances; formation and composite residuals remain |
+| [Block 32 compiler](NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-22.md) | displayed output shapes cannot form its active nonscalar carrier inputs | replace that carrier on the binary-projective parent sector | yes for the self-hosting target; no literal repair or ternary retention is claimed |
+| [PR #7317/#7318](https://github.com/jonathonreilly/qubit-lattice-axiom-framework/pull/7318) | complex determinant amplitudes have no selected positive readout; the measured trace marginal and determinant formation conditional are distinct on one fixture; exact finite blanket locality also fails | conditional amplitude-state algebra plus the select-or-relate fork and next composite target | partial only; not cited as present closure or retained authority |
+
+No nonmatching source is used as evidence for a negative conclusion.
+
+### N5 — Rhetoric and resolution audit
+
+The cached primary runner lands these five substantive execution-certificate
+lines:
+
+```text
+per_element: exact payload quotient, Gaussian support density, copy atom, projector contents, and trace masses are checked
+per_site: empty, partial homogeneous, complete homogeneous, malformed, premature, and permanent site branches are executed
+per_mode: no momentum, spectral, continuum, gravity, or PR determinant-matrix fixture is executed; the ancillary finite inverse-determinant identity is separate
+per_block: the 11-Record scaffold and all 24 proper-cubic copies are checked, with the target fresh until completion
+lattice_wide: checked and not executed — one finite append order is witnessed; no autonomous global formation process is claimed
+```
+
+Accordingly the new negative conclusions established here are limited to
+independent atomless exact shell mass, the countability obstruction to a
+universal positive-singleton atomic seed, and the displayed premature-target
+append. No per-mode, lattice-wide, autonomous-process, or universal
+self-hosting impossibility is stated.
+
+### N6 — Primitive and partial-closure paths
+
+The primitive registry was checked from canonical `origin/main`. The
+realized-state primitive permits pointwise reference to the realized seed and
+history, but supplies no state, selector, measure, weight, probability rule,
+typicality, or value. The scale-reference and kinetic-isotropy primitives are
+irrelevant to this content theorem and are not counted as missing premises.
+
+Live partial-closure paths are:
+
+| Path | Status | What it can close |
+|---|---|---|
+| this homogeneous-payload kernel | current stacked source | binary content capacity, same-law output closure, finite append witness, and selected one-site marginal |
+| parent owner-selected Law | open source proposal | explicit binary/composite trace-history benchmark; not derivation or retention |
+| content-phase or pure-birth append generator | next constructive target | site eligibility, target freshness, collision handling, and recurrent formation |
+| Block 32 opposite-pair compiler | open stacked source | ternary/scaled/repeated-label representation on supplied shells |
+| PR #7317/#7318 plus a two-qubit carrier | open cross-branch pincer | test a physical amplitude-state bridge or derive/select between the measured marginal and formation conditional |
+
+These routes show why “a new axiom is required” would be premature. A selected
+downstream formation Law followed by a bounded theorem and audit is a live
+import-retirement path. No core-axiom amendment is proposed.
+
+### N7 — Strongest steelman
+
+A hostile reviewer should reject any inference that autonomous formation is
+impossible. The present content kernel already supplies the exact payload and
+outcome distributions. A local phase token or readiness field could extend it
+to an append-only pure-birth generator whose rate vanishes at the cavity until
+all six payload neighbors exist, then becomes positive at the target. The
+terminal obligation is concrete: prove existence/nonexplosion, covariance,
+permanence, overlap consistency, and resource regeneration for that joint
+site-content process. No theorem here rules out that mechanism, and the
+Minimal Axioms' decision to leave site/rate downstream is permission to select
+and test such a Law, not evidence that it cannot exist. This steelman succeeds,
+so the note makes only the finite-history boundary and queues that positive
+route.
+
+### N8 — Cross-cycle echo
+
+Repository searches recover repeated writer and carrier boundaries that were
+narrowed by changing the carrier or adding a fresh-fragment mechanism rather
+than editing the foundation: the August 10 Gaussian/effect-label compilers,
+the open staged cq writer stack (#7031/#7036/#7037), the parent finite-history
+candidate, and Block 32. The same mechanism is applied here: choose explicit
+downstream content, prove the exact bounded composition, and leave physical
+selection and audit to their own gates. None of those open sources is promoted
+to retained authority.
+
+The cross-cycle lesson also blocks an inflated negative: moving a supplied
+carrier one radius outward is not autonomous genesis, while an explicit shared
+seed plus conditional atoms can genuinely close output support without making
+formation-site physics disappear.
+
+### Gate result
+
+**PASS** for the scoped theorem and its three narrow negative boundaries: two
+computational deletion cases plus the elementary countability proof. The
+five-resolution certificate lands in the primary cache. Broad no-go language
+is withheld, and the live pure-birth/content-phase and composite pincer routes
+are named as positive successors.
+
+## Review And Axiom Decision
+
+No Minimal Axioms edit is justified by this campaign. The existing ontology is
+large enough, and one admissibility content Law can carry, copy, and read its
+own binary-projective payload. What remains is downstream Law physics:
+
+1. add and test a covariant joint formation eligibility/rate process;
+2. physically calibrate or derive the payload quotient and selected trace Law;
+3. make the append process recurrent and resource-complete; and
+4. select or relate the PR #7317/#7318 marginal and formation-conditional
+   objects, including the two-qubit/four-arm carrier needed by the parent's
+   Bell sector.
+
+Until landing and independent audit, this is source progress only. TOE lane
+percentages and retained-positive theory counts remain unchanged.
+
+## Verification
+
+```text
+python3 scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py
+TOTAL: PASS=21 FAIL=0
+
+python3 scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py
+TOTAL: PASS=12 FAIL=0
+```
+
+Both runners use exact SymPy arithmetic. The independent runner reconstructs
+the decoder, append graph, rotation orbit, complex and endpoint controls, null
+codimension, and generic conditional inverse-determinant four-arm algebra
+without importing the primary implementation. That ancillary four-arm check
+uses arbitrary nonzero determinant values and is not an execution of PR
+#7317's determinant matrices.

--- a/logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.txt
+++ b/logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py
+runner_sha256: 179774c7c49898a54b94c2484a8eb16b73c320b3854370df7da306fd74807e5b
+input_fingerprint_sha256: 6112b69ae0045a24db4481a78bc3fa9fcdd20753e762c388919d2a4489831fb2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.57
+status: ok
+----- stdout -----
+PASS gaussian-normalization: the eight-real-dimensional unit Frobenius Gaussian normalizes exactly
+PASS generic-payload-decoder: one generic M2 Record uniquely decodes a density and binary projector frame
+PASS gaussian-full-support: the Gaussian density is symbolically positive at every finite M2 point; each exact singleton still has mass zero
+PASS canonical-representative: sqrt(C)+iP reaches the intended quotient fiber on this exact mixed fixture; the note gives the general proof
+PASS complex-payload: a genuinely complex Y payload decodes and gives exact nontrivial mass 1/14
+PASS pure-endpoint: a pure aligned payload has literal one/zero Record masses without fabricating the zero branch
+PASS total-kernel-branches: empty, copy, conflicting-payload, complete-read, and malformed conditions all receive one answer
+PASS trace-readout: six identical payload Records produce normalized literal projectors with masses 13/14 and 1/14
+PASS parent-prefix-composition: the payload trace mass equals the selected parent trace-Lueders one-site prefix mass
+PASS preparation-quotient: changing only the anti-Hermitian seed data changes the program while keeping preparation fixed
+PASS append-scaffold: one Gaussian seed plus ten deterministic fresh-site copies builds the exact 11-Record scaffold
+PASS fresh-target-shell: the origin stays fresh until all six nearest neighbors carry the common payload
+PASS record-permanence: the history only appends one target Record and never changes any prior content
+PASS same-law-output-closure: the root is in full Gaussian support and all ten later carrier copies are mass-one outputs of the same kernel
+PASS proper-cubic-history: all 24 proper cubic rotations preserve the seed/copy order and final trace branch
+PASS translation-covariance: translating the complete scaffold leaves the local answer unchanged
+PASS internal-basis-covariance: simultaneous unitary re-presentation transports contents and preserves trace masses
+PASS atomless-independent-deletion: six independent atomless M2 draws meet the exact homogeneous carrier only on a codimension-40 null set
+PASS formation-order-deletion: forming the target after one neighbor locks a payload permanently, so the fresh-buffer order is load-bearing
+PASS degenerate-totality: zero-H or scalar-K payloads are rejected into the declared fallback rather than left undefined
+PASS source-contract: the source binds support language, the formation wall, carrier replacement, pincer, and score boundary
+per_element: exact payload quotient, Gaussian support density, copy atom, projector contents, and trace masses are checked
+per_site: empty, partial homogeneous, complete homogeneous, malformed, premature, and permanent site branches are executed
+per_mode: no momentum, spectral, continuum, gravity, or PR determinant-matrix fixture is executed; the ancillary finite inverse-determinant identity is separate
+per_block: the 11-Record scaffold and all 24 proper-cubic copies are checked, with the target fresh until completion
+lattice_wide: checked and not executed — one finite append order is witnessed; no autonomous global formation process is claimed
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.txt
+++ b/logs/runner-cache/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.txt
@@ -1,0 +1,30 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py
+runner_sha256: 30e5263a07a9e95a12109c69cddd553ff8337dcbb2ba608563b379fac34f9a81
+input_fingerprint_sha256: 6112b69ae0045a24db4481a78bc3fa9fcdd20753e762c388919d2a4489831fb2
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.49
+status: ok
+----- stdout -----
+PASS decoder-reconstruction: an independent implementation recovers C and P from the generic payload
+PASS binary-trace-law: independently reconstructed literal branches have exact normalized masses 13/14 and 1/14
+PASS supported-surjection-fixture: the canonical sqrt(C)+iP representative reaches the same quotient fiber exactly
+PASS complex-control: a separate complex-H/Y-program reconstruction gives mass 1/14
+PASS endpoint-control: a canonical pure payload independently reproduces the exact absent branch
+PASS append-geometry: the independent graph check finds one seed, ten single-parent copies, and the complete target shell
+PASS cubic-orbit: an independent signed-permutation enumeration preserves all 24 append certificates
+PASS quotient-equivariance: a different exact unitary independently transports both decoded objects
+PASS independent-null-codimension: the exact six-payload diagonal has codimension 40 under independent continuous draws
+PASS four-arm-pincer-algebra: explicit rank-one product-basis traces select normalized inverse determinant modulus squared for four nonzero arms
+PASS premature-target-geometry: the origin is already copy-eligible after the first carrier, so formation order is a real boundary
+PASS independent-source-fence: the note preserves the generic/canonical, formation, pincer, and axiom fences
+per_element: independent quotient, complex control, endpoint, trace weights, and canonical representative are checked
+per_site: independent append adjacency, premature target eligibility, and exact six-neighbor completion are checked
+per_mode: checked and not executed — the four-arm test is finite amplitude algebra, not a determinant or continuum mode
+per_block: all 24 rotated 11-Record scaffolds and one conditional two-qubit four-arm readout are checked
+lattice_wide: checked and not executed — no global site-selection, rate, recurrence, or infinite-volume process is claimed
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py
+++ b/scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Exact checks for a homogeneous-payload NN Record writer/readout Law."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import permutations, product
+from pathlib import Path
+
+from sympy import I, Matrix, Rational as Q, exp, integrate, oo, pi, simplify, sqrt, symbols
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_HOMOGENEOUS_PAYLOAD_SELF_HOSTING_WRITER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_HOMOGENEOUS_PAYLOAD_SELF_HOSTING_WRITER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md"
+)
+
+I2 = Matrix.eye(2)
+ZERO2 = Matrix.zeros(2)
+SX = Matrix([[0, 1], [1, 0]])
+SY = Matrix([[0, -I], [I, 0]])
+SZ = Matrix([[1, 0], [0, -1]])
+
+DIRECTIONS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+APPEND_ORDER = (
+    (1, 1, 0),
+    (1, 0, 0),
+    (0, 1, 0),
+    (-1, 1, 0),
+    (-1, 0, 0),
+    (1, 0, 1),
+    (0, 0, 1),
+    (1, 0, -1),
+    (0, 0, -1),
+    (1, -1, 0),
+    (0, -1, 0),
+)
+
+
+@dataclass(frozen=True)
+class PayloadData:
+    preparation: Matrix
+    projector: Matrix
+    complement: Matrix
+
+
+@dataclass(frozen=True)
+class GaussianLaw:
+    name: str = "unit-frobenius-gaussian"
+
+
+def matrix_equal(left: Matrix, right: Matrix) -> bool:
+    return left.shape == right.shape and all(
+        simplify(left[row, column] - right[row, column]) == 0
+        for row in range(left.rows)
+        for column in range(left.cols)
+    )
+
+
+def hermitian_part(value: Matrix) -> Matrix:
+    return simplify((value + value.conjugate().T) / 2)
+
+
+def antihermitian_coefficient(value: Matrix) -> Matrix:
+    return simplify((value - value.conjugate().T) / (2 * I))
+
+
+def positive_truth(value) -> bool:
+    return bool(simplify(value).is_positive)
+
+
+def nonnegative_truth(value) -> bool:
+    return bool(simplify(value).is_nonnegative)
+
+
+def is_density(value: Matrix) -> bool:
+    return (
+        matrix_equal(value, value.conjugate().T)
+        and simplify(value.trace()) == 1
+        and nonnegative_truth(value[0, 0])
+        and nonnegative_truth(value[1, 1])
+        and nonnegative_truth(value.det())
+    )
+
+
+def is_rank_one_projector(value: Matrix) -> bool:
+    return (
+        matrix_equal(value, value.conjugate().T)
+        and matrix_equal(simplify(value * value), value)
+        and simplify(value.trace()) == 1
+    )
+
+
+def decode_payload(value: Matrix) -> PayloadData | None:
+    h_value = hermitian_part(value)
+    k_value = antihermitian_coefficient(value)
+    k_zero = simplify(k_value - k_value.trace() * I2 / 2)
+    density_denominator = simplify((h_value * h_value).trace())
+    radius_squared = simplify((k_zero * k_zero).trace() / 2)
+    if not positive_truth(density_denominator) or not positive_truth(radius_squared):
+        return None
+    radius = sqrt(radius_squared)
+    preparation = simplify(h_value * h_value / density_denominator)
+    projector = simplify((I2 + k_zero / radius) / 2)
+    complement = simplify(I2 - projector)
+    if not (
+        is_density(preparation)
+        and is_rank_one_projector(projector)
+        and is_rank_one_projector(complement)
+    ):
+        return None
+    return PayloadData(preparation, projector, complement)
+
+
+def homogeneous(neighbors: tuple[Matrix, ...]) -> bool:
+    return bool(neighbors) and all(matrix_equal(value, neighbors[0]) for value in neighbors)
+
+
+def distinct_generic_payloads(neighbors: tuple[Matrix, ...]) -> tuple[Matrix, ...]:
+    payloads = []
+    for value in neighbors:
+        if decode_payload(value) is None:
+            continue
+        if not any(matrix_equal(value, prior) for prior in payloads):
+            payloads.append(value)
+    return tuple(payloads)
+
+
+def trace_weight(preparation: Matrix, projector: Matrix):
+    return simplify((preparation * projector).trace())
+
+
+def local_law(neighbors: tuple[Matrix, ...]):
+    """One total kernel on the recorded portion of a six-neighbor shell."""
+    if not neighbors:
+        return GaussianLaw()
+    if len(neighbors) == 6 and homogeneous(neighbors):
+        payload = decode_payload(neighbors[0])
+        if payload is not None:
+            return (
+                (payload.projector, trace_weight(payload.preparation, payload.projector)),
+                (payload.complement, trace_weight(payload.preparation, payload.complement)),
+            )
+    payloads = distinct_generic_payloads(neighbors)
+    if payloads:
+        mass = Q(1, len(payloads))
+        return tuple((payload, mass) for payload in payloads)
+    return GaussianLaw()
+
+
+def finite_law_equal(left, right) -> bool:
+    if isinstance(left, GaussianLaw) or isinstance(right, GaussianLaw):
+        return isinstance(left, GaussianLaw) and isinstance(right, GaussianLaw)
+    if len(left) != len(right):
+        return False
+    unmatched = list(right)
+    for left_content, left_mass in left:
+        for index, (right_content, right_mass) in enumerate(unmatched):
+            if matrix_equal(left_content, right_content) and simplify(left_mass - right_mass) == 0:
+                unmatched.pop(index)
+                break
+        else:
+            return False
+    return not unmatched
+
+
+def content_mass(law, content: Matrix):
+    if isinstance(law, GaussianLaw):
+        return None
+    return simplify(
+        sum(
+            (mass for candidate, mass in law if matrix_equal(candidate, content)),
+            Q(0),
+        )
+    )
+
+
+def add(left: tuple[int, int, int], right: tuple[int, int, int]):
+    return tuple(left[index] + right[index] for index in range(3))
+
+
+def recorded_neighbor_contents(records, site):
+    return tuple(records[add(site, direction)] for direction in DIRECTIONS if add(site, direction) in records)
+
+
+def append_record(records, site, content: Matrix) -> bool:
+    if site in records:
+        return False
+    records[site] = content
+    return True
+
+
+def permutation_sign(perm: tuple[int, int, int]) -> int:
+    inversions = sum(
+        1 for left in range(3) for right in range(left + 1, 3) if perm[left] > perm[right]
+    )
+    return -1 if inversions % 2 else 1
+
+
+def proper_cubic_rotations() -> tuple[Matrix, ...]:
+    rotations = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            if permutation_sign(perm) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            rotation = Matrix.zeros(3)
+            for row, column in enumerate(perm):
+                rotation[row, column] = signs[row]
+            rotations.append(rotation)
+    return tuple(rotations)
+
+
+def rotate_site(rotation: Matrix, site: tuple[int, int, int]):
+    result = rotation * Matrix(site)
+    return tuple(int(result[index]) for index in range(3))
+
+
+def conjugate_law(law, unitary: Matrix):
+    if isinstance(law, GaussianLaw):
+        return law
+    return tuple(
+        (simplify(unitary * content * unitary.conjugate().T), mass)
+        for content, mass in law
+    )
+
+
+def gaussian_density_at(value: Matrix):
+    norm_squared = simplify((value.conjugate().T * value).trace())
+    return exp(-norm_squared) / pi**4
+
+
+def independent_equality_constraint_rank() -> int:
+    """Rank of A_2=A_1,...,A_6=A_1 in 6 copies of R^8."""
+    constraint = Matrix.zeros(5 * 8, 6 * 8)
+    for block in range(5):
+        for coordinate in range(8):
+            constraint[block * 8 + coordinate, coordinate] = -1
+            constraint[block * 8 + coordinate, (block + 1) * 8 + coordinate] = 1
+    return constraint.rank()
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    x = symbols("x", real=True)
+    gaussian_line = integrate(exp(-(x**2)) / sqrt(pi), (x, -oo, oo))
+    check(
+        "gaussian-normalization",
+        gaussian_line == 1 and gaussian_line**8 == 1,
+        "the eight-real-dimensional unit Frobenius Gaussian normalizes exactly",
+    )
+
+    h_real = Matrix([[1, 1], [1, 2]])
+    seed_real = simplify(h_real + I * SX)
+    decoded_real = decode_payload(seed_real)
+    expected_real = simplify(h_real * h_real / (h_real * h_real).trace())
+    expected_px = simplify((I2 + SX) / 2)
+    check(
+        "generic-payload-decoder",
+        decoded_real is not None
+        and matrix_equal(decoded_real.preparation, expected_real)
+        and matrix_equal(decoded_real.projector, expected_px),
+        "one generic M2 Record uniquely decodes a density and binary projector frame",
+    )
+    coordinates = symbols("g0:8", real=True)
+    arbitrary_matrix = Matrix(
+        [
+            [coordinates[0] + I * coordinates[1], coordinates[2] + I * coordinates[3]],
+            [coordinates[4] + I * coordinates[5], coordinates[6] + I * coordinates[7]],
+        ]
+    )
+    check(
+        "gaussian-full-support",
+        positive_truth(gaussian_density_at(arbitrary_matrix))
+        and positive_truth(gaussian_density_at(seed_real)),
+        "the Gaussian density is symbolically positive at every finite M2 point; each exact singleton still has mass zero",
+    )
+
+    canonical_seed = simplify(h_real / sqrt((h_real * h_real).trace()) + I * expected_px)
+    canonical_decoded = decode_payload(canonical_seed)
+    check(
+        "canonical-representative",
+        canonical_decoded is not None
+        and matrix_equal(canonical_decoded.preparation, expected_real)
+        and matrix_equal(canonical_decoded.projector, expected_px),
+        "sqrt(C)+iP reaches the intended quotient fiber on this exact mixed fixture; the note gives the general proof",
+    )
+
+    h_complex = Matrix([[2, I], [-I, 1]])
+    seed_complex = simplify(h_complex + I * SY)
+    decoded_complex = decode_payload(seed_complex)
+    complex_weight = (
+        trace_weight(decoded_complex.preparation, decoded_complex.projector)
+        if decoded_complex is not None
+        else None
+    )
+    check(
+        "complex-payload",
+        decoded_complex is not None
+        and matrix_equal(decoded_complex.projector, simplify((I2 + SY) / 2))
+        and complex_weight == Q(1, 14),
+        "a genuinely complex Y payload decodes and gives exact nontrivial mass 1/14",
+    )
+
+    pz = simplify((I2 + SZ) / 2)
+    seed_endpoint = simplify(pz + I * SZ)
+    endpoint_data = decode_payload(seed_endpoint)
+    endpoint_law = local_law((seed_endpoint,) * 6)
+    check(
+        "pure-endpoint",
+        endpoint_data is not None
+        and matrix_equal(endpoint_data.preparation, pz)
+        and content_mass(endpoint_law, pz) == 1
+        and content_mass(endpoint_law, I2 - pz) == 0,
+        "a pure aligned payload has literal one/zero Record masses without fabricating the zero branch",
+    )
+
+    copy_law = local_law((seed_real,))
+    read_law = local_law((seed_real,) * 6)
+    conflicting_law = local_law((seed_real, seed_complex))
+    malformed_law = local_law((I * I2, I * I2))
+    check(
+        "total-kernel-branches",
+        isinstance(local_law(tuple()), GaussianLaw)
+        and content_mass(copy_law, seed_real) == 1
+        and not isinstance(read_law, GaussianLaw)
+        and content_mass(conflicting_law, seed_real) == Q(1, 2)
+        and content_mass(conflicting_law, seed_complex) == Q(1, 2)
+        and isinstance(malformed_law, GaussianLaw),
+        "empty, copy, conflicting-payload, complete-read, and malformed conditions all receive one answer",
+    )
+
+    read_mass_p = content_mass(read_law, decoded_real.projector)
+    read_mass_q = content_mass(read_law, decoded_real.complement)
+    check(
+        "trace-readout",
+        read_mass_p == Q(13, 14) and read_mass_q == Q(1, 14) and read_mass_p + read_mass_q == 1,
+        "six identical payload Records produce normalized literal projectors with masses 13/14 and 1/14",
+    )
+
+    sigma_prefix = Matrix([[2, 1], [1, 2]])
+    prefix_center = simplify(sigma_prefix / sigma_prefix.trace())
+    prefix_projector = expected_px
+    # Use an exact positive H whose square normalizes to sigma_prefix.
+    prefix_h = Matrix([[1 + sqrt(3), sqrt(3) - 1], [sqrt(3) - 1, 1 + sqrt(3)]])
+    prefix_seed = simplify(prefix_h + I * prefix_projector)
+    prefix_data = decode_payload(prefix_seed)
+    parent_mass = simplify(
+        (prefix_projector * sigma_prefix * prefix_projector).trace() / sigma_prefix.trace()
+    )
+    check(
+        "parent-prefix-composition",
+        prefix_data is not None
+        and matrix_equal(prefix_data.preparation, prefix_center)
+        and trace_weight(prefix_data.preparation, prefix_projector) == parent_mass == Q(3, 4),
+        "the payload trace mass equals the selected parent trace-Lueders one-site prefix mass",
+    )
+
+    second_seed = simplify(h_real + I * SZ)
+    second_data = decode_payload(second_seed)
+    check(
+        "preparation-quotient",
+        second_data is not None
+        and matrix_equal(second_data.preparation, decoded_real.preparation)
+        and not matrix_equal(second_data.projector, decoded_real.projector),
+        "changing only the anti-Hermitian seed data changes the program while keeping preparation fixed",
+    )
+
+    records = {}
+    formation_ok = True
+    predecessor_counts = []
+    for index, site in enumerate(APPEND_ORDER):
+        condition = recorded_neighbor_contents(records, site)
+        predecessor_counts.append(len(condition))
+        if index == 0:
+            formation_ok = formation_ok and isinstance(local_law(condition), GaussianLaw)
+            formation_ok = formation_ok and positive_truth(gaussian_density_at(seed_real))
+        else:
+            formation_ok = formation_ok and content_mass(local_law(condition), seed_real) == 1
+        formation_ok = formation_ok and append_record(records, site, seed_real)
+    check(
+        "append-scaffold",
+        formation_ok and predecessor_counts == [0] + [1] * 10,
+        "one Gaussian seed plus ten deterministic fresh-site copies builds the exact 11-Record scaffold",
+    )
+
+    target = (0, 0, 0)
+    target_condition = recorded_neighbor_contents(records, target)
+    check(
+        "fresh-target-shell",
+        target not in records
+        and len(target_condition) == 6
+        and homogeneous(target_condition)
+        and finite_law_equal(local_law(target_condition), read_law),
+        "the origin stays fresh until all six nearest neighbors carry the common payload",
+    )
+
+    before = dict(records)
+    chosen_output = decoded_real.projector
+    permanent_append = append_record(records, target, chosen_output)
+    rewrite_rejected = not append_record(records, target, decoded_real.complement)
+    check(
+        "record-permanence",
+        permanent_append
+        and rewrite_rejected
+        and all(matrix_equal(records[site], content) for site, content in before.items())
+        and matrix_equal(records[target], chosen_output),
+        "the history only appends one target Record and never changes any prior content",
+    )
+
+    check(
+        "same-law-output-closure",
+        positive_truth(gaussian_density_at(seed_real))
+        and content_mass(copy_law, seed_real) == 1
+        and predecessor_counts == [0] + [1] * 10
+        and matrix_equal(target_condition[0], seed_real)
+        and all(matrix_equal(value, seed_real) for value in target_condition),
+        "the root is in full Gaussian support and all ten later carrier copies are mass-one outputs of the same kernel",
+    )
+
+    rotations = proper_cubic_rotations()
+    rotation_ok = len(rotations) == 24
+    for rotation in rotations:
+        rotated_order = tuple(rotate_site(rotation, site) for site in APPEND_ORDER)
+        rotated_records = {}
+        counts = []
+        for site in rotated_order:
+            condition = recorded_neighbor_contents(rotated_records, site)
+            counts.append(len(condition))
+            rotated_records[site] = seed_real
+        rotated_target = recorded_neighbor_contents(rotated_records, target)
+        rotation_ok = rotation_ok and counts == [0] + [1] * 10
+        rotation_ok = rotation_ok and finite_law_equal(local_law(rotated_target), read_law)
+    check(
+        "proper-cubic-history",
+        rotation_ok,
+        "all 24 proper cubic rotations preserve the seed/copy order and final trace branch",
+    )
+
+    shift = (7, -5, 3)
+    translated_records = {add(site, shift): content for site, content in before.items()}
+    translated_target = add(target, shift)
+    check(
+        "translation-covariance",
+        finite_law_equal(local_law(recorded_neighbor_contents(translated_records, translated_target)), read_law),
+        "translating the complete scaffold leaves the local answer unchanged",
+    )
+
+    hadamard = Matrix([[1, 1], [1, -1]]) / sqrt(2)
+    conjugated_seed = simplify(hadamard * seed_real * hadamard.conjugate().T)
+    conjugated_law = local_law((conjugated_seed,) * 6)
+    check(
+        "internal-basis-covariance",
+        finite_law_equal(conjugated_law, conjugate_law(read_law, hadamard)),
+        "simultaneous unitary re-presentation transports contents and preserves trace masses",
+    )
+
+    check(
+        "atomless-independent-deletion",
+        independent_equality_constraint_rank() == 40,
+        "six independent atomless M2 draws meet the exact homogeneous carrier only on a codimension-40 null set",
+    )
+
+    premature_records = {
+        APPEND_ORDER[0]: seed_real,
+        APPEND_ORDER[1]: seed_real,
+    }
+    premature_law = local_law(recorded_neighbor_contents(premature_records, target))
+    premature_copy = content_mass(premature_law, seed_real) == 1
+    premature_write = append_record(premature_records, target, seed_real)
+    later_rejected = not append_record(premature_records, target, chosen_output)
+    check(
+        "formation-order-deletion",
+        premature_copy and premature_write and later_rejected,
+        "forming the target after one neighbor locks a payload permanently, so the fresh-buffer order is load-bearing",
+    )
+
+    degenerate_seed = I * I2
+    check(
+        "degenerate-totality",
+        decode_payload(degenerate_seed) is None
+        and isinstance(local_law((degenerate_seed,) * 6), GaussianLaw),
+        "zero-H or scalar-K payloads are rejected into the declared fallback rather than left undefined",
+    )
+
+    note_text = NOTE.read_text() if NOTE.exists() else ""
+    check(
+        "source-contract",
+        all(
+            token in note_text
+            for token in (
+                "No-Go Discipline Gate",
+                "Formation-site boundary",
+                "zero singleton mass",
+                "alternative binary-projective carrier",
+                "no TOE-percentage movement",
+                "PR #7317",
+            )
+        ),
+        "the source binds support language, the formation wall, carrier replacement, pincer, and score boundary",
+    )
+
+    print(
+        "per_element: exact payload quotient, Gaussian support density, copy atom, projector contents, and trace masses are checked"
+    )
+    print(
+        "per_site: empty, partial homogeneous, complete homogeneous, malformed, premature, and permanent site branches are executed"
+    )
+    print(
+        "per_mode: no momentum, spectral, continuum, gravity, or PR determinant-matrix fixture is executed; the ancillary finite inverse-determinant identity is separate"
+    )
+    print(
+        "per_block: the 11-Record scaffold and all 24 proper-cubic copies are checked, with the target fresh until completion"
+    )
+    print(
+        "lattice_wide: checked and not executed — one finite append order is witnessed; no autonomous global formation process is claimed"
+    )
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py
+++ b/scripts/nn_record_homogeneous_payload_self_hosting_writer_independent_check_2026_08_22.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Independent exact reconstruction of the homogeneous-payload writer claim."""
+
+from __future__ import annotations
+
+from itertools import permutations, product
+from pathlib import Path
+
+from sympy import I, Matrix, Rational as Q, simplify, sqrt
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_HOMOGENEOUS_PAYLOAD_SELF_HOSTING_WRITER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_HOMOGENEOUS_PAYLOAD_SELF_HOSTING_WRITER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md"
+)
+
+I2 = Matrix.eye(2)
+SX = Matrix([[0, 1], [1, 0]])
+SY = Matrix([[0, -I], [I, 0]])
+SZ = Matrix([[1, 0], [0, -1]])
+
+NEIGHBORS = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+ORDER = (
+    (1, 1, 0),
+    (1, 0, 0),
+    (0, 1, 0),
+    (-1, 1, 0),
+    (-1, 0, 0),
+    (1, 0, 1),
+    (0, 0, 1),
+    (1, 0, -1),
+    (0, 0, -1),
+    (1, -1, 0),
+    (0, -1, 0),
+)
+
+
+def equal(left: Matrix, right: Matrix) -> bool:
+    return all(
+        simplify(left[row, column] - right[row, column]) == 0
+        for row in range(left.rows)
+        for column in range(left.cols)
+    )
+
+
+def payload(value: Matrix):
+    hermitian = simplify((value + value.conjugate().T) / 2)
+    anti = simplify((value - value.conjugate().T) / (2 * I))
+    centered = simplify(anti - anti.trace() * I2 / 2)
+    d_value = simplify((hermitian * hermitian).trace())
+    r2_value = simplify((centered * centered).trace() / 2)
+    if not bool(d_value.is_positive) or not bool(r2_value.is_positive):
+        return None
+    center = simplify(hermitian * hermitian / d_value)
+    projector = simplify((I2 + centered / sqrt(r2_value)) / 2)
+    return center, projector, simplify(I2 - projector)
+
+
+def adjacent(left, right) -> bool:
+    return sum(abs(left[index] - right[index]) for index in range(3)) == 1
+
+
+def determinant_sign(perm):
+    inversions = sum(
+        1 for left in range(3) for right in range(left + 1, 3) if perm[left] > perm[right]
+    )
+    return -1 if inversions % 2 else 1
+
+
+def rotations():
+    result = []
+    for perm in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            if determinant_sign(perm) * signs[0] * signs[1] * signs[2] != 1:
+                continue
+            matrix = Matrix.zeros(3)
+            for row, column in enumerate(perm):
+                matrix[row, column] = signs[row]
+            result.append(matrix)
+    return tuple(result)
+
+
+def rotate(matrix, site):
+    result = matrix * Matrix(site)
+    return tuple(int(result[index]) for index in range(3))
+
+
+def equality_rank() -> int:
+    rows = []
+    for copy_index in range(1, 6):
+        for coordinate in range(8):
+            row = [0] * 48
+            row[coordinate] = -1
+            row[copy_index * 8 + coordinate] = 1
+            rows.append(row)
+    return Matrix(rows).rank()
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name, condition, detail):
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    h_value = Matrix([[1, 1], [1, 2]])
+    seed = simplify(h_value + I * SX)
+    decoded = payload(seed)
+    center_expected = Matrix([[Q(2, 7), Q(3, 7)], [Q(3, 7), Q(5, 7)]])
+    px = simplify((I2 + SX) / 2)
+    check(
+        "decoder-reconstruction",
+        decoded is not None and equal(decoded[0], center_expected) and equal(decoded[1], px),
+        "an independent implementation recovers C and P from the generic payload",
+    )
+
+    center, projector, complement = decoded
+    mass = simplify((center * projector).trace())
+    other_mass = simplify((center * complement).trace())
+    check(
+        "binary-trace-law",
+        mass == Q(13, 14) and other_mass == Q(1, 14) and mass + other_mass == 1,
+        "independently reconstructed literal branches have exact normalized masses 13/14 and 1/14",
+    )
+
+    canonical = simplify(h_value / sqrt(7) + I * px)
+    canonical_data = payload(canonical)
+    check(
+        "supported-surjection-fixture",
+        canonical_data is not None
+        and equal(canonical_data[0], center_expected)
+        and equal(canonical_data[1], px),
+        "the canonical sqrt(C)+iP representative reaches the same quotient fiber exactly",
+    )
+
+    complex_h = Matrix([[2, I], [-I, 1]])
+    complex_data = payload(simplify(complex_h + I * SY))
+    check(
+        "complex-control",
+        complex_data is not None
+        and equal(complex_data[1], simplify((I2 + SY) / 2))
+        and simplify((complex_data[0] * complex_data[1]).trace()) == Q(1, 14),
+        "a separate complex-H/Y-program reconstruction gives mass 1/14",
+    )
+
+    pz = simplify((I2 + SZ) / 2)
+    endpoint = payload(simplify(pz + I * pz))
+    check(
+        "endpoint-control",
+        endpoint is not None
+        and equal(endpoint[0], pz)
+        and equal(endpoint[1], pz)
+        and simplify((endpoint[0] * endpoint[2]).trace()) == 0,
+        "a canonical pure payload independently reproduces the exact absent branch",
+    )
+
+    prior = []
+    predecessor_counts = []
+    for site in ORDER:
+        predecessor_counts.append(sum(adjacent(site, old) for old in prior))
+        prior.append(site)
+    target_neighbors = {site for site in ORDER if adjacent(site, (0, 0, 0))}
+    check(
+        "append-geometry",
+        predecessor_counts == [0] + [1] * 10 and target_neighbors == set(NEIGHBORS),
+        "the independent graph check finds one seed, ten single-parent copies, and the complete target shell",
+    )
+
+    rotation_ok = True
+    proper = rotations()
+    for rotation in proper:
+        rotated = tuple(rotate(rotation, site) for site in ORDER)
+        counts = [
+            sum(adjacent(site, old) for old in rotated[:index])
+            for index, site in enumerate(rotated)
+        ]
+        shell = {site for site in rotated if adjacent(site, (0, 0, 0))}
+        rotation_ok = rotation_ok and counts == [0] + [1] * 10
+        rotation_ok = rotation_ok and shell == {rotate(rotation, d) for d in NEIGHBORS}
+    check(
+        "cubic-orbit",
+        len(proper) == 24 and rotation_ok,
+        "an independent signed-permutation enumeration preserves all 24 append certificates",
+    )
+
+    unitary = Matrix([[1, 1], [I, -I]]) / sqrt(2)
+    transported = payload(simplify(unitary * seed * unitary.conjugate().T))
+    check(
+        "quotient-equivariance",
+        transported is not None
+        and equal(transported[0], simplify(unitary * center * unitary.conjugate().T))
+        and equal(transported[1], simplify(unitary * projector * unitary.conjugate().T)),
+        "a different exact unitary independently transports both decoded objects",
+    )
+
+    check(
+        "independent-null-codimension",
+        equality_rank() == 40,
+        "the exact six-payload diagonal has codimension 40 under independent continuous draws",
+    )
+
+    determinant_values = (1 + I, 2 - I, -1 + 2 * I, 3)
+    z_values = tuple(simplify(Q(1) / value) for value in determinant_values)
+    norm2 = simplify(sum((value.conjugate() * value for value in z_values), Q(0)))
+    psi = Matrix(z_values) / sqrt(norm2)
+    rho = simplify(psi * psi.conjugate().T)
+    projectors = tuple(
+        simplify(Matrix.eye(4)[:, index] * Matrix.eye(4)[:, index].conjugate().T)
+        for index in range(4)
+    )
+    born = tuple(simplify((projector * rho * projector).trace()) for projector in projectors)
+    inverse_determinant = tuple(
+        simplify(Q(1) / (value.conjugate() * value)) for value in determinant_values
+    )
+    inverse_norm = simplify(sum(inverse_determinant, Q(0)))
+    inverse_squared = tuple(simplify(value / inverse_norm) for value in inverse_determinant)
+    check(
+        "four-arm-pincer-algebra",
+        simplify(rho.trace()) == 1
+        and sum(born, Q(0)) == 1
+        and born == inverse_squared,
+        "explicit rank-one product-basis traces select normalized inverse determinant modulus squared for four nonzero arms",
+    )
+
+    check(
+        "premature-target-geometry",
+        adjacent((1, 0, 0), (0, 0, 0)) and len(target_neighbors) == 6,
+        "the origin is already copy-eligible after the first carrier, so formation order is a real boundary",
+    )
+
+    text = NOTE.read_text() if NOTE.exists() else ""
+    check(
+        "independent-source-fence",
+        all(
+            phrase in text
+            for phrase in (
+                "generic Gaussian seed",
+                "canonical representative of a quotient fiber",
+                "Formation-site boundary",
+                "two-qubit",
+                "No Minimal Axioms edit",
+            )
+        ),
+        "the note preserves the generic/canonical, formation, pincer, and axiom fences",
+    )
+
+    print(
+        "per_element: independent quotient, complex control, endpoint, trace weights, and canonical representative are checked"
+    )
+    print(
+        "per_site: independent append adjacency, premature target eligibility, and exact six-neighbor completion are checked"
+    )
+    print(
+        "per_mode: checked and not executed — the four-arm test is finite amplitude algebra, not a determinant or continuum mode"
+    )
+    print(
+        "per_block: all 24 rotated 11-Record scaffolds and one conditional two-qubit four-arm readout are checked"
+    )
+    print(
+        "lattice_wide: checked and not executed — no global site-selection, rate, recurrence, or infinite-volume process is claimed"
+    )
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Block 33 — homogeneous-payload self-hosting writer

Stacked on #7316.

This constructs an alternative carrier for the parent binary-projective Record candidate:

- one full-support conjugation-invariant Gaussian seed on `M_2(C)`;
- a covariant payload quotient decoding a density and complementary rank-one projectors;
- a symmetric conditional copy branch;
- a six-equal-payload trace-read branch;
- an exact seed-plus-ten-copy append scaffold, exhaustive over all 24 proper cubic rotations.

The central advance is content-level output closure. Conditional on the explicitly supplied fresh-site formation order, the Gaussian root is generic almost surely, all ten later copies have conditional mass one, and the completed shell reproduces the parent's trace/Lüders one-site marginal with literal projector outputs. This avoids the codimension-40 null event from six independent continuous draws.

The scope is deliberately narrow. This replaces rather than repairs Block 32's carrier, and does not retain its ternary/scaled/repeated-label domain. Formation site/rate/order, controlled payload calibration, recurrence/resources, composite coupling, trace-Law selection, audit retention, obligations, and TOE percentages remain open. A hostile early-target execution shows why autonomous formation is the immediate next wall.

The note also composes with the open #7317/#7318 pincer without borrowing authority: an imposed amplitude-state calibration conditionally reproduces inverse determinant modulus-squared, while #7318 now distinguishes its measured trace marginal from its formation-conditional determinant law. No readout selector is claimed.

Verification:

- primary exact runner: `TOTAL: PASS=21 FAIL=0`
- independent exact reconstruction: `TOTAL: PASS=12 FAIL=0`
- all runner caches fresh and individually below 6,000 characters
- vocabulary lint: 0 violations
- Python compilation and `git diff --check`: clean
- changed-audit-evidence preflight: clean, with no ledger row affected

No Minimal Axioms, primitive registry, audit verdict, audit ledger, or TOE score is edited.
