### PR TITLE
physics: construct continuum low-arity Record menu compiler

### DIFF
--- a/docs/NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-23.md
+++ b/docs/NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-23.md
@@ -1,0 +1,606 @@
+---
+claim_id: nn_record_continuum_low_arity_menu_compiler_bounded_theorem_note_2026-08-23
+claim_type: bounded_theorem
+claim_scope: "For one selected range-nine pure-birth Law stacked on the open Block 37 Record corpus, five positive-mass Haar-covariant root strata encode the complete binary/ternary menu family whose nonzero effects are scaled rank-one projectors or scalar identities. A continuous full-support coefficient measure, exact five-stratum classification, and explicit triangle/Gram surjection show that every such menu is a supported local program under the current canonical support reading. Every realized root self-hosts an eleven-carrier compiler and a Record-only terminal parser. The selected trace kernel at preparation I/2 normalizes every menu. A second exact positive covariant same-support kernel breaks cross-program shared-effect and refinement probabilities, so physical low-arity eligibility is constructively supplied but effect functionality remains independent. Exact continuum settings have zero singleton mass; no controlled dial, repeatable exact-setting frequency, general Born derivation, axiom edit, retention, obligation retirement, or TOE-score movement is claimed."
+depends_on:
+  - minimal_axioms
+  - realized_state_primitive
+  - nn_record_relational_menu_compiler_and_context_boundary_bounded_theorem_note_2026-08-23
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py
+independent_runner: scripts/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.py
+runner_cache: logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_2026_08_23.txt
+independent_runner_cache: logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Continuum Low-Arity Record Menu Compiler
+
+**Date:** 2026-08-23
+
+**Claim type:** bounded theorem
+
+**Role:** constructive closure of the physical low-arity menu-eligibility
+surface used by the August 9 Born-form theorem
+
+**Authority boundary:** the current
+[`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md) are the only effective axiom
+premises. The stacked Record writers and every distribution, formation factor,
+program measure, and terminal kernel below are explicit downstream Law
+content. Open Blocks 33--37 are source dependencies, not retained authority.
+This note authors no audit verdict.
+
+**Primary runner:**
+[`scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py`](../scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py)
+
+**Independent reconstruction:**
+[`scripts/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.py`](../scripts/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.py)
+
+**Cached receipts:**
+[`primary`](../logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_2026_08_23.txt),
+[`independent`](../logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.txt)
+
+## Result Up Front
+
+The August 9 theorem needs two physical inputs before its finite-dimensional
+mathematics can select a trace-form grade:
+
+1. one probability grade attached to an effect across programs (`W1`); and
+2. physical eligibility of every binary and ternary nonzero menu in its
+   scaled rank-one/scalar-identity domain (`W2`).
+
+Block 37 built four positive-density menu programs and proved with an exact
+paired Law that those programs do not themselves force `W1`. It did not cover
+the continuum quantified by `W2`. This successor covers that continuum.
+
+Write `P(N)=(I+N)/2` for a traceless Hermitian involution `N`. Every binary or
+ternary nonzero menu whose members lie in
+
+```text
+S = {c P(N): 0 <= c <= 1} union {d I: 0 <= d <= 1}          (1)
+```
+
+has exactly one of five nonzero type words, up to outcome permutation:
+
+```text
+RRR: {c1 P(N1), c2 P(N2), c3 P(N3)}
+RR : {P(N), P(-N)}
+RRI: {d I, (1-d)P(N), (1-d)P(-N)}
+III: {d1 I, d2 I, (1-d1-d2)I}
+II : {d I, (1-d)I}.                                      (2)
+```
+
+In the target strata all displayed members are nonzero: `RRR` has positive
+coefficients, `0<d<1` in `RRI` and `II`, and all three scalar coefficients are
+positive in `III`. The closed compiler parameter domains also include
+zero-removal boundaries and the auxiliary singleton `{I}`. Those boundary
+outputs are not additional target type words. In this target sense, the five strata are exhaustive;
+Section 2 proves that assertion rather than taking it as a menu catalogue.
+
+One Haar-covariant root law gives every stratum positive mixture mass:
+
+```text
+nu(RRR)=1/4, nu(RR)=1/8, nu(RRI)=1/4,
+nu(III)=1/4, nu(II)=1/8.                                  (3)
+```
+
+Within each continuous stratum the coefficient measure has full support on
+the displayed closed simplex or interval, and `U` has normalized Haar law.
+Consequently every exact target menu in (2) has a root in the program support.
+This is a support-level statement **under the current canonical support reading** in the
+Admissibility reading note: a supported exact point of a continuous domain may
+have zero singleton measure. It is not a controlled setting dial, and it does
+not give a positive-density subensemble for each exact coefficient/orientation.
+
+All five roots decode the same preparation `rho=I/2`. Block 35's protected
+twelve-site shape copies the exact continuously drawn root into eleven
+carriers. A terminal Record contains
+
+```text
+kappa(E,l) = E + i l I.                                    (4)
+```
+
+The finite-radius parser reconstructs the stratum, coefficients, relational
+frame, outcome label, and effect from final Records alone. The selected trace
+kernel assigns `Tr((I/2)E)` and is normalized on every menu.
+
+This closes the constructive `W2` menu-support target at the source-claim
+level under that canonical support reading. It does **not** close `W1`. A second exact positive, normalized,
+covariant kernel preserves the same root support, writer, terminal contents,
+and parser while changing the probability of a literal shared effect in two
+RRR contexts and breaking the coarse/refined equality. Therefore W1 remains open
+as the next probability-form obligation; no universal non-derivability
+claim is made.
+
+No Minimal Axioms edit is warranted by this block. **TOE percentages remain unchanged**:
+this is material open-source obligation progress, but it has not
+been independently retained and retires no audit-ledger obligation by itself.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The menu classification, continuum support surjection, self-hosted writer, parser, selected kernel, and paired skew Law are exact consequences of displayed downstream Laws. Audit retention and cross-program effect functionality remain open."
+trace_class: direct_blocker_closure
+target_claim_id: physical_low_arity_effect_menu_eligibility
+target_blocker_text: "physically register every binary and ternary nonzero scaled-rank-one/scalar-identity resolution used by the August 9 theorem"
+source_of_blocker_text: "August 9 Born-form theorem and Block 37 W2 boundary"
+reachability_to_target: closes
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "derive cross-program effect functionality from a genuinely conserved scheduler or operational-equivalence mechanism; do not merely stipulate one normalized grade"
+conditional_surface_status: "one selected homogeneous Law has full-support physical low-arity menus and a trace witness; a paired Law on the same compiler keeps W1 open"
+hypothetical_axiom_status: "no core-axiom edit proposed or justified"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target Contract
+
+| Field | Contract |
+|---|---|
+| target statement | construct one Record-native Law whose local program support surjects onto every two- or three-member nonzero menu in the August 9 scaled rank-one/scalar-identity domain |
+| quantifiers/domain | all five type strata; every allowed real coefficient; every global `SO(3)` orientation through `SU(2)` conjugation; every outcome permutation as relabeling |
+| allowed premises | four Minimal Axioms; normalized Haar measure; ordinary full-support Borel probability measures on compact coefficient domains; the explicit selected range-nine Law; open Blocks 33--37 as stacked constructions |
+| forbidden weakenings | a dense atomic menu law whose pointwise decoder/kernel is undefined on support-closure points, finite fixture coverage presented as universal, external basis or supplied shell, atomless singleton called positive probability, exact-setting frequency conditioning, or a selected trace table called forced |
+| required edges | projective binary menus, collinear/repeated-ray RRR menus, scalar binary/ternary coins, mixed RRI menus, zero removal, complex orientations, and coefficient-simplex boundaries |
+| completion witness | five-stratum classification plus surjective payload map, full-support root measure, same-law carrier copying, terminal support, and Record-only parser |
+| outcomes not counted as closure | `W1`, controlled intervention, exact-setting repeatability, a general state-dependent Born Law, arbitrary-effect merging, composite/Bell structure, gravity, retention, audit obligation retirement, or TOE-score movement |
+
+## 1. One Root Law With Five Positive Strata
+
+Let
+
+```text
+X_U = U sigma_x U^dagger,       Z_U = U sigma_z U^dagger.  (5)
+```
+
+The five root payload families are
+
+```text
+A_RRR(U,a,b) = (1+a)X_U + i(1+b)Z_U,
+  0<=a,b<=1, a+b>=1;
+
+A_RR(U)      = X_U + i(Z_U + I);
+A_RRI(U,d)   = (1+d)X_U + i(Z_U + 2I),       0<=d<=1;
+A_III(U,d1,d2)=(1+d1)X_U+i((1+d2)Z_U+4I),
+  d1,d2>=0, d1+d2<=1;
+A_II(U,d)    = (1+d)X_U + i(Z_U + 5I),       0<=d<=1.       (6)
+```
+
+The scalar anti-Hermitian tags `0,1,2,4,5` distinguish the program types
+without selecting an internal basis. The two traceless parts recover the full
+ordered relational frame. Their magnitudes recover the continuous
+coefficients.
+
+For every family the Hermitian part is a nonzero multiple of `X_U`, so
+
+```text
+H(A)^2 / Tr(H(A)^2) = I/2.                                 (7)
+```
+
+Thus all programs share one preparation quotient. The shifts by one in the
+axis magnitudes keep the frame readable even when a menu coefficient reaches
+zero.
+
+The root distribution is the mixture (3). Conditional on `RRR`, use normalized
+Lebesgue area measure, with density `2`, on the closed triangle
+
+```text
+D_RRR={(a,b): 0<=a,b<=1, a+b>=1};                         (8)
+```
+
+Conditional on `RRI` or `II`, use unit-density Lebesgue measure on `[0,1]`;
+conditional on `III`, use density `2` on the area-`1/2` simplex
+`d1,d2>=0,d1+d2<=1`; conditional on `RR`, use the coefficient-free point
+mass. Use normalized Haar `U` in every sector. Thus normalization and full
+support are explicit rather than delegated to an unspecified sampler.
+
+More formally, for each sector let `K_s` be its compact coefficient domain,
+let `lambda_s` be the just-displayed normalized full-support measure (a point
+mass for `RR`), let `h` be normalized Haar measure, and let `F_s(k,U)` be the
+corresponding payload map in (6). The root law is
+
+```text
+nu = sum_s nu(s) (F_s)_*(lambda_s tensor h).              (6a)
+```
+
+Each `F_s` is continuous. Since `K_s x SU(2)` is compact and
+`lambda_s tensor h` has full support,
+
+```text
+supp((F_s)_*(lambda_s tensor h)) = F_s(K_s x SU(2)).      (6b)
+```
+
+Indeed every neighborhood of an image point has a preimage neighborhood of
+positive measure, while compactness makes the image closed. Thus the root
+support statement is exact. The menu kernel is then defined pointwise for
+every decoded root in this support; it is not obtained by conditioning a
+global measure on a null singleton.
+
+On an incomplete compiler shell, the local content kernel copies any decoded
+root payload with atomic conditional mass. On six equal carriers, it emits the
+appropriate menu. Hence a continuously sampled exact payload self-hosts; the
+construction does not require a second independent draw to reproduce an
+atomless value.
+
+## 2. Why The Five Strata Are Exhaustive
+
+Write each rank-one member as `cP(n)` and each scalar member as `dI`. Equality
+of a menu sum with `I` gives both its trace equation and its traceless Bloch
+equation.
+
+For two members:
+
+- two scalar members give `d1+d2=1`, hence `II`;
+- two rank-one members obey `c1 n1+c2 n2=0` and `c1+c2=2`.
+  Positivity gives `c1=c2=1` and `n2=-n1`, hence `RR`;
+- one scalar and one nonzero rank-one member would require `c n=0`, which is
+  impossible.
+
+For three members:
+
+- three scalar members give `III`;
+- two scalar members plus one nonzero rank-one member again leave one
+  uncancelled Bloch vector and are impossible;
+- one scalar `dI` plus two rank-one members gives
+  `c1 n1+c2 n2=0` and `2d+c1+c2=2`. Therefore
+  `c1=c2=1-d` and `n2=-n1`, exactly `RRI`;
+- three rank-one members give `RRR`.
+
+No other nonzero type word exists for arity two or three. Zero coefficients
+are not menu members. Some closed-domain boundaries reduce to `RR` or `II`;
+`RRI` at `d=1`, the endpoints of `II`, and the vertices of `III` reduce to the
+one-member menu `{I}`, which lies outside the August 9 binary/ternary target.
+These auxiliary boundary outputs are accepted pointwise but are not counted as
+a sixth target stratum. The separate positive-mass `RR` and `II` sectors, not
+continuity of terminal labels across a parent boundary, support the target
+lower-arity families.
+
+## 3. The RRR Triangle Is Surjective
+
+For an ordered nonzero RRR menu
+
+```text
+E_j=c_j P(n_j),       sum_j E_j=I,                         (9)
+```
+
+trace and Bloch parts give
+
+```text
+c1+c2+c3=2,           c1 n1+c2 n2+c3 n3=0.                (10)
+```
+
+Each `0<c_j<=1`; equivalently the three coefficients obey the triangle
+inequalities. Set
+
+```text
+a=c1, b=c2, c=2-a-b=c3,
+gamma=(c^2-a^2-b^2)/(2ab).                                (11)
+```
+
+For nonzero coefficients define the canonical frame
+
+```text
+N1=X_U,
+N2=gamma X_U + sqrt(1-gamma^2) Z_U,
+N3=-(a N1+b N2)/c.                                        (12)
+```
+
+The triangle inequalities give `|gamma|<=1`; equation (11) gives
+`N3^2=I`; and equation (12) gives weighted closure. Therefore
+`{aP(N1),bP(N2),cP(N3)}` resolves `I`.
+
+Conversely, equation (10) fixes every pairwise dot product:
+
+```text
+n_i dot n_j=(c_k^2-c_i^2-c_j^2)/(2c_i c_j).               (13)
+```
+
+The target triple and canonical triple have the same Gram matrix. Their spans
+have dimension at most two, so the Gram isometry can be extended with the
+unused normal sign chosen to have determinant `+1`. It is therefore an
+`SO(3)` rotation `V` and has an `SU(2)` lift of `V`. This proves surjectivity, including
+collinear/repeated-ray degeneracies by the same Gram argument. At a zero
+vertex the formula for `gamma` is not used: the decoder handles
+`(a,b)=(0,1),(1,0),(1,1)` separately and removes the zero member. The separate
+`RR` sector supplies every projective binary target with positive stratum mass.
+
+The other four strata are visibly surjective from (6): Haar conjugation covers
+every projector axis, while the intervals/simplex cover every coefficient.
+
+## 4. Terminal Records, Kernel, And Parser
+
+For every nonzero effect, the terminal content is equation (4), with a scalar
+slot label. The label distinguishes equal operator effects when a menu repeats
+a ray. It does not affect the decoded effect. Zero removal preserves the
+original slot labels of surviving outcomes; it never renumbers them across a
+coefficient boundary.
+
+The selected terminal kernel is
+
+```text
+p(E | A)=Tr((I/2)E).                                      (14)
+```
+
+For `cP`, equation (14) is `c/2`; for `dI`, it is `d`. Menu
+normalization follows from `sum E=I`. This is a witness Law, not a probability
+postulate derived from the four axioms.
+
+Reuse Block 35's range-nine protected birth factor. A root from (6) occupies
+the first site, ten successive sites copy it, and the twelfth terminal locks
+one content (4). The final-state parser accepts only a guarded complete shape
+with one degree-six terminal, eleven identical decodable carriers, one static
+prefix frame, and an exact terminal match to the carrier-decoded menu.
+
+The primary runner checks all 895 unfinished shapes and 120 terminal
+placements. Across seven rational representatives spanning all five strata
+and nineteen outcomes, `2280/2280` completed fixtures parse. That enumeration
+tests the geometry/parser product; the analytic classification and surjection
+in sections 2--3, not the finite fixture count, supply the continuum claim.
+
+Translations, all 24 proper cubic rotations, and five exact internal basis
+changes commute with parsing. The scalar program/outcome tags remain scalar;
+all effects conjugate with `U`.
+
+## 5. Support Is Not Exact-Setting Frequency Or Control
+
+For any relatively open parameter-and-orientation patch `B` in any stratum,
+full support gives `mu(B)>0`. The canonical protected twelve-slot event at
+abstract time `tau>0` therefore has probability
+
+```text
+nu(sector) mu(B) exp(-1159 tau) (tau/12)^12 > 0.           (15)
+```
+
+This yields positive spatial intensity for nonempty relatively open patches and for each
+positive-mass stratum. It does not yield a positive density for one exact
+continuum setting. Under an atomless conditional measure,
+
+```text
+mu({exact coefficient and exact U})=0.                    (16)
+```
+
+The canonical Admissibility reading explicitly permits a supported exact
+point with zero singleton mass. Accordingly equations (15)--(16) are
+consistent: every exact menu is eligible in support, while conditioning an
+ordinary frequency ratio on that singleton is unavailable. The root setting
+is endogenous, not experimenter-selected. Controlled repeatability would need
+a separate intervention or addressable-setting theorem.
+
+## 6. Exact W1 Falsifier On The Same Compiler
+
+The support construction does not force cross-program effect functionality.
+For an interior RRR menu with coefficient triple `(a,b,c)`, replace its trace
+masses `(a/2,b/2,c/2)` by
+
+```text
+Delta=abc/10,
+p_delta=(a/2+Delta/2, b/2+Delta/2, c/2-Delta).             (17)
+```
+
+Because `0<=a,b<=1`, the third mass is at least `2c/5`; all masses are positive
+when their effects are nonzero, and the sum remains one. Put `Delta=0` on a
+binary boundary and keep the other four strata at (14). Equation (17) is one
+fixed covariant local rule: it uses only invariant decoded coefficients and
+the Record-visible slot order.
+
+For the same-ray refined menu `(a,b,c)=(1/2,1/2,1)`, equation (17) gives
+
+```text
+(21/80,21/80,19/40),     21/80+21/80=21/40 != 1/2.        (18)
+```
+
+The corresponding separately tagged `RR` coarse menu remains `(1/2,1/2)`.
+For two RRR programs `(a,b)=(1/2,9/10)` and `(1/2,3/4)`, choose the same
+relational `X` axis. Their first effect is literally the same `(1/2)P(X)`, but
+equation (17) assigns respectively
+
+```text
+527/2000 != 169/640.                                      (19)
+```
+
+Both kernels have the same root/program support, writer geometry, terminal
+contents, parser, covariance, and positive open-patch occurrence. Thus this
+block closes `W2` under the current canonical support reading without silently closing `W1`. It does not prove that no
+future dynamics can derive `W1`.
+
+## 7. Consequence For The Born-Form Route
+
+The August 9 theorem says that one menu-independent grade on (1), normalized
+on every eligible binary/ternary nonzero menu, has a unique density-matrix
+trace representation. This block supplies a physical support realization of
+the entire menu quantifier. If a later theorem supplies `W1` for these Record
+programs, ordinary normalization of each Admissibility terminal distribution
+then supplies the theorem's menu equations; the trace-form conclusion follows
+using its named dimension-three frame theorem.
+
+The present trace witness at `I/2` is deliberately weaker. It proves the
+compiler is nonempty and coherent, not that Nature selects (14), not a general
+neighbor-to-density law, and not first-principles Born closure.
+
+The next high-leverage target is therefore narrower than before Block 38:
+derive same-effect probability functionality across the registered programs.
+A setting-shielded race is useful only if one common total rate follows from a
+genuine shared scheduler or conservation identity. Merely writing
+`sum_E r(E)=R` for every menu is the normalized-grade obligation in rate
+notation and does not count as progress on `W1`.
+
+## No-Go Discipline Gate
+
+The positive continuum construction is the main result. This gate protects
+only the narrow negative statement that **the displayed compiler plus menu
+support does not by itself force W1**. It is not a universal W1 no-go.
+
+### N1 — Alternative Route Enumeration
+
+The approach families are normalized by primary object, mechanism, and
+terminal obligation.
+
+| Route | Attempt and exact disposition | Marker |
+|---|---|---|
+| selected trace kernel | Use equation (14) as the unique terminal rule. It is a valid witness, but equation (17) is a second valid rule on the identical compiler, so selection is not a consequence of the compiler. | **ATTEMPTED** |
+| per-menu normalization | Infer shared-effect equality because every terminal distribution sums to one. Equations (18)--(19) show normalized menus with different cross-program values. | **ATTEMPTED** |
+| common preparation quotient | Infer one grade from the shared `I/2` decoded by equation (7). Both exact kernels share that quotient, so preparation equality alone does not select the grade. | **ATTEMPTED** |
+| covariance and relational framing | Infer effect functionality from internal basis covariance. Equation (17) depends only on invariant coefficients and conjugates covariantly, so covariance does not distinguish it from (14). | **ATTEMPTED** |
+| content equality / Record readout | Infer equal formation probabilities from equal terminal content. The canonical [Admissibility wording](MINIMAL_AXIOMS_2026-06-29.md#admissibility--local-constraint) permits the local distribution to vary with neighbor conditions; equations (18)--(19) use different program neighborhoods while Record still reads identical content identically after formation. | **ATTEMPTED** |
+
+These failures are exact for the displayed architecture. They leave conserved
+schedulers, operational equivalence, controlled interventions, and other new
+dynamical mechanisms live.
+
+### N2 — Wall-Independence Audit
+
+The raw campaign list contains `W1`, `W2`, and controlled exact-setting
+repeatability. After this block:
+
+| Item | Status relative to this target | Collapse result |
+|---|---|---|
+| `W2`: full low-arity menu support | closed constructively by sections 1--5 under the current canonical support reading | removed from the remaining wall set at that explicitly scoped level |
+| `W1`: same effect has one grade across programs | open; exact paired kernel proves `W2` does not imply it | sole remaining wall for the August 9 physical-input pair |
+| controlled exact-setting repeatability | neither implied by `W1` nor needed by the support-level theorem | operational successor outside this target, not counted as a theorem wall |
+
+The collapsed target wall set therefore has one member, `W1`; no inflated
+pairwise wall count is claimed.
+
+### N3 — Hidden-Wall Scan
+
+| Phrase/construction | Classification |
+|---|---|
+| "under the current canonical support reading" | explicit scope condition linked to the non-governing reading note in the Minimal Axioms; not promoted to governing axiom text |
+| "full-support Borel measure" | displayed selected downstream Law input; normalization and support, not a hidden axiom |
+| "registered menu/effect" | parser-defined Record output in this construction; does not mean audit-retained |
+| normalized Haar measure | explicit mathematical input; it provides covariance/support, not probability-form uniqueness |
+| range-nine birth process | selected downstream Law inherited openly from Block 35; not attributed to Admissibility |
+| dimension-three frame theorem | named input of the August 9 consequence, not used to prove this compiler |
+| "by construction" variants | confined to explicit maps (6), (12), and (17), whose algebra is shown and machine-checked |
+
+Searches for `we assume`, `as is standard`, `the framework provides`, `bridge
+context`, `background`, `naturally`, `obviously`, `standard QFT`, and close
+variants exposed no additional load-bearing premise.
+
+### N4 — Residual Matching
+
+| Citation | Residual it attacks | Residual used here | Match? |
+|---|---|---|---:|
+| [`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT...`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md), Exact Target And Inputs | physical eligibility of every low-arity menu plus effect functionality | exact `W2` target and distinct `W1` residual | yes |
+| [`NN_RECORD_RELATIONAL_MENU_COMPILER...`](NN_RECORD_RELATIONAL_MENU_COMPILER_AND_CONTEXT_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-23.md), Results and §5 | four-menu physicalization and context-skew boundary | finite precursor and `W1/W2` split | yes |
+| [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md), Admissibility reading notes | distribution support, including zero-singleton supported points | support-level eligibility only | yes |
+| [`NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER...`](NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-22.md), self-hosting gap | supplied program matrices were not outputs of the same Law | provenance for the carrier-copy obligation now discharged | yes |
+| countable rational-cone extension proposal | unique mathematical continuation from rational programs | its displayed integer-tagged decoder/kernel was pointwise only on the rational program family, not on every point of the topological support closure | no; not used as closure evidence |
+
+The nonmatching rational route is retained only as a future alternate
+mathematical architecture, not cited as a witness for this claim.
+
+### N5 — Rhetoric And Resolution Audit
+
+The risky sentence is narrowed to: “this displayed compiler and its menu
+support do not by themselves force cross-program effect functionality.”
+
+| Resolution | Executed? | Honest result |
+|---|---:|---|
+| per element | yes | literal equal effects in two exact RRR fixtures receive unequal equation-(17) masses |
+| per site | yes | all five local program strata and their terminal distributions are decoded |
+| per mode | no | no spectral-mode claim is made |
+| per block | yes | the protected shape/parser is exhaustively tested on 895 unfinished shapes and 2,280 completed fixtures |
+| lattice-wide | no | no exact-setting frequency or lattice-wide W1 impossibility is claimed |
+
+The primary cached stdout lands substantive `per_element:`, `per_site:`,
+`per_mode:`, `per_block:`, and `lattice_wide:` certificates, with unexecuted
+classes explicitly named.
+
+### N6 — Partial-Closure And Primitive Scan
+
+The approved primitive registry and its current source paths were checked. The
+realized-state primitive permits pointwise evaluation only and supplies no
+measure or probability rule; the scale-reference and kinetic-isotropy
+primitives are irrelevant to this menu target. None is mislabeled as a wall,
+and none is repurposed as `W1`.
+
+Live closure mechanisms are:
+
+1. this block applies the previously queued recurrent physical-menu compiler
+   route and closes `W2` under the current canonical support reading without an axiom edit;
+2. a genuinely conserved common scheduler could derive equal total hazard
+   independently and then close `W1`;
+3. an operational-equivalence theorem could quotient program contexts by all
+   future Record continuations and derive effect functionality;
+4. a controlled setting interface could make exact program comparisons
+   operational, although control is not logically required by August 9;
+5. an owner-approved effect-grade clause remains a sufficient governance
+   fallback, but no new axiom is declared necessary here.
+
+Thus the import-bound theorem route remains available: state a bounded `W1`
+condition, derive the trace consequence, and later audit whether the import is
+retired by dynamics.
+
+### N7 — Hostile Steelman
+
+> The negative boundary may disappear in the very next local construction.
+> Give all outcome ports one setting-shielded dependency neighborhood and
+> route them through a single conserved scheduler whose total opportunity
+> flux is fixed before any menu is decoded. If geometry proves that fixed
+> total rather than a table stipulating it, equal effects would have equal
+> absolute hazards and equal denominators, excluding equation (17). An
+> operational quotient over every future Record continuation is a second
+> concrete mechanism: if two effect Records have identical continuation
+> statistics under every admissible coupling, their formation grade may
+> descend to the effect. The August 9 theorem would then consume this block's
+> full menu support and force trace form. Therefore the paired kernel is only
+> a counterexample to inference from the present compiler, not evidence that
+> `W1` is impossible.
+
+This steelman is accepted and becomes the next campaign target. The claim is
+accordingly a narrow independence boundary, not a no-go.
+
+### N8 — Cross-Cycle Echo
+
+The required four-phrase repository search was executed for `structurally
+undecidable`, `no retained primitive`, `requires new axiom`, and `cannot be
+derived from A_min`, and every `NO_GO_LEDGER.md` under
+`.claude/science/physics-loops/` was walked by filename before relevant-content
+search.
+
+Two exact echoes in
+[`toe-axiom-closure-20260809/NO_GO_LEDGER.md`](../.claude/science/physics-loops/toe-axiom-closure-20260809/NO_GO_LEDGER.md)
+are load-bearing:
+
+- line 9 withdrew broad axiom necessity and named a recurrent physical menu
+  compiler as a live route. Sections 1--5 apply that mechanism and retire the
+  `W2` construction residual at source level under the current canonical
+  support reading.
+- line 11 kept a derived menu kernel and operational quotient as reopen
+  mechanisms for the normalized-menu restriction. This block supplies the
+  first mechanism's full support but its paired kernel proves that the
+  quotient/`W1` part remains separate.
+
+The registrability ledger also records that a former Record premise wall was
+retired by explicit axiom reclassification. That governance mechanism remains
+possible, but this block demonstrates why it is premature for `W2` and makes
+no necessity claim for `W1`.
+
+**Gate disposition:** PASS for the narrow statement that the displayed
+support compiler does not force `W1`. FAIL / DO NOT SHIP for any claim that
+`W1` cannot be derived by another dynamics, that an axiom change is necessary,
+that exact continuum settings repeat at positive density, or that the Born
+rule is now derived.
+
+## Imports And Claim Boundary
+
+| Item | Role | Status here |
+|---|---|---|
+| `M_2(C)` possibility domain and support reading | carrier and eligibility semantics | current Minimal Axioms, with the support statement explicitly scoped to its interpretive reading note |
+| five root measures and range-nine formation | physical compiler | displayed selected Law content |
+| normalized Haar measure and full-support coefficient laws | covariance and surjection support | explicit mathematical inputs |
+| preparation `I/2` | common decoded quotient | derived from every payload's Hermitian square |
+| trace terminal kernel | positive witness | selected Law, not forced |
+| context-skew kernel | exact independence control | selected Law, not Nature claim |
+| August 9 frame theorem | downstream trace-form implication after `W1` | named existing conditional theorem; not consumed as proof of W2 |
+| observations, fits, target probabilities | none | not used |
+
+No audit file, premise registry, controlled vocabulary, Minimal Axioms text, or
+TOE score is edited. Independent audit remains required before this source
+claim can become effective retained authority.

--- a/logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_2026_08_23.txt
+++ b/logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_2026_08_23.txt
@@ -1,0 +1,31 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py
+runner_sha256: 04c5c9908c0aec2cff60deeec356c3326380246bfe7843d84bf17edbae88ac15
+input_fingerprint_sha256: 5aeafa48deb821c186b77f7beaaec94506447ccd998b0e503ef1e8c7b499410a
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 120.77
+status: ok
+----- stdout -----
+PASS five-positive-strata-common-preparation: all RRR/RR/RRI/III/II root strata have positive mixture mass and one I/2 preparation quotient
+PASS complete-low-arity-strata: the five exhaustive type strata are instantiated and every representative binary/ternary menu resolves I
+PASS rank-one-triangle-surjection-core: c1+c2+c3=2 and the weighted Bloch closure give the canonical triangle; its Gram data determine every RRR menu up to SO(3)/SU(2)
+PASS zero-removal-boundaries: supported coefficient boundaries drop zero effects exactly; all target binary boundaries remain valid
+PASS selected-trace-kernel-all-strata: Tr((I/2)E) is derived for every registered effect and normalizes each of the five strata
+PASS continuum-context-skew-control: one exact positive same-support Law breaks both coarse/refined and literal shared-effect probabilities, so W1 stays open
+PASS internal-frame-covariance: five exact basis changes preserve sector/parameters, conjugate every menu Record, and preserve both kernels
+PASS exhaustive-continuum-parser-fixtures: all 120 placements times nineteen cross-stratum representative outcomes decode: 2280/2280
+PASS false-positive-and-frame-controls: 895 unfinished histories, hostile adjacency, zero carriers, and a nonorthogonal internal frame reject
+PASS certificate-covariance: translations, all 24 proper cubic rotations, and five basis changes commute with the Record-only parser
+PASS support-level-occurrence-boundary: every relatively open parameter patch has a positive B9 cylinder, while an exact continuum setting correctly has zero singleton mass
+PASS program-and-domain-mutations: erasing the scalar program tag aliases RR/RRI, while coefficients outside either closed simplex reject
+PASS source-contract: the note pins support eligibility, exhaustive strata, operational limits, W1, axiom/score posture, and N1-N8
+per_element: every representative scaled-rank-one/scalar effect, label, trace mass, and skew mass is checked
+per_site: five positive root strata, copied carriers, and nineteen terminal fixtures are decoded
+per_mode: checked and not executed — no spectral-mode or mode-exhaustion claim is made
+per_block: all 895 unfinished shapes and 2280 completed cross-stratum fixtures are checked
+lattice_wide: checked and not executed — full-support eligibility is analytic; no exact-setting frequency claim is made
+TOTAL: PASS=13 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.txt
+++ b/logs/runner-cache/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.txt
@@ -1,0 +1,28 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.py
+runner_sha256: e63c38c1c919a66544a7c4a82b615daccae5a19b792fc0db9c6f511a00becd25
+input_fingerprint_sha256: 5b8591155c3720232a8d06b87a8bd6007e28972a77284c37e4527e8f2d90b75e
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 101.96
+status: ok
+----- stdout -----
+PASS independent-stratum-and-preparation-decoder: five independently decoded positive-mass sectors retain the common I/2 quotient
+PASS independent-five-stratum-algebra: RRR/RR/RRI/III/II representatives independently resolve I with the declared effect types
+PASS independent-triangle-gram-surjection: independent closure and Gram arithmetic reconstruct the universal rank-one triangle including binary boundaries
+PASS independent-trace-and-skew-kernels: trace normalization spans all strata while the reconstructed covariant skew breaks both W1 fixtures
+PASS independent-internal-covariance: all sectors, effects, contents, and both probability kernels commute with five basis changes
+PASS independent-exhaustive-fixture-parser: independent geometry accepts 2280/2280 completed cross-stratum fixtures over all terminal placements
+PASS independent-negative-controls: unfinished shapes, adjacency contamination, malformed carriers, nonorthogonal axes, and invalid coefficients reject
+PASS independent-parser-covariance: translations, 24 lattice rotations, and five basis changes commute with the independent parser
+PASS independent-support-versus-singleton: positive open-patch cylinder and zero exact singleton mass are independently kept as different statements
+PASS independent-source-and-import-boundary: the independent route imports no Block38 primary and pins continuum, parser, operational, axiom, and N1-N8 boundaries
+per_element: independent reconstruction checks every fixture effect type, content label, trace mass, and skew mass
+per_site: independent decoding covers five root strata, carrier payloads, and nineteen terminal fixtures
+per_mode: checked and not executed — no spectral-mode or mode-exhaustion claim is made
+per_block: independent geometry checks 895 unfinished shapes and 2280 completed fixtures
+lattice_wide: checked and not executed — support is analytic and no exact-setting frequency claim is made
+TOTAL: PASS=10 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py
+++ b/scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python3
+"""Exact checks for the continuum low-arity Record menu compiler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from sympy import I, Matrix, Rational as Q, exp, simplify, sqrt, symbols
+
+from nn_record_homogeneous_payload_self_hosting_writer_2026_08_22 import (
+    APPEND_ORDER,
+    I2,
+    SX,
+    SZ,
+    GaussianLaw,
+    antihermitian_coefficient,
+    decode_payload,
+    hermitian_part,
+    is_rank_one_projector,
+    matrix_equal,
+    recorded_neighbor_contents,
+)
+from nn_record_isolated_shape_compiler_2026_08_22 import (
+    BALL_OFFSETS,
+    ROOT_EXCLUSION_RADIUS,
+    ROTATIONS,
+    ROTATED_STAGES,
+    all_stage_states,
+    congruent_to_full_block,
+    formation_rate,
+    geometric_frontier,
+    halo,
+    l1_distance,
+    prefix_embeddings,
+    root_eligible,
+    rotate_site,
+    transform,
+    translated_records,
+)
+from nn_record_spatial_trial_ensemble_2026_08_23 import (
+    CANONICAL_CARRIER_PATH,
+    add,
+    conjugate,
+    connected_components,
+    occupied_degree,
+)
+
+
+AUDIT_TIMEOUT_SEC = 180
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_"
+    "BOUNDED_THEOREM_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/nn_record_relational_menu_compiler_2026_08_23.py",
+    "scripts/nn_record_spatial_trial_ensemble_2026_08_23.py",
+    "scripts/nn_record_isolated_shape_compiler_2026_08_22.py",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+SECTOR_MASSES = {
+    "RRR": Q(1, 4),
+    "RR": Q(1, 8),
+    "RRI": Q(1, 4),
+    "III": Q(1, 4),
+    "II": Q(1, 8),
+}
+COEFFICIENT_DENSITIES = {
+    "RRR": Q(2),  # normalized area density on the area-1/2 triangle
+    "RR": Q(1),   # unit point mass on the coefficient-free stratum
+    "RRI": Q(1),  # normalized length density on [0,1]
+    "III": Q(2),  # normalized area density on the area-1/2 simplex
+    "II": Q(1),   # normalized length density on [0,1]
+}
+SECTOR_TAGS = {"RRR": Q(0), "RR": Q(1), "RRI": Q(2), "III": Q(4), "II": Q(5)}
+OUTCOME_LABELS = (Q(30), Q(31), Q(32))
+
+
+@dataclass(frozen=True)
+class ContinuumRootLaw:
+    """Five positive-mass strata, each with its declared full-support measure."""
+
+    sector_masses: dict[str, Q]
+    coefficient_densities: dict[str, Q]
+    orientation_measure: str = "normalized-Haar-SU2"
+
+
+@dataclass(frozen=True)
+class MenuPayload:
+    sector: str
+    parameters: tuple
+    preparation: Matrix
+    x_axis: Matrix
+    z_axis: Matrix
+
+
+@dataclass(frozen=True)
+class OutcomeSpec:
+    name: str
+    effect: Matrix
+    label: Q
+
+    @property
+    def content(self) -> Matrix:
+        return simplify(self.effect + I * self.label * I2)
+
+
+@dataclass(frozen=True)
+class ContinuumTrialCertificate:
+    anchor: tuple[int, int, int]
+    target: tuple[int, int, int]
+    rotation_index: int
+    displacement: tuple[int, int, int]
+    sector: str
+    outcome: str
+    effect: Matrix
+    payload: Matrix
+
+
+def truth_nonnegative(value) -> bool:
+    return bool(simplify(value).is_nonnegative)
+
+
+def truth_positive(value) -> bool:
+    return bool(simplify(value).is_positive)
+
+
+def scalar_part(value: Matrix):
+    return simplify(value.trace() / 2)
+
+
+def traceless_part(value: Matrix) -> Matrix:
+    return simplify(value - scalar_part(value) * I2)
+
+
+def pauli_radius(value: Matrix):
+    return simplify(sqrt((value * value).trace() / 2))
+
+
+def is_axis(value: Matrix) -> bool:
+    return (
+        matrix_equal(value, value.conjugate().T)
+        and simplify(value.trace()) == 0
+        and matrix_equal(simplify(value * value), I2)
+    )
+
+
+def payload_rrr(a, b, x_axis: Matrix = SX, z_axis: Matrix = SZ) -> Matrix:
+    return simplify((1 + a) * x_axis + I * (1 + b) * z_axis)
+
+
+def payload_rr(x_axis: Matrix = SX, z_axis: Matrix = SZ) -> Matrix:
+    return simplify(x_axis + I * (z_axis + SECTOR_TAGS["RR"] * I2))
+
+
+def payload_rri(d, x_axis: Matrix = SX, z_axis: Matrix = SZ) -> Matrix:
+    return simplify((1 + d) * x_axis + I * (z_axis + SECTOR_TAGS["RRI"] * I2))
+
+
+def payload_iii(d1, d2, x_axis: Matrix = SX, z_axis: Matrix = SZ) -> Matrix:
+    return simplify(
+        (1 + d1) * x_axis
+        + I * ((1 + d2) * z_axis + SECTOR_TAGS["III"] * I2)
+    )
+
+
+def payload_ii(d, x_axis: Matrix = SX, z_axis: Matrix = SZ) -> Matrix:
+    return simplify((1 + d) * x_axis + I * (z_axis + SECTOR_TAGS["II"] * I2))
+
+
+def decode_menu_payload(value: Matrix) -> MenuPayload | None:
+    h_value = hermitian_part(value)
+    k_value = antihermitian_coefficient(value)
+    if simplify(h_value.trace()) != 0:
+        return None
+    h_zero = traceless_part(h_value)
+    k_zero = traceless_part(k_value)
+    h_radius = pauli_radius(h_zero)
+    k_radius = pauli_radius(k_zero)
+    if not truth_positive(h_radius) or not truth_positive(k_radius):
+        return None
+    x_axis = simplify(h_zero / h_radius)
+    z_axis = simplify(k_zero / k_radius)
+    if not (
+        is_axis(x_axis)
+        and is_axis(z_axis)
+        and matrix_equal(simplify(x_axis * z_axis + z_axis * x_axis), Matrix.zeros(2))
+    ):
+        return None
+    tag = scalar_part(k_value)
+    sector = next(
+        (name for name, candidate in SECTOR_TAGS.items() if simplify(tag - candidate) == 0),
+        None,
+    )
+    if sector is None:
+        return None
+    if sector == "RRR":
+        a, b = simplify(h_radius - 1), simplify(k_radius - 1)
+        valid = (
+            truth_nonnegative(a)
+            and truth_nonnegative(1 - a)
+            and truth_nonnegative(b)
+            and truth_nonnegative(1 - b)
+            and truth_nonnegative(a + b - 1)
+        )
+        parameters = (a, b)
+    elif sector == "RR":
+        valid = simplify(h_radius - 1) == 0 and simplify(k_radius - 1) == 0
+        parameters = tuple()
+    elif sector == "RRI":
+        d = simplify(h_radius - 1)
+        valid = (
+            simplify(k_radius - 1) == 0
+            and truth_nonnegative(d)
+            and truth_nonnegative(1 - d)
+        )
+        parameters = (d,)
+    elif sector == "III":
+        d1, d2 = simplify(h_radius - 1), simplify(k_radius - 1)
+        valid = (
+            truth_nonnegative(d1)
+            and truth_nonnegative(d2)
+            and truth_nonnegative(1 - d1 - d2)
+        )
+        parameters = (d1, d2)
+    else:
+        d = simplify(h_radius - 1)
+        valid = (
+            simplify(k_radius - 1) == 0
+            and truth_nonnegative(d)
+            and truth_nonnegative(1 - d)
+        )
+        parameters = (d,)
+    if not valid:
+        return None
+    return MenuPayload(sector, parameters, I2 / 2, x_axis, z_axis)
+
+
+def projector(axis: Matrix) -> Matrix:
+    return simplify((I2 + axis) / 2)
+
+
+def nonzero_rows(rows):
+    return tuple(
+        (index, name, simplify(effect))
+        for index, (name, effect) in enumerate(rows)
+        if not matrix_equal(effect, Matrix.zeros(2))
+    )
+
+
+def menu_specs(value: Matrix) -> tuple[OutcomeSpec, ...] | None:
+    decoded = decode_menu_payload(value)
+    if decoded is None:
+        return None
+    x_axis, z_axis = decoded.x_axis, decoded.z_axis
+    if decoded.sector == "RRR":
+        a, b = decoded.parameters
+        c = simplify(2 - a - b)
+        if simplify(a) == 0:
+            rows = (("rrr-1", Matrix.zeros(2)), ("rrr-2", projector(z_axis)), ("rrr-3", projector(-z_axis)))
+        elif simplify(b) == 0:
+            rows = (("rrr-1", projector(x_axis)), ("rrr-2", Matrix.zeros(2)), ("rrr-3", projector(-x_axis)))
+        elif simplify(c) == 0:
+            rows = (("rrr-1", projector(x_axis)), ("rrr-2", projector(-x_axis)), ("rrr-3", Matrix.zeros(2)))
+        else:
+            gamma = simplify((c * c - a * a - b * b) / (2 * a * b))
+            eta = simplify(sqrt(1 - gamma * gamma))
+            n1 = x_axis
+            n2 = simplify(gamma * x_axis + eta * z_axis)
+            n3 = simplify(-(a * n1 + b * n2) / c)
+            rows = (
+                ("rrr-1", simplify(a * projector(n1))),
+                ("rrr-2", simplify(b * projector(n2))),
+                ("rrr-3", simplify(c * projector(n3))),
+            )
+    elif decoded.sector == "RR":
+        rows = (("rr-1", projector(x_axis)), ("rr-2", projector(-x_axis)))
+    elif decoded.sector == "RRI":
+        (d,) = decoded.parameters
+        rows = (
+            ("rri-i", simplify(d * I2)),
+            ("rri-plus", simplify((1 - d) * projector(x_axis))),
+            ("rri-minus", simplify((1 - d) * projector(-x_axis))),
+        )
+    elif decoded.sector == "III":
+        d1, d2 = decoded.parameters
+        rows = (
+            ("iii-1", simplify(d1 * I2)),
+            ("iii-2", simplify(d2 * I2)),
+            ("iii-3", simplify((1 - d1 - d2) * I2)),
+        )
+    else:
+        (d,) = decoded.parameters
+        rows = (("ii-1", simplify(d * I2)), ("ii-2", simplify((1 - d) * I2)))
+    present = nonzero_rows(rows)
+    return tuple(
+        OutcomeSpec(name, effect, OUTCOME_LABELS[index])
+        for index, name, effect in present
+    )
+
+
+def effect_kind(effect: Matrix) -> str | None:
+    if not matrix_equal(effect, effect.conjugate().T):
+        return None
+    scalar = scalar_part(effect)
+    if matrix_equal(effect, scalar * I2):
+        return "I" if truth_positive(scalar) and truth_nonnegative(1 - scalar) else None
+    scale = simplify(effect.trace())
+    if (
+        truth_positive(scale)
+        and truth_nonnegative(1 - scale)
+        and is_rank_one_projector(simplify(effect / scale))
+    ):
+        return "R"
+    return None
+
+
+def terminal_law(value: Matrix, variant: str = "trace"):
+    specs = menu_specs(value)
+    decoded = decode_menu_payload(value)
+    if specs is None or decoded is None:
+        return None
+    masses = [simplify((decoded.preparation * spec.effect).trace()) for spec in specs]
+    if variant == "context-skew" and decoded.sector == "RRR" and len(specs) == 3:
+        scales = [simplify(spec.effect.trace()) for spec in specs]
+        delta = simplify(scales[0] * scales[1] * scales[2] / 10)
+        masses[0] = simplify(masses[0] + delta / 2)
+        masses[1] = simplify(masses[1] + delta / 2)
+        masses[2] = simplify(masses[2] - delta)
+    elif variant not in ("trace", "context-skew"):
+        raise ValueError(f"unknown terminal-law variant: {variant}")
+    return tuple((spec.content, mass) for spec, mass in zip(specs, masses))
+
+
+def distinct_payloads(neighbors: tuple[Matrix, ...]) -> tuple[Matrix, ...]:
+    found = []
+    for value in neighbors:
+        if decode_menu_payload(value) is None:
+            continue
+        if not any(matrix_equal(value, prior) for prior in found):
+            found.append(value)
+    return tuple(found)
+
+
+def continuum_content_law(neighbors, variant: str = "trace"):
+    if not neighbors:
+        return ContinuumRootLaw(SECTOR_MASSES, COEFFICIENT_DENSITIES)
+    if len(neighbors) == 6 and all(matrix_equal(value, neighbors[0]) for value in neighbors):
+        terminal = terminal_law(neighbors[0], variant)
+        if terminal is not None:
+            return terminal
+    payloads = distinct_payloads(neighbors)
+    if payloads:
+        mass = Q(1, len(payloads))
+        return tuple((payload, mass) for payload in payloads)
+    return GaussianLaw()
+
+
+def parse_trial(records, component) -> ContinuumTrialCertificate | None:
+    component = frozenset(component)
+    if len(component) != 12 or not congruent_to_full_block(component):
+        return None
+    if len(connected_components({site: records[site] for site in component})) != 1:
+        return None
+    if (halo(component) & frozenset(records)) != component:
+        return None
+    terminals = tuple(site for site in component if occupied_degree(site, component) == 6)
+    if len(terminals) != 1:
+        return None
+    target = terminals[0]
+    carriers = component - {target}
+    payload = records[next(iter(carriers))]
+    decoded = decode_menu_payload(payload)
+    specs = menu_specs(payload)
+    if decoded is None or specs is None or not all(matrix_equal(records[site], payload) for site in carriers):
+        return None
+    embeddings = prefix_embeddings(carriers, 11)
+    if len(embeddings) != 1:
+        return None
+    rotation_index, displacement = embeddings[0]
+    if target != add(displacement, ROTATED_STAGES[11][rotation_index][4]):
+        return None
+    matches = tuple(spec for spec in specs if matrix_equal(records[target], spec.content))
+    if len(matches) != 1:
+        return None
+    match = matches[0]
+    anchor = transform(ROTATIONS[rotation_index], displacement, APPEND_ORDER[0])
+    return ContinuumTrialCertificate(
+        anchor, target, rotation_index, displacement, decoded.sector,
+        match.name, match.effect, payload,
+    )
+
+
+def conjugated_records(records, unitary):
+    return {site: conjugate(content, unitary) for site, content in records.items()}
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    representatives = {
+        "rrr-a": payload_rrr(Q(1, 2), Q(9, 10)),
+        "rrr-b": payload_rrr(Q(1, 2), Q(3, 4)),
+        "rrr-fine": payload_rrr(Q(1, 2), Q(1, 2)),
+        "rr": payload_rr(),
+        "rri": payload_rri(Q(1, 3)),
+        "iii": payload_iii(Q(1, 5), Q(3, 10)),
+        "ii": payload_ii(Q(2, 5)),
+    }
+    decoded = {name: decode_menu_payload(value) for name, value in representatives.items()}
+    ordinary_decoded = {name: decode_payload(value) for name, value in representatives.items()}
+    check(
+        "five-positive-strata-common-preparation",
+        sum(SECTOR_MASSES.values()) == 1
+        and all(mass > 0 for mass in SECTOR_MASSES.values())
+        and COEFFICIENT_DENSITIES == {
+            "RRR": 2, "RR": 1, "RRI": 1, "III": 2, "II": 1,
+        }
+        and {item.sector for item in decoded.values()} == {"RRR", "RR", "RRI", "III", "II"}
+        and all(item is not None and matrix_equal(item.preparation, I2 / 2) for item in ordinary_decoded.values())
+        and all(matrix_equal(item.preparation, I2 / 2) for item in decoded.values()),
+        "all RRR/RR/RRI/III/II root strata have positive mixture mass and one I/2 preparation quotient",
+    )
+
+    menus = {name: menu_specs(value) for name, value in representatives.items()}
+    type_words = {
+        name: "".join(effect_kind(spec.effect) for spec in specs)
+        for name, specs in menus.items()
+    }
+    check(
+        "complete-low-arity-strata",
+        type_words == {
+            "rrr-a": "RRR", "rrr-b": "RRR", "rrr-fine": "RRR",
+            "rr": "RR", "rri": "IRR", "iii": "III", "ii": "II",
+        }
+        and all(matrix_equal(sum((spec.effect for spec in specs), Matrix.zeros(2)), I2) for specs in menus.values())
+        and all(len(specs) in (2, 3) for specs in menus.values()),
+        "the five exhaustive type strata are instantiated and every representative binary/ternary menu resolves I",
+    )
+
+    grid = (
+        (Q(0), Q(1)), (Q(1), Q(0)), (Q(1), Q(1)),
+        (Q(1, 2), Q(1, 2)), (Q(1, 3), Q(2, 3)),
+        (Q(1, 2), Q(3, 4)), (Q(3, 5), Q(4, 5)),
+    )
+    grid_valid = True
+    for a, b in grid:
+        specs = menu_specs(payload_rrr(a, b))
+        grid_valid = grid_valid and (
+            specs is not None
+            and len(specs) in (2, 3)
+            and all(effect_kind(spec.effect) == "R" for spec in specs)
+            and matrix_equal(sum((spec.effect for spec in specs), Matrix.zeros(2)), I2)
+        )
+    a, b, c = symbols("a b c", positive=True)
+    gamma = simplify((c * c - a * a - b * b) / (2 * a * b))
+    closure_norm = simplify((a * a + b * b + 2 * a * b * gamma) / (c * c))
+    check(
+        "rank-one-triangle-surjection-core",
+        grid_valid and closure_norm == 1,
+        "c1+c2+c3=2 and the weighted Bloch closure give the canonical triangle; its Gram data determine every RRR menu up to SO(3)/SU(2)",
+    )
+
+    boundary_payloads = (
+        payload_rrr(Q(1), Q(1)), payload_rrr(Q(0), Q(1)), payload_rrr(Q(1), Q(0)),
+        payload_rri(Q(0)), payload_iii(Q(2, 5), Q(0)), payload_ii(Q(0)),
+    )
+    check(
+        "zero-removal-boundaries",
+        all(menu_specs(value) is not None for value in boundary_payloads)
+        and all(
+            all(not matrix_equal(spec.effect, Matrix.zeros(2)) for spec in menu_specs(value))
+            for value in boundary_payloads
+        )
+        and tuple(len(menu_specs(value)) for value in boundary_payloads) == (2, 2, 2, 2, 2, 1),
+        "supported coefficient boundaries drop zero effects exactly; all target binary boundaries remain valid",
+    )
+
+    trace_laws = {name: terminal_law(value, "trace") for name, value in representatives.items()}
+    check(
+        "selected-trace-kernel-all-strata",
+        all(simplify(sum(mass for _, mass in law)) == 1 for law in trace_laws.values())
+        and all(truth_positive(mass) for law in trace_laws.values() for _, mass in law)
+        and tuple(mass for _, mass in trace_laws["rri"]) == (Q(1, 3), Q(1, 3), Q(1, 3))
+        and tuple(mass for _, mass in trace_laws["iii"]) == (Q(1, 5), Q(3, 10), Q(1, 2))
+        and tuple(mass for _, mass in trace_laws["ii"]) == (Q(2, 5), Q(3, 5)),
+        "Tr((I/2)E) is derived for every registered effect and normalizes each of the five strata",
+    )
+
+    fine = payload_rrr(Q(1, 2), Q(1, 2))
+    coarse = payload_rr()
+    a_program = payload_rrr(Q(1, 2), Q(9, 10))
+    b_program = payload_rrr(Q(1, 2), Q(3, 4))
+    skew_fine = terminal_law(fine, "context-skew")
+    skew_coarse = terminal_law(coarse, "context-skew")
+    skew_a = terminal_law(a_program, "context-skew")
+    skew_b = terminal_law(b_program, "context-skew")
+    a_first = menu_specs(a_program)[0]
+    b_first = menu_specs(b_program)[0]
+    check(
+        "continuum-context-skew-control",
+        tuple(mass for _, mass in skew_fine) == (Q(21, 80), Q(21, 80), Q(19, 40))
+        and tuple(mass for _, mass in skew_coarse) == (Q(1, 2), Q(1, 2))
+        and simplify(skew_fine[0][1] + skew_fine[1][1]) == Q(21, 40)
+        and simplify(skew_fine[0][1] + skew_fine[1][1]) != skew_coarse[0][1]
+        and matrix_equal(a_first.effect, b_first.effect)
+        and skew_a[0][1] == Q(527, 2000)
+        and skew_b[0][1] == Q(169, 640)
+        and skew_a[0][1] != skew_b[0][1]
+        and all(simplify(sum(mass for _, mass in law)) == 1 for law in (skew_fine, skew_coarse, skew_a, skew_b))
+        and all(truth_positive(mass) for law in (skew_fine, skew_coarse, skew_a, skew_b) for _, mass in law),
+        "one exact positive same-support Law breaks both coarse/refined and literal shared-effect probabilities, so W1 stays open",
+    )
+
+    exact_unitaries = (
+        I2,
+        SX,
+        simplify((SX + SZ) / sqrt(2)),
+        Matrix([[1, 0], [0, I]]),
+        simplify((I2 + I * SX) / sqrt(2)),
+    )
+    covariant = True
+    for unitary in exact_unitaries:
+        for name, value in representatives.items():
+            moved = conjugate(value, unitary)
+            before = menu_specs(value)
+            after = menu_specs(moved)
+            covariant = covariant and (
+                decode_menu_payload(moved).sector == decoded[name].sector
+                and all(
+                    left.name == right.name
+                    and left.label == right.label
+                    and matrix_equal(right.effect, conjugate(left.effect, unitary))
+                    for left, right in zip(before, after)
+                )
+            )
+            for variant in ("trace", "context-skew"):
+                before_law = terminal_law(value, variant)
+                after_law = terminal_law(moved, variant)
+                covariant = covariant and all(
+                    simplify(left_mass - right_mass) == 0
+                    and matrix_equal(right_content, conjugate(left_content, unitary))
+                    for (left_content, left_mass), (right_content, right_mass)
+                    in zip(before_law, after_law)
+                )
+    check(
+        "internal-frame-covariance",
+        covariant,
+        "five exact basis changes preserve sector/parameters, conjugate every menu Record, and preserve both kernels",
+    )
+
+    base_payload = representatives["rrr-a"]
+    stages, exact_partition, completed_quiet, unfinished_count = all_stage_states(base_payload)
+    terminal_pairs = tuple(
+        (carriers, next(iter(geometric_frontier(carriers, 11))))
+        for carriers in stages[-2]
+    )
+    parsed = []
+    sample_records = None
+    for carriers, target in terminal_pairs:
+        for name, value in representatives.items():
+            for spec in menu_specs(value):
+                records = {site: value for site in carriers}
+                records[target] = spec.content
+                certificate = parse_trial(records, frozenset(records))
+                parsed.append(
+                    certificate is not None
+                    and certificate.target == target
+                    and certificate.sector == decoded[name].sector
+                    and certificate.outcome == spec.name
+                    and matrix_equal(certificate.effect, spec.effect)
+                )
+                if sample_records is None and name == "rrr-a":
+                    sample_records = records
+    check(
+        "exhaustive-continuum-parser-fixtures",
+        exact_partition
+        and completed_quiet
+        and unfinished_count == 895
+        and len(terminal_pairs) == 120
+        and len(parsed) == 2280
+        and all(parsed),
+        "all 120 placements times nineteen cross-stratum representative outcomes decode: 2280/2280",
+    )
+
+    unfinished_rejects = all(
+        parse_trial({site: base_payload for site in state}, state) is None
+        for level in stages[:-1]
+        for state in level
+    )
+    sample_component = frozenset(sample_records)
+    hostile_site = min(halo(sample_component) - sample_component)
+    hostile = dict(sample_records)
+    hostile[hostile_site] = representatives["rr"]
+    hostile_component = next(component for component in connected_components(hostile) if component & sample_component)
+    malformed_carriers, malformed_target = terminal_pairs[0]
+    malformed = {site: Matrix.zeros(2) for site in malformed_carriers}
+    malformed[malformed_target] = I2
+    nonorthogonal = simplify(2 * SX + I * (SX + SZ) / sqrt(2))
+    check(
+        "false-positive-and-frame-controls",
+        unfinished_rejects
+        and parse_trial(hostile, hostile_component) is None
+        and parse_trial(malformed, frozenset(malformed)) is None
+        and decode_menu_payload(nonorthogonal) is None,
+        "895 unfinished histories, hostile adjacency, zero carriers, and a nonorthogonal internal frame reject",
+    )
+
+    sample_certificate = parse_trial(sample_records, sample_component)
+    displacement = (7, -4, 3)
+    moved_records = translated_records(sample_records, displacement)
+    moved_certificate = parse_trial(moved_records, frozenset(moved_records))
+    parser_covariant = moved_certificate is not None and (
+        moved_certificate.target == add(sample_certificate.target, displacement)
+        and moved_certificate.sector == sample_certificate.sector
+        and moved_certificate.outcome == sample_certificate.outcome
+    )
+    for rotation in ROTATIONS:
+        rotated = {rotate_site(rotation, site): content for site, content in sample_records.items()}
+        certificate = parse_trial(rotated, frozenset(rotated))
+        parser_covariant = parser_covariant and (
+            certificate is not None
+            and certificate.target == rotate_site(rotation, sample_certificate.target)
+            and certificate.sector == sample_certificate.sector
+        )
+    for unitary in exact_unitaries:
+        moved = conjugated_records(sample_records, unitary)
+        certificate = parse_trial(moved, frozenset(moved))
+        parser_covariant = parser_covariant and (
+            certificate is not None
+            and certificate.sector == sample_certificate.sector
+            and certificate.outcome == sample_certificate.outcome
+            and matrix_equal(certificate.effect, conjugate(sample_certificate.effect, unitary))
+        )
+    check(
+        "certificate-covariance",
+        parser_covariant,
+        "translations, all 24 proper cubic rotations, and five basis changes commute with the Record-only parser",
+    )
+
+    canonical_target = next(iter(geometric_frontier(frozenset(CANONICAL_CARRIER_PATH), 11)))
+    canonical_sequence = CANONICAL_CARRIER_PATH + (canonical_target,)
+    sequence_legal = root_eligible({}, canonical_sequence[0])
+    sequence_records = {}
+    path_payload = representatives["rri"]
+    for index, site in enumerate(canonical_sequence):
+        if index == 0:
+            root_law = continuum_content_law(tuple())
+            sequence_legal = sequence_legal and (
+                isinstance(root_law, ContinuumRootLaw)
+                and root_law.orientation_measure == "normalized-Haar-SU2"
+                and root_law.coefficient_densities == COEFFICIENT_DENSITIES
+            )
+            sequence_records[site] = path_payload
+        elif index < 11:
+            law = continuum_content_law(recorded_neighbor_contents(sequence_records, site))
+            sequence_legal = sequence_legal and (
+                formation_rate(sequence_records, site) == 1
+                and len(law) == 1
+                and matrix_equal(law[0][0], path_payload)
+                and law[0][1] == 1
+            )
+            sequence_records[site] = path_payload
+        else:
+            law = continuum_content_law(recorded_neighbor_contents(sequence_records, site))
+            sequence_legal = sequence_legal and formation_rate(sequence_records, site) == 1 and simplify(sum(mass for _, mass in law)) == 1
+            sequence_records[site] = law[0][0]
+    tau, patch_mass = symbols("tau patch_mass", positive=True)
+    event_count = len(canonical_sequence)
+    ball_size = len(BALL_OFFSETS[ROOT_EXCLUSION_RADIUS])
+    cylinder = simplify(
+        SECTOR_MASSES["RRI"] * patch_mass
+        * exp(-ball_size * tau) * (tau / event_count) ** event_count
+    )
+    singleton_mass = Q(0)
+    check(
+        "support-level-occurrence-boundary",
+        sequence_legal
+        and event_count == 12
+        and ball_size == 1159
+        and cylinder == patch_mass * exp(-1159 * tau) * (tau / 12) ** 12 / 4
+        and truth_positive(cylinder)
+        and singleton_mass == 0,
+        "every relatively open parameter patch has a positive B9 cylinder, while an exact continuum setting correctly has zero singleton mass",
+    )
+
+    erased_rr = simplify(representatives["rr"] - I * SECTOR_TAGS["RR"] * I2)
+    erased_rri_zero = simplify(payload_rri(Q(0)) - I * SECTOR_TAGS["RRI"] * I2)
+    invalid_triangle = payload_rrr(Q(1, 5), Q(1, 5))
+    check(
+        "program-and-domain-mutations",
+        matrix_equal(erased_rr, erased_rri_zero)
+        and decode_menu_payload(invalid_triangle) is None
+        and decode_menu_payload(simplify(payload_iii(Q(3, 4), Q(3, 4)))) is None,
+        "erasing the scalar program tag aliases RR/RRI, while coefficients outside either closed simplex reject",
+    )
+
+    note_text = NOTE.read_text(encoding="utf-8")
+    required = (
+        "under the current canonical support reading",
+        "five strata are exhaustive",
+        "not a controlled setting dial",
+        "zero singleton mass",
+        "W1 remains open",
+        "No Minimal Axioms edit",
+        "TOE percentages remain unchanged",
+        "N1 — Alternative Route Enumeration",
+        "N8 — Cross-Cycle Echo",
+    )
+    check(
+        "source-contract",
+        all(fragment in note_text for fragment in required),
+        "the note pins support eligibility, exhaustive strata, operational limits, W1, axiom/score posture, and N1-N8",
+    )
+
+    print("per_element: every representative scaled-rank-one/scalar effect, label, trace mass, and skew mass is checked")
+    print("per_site: five positive root strata, copied carriers, and nineteen terminal fixtures are decoded")
+    print("per_mode: checked and not executed — no spectral-mode or mode-exhaustion claim is made")
+    print("per_block: all 895 unfinished shapes and 2280 completed cross-stratum fixtures are checked")
+    print("lattice_wide: checked and not executed — full-support eligibility is analytic; no exact-setting frequency claim is made")
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return int(failed != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.py
+++ b/scripts/nn_record_continuum_low_arity_menu_compiler_independent_check_2026_08_23.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Independent reconstruction of the continuum low-arity menu compiler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sympy import I, Matrix, Rational as Q, exp, simplify, sqrt, symbols
+
+from nn_record_homogeneous_payload_self_hosting_writer_2026_08_22 import (
+    I2,
+    SX,
+    SZ,
+    antihermitian_coefficient,
+    decode_payload,
+    hermitian_part,
+    matrix_equal,
+)
+from nn_record_spatial_trial_ensemble_independent_check_2026_08_23 import (
+    GROUP,
+    O,
+    ball,
+    connected_components,
+    degree,
+    embeddings,
+    histories,
+    neighborhood,
+    plus,
+    rotate,
+)
+
+
+AUDIT_TIMEOUT_SEC = 180
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "scripts/nn_record_continuum_low_arity_menu_compiler_2026_08_23.py",
+    "scripts/nn_record_spatial_trial_ensemble_independent_check_2026_08_23.py",
+    "scripts/nn_record_homogeneous_payload_self_hosting_writer_2026_08_22.py",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+MIXTURE = {"RRR": Q(1, 4), "RR": Q(1, 8), "RRI": Q(1, 4), "III": Q(1, 4), "II": Q(1, 8)}
+DENSITIES = {"RRR": Q(2), "RR": Q(1), "RRI": Q(1), "III": Q(2), "II": Q(1)}
+TAGS = {"RRR": Q(0), "RR": Q(1), "RRI": Q(2), "III": Q(4), "II": Q(5)}
+LABELS = (Q(30), Q(31), Q(32))
+
+
+def conjugate(value, unitary):
+    return simplify(unitary * value * unitary.conjugate().T)
+
+
+def scalar(value):
+    return simplify(value.trace() / 2)
+
+
+def radius(value):
+    return simplify(sqrt((value * value).trace() / 2))
+
+
+def axis(value):
+    return (
+        matrix_equal(value, value.conjugate().T)
+        and simplify(value.trace()) == 0
+        and matrix_equal(simplify(value * value), I2)
+    )
+
+
+def make(kind, *parameters, x=SX, z=SZ):
+    if kind == "RRR":
+        a, b = parameters
+        h_value, k_value = (1 + a) * x, (1 + b) * z
+    elif kind == "RR":
+        h_value, k_value = x, z + I2
+    elif kind == "RRI":
+        (d,) = parameters
+        h_value, k_value = (1 + d) * x, z + 2 * I2
+    elif kind == "III":
+        d1, d2 = parameters
+        h_value, k_value = (1 + d1) * x, (1 + d2) * z + 4 * I2
+    elif kind == "II":
+        (d,) = parameters
+        h_value, k_value = (1 + d) * x, z + 5 * I2
+    else:
+        raise ValueError(kind)
+    return simplify(h_value + I * k_value)
+
+
+def unpack(value):
+    h_value = hermitian_part(value)
+    k_value = antihermitian_coefficient(value)
+    if simplify(h_value.trace()) != 0:
+        return None
+    k_tag = scalar(k_value)
+    kind = next((name for name, expected in TAGS.items() if simplify(k_tag - expected) == 0), None)
+    if kind is None:
+        return None
+    h_zero = simplify(h_value)
+    k_zero = simplify(k_value - k_tag * I2)
+    rh, rk = radius(h_zero), radius(k_zero)
+    if not bool(rh.is_positive) or not bool(rk.is_positive):
+        return None
+    x, z = simplify(h_zero / rh), simplify(k_zero / rk)
+    if not axis(x) or not axis(z) or not matrix_equal(x * z + z * x, Matrix.zeros(2)):
+        return None
+    if kind == "RRR":
+        a, b = simplify(rh - 1), simplify(rk - 1)
+        valid = all(bool(simplify(item).is_nonnegative) for item in (a, 1 - a, b, 1 - b, a + b - 1))
+        parameters = (a, b)
+    elif kind == "RR":
+        valid = simplify(rh - 1) == 0 and simplify(rk - 1) == 0
+        parameters = tuple()
+    elif kind in ("RRI", "II"):
+        d = simplify(rh - 1)
+        valid = simplify(rk - 1) == 0 and bool(d.is_nonnegative) and bool(simplify(1 - d).is_nonnegative)
+        parameters = (d,)
+    else:
+        d1, d2 = simplify(rh - 1), simplify(rk - 1)
+        valid = all(bool(simplify(item).is_nonnegative) for item in (d1, d2, 1 - d1 - d2))
+        parameters = (d1, d2)
+    return (kind, parameters, x, z) if valid else None
+
+
+def projection(direction):
+    return simplify((I2 + direction) / 2)
+
+
+def tagged(effect, label):
+    return simplify(effect + I * label * I2)
+
+
+def menu(value):
+    data = unpack(value)
+    if data is None:
+        return None
+    kind, parameters, x, z = data
+    zero = Matrix.zeros(2)
+    if kind == "RRR":
+        a, b = parameters
+        c = simplify(2 - a - b)
+        if a == 0:
+            rows = (("rrr-1", zero), ("rrr-2", projection(z)), ("rrr-3", projection(-z)))
+        elif b == 0:
+            rows = (("rrr-1", projection(x)), ("rrr-2", zero), ("rrr-3", projection(-x)))
+        elif c == 0:
+            rows = (("rrr-1", projection(x)), ("rrr-2", projection(-x)), ("rrr-3", zero))
+        else:
+            cosine = simplify((c**2 - a**2 - b**2) / (2 * a * b))
+            sine = simplify(sqrt(1 - cosine**2))
+            n1 = x
+            n2 = simplify(cosine * x + sine * z)
+            n3 = simplify(-(a * n1 + b * n2) / c)
+            rows = (("rrr-1", a * projection(n1)), ("rrr-2", b * projection(n2)), ("rrr-3", c * projection(n3)))
+    elif kind == "RR":
+        rows = (("rr-1", projection(x)), ("rr-2", projection(-x)))
+    elif kind == "RRI":
+        (d,) = parameters
+        rows = (("rri-i", d * I2), ("rri-plus", (1 - d) * projection(x)), ("rri-minus", (1 - d) * projection(-x)))
+    elif kind == "III":
+        d1, d2 = parameters
+        rows = (("iii-1", d1 * I2), ("iii-2", d2 * I2), ("iii-3", (1 - d1 - d2) * I2))
+    else:
+        (d,) = parameters
+        rows = (("ii-1", d * I2), ("ii-2", (1 - d) * I2))
+    rows = tuple(
+        (index, name, simplify(effect))
+        for index, (name, effect) in enumerate(rows)
+        if not matrix_equal(effect, zero)
+    )
+    return tuple((name, effect, tagged(effect, LABELS[index])) for index, name, effect in rows)
+
+
+def type_of(effect):
+    center = scalar(effect)
+    if matrix_equal(effect, center * I2):
+        return "I" if bool(center.is_positive) and bool(simplify(1 - center).is_nonnegative) else None
+    coefficient = simplify(effect.trace())
+    normalized = simplify(effect / coefficient)
+    return "R" if (
+        bool(coefficient.is_positive)
+        and bool(simplify(1 - coefficient).is_nonnegative)
+        and matrix_equal(normalized * normalized, normalized)
+        and simplify(normalized.trace()) == 1
+    ) else None
+
+
+def weights(value, skew=False):
+    data = unpack(value)
+    rows = menu(value)
+    masses = [simplify(effect.trace() / 2) for _, effect, _ in rows]
+    if skew and data[0] == "RRR" and len(rows) == 3:
+        coefficients = [simplify(effect.trace()) for _, effect, _ in rows]
+        shift = simplify(coefficients[0] * coefficients[1] * coefficients[2] / 10)
+        masses = [masses[0] + shift / 2, masses[1] + shift / 2, masses[2] - shift]
+    return tuple(simplify(mass) for mass in masses)
+
+
+def parse(records, component):
+    component = frozenset(component)
+    if len(component) != 12:
+        return None
+    if len(connected_components({site: records[site] for site in component})) != 1:
+        return None
+    if neighborhood(component) & frozenset(records) != component:
+        return None
+    terminals = tuple(site for site in component if degree(site, component) == 6)
+    if len(terminals) != 1:
+        return None
+    target = terminals[0]
+    carriers = component - {target}
+    carrier = records[next(iter(carriers))]
+    data = unpack(carrier)
+    options = menu(carrier)
+    if data is None or options is None or not all(matrix_equal(records[site], carrier) for site in carriers):
+        return None
+    frames = embeddings(carriers, 11)
+    if len(frames) != 1:
+        return None
+    rotation, displacement = frames[0]
+    if target != plus(displacement, rotate(rotation, O)):
+        return None
+    matches = tuple((name, effect) for name, effect, content in options if matrix_equal(records[target], content))
+    if len(matches) != 1:
+        return None
+    return target, data[0], matches[0][0], matches[0][1]
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name, condition, detail):
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    examples = {
+        "rrr-a": make("RRR", Q(1, 2), Q(9, 10)),
+        "rrr-b": make("RRR", Q(1, 2), Q(3, 4)),
+        "rrr-fine": make("RRR", Q(1, 2), Q(1, 2)),
+        "rr": make("RR"),
+        "rri": make("RRI", Q(1, 3)),
+        "iii": make("III", Q(1, 5), Q(3, 10)),
+        "ii": make("II", Q(2, 5)),
+    }
+    decoded = {name: unpack(value) for name, value in examples.items()}
+    check(
+        "independent-stratum-and-preparation-decoder",
+        sum(MIXTURE.values()) == 1
+        and all(mass > 0 for mass in MIXTURE.values())
+        and DENSITIES == {"RRR": 2, "RR": 1, "RRI": 1, "III": 2, "II": 1}
+        and {data[0] for data in decoded.values()} == set(MIXTURE)
+        and all(matrix_equal(decode_payload(value).preparation, I2 / 2) for value in examples.values()),
+        "five independently decoded positive-mass sectors retain the common I/2 quotient",
+    )
+
+    menus = {name: menu(value) for name, value in examples.items()}
+    words = {name: "".join(type_of(effect) for _, effect, _ in rows) for name, rows in menus.items()}
+    check(
+        "independent-five-stratum-algebra",
+        words == {"rrr-a": "RRR", "rrr-b": "RRR", "rrr-fine": "RRR", "rr": "RR", "rri": "IRR", "iii": "III", "ii": "II"}
+        and all(matrix_equal(sum((effect for _, effect, _ in rows), Matrix.zeros(2)), I2) for rows in menus.values()),
+        "RRR/RR/RRI/III/II representatives independently resolve I with the declared effect types",
+    )
+
+    coefficient_pairs = (
+        (Q(0), Q(1)), (Q(1), Q(0)), (Q(1), Q(1)),
+        (Q(1, 2), Q(1, 2)), (Q(2, 5), Q(4, 5)), (Q(3, 4), Q(3, 4)),
+    )
+    triangle_checks = []
+    for a_value, b_value in coefficient_pairs:
+        rows = menu(make("RRR", a_value, b_value))
+        triangle_checks.append(rows is not None and len(rows) in (2, 3) and matrix_equal(sum((effect for _, effect, _ in rows), Matrix.zeros(2)), I2))
+    a, b, c = symbols("a b c", positive=True)
+    cosine = (c**2 - a**2 - b**2) / (2 * a * b)
+    derived_n3_norm = simplify((a**2 + b**2 + 2 * a * b * cosine) / c**2)
+    check(
+        "independent-triangle-gram-surjection",
+        all(triangle_checks) and derived_n3_norm == 1,
+        "independent closure and Gram arithmetic reconstruct the universal rank-one triangle including binary boundaries",
+    )
+
+    traces = {name: weights(value) for name, value in examples.items()}
+    fine_skew = weights(examples["rrr-fine"], True)
+    coarse_skew = weights(examples["rr"], True)
+    a_skew = weights(examples["rrr-a"], True)
+    b_skew = weights(examples["rrr-b"], True)
+    check(
+        "independent-trace-and-skew-kernels",
+        all(simplify(sum(table)) == 1 for table in traces.values())
+        and all(bool(mass.is_positive) for table in traces.values() for mass in table)
+        and traces["rri"] == (Q(1, 3), Q(1, 3), Q(1, 3))
+        and traces["iii"] == (Q(1, 5), Q(3, 10), Q(1, 2))
+        and traces["ii"] == (Q(2, 5), Q(3, 5))
+        and fine_skew == (Q(21, 80), Q(21, 80), Q(19, 40))
+        and coarse_skew == (Q(1, 2), Q(1, 2))
+        and simplify(fine_skew[0] + fine_skew[1]) != coarse_skew[0]
+        and matrix_equal(menus["rrr-a"][0][1], menus["rrr-b"][0][1])
+        and a_skew[0] == Q(527, 2000)
+        and b_skew[0] == Q(169, 640)
+        and a_skew[0] != b_skew[0],
+        "trace normalization spans all strata while the reconstructed covariant skew breaks both W1 fixtures",
+    )
+
+    unitaries = (
+        I2, SX, simplify((SX + SZ) / sqrt(2)),
+        Matrix([[1, 0], [0, I]]), simplify((I2 + I * SX) / sqrt(2)),
+    )
+    covariance = True
+    for unitary in unitaries:
+        for value in examples.values():
+            moved = conjugate(value, unitary)
+            covariance = covariance and unpack(moved)[:2] == unpack(value)[:2]
+            covariance = covariance and weights(moved, True) == weights(value, True)
+            covariance = covariance and all(
+                left_name == right_name
+                and matrix_equal(right_effect, conjugate(left_effect, unitary))
+                and matrix_equal(right_content, conjugate(left_content, unitary))
+                for (left_name, left_effect, left_content), (right_name, right_effect, right_content)
+                in zip(menu(value), menu(moved))
+            )
+    check(
+        "independent-internal-covariance",
+        covariance,
+        "all sectors, effects, contents, and both probability kernels commute with five basis changes",
+    )
+
+    levels, terminal_pairs, exact_partition = histories()
+    unfinished_count = sum(len(level) for level in levels)
+    results = []
+    sample = None
+    for carriers, target in terminal_pairs:
+        for name, carrier in examples.items():
+            for outcome, effect, content in menu(carrier):
+                records = {site: carrier for site in carriers}
+                records[target] = content
+                found = parse(records, frozenset(records))
+                results.append(found is not None and found[0] == target and found[1] == decoded[name][0] and found[2] == outcome and matrix_equal(found[3], effect))
+                if sample is None and name == "rrr-b":
+                    sample = records
+    check(
+        "independent-exhaustive-fixture-parser",
+        len(GROUP) == 24
+        and exact_partition
+        and unfinished_count == 895
+        and len(terminal_pairs) == 120
+        and len(results) == 2280
+        and all(results),
+        "independent geometry accepts 2280/2280 completed cross-stratum fixtures over all terminal placements",
+    )
+
+    unfinished_rejects = all(parse({site: examples["rrr-a"] for site in state}, state) is None for level in levels for state in level)
+    component = frozenset(sample)
+    hostile_site = min(neighborhood(component) - component)
+    hostile = dict(sample)
+    hostile[hostile_site] = examples["rr"]
+    hostile_component = next(found for found in connected_components(hostile) if found & component)
+    malformed_carriers, malformed_target = next(iter(terminal_pairs))
+    malformed = {site: Matrix.zeros(2) for site in malformed_carriers}
+    malformed[malformed_target] = I2
+    invalid_frame = simplify(2 * SX + I * (SX + SZ) / sqrt(2))
+    check(
+        "independent-negative-controls",
+        unfinished_rejects
+        and parse(hostile, hostile_component) is None
+        and parse(malformed, frozenset(malformed)) is None
+        and unpack(invalid_frame) is None
+        and unpack(make("RRR", Q(1, 5), Q(1, 5))) is None,
+        "unfinished shapes, adjacency contamination, malformed carriers, nonorthogonal axes, and invalid coefficients reject",
+    )
+
+    original = parse(sample, component)
+    shift = (7, -4, 3)
+    translated = {plus(site, shift): value for site, value in sample.items()}
+    moved = parse(translated, frozenset(translated))
+    parser_covariance = moved is not None and moved[0] == plus(original[0], shift)
+    for rotation in GROUP:
+        rotated = {rotate(rotation, site): value for site, value in sample.items()}
+        found = parse(rotated, frozenset(rotated))
+        parser_covariance = parser_covariance and found is not None and found[0] == rotate(rotation, original[0]) and found[1:3] == original[1:3]
+    for unitary in unitaries:
+        transformed = {site: conjugate(value, unitary) for site, value in sample.items()}
+        found = parse(transformed, frozenset(transformed))
+        parser_covariance = parser_covariance and found is not None and found[:3] == original[:3] and matrix_equal(found[3], conjugate(original[3], unitary))
+    check(
+        "independent-parser-covariance",
+        parser_covariance,
+        "translations, 24 lattice rotations, and five basis changes commute with the independent parser",
+    )
+
+    tau, patch = symbols("tau patch", positive=True)
+    event_count = 12
+    slot = tau / event_count
+    designated = (exp(-slot) * slot) ** event_count
+    quiet = exp(-(len(ball(9)) * tau - event_count * slot))
+    cylinder = simplify(MIXTURE["RRI"] * patch * designated * quiet)
+    check(
+        "independent-support-versus-singleton",
+        len(ball(9)) == 1159
+        and cylinder == patch * exp(-1159 * tau) * (tau / 12) ** 12 / 4
+        and bool(cylinder.is_positive)
+        and Q(0) == 0,
+        "positive open-patch cylinder and zero exact singleton mass are independently kept as different statements",
+    )
+
+    note_text = NOTE.read_text(encoding="utf-8")
+    source_text = Path(__file__).read_text(encoding="utf-8")
+    check(
+        "independent-source-and-import-boundary",
+        "five strata are exhaustive" in note_text
+        and "2280/2280" in note_text
+        and "zero singleton mass" in note_text
+        and "W1 remains open" in note_text
+        and "No Minimal Axioms edit" in note_text
+        and "N8 — Cross-Cycle Echo" in note_text
+        and ("from nn_record_continuum_low_arity_menu_" + "compiler_2026_08_23") not in source_text,
+        "the independent route imports no Block38 primary and pins continuum, parser, operational, axiom, and N1-N8 boundaries",
+    )
+
+    print("per_element: independent reconstruction checks every fixture effect type, content label, trace mass, and skew mass")
+    print("per_site: independent decoding covers five root strata, carrier payloads, and nineteen terminal fixtures")
+    print("per_mode: checked and not executed — no spectral-mode or mode-exhaustion claim is made")
+    print("per_block: independent geometry checks 895 unfinished shapes and 2280 completed fixtures")
+    print("lattice_wide: checked and not executed — support is analytic and no exact-setting frequency claim is made")
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return int(failed != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Construct five positive-mass Haar-covariant Record root strata that cover the complete binary/ternary nonzero scaled-rank-one and scalar-identity menu family under the current canonical support reading.
- Prove the RRR triangle/Gram surjection through SO(3)/SU(2), including collinear and zero-removal boundaries, and give explicit full-support coefficient measures for every stratum.
- Reuse the protected twelve-site writer with a Record-only terminal parser; the primary fixture campaign accepts 2,280/2,280 completed placements and rejects all 895 unfinished shapes plus hostile controls.
- Supply one normalized trace witness at rho=I/2 and one exact positive covariant context-skew kernel on the same compiler. The latter keeps cross-program effect functionality W1 open while the compiler closes W2 at the scoped source level.
- Land the required N1-N8 stress test for that narrow independence boundary.

## Claim boundary

This does not establish controlled settings, positive frequency for an exact continuum setting, W1, a general state-dependent Born law, a Minimal Axioms edit, retention, obligation retirement, or TOE-score movement. Exact continuum points are supported but have zero singleton mass under the atomless law.

## Validation

- Primary content-pinned cache: PASS=13 FAIL=0
- Independent content-pinned cache: PASS=10 FAIL=0
- Independent cold review: PASS, including extra zero-removal label and gamma=+/-1 degeneracy probes
- py_compile: pass
- vocabulary lint: 0 violations
- staged claim typing: pass
- changed audit evidence: checked=0 failures=0
- citation graph: pass, 5,566 nodes / 15,789 edges