### PR TITLE
physics: construct pin-faithful joint Record sector

### DIFF
--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_PIN_FAITHFUL_JOINT_SECTOR_ACTION_BOUNDED_THEOREM_NOTE_2026-08-23.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_PIN_FAITHFUL_JOINT_SECTOR_ACTION_BOUNDED_THEOREM_NOTE_2026-08-23.md
@@ -1,0 +1,670 @@
+---
+claim_id: admissibility_dirac_kahler_pin_faithful_joint_sector_action_bounded_theorem_note_2026-08-23
+claim_type: bounded_theorem
+claim_scope: "On the committed Block 174/175 four-pin Dirac--Kahler fixture, let q_a be the complex action at alternative a, S_a=Herm(q_a)>0, K_W,a=q_a^dagger S_a^-1 q_a, and C_a=(K_W,a^-1)_RR/Tr((K_W,a^-1)_RR). The positive product sector J_a=K_W,a direct-sum S_a has det(J_a)=|det q_a|^2. A disjoint sum over the four sectors therefore has the exact parent formation weights p_det(a) proportional to |det q_a|^-2. Coupling a local effect E only to the K_W arm with an imposed per-arm identity calibration 1/Tr((K_W,a^-1)_RR), whose value is computed from the action, gives the exact positive additive functional P(a,E)=p_det(a)Tr(C_a E), normalized on the identity; the declared projector POVM gives a normalized product-event probability table, with coarse additivity, conditionals, and total probability exact on all four free response slices. Its true outcome marginal after summing over alternatives, sum_a p_det(a)C_a, differs in all four entries from the current fixed-default W9 density, with residual signs (+,-,-,+). The proper effect diag(0,4/7,3/7,0) exposes that default density from the convex hull of all eight pinned K_W and K_mod conditional endpoint states: every endpoint has strictly positive displacement except the default W endpoint, which has zero. Hence any positive endpoint kernel that preserves the old density must map every formation pin to the default response and is not pin-faithful. Uniform duplicate-label counting also changes the sector law; representation-preserving refinement requires a supplied additive base measure. Determinant compensation does not uniquely select the S spectator. On the default-carrier cover extents 8,12,16,20,24, q and S remain temporal range one and K_mod=q^dagger q range two, while K_W reaches half of each physical-time cover, ranges 2,3,4,5,6; both determinant and W-sector alternative laws also differ on an exact matched-blanket twin. Thus this block constructs one exact positive pin-faithful joint probability object and closes its finite-fixture algebraic existence question, but it does not select that object as the physical Admissibility/Record law, supply its alternative base measure under arbitrary refinements, derive an exact nearest-neighbor positive realization, cross the m=0 boundary, produce a Record clock/write process, earn audit retention, retire a tracked obligation, amend an axiom, or move a TOE percentage."
+depends_on:
+  - minimal_axioms
+  - admissibility_dirac_kahler_schur_record_response_bridge_bounded_theorem_note_2026-08-23
+runner: scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py
+independent_runner: scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py
+runner_cache: logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.txt
+independent_runner_cache: logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.txt
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# A Pin-Faithful Joint Positive Sector And Its Exact Locality Price
+
+**Date:** 2026-08-23
+
+**Claim type:** bounded_theorem
+
+**Role:** constructive sum over Record alternatives, followed by exact
+refinement, endpoint, and locality discriminators
+
+**Authority boundary:** the current
+[`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md) remain the complete approved
+foundation. The
+[`Schur-response bridge`](ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-08-23.md)
+and its Block 174/175 parents supply an explicitly committed but unaudited
+finite action fixture. This note adds a downstream mathematical construction.
+It does not register a probability Law, edit an axiom or premise registry, or
+author an audit verdict.
+
+**Primary runner:**
+[`scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py`](../scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py)
+
+**Independent reconstruction:**
+[`scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py`](../scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py)
+
+**Cached receipts:**
+[`primary`](../logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.txt),
+[`independent`](../logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.txt)
+
+## Result Up Front
+
+Block 41 showed that the committed complex action `q` has two relevant positive
+completions:
+
+```text
+K_mod = q^dagger q,
+K_W   = q^dagger Herm(q)^-1 q.
+```
+
+The first has the parent's determinant formation weights. The second has the
+W9 covariance needed for the trace conditional. Neither completion alone has
+both properties.
+
+There is, however, an exact positive product construction. For each hard-pin
+alternative
+
+```text
+a in A={0,1/5,2/5,3/5},
+S_a=Herm(q_a),
+J_a=K_W,a direct-sum S_a.                            (1)
+```
+
+Both blocks in `J_a` are positive on the declared `m>0` action domain. Their
+determinants obey
+
+```text
+det K_W,a = |det q_a|^2/det S_a,
+det J_a   = det K_W,a det S_a = |det q_a|^2.         (2)
+```
+
+Thus one complex Gaussian field in each block gives
+
+```text
+Z_a(0) proportional to 1/|det q_a|^2.                (3)
+```
+
+A disjoint sum of the four positive sectors therefore reproduces the parent
+formation conditional exactly:
+
+```text
+p(a)=Z_a(0)/sum_b Z_b(0)=p_det(a).                   (4)
+```
+
+Let `R` be a four-coordinate response slice,
+
+```text
+G_a=(K_W,a^-1)_RR,
+t_a=Tr(G_a),
+C_a=G_a/t_a.                                         (5)
+```
+
+Embed an effect `E` into `R` of the `K_W` field and impose the arm-specific
+identity calibration `lambda_a=1/t_a`, whose value is computed from the action.
+Jacobi differentiation gives
+
+```text
+D Z_a(0)[E] = Z_a(0) Tr(C_a E).                      (6)
+```
+
+Dividing by the complete zero-source partition produces one exact joint
+grade:
+
+```text
+P(a,E)=p_det(a) Tr(C_a E).                           (7)
+```
+
+Equation (7) is a positive additive effect functional, normalized on the
+identity. The declared coordinate-projector POVM induces a normalized finite
+product-event table that obeys ordinary conditioning and total probability.
+The primary runner checks every alternative/projector atom on all four free
+response slices. This is the constructive hit sought by the Block 175 pincer:
+formation weights and W9 conditional responses arise inside one displayed
+positive sector sum rather than being juxtaposed after the fact.
+
+The hit has three exact prices.
+
+1. The true outcome marginal after summing over alternatives is
+
+   ```text
+   C_bar=sum_a p_det(a) C_a,                          (8)
+   ```
+
+   not the current unpinned W9 density. The latter is exactly the fixed
+   `a=3/5` profile. `C_default-C_bar` is nonzero in all four diagonal entries,
+   with signs `(+,-,-,+)`.
+
+2. Treating every written label as one unit of counting measure is not
+   refinement-invariant. Duplicating one physically unchanged alternative
+   doubles its raw sector mass and changes (4). A split with base-measure
+   shares whose sum equals the parent share recombines exactly. The sector
+   action supplies `Z_a`; it does not by itself supply a representation-free
+   base measure on arbitrary refinements of `A`.
+
+3. On the five tested default-carrier covers, the positive response precision's
+   exact temporal support radius grows `2,3,4,5,6` at physical time sizes
+   `4,6,8,10,12`, equal to half-cover each time. In the same matrices, `q` and
+   `S` remain radius one and `K_mod` radius two. This finite ladder does not
+   decide an all-cover bound or limit. A matched-nearest-neighbor twin has
+   exactly different determinant and W-sector laws, so the executed candidate
+   is not an exact nearest-neighbor Admissibility Law on that fixture.
+
+This is significant scientific movement: the campaign now knows how to build
+the desired joint probability algebra and exactly what prevents immediate TOE
+closure. It has **zero TOE-percentage movement** because no physical sector
+choice, base measure, strict-neighbor realization, or Record process is
+retained.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The determinant compensation, positive four-sector sum, normalized source derivative, exact joint law, total-probability marginal, exposed endpoint, refinement counterexample, spectator nonuniqueness, five-cover support ladder, matched-blanket gaps, and zero-mass separation are finite exact consequences of displayed matrices and finite sums. Physical Law selection and nearest-neighbor Record realization remain open."
+trace_class: direct_blocker_closure
+target_claim_id: pincer_pin_faithful_joint_sector_action
+target_blocker_text: "construct one joint alternative ensemble whose partition and source response derive the formation conditional and W9 conditional from the same object"
+source_of_blocker_text: admissibility_dirac_kahler_schur_record_response_bridge_bounded_theorem_note_2026-08-23
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "attempt one exact local positive dilation or strict-nearest-neighbor compiler for the joint sector; if it fails, isolate whether the owner must accept a screened effective Law, the local modulus response, or an independently selected Record instrument"
+conditional_surface_status: "finite-fixture joint probability algebra constructed exactly; alternative-base-measure, physical-sector, exact-locality, and Record-event selection remain open"
+hypothetical_axiom_status: "no axiom edit; the missing choices are candidate downstream Law and realization content explicitly outside the Minimal Axioms"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Exact Target Contract
+
+| Field | Contract |
+|---|---|
+| target statement | construct or refute one positive action-derived joint object that supplies the determinant arm law and W9 conditional response together |
+| quantifiers/domain | the committed 12x4 fixture; all four hard pins; all four free response slices; default-carrier support ladder at cover extents 8, 12, 16, 20, 24; one width-eight matched-blanket twin |
+| allowed premises | exact parent action builder; the Block 41 positive completion; finite positive Gaussian, determinant, derivative, convexity, and probability algebra |
+| forbidden weakenings | forcing the new marginal to equal the fixed-default profile; fitting arbitrary arm weights; calling label counting refinement-invariant; hiding the `S` spectator; or calling a screened effective precision nearest-neighbor |
+| boundary cases | `m=0`; hard pin versus fixed default; ordinary marginal versus identity-source reweighting; duplicated labels; alternative positive spectators; cover growth |
+| positive completion witness | equations (1)--(7), including exact normalization and total probability |
+| negative endpoint witness | one proper effect exposing the default W state from eight pinned conditional endpoints |
+| outcomes not counted as TOE closure | a finite joint partition, a decoupled default response, a fitted base measure, an effective nonlocal action, audit retention, obligation retirement, or score movement |
+
+## 1. One Positive Partition Supplies The Formation Law
+
+For one complex `N`-component Gaussian field with positive precision `K`, the
+partition is proportional to `1/det K`. Equation (1) has two independent
+complex fields and hence
+
+```text
+Z_a(0)=pi^(2N)/(det K_W,a det S_a).
+```
+
+Equation (2) reduces this to (3). No pin-dependent coefficient was fitted: the
+compensating determinant is the same `S_a=Herm(q_a)` that appears in the exact
+factorization of `K_W,a`.
+
+The extra `S` field is nevertheless an added downstream sector. The original
+complex action does not already contain a second independently integrated
+positive boson named by (1). The determinant identity makes `S` an economical
+action-derived candidate; it does not make that field content physically
+mandatory.
+
+## 2. The Normalized Source Produces A Genuine Joint Grade
+
+Let `E_hat` be an effect on `R` embedded by zero on the other coordinates. In
+sector `a`, use
+
+```text
+K_W,a(sE)=K_W,a-s E_hat/t_a.
+```
+
+The determinant lemma and Jacobi differentiation give
+
+```text
+Z_a(sE)/Z_a(0)
+ =1/det(I-s K_W,a^-1 E_hat/t_a),
+D[Z_a(sE)/Z_a(0)]_(s=0)=Tr(C_a E).
+```
+
+This proves (6). For `E=I_R`, the derivative is one in every arm. Within the
+class of scalar arm source couplings, identity certainty therefore fixes
+`lambda_a=1/t_a` uniquely.
+
+This normalization is load-bearing. The four exact `t_a` are positive and
+pairwise distinct. If the same unscaled source is coupled in every arm, the
+identity-normalized response uses
+
+```text
+p_tilde(a)=p_det(a)t_a/sum_b p_det(b)t_b,            (9)
+```
+
+not `p_det(a)`. Its response density differs exactly from (8). The runner keeps
+the partition law, the per-arm conditional, the ordinary marginal, and the
+identity-source reweighted marginal as four separate objects.
+
+Equation (7) is a normalized positive effect functional; the declared
+coordinate-projector POVM induces a finite product-event probability table.
+Identifying its source mark with a physical forming Record, its clock, and its
+permanent write remains separate downstream content.
+
+## 3. Total Probability Retypes The Old Fixed Profile
+
+For the coordinate projectors `E_j`, define
+
+```text
+P(a,j)=p_det(a) Tr(C_a E_j).
+```
+
+Every one of the sixteen entries is strictly positive and their sum is one.
+The alternative marginal and conditional are
+
+```text
+sum_j P(a,j)=p_det(a),
+P(j|a)=Tr(C_a E_j).
+```
+
+The outcome marginal is equation (8). Coarse alternative cells and union
+effects inherit their values by finite addition, and the primary runner checks
+two nontrivial partitions in both arguments.
+
+Block 41 proved that the parent unpinned action is exactly the action with its
+unrecorded carrier fixed to `sigma=3/5`. It is therefore consistent, rather
+than paradoxical, that (8) differs from that profile. The earlier word
+"marginal" referred to a slice/profile reduction of the fixed action. It was
+not an executed marginal over the four Record values.
+
+The scientific choice is now explicit for this construction: a pin-faithful
+sum using the four pinned `C_a` requires (8) as its outcome marginal. Keeping
+the old fixed-default density with these same conditionals and weights would
+violate ordinary total probability. Other conditional states or enlarged
+instruments are not excluded.
+
+## 4. An Exact Endpoint Exposure Makes The Choice Sharp
+
+Let the eight endpoint conditional densities be the four normalized W9 blocks
+and the four normalized modulus-completion blocks. Use the proper effect
+
+```text
+E_star=diag(0,4/7,3/7,0).                            (10)
+```
+
+Against `C_default`, exact arithmetic gives
+
+```text
+sign Tr[(C_W,a-C_default)E_star] = (+,+,+,0),
+sign Tr[(C_mod,a-C_default)E_star] = (+,+,+,+).      (11)
+```
+
+Thus `C_default` is exposed from the convex hull of all eight endpoints. A
+positive mixture equals it only when all weight is on the default W endpoint.
+Because every `p_det(a)` is strictly positive, any stochastic cross-kernel
+that first chooses the formation pin and then chooses one of these eight
+responses must map every arm to the same default W response if it is to retain
+`C_default`.
+
+That decoupled product is mathematically valid:
+
+```text
+P_decoupled(a,j)=p_det(a) Tr(C_default E_j).         (12)
+```
+
+It gives the old arm law and old outcome density together, but its conditional
+response is independent of `a`. It therefore abandons the pin-faithful action
+interpretation. Equations (10)--(11) do not exclude new conditional states,
+coherent cross terms, signed intermediate representations, or non-endpoint
+positive precisions. The negative is deliberately confined to positive
+mixtures of the eight executed endpoints.
+
+## 5. Refining Labels Reveals A Base-Measure Input
+
+The four-value menu is a supplied finite set, so equation (4) initially uses
+one copy of each atomic alternative. Suppose the label for `a=0` is replaced
+by two physically equivalent duplicate labels and each written label again
+receives one unit of counting measure. The recombined raw mass of that event
+becomes `2Z_0`, so its normalized probability changes.
+
+If instead the parent alternative has a base-measure share `nu_0` and the two
+children receive `r nu_0` and `(1-r)nu_0`, their actions and probabilities
+recombine exactly for every `0<r<1`. The primary and independent runners use
+different exact split ratios.
+
+Therefore "split and recombine the same event" means preserving an additive
+base measure, not counting the number of descriptions. The action determines
+the density factor `Z_a`; it does not determine the measure assigned to every
+possible future re-presentation of the alternative space. This is the precise
+version of the refinement issue raised in the preceding conceptual discussion:
+equivalent descriptions need not be the same micro-alternative, but the event
+and its total base measure must be representation-invariant.
+
+## 6. Determinant Compensation Does Not Select The Spectator
+
+Equation (2) fixes the determinant factor required beside `K_W`:
+
+```text
+det H_a=det S_a.                                    (13)
+```
+
+It does not uniquely fix `H_a`. If `G` has determinant one, then
+
+```text
+H_a=G^dagger S_a G
+```
+
+is positive, has the same determinant, and is generally different from `S_a`.
+Both runners exhibit explicit rational diagonal `G` and verify the result.
+
+Choosing the already present Hermitian action `S_a` is structurally economical
+and preserves its finite support. That is evidence for the candidate, not a
+uniqueness theorem. A physical selection principle or a derived field-content
+argument is still required.
+
+## 7. The Exact Locality Pincer
+
+The default-carrier cover ladder measures temporal support radii directly:
+
+| `T_cover` | physical `T` | `q` | `S` | `K_mod` | `K_W` |
+|---:|---:|---:|---:|---:|---:|
+| 8 | 4 | 1 | 1 | 2 | 2 |
+| 12 | 6 | 1 | 1 | 2 | 3 |
+| 16 | 8 | 1 | 1 | 2 | 4 |
+| 20 | 10 | 1 | 1 | 2 | 5 |
+| 24 | 12 | 1 | 1 | 2 | 6 |
+
+The positive modulus completion is uniformly bounded-range and has the desired
+formation partition, but its conditional covariance differs from W9. The
+positive W9 completion has the desired conditional covariance, and the `S`
+sector repairs its determinant, but its precision reaches half-cover on every
+tested size.
+
+This is not only a matrix-support diagnosis. On the width-eight twin fixture,
+two sites with the same declared nearest-neighbor blanket have exactly
+different arm laws:
+
+```text
+4931/100000000 < Delta_det < 1233/25000000,
+209783/10000000000 < Delta_W < 26223/1250000000.     (14)
+```
+
+Both effects are small and screened, but exact nearest-neighbor dependence is
+binary: a nonzero residual does not become zero because it is small. No
+infinite-width limit is proved here.
+
+A local microscopic dilation whose positive effective response is W9 could
+still break this finite-action pincer. A singular constrained field, coherent
+complex amplitude, fermionic determinant, or enlarged local carrier is not
+excluded. That is the highest-value next attack.
+
+## 8. The Zero-Mass Edge
+
+At `m=0`, `S=0` exactly while `q` remains invertible on the tested
+antiperiodic fixture. The W precision and the product sector (1) therefore
+stop. In contrast, `K_mod=q^dagger q` remains positive.
+
+This boundary favors the modulus completion only if a physical Law is required
+to extend through `m=0`. The current positive W construction explicitly has
+domain `m>0`, and no approved axiom supplies a zero-mass continuation rule.
+
+## 9. What Closed And What Remains
+
+| Obligation | Disposition |
+|---|---|
+| existence of one positive joint sector with parent formation weights and pinned W9 conditionals | closed exactly on the finite fixture by (1)--(7) |
+| ordinary product-event normalization, conditioning, marginalization, and coarse additivity | closed exactly |
+| fixed-default profile as the marginal of a pin-faithful positive endpoint ensemble | excluded within the eight executed endpoints by (10)--(11) |
+| representation-independent alternative refinement | open; requires an additive base measure, not duplicate-label counting |
+| physical choice of the `S` spectator and W9 completion | open; determinant compensation is not unique |
+| exact nearest-neighbor positive realization | open; the tested `K_W` range grows with cover and the twin gaps are nonzero |
+| source mark as a physical Record event with clock/write semantics | open |
+| pure/zero-mass continuation | open |
+| audit retention, tracked-obligation retirement, or TOE score | unchanged |
+
+The collapsed residual set is:
+
+- `W_J`: physically select the alternative base measure, positive sector, and
+  normalized source identification rather than merely exhibit one;
+- `W_L`: derive an exact nearest-neighbor positive realization or an approved
+  microscopic local dilation of its effective response;
+- `W_R`: map the joint source mark to one permanent Record with an
+  outcome-blind clock and write process.
+
+These walls are not repaired by renaming the old fixed profile a joint
+marginal. The total-probability calculation decides that point exactly.
+
+## Five-Physicist Portfolio Gate
+
+The post-Block-41 independent five-lens panel allocated the main campaign to
+this construction and imposed a two-block kill switch.
+
+| Lens | Required discriminator | Result here |
+|---|---|---|
+| mathematical physics | exact existence, total probability, and minimality | existence succeeds; determinant-only spectator uniqueness fails |
+| QFT/statistical mechanics | decide whether `K_W direct-sum S` is a local action rather than a compensator | positive with action-computed blocks at finite size; measured `K_W` radius grows to half-cover on all five tested extents |
+| quantum foundations | define `P(a,j)` before calling either object a Record probability | equation (7) succeeds mathematically; source-to-Record semantics remain open |
+| lattice/condensed matter | replace fixed background by a homogeneous local alternative rule | fixed background is retyped; matched-blanket and support tests block an exact local claim |
+| adversarial TOE strategy | close `W_J` materially or identify the precise obstruction | algebraic existence closes; physical selection, base measure, and `W_L/W_R` are now explicit |
+
+The panel's continue criterion is met for exactly one successor block: attempt a
+local positive dilation or strict-neighbor compiler. Continue beyond that only
+if `W_L` closes or `W_R` becomes a smaller non-equivalent terminal obligation.
+
+## No-Go Discipline Gate
+
+The positive construction is the main result. This gate applies to the narrow
+negative that `C_default` cannot be the marginal of a **pin-faithful positive
+mixture of the eight executed W/modulus endpoint conditional states**. It does
+not claim that a new precision, coherent instrument, signed intermediate
+representation, local dilation, or owner-governed Law is impossible.
+
+### N1 — Normalized Alternative Route Families
+
+| Route family | Object, mechanism, terminal obligation | Exact disposition | Marker |
+|---|---|---|---|
+| W-endpoint affine family | arbitrary positive weights on the four pinned W conditional densities; retain `C_default` | the exposing effect is positive on the first three and zero only at default, so only the default delta survives | **ATTEMPTED** |
+| modulus-endpoint affine family | arbitrary positive weights on the four pinned modulus conditional densities; retain `C_default` | the exposing effect is strictly positive on all four, so no positive mixture reaches the target | **ATTEMPTED** |
+| native identity-source families | use the `K_W` or `K_mod` partition weights reweighted by their branch trace susceptibilities | all weights remain positive endpoint mixtures and the exact target residual remains nonzero | **ATTEMPTED** |
+| arm-matched cross family | use determinant formation weights with pinned W responses, equations (1)--(8) | succeeds as a pin-faithful joint law but its true marginal is `C_bar`, not `C_default` | **ATTEMPTED** |
+| pin-dependent stochastic endpoint kernel | after each positive formation pin, choose any of all eight endpoint responses | strict positivity of every arm plus the exposing effect forces the default W response with probability one after every pin | **ATTEMPTED** |
+| decoupled default product | use `p_det(a)` but the same `C_default` response after every pin | reproduces both old marginals exactly and demonstrates compatibility, but fails the stated pin-faithfulness obligation | **ATTEMPTED** |
+
+The last row is the live partial closure that prevents a broader incompatibility
+claim. New response states and coherent routes remain outside the endpoint
+negative.
+
+### N2 — Wall Independence
+
+| Pair | Does closing the first close the second? | Does closing the second close the first? | Independent? |
+|---|---|---|---:|
+| `W_J` / `W_L` | no: selecting equation (7) does not make its precision nearest-neighbor | no: a local carrier need not select its base measure or completion | yes |
+| `W_J` / `W_R` | no: a joint mathematical probability need not be a forming permanent Record | no: a stipulated Record process need not derive a joint action partition | yes |
+| `W_L` / `W_R` | no: local response transport does not provide a clock or append-once write | no: a Record process can be postulated around a nonlocal effective law | yes |
+
+The source normalization, spectator choice, and alternative base measure are
+collapsed into `W_J`; presenting each as an independent wall would inflate the
+count.
+
+### N3 — Hidden-Condition Scan
+
+The scan covered `we assume`, `by construction`, `as is standard`, `the
+framework provides`, `bridge context`, `background`, `naturally`, `obviously`,
+`standard QFT`, `registered`, `canonical`, `selected`, and `declared`.
+
+| Hit | Classification |
+|---|---|
+| committed/declared action and menu | explicit unaudited parent dependency |
+| fixed `background` / default | measured field-code semantics, load-bearing only in the retyping result |
+| selected sector, base measure, source, or Record process | explicit `W_J` or `W_R` open content |
+| registered Law or premise | governance boundary; none is registered here |
+| finite Gaussian and convex mathematics | verified construction, not attributed to the axioms |
+
+No affirmative step rests on an unlisted convention or on a claim that the
+framework already supplies the new sector sum.
+
+### N4 — Residual Matching
+
+| Witness and exact source location | Witness residual | Residual used here | Match? |
+|---|---|---|---:|
+| [`Block 41`](ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-08-23.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-08-23.md:55-151,292-336,394-425` | two positive completions; fixed-default object is not the determinant-weighted pinned-W marginal; construct a joint sum | use `K_W direct-sum S`, preserve the fixed-default typing, and execute the joint sum | yes |
+| [`Block 175`](ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_BOUNDED_THEOREM_NOTE_2026-08-22.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_BOUNDED_THEOREM_NOTE_2026-08-22.md:147-282,505-517` | select or relate the W9 profile and formation conditional | derive determinant arm weights and W9 conditionals in one joint probability | yes |
+| [`Block 174`](ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_BOUNDED_THEOREM_NOTE_2026-08-22.md), `docs/ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_BOUNDED_THEOREM_NOTE_2026-08-22.md:299-360,375-377,432-437` | positive readout family is not uniquely selected; exact locality and zero-mass boundaries | preserve spectator/source selection, re-run finite locality, and keep `m=0` open | yes |
+| [`Minimal Axioms`](MINIMAL_AXIOMS_2026-06-29.md), `docs/MINIMAL_AXIOMS_2026-06-29.md:114-146,173-190` | probability values, source/action, formation rule, and process remain downstream | keep `W_J`, `W_L`, and `W_R` explicit | yes |
+
+No unrelated no-go is used as a witness.
+
+### N5 — Resolution Audit
+
+| Claim | Per element | Per site | Per mode | Per block | Lattice-wide |
+|---|---|---|---|---|---|
+| joint sector and source | all sixteen alternative/effect atoms and coarse unions | four hard pins on all four free slices | both 24-mode positive blocks and their source covariance | four exact product sectors | no global history |
+| endpoint exposure | all eight endpoint states under one proper effect | selected hard-pin cell and fixed-default profile | both W and modulus precisions | baseline pinned variants | no new state family excluded |
+| refinement price | duplicate and two additive split ratios | finite alternative menu | partition scalar factors | baseline sector sum | no universal possibility measure |
+| locality tradeoff | every nonzero matrix entry | matched-blanket twin and response slice | full q/S/K_mod/K_W supports | five covers | no infinite-size limit or homogeneous update |
+
+The primary and independent cached stdout land substantive `per_element`,
+`per_site`, `per_mode`, `per_block`, and `lattice_wide` certificate lines.
+
+### N6 — Partial Closure And Primitive Scan
+
+The complete approved premise registry and current source notes for the
+scale-reference, kinetic-isotropy, and realized-state primitives were read.
+They supply units, kinetic-form isotropy, and realized-state evaluation. They
+do not supply an alternative base measure, positive action completion, source
+normalization, physical probability readout, nearest-neighbor dilation, or
+Record process.
+
+Partial closure is substantial:
+
+1. a positive joint probability witness now exists;
+2. the correct new marginal follows without an axiom change;
+3. ordinary additive base-measure refinement is an available downstream path;
+4. `S` is an already computed local action object, although its extra field
+   role is not selected;
+5. a local-dilation search is executable before any owner adoption decision.
+
+No result here requires a new axiom. The remaining physical choices are
+exactly the downstream content that the Minimal Axioms leave open.
+
+### N7 — Hostile Steelman
+
+> The endpoint exposure proves too little to threaten the joint program. The
+> pin-faithful sector sum already works if one accepts its new marginal, and a
+> local microscopic theory can have a nonlocal positive Schur response after
+> auxiliary fields are integrated out. Search for a finite-range positive
+> dilation, constrained local carrier, coherent complex-amplitude instrument,
+> or strict-neighbor compiler whose effective conditional is `C_a`. Such a
+> construction would preserve equation (7), satisfy the Admissibility locality
+> clause at the microscopic level, and make the present range table an
+> effective-action observation rather than a physical obstruction.
+
+This steelman is correct. It is the next campaign target. The endpoint negative
+is therefore not widened to new precisions, coherent sources, or dilations.
+
+### N8 — Cross-Cycle Echo
+
+The mandated negative-phrase search matched 53 files under `docs/`. All 159
+`NO_GO_LEDGER.md` files under `.claude/science/physics-loops/` were readable
+and walked; 51 matched the semantic readout/marginal/conditional/formation/
+joint-law scan and 109 matched the lifecycle scan for retirement, reframing,
+ratification, convention, supersession, or closure.
+
+| Earlier surface | Lifecycle / retirement status | Movement mechanism | Applicability here |
+|---|---|---|---|
+| Block 174 readout family | readout selection remains open; positive family and screened locality survive | construct and compare explicit positive completions | applied: the product sector relates two arms but does not uniquely select its spectator |
+| Block 175 pincer | select-or-relate handoff partially closes here | one product-event probability supplies both conditional objects | applied: algebraic relation succeeds with the new marginal |
+| Block 41 Schur bridge | joint ensemble and Record-event realization were open | determinant compensation plus an alternative sum | applied directly; existence closes while locality/refinement prices emerge |
+| [`staggered-Dirac labeling wall`](STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md) | naming obligation is convention-clearable; physical derivation remains separate | honest label convention | not sufficient: a name cannot repair the nonzero total-probability or locality residuals |
+| [`observable-principle structural reframe`](OBSERVABLE_PRINCIPLE_P1_BRIDGE_STRUCTURAL_REFRAMING_NARROW_NOTE_2026-05-21.md) | physical-selection wall was not retired by rewording it as a convention | identification merely relocates the load-bearing choice | directly applicable warning: calling equation (7) the Record Law would not derive `W_R` |
+
+No searched convention-only retirement mechanism closes the current numeric or
+support residual. The live movement mechanism is constructive local dilation.
+
+**Gate disposition:** PASS for the eight-endpoint convex statement and the
+named `W_J/W_L/W_R` boundary. FAIL / DO NOT SHIP for a universal incompatibility,
+local-dilation no-go, axiom necessity, physical Law selection, retained TOE
+closure, or score movement.
+
+## Axiom-Decision Surface
+
+The result does not justify changing the Minimal Axioms. In particular, the
+Admissibility clause already says the probability distribution is determined
+by nearest-neighbor conditions while explicitly leaving its form and values to
+downstream physics. This campaign has found candidate downstream physics and
+then measured that its present positive effective precision is not exactly
+nearest-neighbor.
+
+A future downstream-Law candidate, not adopted here, would need to state:
+
+> The alternatives at a forming site carry one representation-invariant
+> additive base measure. Before normalization they index disjoint positive
+> action sectors. One specified sector completion and normalized local source
+> generate the joint alternative/effect grade; one microscopic
+> nearest-neighbor realization then maps the selected mark to a permanent
+> Record by an outcome-blind clock/write process.
+
+The present block supplies the finite sector algebra but not the emphasized
+physical choices or microscopic locality. Updating the axiom now would hide
+those missing derivations rather than solve them.
+
+## Recommended Successor Decision
+
+The next block should try exactly one local-positive pincer:
+
+1. a finite-range positive auxiliary-field dilation whose effective response
+   is `K_W^-1` while the complete partition retains `|det q|^-2`;
+2. failing that, a strict-nearest-neighbor compiler that derives the same
+   `P(a,j)` from local carrier data without importing a global inverse;
+3. if both fail at their explicit scope, stop the pincer after the panel's
+   two-block kill switch and present the owner with the genuine choice:
+   screened effective joint Law, local modulus response, or an independently
+   selected Record instrument.
+
+Gravity, gauge, and Lorentz work should not displace this one-block attempt:
+none currently sits one constructive locality bridge from a joint probability
+and Record interface.
+
+## Verification
+
+Run:
+
+```text
+python3 scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py
+python3 scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py
+```
+
+The primary runner executes the four positive sectors, determinant
+compensation, four-level normalized sources, sixteen-event joint law, coarse
+refinement, identity-source control, duplicate-label and additive splits,
+fixed-default residual, exposed endpoint, decoupled control, spectator
+nonuniqueness, five-cover support ladder, matched-blanket gaps, and zero-mass
+edge. The independent runner imports Block 174 directly, rebuilds the matrices
+with a different inverse route, uses a different refinement split and
+spectator congruence, and samples three covers independently.
+
+## Imports And Claim Boundary
+
+| Input | Role | Standing here |
+|---|---|---|
+| Minimal Axioms | ontology, nearest-neighbor probability clause, and Record semantic boundary | supplied; unchanged |
+| Block 174/175 fixture | exact complex action, pins, menu, and pincer handoff | load-bearing unaudited parent chain |
+| Block 41 | positive W precision, two completions, fixed-default typing | load-bearing unaudited direct parent |
+| positive Gaussian, determinant, derivative, finite probability and convexity algebra | mathematical engine | proved or independently reconstructed here |
+| disjoint four-sector sum with one copy per menu atom | new downstream construction | executed; not registered or selected physically |
+| additive alternative base measure under arbitrary refinements | representation-invariance input | absent/open beyond the executed finite menu |
+| local positive dilation / strict-neighbor compiler | next physical realization | absent/open |
+| source-to-Record event, clock, and write | physical selection and process | absent/open |
+| axiom, premise registry, audit ledger, or effective status | governance | unchanged |
+
+## Decision
+
+**SHIP** the bounded positive construction: `K_W,a direct-sum S_a`, with the
+imposed inverse-trace identity calibration computed from each arm, gives one
+exact positive pin-faithful joint grade whose arm law is the determinant
+formation conditional and whose conditionals are the pinned W9 trace responses.
+
+**SHIP** the exact interpretation cut: its true outcome marginal is (8), not
+the fixed-default density; among the eight executed endpoint states, retaining
+the old density forces a pin-decoupled default response.
+
+**SHIP** the measured price: additive base-measure shares are required under
+equivalent refinements, determinant compensation does not uniquely select a
+spectator, the measured `K_W` radius grows to half-cover on all five tested
+default-carrier covers, and the determinant/W-sector alternative laws are not
+exactly blanket-local on the matched twin. No all-cover bound is decided.
+
+**DO NOT SHIP** a physical Law selection, universal no-go, local-dilation
+obstruction, axiom change, Record process, retained result, obligation
+retirement, or TOE-score movement. The next attack is one local positive
+dilation/strict-neighbor campaign.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16114,
- "node_count": 5605,
+ "edge_count": 16120,
+ "node_count": 5606,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -573,6 +573,10 @@
   "admissibility_dirac_kahler_paired_floor_refutation_mixed_circle_bounded_theorem_note_2026-08-15": {
    "deps_hash": "26cdf7e4282e",
    "out_degree": 4
+  },
+  "admissibility_dirac_kahler_pin_faithful_joint_sector_action_bounded_theorem_note_2026-08-23": {
+   "deps_hash": "7ef2a768d071",
+   "out_degree": 6
   },
   "admissibility_dirac_kahler_pincer_identity_cross_lane_bounded_theorem_note_2026-08-22": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py
+runner_sha256: 48fc5960ce548c476b0afa54df7c3d4351c25dc4cef1edc189de23571f070317
+input_fingerprint_sha256: e19889de5034e2a721903ad6f9b69a460db10b663525ee66bffcb4c05116c43e
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 49.11
+status: ok
+----- stdout -----
+PASS positive-joint-sector-completion: every K_W(a) direct-summed with S(a) is an exact positive two-field Gaussian sector
+PASS determinant-compensation-identity: det(K_W(a)) det(S(a))=|det q(a)|^2, so the positive product sector has the determinant formation weight
+PASS formation-law-from-one-positive-partition: the four alternative-sector masses reproduce the parent |det q_a|^-2 law without fitted pin weights
+PASS normalized-source-conditionals: the imposed per-arm identity calibration 1/Tr(W_RR), computed from the action, makes each sector source derivative equal its W9 trace conditional at all four free levels
+PASS joint-normalization-and-total-probability: P(a,j)=p_det(a) Tr(C_a E_j) is positive, normalized, and obeys ordinary marginalization exactly
+PASS coarse-event-refinement-additivity: coarse alternative cells and union effects inherit their joint probabilities by exact finite addition
+PASS branch-source-normalization-is-load-bearing: without the per-arm 1/Tr(W_RR) scale an outcome-blind source reweights the formation law, while identity certainty fixes that scalar uniquely
+PASS alternative-base-measure-refinement-price: uniform duplicate-label counting changes the law; representation-preserving refinement needs additive base-measure shares
+PASS true-joint-marginal-retypes-fixed-default: the pin-faithful joint marginal is new and differs exactly from the fixed sigma=3/5 W9 density
+PASS default-density-exposed-endpoint: one proper effect exposes the default W endpoint from the convex hull of all eight W and modulus conditional states
+PASS only-endpoint-preserving-route-is-decoupled: retaining the old density with positive endpoint responses forces every pin to use the same default response and abandons pin faithfulness
+PASS spectator-determinant-does-not-select-unique-kernel: determinant compensation fixes det(H)=det(S) but not the positive spectator H; choosing the existing S remains downstream content
+PASS uniform-temporal-locality-tradeoff: on the default-carrier ladder q and S stay temporal range one and K_mod range two, while K_W reaches half-cover
+PASS matched-blanket-finite-locality-failure: both determinant and W-sector alternative laws differ exactly at a matched-nearest-neighbor twin fixture
+PASS zero-mass-domain-separation: at m=0 the W/S product sector stops because S=0, while the local modulus completion remains positive
+PASS source-contract-and-input-closure: the bounded note and every declared action, parent, and axiom input exist with the no-score boundary explicit
+per_element: every alternative-effect atom, normalized sector source, endpoint exposure, and refinement coefficient is checked exactly
+per_site: four hard pins, four free response slices, the fixed-default cell, and a matched-blanket twin pair are checked
+per_mode: full positive K_W/S and K_mod sectors, determinant compensation, source blocks, and temporal supports are checked
+per_block: four baseline joint sectors and five default-carrier cover extents separate the algebraic construction from uniform locality
+lattice_wide: checked and not executed — no homogeneous nearest-neighbor Record history or physical sector selector is constructed
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py
+runner_sha256: eb71ff15d625d46857044843d7b6997e0b5bb3a9139aa90d300afb6e5958ca38
+input_fingerprint_sha256: 729d6309fa9622dffc19b10d276e544558544ca60fa50518f1c863cd70f6ae3c
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 12.34
+status: ok
+----- stdout -----
+PASS independent-positive-product-sectors: four independently inverted W kernels give the same positive q^dagger S^-1 q precision beside positive S
+PASS independent-determinant-cancellation: the product-sector determinant independently reduces to |det q_a|^2 at every hard pin
+PASS independent-joint-law: the independently rebuilt P(a,j) is positive, normalized, and has the determinant arm marginal
+PASS independent-source-normalization-price: the unnormalized source shifts the arm law, while the inverse-trace scalar restores identity certainty sector by sector
+PASS independent-base-measure-refinement: a second split ratio independently confirms that only additive base-measure refinement preserves the law
+PASS independent-fixed-default-separation: the true total-probability marginal independently differs from the default-pin density in all four entries
+PASS independent-endpoint-exposure: the independently reconstructed proper effect exposes only the default W state among eight positive endpoint states
+PASS independent-spectator-nonuniqueness: a second unit-determinant congruence gives a distinct positive compensator with the same partition factor
+PASS independent-cover-range-tradeoff: three independently rebuilt default-carrier covers keep native actions bounded-range while K_W reaches half-cover
+PASS independent-zero-mass-edge: the W/S product stops at zero mass while the local modulus completion remains exact and positive
+PASS independent-input-closure: the checker reads only the final note, Minimal Axioms, and its direct Block 174 action fixture
+per_element: independent alternative-effect atoms, source scales, endpoint witnesses, and refinement shares are reconstructed
+per_site: four hard pins, one response slice, the fixed-default profile, and one different exact split ratio are checked
+per_mode: full 24-mode positive product sectors, modulus controls, determinant factors, and source covariances are checked
+per_block: four baseline sectors and three independently rebuilt default-carrier cover extents certify the range tradeoff
+lattice_wide: checked and not executed — no physical alternative base measure, nearest-neighbor law, or Record process is selected
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py
+++ b/scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_2026_08_23.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Exact joint-sector attack on the pincer marginal/conditional split.
+
+For each hard-pin alternative a, the runner combines the Block 41 W9
+precision K_W(a) with the positive Hermitian action S(a).  Their determinant
+factors cancel, so the disjoint-sector partition has the parent
+|det q(a)|^-2 formation weights while a normalized source in the K_W sector
+has the pinned W9 trace response.  The runner also measures the exact prices:
+the true outcome marginal is not the fixed-default density, counting
+measure is not invariant under a duplicate-label refinement, the positive
+spectator is not determinant-unique, and the K_W temporal range grows with
+the cover even though q, S, and q^dagger q remain bounded-range.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sympy as sp
+
+import admissibility_dirac_kahler_schur_record_response_bridge_2026_08_23 as b41
+
+
+b175 = b41.b175
+b174 = b41.b174
+R = sp.Rational
+ZERO = sp.Integer(0)
+ONE = sp.Integer(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_PIN_FAITHFUL_JOINT_SECTOR_ACTION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+AUDIT_TIMEOUT_SEC = 240
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_PIN_FAITHFUL_JOINT_SECTOR_ACTION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SCHUR_RECORD_RESPONSE_BRIDGE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "scripts/admissibility_dirac_kahler_schur_record_response_bridge_"
+    "2026_08_23.py",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_PINCER_IDENTITY_CROSS_LANE_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+    "scripts/admissibility_dirac_kahler_pincer_identity_cross_lane_"
+    "2026_08_22.py",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+    "scripts/admissibility_dirac_kahler_site_conditional_law_family_"
+    "2026_08_22.py",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(values: tuple) -> tuple:
+    total = sp.cancel(sum(values, ZERO))
+    return tuple(sp.cancel(value / total) for value in values)
+
+
+def matrix_zero(value: sp.Matrix) -> bool:
+    return all(sp.expand(entry) == 0 for entry in value)
+
+
+def matrix_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return left.shape == right.shape and matrix_zero(sp.expand(left - right))
+
+
+def arm_data(fixture: object, value, rows: tuple[int, ...]) -> dict:
+    q = fixture.q({b175.RECORD_CELL: value})
+    w = b41.positive_completion(q)
+    modulus = b41.modulus_completion(q, w["q_inv"])
+    det_q = b174.dm_det(q)
+    det_s = b174.dm_det(w["symmetric"])
+    det_kw = b174.dm_det(w["precision"])
+    w_block = w["covariance"].extract(rows, rows)
+    m_block = modulus["covariance"].extract(rows, rows)
+    trace_w = sp.cancel(sp.trace(w_block))
+    trace_m = sp.cancel(sp.trace(m_block))
+    return {
+        "value": value,
+        "q": q,
+        "S": w["symmetric"],
+        "KW": w["precision"],
+        "W": w["covariance"],
+        "KM": modulus["precision"],
+        "V": modulus["covariance"],
+        "det_q": det_q,
+        "det_s": det_s,
+        "det_kw": det_kw,
+        "z_joint": sp.cancel(ONE / (det_kw * det_s)),
+        "z_mod": sp.cancel(ONE / b174.norm2(det_q)),
+        "z_w": sp.cancel(det_s / b174.norm2(det_q)),
+        "block_w": w_block,
+        "block_m": m_block,
+        "trace_w": trace_w,
+        "trace_m": trace_m,
+        "rho_w": sp.expand(w_block / trace_w),
+        "rho_m": sp.expand(m_block / trace_m),
+    }
+
+
+def temporal_range(matrix: sp.Matrix, fixture: object) -> int:
+    distances = []
+    for row in range(matrix.rows):
+        t_row = row // fixture.lx
+        for column in range(matrix.cols):
+            if matrix[row, column] == 0:
+                continue
+            t_column = column // fixture.lx
+            distances.append(
+                min(
+                    (t_row - t_column) % fixture.T,
+                    (t_column - t_row) % fixture.T,
+                )
+            )
+    return max(distances)
+
+
+def source_derivative(block: sp.Matrix, effect: sp.Matrix):
+    """Derivative of the normalized determinant-lemma source ratio."""
+    source = sp.symbols("source", real=True)
+    scale = sp.cancel(ONE / sp.trace(block))
+    ratio = sp.cancel(
+        ONE / (sp.eye(block.rows) - source * scale * block * effect).det()
+    )
+    return sp.cancel(sp.diff(ratio, source).subs(source, ZERO))
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    fixture = b174.Fixture(b175.LX, tag="b177-joint")
+    rows = b41.slice_rows(fixture, fixture.tstar)
+    arms = tuple(arm_data(fixture, value, rows) for value in b175.MENU)
+
+    check(
+        "positive-joint-sector-completion",
+        all(
+            b174.ldl_certificate(arm["S"])["pd"]
+            and b174.ldl_certificate(arm["KW"])["pd"]
+            for arm in arms
+        ),
+        "every K_W(a) direct-summed with S(a) is an exact positive two-field Gaussian sector",
+    )
+
+    check(
+        "determinant-compensation-identity",
+        all(
+            sp.cancel(
+                arm["det_kw"] * arm["det_s"]
+                - b174.norm2(arm["det_q"])
+            )
+            == 0
+            and sp.cancel(arm["z_joint"] - arm["z_mod"]) == 0
+            for arm in arms
+        ),
+        "det(K_W(a)) det(S(a))=|det q(a)|^2, so the positive product sector has the determinant formation weight",
+    )
+
+    p_joint = normalize(tuple(arm["z_joint"] for arm in arms))
+    p_det = normalize(tuple(arm["z_mod"] for arm in arms))
+    p_w = normalize(tuple(arm["z_w"] for arm in arms))
+    check(
+        "formation-law-from-one-positive-partition",
+        p_joint == p_det
+        and all(value > 0 for value in p_joint)
+        and p_joint != p_w,
+        "the four alternative-sector masses reproduce the parent |det q_a|^-2 law without fitted pin weights",
+    )
+
+    all_level_source_ok = True
+    for level in fixture.free_levels:
+        level_rows = b41.slice_rows(fixture, level)
+        level_arms = tuple(
+            arm_data(fixture, value, level_rows) for value in b175.MENU
+        )
+        for arm in level_arms:
+            for slot in range(fixture.lx):
+                effect = b41.basis_projector(slot, fixture.lx)
+                derivative = source_derivative(arm["block_w"], effect)
+                all_level_source_ok = all_level_source_ok and (
+                    derivative == arm["rho_w"][slot, slot]
+                )
+    check(
+        "normalized-source-conditionals",
+        all_level_source_ok,
+        "the imposed per-arm identity calibration 1/Tr(W_RR), computed from the action, makes each sector source derivative equal its W9 trace conditional at all four free levels",
+    )
+
+    event = sp.Matrix(
+        [
+            [p_joint[a] * arms[a]["rho_w"][slot, slot] for slot in range(4)]
+            for a in range(4)
+        ]
+    )
+    marginal = sp.diag(*(sum(event[a, slot] for a in range(4)) for slot in range(4)))
+    expected_marginal = sp.expand(
+        sum(
+            (p_joint[a] * arms[a]["rho_w"] for a in range(4)),
+            sp.zeros(4),
+        )
+    )
+    check(
+        "joint-normalization-and-total-probability",
+        all(event[a, slot] > 0 for a in range(4) for slot in range(4))
+        and sp.cancel(sum(event, ZERO)) == ONE
+        and all(
+            sp.cancel(sum(event[a, slot] for slot in range(4)) - p_joint[a])
+            == 0
+            for a in range(4)
+        )
+        and matrix_equal(marginal, expected_marginal),
+        "P(a,j)=p_det(a) Tr(C_a E_j) is positive, normalized, and obeys ordinary marginalization exactly",
+    )
+
+    alternative_parts = ((0, 1), (2, 3))
+    effect_parts = ((0, 2), (1, 3))
+    refinement_ok = True
+    for a_part in alternative_parts:
+        for e_part in effect_parts:
+            direct = sum(event[a, j] for a in a_part for j in e_part)
+            separate = sum(
+                p_joint[a]
+                * sp.trace(
+                    arms[a]["rho_w"]
+                    * sum(
+                        (b41.basis_projector(j, 4) for j in e_part),
+                        sp.zeros(4),
+                    )
+                )
+                for a in a_part
+            )
+            refinement_ok = refinement_ok and sp.cancel(direct - separate) == 0
+    check(
+        "coarse-event-refinement-additivity",
+        refinement_ok,
+        "coarse alternative cells and union effects inherit their joint probabilities by exact finite addition",
+    )
+
+    traces = tuple(arm["trace_w"] for arm in arms)
+    source_weights = normalize(
+        tuple(p_joint[a] * traces[a] for a in range(4))
+    )
+    identity_source_density = sp.expand(
+        sum(
+            (source_weights[a] * arms[a]["rho_w"] for a in range(4)),
+            sp.zeros(4),
+        )
+    )
+    check(
+        "branch-source-normalization-is-load-bearing",
+        len(set(traces)) == 4
+        and source_weights != p_joint
+        and not matrix_equal(identity_source_density, expected_marginal)
+        and all(sp.cancel((ONE / traces[a]) * traces[a] - ONE) == 0 for a in range(4)),
+        "without the per-arm 1/Tr(W_RR) scale an outcome-blind source reweights the formation law, while identity certainty fixes that scalar uniquely",
+    )
+
+    z_values = tuple(arm["z_joint"] for arm in arms)
+    duplicated = normalize((z_values[0], z_values[0], *z_values[1:]))
+    split = R(2, 5)
+    refined = normalize(
+        (split * z_values[0], (ONE - split) * z_values[0], *z_values[1:])
+    )
+    check(
+        "alternative-base-measure-refinement-price",
+        sp.cancel(duplicated[0] + duplicated[1] - p_joint[0]) != 0
+        and sp.cancel(refined[0] + refined[1] - p_joint[0]) == 0
+        and tuple(refined[index + 1] for index in range(1, 4)) == p_joint[1:],
+        "uniform duplicate-label counting changes the law; representation-preserving refinement needs additive base-measure shares",
+    )
+
+    q_unpinned = fixture.q({})
+    default_completion = b41.positive_completion(q_unpinned)
+    default_density = b41.normalized_block(default_completion["covariance"], rows)
+    fixed_residual = sp.expand(default_density - expected_marginal)
+    check(
+        "true-joint-marginal-retypes-fixed-default",
+        matrix_equal(default_density, arms[-1]["rho_w"])
+        and not matrix_zero(fixed_residual)
+        and tuple(sp.sign(fixed_residual[j, j]) for j in range(4))
+        == (1, -1, -1, 1),
+        "the pin-faithful joint marginal is new and differs exactly from the fixed sigma=3/5 W9 density",
+    )
+
+    exposing_effect = sp.diag(ZERO, R(4, 7), R(3, 7), ZERO)
+    w_exposure = tuple(
+        sp.sign(sp.factor(sp.trace((arm["rho_w"] - default_density) * exposing_effect)))
+        for arm in arms
+    )
+    m_exposure = tuple(
+        sp.sign(sp.factor(sp.trace((arm["rho_m"] - default_density) * exposing_effect)))
+        for arm in arms
+    )
+    check(
+        "default-density-exposed-endpoint",
+        w_exposure == (1, 1, 1, 0) and m_exposure == (1, 1, 1, 1),
+        "one proper effect exposes the default W endpoint from the convex hull of all eight W and modulus conditional states",
+    )
+
+    decoupled_event = sp.Matrix(
+        [
+            [p_joint[a] * default_density[j, j] for j in range(4)]
+            for a in range(4)
+        ]
+    )
+    check(
+        "only-endpoint-preserving-route-is-decoupled",
+        sp.cancel(sum(decoupled_event, ZERO)) == ONE
+        and all(
+            sp.cancel(sum(decoupled_event[a, j] for j in range(4)) - p_joint[a])
+            == 0
+            for a in range(4)
+        )
+        and any(not matrix_equal(arms[a]["rho_w"], default_density) for a in range(3)),
+        "retaining the old density with positive endpoint responses forces every pin to use the same default response and abandons pin faithfulness",
+    )
+
+    base_s = arms[-1]["S"]
+    congruence = sp.eye(fixture.N)
+    congruence[0, 0] = 2
+    congruence[1, 1] = R(1, 2)
+    alternate_spectator = sp.expand(congruence.H * base_s * congruence)
+    check(
+        "spectator-determinant-does-not-select-unique-kernel",
+        b174.ldl_certificate(alternate_spectator)["pd"]
+        and b174.dm_det(alternate_spectator) == b174.dm_det(base_s)
+        and not matrix_equal(alternate_spectator, base_s),
+        "determinant compensation fixes det(H)=det(S) but not the positive spectator H; choosing the existing S remains downstream content",
+    )
+
+    cover_values = (8, 12, 16, 20, 24)
+    locality_rows = []
+    for cover in cover_values:
+        cover_fixture = b174.Fixture(4, tag=f"b177-cover-{cover}", cover_t=cover)
+        cover_q = cover_fixture.q({})
+        cover_w = b41.positive_completion(cover_q)
+        cover_m = b41.modulus_completion(cover_q, cover_w["q_inv"])
+        locality_rows.append(
+            (
+                cover_fixture.T,
+                temporal_range(cover_q, cover_fixture),
+                temporal_range(cover_w["symmetric"], cover_fixture),
+                temporal_range(cover_m["precision"], cover_fixture),
+                temporal_range(cover_w["precision"], cover_fixture),
+            )
+        )
+    check(
+        "uniform-temporal-locality-tradeoff",
+        tuple(row[0] for row in locality_rows) == (4, 6, 8, 10, 12)
+        and tuple(row[1] for row in locality_rows) == (1, 1, 1, 1, 1)
+        and tuple(row[2] for row in locality_rows) == (1, 1, 1, 1, 1)
+        and tuple(row[3] for row in locality_rows) == (2, 2, 2, 2, 2)
+        and tuple(row[4] for row in locality_rows) == (2, 3, 4, 5, 6),
+        "on the default-carrier ladder q and S stay temporal range one and K_mod range two, while K_W reaches half-cover",
+    )
+
+    twin_pattern = b174.twin_pattern(8)
+    twin_fixture = b174.Fixture(8, pattern=twin_pattern, tag="b177-twin")
+    twin_left_states = b174.menu_states(twin_fixture, b174.RECORD_LEVEL, 0)
+    twin_right_states = b174.menu_states(twin_fixture, b174.RECORD_LEVEL, 4)
+    twin_det_left = b174.readout_laws(twin_left_states)["sq"]["law"]
+    twin_det_right = b174.readout_laws(twin_right_states)["sq"]["law"]
+    twin_w_left = normalize(
+        tuple(sp.cancel(state["cert"]["det"] / state["n2"]) for state in twin_left_states)
+    )
+    twin_w_right = normalize(
+        tuple(sp.cancel(state["cert"]["det"] / state["n2"]) for state in twin_right_states)
+    )
+    det_gap = max(
+        sp.Abs(sp.cancel(left - right))
+        for left, right in zip(twin_det_left, twin_det_right)
+    )
+    w_gap = max(
+        sp.Abs(sp.cancel(left - right))
+        for left, right in zip(twin_w_left, twin_w_right)
+    )
+    check(
+        "matched-blanket-finite-locality-failure",
+        b174.pattern_certificate(twin_pattern)["same_blanket"]
+        and R(4931, 100000000) < det_gap < R(1233, 25000000)
+        and R(209783, 10000000000) < w_gap < R(26223, 1250000000),
+        "both determinant and W-sector alternative laws differ exactly at a matched-nearest-neighbor twin fixture",
+    )
+
+    zero_q = fixture.q({}, mass=ZERO)
+    zero_modulus = b41.modulus_completion(zero_q)
+    check(
+        "zero-mass-domain-separation",
+        matrix_zero(b175.herm(zero_q))
+        and b174.dm_det(zero_q) != 0
+        and b174.ldl_certificate(zero_modulus["precision"])["pd"],
+        "at m=0 the W/S product sector stops because S=0, while the local modulus completion remains positive",
+    )
+
+    check(
+        "source-contract-and-input-closure",
+        NOTE.exists()
+        and all((ROOT / path).exists() for path in AUDIT_INPUT_PATHS)
+        and "zero TOE-percentage movement" in NOTE.read_text(encoding="utf-8"),
+        "the bounded note and every declared action, parent, and axiom input exist with the no-score boundary explicit",
+    )
+
+    print("per_element: every alternative-effect atom, normalized sector source, endpoint exposure, and refinement coefficient is checked exactly")
+    print("per_site: four hard pins, four free response slices, the fixed-default cell, and a matched-blanket twin pair are checked")
+    print("per_mode: full positive K_W/S and K_mod sectors, determinant compensation, source blocks, and temporal supports are checked")
+    print("per_block: four baseline joint sectors and five default-carrier cover extents separate the algebraic construction from uniform locality")
+    print("lattice_wide: checked and not executed — no homogeneous nearest-neighbor Record history or physical sector selector is constructed")
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return failed
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py
+++ b/scripts/admissibility_dirac_kahler_pin_faithful_joint_sector_action_independent_check_2026_08_23.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Independent exact reconstruction of the pin-faithful joint sector.
+
+This checker imports the Block 174 action fixture directly.  It does not
+import the Block 42 primary runner, Block 41, or Block 175.  SymPy DomainMatrix
+inverses rebuild the two positive completions, determinant compensation,
+normalized joint source law, exposed-endpoint result, refinement price, and
+cover-range tradeoff by a separate route.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sympy as sp
+
+import admissibility_dirac_kahler_site_conditional_law_family_2026_08_22 as b174
+
+
+R = sp.Rational
+ZERO = sp.Integer(0)
+ONE = sp.Integer(1)
+MENU = b174.MENU
+RECORD_CELL = (b174.RECORD_LEVEL, 0)
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / "docs" / (
+    "ADMISSIBILITY_DIRAC_KAHLER_PIN_FAITHFUL_JOINT_SECTOR_ACTION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+AUDIT_TIMEOUT_SEC = 240
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_PIN_FAITHFUL_JOINT_SECTOR_ACTION_"
+    "BOUNDED_THEOREM_NOTE_2026-08-23.md",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_SITE_CONDITIONAL_LAW_FAMILY_"
+    "BOUNDED_THEOREM_NOTE_2026-08-22.md",
+    "scripts/admissibility_dirac_kahler_site_conditional_law_family_"
+    "2026_08_22.py",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def inverse(matrix: sp.Matrix) -> sp.Matrix:
+    return matrix.inv(method="DM")
+
+
+def hermitian(matrix: sp.Matrix) -> sp.Matrix:
+    return sp.expand((matrix + matrix.H) / 2)
+
+
+def matrix_equal(left: sp.Matrix, right: sp.Matrix) -> bool:
+    return left.shape == right.shape and all(
+        sp.expand(value) == 0 for value in sp.expand(left - right)
+    )
+
+
+def normalize(values: tuple) -> tuple:
+    total = sp.cancel(sum(values, ZERO))
+    return tuple(sp.cancel(value / total) for value in values)
+
+
+def rows_for(fixture: object, level: int) -> tuple[int, ...]:
+    return tuple(fixture.lx * (level % fixture.T) + x for x in range(fixture.lx))
+
+
+def rebuild_arm(fixture: object, value, rows: tuple[int, ...]) -> dict:
+    q = fixture.q({RECORD_CELL: value})
+    q_inv = inverse(q)
+    symmetric = hermitian(q)
+    covariance_w = hermitian(q_inv)
+    precision_w = inverse(covariance_w)
+    covariance_m = sp.expand(q_inv * q_inv.H)
+    precision_m = sp.expand(q.H * q)
+    block_w = covariance_w.extract(rows, rows)
+    block_m = covariance_m.extract(rows, rows)
+    det_q = b174.dm_det(q)
+    det_s = b174.dm_det(symmetric)
+    det_kw = b174.dm_det(precision_w)
+    return {
+        "q": q,
+        "S": symmetric,
+        "W": covariance_w,
+        "KW": precision_w,
+        "KW_factored": sp.expand(q.H * inverse(symmetric) * q),
+        "KM": precision_m,
+        "V": covariance_m,
+        "rho_w": sp.expand(block_w / sp.trace(block_w)),
+        "rho_m": sp.expand(block_m / sp.trace(block_m)),
+        "trace_w": sp.cancel(sp.trace(block_w)),
+        "det_q": det_q,
+        "det_s": det_s,
+        "det_kw": det_kw,
+        "z_joint": sp.cancel(ONE / (det_kw * det_s)),
+        "z_det": sp.cancel(ONE / b174.norm2(det_q)),
+    }
+
+
+def temporal_range(matrix: sp.Matrix, fixture: object) -> int:
+    result = ZERO
+    for row in range(matrix.rows):
+        t_row = row // fixture.lx
+        for column in range(matrix.cols):
+            if matrix[row, column] == 0:
+                continue
+            t_column = column // fixture.lx
+            result = max(
+                result,
+                min(
+                    (t_row - t_column) % fixture.T,
+                    (t_column - t_row) % fixture.T,
+                ),
+            )
+    return int(result)
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str) -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"PASS {name}: {detail}")
+        else:
+            failed += 1
+            print(f"FAIL {name}: {detail}")
+
+    fixture = b174.Fixture(4, tag="b177-independent")
+    rows = rows_for(fixture, fixture.tstar)
+    arms = tuple(rebuild_arm(fixture, value, rows) for value in MENU)
+
+    check(
+        "independent-positive-product-sectors",
+        all(
+            b174.ldl_certificate(arm["S"])["pd"]
+            and b174.ldl_certificate(arm["KW"])["pd"]
+            and matrix_equal(arm["KW"], arm["KW_factored"])
+            for arm in arms
+        ),
+        "four independently inverted W kernels give the same positive q^dagger S^-1 q precision beside positive S",
+    )
+
+    check(
+        "independent-determinant-cancellation",
+        all(
+            sp.cancel(
+                arm["det_kw"] * arm["det_s"]
+                - b174.norm2(arm["det_q"])
+            )
+            == 0
+            and arm["z_joint"] == arm["z_det"]
+            for arm in arms
+        ),
+        "the product-sector determinant independently reduces to |det q_a|^2 at every hard pin",
+    )
+
+    probabilities = normalize(tuple(arm["z_joint"] for arm in arms))
+    event = sp.Matrix(
+        [
+            [probabilities[a] * arms[a]["rho_w"][j, j] for j in range(4)]
+            for a in range(4)
+        ]
+    )
+    marginal = sp.diag(*(sum(event[a, j] for a in range(4)) for j in range(4)))
+    check(
+        "independent-joint-law",
+        all(event[a, j] > 0 for a in range(4) for j in range(4))
+        and sp.cancel(sum(event, ZERO)) == ONE
+        and all(
+            sp.cancel(sum(event[a, j] for j in range(4)) - probabilities[a])
+            == 0
+            for a in range(4)
+        ),
+        "the independently rebuilt P(a,j) is positive, normalized, and has the determinant arm marginal",
+    )
+
+    traces = tuple(arm["trace_w"] for arm in arms)
+    shifted = normalize(tuple(probabilities[a] * traces[a] for a in range(4)))
+    check(
+        "independent-source-normalization-price",
+        len(set(traces)) == 4
+        and shifted != probabilities
+        and all(
+            sp.cancel((ONE / traces[a]) * traces[a] - ONE) == 0
+            for a in range(4)
+        ),
+        "the unnormalized source shifts the arm law, while the inverse-trace scalar restores identity certainty sector by sector",
+    )
+
+    z_values = tuple(arm["z_joint"] for arm in arms)
+    duplicate = normalize((z_values[0], z_values[0], *z_values[1:]))
+    split = R(3, 7)
+    additive = normalize(
+        (split * z_values[0], (ONE - split) * z_values[0], *z_values[1:])
+    )
+    check(
+        "independent-base-measure-refinement",
+        sp.cancel(duplicate[0] + duplicate[1] - probabilities[0]) != 0
+        and sp.cancel(additive[0] + additive[1] - probabilities[0]) == 0,
+        "a second split ratio independently confirms that only additive base-measure refinement preserves the law",
+    )
+
+    default_q = fixture.q({})
+    default_w = hermitian(inverse(default_q))
+    default_block = default_w.extract(rows, rows)
+    default_density = sp.expand(default_block / sp.trace(default_block))
+    residual = sp.expand(default_density - marginal)
+    check(
+        "independent-fixed-default-separation",
+        matrix_equal(default_density, arms[-1]["rho_w"])
+        and tuple(sp.sign(residual[j, j]) for j in range(4))
+        == (1, -1, -1, 1),
+        "the true total-probability marginal independently differs from the default-pin density in all four entries",
+    )
+
+    exposing_effect = sp.diag(ZERO, R(4, 7), R(3, 7), ZERO)
+    w_signs = tuple(
+        sp.sign(sp.factor(sp.trace((arm["rho_w"] - default_density) * exposing_effect)))
+        for arm in arms
+    )
+    m_signs = tuple(
+        sp.sign(sp.factor(sp.trace((arm["rho_m"] - default_density) * exposing_effect)))
+        for arm in arms
+    )
+    check(
+        "independent-endpoint-exposure",
+        w_signs == (1, 1, 1, 0) and m_signs == (1, 1, 1, 1),
+        "the independently reconstructed proper effect exposes only the default W state among eight positive endpoint states",
+    )
+
+    transform = sp.eye(fixture.N)
+    transform[0, 0] = 3
+    transform[1, 1] = R(1, 3)
+    spectator = sp.expand(transform.H * arms[-1]["S"] * transform)
+    check(
+        "independent-spectator-nonuniqueness",
+        b174.ldl_certificate(spectator)["pd"]
+        and b174.dm_det(spectator) == arms[-1]["det_s"]
+        and not matrix_equal(spectator, arms[-1]["S"]),
+        "a second unit-determinant congruence gives a distinct positive compensator with the same partition factor",
+    )
+
+    cover_rows = []
+    for cover in (8, 16, 24):
+        cover_fixture = b174.Fixture(4, tag=f"b177-i-{cover}", cover_t=cover)
+        q = cover_fixture.q({})
+        q_inv = inverse(q)
+        symmetric = hermitian(q)
+        precision_w = sp.expand(q.H * inverse(symmetric) * q)
+        precision_m = sp.expand(q.H * q)
+        cover_rows.append(
+            (
+                cover_fixture.T,
+                temporal_range(q, cover_fixture),
+                temporal_range(symmetric, cover_fixture),
+                temporal_range(precision_m, cover_fixture),
+                temporal_range(precision_w, cover_fixture),
+                matrix_equal(inverse(hermitian(q_inv)), precision_w),
+            )
+        )
+    check(
+        "independent-cover-range-tradeoff",
+        tuple(row[:5] for row in cover_rows)
+        == ((4, 1, 1, 2, 2), (8, 1, 1, 2, 4), (12, 1, 1, 2, 6))
+        and all(row[5] for row in cover_rows),
+        "three independently rebuilt default-carrier covers keep native actions bounded-range while K_W reaches half-cover",
+    )
+
+    zero_q = fixture.q({}, mass=ZERO)
+    zero_s = hermitian(zero_q)
+    zero_km = sp.expand(zero_q.H * zero_q)
+    check(
+        "independent-zero-mass-edge",
+        matrix_equal(zero_s, sp.zeros(fixture.N))
+        and b174.dm_det(zero_q) != 0
+        and b174.ldl_certificate(zero_km)["pd"],
+        "the W/S product stops at zero mass while the local modulus completion remains exact and positive",
+    )
+
+    check(
+        "independent-input-closure",
+        NOTE.exists()
+        and all((ROOT / path).exists() for path in AUDIT_INPUT_PATHS)
+        and "No-Go Discipline Gate" in NOTE.read_text(encoding="utf-8"),
+        "the checker reads only the final note, Minimal Axioms, and its direct Block 174 action fixture",
+    )
+
+    print("per_element: independent alternative-effect atoms, source scales, endpoint witnesses, and refinement shares are reconstructed")
+    print("per_site: four hard pins, one response slice, the fixed-default profile, and one different exact split ratio are checked")
+    print("per_mode: full 24-mode positive product sectors, modulus controls, determinant factors, and source covariances are checked")
+    print("per_block: four baseline sectors and three independently rebuilt default-carrier cover extents certify the range tradeoff")
+    print("lattice_wide: checked and not executed — no physical alternative base measure, nearest-neighbor law, or Record process is selected")
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return failed
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

Constructs an exact positive four-sector joint object `J_a = K_W,a direct-sum Herm(q_a)`. Its partition reproduces the determinant formation weights, and an imposed per-arm identity calibration computed from the action gives the pinned W9 conditional response.

## Exact prices

- the true outcome marginal is the determinant-weighted mixture, not the old fixed-default profile;
- refinement invariance needs an additive alternative base measure;
- determinant compensation does not uniquely select the spectator;
- `K_W` reaches half-cover on five tested default-carrier extents, and matched-neighbor twins have distinct determinant/W-sector laws;
- no physical sector selection, Record clock/write process, axiom edit, retained claim, obligation retirement, or TOE-score movement is claimed.

## Verification

- primary exact runner: 16/16 PASS
- independent reconstruction: 11/11 PASS
- both caches fresh and input-bound
- staged claim typing, controlled vocabulary, changed-evidence, citation-graph, link, and repo invariant checks pass
- independent cold review: PASS