### PR TITLE
physics: derive pincer marginal from Schur response

### DIFF
--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-08-23.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-08-23.md
@@ -1,0 +1,630 @@
+---
+claim_id: admissibility_dirac_kahler_schur_record_response_bridge_bounded_theorem_note_2026-08-23
+claim_type: bounded_theorem
+claim_scope: "On the Block 175 12x4 antiperiodic Dirac--Kahler fixture and its Block 174 declared action-dial surface, let q be the exact invertible complex action and S=Herm(q). At every one of the fourteen declared nonzero-mass dial entries and all four free time levels, the exact positive kernel W=Herm(q^-1)=q^-1 S q^-dagger has precision K_W=q^dagger S^-1 q. Integrating the exterior modes by a Schur complement gives K_eff=(W_RR)^-1 proportional to C_R^-1, where C_R=W_RR/Tr(W_RR). An additive local Gaussian source therefore gives the exact trace grade Tr(C_R E), reproducing the parent pincer W9 marginal; all 56 tested local blocks are positive, S-DIAG, and Schur exact. This action-derived inverse precision is a positive bridge for the marginal, not a selection of the physical Record law. The same q also has the distinct positive completion K_mod=q^dagger q whose partition weights are proportional to |det q|^-2 and reproduce the parent formation-law readout shape. The K_W partition instead carries det(S)/|det q|^2; the two local covariances and four-pin laws differ exactly. Averaging the four pinned W9 densities with the determinant formation law does not reconstruct the unpinned marginal. On this fixture the only nonnegative affine reconstruction of the unpinned density is the delta weight at the default unrecorded value sigma=3/5, because the current field builder fixes that background rather than summing over Record alternatives. Thus the existing action supplies the inverse-precision marginal route and sharply localizes the remaining task to a selected joint alternative ensemble plus its Record-event realization. It does not prove a universal no-go, select between all possible joint completions, derive a strict-nearest-neighbor global history, earn audit retention, retire an obligation, amend an axiom, or move a TOE percentage."
+depends_on:
+  - minimal_axioms
+  - admissibility_dirac_kahler_site_conditional_law_family_bounded_theorem_note_2026-08-22
+  - admissibility_dirac_kahler_pincer_identity_cross_lane_bounded_theorem_note_2026-08-22
+runner: scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py
+independent_runner: scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py
+runner_cache: logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.txt
+independent_runner_cache: logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Action-Derived Schur Precision And The Remaining Record-Joint Gap
+
+**Date:** 2026-08-23
+
+**Claim type:** bounded_theorem
+
+**Role:** positive cross-lane derivation of the pincer marginal from an exact
+positive precision, followed by an exact separation from the hard-pin
+formation law
+
+**Authority boundary:** the current
+[`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md) remain the only effective
+axiom premise. The
+[`site-conditional family`](ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_BOUNDED_THEOREM_NOTE_2026-08-22.md)
+and
+[`pincer identity`](ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_BOUNDED_THEOREM_NOTE_2026-08-22.md)
+supply an explicitly committed but unaudited action fixture. This note derives
+new exact consequences on that fixture. It does not promote either parent,
+edit an axiom or registry, or author an audit verdict.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py`](../scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py)
+
+**Independent reconstruction:**
+[`scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py`](../scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py)
+
+**Cached receipts:**
+[`primary`](../logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.txt),
+[`independent`](../logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.txt)
+
+## Result Up Front
+
+Block 175 put two exact probability objects side by side on one action
+fixture:
+
+1. a W9 marginal that equals a trace grade;
+2. a distinct formation conditional proportional to `|det q_a|^-2` over four
+   hard-pinned alternatives.
+
+It left the highest-value question: can the action itself produce the inverse
+precision needed for the trace grade, and can the two probability objects be
+related by one joint law?
+
+The first answer is **yes**, at a substantially wider exact scope than the
+single Block 175 read slice. For every tested nonzero-mass action, put
+
+```text
+S = Herm(q) = (q+q^dagger)/2,
+W = Herm(q^-1).
+```
+
+Then
+
+```text
+W = q^-1 S q^-dagger > 0,
+K_W = W^-1 = q^dagger S^-1 q > 0.                 (1)
+```
+
+For a four-coordinate free Record slice `R`, integrate the other twenty modes.
+The exact Schur complement is
+
+```text
+K_eff = (K_W)_RR
+        -(K_W)_RbarR (K_W)_barRbarR^-1 (K_W)_barRR
+      = W_RR^-1.                                   (2)
+```
+
+Normalize the local covariance,
+
+```text
+C_R = W_RR / Tr(W_RR).                             (3)
+```
+
+Equations (2)--(3) give
+
+```text
+K_eff = Tr(W_RR)^-1 C_R^-1.                        (4)
+```
+
+Thus inverse precision is not guessed on this action surface. It descends from
+the global action by positive completion and exact exterior-mode integration.
+An additive Gaussian source in a local effect direction `E` gives
+
+```text
+mu_R(E) = Tr(K_eff^-1 E) / Tr(K_eff^-1)
+        = Tr(C_R E).                                (5)
+```
+
+For the four coordinate projectors, equation (5) reproduces the parent W9
+marginal entry for entry. The runner proves this at every one of the four free
+levels and all fourteen declared nonzero-mass entries of the Block 174 action
+dial: **56 exact local blocks**, all positive, S-DIAG, and Schur exact. The four
+baseline free-level profiles remain pairwise distinct, so the earlier
+level-indexing result is preserved rather than averaged away.
+
+The second answer is **not yet**. The same complex `q` supplies two different
+positive completions:
+
+```text
+K_mod = q^dagger q,            K_mod^-1 = q^-1 q^-dagger,
+K_W   = q^dagger S^-1 q,       K_W^-1   = W.             (6)
+```
+
+Their positive Gaussian partition weights are proportional to
+
+```text
+Z_mod(q)  proportional to 1/|det q|^2,
+Z_W(q)    proportional to det(S)/|det q|^2.              (7)
+```
+
+The first is exactly the squared-amplitude formation-law shape used by the
+parent. The second is the Gaussian partition of the W9 precision.
+The four-pin laws and their local covariance profiles differ exactly.
+
+The direct law-of-total-probability probe also fails on the current objects:
+
+```text
+C_unpinned != sum_a p_det(a) C_a,                  (8)
+```
+
+with exact diagonal residual signs `(+,-,-,+)`. This is not mysterious. The
+current field builder evaluates an unrecorded cell at the fixed default
+`sigma=3/5`; it does not sum or integrate over the four possible future Record
+values. Indeed `q_unpinned=q_(a=3/5)` exactly. The affine reconstruction
+equations have a one-parameter real solution family, but positivity forces the
+single probability vector `(0,0,0,1)`, not the strictly positive determinant
+formation law.
+
+So the campaign has closed a real part of the action-selection problem: the
+existing pincer action generates the inverse local precision and trace marginal
+without postulating `C -> C^-1`. The remaining physics is now more precise: a
+joint alternative ensemble must be constructed and physically identified with
+Record formation. The present fixed-background object is not that ensemble.
+
+This is significant source-level progress. The result has **zero TOE-percentage movement**.
+Neither parent is retained, and no formal obligation is retired.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The positive-completion identity, Schur inverse, 56 exact local response blocks, two-completion determinant split, four-pin mixture residual, and unique nonnegative default reconstruction are exact consequences of displayed finite matrices on the committed action fixture. Physical selection of a joint alternative ensemble and Record-event process remains open."
+trace_class: direct_blocker_closure
+target_claim_id: pincer_action_schur_record_response_bridge
+target_blocker_text: "derive or sharply separate the pincer marginal and formation conditional from one action-native probability construction"
+source_of_blocker_text: admissibility_dirac_kahler_pincer_identity_cross_lane_bounded_theorem_note_2026-08-22
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "construct a true sum-or-integral over the four Record alternatives using one positive completion, derive its conditional and marginal from the same partition object, and test which completion survives the action, locality, refinement, and Record-write requirements"
+conditional_surface_status: "the inverse-precision W9 marginal is action-derived on 56 exact local blocks; the current hard-pin determinant law and fixed-background marginal are not one total-probability pair"
+hypothetical_axiom_status: "no axiom edit; a joint-ensemble/Record-event clause remains a candidate downstream Law, not an approved premise"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target Contract
+
+| Field | Contract |
+|---|---|
+| target statement | determine whether the committed pincer action derives the inverse local precision and whether its existing marginal and hard-pin conditional are one joint probability law |
+| quantifiers/domain | the 12x4 committed action fixture; all four free levels; all fourteen declared nonzero-mass dial entries; the four-value hard-pin menu at `(2,0)` |
+| allowed premises | exact parent action builder and conventions; finite-dimensional positive Gaussian and Schur-complement mathematics; the current axioms only as the semantic boundary |
+| forbidden weakenings | declaring `C` to be a covariance without deriving it from `q`; treating `q_unpinned` as a hidden alternative sum; calling a normalized susceptibility a Record event; or identifying the two positive completions |
+| boundary cases | `m=0`; scalar precision gauge; full-rank versus pure preparation; level indexing; hard pin versus fixed background |
+| completion witness | exact equation (1), exact equation (2), equation (5) equal to the W9 profile, and one joint partition whose marginal and conditional obey total probability |
+| outcomes not counted as closure | a selected new ensemble, a projective uniqueness lemma alone, a fixed-background trace identity, a strict-nearest-neighbor oracle, audit retention, obligation retirement, or score movement |
+
+## 1. Why This Positive Precision Follows From The Action
+
+Let `q` be invertible and let `S=Herm(q)>0`. Multiplication gives
+
+```text
+q^-1 S q^-dagger
+ = (q^-1 q q^-dagger + q^-1 q^dagger q^-dagger)/2
+ = (q^-dagger + q^-1)/2
+ = Herm(q^-1).
+```
+
+This proves the first identity in (1). Positivity is also direct:
+
+```text
+v^dagger W v = (q^-dagger v)^dagger S (q^-dagger v) > 0
+```
+
+for every nonzero `v`. Inverting gives the displayed factored precision.
+Nothing is fitted to the marginal profile.
+
+Partition `K_W` into the four chosen slice coordinates and the exterior.
+The block-inverse identity gives equation (2). Both runners verify it
+with exact rational arithmetic; the independent runner also checks a separate
+non-diagonal rational block example. No diagonality premise is needed for the
+Schur theorem. S-DIAG is an additional measured property of all 56 action
+blocks in the tested ladder.
+
+At `m=0`, the parent action has `S=0` exactly. This note does not smooth or
+invert that boundary: the positive precision route genuinely stops there.
+
+## 2. The Local Source Response
+
+For one complex local Gaussian vector `b` and positive `K_eff`, use
+
+```text
+Z_R(sE)=integral exp[-b^dagger(K_eff-sE)b] db
+        =pi^4/det(K_eff-sE).
+```
+
+Jacobi differentiation gives
+
+```text
+D Z_R(0)[E]=Z_R(0) Tr(K_eff^-1 E).
+```
+
+The identity-source quotient is exactly (5). The Gaussian multiplicity would
+multiply numerator and denominator by the same positive constant, so the grade
+is unchanged. On the CM-SITE coordinate effects `E_j=|j><j|`, S-DIAG makes
+the result the normalized diagonal of `W_RR`, which is the parent's W9 profile.
+
+This is an **action-derived marginal response**. Turning the source response
+into the probability of a forming permanent Record still requires a physical
+source/event and clock/write bridge. That distinction is not erased by the
+exact algebra.
+
+## 3. What The 56-Block Ladder Adds
+
+The primary runner evaluates all fourteen declared nonzero-mass entries of the
+parent dial, including its bench, temporal, holomorphic-temporal,
+holomorphic-spatial, carrier, and positive-mass variations. Some entries are
+deliberate repeated anchors; the claim is fourteen declared dial entries, not
+fourteen distinct actions.
+
+For each entry and each free level `t=2,3,4,5`, it proves:
+
+- `S>0` by an exact LDL certificate;
+- `K_W W=I` exactly;
+- the exterior block is positive;
+- the Schur complement equals `W_RR^-1` exactly;
+- all twelve off-diagonal entries of the `4x4` block vanish exactly;
+- every diagonal response is positive and the four sum to one.
+
+The baseline profiles at the four levels are pairwise distinct. Thus the
+action-derived response is a level-indexed family relative to the pinned band,
+not a translation-free universal site law. No width limit or infinite-volume
+claim is made.
+
+## 4. Two Positive Completions Of One Complex Action
+
+Equation (6) exposes the key physical choice cleanly. Both matrices are
+Hermitian positive whenever their displayed inverses exist, but they preserve
+different information from `q`.
+
+For `K_mod=q^dagger q`,
+
+```text
+det K_mod=conj(det q) det q=|det q|^2.
+```
+
+For `K_W=q^dagger S^-1 q`,
+
+```text
+det K_W=|det q|^2/det S.
+```
+
+Their Gaussian partition weights are therefore (7). On the four exact pins,
+`det S_a` is not constant. The normalized `K_W` and `K_mod` laws differ with
+exact sign pattern `(-,-,+,+)` when `p_W-p_mod` is ordered by
+`a=(0,1/5,2/5,3/5)`. Their unpinned local profiles differ as well.
+
+This explains the parent split more sharply. The squared-amplitude conditional
+and W9 marginal do not merely apply two readouts to one already fixed positive
+probability action. They can be represented by two distinct positive
+completions of the same complex action; the action has not yet selected which
+completion is physical.
+
+## 5. The Total-Probability Probe
+
+For each hard pin `a`, let
+
+```text
+C_a = (W_a)_RR / Tr((W_a)_RR),
+p_det(a) proportional to |det q_a|^-2.
+```
+
+If the existing unpinned object were the marginal of those four conditional
+objects, the most direct finite total-probability equation would be
+
+```text
+C_unpinned = sum_a p_det(a) C_a.                  (9)
+```
+
+The exact residual is nonzero with diagonal signs `(+,-,-,+)`. The primary and
+independent runners rebuild it by separate routes.
+
+The stronger affine question permits arbitrary weights `p_a`. The matrix of
+three differences `C_a-C_(3/5)` has rank two, so the real normalized solutions
+form a one-parameter family. Written in the free coordinate `z=p_(3/5)`, the
+four coefficients have derivative signs `(-,+,-,+)` and all equal
+`(0,0,0,1)` at `z=1`. Positivity of the first and third forces `z<=1`, while
+positivity of the second forces `z>=1`; hence the unique probability solution
+is the default delta.
+
+That solution reflects the field code exactly:
+
+```text
+records.get((t,x), sigma)
+```
+
+uses the supplied carrier `sigma=3/5` whenever the cell is unrecorded. It is a
+fixed background evaluation, not a sum over future records. This is a typing
+result about the present machinery, not a theorem that no enlarged joint
+action can exist.
+
+Two explicit enlarged candidates were also constructed as diagnostics: a sum
+of pinned `K_W` Gaussians and a sum of pinned `K_mod` Gaussians. Their response
+densities differ from the fixed-background objects and from each other. They
+are possible new downstream Laws, not hidden content of the parent.
+
+## 6. Abstract Nearest-Neighbor Uniqueness Versus This Action Derivation
+
+The strict-nearest-neighbor carrier can decode an arbitrary full-rank qubit
+density `C`, but unitary covariance, positivity, locality, effect additivity,
+and refinement do not select its precision map. For example,
+
+```text
+Q_1(C)=C^-1,       rho_1(C)=C,
+Q_2(C)=C^-2,       rho_2(C)=C^2/Tr(C^2)
+```
+
+have all of those properties. At `C=I/2` they give the same grade. At the
+existing non-scalar fixture
+
+```text
+C=diag(3/5,2/5),       E_0=(1/2)P_z,
+```
+
+they give `3/10` and `9/26`, differing by `3/65`.
+
+One clean mathematical selector is **projective contravariant congruence**.
+For `G` invertible, define
+
+```text
+G star C = G C G^dagger / Tr(G C G^dagger).
+```
+
+If a positive precision ray obeys
+
+```text
+[Q_(G star C)] = [G^-dagger Q_C G^-1],             (10)
+```
+
+then `[Q_C]=[C^-1]`. At `C=I/n`, the unitary stabilizer forces the precision
+to be scalar. Choosing `G=(nC)^(1/2)` transports that scalar ray to the inverse
+ray at arbitrary full-rank `C`. No continuity or tensor premise is needed.
+
+Equation (10) is not supplied by the current axioms; a general nonunitary
+congruence is not an internal unitary re-presentation. The runner uses an exact
+nonunitary matrix to show that (10) rejects a positive unitary-covariant
+counterfamily. The pincer route is stronger at its tested scope because it does
+not import (10): its actual global action constructs `W`, and Schur integration
+then constructs the inverse local precision.
+
+Only the precision **ray** enters an identity-normalized source grade. A scalar
+rescaling `Q -> gQ` cancels. In the two-column `M_2(C)` source calculus, the raw
+partition derivative scales as `g^-5` and the calibrated clock prefactor as
+`g^5`; the runner checks the cancellation exactly. Absolute scale therefore
+requires a raw-current or action normalization, even after the response ray is
+fixed.
+
+A finite positive precision also has a full-rank normalized inverse. An exact
+pure preparation cannot be represented without a singular/limiting precision
+or another measure prescription. No pure-boundary rule is selected here.
+
+## 7. What Closed And What Remains
+
+| Obligation | Disposition |
+|---|---|
+| positive state-dependent precision on the pincer action | closed on the tested action domain by `K_W=q^dagger Herm(q)^-1 q` |
+| inverse local precision | closed on all 56 tested blocks by the Schur identity |
+| pincer W9 marginal as an additive Gaussian response | closed exactly by equation (5) |
+| S-DIAG beyond the one parent slice | extended to all four free levels at all fourteen declared nonzero-mass dial entries |
+| squared-amplitude conditional versus W9 response | separated as two distinct positive completions |
+| current hard-pin law as a total-probability parent of the current unpinned marginal | refuted on the exact fixture by (8)--(9) |
+| one selected joint alternative ensemble | open; the present fixed-background action is not one |
+| physical source-to-Record event, clock, and write process | open |
+| general strict-nearest-neighbor action derivation | open; symmetry alone admits counterfamilies |
+| pure/singular preparation | open |
+| retention, obligation retirement, or TOE score | unchanged |
+
+The collapsed open selection set for the next local target is:
+
+- `W_J`: select and derive one joint alternative ensemble, including which
+  positive completion and alternative measure it uses, so its marginal and
+  conditional are consequences of the same partition object;
+- `W_R`: identify that ensemble's additive response/conditional with the
+  physical Record event and its formation clock/write semantics.
+
+These are independent. A mathematical joint ensemble need not be the Record
+process, and a selected Record process can be postulated without deriving an
+action-native joint ensemble.
+
+## Five-Physicist Portfolio Gate
+
+The campaign began with an independent five-lens decision gate.
+
+| Lens | Decisive conclusion | Effect on this block |
+|---|---|---|
+| mathematical physicist | unitary equivariance admits power and spectral counterfamilies; seek an action or stronger naturality | kept the abstract nonselection control and proved the congruence-ray lemma |
+| QFT/statistical mechanics | test the effective precision obtained after integrating exterior modes | produced equations (1)--(4), the central positive result |
+| quantum foundations | inverse precision alone does not choose marginal versus formation conditional | forced the total-probability and two-completion probes |
+| lattice/condensed matter | demand an actual local block of the committed action and keep the zero-mass edge | executed 56 exact local blocks and separated `m=0` |
+| adversarial TOE portfolio | stop if the block only restates inverse covariance | pivoted from abstract uniqueness to the action-derived Schur bridge |
+
+The panel's continue criterion is met: this block derives the inverse ray from
+an actual global action and sharpens the remaining joint-law obligation. Its
+retention criterion is not met because `W_J` and `W_R` remain open.
+
+## No-Go Discipline Gate
+
+The theorem is positive. This gate applies to the narrow negative that the
+**current** fixed-background marginal and four current hard-pin laws are not
+already one total-probability construction. It expressly does not claim that
+no enlarged joint action, instrument, or owner-governed Law can relate them.
+
+### N1 — Normalized Alternative Route Families
+
+| Family | Object, mechanism, terminal obligation | Exact disposition | Marker |
+|---|---|---|---|
+| W9 positive completion | `K_W=q^dagger S^-1q`; Schur integration; reproduce the marginal response | succeeds for the marginal on 56 blocks but does not generate the current determinant formation law | **ATTEMPTED** |
+| modulus-square positive completion | `K_mod=q^dagger q`; positive partition; reproduce the hard-pin weights | succeeds for `|det q_a|^-2` but its covariance and marginal differ from W9 | **ATTEMPTED** |
+| direct total-probability mixture | mix the four pinned W9 densities with the determinant conditional | fails on the exact fixture with residual signs `(+,-,-,+)` | **ATTEMPTED** |
+| arbitrary affine reconstruction | solve `C_unpinned=sum p_a C_a`, `sum p_a=1`, `p_a>=0` | the only probability solution is the default delta, because the current background is a fixed pin | **ATTEMPTED** |
+| positive sum-over-pin ensembles | sum the pinned `K_W` or pinned `K_mod` partition/source objects before normalization | both give valid new candidate densities, but neither equals the current fixed-background object and they disagree with each other | **ATTEMPTED** |
+| projective action naturality | use contravariant congruence to select the inverse ray | closes abstract precision-ray uniqueness but supplies neither an alternative sum nor Record-event semantics | **ATTEMPTED** |
+
+These are distinct in primary object, mechanism, and terminal obligation. A
+future joint instrument remains live, so no universal no-go is licensed.
+
+### N2 — Wall Independence
+
+| Pair | First closes second? | Second closes first? | Independent? |
+|---|---|---|---:|
+| `W_J` / `W_R` | no: a joint partition can remain an unobserved mathematical ensemble | no: a stipulated Record process need not derive from a joint action | yes |
+
+The precision ray is not retained as a third wall: it is closed inside the
+tested pincer action by (1)--(4). Completion choice is part of `W_J`, not an
+inflated independent wall.
+
+### N3 — Hidden-Condition Scan
+
+The required scan covered `we assume`, `by construction`, `as is standard`,
+`the framework provides`, `bridge context`, `background`, `naturally`,
+`obviously`, `standard QFT`, `registered`, `canonical`, `selected`, and
+`declared`.
+
+| Hit | Classification |
+|---|---|
+| committed/declared action and dial | explicit unaudited parent dependency; not attributed to the axioms |
+| fixed `background` | measured field-code semantics and load-bearing in the mixture result |
+| `selected` joint ensemble or Record process | explicit `W_J` or `W_R` open condition |
+| Gaussian source direction | finite mathematical construction; its physical Record identification remains `W_R` |
+| proper CM-SITE effects and pin menu | imposed parent fixture data, not a registered physical measurement context |
+
+There is no affirmative proof use of `we assume`, `as is standard`, `the
+framework provides`, `bridge context`, `naturally`, `obviously`, or `standard
+QFT`.
+
+### N4 — Residual Matching
+
+| Witness | Witness residual | Residual used here | Match? |
+|---|---|---|---:|
+| [`Block 175`](ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_BOUNDED_THEOREM_NOTE_2026-08-22.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_BOUNDED_THEOREM_NOTE_2026-08-22.md:147-238,505-517` | marginal identity; exact split from formation conditional; select-or-relate handoff | derive the marginal precision, then test a direct relation to the same hard-pin conditional | yes |
+| [`Block 174`](ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_BOUNDED_THEOREM_NOTE_2026-08-22.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_BOUNDED_THEOREM_NOTE_2026-08-22.md:299-360,375-377,432-437` | complex amplitude does not select one positive readout; `m=0` positive-action failure | exhibit two positive completions and preserve the same zero-mass boundary | yes; this note narrows but does not close readout selection |
+| [`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md), `docs/MINIMAL_AXIOMS_2026-06-29.md:114-146,173-190` | distribution form/values, source/action, formation rule, and process remain downstream | keep `W_J` and `W_R` explicit | yes |
+
+No unrelated no-go is used as a witness.
+
+### N5 — Resolution Audit
+
+| Claim | Per element | Per site | Per mode | Per block | Lattice-wide |
+|---|---|---|---|---|---|
+| inverse precision and response | every coordinate projector source | every one of four free slices | all 24 complex modes plus exterior integration | 56 exact local blocks | not executed |
+| hard-pin versus marginal relation | four pins and four signed residuals | tested Record cell `(2,0)` | both complete positive precisions | baseline action plus pinned variants | no history inferred |
+| abstract nearest-neighbor selection | one existing non-scalar effect distinguishes `C` and `C^2` | one decoded preparation | full `M_2(C)` response state | mixed and non-scalar fixtures | no universal carrier theorem claimed |
+
+The primary and independent cached stdout land substantive `per_element`,
+`per_site`, `per_mode`, `per_block`, and `lattice_wide` certificate lines.
+
+### N6 — Partial Closure And Primitive Scan
+
+The machine premise registry and the complete current source notes for the
+scale-reference, kinetic-isotropy, and realized-state primitives were read.
+They supply units, kinetic-form isotropy, and pointwise realized-state
+evaluation respectively. None supplies an alternative measure, probability
+readout, action completion, source/event identification, normalization rule,
+or Record process.
+
+Partial closures found here are real:
+
+1. the W9 identity and Schur theorem close state-dependent inverse precision
+   on the tested action surface;
+2. the fixed-background retyping explains why the current objects do not obey
+   total probability without calling that failure a new-axiom necessity;
+3. a sum-over-pin action is an executable downstream-Law construction path;
+4. a later owner decision could govern a successfully tested joint Law, but
+   governance is not evidence that one is scientifically selected.
+
+No new axiom is requested by this result.
+
+### N7 — Hostile Steelman
+
+> The failure of equation (9) is an artefact of comparing a fixed-background
+> action with four separately pinned actions. Complete the functional integral
+> by summing over the Record value as another local degree of freedom. If the
+> same positive partition generates both the pin probability and the
+> source-derived conditional covariance, the law of total expectation will
+> hold automatically. That would relate the marginal and conditional by an
+> ordinary joint ensemble, with no axiom amendment and no reason to elevate the
+> present residual into a structural no-go.
+
+This steelman is correct and actionable. It is the next campaign target. The
+current theorem says only that such an ensemble is not already hidden in the
+fixed-background parent machinery, and that `K_W` versus `K_mod` must be chosen
+and tested when it is built.
+
+### N8 — Cross-Cycle Echo
+
+The required repository search was executed on 2026-08-23. The four mandated
+negative phrases matched 53 files under `docs/`. Every one of the 159
+`NO_GO_LEDGER.md` files under `.claude/science/physics-loops/` was readable and
+walked; a semantic scan for readout, marginal/conditional, formation,
+fixed-background, and joint-law walls matched 51 ledgers. A separate lifecycle
+scan for retirement, reframing, ratification, convention, supersession, or
+closure matched 109 ledgers. The closest echoes and their current lifecycle are:
+
+| Earlier surface | Lifecycle / retirement status found in the search | Movement or retirement mechanism | Could that mechanism apply here? |
+|---|---|---|---|
+| Block 174 readout family and its `NO_GO_LEDGER.md` | readout principle remains open; partially narrowed here because the W9 precision is now action-derived | separate positive readouts, then seek an independent physical selector | yes: the two completions must be tested in one joint ensemble; separation alone does not select one |
+| Block 175 pincer and its `NO_GO_LEDGER.md` | select-or-relate handoff remains open; the marginal precision and fixed-background typing are partially closed here | construct an explicit alternative sum and derive marginal plus conditional from it | yes: this is the live `W_J` successor, not a reason to universalize the present mismatch |
+| [`non-affine purity-weighted kernel`](NONAFFINE_PURITY_WEIGHTED_KERNEL_IS_NOT_BARYCENTER_EVALUATION_BOUNDED_THEOREM_NOTE_2026-08-13.md) | no retirement was found in the searched lifecycle surfaces | exact counterfamily exposes preparation affinity as load-bearing | yes as a control: retain `C^2` until the action, rather than symmetry, rejects it |
+| [`staggered-Dirac labeling wall`](STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md) | its naming obligation is explicitly clearable by an honest labeling convention, while physical derivation within `A_min` remains separate | convention retires a name assignment without adding dynamics | no: a convention cannot change `q_unpinned=q_(3/5)` into a sum over four actions or erase the exact mixture residual |
+| [`observable-principle structural reframe`](OBSERVABLE_PRINCIPLE_P1_BRIDGE_STRUCTURAL_REFRAMING_NARROW_NOTE_2026-05-21.md) | the reframe explicitly does not retire its physical-selection wall | calling the physical generator a textbook convention merely restates the load-bearing identification | no as a closure; it is a warning that naming a source response a Record probability would only relocate `W_R` |
+
+No similar wall is known to have been retired by a convention-only wording
+change. The live mechanism is constructive: build the missing joint ensemble
+and then test physical identification.
+
+**Gate disposition:** PASS for the exact present-machinery statement and its
+named `W_J`/`W_R` boundary. FAIL / DO NOT SHIP for universal nonrelation,
+exhaustion of joint instruments, necessity of an axiom change, global Record
+dynamics, retained closure, or TOE-score movement.
+
+## Axiom-Decision Surface
+
+The current result does not justify editing the Minimal Axioms. A sufficient
+future downstream-Law candidate would have the form:
+
+> At a forming site, the alternative value is included in one specified
+> positive local action ensemble before normalization. The same joint
+> partition supplies its hard-value conditional weights and its additive
+> source response. The selected mark is then mapped to the permanent Record by
+> one outcome-blind local clock/write process.
+
+This wording is hypothetical and deliberately incomplete until a runner
+chooses `K_W`, `K_mod`, or another action-native completion and demonstrates
+the required locality, covariance, refinement, and parent-fixture identities.
+It is not adopted or proposed for registry insertion here.
+
+## Verification
+
+Run:
+
+```text
+python3 scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py
+python3 scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py
+```
+
+The primary runner executes all 56 local action blocks, the four hard pins,
+both positive completions, the mixture solve, the strict-neighbor
+counterfamily, congruence selector, scale gauge, and singular boundary. The
+independent runner imports Block 174 directly, uses a different inverse route,
+checks a separate non-diagonal rational Schur example, reconstructs all four
+free levels, samples twenty action-family blocks, and independently rebuilds
+the partition and mixture residuals.
+
+## Imports And Claim Boundary
+
+| Input | Role | Standing here |
+|---|---|---|
+| four Minimal Axioms | ontology and semantic boundary | supplied; unchanged; not a source of the action/readout choices |
+| Block 174 action family | exact action builder, dial, positive domain, and pin menu | load-bearing unaudited parent |
+| Block 175 pincer | exact marginal/conditional split and target handoff | load-bearing unaudited parent |
+| positive completion, Gaussian differentiation, Schur identity | finite mathematics | proved and independently reconstructed here |
+| CM-SITE coordinate effects | imposed parent interface | tested; not promoted to a generic measurement premise |
+| joint alternative ensemble | next constructive object | absent/open |
+| source-to-Record event and clock/write bridge | physical selection | absent/open |
+| axiom, premise registry, audit ledger, or effective status | governance | unchanged |
+
+## Decision
+
+**SHIP** the bounded positive theorem: the committed pincer action produces a
+positive W9 precision, its local Schur complement is proportional to the
+inverse density, and its additive response reproduces the exact W9 marginal on
+56 tested blocks.
+
+**SHIP** the narrow exact separation: the squared-amplitude formation law and
+W9 marginal are represented by distinct positive completions, and the present
+fixed-background density is not the `p_det`-weighted marginal of the four
+pinned W9 conditional densities.
+
+**DO NOT SHIP** a universal no-go, a choice of physical formation law, a new
+axiom, a retained result, obligation retirement, or TOE-score movement. The
+next high-leverage attack is the explicit sum-over-alternatives joint action.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16109,
- "node_count": 5604,
+ "edge_count": 16114,
+ "node_count": 5605,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -613,6 +613,10 @@
   "admissibility_dirac_kahler_scaling_probe_bounded_theorem_note_2026-08-21": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
+  },
+  "admissibility_dirac_kahler_schur_record_response_bridge_bounded_theorem_note_2026-08-23": {
+   "deps_hash": "98070118f38c",
+   "out_degree": 5
   },
   "admissibility_dirac_kahler_seam_dichotomy_bounded_theorem_note_2026-08-19": {
    "deps_hash": "d793236fddf7",

--- a/logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py
+runner_sha256: ee05c5490547526b5d26948de667bdf8f9723be8b5490851c070c8f38d4d77ac
+input_fingerprint_sha256: 55f50a00545d708969067c5255ac237afb5b72878a2a093702deee6735326b49
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 23.07
+status: ok
+----- stdout -----
+PASS positive-action-completion: W=Herm(q^-1)=q^-1 Herm(q) q^-dagger has exact positive precision K_W=q^dagger Herm(q)^-1 q
+PASS exact-local-schur-inverse: integrating the twenty exterior modes gives the exact inverse of the four-mode W9 block
+PASS action-derived-pincer-marginal: the local Gaussian source response reproduces the parent pincer marginal entry for entry
+PASS four-free-level-ladder: all four free levels are S-DIAG, positive, Schur-derived, response-consistent, and pairwise distinct
+PASS nonzero-mass-action-ladder: fourteen exact nonzero-mass action dials give 56 positive S-DIAG blocks with zero Schur residual
+PASS zero-mass-boundary: at m=0 the Hermitian action vanishes, so the positive W precision construction honestly has no inverse
+PASS two-positive-completions: K_mod=q^dagger q and K_W=q^dagger Herm(q)^-1 q are distinct exact positive completions of one complex q
+PASS completion-partition-split: the squared-amplitude formation law is the K_mod partition, while the W9-positive completion carries a distinct determinant factor
+PASS formation-law-total-mixture-fails: averaging pinned W9 densities with the determinant formation law does not reconstruct the unpinned marginal
+PASS only-nonnegative-reconstruction-is-default: the affine solution is one-dimensional but positivity forces delta at the default sigma=3/5, not the four-positive formation law
+PASS fixed-background-not-value-union: an unrecorded cell uses the fixed default sigma=3/5; the present q is not a sum or integral over Record alternatives
+PASS candidate-joint-ensembles-are-new: both explicit sum-over-pin ensembles differ from the fixed-background object and from each other
+PASS strict-neighbor-equivariant-counterfamily: C and C^2 response states agree at I/2 but differ by 3/65 on the existing non-scalar nearest-neighbor effect
+PASS projective-congruence-selector: contravariant GL congruence selects the inverse ray and rejects an exact positive unitary-covariant counterfamily
+PASS scalar-action-gauge: Q->gQ rescales raw DZ by g^-5 but leaves the identity-normalized grade and calibrated hazard unchanged
+PASS pure-boundary-separation: a finite positive precision has a full-rank response state, so an exact pure preparation needs a singular or limiting prescription
+PASS source-contract-and-input-closure: the final theorem note and every declared action, axiom, and parent input exist with the no-score boundary explicit
+per_element: every local projector source, pinned alternative, response grade, and mixture coefficient is checked exactly
+per_site: four free slices and the hard-pin versus fixed-background semantics at the selected Record cell are checked
+per_mode: all 24 complex action modes, two positive completions, exterior integrations, and source-response quotients are checked
+per_block: fourteen nonzero-mass action dials produce 56 exact Schur-response blocks plus the m=0 boundary
+lattice_wide: checked and not executed — no autonomous global Record history or infinite-volume selector is claimed
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py
+runner_sha256: 726e3ae83d8a3d93c43b28254addbbc94ed21901eb13959c7ceb16cac417a754
+input_fingerprint_sha256: c4ab0ec76a135a51849ec0a6084413c6e4b087707e95e1a193b35837855be497
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 12.61
+status: ok
+----- stdout -----
+PASS independent-positive-completion: a direct inverse of Herm(q^-1) equals the independently factored q^dagger Herm(q)^-1 q precision
+PASS independent-generic-schur-theorem: a non-diagonal rational block example independently certifies the inverse-block Schur identity
+PASS independent-free-level-response: four independently rebuilt free-level blocks are diagonal, Schur exact, response exact, and pairwise distinct
+PASS independent-action-dial-sample: five independently chosen action families give twenty exact positive diagonal Schur blocks
+PASS independent-zero-mass-boundary: the positive precision route stops rather than inverting the exactly zero Hermitian action at m=0
+PASS independent-positive-partition-split: the four hard pins give distinct positive partition laws for q^dagger q and the W9 precision
+PASS independent-total-mixture-residual: the determinant-weighted mixture fails with four exact signed residuals while the default pin reproduces the background
+PASS independent-background-typing: the unpinned field is a fixed default value and not a hidden sum over alternative record values
+PASS independent-neighbor-counterfamily: the exact full-rank power counterfamily independently separates 3/10 from 9/26 while retaining the mixed-point value
+PASS independent-congruence-ray: one nonunitary exact transport confirms the contravariant projective inverse-precision law
+PASS independent-input-closure: the independent checker reads only the final note and its Block 174 fixture parent
+per_element: independent projectors, hard-pin weights, local densities, and exact residual signs are reconstructed
+per_site: all four free levels plus the selected hard-pin cell and fixed-background rule are independently checked
+per_mode: the full 24-mode W precision, two positive partition laws, and a separate rational block-Schur example are checked
+per_block: five action-family dials produce twenty independent local Schur blocks with the zero-mass edge separated
+lattice_wide: checked and not executed — the checker establishes no autonomous history or infinite-volume law
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py
+++ b/scripts/admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Exact Schur-response bridge between the pincer action and Record grades.
+
+The parent pincer fixture supplies a complex action matrix q and the positive
+kernel W9 = herm(q^-1).  This runner proves that W9 has the positive precision
+K_W = q^dagger herm(q)^-1 q, integrates exterior modes by an exact Schur
+complement, and evaluates the resulting local Gaussian source response.  It
+also keeps the distinct modulus-square completion and hard-pin formation law
+separate, so an action-derived marginal is not silently renamed a formation
+conditional.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import sympy as sp
+
+import admissibility_dirac_kahler_pincer_identity_cross_lane_2026_08_22 as b175
+
+
+b174 = b175.b174
+R = sp.Rational
+ZERO = sp.Integer(0)
+ONE = sp.Integer(1)
+I2 = sp.eye(2)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+AUDIT_TIMEOUT_SEC = 240
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+    "scripts/admissibility_dirac_kahler_pincer_identity_cross_lane_"
+    "2026_08_22.py",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+    "scripts/admissibility_dirac_kahler_site_conditional_law_family_"
+    "2026_08_22.py",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def matrix_zero(value: sp.Matrix) -> bool:
+    return all(sp.expand(entry) == 0 for entry in value)
+
+
+def matrix_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return left.shape == right.shape and matrix_zero(sp.expand(left - right))
+
+
+def positive_completion(q: sp.Matrix) -> dict:
+    """The W9 covariance and its positive precision, rebuilt from q."""
+    q_inv = b175.exact_inv(q)
+    symmetric = b175.herm(q)
+    symmetric_inv = b175.exact_inv(symmetric)
+    covariance = sp.expand((q_inv + q_inv.H) / 2)
+    precision = sp.expand(q.H * symmetric_inv * q)
+    return {
+        "q_inv": q_inv,
+        "symmetric": symmetric,
+        "covariance": covariance,
+        "precision": precision,
+    }
+
+
+def modulus_completion(q: sp.Matrix, q_inv: sp.Matrix | None = None) -> dict:
+    """The distinct positive completion whose determinant is |det q|^2."""
+    q_inv = b175.exact_inv(q) if q_inv is None else q_inv
+    return {
+        "covariance": sp.expand(q_inv * q_inv.H),
+        "precision": sp.expand(q.H * q),
+    }
+
+
+def slice_rows(fixture: object, level: int) -> tuple[int, ...]:
+    return tuple(fixture.lx * (level % fixture.T) + x for x in range(fixture.lx))
+
+
+def normalized_block(covariance: sp.Matrix, rows: tuple[int, ...]) -> sp.Matrix:
+    block = covariance.extract(rows, rows)
+    return sp.expand(block / sp.trace(block))
+
+
+def schur_precision(
+    precision: sp.Matrix, rows: tuple[int, ...]
+) -> tuple[sp.Matrix, sp.Matrix]:
+    exterior = tuple(index for index in range(precision.rows) if index not in rows)
+    local = precision.extract(rows, rows)
+    local_exterior = precision.extract(rows, exterior)
+    exterior_local = precision.extract(exterior, rows)
+    exterior_precision = precision.extract(exterior, exterior)
+    schur = sp.expand(
+        local
+        - local_exterior
+        * b175.exact_inv(exterior_precision)
+        * exterior_local
+    )
+    return schur, exterior_precision
+
+
+def source_grade(precision: sp.Matrix, effect: sp.Matrix):
+    covariance = b175.exact_inv(precision)
+    return sp.cancel(sp.trace(covariance * effect) / sp.trace(covariance))
+
+
+def basis_projector(index: int, dimension: int = 4) -> sp.Matrix:
+    return sp.diag(*(ONE if position == index else ZERO for position in range(dimension)))
+
+
+def normalize(values: tuple) -> tuple:
+    total = sp.cancel(sum(values, ZERO))
+    return tuple(sp.cancel(value / total) for value in values)
+
+
+def projectively_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    ratio = None
+    for l_value, r_value in zip(left, right):
+        if r_value != 0:
+            ratio = sp.cancel(l_value / r_value)
+            break
+        if l_value != 0:
+            return False
+    if ratio is None or ratio <= 0:
+        return False
+    return matrix_equal(left, sp.expand(ratio * right))
+
+
+def response_state(precision: sp.Matrix) -> sp.Matrix:
+    inverse = b175.exact_inv(precision)
+    return sp.expand(inverse / sp.trace(inverse))
+
+
+def raw_response(precision: sp.Matrix, effect: sp.Matrix):
+    partition = sp.cancel(sp.pi**4 / precision.det() ** 2)
+    return sp.cancel(2 * partition * sp.trace(b175.exact_inv(precision) * effect))
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    fixture = b174.Fixture(b175.LX, tag="b176-schur")
+    q = fixture.q({})
+    completion = positive_completion(q)
+    covariance = completion["covariance"]
+    precision = completion["precision"]
+
+    check(
+        "positive-action-completion",
+        b174.ldl_certificate(completion["symmetric"])["pd"]
+        and matrix_equal(
+            covariance,
+            sp.expand(
+                completion["q_inv"]
+                * completion["symmetric"]
+                * completion["q_inv"].H
+            ),
+        )
+        and matrix_equal(precision * covariance, sp.eye(fixture.N))
+        and b174.ldl_certificate(precision)["pd"],
+        "W=Herm(q^-1)=q^-1 Herm(q) q^-dagger has exact positive precision K_W=q^dagger Herm(q)^-1 q",
+    )
+
+    rows = slice_rows(fixture, fixture.tstar)
+    block = covariance.extract(rows, rows)
+    schur, exterior_precision = schur_precision(precision, rows)
+    check(
+        "exact-local-schur-inverse",
+        b174.ldl_certificate(exterior_precision)["pd"]
+        and matrix_equal(schur, b175.exact_inv(block)),
+        "integrating the twenty exterior modes gives the exact inverse of the four-mode W9 block",
+    )
+
+    density = normalized_block(covariance, rows)
+    pincer_profile = tuple(b174.profile_of(fixture, {})[0])
+    schur_profile = tuple(source_grade(schur, basis_projector(j)) for j in range(4))
+    check(
+        "action-derived-pincer-marginal",
+        schur_profile == pincer_profile
+        and schur_profile == tuple(density[j, j] for j in range(4)),
+        "the local Gaussian source response reproduces the parent pincer marginal entry for entry",
+    )
+
+    level_profiles = []
+    level_ok = True
+    for level in fixture.free_levels:
+        level_rows = slice_rows(fixture, level)
+        level_block = covariance.extract(level_rows, level_rows)
+        level_schur, level_exterior = schur_precision(precision, level_rows)
+        level_density = normalized_block(covariance, level_rows)
+        level_profile = tuple(level_density[j, j] for j in range(fixture.lx))
+        level_profiles.append(level_profile)
+        level_ok = level_ok and (
+            b174.ldl_certificate(level_exterior)["pd"]
+            and matrix_equal(level_schur, b175.exact_inv(level_block))
+            and all(
+                level_block[i, j] == 0
+                for i in range(fixture.lx)
+                for j in range(fixture.lx)
+                if i != j
+            )
+            and all(value > 0 for value in level_profile)
+            and sp.cancel(sum(level_profile, ZERO)) == ONE
+            and tuple(
+                source_grade(level_schur, basis_projector(j))
+                for j in range(fixture.lx)
+            )
+            == level_profile
+        )
+    check(
+        "four-free-level-ladder",
+        level_ok
+        and len(level_profiles) == 4
+        and len(set(level_profiles)) == 4,
+        "all four free levels are S-DIAG, positive, Schur-derived, response-consistent, and pairwise distinct",
+    )
+
+    dial_ok = True
+    dial_count = 0
+    block_count = 0
+    for index, (_label, config) in enumerate(b174.DIAL_POINTS):
+        if index == b174.ZERO_MASS_INDEX:
+            continue
+        dial_count += 1
+        dial_q = fixture.q({}, **config)
+        dial_completion = positive_completion(dial_q)
+        dial_ok = dial_ok and b174.ldl_certificate(dial_completion["symmetric"])["pd"]
+        dial_ok = dial_ok and matrix_equal(
+            dial_completion["precision"] * dial_completion["covariance"],
+            sp.eye(fixture.N),
+        )
+        for level in fixture.free_levels:
+            block_count += 1
+            dial_rows = slice_rows(fixture, level)
+            dial_block = dial_completion["covariance"].extract(dial_rows, dial_rows)
+            dial_schur, _ = schur_precision(dial_completion["precision"], dial_rows)
+            dial_density = normalized_block(dial_completion["covariance"], dial_rows)
+            dial_ok = dial_ok and matrix_equal(dial_schur, b175.exact_inv(dial_block))
+            dial_ok = dial_ok and all(
+                dial_block[i, j] == 0
+                for i in range(fixture.lx)
+                for j in range(fixture.lx)
+                if i != j
+            )
+            dial_ok = dial_ok and all(dial_density[j, j] > 0 for j in range(fixture.lx))
+    check(
+        "nonzero-mass-action-ladder",
+        dial_ok and dial_count == 14 and block_count == 56,
+        "fourteen exact nonzero-mass action dials give 56 positive S-DIAG blocks with zero Schur residual",
+    )
+
+    zero_mass_q = fixture.q({}, mass=ZERO)
+    check(
+        "zero-mass-boundary",
+        matrix_zero(b175.herm(zero_mass_q)),
+        "at m=0 the Hermitian action vanishes, so the positive W precision construction honestly has no inverse",
+    )
+
+    modulus = modulus_completion(q, completion["q_inv"])
+    w_profile = tuple(normalized_block(covariance, rows)[j, j] for j in range(4))
+    v_profile = tuple(
+        normalized_block(modulus["covariance"], rows)[j, j] for j in range(4)
+    )
+    det_q = b174.dm_det(q)
+    det_symmetric = b174.dm_det(completion["symmetric"])
+    check(
+        "two-positive-completions",
+        matrix_equal(modulus["precision"] * modulus["covariance"], sp.eye(fixture.N))
+        and b174.ldl_certificate(modulus["precision"])["pd"]
+        and b174.dm_det(modulus["precision"]) == b174.norm2(det_q)
+        and sp.cancel(b174.dm_det(precision) - b174.norm2(det_q) / det_symmetric) == 0
+        and w_profile != v_profile,
+        "K_mod=q^dagger q and K_W=q^dagger Herm(q)^-1 q are distinct exact positive completions of one complex q",
+    )
+
+    pinned = []
+    raw_modulus = []
+    raw_w = []
+    for value in b175.MENU:
+        pinned_q = fixture.q({b175.RECORD_CELL: value})
+        pinned_completion = positive_completion(pinned_q)
+        pinned_modulus = modulus_completion(pinned_q, pinned_completion["q_inv"])
+        pinned.append((pinned_completion, pinned_modulus))
+        pinned_det = b174.dm_det(pinned_q)
+        pinned_det_symmetric = b174.dm_det(pinned_completion["symmetric"])
+        raw_modulus.append(sp.cancel(ONE / b174.norm2(pinned_det)))
+        raw_w.append(sp.cancel(pinned_det_symmetric / b174.norm2(pinned_det)))
+    modulus_law = normalize(tuple(raw_modulus))
+    w_partition_law = normalize(tuple(raw_w))
+    check(
+        "completion-partition-split",
+        all(value > 0 for value in raw_modulus)
+        and all(value > 0 for value in raw_w)
+        and modulus_law != w_partition_law
+        and tuple(
+            sp.sign(sp.cancel(w_partition_law[j] - modulus_law[j]))
+            for j in range(4)
+        )
+        == (-1, -1, 1, 1),
+        "the squared-amplitude formation law is the K_mod partition, while the W9-positive completion carries a distinct determinant factor",
+    )
+
+    pinned_densities = tuple(
+        normalized_block(item[0]["covariance"], rows) for item in pinned
+    )
+    formation_mix = sp.expand(
+        sum(
+            (modulus_law[j] * pinned_densities[j] for j in range(4)),
+            sp.zeros(4),
+        )
+    )
+    formation_residual = sp.expand(density - formation_mix)
+    check(
+        "formation-law-total-mixture-fails",
+        not matrix_zero(formation_residual)
+        and tuple(sp.sign(formation_residual[j, j]) for j in range(4))
+        == (1, -1, -1, 1),
+        "averaging pinned W9 densities with the determinant formation law does not reconstruct the unpinned marginal",
+    )
+
+    weights = sp.symbols("p0:4", real=True)
+    equations = [
+        sum(weights[a] * pinned_densities[a][j, j] for a in range(4))
+        - density[j, j]
+        for j in range(4)
+    ] + [sum(weights, ZERO) - ONE]
+    solution = next(iter(sp.linsolve(equations, weights)))
+    derivatives = tuple(sp.sign(sp.diff(entry, weights[3])) for entry in solution)
+    at_default = tuple(sp.cancel(entry.subs(weights[3], ONE)) for entry in solution)
+    check(
+        "only-nonnegative-reconstruction-is-default",
+        sp.Matrix(
+            [
+                [pinned_densities[a][j, j] - pinned_densities[3][j, j] for a in range(3)]
+                for j in range(4)
+            ]
+        ).rank()
+        == 2
+        and derivatives == (-1, 1, -1, 1)
+        and at_default == (ZERO, ZERO, ZERO, ONE)
+        and matrix_equal(density, pinned_densities[3])
+        and all(value > 0 for value in modulus_law),
+        "the affine solution is one-dimensional but positivity forces delta at the default sigma=3/5, not the four-positive formation law",
+    )
+
+    field_source = inspect.getsource(b174.Fixture.field)
+    check(
+        "fixed-background-not-value-union",
+        "records.get((t, x), sigma)" in field_source
+        and matrix_equal(q, fixture.q({b175.RECORD_CELL: b175.MENU[-1]})),
+        "an unrecorded cell uses the fixed default sigma=3/5; the present q is not a sum or integral over Record alternatives",
+    )
+
+    w_joint_block = sum(
+        (
+            raw_w[j] * pinned[j][0]["covariance"].extract(rows, rows)
+            for j in range(4)
+        ),
+        sp.zeros(4),
+    )
+    w_joint_density = sp.expand(w_joint_block / sp.trace(w_joint_block))
+    mod_joint_block = sum(
+        (
+            raw_modulus[j] * pinned[j][1]["covariance"].extract(rows, rows)
+            for j in range(4)
+        ),
+        sp.zeros(4),
+    )
+    mod_joint_density = sp.expand(mod_joint_block / sp.trace(mod_joint_block))
+    check(
+        "candidate-joint-ensembles-are-new",
+        not matrix_equal(w_joint_density, density)
+        and not matrix_equal(
+            mod_joint_density,
+            normalized_block(modulus["covariance"], rows),
+        )
+        and not matrix_equal(w_joint_density, mod_joint_density),
+        "both explicit sum-over-pin ensembles differ from the fixed-background object and from each other",
+    )
+
+    center = sp.diag(R(3, 5), R(2, 5))
+    shared_effect = sp.diag(R(1, 2), ZERO)
+    mixed = I2 / 2
+    inverse_grade = source_grade(b175.exact_inv(center), shared_effect)
+    square_grade = source_grade(b175.exact_inv(center**2), shared_effect)
+    check(
+        "strict-neighbor-equivariant-counterfamily",
+        inverse_grade == R(3, 10)
+        and square_grade == R(9, 26)
+        and source_grade(b175.exact_inv(mixed), shared_effect) == R(1, 4)
+        and source_grade(b175.exact_inv(mixed**2), shared_effect) == R(1, 4),
+        "C and C^2 response states agree at I/2 but differ by 3/65 on the existing non-scalar nearest-neighbor effect",
+    )
+
+    transform = sp.Matrix([[2, 1], [0, 1]])
+    transformed_center = sp.expand(
+        transform * center * transform.H
+        / sp.trace(transform * center * transform.H)
+    )
+    inverse_pullback = sp.expand(
+        transform.inv().H * b175.exact_inv(center) * transform.inv()
+    )
+
+    def alpha_precision(value: sp.Matrix, alpha=ONE) -> sp.Matrix:
+        inverse = b175.exact_inv(value)
+        raw = sp.expand(inverse + alpha * sp.trace(inverse) * I2)
+        return sp.expand(raw / (2 * sp.trace(value * raw)))
+
+    check(
+        "projective-congruence-selector",
+        projectively_equal(b175.exact_inv(transformed_center), inverse_pullback)
+        and not projectively_equal(
+            alpha_precision(transformed_center),
+            sp.expand(transform.inv().H * alpha_precision(center) * transform.inv()),
+        ),
+        "contravariant GL congruence selects the inverse ray and rejects an exact positive unitary-covariant counterfamily",
+    )
+
+    scale = sp.Integer(3)
+    base_raw = raw_response(b175.exact_inv(center), shared_effect)
+    scaled_raw = raw_response(scale * b175.exact_inv(center), shared_effect)
+    base_identity = raw_response(b175.exact_inv(center), I2)
+    scaled_identity = raw_response(scale * b175.exact_inv(center), I2)
+    check(
+        "scalar-action-gauge",
+        sp.cancel(scaled_raw - base_raw / scale**5) == 0
+        and source_grade(scale * b175.exact_inv(center), shared_effect) == inverse_grade
+        and sp.cancel(
+            scaled_raw / scaled_identity - base_raw / base_identity
+        )
+        == 0,
+        "Q->gQ rescales raw DZ by g^-5 but leaves the identity-normalized grade and calibrated hazard unchanged",
+    )
+
+    check(
+        "pure-boundary-separation",
+        response_state(sp.diag(2, 3)).det() > 0
+        and sp.diag(ONE, ZERO).det() == 0,
+        "a finite positive precision has a full-rank response state, so an exact pure preparation needs a singular or limiting prescription",
+    )
+
+    check(
+        "source-contract-and-input-closure",
+        NOTE.exists()
+        and all((ROOT / path).exists() for path in AUDIT_INPUT_PATHS)
+        and "zero TOE-percentage movement" in NOTE.read_text(encoding="utf-8"),
+        "the final theorem note and every declared action, axiom, and parent input exist with the no-score boundary explicit",
+    )
+
+    print("per_element: every local projector source, pinned alternative, response grade, and mixture coefficient is checked exactly")
+    print("per_site: four free slices and the hard-pin versus fixed-background semantics at the selected Record cell are checked")
+    print("per_mode: all 24 complex action modes, two positive completions, exterior integrations, and source-response quotients are checked")
+    print("per_block: fourteen nonzero-mass action dials produce 56 exact Schur-response blocks plus the m=0 boundary")
+    print("lattice_wide: checked and not executed — no autonomous global Record history or infinite-volume selector is claimed")
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return failed
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py
+++ b/scripts/admissibility_dirac_kahler_schur_record_response_bridge_independent_check_2026_08_23.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Independent reconstruction of the Block 41 Schur-response bridge.
+
+This checker imports the Block 174 fixture directly, not the primary Block 41
+runner or the Block 175 pincer runner.  It uses SymPy exact inverses and a
+separate generic block-matrix certificate to reconstruct the positive action,
+local Schur precision, response grades, and the hard-pin mixture failure.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import sympy as sp
+
+import admissibility_dirac_kahler_site_conditional_law_family_2026_08_22 as b174
+
+
+R = sp.Rational
+ZERO = sp.Integer(0)
+ONE = sp.Integer(1)
+I2 = sp.eye(2)
+RECORD_CELL = (b174.RECORD_LEVEL, 0)
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+AUDIT_TIMEOUT_SEC = 240
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+    "scripts/admissibility_dirac_kahler_site_conditional_law_family_"
+    "2026_08_22.py",
+)
+
+
+def inverse(matrix: sp.Matrix) -> sp.Matrix:
+    return matrix.inv(method="DM")
+
+
+def matrix_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return left.shape == right.shape and all(
+        sp.expand(value) == 0 for value in sp.expand(left - right)
+    )
+
+
+def hermitian(matrix: sp.Matrix) -> sp.Matrix:
+    return sp.expand((matrix + matrix.H) / 2)
+
+
+def completion(q: sp.Matrix) -> dict:
+    q_inv = inverse(q)
+    symmetric = hermitian(q)
+    covariance = sp.expand((q_inv + q_inv.H) / 2)
+    precision_direct = inverse(covariance)
+    precision_factored = sp.expand(q.H * inverse(symmetric) * q)
+    return {
+        "q_inv": q_inv,
+        "symmetric": symmetric,
+        "covariance": covariance,
+        "precision": precision_direct,
+        "precision_factored": precision_factored,
+    }
+
+
+def rows_for(fixture: object, level: int) -> tuple[int, ...]:
+    return tuple(fixture.lx * (level % fixture.T) + x for x in range(fixture.lx))
+
+
+def schur(precision: sp.Matrix, rows: tuple[int, ...]) -> sp.Matrix:
+    exterior = tuple(index for index in range(precision.rows) if index not in rows)
+    return sp.expand(
+        precision.extract(rows, rows)
+        - precision.extract(rows, exterior)
+        * inverse(precision.extract(exterior, exterior))
+        * precision.extract(exterior, rows)
+    )
+
+
+def normalized_block(covariance: sp.Matrix, rows: tuple[int, ...]) -> sp.Matrix:
+    block = covariance.extract(rows, rows)
+    return sp.expand(block / sp.trace(block))
+
+
+def projector(index: int, dimension: int) -> sp.Matrix:
+    return sp.diag(*(ONE if slot == index else ZERO for slot in range(dimension)))
+
+
+def grade(precision: sp.Matrix, effect: sp.Matrix):
+    covariance = inverse(precision)
+    return sp.cancel(sp.trace(covariance * effect) / sp.trace(covariance))
+
+
+def normalize(values: tuple) -> tuple:
+    total = sp.cancel(sum(values, ZERO))
+    return tuple(sp.cancel(value / total) for value in values)
+
+
+def projective_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    for l_value, r_value in zip(left, right):
+        if r_value != 0:
+            ratio = sp.cancel(l_value / r_value)
+            return ratio > 0 and matrix_equal(left, sp.expand(ratio * right))
+        if l_value != 0:
+            return False
+    return False
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    fixture = b174.Fixture(4, tag="b176-independent")
+    q = fixture.q({})
+    data = completion(q)
+    identity = sp.eye(fixture.N)
+    check(
+        "independent-positive-completion",
+        b174.ldl_certificate(data["symmetric"])["pd"]
+        and matrix_equal(data["precision"], data["precision_factored"])
+        and matrix_equal(data["precision"] * data["covariance"], identity),
+        "a direct inverse of Herm(q^-1) equals the independently factored q^dagger Herm(q)^-1 q precision",
+    )
+
+    generic_covariance = sp.Matrix(
+        [
+            [4, 1, 1, 0],
+            [1, 3, 0, 1],
+            [1, 0, 5, 1],
+            [0, 1, 1, 4],
+        ]
+    )
+    generic_precision = inverse(generic_covariance)
+    generic_rows = (0, 1)
+    check(
+        "independent-generic-schur-theorem",
+        b174.ldl_certificate(generic_covariance)["pd"]
+        and matrix_equal(
+            schur(generic_precision, generic_rows),
+            inverse(generic_covariance.extract(generic_rows, generic_rows)),
+        ),
+        "a non-diagonal rational block example independently certifies the inverse-block Schur identity",
+    )
+
+    profiles = []
+    levels_ok = True
+    for level in fixture.free_levels:
+        rows = rows_for(fixture, level)
+        block = data["covariance"].extract(rows, rows)
+        local_precision = schur(data["precision"], rows)
+        density = normalized_block(data["covariance"], rows)
+        profile = tuple(density[index, index] for index in range(fixture.lx))
+        profiles.append(profile)
+        levels_ok = levels_ok and matrix_equal(local_precision, inverse(block))
+        levels_ok = levels_ok and all(
+            block[i, j] == 0
+            for i in range(fixture.lx)
+            for j in range(fixture.lx)
+            if i != j
+        )
+        levels_ok = levels_ok and tuple(
+            grade(local_precision, projector(index, fixture.lx))
+            for index in range(fixture.lx)
+        ) == profile
+    check(
+        "independent-free-level-response",
+        levels_ok and len(profiles) == 4 and len(set(profiles)) == 4,
+        "four independently rebuilt free-level blocks are diagonal, Schur exact, response exact, and pairwise distinct",
+    )
+
+    representative_indices = (0, 5, 8, 11, 14)
+    dial_blocks = 0
+    dial_ok = True
+    for index in representative_indices:
+        _label, config = b174.DIAL_POINTS[index]
+        dial_data = completion(fixture.q({}, **config))
+        dial_ok = dial_ok and b174.ldl_certificate(dial_data["symmetric"])["pd"]
+        for level in fixture.free_levels:
+            dial_blocks += 1
+            rows = rows_for(fixture, level)
+            block = dial_data["covariance"].extract(rows, rows)
+            dial_ok = dial_ok and matrix_equal(
+                schur(dial_data["precision"], rows), inverse(block)
+            )
+            dial_ok = dial_ok and all(
+                block[i, j] == 0
+                for i in range(fixture.lx)
+                for j in range(fixture.lx)
+                if i != j
+            )
+    check(
+        "independent-action-dial-sample",
+        dial_ok and dial_blocks == 20,
+        "five independently chosen action families give twenty exact positive diagonal Schur blocks",
+    )
+
+    zero_q = fixture.q({}, mass=ZERO)
+    check(
+        "independent-zero-mass-boundary",
+        matrix_equal(hermitian(zero_q), sp.zeros(fixture.N)),
+        "the positive precision route stops rather than inverting the exactly zero Hermitian action at m=0",
+    )
+
+    rows = rows_for(fixture, fixture.tstar)
+    density = normalized_block(data["covariance"], rows)
+    pinned_data = []
+    raw_squared = []
+    raw_w = []
+    det_s_values = []
+    for value in b174.MENU:
+        pinned_q = fixture.q({RECORD_CELL: value})
+        pinned = completion(pinned_q)
+        pinned_data.append(pinned)
+        determinant = b174.dm_det(pinned_q)
+        determinant_s = b174.dm_det(pinned["symmetric"])
+        det_s_values.append(determinant_s)
+        raw_squared.append(sp.cancel(ONE / b174.norm2(determinant)))
+        raw_w.append(sp.cancel(determinant_s / b174.norm2(determinant)))
+    squared_law = normalize(tuple(raw_squared))
+    w_law = normalize(tuple(raw_w))
+    check(
+        "independent-positive-partition-split",
+        len(set(det_s_values)) > 1
+        and all(value > 0 for value in raw_squared)
+        and all(value > 0 for value in raw_w)
+        and squared_law != w_law,
+        "the four hard pins give distinct positive partition laws for q^dagger q and the W9 precision",
+    )
+
+    pinned_densities = tuple(
+        normalized_block(item["covariance"], rows) for item in pinned_data
+    )
+    mixed = sp.expand(
+        sum(
+            (squared_law[index] * pinned_densities[index] for index in range(4)),
+            sp.zeros(4),
+        )
+    )
+    residual = sp.expand(density - mixed)
+    check(
+        "independent-total-mixture-residual",
+        not matrix_equal(residual, sp.zeros(4))
+        and tuple(sp.sign(residual[index, index]) for index in range(4))
+        == (1, -1, -1, 1)
+        and matrix_equal(density, pinned_densities[3]),
+        "the determinant-weighted mixture fails with four exact signed residuals while the default pin reproduces the background",
+    )
+
+    source = inspect.getsource(b174.Fixture.field)
+    check(
+        "independent-background-typing",
+        "records.get((t, x), sigma)" in source
+        and matrix_equal(q, fixture.q({RECORD_CELL: b174.MENU[-1]})),
+        "the unpinned field is a fixed default value and not a hidden sum over alternative record values",
+    )
+
+    center = sp.diag(R(3, 5), R(2, 5))
+    effect = sp.diag(R(1, 2), ZERO)
+    check(
+        "independent-neighbor-counterfamily",
+        grade(inverse(center), effect) == R(3, 10)
+        and grade(inverse(center**2), effect) == R(9, 26)
+        and grade(2 * I2, effect) == R(1, 4),
+        "the exact full-rank power counterfamily independently separates 3/10 from 9/26 while retaining the mixed-point value",
+    )
+
+    transform = sp.Matrix([[2, 1], [0, 1]])
+    moved = sp.expand(
+        transform * center * transform.H
+        / sp.trace(transform * center * transform.H)
+    )
+    expected = sp.expand(transform.inv().H * inverse(center) * transform.inv())
+    check(
+        "independent-congruence-ray",
+        projective_equal(inverse(moved), expected),
+        "one nonunitary exact transport confirms the contravariant projective inverse-precision law",
+    )
+
+    check(
+        "independent-input-closure",
+        NOTE.exists()
+        and all((ROOT / path).exists() for path in AUDIT_INPUT_PATHS)
+        and "No-Go Discipline Gate" in NOTE.read_text(encoding="utf-8"),
+        "the independent checker reads only the final note and its Block 174 fixture parent",
+    )
+
+    print("per_element: independent projectors, hard-pin weights, local densities, and exact residual signs are reconstructed")
+    print("per_site: all four free levels plus the selected hard-pin cell and fixed-background rule are independently checked")
+    print("per_mode: the full 24-mode W precision, two positive partition laws, and a separate rational block-Schur example are checked")
+    print("per_block: five action-family dials produce twenty independent local Schur blocks with the zero-mass edge separated")
+    print("lattice_wide: checked and not executed — the checker establishes no autonomous history or infinite-volume law")
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return failed
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary

- derives the exact positive W9 precision K_W = q^dagger Herm(q)^-1 q from the committed pincer action
- proves exterior-mode Schur integration gives the inverse local W9 block and the trace response on 56 exact local blocks
- separates K_W from K_mod = q^dagger q and their distinct positive partition laws
- proves the determinant-weighted four-pin W9 mixture does not equal the current fixed-default density; only the default delta gives a positive affine reconstruction
- leaves the joint alternative ensemble and physical Record event/clock/write bridge explicitly open

Validation

- primary exact runner: 17 PASS, 0 FAIL
- independent reconstruction: 11 PASS, 0 FAIL
- fresh cached receipts, py_compile, claim typing, controlled vocabulary, changed-evidence guard, citation graph, and enforced repo invariants pass
- cold adversarial source review: PASS

Scope

This is a bounded theorem stacked on PR #7318. It authors no audit verdict, retires no obligation, changes no axiom, and moves no TOE percentage. The next attack is one explicit sum over alternatives whose partition and source response derive the formation conditional and marginal from the same object.