### PR TITLE
physics: prove nearest-neighbor W1 nonselection

### DIFF
--- a/docs/NN_RECORD_NEAREST_NEIGHBOR_EFFECT_FUNCTIONALITY_INDEPENDENCE_NO_GO_NOTE_2026-08-23.md
+++ b/docs/NN_RECORD_NEAREST_NEIGHBOR_EFFECT_FUNCTIONALITY_INDEPENDENCE_NO_GO_NOTE_2026-08-23.md
@@ -1,0 +1,550 @@
+---
+claim_id: nn_record_nearest_neighbor_effect_functionality_independence_no_go_note_2026-08-23
+claim_type: no_go
+claim_scope: "At support-level local conditional-law resolution on the explicit Block 32 qubit preparation/program carrier, the current four Minimal Axioms plus the fixed Record-content decoder do not select cross-program effect functionality W1. Two total strict nearest-neighbor probability kernels use the same six-neighbour conditions, preparation quotient, registered output contents, and support. The trace kernel satisfies W1; the contextual kernel applies the permutation-equivariant map p_j=b_j(1+b_j-sum_k b_k^2) on every valid ternary program and violates W1 by exactly -27/50000 on two programs sharing one literal effect-label Record. The contextual kernel is normalized, support-preserving, translation/proper-cubic covariant, internally basis covariant, total on all neighbour conditions, and compatible with one-time permanent Record locking. No autonomous global history or positive exact-setting frequency is claimed. This is a local law-selection no-go on the stated carrier, not a claim that no selected downstream Law, action-native joint/current theorem, operational reconstruction, reachability restriction, or owner-approved premise can establish W1. It does not derive Born probabilities, amend an axiom, retire an audit obligation, or move a TOE percentage."
+depends_on:
+  - minimal_axioms
+  - nn_record_program_preparation_quotient_trace_compiler_bounded_theorem_note_2026-08-22
+  - nn_record_continuum_low_arity_menu_compiler_bounded_theorem_note_2026-08-23
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py
+independent_runner: scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py
+runner_cache: logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.txt
+independent_runner_cache: logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Nearest-Neighbor Effect-Functionality Independence No-Go
+
+**Date:** 2026-08-23
+
+**Claim type:** no_go
+
+**Role:** exact law-selection boundary for the final `W1` input to the
+low-arity Born-form theorem
+
+**Authority boundary:** the current
+[`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md) are the only effective
+framework premises. The Block 32 carrier/decoder, both probability kernels,
+the Block 38 compiler, and the August 9 representation theorem are open source
+claims, not retained premises. This note authors no audit verdict, no ledger
+entry, and no axiom or primitive change.
+
+**Primary runner:**
+[`scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py`](../scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py)
+
+**Independent reconstruction:**
+[`scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py`](../scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py)
+
+**Cached receipts:**
+[`primary`](../logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.txt),
+[`independent`](../logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.txt)
+
+## Result Up Front
+
+The August 9 finite-dimensional theorem forces a trace-form grade after two
+physical inputs are supplied:
+
+1. `W1`: at a fixed preparation, one registered effect has one probability
+   grade independent of which complete binary or ternary program contains it;
+2. `W2`: every low-arity program in the theorem's scaled-projector/scalar
+   domain is physically eligible.
+
+Block 38 constructs `W2` at source level under the repository's current
+support reading. It also contains a context-skew kernel, but that compiler's
+terminal parser has range nine. This note removes the possible escape that
+the contextuality came from that extended geometry. The countermodel below is
+a **strict nearest-neighbor** Admissibility rule on the original six-neighbour
+Block 32 carrier.
+
+For a valid program, let
+
+```text
+b_j = Tr(C E_j),               sum_j b_j = 1.             (1)
+```
+
+The selected trace kernel is `p_j=b_j`. A second one fixed kernel agrees with
+it on every binary program and, on every ternary program, uses the symmetric
+second moment
+
+```text
+S_2 = sum_k b_k^2,
+p_j = b_j (1+b_j-S_2).                                  (2)
+```
+
+Because `0<=S_2<=1`, equation (2) is nonnegative and normalized. Its zero set
+is exactly the zero set of `(b_0,b_1,b_2)`, so it preserves support. It uses
+only the decoded preparation and effects and is permutation-equivariant; even
+the host enumeration order of the Record labels is irrelevant. The inputs are
+invariant under proper cubic rotations of the shell and transform covariantly
+under internal basis changes.
+
+The two exact Block 32 programs share the same preparation
+`C=diag(3/5,2/5)` and the same first effect-label Record. Their trace vectors
+are
+
+```text
+b(A) = (3/10, 19/50, 8/25),
+b(B) = (3/10,  7/20, 7/20).                              (3)
+```
+
+Equation (2) gives
+
+```text
+p(A) = (903/3125, 6194/15625, 4916/15625),
+p(B) = ( 579/2000, 1421/4000, 1421/4000).                (4)
+```
+
+The first registered content is literally identical in both programs, but
+
+```text
+p_A(E_0,label=1) - p_B(E_0,label=1) = -27/50000 != 0.     (5)
+```
+
+Thus the four axioms and this carrier/readout typing admit both a
+`W1`-satisfying kernel and a `W1`-violating kernel. They do not select `W1` on
+this domain. That is the complete no-go claim.
+
+This result **does not prove that no downstream Law can derive `W1`**. A
+selected exact Law can exclude equation (2). So can a genuinely derived
+action-level current or joint-event theorem, a stronger operational
+reconstruction, or a reachability theorem that excludes one of the displayed
+conditions. An owner-approved premise can also close the implication, but it
+would add `W1`-equivalent physical content rather than restate something
+already forced by the current axioms.
+
+This is decision-quality blocker identification, not TOE closure. There is
+**no TOE-percentage movement**, no audit obligation retirement, and no claim
+of positive retention.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: no-go
+target_claim_type: no_go
+claim_type_reason: "One explicit total covariant nearest-neighbor countermodel satisfies the stated axiom and carrier interfaces while violating W1; the conclusion is only nonselection by that premise surface."
+trace_class: negative_route_pruning
+target_claim_id: born_effect_functionality_w1_selection
+target_blocker_text: "derive one probability grade for a shared registered effect across every eligible low-arity program at fixed preparation"
+source_of_blocker_text: user_goal
+reachability_to_target: prunes
+artifact_role: no_go
+campaign_native_target_reachability: advances
+next_trace_action: "construct an action-native event current mu_rho(E) and prove outcome-blind menu exposure H_rho(M,E)=alpha_rho(M)mu_rho(E), or request explicit owner governance on a W1-equivalent premise"
+conditional_surface_status: "W2 is source-closed in Block 38; W1 is not selected by the current axioms plus the explicit nearest-neighbor carrier typing"
+hypothetical_axiom_status: "one narrow W1-equivalent clause is sufficient but unapproved; this worker does not edit the premise surface"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target Contract
+
+| Field | Contract |
+|---|---|
+| target statement | determine whether the current four axioms plus a literal strict-nearest-neighbor preparation/program decoder force `W1` |
+| quantifiers/domain | the one fixed total kernel on every six-neighbour condition; all valid binary/ternary Block 32 programs for the universal positivity/support claim; the exact shared-effect pair for failure of `W1` |
+| allowed premises | cubic `Z^3`; one-site `M_2(C)`; one fixed nearest-neighbor probability rule; fixed content-only readout and permanent one-time Record locking; explicit downstream carrier definitions |
+| forbidden weakenings | a host-side pair of arbitrary probability tables without one total kernel; a range greater than one; a coordinate-named spatial axis; a signed label that flips under rotation; zero/negative mass; changed output support; calling a supplied Law selected or derived |
+| required edges | two complete shared-effect programs, binary control, probability-simplex boundary, empty/incomplete/malformed conditions, all 24 proper rotations, nontrivial internal basis changes, one-time locking, and common-total-scheduler control |
+| completion witness | one W1 kernel and one non-W1 kernel satisfying the same stated interfaces, with exact nonzero shared-grade residual |
+| outcomes not counted as closure | physical selection of either kernel, a complete autonomous history, preparation calibration, Born derivation, pincer joint, retained result, audit verdict, gravity result, or TOE-score change |
+
+## 1. One Fixed Total Nearest-Neighbor Rule
+
+Block 32 encodes a preparation and up to three effect/label items in the six
+matrices at the unoriented pairs `+/-e_x,+/-e_y,+/-e_z`. Hermitian averaging
+decodes `C`. Opposite-pair anti-Hermitian sums decode `E_j`, while their scalar
+differences decode positive labels. The inherited decoder enumerates outcomes
+by a stable serialization of those labels, but equation (2) is
+permutation-equivariant: reordering the decoded pairs merely reorders the
+same content/mass pairs. A `(2,10,3)` regression fixture makes that distinction
+load-bearing and proves that string order supplies no probability content.
+
+The contextual branch applies equation (2) whenever that decoder returns a
+valid ternary resolution of the identity. It uses the selected trace baseline
+only as explicit downstream Law content; the point is not that trace is
+derived, but that the permitted contextual deformation is exact and remains a
+probability law. Valid binary programs use the undeformed trace baseline.
+
+On a complete but invalid shell, the rule puts unit mass on the Hermitian
+neighbour average. Empty or incomplete recorded shells receive the normalized
+complex-matrix Gaussian
+
+```text
+d nu(A) = pi^(-4) exp[-Tr(A^dagger A)] d^8 A.             (6)
+```
+
+Equation (6) is invariant under unitary conjugation and has full support on
+`M_2(C)`. The six sites neighbouring one target are pairwise nonadjacent on
+the cubic lattice. They can therefore each take the Gaussian branch while the
+target remains fresh. The product law has full support on `M_2(C)^6`, so both
+exact carrier shells lie in the support of this same-law finite formation
+order. As with Block 38, an exact continuous shell has zero singleton mass
+while remaining a support point. No exact-setting frequency is inferred.
+
+This makes the kernel total on recorded nearest-neighbor conditions. It also
+removes a purely syntactic supplied-shell objection at the support level. An
+autonomous global formation order is still not claimed or needed for the
+law-selection countermodel; the axioms do not supply site, rate, cadence, or
+initial-history selection.
+
+## 2. Probability And Support Proof
+
+For a valid program, positivity of `C` and every `E_j`, with
+`sum_j E_j=I`, gives
+
+```text
+b_j >= 0,          sum_j b_j = Tr(C)=1.                  (7)
+```
+
+For ternary programs put `S_2=sum_j b_j^2`. Since the `b_j` lie on the
+probability simplex,
+
+```text
+0 < S_2 <= 1,
+p_j = b_j(1+b_j-S_2).                                    (8)
+```
+
+Every component is nonnegative because `1+b_j-S_2>=b_j>=0`, and
+
+```text
+sum_j p_j = 1 + S_2 - S_2 = 1.                          (9)
+```
+
+If `b_j>0`, then either `S_2<1`, giving `1+b_j-S_2>0`, or the simplex point is
+a vertex with `b_j=1`, again giving a positive factor. Thus `p_j=0` exactly
+when `b_j=0`. The trace and contextual rules have identical support,
+including every boundary.
+
+The runner checks the factorization on every rational simplex point with
+denominator through seventeen in addition to the symbolic proof above. That
+finite sweep is a regression check, not the source of the universal theorem.
+
+## 3. Covariance And Record Semantics
+
+The rule contains no site coordinate and is therefore translation invariant.
+A proper cubic rotation only permutes or reverses the three opposite-neighbour
+pairs. The absolute scalar label decoder recovers the same program, and the
+symmetric map commutes with any enumeration of its members, so all 24 proper
+rotations preserve the distribution.
+
+Under an internal basis change `A -> U A U^dagger`, the decoded preparation,
+effects, and output contents conjugate. Each `b_j=Tr(C E_j)` is unchanged, so
+equation (2) is internally basis covariant. The primary runner checks five
+exact unitaries; the independent runner reconstructs a nontrivial complex
+transport.
+
+The output values are actual matrices in `M_2(C)`. The fixed Hermitian map
+recovers the effect from every valid output. On the ternary and repeated-effect
+codeword sectors, the imaginary trace also recovers the label. The selected
+literal binary-projector sector deliberately writes only the projector, so its
+label is not retained; its two complementary contents remain distinct.
+Selecting one supported output locks exactly one possibility at the target,
+and an append-once map forbids overwrite. Context dependence belongs to
+formation probability; the readout of an already formed content remains
+content-only.
+
+These facts match the four axiom types:
+
+- Lattice: the rule sees exactly the six nearest neighbours and is covariant
+  under translations and proper cubic rotations.
+- Qubit: inputs and outputs are in `M_2(C)` and no unregistered internal basis
+  is used.
+- Admissibility: every neighbour condition receives one normalized
+  probability measure, and the distribution demonstrably varies between the
+  two valid conditions.
+- Record: one supported output locks once, remains fixed, and has a
+  content-determined readout.
+
+The exact probability values, decoder, Gaussian, and formation choice are
+downstream model content. Their consistency with the axioms is what a
+countermodel requires; their derivation is not claimed.
+
+## 4. What Common Scheduling Does Not Buy
+
+Both laws in equation (4) have total mass one. Equivalently, attach the same
+rate-one proposal clock to each program and read the displayed probabilities
+as branch currents. Then
+
+```text
+J_E + J_not-E = J_in = 1                                  (10)
+```
+
+holds in both contexts, while the current into the shared `E` branch differs.
+So a common total scheduler or samplewise conserved opportunity token is not
+enough. It proves a denominator, not equality of the relevant numerator.
+
+A positive conserved-current route must instead derive both:
+
+1. an effect event current before menu normalization; and
+2. an isomorphism or factorization proving that the shared branch has the
+   same complete upstream current in every context.
+
+Writing the conclusion as `h_M(E)=h_M'(E)` simply moves `W1` to raw-rate
+notation. The equality must follow from independently defined geometry,
+action, or event structure.
+
+One sufficient positive target is
+
+```text
+H_rho(M,E) = alpha_rho(M) mu_rho(E),                     (11)
+```
+
+where `mu_rho` is an action-native nonnegative event measure additive under
+actual refinement unions, and `alpha_rho(M)>0` is an outcome-blind exposure
+factor. For an exhaustive menu,
+
+```text
+P_rho(E | M)
+  = H_rho(M,E) / sum_(F in M) H_rho(M,F)
+  = mu_rho(E) / mu_rho(I).                               (12)
+```
+
+Equation (12) allows menu-dependent total formation rates. The substantive
+physics is the independently derived event measure and outcome-blind
+factorization—not common normalization alone.
+
+## 5. Decision Boundary
+
+There are now three honest choices.
+
+1. **Selected exact Law.** Construct equation (11), an equivalent action
+   current/joint theorem, or another canonical dynamics that excludes the
+   contextual kernel without assuming `W1`. This is the preferred explanatory
+   route.
+2. **Owner-approved premise.** Explicitly adopt a narrow clause such as:
+
+   > For a fixed decoded preparation, the Admissibility probability grade of
+   > a registered Record alternative descends to its decoded effect across
+   > completed nearest-neighbor programs.
+
+   On this domain that clause is `W1`-equivalent. It is a substantive model
+   restriction, not a harmless wording clarification. Under the binding
+   [Axiom Minimality Policy](audit/AXIOM_MINIMALITY_POLICY.md), a science worker
+   cannot install it; explicit owner approval must be recorded in the policy
+   and machine premise registry.
+3. **Leave `W1` open.** Then the August 9 theorem remains a conditional
+   representation theorem and the TOE probability lane does not close.
+
+If `W1` is obtained, Block 38's source-level `W2` construction and the August
+9 mathematics force a unique trace-form grade on their declared domain.
+Identifying its representing density with Block 38's decoded `I/2` is a
+separate calibration step and must not be hidden in the same decision.
+
+## 6. Scope And Deletion Controls
+
+| Deleted or changed ingredient | Exact result |
+|---|---|
+| symmetric context map `b_j(1+b_j-S_2)` | replacing it by `b_j` returns the trace kernel and shared grade `3/10`; `W1` is restored |
+| complete ternary menu | binary programs use the selected trace branch unchanged |
+| label magnitude | repeated or reordered effects no longer have a rotation-safe registered outcome identifier |
+| probability-simplex constraint | positivity/normalization proof no longer applies |
+| total fallback | the rule becomes undefined on part of the axiom domain |
+| common total scheduler only | both totals remain one while the shared branch differs by `-27/50000` |
+| selected-Law authority | neither kernel is chosen as framework physics |
+
+The result is not a theorem that contextual probabilities are true. It is a
+theorem that the stated premises allow them.
+
+## No-Go Discipline Gate
+
+The `no-go-discipline` gate is applied because the headline is a model-class
+nonselection claim. The gate passes only for the exact scope above.
+
+### N1 — Alternative route enumeration
+
+| Route family | Attack | Disposition and honesty marker |
+|---|---|---|
+| selected trace/effect Law | directly select `p(E)=Tr(rho E)` or another effect-only grade | **ATTEMPTED**: succeeds conditionally in Block 32 and Block 38, but no current premise selects that member over equation (2); this remains a live positive Law route |
+| pre-normalization conserved current | derive absolute effect currents and a common total before normalization | **ATTEMPTED**: the repository's common-resource examples supply their scheduler; equation (10) proves a common total alone fails, while a genuinely derived shared-branch causal isomorphism remains live |
+| action-native joint/pincer | obtain formation and content as marginals/conditionals of one unpinned action event measure | **ATTEMPTED**: the current pincer compares separately pinned interventions and does not construct that joint; a new augmented action with independently verified marginals remains live |
+| probability-free operational quotient | identify same-effect programs through support/bisimulation and strongly lump the local kernel | **ATTEMPTED**: identical support and identical post-Record content coexist with equation (5); full statistical equivalence that includes first occurrence would assume the grade being derived |
+| controlled intervention | vary only the program setting and compare the shared output | **ATTEMPTED**: a dial makes equation (5) operationally testable but does not force its residual to vanish unless outcome-current invariance is separately proved |
+| owner-governed effect descent | adopt the narrow clause in section 5 as an axiom or approved primitive | **ATTEMPTED**: sufficient and currently unapproved; because it excludes the countermodel by stating `W1`-equivalent content, it is governance rather than a derivation from the present surface |
+| totality/covariance incompatibility attack | try to reject the contextual member as partial, basis-dependent, spatially oriented, or non-probabilistic | **ATTEMPTED**: the executable normalized Gaussian, 64 occupancy masks, malformed-shell transports, simplex proof, 24 rotations, internal unitaries, and permutation-equivariant map close those defects on the stated domain |
+| zero-measure/history attack | require both exact program shells to occur within one same-law formation construction | **ATTEMPTED**: the six pairwise nonadjacent seeds take the common full-support Gaussian branch before the target; the product support contains both shells, while positive exact-setting frequency and a lattice-wide scheduler remain explicitly unclaimed |
+| possibility-privilege/content-descent attack | argue that labels, one fixed rule, or content-only readout already identify the probabilities | **ATTEMPTED**: equation (2) is label-order independent and invariant under the supplied transformations; one fixed rule may depend on the full neighbour condition, while content-only readout constrains the formed value rather than its cross-condition formation grade |
+
+These routes act on different objects: a chosen kernel, raw current, joint
+event measure, structural quotient, intervention, premise surface, and direct
+countermodel-validity attacks. None is counted twice under a renamed
+normalization argument.
+
+### N2 — Wall-independence audit
+
+The raw probability-form list now collapses to one wall for the August 9
+consumer: `W1` selection. Common normalization, support equality, content-only
+readout, and equal post-Record continuation are failed attacks on that wall,
+not independent walls.
+
+Other TOE interfaces remain independent of this no-go:
+
+| Pair | Closing first closes second? | Closing second closes first? | Independent? |
+|---|---:|---:|---:|
+| `W1` selection vs low-arity menu eligibility `W2` | no; equation (2) has the Block 32 finite menus only | no; Block 38 has full support and a context-skew kernel | yes |
+| `W1` selection vs preparation/effect calibration | no | no | yes |
+| `W1` selection vs autonomous formation history/rate | no | no; equation (10) permits common formation cadence with contextual grades | yes |
+| source no-go vs audit retention | no | no | yes |
+
+The headline does not inflate those independent open interfaces into reasons
+for `W1` failure.
+
+### N3 — Hidden-wall scan
+
+| Phrase or move | Classification |
+|---|---|
+| `registered` | means a displayed kernel output whose fixed codeword is recoverable from Record content; it does not import measurement theory |
+| `effect` and `preparation` | explicit Block 32 downstream decoder types, not Qubit-axiom primitives |
+| `physical eligibility` | used for Block 38's source-level support claim only; zero singleton probability is not called positive frequency |
+| `standard Gaussian` | equation (6) gives the density and normalization; the adjective is not load-bearing |
+| `by construction` | avoided as a substitute for the positivity, covariance, or Record arguments |
+| `framework provides` | not used for weights, currents, events, settings, histories, or calibration |
+| `canonical`, `natural`, `obvious`, `background`, `bridge context` | none supplies a missing physical identification |
+
+The model's exact Law content is deliberately supplied. That is not a hidden
+wall: a countermodel needs one admissible member of the allowed Law class, not
+a derivation selecting that member.
+
+### N4 — Residual matching
+
+| Source | Source residual | Use here | Match? |
+|---|---|---|---|
+| [Minimal Axioms](MINIMAL_AXIOMS_2026-06-29.md) | distribution form/values, context selection, formation site/rate, and dynamics remain downstream | defines the model class whose nonselection is tested | yes |
+| [Block 32 carrier](NN_RECORD_PROGRAM_PREPARATION_QUOTIENT_TRACE_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-22.md) | its displayed deletion arrays show normalization alone permits shared-effect skew, but are not one complete contextual rule | supplies exact radius-one decoder/fixtures; this note upgrades the deletion to one total covariant kernel | yes after the stated upgrade |
+| [Block 38 compiler](NN_RECORD_CONTINUUM_LOW_ARITY_MENU_COMPILER_BOUNDED_THEOREM_NOTE_2026-08-23.md) | source-level `W2` support plus paired context-skew Law; `W1` remains open | establishes that full menu eligibility does not by itself close `W1` | yes; not used to prove strict radius one |
+| [August 9 frame lift](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md) | trace form conditional on one cross-program effect grade and binary/ternary coverage | names the exact `W1` consumer | yes; source evidence only, audit pending |
+| [Cycle 20 operational quotient](work_history/repo/review_feedback/OPERATIONAL_QUOTIENT_BORN_AFFINITY_CYCLE20_NOTE_2026-07-14.md) | support-only operational structure permits paired grades; stronger process principles remain live | constrains the quotient attack, not the countermodel proof | yes |
+| [Cycle 9 common resource](work_history/repo/review_feedback/LOCAL_CONSERVATIVE_COMMIT_RESOURCE_GRAVITY_CYCLE9_NOTE_2026-07-14.md) | a common scheduler is explicitly supplied rather than derived | prevents treating repository scheduler syntax as `W1` authority | yes |
+
+No source's absence result is broadened beyond its residual. The load-bearing
+negative is equation (5), executed independently here.
+
+### N5 — Resolution audit
+
+The primary and independent caches must contain substantive resolution lines:
+
+```text
+per_element: the identical effect-label content and unequal grade are checked
+per_site: the total radius-one kernel and two complete conditions are checked
+per_mode: checked and not executed — no mode claim belongs to this countermodel
+per_block: menus, rotations, basis transports, and deletion controls are checked
+lattice_wide: checked and not executed — no autonomous global history is claimed
+```
+
+The no-go is per local Law domain. It is not silently promoted to a spectral,
+continuum-limit, typical-history, or lattice-wide dynamical statement.
+
+### N6 — Partial-closure and primitive-registry audit
+
+The machine premise registry and all three current primitive source notes were
+checked. The scale-reference primitive supplies units only. Kinetic isotropy
+supplies one graining ratio only. The realized-state primitive supplies a
+pointwise reference slot but explicitly no state, selector, measure,
+weighting, probability rule, or boundary. None selects between equations (1)
+and (2).
+
+Partial positive closures remain available:
+
+1. a selected exact Law can adopt the trace member without changing an axiom;
+2. an independently defined action event measure plus equation (11) derives
+   `W1` while allowing menu-dependent total rates;
+3. a full statistical process theorem can derive strong lumpability, provided
+   its equivalence is not defined using the target occurrence probabilities;
+4. a reachability theorem can exclude the contextual conditions for a
+   selected Law, though Block 38's current source makes that harder by
+   supporting the full low-arity menu family; and
+5. explicit owner governance can add the section-5 clause.
+
+Therefore the note does not say an additional axiom is logically necessary.
+It proves only that the current premise surface does not select `W1` on the
+displayed carrier.
+
+### N7 — Hostile steelman
+
+> This is not yet a countermodel to the four axioms. A name-only Gaussian tag
+> is not a probability measure; support of six isolated matrices is not one
+> translation-covariant Record-formation history; exact continuous shells
+> occur with probability zero; ordering outcomes by labels privileges one
+> possibility; and “one fixed rule” or content-only readout may already force
+> the same probability for one identical output content. At most the runner
+> displays two normalized tables on supplied shells.
+
+The objection is answered only at the note's declared local-law resolution:
+
+1. The runner implements equation (6) as an evaluable density, verifies its
+   eight-coordinate normalization, and evaluates strict positivity at every
+   carrier matrix. All 64 recorded/blank masks receive an executed branch.
+2. The six carrier sites are pairwise nonadjacent. They can take the same
+   full-support Gaussian branch before the fresh target forms, so the exact
+   six-tuple is in one finite same-law history's product support. The claim is
+   support-level, exactly matching the current Admissibility reading; it does
+   not claim positive exact-setting frequency or a lattice-wide scheduler.
+3. Equation (2) is symmetric in the complete baseline vector and associates
+   each transformed mass with its own effect. It reads no label value or
+   ordering. The `(2,10,3)` trap proves that the inherited host string order
+   does not affect the physical measure. All tested internal conjugations and
+   lattice rotations preserve the rule, and both contexts give the shared
+   outcome the same label as well as the same effect.
+4. “One fixed rule” is equation (2) applied at every site. Admissibility
+   expressly allows its distribution to vary with the full neighbour
+   condition. Record's content-only clause fixes readout after formation; it
+   does not identify formation probabilities across distinct conditions.
+
+A stronger reading demanding positive-mass repeatable exact settings, an
+autonomous lattice-wide formation process, or a label-erasing operational
+quotient would escape this countermodel. None is current premise content, and
+all are excluded from the headline scope. Separately, a complete action or
+process theorem could derive `W1`; that remains a positive route rather than a
+refutation of premise-surface nonselection.
+
+### N8 — Cross-cycle echo
+
+On 2026-08-23 the prescribed repository search was rerun for all four exact
+phrases
+
+```text
+structurally undecidable | no retained primitive | requires new axiom |
+cannot be derived from A_min
+```
+
+under `docs/` and the physics-loop corpus. Every one of the eighty
+`.claude/science/physics-loops/**/NO_GO_LEDGER.md` files was walked by filename
+before a relevant-content search.
+
+The closest echoes change the scope rather than overturn it:
+
+- [`toe-axiom-closure-20260809/NO_GO_LEDGER.md`](../.claude/science/physics-loops/toe-axiom-closure-20260809/NO_GO_LEDGER.md)
+  line 9 withdrew broad axiom necessity and named operational equivalence or a
+  recurrent physical compiler as live routes. Block 38 applies the compiler
+  route and closes `W2` at source level; equations (2)--(5) show why that does
+  not also close `W1`.
+- The same ledger's line 11 kept a derived menu kernel, event algebra,
+  barycenter/evaluation map, or operational quotient as reopen mechanisms.
+  Equation (11) preserves the event-algebra/current route; this note rejects
+  only inference from the current premises without it.
+- The staggered-kinetic ledger records the analogous, already accepted scope
+  pattern: an explicit covariant countermodel proves that the current minimal
+  surface does not select one kinetic law, while a later dynamics theorem can
+  still select it. The present rhetoric follows that model-class boundary.
+- The registrability history shows that some former walls were retired by
+  explicit owner axiom governance. That is a valid future mechanism here, not
+  current premise authority.
+
+**Gate disposition:** PASS for the exact no-go that the current four axioms
+plus the displayed radius-one carrier/readout typing do not select `W1`.
+FAIL / DO NOT SHIP for claims that no downstream dynamics can derive `W1`,
+that Born form is impossible, that a new axiom is necessary, that the proposed
+clause is merely clarification, or that this source changes TOE percentages.
+
+## Runner Contract
+
+```bash
+python3 scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py
+python3 scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py
+```
+
+Both runners use exact SymPy arithmetic. The independent runner imports only
+the antecedent Block 32 carrier/decoder and reconstructs equation (2) without
+importing the primary implementation.

--- a/logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.txt
+++ b/logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py
+runner_sha256: 2f712725e16bb7758fa4b96470f0e0403ffde6d760ff6d1cb764d426c15dd7ad
+input_fingerprint_sha256: b08539b5842dcc62cd8bf8df631377b36d7066fb9f8112e6647c2436aedd61ca
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 5.54
+status: ok
+----- stdout -----
+PASS strict-nearest-neighbor-domain: two contextual programs, a label-order trap, a binary control, and two endpoints occupy the six radius-one neighbours
+PASS exact-trace-baselines: the two legal programs share the exact effect baseline 3/10 and differ only in their complements
+PASS exact-contextual-map: p_j=b_j(1+b_j-sum_k b_k^2) produces two exact positive normalized ternary laws
+PASS shared-effect-w1-failure: one literal effect-label Record has masses 903/3125 and 579/2000, differing by -27/50000
+PASS universal-simplex-identity: factorization proves positivity, normalization, and support preservation; 1139 exact rational edge/interior points are also checked
+PASS paired-law-independence: the W1-satisfying and W1-violating kernels use identical neighbour programs, output contents, and supports
+PASS label-serialization-independence: labels (2,10,3) may be host-enumerated as (10,2,3), but the symmetric map assigns each effect its invariant mass
+PASS simplex-endpoint-support: the b=(1,0,0) and b=(0,0,1) boundaries remain normalized and preserve the trace support exactly
+PASS proper-cubic-covariance: all 24 proper cubic rotations preserve each decoded law on both contextual fixtures and the binary control
+PASS internal-basis-covariance: five exact unitary basis transports conjugate contents and leave all contextual grades invariant
+PASS total-kernel-fallback: all 64 occupancy masks and every rotated/basis-transported malformed shell receive the covariant total-kernel branch
+PASS support-level-shell-reachability: the executable Gaussian density is normalized and positive on every carrier matrix at six pairwise nonadjacent seed sites
+PASS binary-deletion-control: the contextual transfer is absent on binary programs and the selected trace law is recovered there
+PASS w1-restoration-control: deleting the context transfer restores equal 3/10 grades for the shared Record
+PASS record-lock-and-permanence: one selected admissible content locks once at the target and cannot be overwritten
+PASS common-scheduler-not-sufficient: equal unit total hazard and exact conservation coexist with unequal shared-branch current
+PASS source-contract: the source carries the narrow no-go scope, all N1-N8 gates, live escape, and score firewall
+per_element: identical shared effect-label content and its unequal exact 903/3125 versus 579/2000 grades are checked
+per_site: one total six-neighbour kernel, exact fallback, one-time locking, and the two target conditions are checked
+per_mode: checked and not executed — no spectral, momentum, transfer, or continuum-mode claim belongs to this local countermodel
+per_block: both complete ternary programs, a binary deletion control, 24 rotations, and five internal bases are checked
+lattice_wide: checked and not executed — the formula is translation-independent, but no autonomous global formation history is claimed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.txt
+++ b/logs/runner-cache/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py
+runner_sha256: b23a5de32c79801161b0a6c5712e1eff162d4a15737ce039e2ee28779f16545c
+input_fingerprint_sha256: b08539b5842dcc62cd8bf8df631377b36d7066fb9f8112e6647c2436aedd61ca
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 3.46
+status: ok
+----- stdout -----
+PASS reconstructed-carriers: both independently assembled radius-one shells decode the same preparation and valid menus
+PASS independent-exact-masses: the independently written symmetric simplex map reproduces both exact distributions
+PASS independent-w1-counterexample: identical registered content receives two positive grades separated by -27/50000
+PASS probability-and-support: both kernels are normalized and positive while their shared first output is literally identical
+PASS independent-simplex-boundary: an independently assembled b=(1,0,0) ternary endpoint remains normalized with exact zero support
+PASS independent-label-order-trap: the permutation-equivariant map is independent of the inherited string order on labels 2,10,3
+PASS independent-cubic-covariance: an independent 24-element cubic-group enumeration leaves both local laws unchanged
+PASS independent-basis-covariance: a nontrivial exact unitary transports outputs and preserves the reconstructed grades
+PASS independent-totality: all 64 masks are total and the independent normalized Gaussian density is positive on every carrier point
+PASS independent-scheduler-control: equal total opportunity rate does not equalize the shared branch current
+PASS independent-scope-contract: the note keeps the countermodel, live selected-Law escape, governance boundary, and score claim separate
+per_element: the common effect-label content and exact 903/3125 versus 579/2000 masses are independently checked
+per_site: two complete radius-one conditions and total invariant fallbacks are independently evaluated
+per_mode: checked and not executed — the claim has no mode-space or continuum-spectrum component
+per_block: two ternary blocks, all 24 rotations, and a nontrivial internal basis transport are checked
+lattice_wide: checked and not executed — translation covariance is syntactic; no global scheduler or history is asserted
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py
+++ b/scripts/nn_record_nearest_neighbor_effect_functionality_independence_2026_08_23.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Exact nearest-neighbor countermodel for Record effect functionality W1.
+
+The carrier and exact menu fixtures are reconstructed by the Block 32 source.
+This runner adds a second total, translation/proper-cubic-covariant local
+kernel.  It has the same registered contents and support as the trace kernel,
+but applies a permutation-equivariant nonlinear simplex map to every valid
+ternary program.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from sympy import I, Matrix, Rational as Q, exp, integrate, oo, pi, simplify, sqrt, symbols
+from sympy.matrices.matrixbase import MatrixBase
+
+from nn_record_program_preparation_quotient_trace_compiler_2026_08_22 import (
+    AXES,
+    DIRECTIONS,
+    I2,
+    SX,
+    SY,
+    ZERO2,
+    Item,
+    codeword,
+    conjugate_shell,
+    decode_program,
+    encode_shell,
+    is_density,
+    law_equal,
+    literal_projective_program,
+    matrix_equal,
+    p,
+    preparation_center,
+    proper_cubic_rotations,
+    rotate_shell,
+    valid_program,
+    weight,
+)
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_NEAREST_NEIGHBOR_EFFECT_FUNCTIONALITY_"
+    "INDEPENDENCE_NO_GO_NOTE_2026-08-23.md",
+    "scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_NEAREST_NEIGHBOR_EFFECT_FUNCTIONALITY_"
+    "INDEPENDENCE_NO_GO_NOTE_2026-08-23.md"
+)
+
+
+@dataclass(frozen=True)
+class GaussianLaw:
+    name: str = "unit-frobenius-gaussian"
+
+    @staticmethod
+    def density(value: Matrix):
+        norm_squared = simplify((value.conjugate().T * value).trace())
+        return simplify(exp(-norm_squared) / pi**4)
+
+    @staticmethod
+    def one_coordinate_mass():
+        coordinate = symbols("gaussian_coordinate", real=True)
+        return integrate(exp(-(coordinate**2)) / sqrt(pi), (coordinate, -oo, oo))
+
+    def normalized(self) -> bool:
+        return self.one_coordinate_mass() ** 8 == 1
+
+    def support_contains(self, value: Matrix) -> bool:
+        return bool(self.density(value).is_positive)
+
+
+def complete_shell(shell) -> bool:
+    return (
+        isinstance(shell, dict)
+        and set(shell) == set(DIRECTIONS)
+        and all(isinstance(shell[direction], MatrixBase) for direction in DIRECTIONS)
+    )
+
+
+def contextual_law(shell):
+    """One total radius-one kernel with a symmetric ternary context map."""
+    if not complete_shell(shell):
+        return GaussianLaw()
+    center = preparation_center(shell)
+    try:
+        items = decode_program(shell)
+    except (TypeError, ValueError):
+        return ((center, Q(1)),)
+    if not is_density(center) or not valid_program(items):
+        return ((center, Q(1)),)
+
+    baseline = tuple(weight(center, item.effect) for item in items)
+    probabilities = baseline
+    if len(items) == 3:
+        second_moment = simplify(sum(value**2 for value in baseline))
+        probabilities = tuple(
+            simplify(value * (1 + value - second_moment))
+            for value in baseline
+        )
+
+    literal = literal_projective_program(items)
+    return tuple(
+        (item.effect if literal else codeword(item), probability)
+        for item, probability in zip(items, probabilities, strict=True)
+    )
+
+
+def trace_comparator_law(shell):
+    """Total comparator with the same fallback and output typing."""
+    if not complete_shell(shell):
+        return GaussianLaw()
+    center = preparation_center(shell)
+    try:
+        items = decode_program(shell)
+    except (TypeError, ValueError):
+        return ((center, Q(1)),)
+    if not is_density(center) or not valid_program(items):
+        return ((center, Q(1)),)
+    literal = literal_projective_program(items)
+    return tuple(
+        (item.effect if literal else codeword(item), weight(center, item.effect))
+        for item in items
+    )
+
+
+def support_equal(left, right) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(
+        matrix_equal(left_code, right_code)
+        and (simplify(left_mass) == 0) == (simplify(right_mass) == 0)
+        for (left_code, left_mass), (right_code, right_mass) in zip(left, right, strict=True)
+    )
+
+
+def lock_once(records, site, content: Matrix) -> bool:
+    if site in records:
+        return False
+    records[site] = content
+    return True
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    root2 = sqrt(2)
+    center = Matrix([[Q(3, 5), 0], [0, Q(2, 5)]])
+    shared = Q(1, 2) * p(0, 1)
+    menu_a = (
+        Item(shared, Q(1)),
+        Item(Q(9, 10) * p(4 * root2 / 9, Q(-7, 9)), Q(2)),
+        Item(Q(3, 5) * p(-2 * root2 / 3, Q(1, 3)), Q(3)),
+    )
+    menu_b = (
+        Item(shared, Q(1)),
+        Item(Q(3, 4) * p(2 * root2 / 3, Q(-1, 3)), Q(2)),
+        Item(Q(3, 4) * p(-2 * root2 / 3, Q(-1, 3)), Q(3)),
+    )
+    binary = (
+        Item(p(0, 1), Q(1)),
+        Item(p(0, -1), Q(2)),
+    )
+    endpoint_first = (
+        Item(p(0, 1), Q(1)),
+        Item(Q(1, 2) * p(0, -1), Q(2)),
+        Item(Q(1, 2) * p(0, -1), Q(3)),
+    )
+    endpoint_last = (
+        Item(Q(1, 2) * p(0, -1), Q(1)),
+        Item(Q(1, 2) * p(0, -1), Q(2)),
+        Item(p(0, 1), Q(3)),
+    )
+    shell_a = encode_shell(center, menu_a)
+    shell_b = encode_shell(center, menu_b)
+    shell_binary = encode_shell(center, binary)
+    serialization_trap_menu = (
+        Item(menu_a[0].effect, Q(2)),
+        Item(menu_a[1].effect, Q(10)),
+        Item(menu_a[2].effect, Q(3)),
+    )
+    serialization_trap_shell = encode_shell(center, serialization_trap_menu)
+    pure_center = p(0, 1)
+    shell_endpoint_first = encode_shell(pure_center, endpoint_first)
+    shell_endpoint_last = encode_shell(pure_center, endpoint_last)
+
+    check(
+        "strict-nearest-neighbor-domain",
+        all(
+            complete_shell(shell)
+            for shell in (
+                shell_a,
+                shell_b,
+                shell_binary,
+                serialization_trap_shell,
+                shell_endpoint_first,
+                shell_endpoint_last,
+            )
+        )
+        and all(
+            valid_program(menu)
+            for menu in (menu_a, menu_b, binary, serialization_trap_menu, endpoint_first, endpoint_last)
+        ),
+        "two contextual programs, a label-order trap, a binary control, and two endpoints occupy the six radius-one neighbours",
+    )
+
+    baseline_a = tuple(weight(center, item.effect) for item in menu_a)
+    baseline_b = tuple(weight(center, item.effect) for item in menu_b)
+    check(
+        "exact-trace-baselines",
+        baseline_a == (Q(3, 10), Q(19, 50), Q(8, 25))
+        and baseline_b == (Q(3, 10), Q(7, 20), Q(7, 20)),
+        "the two legal programs share the exact effect baseline 3/10 and differ only in their complements",
+    )
+
+    skew_a = contextual_law(shell_a)
+    skew_b = contextual_law(shell_b)
+    probabilities_a = tuple(mass for _, mass in skew_a)
+    probabilities_b = tuple(mass for _, mass in skew_b)
+    check(
+        "exact-contextual-map",
+        probabilities_a == (Q(903, 3125), Q(6194, 15625), Q(4916, 15625))
+        and probabilities_b == (Q(579, 2000), Q(1421, 4000), Q(1421, 4000)),
+        "p_j=b_j(1+b_j-sum_k b_k^2) produces two exact positive normalized ternary laws",
+    )
+    check(
+        "shared-effect-w1-failure",
+        matrix_equal(skew_a[0][0], skew_b[0][0])
+        and matrix_equal(skew_a[0][0], codeword(menu_a[0]))
+        and simplify(skew_a[0][1] - skew_b[0][1]) == -Q(27, 50000),
+        "one literal effect-label Record has masses 903/3125 and 579/2000, differing by -27/50000",
+    )
+
+    # Universal algebra: p_j=b_j(1+b_j-S2), S2=sum b_k^2.  On the
+    # probability simplex S2<=1, every factor is nonnegative, and support is
+    # unchanged.
+    simplex_ok = True
+    simplex_count = 0
+    for denominator in range(1, 18):
+        for i0 in range(denominator + 1):
+            for i1 in range(denominator - i0 + 1):
+                simplex_count += 1
+                b0 = Q(i0, denominator)
+                b1 = Q(i1, denominator)
+                b2 = 1 - b0 - b1
+                baseline = (b0, b1, b2)
+                second_moment = sum(value**2 for value in baseline)
+                transformed = tuple(
+                    value * (1 + value - second_moment)
+                    for value in baseline
+                )
+                simplex_ok = simplex_ok and sum(transformed) == 1
+                simplex_ok = simplex_ok and all(bool(value.is_nonnegative) for value in transformed)
+                simplex_ok = simplex_ok and tuple(value == 0 for value in transformed) == (
+                    b0 == 0,
+                    b1 == 0,
+                    b2 == 0,
+                )
+    check(
+        "universal-simplex-identity",
+        simplex_ok,
+        f"factorization proves positivity, normalization, and support preservation; {simplex_count} exact rational edge/interior points are also checked",
+    )
+
+    trace_a = trace_comparator_law(shell_a)
+    trace_b = trace_comparator_law(shell_b)
+    check(
+        "paired-law-independence",
+        trace_a[0][1] == trace_b[0][1] == Q(3, 10)
+        and support_equal(trace_a, skew_a)
+        and support_equal(trace_b, skew_b),
+        "the W1-satisfying and W1-violating kernels use identical neighbour programs, output contents, and supports",
+    )
+
+    serialization_law = contextual_law(serialization_trap_shell)
+    serialization_expected = (
+        Q(903, 3125),
+        Q(6194, 15625),
+        Q(4916, 15625),
+    )
+    serialization_ok = all(
+        any(
+            matrix_equal(content, codeword(item)) and mass == expected_mass
+            for content, mass in serialization_law
+        )
+        for item, expected_mass in zip(serialization_trap_menu, serialization_expected, strict=True)
+    )
+    check(
+        "label-serialization-independence",
+        serialization_ok,
+        "labels (2,10,3) may be host-enumerated as (10,2,3), but the symmetric map assigns each effect its invariant mass",
+    )
+
+    endpoint_law_first = contextual_law(shell_endpoint_first)
+    endpoint_law_last = contextual_law(shell_endpoint_last)
+    check(
+        "simplex-endpoint-support",
+        tuple(mass for _, mass in endpoint_law_first) == (1, 0, 0)
+        and tuple(mass for _, mass in endpoint_law_last) == (0, 0, 1)
+        and support_equal(endpoint_law_first, trace_comparator_law(shell_endpoint_first))
+        and support_equal(endpoint_law_last, trace_comparator_law(shell_endpoint_last)),
+        "the b=(1,0,0) and b=(0,0,1) boundaries remain normalized and preserve the trace support exactly",
+    )
+
+    rotations = proper_cubic_rotations()
+    rotation_ok = len(rotations) == 24 and all(
+        law_equal(contextual_law(rotate_shell(shell, rotation)), contextual_law(shell))
+        for rotation in rotations
+        for shell in (
+            shell_a,
+            shell_b,
+            shell_binary,
+            serialization_trap_shell,
+            shell_endpoint_first,
+            shell_endpoint_last,
+        )
+    )
+    check(
+        "proper-cubic-covariance",
+        rotation_ok,
+        "all 24 proper cubic rotations preserve each decoded law on both contextual fixtures and the binary control",
+    )
+
+    unitaries = (
+        I2,
+        SX,
+        (SX + Matrix([[1, 0], [0, -1]])) / root2,
+        Matrix([[1, 0], [0, I]]),
+        (I2 + I * SY) / root2,
+    )
+    basis_ok = True
+    for unitary in unitaries:
+        basis_ok = basis_ok and matrix_equal(simplify(unitary * unitary.conjugate().T), I2)
+        for shell in (
+            shell_a,
+            shell_b,
+            shell_binary,
+            serialization_trap_shell,
+            shell_endpoint_first,
+            shell_endpoint_last,
+        ):
+            original = contextual_law(shell)
+            expected = tuple(
+                (simplify(unitary * content * unitary.conjugate().T), mass)
+                for content, mass in original
+            )
+            basis_ok = basis_ok and law_equal(contextual_law(conjugate_shell(shell, unitary)), expected)
+    check(
+        "internal-basis-covariance",
+        basis_ok,
+        "five exact unitary basis transports conjugate contents and leave all contextual grades invariant",
+    )
+
+    incomplete = {AXES[0]: center}
+    malformed = {direction: center for direction in DIRECTIONS}
+    malformed[AXES[0]] = center + I * SX
+    masks_ok = True
+    for mask in range(1 << len(DIRECTIONS)):
+        partial = {
+            direction: shell_a[direction]
+            for index, direction in enumerate(DIRECTIONS)
+            if mask & (1 << index)
+        }
+        if mask == (1 << len(DIRECTIONS)) - 1:
+            masks_ok = masks_ok and not isinstance(contextual_law(partial), GaussianLaw)
+        else:
+            masks_ok = masks_ok and isinstance(contextual_law(partial), GaussianLaw)
+            masks_ok = masks_ok and isinstance(trace_comparator_law(partial), GaussianLaw)
+            masks_ok = masks_ok and all(
+                isinstance(contextual_law(rotate_shell(partial, rotation)), GaussianLaw)
+                for rotation in rotations
+            )
+    malformed_covariant = all(
+        law_equal(contextual_law(rotate_shell(malformed, rotation)), contextual_law(malformed))
+        for rotation in rotations
+    )
+    malformed_original = contextual_law(malformed)
+    malformed_basis_covariant = all(
+        law_equal(
+            contextual_law(conjugate_shell(malformed, unitary)),
+            tuple(
+                (simplify(unitary * content * unitary.conjugate().T), mass)
+                for content, mass in malformed_original
+            ),
+        )
+        for unitary in unitaries
+    )
+    check(
+        "total-kernel-fallback",
+        isinstance(contextual_law({}), GaussianLaw)
+        and isinstance(contextual_law(incomplete), GaussianLaw)
+        and isinstance(trace_comparator_law({}), GaussianLaw)
+        and isinstance(trace_comparator_law(incomplete), GaussianLaw)
+        and len(contextual_law(malformed)) == 1
+        and contextual_law(malformed)[0][1] == 1
+        and masks_ok
+        and malformed_covariant
+        and malformed_basis_covariant,
+        "all 64 occupancy masks and every rotated/basis-transported malformed shell receive the covariant total-kernel branch",
+    )
+
+    gaussian = GaussianLaw()
+    carrier_sites_are_independent = all(
+        sum(abs(left[index] - right[index]) for index in range(3)) != 1
+        for left_index, left in enumerate(DIRECTIONS)
+        for right in DIRECTIONS[left_index + 1 :]
+    )
+    check(
+        "support-level-shell-reachability",
+        gaussian.normalized()
+        and carrier_sites_are_independent
+        and all(
+            gaussian.support_contains(value)
+            for shell in (shell_a, shell_b, shell_endpoint_first, shell_endpoint_last)
+            for value in shell.values()
+        ),
+        "the executable Gaussian density is normalized and positive on every carrier matrix at six pairwise nonadjacent seed sites",
+    )
+
+    binary_skew = contextual_law(shell_binary)
+    check(
+        "binary-deletion-control",
+        law_equal(binary_skew, trace_comparator_law(shell_binary))
+        and tuple(mass for _, mass in binary_skew) == (Q(3, 5), Q(2, 5)),
+        "the contextual transfer is absent on binary programs and the selected trace law is recovered there",
+    )
+    zero_transfer_a = tuple((code, mass) for code, mass in trace_a)
+    zero_transfer_b = tuple((code, mass) for code, mass in trace_b)
+    check(
+        "w1-restoration-control",
+        law_equal(zero_transfer_a, trace_a)
+        and law_equal(zero_transfer_b, trace_b)
+        and zero_transfer_a[0][1] == zero_transfer_b[0][1],
+        "deleting the context transfer restores equal 3/10 grades for the shared Record",
+    )
+
+    records = {direction: shell_a[direction] for direction in DIRECTIONS}
+    target = (0, 0, 0)
+    first_lock = lock_once(records, target, skew_a[0][0])
+    second_lock = lock_once(records, target, skew_a[1][0])
+    check(
+        "record-lock-and-permanence",
+        first_lock and not second_lock and matrix_equal(records[target], skew_a[0][0]),
+        "one selected admissible content locks once at the target and cannot be overwritten",
+    )
+
+    common_total_a = simplify(sum(mass for _, mass in skew_a))
+    common_total_b = simplify(sum(mass for _, mass in skew_b))
+    check(
+        "common-scheduler-not-sufficient",
+        common_total_a == common_total_b == 1 and skew_a[0][1] != skew_b[0][1],
+        "equal unit total hazard and exact conservation coexist with unequal shared-branch current",
+    )
+
+    note_text = NOTE.read_text(encoding="utf-8") if NOTE.exists() else ""
+    check(
+        "source-contract",
+        all(
+            token in note_text
+            for token in (
+                "Claim type:** no_go",
+                "N1 — Alternative route enumeration",
+                "N2 — Wall-independence audit",
+                "N3 — Hidden-wall scan",
+                "N4 — Residual matching",
+                "N5 — Resolution audit",
+                "N6 — Partial-closure and primitive-registry audit",
+                "N7 — Hostile steelman",
+                "N8 — Cross-cycle echo",
+                "no TOE-percentage movement",
+                "does not prove that no downstream Law can derive `W1`",
+            )
+        ),
+        "the source carries the narrow no-go scope, all N1-N8 gates, live escape, and score firewall",
+    )
+
+    print(
+        "per_element: identical shared effect-label content and its unequal exact 903/3125 versus 579/2000 grades are checked"
+    )
+    print(
+        "per_site: one total six-neighbour kernel, exact fallback, one-time locking, and the two target conditions are checked"
+    )
+    print(
+        "per_mode: checked and not executed — no spectral, momentum, transfer, or continuum-mode claim belongs to this local countermodel"
+    )
+    print(
+        "per_block: both complete ternary programs, a binary deletion control, 24 rotations, and five internal bases are checked"
+    )
+    print(
+        "lattice_wide: checked and not executed — the formula is translation-independent, but no autonomous global formation history is claimed"
+    )
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py
+++ b/scripts/nn_record_nearest_neighbor_effect_functionality_independence_independent_check_2026_08_23.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Independent reconstruction of the nearest-neighbor W1 countermodel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from sympy import I, Matrix, Rational as Q, exp, integrate, oo, pi, simplify, sqrt, symbols
+
+from nn_record_program_preparation_quotient_trace_compiler_2026_08_22 import (
+    DIRECTIONS,
+    I2,
+    SX,
+    ZERO2,
+    Item,
+    codeword,
+    conjugate_shell,
+    decode_program,
+    encode_shell,
+    is_density,
+    law_equal,
+    literal_projective_program,
+    matrix_equal,
+    p,
+    preparation_center,
+    proper_cubic_rotations,
+    rotate_shell,
+    valid_program,
+)
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/NN_RECORD_NEAREST_NEIGHBOR_EFFECT_FUNCTIONALITY_"
+    "INDEPENDENCE_NO_GO_NOTE_2026-08-23.md",
+    "scripts/nn_record_program_preparation_quotient_trace_compiler_2026_08_22.py",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "NN_RECORD_NEAREST_NEIGHBOR_EFFECT_FUNCTIONALITY_"
+    "INDEPENDENCE_NO_GO_NOTE_2026-08-23.md"
+)
+
+
+@dataclass(frozen=True)
+class FullSupportLaw:
+    name: str = "independently-reconstructed-gaussian"
+
+    @staticmethod
+    def density(value: Matrix):
+        return simplify(exp(-((value.conjugate().T * value).trace())) / pi**4)
+
+    def normalized(self) -> bool:
+        coordinate = symbols("independent_coordinate", real=True)
+        one_mass = integrate(exp(-(coordinate**2)) / sqrt(pi), (coordinate, -oo, oo))
+        return one_mass**8 == 1
+
+    def support_contains(self, value: Matrix) -> bool:
+        return bool(self.density(value).is_positive)
+
+
+def tr_weight(center: Matrix, effect: Matrix):
+    return simplify((center * effect).trace())
+
+
+def reconstructed_kernel(shell):
+    if not isinstance(shell, dict) or set(shell) != set(DIRECTIONS):
+        return FullSupportLaw()
+    center = preparation_center(shell)
+    try:
+        items = decode_program(shell)
+    except (TypeError, ValueError):
+        return ((center, Q(1)),)
+    if not is_density(center) or not valid_program(items):
+        return ((center, Q(1)),)
+    baseline = tuple(tr_weight(center, item.effect) for item in items)
+    if len(items) == 3:
+        second_moment = simplify(sum(value**2 for value in baseline))
+        probabilities = tuple(
+            simplify(value * (1 + value - second_moment))
+            for value in baseline
+        )
+    else:
+        probabilities = baseline
+    literal = literal_projective_program(items)
+    return tuple(
+        (item.effect if literal else codeword(item), mass)
+        for item, mass in zip(items, probabilities, strict=True)
+    )
+
+
+def fixtures():
+    root2 = sqrt(2)
+    center = Matrix([[Q(3, 5), 0], [0, Q(2, 5)]])
+    shared = Q(1, 2) * p(0, 1)
+    menu_a = (
+        Item(shared, Q(1)),
+        Item(Q(9, 10) * p(4 * root2 / 9, Q(-7, 9)), Q(2)),
+        Item(Q(3, 5) * p(-2 * root2 / 3, Q(1, 3)), Q(3)),
+    )
+    menu_b = (
+        Item(shared, Q(1)),
+        Item(Q(3, 4) * p(2 * root2 / 3, Q(-1, 3)), Q(2)),
+        Item(Q(3, 4) * p(-2 * root2 / 3, Q(-1, 3)), Q(3)),
+    )
+    endpoint = (
+        Item(p(0, 1), Q(1)),
+        Item(Q(1, 2) * p(0, -1), Q(2)),
+        Item(Q(1, 2) * p(0, -1), Q(3)),
+    )
+    serialization_trap = (
+        Item(menu_a[0].effect, Q(2)),
+        Item(menu_a[1].effect, Q(10)),
+        Item(menu_a[2].effect, Q(3)),
+    )
+    return (
+        center,
+        menu_a,
+        menu_b,
+        encode_shell(center, menu_a),
+        encode_shell(center, menu_b),
+        encode_shell(p(0, 1), endpoint),
+        serialization_trap,
+        encode_shell(center, serialization_trap),
+    )
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    (
+        center,
+        menu_a,
+        menu_b,
+        shell_a,
+        shell_b,
+        endpoint_shell,
+        serialization_trap,
+        serialization_trap_shell,
+    ) = fixtures()
+    check(
+        "reconstructed-carriers",
+        valid_program(menu_a)
+        and valid_program(menu_b)
+        and all(matrix_equal(preparation_center(shell), center) for shell in (shell_a, shell_b)),
+        "both independently assembled radius-one shells decode the same preparation and valid menus",
+    )
+
+    law_a = reconstructed_kernel(shell_a)
+    law_b = reconstructed_kernel(shell_b)
+    masses_a = tuple(mass for _, mass in law_a)
+    masses_b = tuple(mass for _, mass in law_b)
+    check(
+        "independent-exact-masses",
+        masses_a == (Q(903, 3125), Q(6194, 15625), Q(4916, 15625))
+        and masses_b == (Q(579, 2000), Q(1421, 4000), Q(1421, 4000)),
+        "the independently written symmetric simplex map reproduces both exact distributions",
+    )
+    check(
+        "independent-w1-counterexample",
+        matrix_equal(law_a[0][0], law_b[0][0])
+        and simplify(law_a[0][1] - law_b[0][1]) == -Q(27, 50000),
+        "identical registered content receives two positive grades separated by -27/50000",
+    )
+    check(
+        "probability-and-support",
+        all(sum(masses) == 1 for masses in (masses_a, masses_b))
+        and all(mass > 0 for mass in masses_a + masses_b)
+        and matrix_equal(law_a[0][0], law_b[0][0]),
+        "both kernels are normalized and positive while their shared first output is literally identical",
+    )
+
+    endpoint_law = reconstructed_kernel(endpoint_shell)
+    check(
+        "independent-simplex-boundary",
+        tuple(mass for _, mass in endpoint_law) == (1, 0, 0),
+        "an independently assembled b=(1,0,0) ternary endpoint remains normalized with exact zero support",
+    )
+
+    trap_law = reconstructed_kernel(serialization_trap_shell)
+    trap_expected = (Q(903, 3125), Q(6194, 15625), Q(4916, 15625))
+    check(
+        "independent-label-order-trap",
+        all(
+            any(
+                matrix_equal(content, codeword(item)) and mass == expected
+                for content, mass in trap_law
+            )
+            for item, expected in zip(serialization_trap, trap_expected, strict=True)
+        ),
+        "the permutation-equivariant map is independent of the inherited string order on labels 2,10,3",
+    )
+
+    rotations = proper_cubic_rotations()
+    check(
+        "independent-cubic-covariance",
+        len(rotations) == 24
+        and all(
+            law_equal(reconstructed_kernel(rotate_shell(shell, rotation)), reconstructed_kernel(shell))
+            for shell in (shell_a, shell_b, endpoint_shell, serialization_trap_shell)
+            for rotation in rotations
+        ),
+        "an independent 24-element cubic-group enumeration leaves both local laws unchanged",
+    )
+
+    unitary = (I2 + I * SX) / sqrt(2)
+    basis_ok = matrix_equal(simplify(unitary * unitary.conjugate().T), I2)
+    for shell in (shell_a, shell_b, endpoint_shell, serialization_trap_shell):
+        expected = tuple(
+            (simplify(unitary * content * unitary.conjugate().T), mass)
+            for content, mass in reconstructed_kernel(shell)
+        )
+        basis_ok = basis_ok and law_equal(reconstructed_kernel(conjugate_shell(shell, unitary)), expected)
+    check(
+        "independent-basis-covariance",
+        basis_ok,
+        "a nontrivial exact unitary transports outputs and preserves the reconstructed grades",
+    )
+
+    masks_ok = True
+    for mask in range(1 << len(DIRECTIONS)):
+        partial = {
+            direction: shell_a[direction]
+            for index, direction in enumerate(DIRECTIONS)
+            if mask & (1 << index)
+        }
+        if mask == (1 << len(DIRECTIONS)) - 1:
+            masks_ok = masks_ok and not isinstance(reconstructed_kernel(partial), FullSupportLaw)
+        else:
+            masks_ok = masks_ok and isinstance(reconstructed_kernel(partial), FullSupportLaw)
+            masks_ok = masks_ok and all(
+                isinstance(reconstructed_kernel(rotate_shell(partial, rotation)), FullSupportLaw)
+                for rotation in rotations
+            )
+
+    gaussian = FullSupportLaw()
+    check(
+        "independent-totality",
+        isinstance(reconstructed_kernel({}), FullSupportLaw)
+        and reconstructed_kernel({direction: center for direction in DIRECTIONS})[0][1] == 1
+        and masks_ok
+        and gaussian.normalized()
+        and all(
+            gaussian.support_contains(value)
+            for shell in (shell_a, shell_b, endpoint_shell, serialization_trap_shell)
+            for value in shell.values()
+        ),
+        "all 64 masks are total and the independent normalized Gaussian density is positive on every carrier point",
+    )
+
+    common_totals = (sum(masses_a), sum(masses_b))
+    check(
+        "independent-scheduler-control",
+        common_totals == (1, 1) and masses_a[0] != masses_b[0],
+        "equal total opportunity rate does not equalize the shared branch current",
+    )
+
+    note_text = NOTE.read_text(encoding="utf-8") if NOTE.exists() else ""
+    check(
+        "independent-scope-contract",
+        all(
+            phrase in note_text
+            for phrase in (
+                "strict nearest-neighbor",
+                "selected exact Law",
+                "owner-approved",
+                "N8 — Cross-cycle echo",
+                "no TOE-percentage movement",
+            )
+        ),
+        "the note keeps the countermodel, live selected-Law escape, governance boundary, and score claim separate",
+    )
+
+    print(
+        "per_element: the common effect-label content and exact 903/3125 versus 579/2000 masses are independently checked"
+    )
+    print(
+        "per_site: two complete radius-one conditions and total invariant fallbacks are independently evaluated"
+    )
+    print(
+        "per_mode: checked and not executed — the claim has no mode-space or continuum-spectrum component"
+    )
+    print(
+        "per_block: two ternary blocks, all 24 rotations, and a nontrivial internal basis transport are checked"
+    )
+    print(
+        "lattice_wide: checked and not executed — translation covariance is syntactic; no global scheduler or history is asserted"
+    )
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

Constructs a strict nearest-neighbor, total, covariant Admissibility countermodel showing that the current four axioms plus the explicit Block 32 carrier/readout typing do not select cross-program effect functionality W1.

The trace comparator and the permutation-equivariant contextual law use identical conditions, output contents, and support. For the two exact shared-effect fixtures, the contextual map

    p_j = b_j (1 + b_j - sum_k b_k^2)

assigns the identical effect-label Record masses 903/3125 and 579/2000, an exact residual of -27/50000. Equal total rate therefore does not force equal shared-branch current.

Scope is deliberately local/support-level: this is W1 nonselection, not W1 impossibility, axiom necessity, Born closure, retention, or TOE-score movement. A selected action/current/joint theorem remains live. The note includes the complete N1-N8 no-go packet and an explicit owner-governance boundary.

## Verification

- primary exact runner: 17/17
- independent reconstruction: 11/11
- executable normalized full-support Gaussian fallback
- all 64 occupancy masks
- simplex vertices and universal exact positivity/support proof
- all 24 proper cubic rotations
- five internal basis transports
- labels (2,10,3) host-order trap
- cache identity/freshness, py_compile, controlled vocabulary, claim typing, evidence, repository invariants, links, and citation graph clean
- two adversarial science cold checks: PASS

Stacked on #7324.