### PR TITLE
physics: block 178 — refute the rank-one-only scalar compression thesis

### DIFF
--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_RANK_TWO_SCALAR_TRANSPORT_COUNTEREXAMPLE_BOUNDED_THEOREM_NOTE_2026-08-23.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_RANK_TWO_SCALAR_TRANSPORT_COUNTEREXAMPLE_BOUNDED_THEOREM_NOTE_2026-08-23.md
@@ -1,0 +1,287 @@
+---
+claim_id: admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_bounded_theorem_note_2026-08-23
+final_path: docs/ADMISSIBILITY_DIRAC_KAHLER_RANK_TWO_SCALAR_TRANSPORT_COUNTEREXAMPLE_BOUNDED_THEOREM_NOTE_2026-08-23.md
+claim_type: bounded_theorem
+claim_scope: "on the committed Block-170 reflection-pairing form F_T(s_t) = Herm(Sel_S^T r_T Q_T(s_t) Sel_S), with Q_T = m Hq_T + Kq_T, at the two retained finite antiperiodic cover extents 8x4 and 12x4, fixed slice c = 1, region pin on the two links incident to c, sigma = s_x = 3/5 and m = 1, selecting ambient rows S = (4,5,6,7,8,9,10,11), and reading compression in the standard isometric sense X^dag F_T X. THE VERDICT: the literal Block-176 successor thesis that positive transport-sensitive scalar readouts occur exactly at rank one, with every rank >= 2 compression blind or indefinite, is FALSE on both committed fixtures. The exact rank-two isometry X = [x_0,x_2], x_0 = (4e_0+3e_4)/5 and x_2 = (4e_2+3e_6)/5, gives X^dag X = I_2 and X^dag F_T(s_t) X = (114/125 + 171 s_t/250) I_2 at both extents. It is positive definite for s_t > -4/3 and transport-sensitive with derivative 171/250; between s_t = 1/8 and 1/2 it changes by 513/2000. This is a finite-fixture exact counterexample and a route-pruning result. It does NOT select a physical readout, derive the Born rule, prove completeness of the affine effect class, exclude determinant/exterior-power or other non-affine non-convex categories, establish an infinite-volume statement, retire an axiom or obligation, justify an axiom amendment, or move a TOE percentage."
+depends_on:
+  - admissibility_dirac_kahler_conditional_symmetric_power_theorem_note_2026-08-23
+runner: scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.py
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: upstream_support
+target_claim_id: admissibility_dirac_kahler_complex_structure_synthesis_bounded_theorem_note_2026-08-23
+target_blocker_text: "PROVE OR REFUTE THE SCALAR-SECTOR THEOREM. Within the committed reflection-pairing structure, do positive AND transport-sensitive readouts exist EXACTLY at rank one -- the matrix-element level -- with every rank >= 2 compression blind-or-indefinite?"
+source_of_blocker_text: next_trace_action
+reachability_to_target: prunes
+artifact_role: theorem
+next_trace_action: "Do not continue the literal rank-one-only compression thesis. If the readout route continues, first derive and state an exhaustive presentation-invariant operational readout category; determinant or exterior-power subclasses may be tested only as bounded supplied categories. Run the already specified holomorphic interference discriminator J(a) only if its transport carrier is controlled. At portfolio level, pivot the main science budget to the Wilson-Q discriminator rather than another rank-family scan."
+conditional_surface_status: "audited_conditional expected (dependency_not_retained; Blocks 103-177 content-bound unaudited)"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the load-bearing result is an exact symbolic matrix identity reconstructed from the committed Block-170 fixture at both retained cover extents. The isometry, compressed form, determinant, positivity interval, derivative and two-point gap are exact SymPy expressions with no floating-point input. The theorem is bounded because only two finite extents, one carrier family, one selected eight-row support and the standard isometric-compression reading are tested. The generic convex-affine admixture lemma is exact linear algebra, but it does not establish that Nature's full physical readout category is affine, convex or exhausted by PSD effects."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Rank-two scalar transport counterexample — the literal rank-one-only successor dies
+
+**Date:** 2026-08-23
+
+**Runner:** `scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.py`
+
+**Independent checker:** `scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_independent_check_2026_08_23.py`
+
+**Parent:** Block 176, the complex-structure synthesis
+
+**Standing:** exact bounded counterexample; nothing registered or adopted.
+
+## Result in one paragraph
+
+Block 176 deliberately posed a kill test: if a positive, transport-sensitive
+rank-two compression exists, report it and abandon the proposed rank-one-only
+scalar theorem. It exists at both committed extents. With local basis
+`e_0,...,e_7` in the parent's selected row order, define
+
+\[
+x_0={4e_0+3e_4\over5},\qquad
+x_2={4e_2+3e_6\over5},\qquad X=[x_0,x_2].
+\]
+
+Then, exactly,
+
+\[
+X^\dagger X=I_2,
+\qquad
+X^\dagger F_T(s_t)X
+=\left({114\over125}+{171\over250}s_t\right)I_2
+\]
+
+for both `8x4` and `12x4`. This is rank two, scalar, positive definite for
+`s_t > -4/3`, and not transport-blind. At the two parent's retained transport
+values,
+
+\[
+F_X(1/8)={399\over400}I_2,
+\quad
+F_X(1/2)={627\over500}I_2,
+\quad
+{1\over2}\operatorname{tr}[F_X(1/2)-F_X(1/8)]={513\over2000}.
+\]
+
+The derivative of the half-trace is `171/250`, and
+
+\[
+\det F_X(s_t)={3249\over62500}(3s_t+4)^2.
+\]
+
+Therefore the literal successor is refuted on its own committed fixtures. This
+is useful route pruning, not TOE closure.
+
+## Relation to parallel Block 177
+
+The parallel Block 177 conditional symmetric-power theorem arrived while this
+counterexample was being packaged. The two results are compatible and are now
+stacked in that order. Block 177 proves that the **full** displayed one-particle
+kernel is indefinite and that symmetric powers inherit an indefinite minor,
+conditional on a named quasi-free grading premise. This block proves that the
+same indefinite full form contains an exact two-dimensional **positive**
+subspace whose isometric compression is transport-sensitive. An indefinite
+Hermitian form can have positive subspaces, so neither calculation overturns
+the other.
+
+The combined cut is sharper than either alone: Block 177's conditional
+sector-indefiniteness survives, while the older claim that **every** rank-two
+compression must be blind or indefinite does not. Block 177 already withdraws
+unconditional Born-readout uniqueness; this counterexample independently
+prevents that stronger wording from returning through the compression route.
+
+## Provenance and what was actually reconstructed
+
+The runner imports the landed
+`scripts/admissibility_dirac_kahler_closure_audit_two_2026_08_21.py` machinery.
+Its `Bench` constructs
+
+\[
+F_T(s_t)=\operatorname{Herm}
+\left(\mathrm{Sel}_S^\top r_T Q_T(s_t)\mathrm{Sel}_S\right),
+\qquad Q_T=mH_{q,T}+K_{q,T},
+\]
+
+after the committed region pin and carrier substitution. In both extents the
+selected ambient rows are exactly
+`S = (4,5,6,7,8,9,10,11)`, so the displayed local basis has an unambiguous
+meaning. The primary runner reconstructs the full `8x8` form before applying
+`X`; it does not insert the `2x2` answer as its input.
+
+There is a second consistency fact, and it is not promoted beyond its role.
+Block 175's declared coarse effects already include native rank-two projectors,
+for example `E_12 = diag(0,1,1,0)`, with a strictly positive trace reading on
+its exact classical density. That does not by itself prove transport
+sensitivity; it only shows that rank-two effects are not alien to the committed
+effect vocabulary.
+
+## The convex-affine obstruction
+
+The explicit fixture is stronger than a generic warning, but the warning
+explains why the failed thesis was structurally fragile. For an affine effect
+readout
+
+\[
+R_E(g)=\operatorname{Tr}[E W(g)],
+\]
+
+let `D = W(g)-W(0)`. If a rank-one effect `P` is sensitive, then
+`d = Tr(PD) != 0`. For any orthogonal positive effect `Q`,
+
+\[
+E_\epsilon=P+\epsilon Q,\qquad
+\Delta R_{E_\epsilon}=d+\epsilon\operatorname{Tr}(QD).
+\]
+
+For positive `epsilon`, `E_epsilon` has rank at least two, and its response is
+nonzero for all sufficiently small `epsilon` except at most one tuned value.
+Dividing by `Tr(E_epsilon)` does not turn a nonzero numerator into zero. Thus a
+convex PSD-effect class closed under small positive admixtures cannot make
+transport sensitivity rank-one-only.
+
+This lemma does **not** forbid non-affine or non-convex categories such as
+determinants, exterior powers or a supplied extreme-effect-only domain.
+
+## N1 — alternative-route enumeration
+
+The negative conclusion is scoped to the literal successor and, generically,
+to affine convex PSD effects. The following escape routes were examined:
+
+1. **ATTEMPTED — pure or extreme effects only.** This avoids convex admixture,
+   but selects rank one by restricting the domain; it does not classify all
+   physical readouts.
+2. **ATTEMPTED — equal-weight orthogonal projections only.** In dimension at
+   least three, blindness of every rank-two projection forces the quadratic
+   response to vanish, so some rank-two sensitivity follows from any rank-one
+   sensitivity. A two-dimensional traceless exception remains live.
+3. **ATTEMPTED — determinant or exterior-power readouts.** These genuinely
+   evade affinity. They remain a bounded route only if the nonlinear category
+   is independently derived, exhaustive and presentation-invariant.
+4. **ATTEMPTED — a superselection rule forbidding support mixtures.** This can
+   exclude `E_epsilon`, but the rule is then the missing physical premise.
+5. **ATTEMPTED — rank modulo dilation or refinement.** This could repair
+   presentation dependence, but no exhaustive naturality theorem is supplied.
+6. **ATTEMPTED — nonlinear normalized contrast.** A contrast can be engineered
+   to vanish at higher rank, but that supplies the selection functional.
+
+These live alternatives are why no universal no-go is claimed.
+
+## N2 — wall-independence audit
+
+Four walls are kept distinct:
+
+- `W_R`: derive the complete operational readout/effect domain, including its
+  mixture, coarse-graining and presentation-equivalence rules;
+- `W_T`: identify the imposed chart dial with a physical transport carrier;
+- `W_A`: show that the committed sesquilinear action class is exhaustive;
+- `W_J`: obtain a nonzero controlled holomorphic interference signature.
+
+They are pairwise independent. Closing `W_R` neither identifies transport nor
+completes the action nor makes `J` nonzero. Closing `W_T` does not choose a
+readout or action. Closing `W_A` does not choose a readout or certify the dial.
+A measured `J != 0` would not prove any class complete. Rank and dilation
+questions are included in `W_R`, not counted as a fifth wall.
+
+## N3 — hidden-wall scan
+
+The exact counterexample assumes the parent's standard isometric compression
+language and uses its supplied finite fixtures, reflection, support, action and
+transport dial. It does not silently promote any of those to axioms or to facts
+about Nature. The generic lemma separately assumes affinity in the effect,
+convex PSD closure and a fixed transport difference or derivative. The physical
+event-to-effect map, global positivity of the uncompressed form, rank under
+auxiliary dilation, action completeness and physical meaning of the chart dial
+remain unsupplied.
+
+## N4 — residual matching
+
+- The parent says explicitly that a sensitive rank-two PSD compression kills
+  its candidate. The `X^dag F_T X` witness answers exactly that residual.
+- The parent calls the holomorphic `J(a)` arm unrun. This result does not cite
+  the counterexample as a substitute for `J`.
+- The parent's sesquilinear-only limitation maps to `W_A`, not to an
+  all-actions theorem.
+- Block 175's union effects support only the statement that rank-two projectors
+  already occur in the effect vocabulary; they are not used to prove this
+  transport response.
+- Effect-Gleason and probability-simplex work are cross-cycle analogies only;
+  the load-bearing result here is direct exact matrix algebra.
+
+## N5 — rhetoric audit and resolution level
+
+- **per_element:** proved exactly for the displayed isometric compression and
+  for the convex-affine admixture lemma; nonlinear categories remain open.
+- **per_site:** reconstructed on the selected eight-row finite reflection form
+  at the two committed extents; no full site-effect algebra is derived.
+- **per_mode:** proved transport-sensitive with respect to the supplied `s_t`
+  dial; the dial's physical carrier identification remains open.
+- **per_block:** the literal Block-176 rank-one-only successor is falsified.
+- **lattice_wide:** not established; two finite extents are not a limit.
+- **whole TOE:** no obligation or axiom is retired and no percentage moves.
+
+Safe wording is: **“The literal rank-one-only successor fails under standard
+isometric compression on both committed fixtures, and it also cannot hold in
+an affine convex PSD-effect class.”** Unsafe wording is: **“No scalar-sector
+principle can select a Born readout.”**
+
+## N6 — partial positive closure paths
+
+The counterexample leaves several honest positive programs:
+
+- derive a complete physical effect algebra, then apply the existing
+  additivity/trace-form machinery;
+- prove a determinant or exterior-power theorem on a derived non-convex
+  category;
+- derive squared amplitude from orthogonal-alternative additivity rather than
+  assuming bilinearity;
+- run the controlled holomorphic `J(a)` arm;
+- identify the physical transport carrier;
+- classify action/readout pairs including auxiliary and antilinear extensions.
+
+No statement that a new axiom is required is justified by this block.
+
+## N7 — hostile-reviewer steelman
+
+A strong objection is that Block 176 may have intended “compression” to mean a
+determinant or exterior-power scalar of an exact-rank invariant block, not the
+standard isometric matrix compression used here. Convex mixtures would then be
+inadmissible, and a two-dimensional traceless sector could make the unique
+full-rank trace blind while rank-one matrix elements remain sensitive.
+Reflection positivity and composition might privilege a determinant-line
+pairing.
+
+That steelman defeats a universal impossibility claim. It does not rescue the
+literal text, which neither defines such a narrow category nor supplies a
+reason to exclude this exact `X`. A repaired theorem would need to derive that
+category, prove it exhaustive and invariant under equivalent presentations,
+and then demonstrate a controlled nonzero physical signature.
+
+## N8 — cross-cycle echo
+
+Earlier readout cycles obtained trace form only after enlarging to a complete
+effect/menu domain and imposing normalization and additivity. Those results
+show the right theorem shape: a representation theorem can follow from a
+supplied full effect algebra, but it does not derive which effects are physical,
+the state, the action or the transport map. Likewise, phase invariance and
+multiplicativity leave `|Z|^p`; selecting `p=2` needs an independent
+orthogonal-alternative additivity or equivalent Hilbert-space premise. This
+mechanism has been considered here. It supports an exhaustive effect-algebra
+program, not the failed rank-one-only exclusion.
+
+## Decision cut
+
+Stop spending campaign time on the literal rank-one-only compression thesis.
+The exact counterexample is the requested kill condition, not an invitation to
+search for a friendlier fixture. A narrower determinant/exterior-power theorem
+may proceed only after its category is physically derived and stated. The main
+portfolio should now move to the Wilson-`Q` discriminator, while the readout
+lane retains `W_R`, `W_T`, `W_A` and `W_J` as named independent walls.
+
+**TOE:** zero axiom retirement; zero obligation retirement; zero TOE movement;
+no TOE percentage moves; retained-positive end-to-end theory count remains
+zero.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 16109,
- "node_count": 5606,
+ "node_count": 5607,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -597,6 +597,10 @@
   "admissibility_dirac_kahler_quotient_observable_obstruction_bounded_theorem_note_2026-08-16": {
    "deps_hash": "36a014d4d7f1",
    "out_degree": 3
+  },
+  "admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_bounded_theorem_note_2026-08-23": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "admissibility_dirac_kahler_refinement_census_stationary_kernel_bounded_theorem_note_2026-08-21": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.txt
@@ -1,0 +1,29 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.py
+runner_sha256: 50f6db0ba1e2e2283b843e17406c10df5eb86a611ce37f345ba73e54549c6f67
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 2.98
+status: ok
+----- stdout -----
+PASS: 8x4 committed row map :: rows=(4, 5, 6, 7, 8, 9, 10, 11), form_shape=(8, 8)
+PASS: 8x4 exact rank-two scalar compression :: X^H F X=Matrix([[171*s_t/250 + 114/125, 0], [0, 171*s_t/250 + 114/125]])
+PASS: 8x4 positive and transport-sensitive :: slope=171/250, gap=513/2000, det=3249*(3*s_t + 4)**2/62500, endpoints=(399/400,627/500)
+PASS: 12x4 committed row map :: rows=(4, 5, 6, 7, 8, 9, 10, 11), form_shape=(8, 8)
+PASS: 12x4 exact rank-two scalar compression :: X^H F X=Matrix([[171*s_t/250 + 114/125, 0], [0, 171*s_t/250 + 114/125]])
+PASS: 12x4 positive and transport-sensitive :: slope=171/250, gap=513/2000, det=3249*(3*s_t + 4)**2/62500, endpoints=(399/400,627/500)
+PASS: rank-two isometry :: X^H X=Matrix([[1, 0], [0, 1]]), rank=2
+PASS: extent-independent compressed law :: the exact 2x2 law agrees at cover extents 8x4 and 12x4
+PASS: generic affine admixture obstruction :: response d+epsilon*q has nonzero constant d and at most one tuned root
+PASS: normalized rank-two affine witness :: rank=2, raw=1/2, normalized=2/5
+PASS: native rank-two union effect :: rank=2, Tr(C E_12)=439357412910769360932538655107114128554155761811678874279976303924187781349/894555786619317339421650665156104028453509785664333673843970497575127328208
+PASS: exact-source and no-go-discipline surface :: float_literals=0, N_sections=8/8
+per_element: exact affine-effect response and the rank-two isometry are proved, with no statement about nonlinear determinant categories
+per_site: the committed eight-row reflection form is reconstructed exactly at both retained 8x4 and 12x4 finite fixtures
+per_mode: the displayed rank-two scalar compression is positive definite and changes exactly with the supplied s_t transport dial
+per_block: the literal Block-176 rank-one-only successor thesis is falsified; the parent proposal remains unadopted and unselected
+lattice_wide: no infinite-volume, all-lattice, physical-readout-selection, Born-rule, gravity, or whole-TOE conclusion is licensed
+TOTAL: 12/12 PASS
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.py
+++ b/scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_2026_08_23.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Exact Block-177 falsifier for the proposed rank-one-only scalar theorem.
+
+The parent (Block 176) explicitly asks whether every transport-sensitive
+positive compression of its committed reflection form is rank one.  This
+runner reconstructs that committed form through the landed Block-170 bench and
+exhibits a rank-two isometric compression that is positive definite and has a
+nonzero exact transport derivative at both retained cover extents.
+
+The result is deliberately narrow.  It falsifies the literal successor thesis;
+it does not select a readout, derive the Born rule, or exclude narrower
+non-affine/non-convex readout categories.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import sympy as sp
+
+import admissibility_dirac_kahler_closure_audit_two_2026_08_21 as b170
+import admissibility_dirac_kahler_pincer_identity_cross_lane_2026_08_22 as b175
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE = ROOT / (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_RANK_TWO_SCALAR_TRANSPORT_"
+    "COUNTEREXAMPLE_BOUNDED_THEOREM_NOTE_2026-08-23.md"
+)
+
+R = sp.Rational
+ZERO = sp.Integer(0)
+ONE = sp.Integer(1)
+TRANSPORT = sp.symbols("s_t", real=True)
+EXPECTED_ROWS = (4, 5, 6, 7, 8, 9, 10, 11)
+EXPECTED_SCALAR = R(114, 125) + R(171, 250) * TRANSPORT
+EXPECTED_GAP = R(513, 2000)
+EXPECTED_DETERMINANT = (
+    R(3249, 62500) * (3 * TRANSPORT + 4) ** 2
+)
+
+CHECKS: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, condition: bool, detail: str) -> None:
+    CHECKS.append((name, bool(condition), detail))
+
+
+def is_zero(matrix: sp.MatrixBase) -> bool:
+    return all(sp.expand(entry) == 0 for entry in matrix)
+
+
+def isometry() -> sp.Matrix:
+    x0 = sp.zeros(8, 1)
+    x2 = sp.zeros(8, 1)
+    x0[0], x0[4] = R(4, 5), R(3, 5)
+    x2[2], x2[6] = R(4, 5), R(3, 5)
+    return x0.row_join(x2)
+
+
+def committed_form(tag: str, cover_t: int) -> tuple[b170.Bench, sp.Matrix]:
+    """F_T(s_t)=Herm(Sel_S^T r_T Q_T(s_t) Sel_S), from Block 170."""
+    bench = b170.Bench(tag, cover_t, 4)
+    return bench, sp.expand(bench.form.subs(bench.carrier(st=TRANSPORT)))
+
+
+def exact_fixture_checks() -> dict[str, dict]:
+    x = isometry()
+    expected = EXPECTED_SCALAR * sp.eye(2)
+    results: dict[str, dict] = {}
+    for tag, cover_t in (("8x4", 8), ("12x4", 12)):
+        bench, form = committed_form(tag, cover_t)
+        compression = sp.expand(x.H * form * x)
+        determinant = sp.factor(compression.det())
+        at_small = sp.expand(compression.subs(TRANSPORT, R(1, 8)))
+        at_large = sp.expand(compression.subs(TRANSPORT, R(1, 2)))
+        derivative = sp.diff(sp.trace(compression) / 2, TRANSPORT)
+        gap = sp.expand(sp.trace(at_large - at_small) / 2)
+        results[tag] = {
+            "rows": tuple(bench.rows),
+            "shape": compression.shape,
+            "compression": compression,
+            "determinant": determinant,
+            "at_small": at_small,
+            "at_large": at_large,
+            "derivative": derivative,
+            "gap": gap,
+        }
+        check(
+            f"{tag} committed row map",
+            tuple(bench.rows) == EXPECTED_ROWS and form.shape == (8, 8),
+            f"rows={tuple(bench.rows)}, form_shape={form.shape}",
+        )
+        check(
+            f"{tag} exact rank-two scalar compression",
+            is_zero(compression - expected),
+            f"X^H F X={compression}",
+        )
+        check(
+            f"{tag} positive and transport-sensitive",
+            (
+                compression.rank() == 2
+                and at_small == R(399, 400) * sp.eye(2)
+                and at_large == R(627, 500) * sp.eye(2)
+                and derivative == R(171, 250)
+                and gap == EXPECTED_GAP
+                and determinant == EXPECTED_DETERMINANT
+            ),
+            (
+                f"slope={derivative}, gap={gap}, "
+                f"det={determinant}, endpoints=({at_small[0, 0]},"
+                f"{at_large[0, 0]})"
+            ),
+        )
+    check(
+        "rank-two isometry",
+        x.H * x == sp.eye(2) and x.rank() == 2,
+        f"X^H X={x.H * x}, rank={x.rank()}",
+    )
+    check(
+        "extent-independent compressed law",
+        results["8x4"]["compression"] == results["12x4"]["compression"],
+        "the exact 2x2 law agrees at cover extents 8x4 and 12x4",
+    )
+    return results
+
+
+def affine_closure_checks() -> None:
+    """The convex-affine obstruction and one exact normalized witness.
+
+    If an affine effect P has response d != 0, adding epsilon Q changes the
+    response to d+epsilon*q.  This affine polynomial is not identically zero
+    and has at most one tuned root.  The concrete diagonal witness also shows
+    that normalization by trace does not restore blindness.
+    """
+    epsilon, d, q = sp.symbols("epsilon d q", real=True)
+    response = d + epsilon * q
+    polynomial = sp.Poly(response, epsilon)
+    check(
+        "generic affine admixture obstruction",
+        polynomial.degree() <= 1 and polynomial.eval(0) == d,
+        "response d+epsilon*q has nonzero constant d and at most one tuned root",
+    )
+
+    p = sp.diag(1, 0)
+    q_effect = sp.diag(0, 1)
+    difference = sp.diag(1, -2)
+    eps = R(1, 4)
+    mixed = p + eps * q_effect
+    raw = sp.trace(mixed * difference)
+    normalized = sp.cancel(raw / sp.trace(mixed))
+    check(
+        "normalized rank-two affine witness",
+        (
+            mixed.rank() == 2
+            and raw == R(1, 2)
+            and normalized == R(2, 5)
+            and mixed.is_positive_definite
+        ),
+        f"rank={mixed.rank()}, raw={raw}, normalized={normalized}",
+    )
+
+
+def native_effect_check() -> None:
+    """Block 175 already uses rank-two union effects in its effect algebra."""
+    density = sp.diag(
+        *(
+            R(n, b175.DENSITY_DENOMINATOR)
+            for n in b175.DENSITY_NUMERATORS
+        )
+    )
+    effect = b175.effect_for((b175.MENU[1], b175.MENU[2]))
+    reading = b175.trace_reading(density, effect)
+    expected = R(
+        b175.DENSITY_NUMERATORS[1] + b175.DENSITY_NUMERATORS[2],
+        b175.DENSITY_DENOMINATOR,
+    )
+    check(
+        "native rank-two union effect",
+        (
+            effect.rank() == 2
+            and effect == sp.diag(0, 1, 1, 0)
+            and reading == expected
+            and reading > 0
+        ),
+        f"rank={effect.rank()}, Tr(C E_12)={reading}",
+    )
+
+
+def source_hygiene_check() -> None:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    floats = [node for node in ast.walk(tree)
+              if isinstance(node, ast.Constant) and isinstance(node.value, float)]
+    note = NOTE.read_text(encoding="utf-8") if NOTE.exists() else ""
+    required = tuple(f"## N{i}" for i in range(1, 9))
+    check(
+        "exact-source and no-go-discipline surface",
+        not floats and all(section in note for section in required),
+        f"float_literals={len(floats)}, N_sections={sum(s in note for s in required)}/8",
+    )
+
+
+def main() -> int:
+    exact_fixture_checks()
+    affine_closure_checks()
+    native_effect_check()
+    source_hygiene_check()
+
+    for name, passed, detail in CHECKS:
+        print(f"{'PASS' if passed else 'FAIL'}: {name} :: {detail}")
+
+    # N5 resolution lines are intentionally explicit in cached stdout.
+    print("per_element: exact affine-effect response and the rank-two isometry are proved, with no statement about nonlinear determinant categories")
+    print("per_site: the committed eight-row reflection form is reconstructed exactly at both retained 8x4 and 12x4 finite fixtures")
+    print("per_mode: the displayed rank-two scalar compression is positive definite and changes exactly with the supplied s_t transport dial")
+    print("per_block: the literal Block-176 rank-one-only successor thesis is falsified; the parent proposal remains unadopted and unselected")
+    print("lattice_wide: no infinite-volume, all-lattice, physical-readout-selection, Born-rule, gravity, or whole-TOE conclusion is licensed")
+
+    passed = sum(ok for _, ok, _ in CHECKS)
+    total = len(CHECKS)
+    print(f"TOTAL: {passed}/{total} {'PASS' if passed == total else 'FAIL'}")
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_independent_check_2026_08_23.py
+++ b/scripts/admissibility_dirac_kahler_rank_two_scalar_transport_counterexample_independent_check_2026_08_23.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Independent exact check of the Block 177 rank-two scalar witness.
+
+The committed two-slice forms are reconstructed through Block 170's ``Bench``
+objects.  This checker then builds its compression witness independently and
+also proves a separate symbolic affine-admixture lemma.  No floating-point
+arithmetic is used.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import sympy as sp
+
+
+sys.dont_write_bytecode = True
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+BLOCK170_MODULE = "admissibility_dirac_kahler_closure_audit_two_2026_08_21"
+BLOCK170_PATH = SCRIPTS / f"{BLOCK170_MODULE}.py"
+
+R = sp.Rational
+I = sp.I
+
+
+@dataclass
+class Reporter:
+    passed: int = 0
+    failed: int = 0
+
+    def check(self, name: str, condition: bool, detail: str) -> None:
+        if bool(condition):
+            self.passed += 1
+            status = "PASS"
+        else:
+            self.failed += 1
+            status = "FAIL"
+        print(f"{status} {name}: {detail}")
+
+    def total(self) -> None:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+
+
+def matrix_equal(left: sp.MatrixBase, right: sp.MatrixBase) -> bool:
+    """Exact entrywise matrix equality, with no numerical fallback."""
+    if left.shape != right.shape:
+        return False
+    return all(sp.simplify(a - b) == 0 for a, b in zip(left, right))
+
+
+def is_exact_pd_2x2(matrix: sp.MatrixBase) -> bool:
+    """Sylvester's criterion, evaluated exactly for a Hermitian 2x2 matrix."""
+    return bool(
+        matrix.shape == (2, 2)
+        and matrix_equal(matrix, matrix.H)
+        and sp.simplify(matrix[0, 0]).is_positive is True
+        and sp.simplify(matrix.det()).is_positive is True
+    )
+
+
+def witness_isometry(size: int) -> sp.Matrix:
+    """X=[(4e0+3e4)/5,(4e2+3e6)/5] in the two-slice support."""
+    identity = sp.eye(size)
+    e0, e2 = identity.col(0), identity.col(2)
+    e4, e6 = identity.col(4), identity.col(6)
+    return sp.Matrix.hstack((4 * e0 + 3 * e4) / 5,
+                            (4 * e2 + 3 * e6) / 5)
+
+
+def reconstruct_fixture(b170, fixture: tuple[str, int, int]) -> dict:
+    """Reconstruct F_T(s_t) directly from one committed Block 170 Bench."""
+    tag, cover_t, width = fixture
+    bench = b170.Bench(tag, cover_t, width)
+    environment = bench.carrier(st=None)
+    form = sp.expand(bench.form.subs(environment))
+    witness = witness_isometry(form.rows)
+    compression = sp.expand(witness.H * form * witness)
+    return {
+        "tag": tag,
+        "form": form,
+        "witness": witness,
+        "compression": compression,
+    }
+
+
+def check_fixture(reconstruction: dict, st: sp.Symbol,
+                  reporter: Reporter) -> None:
+    tag = reconstruction["tag"]
+    form = reconstruction["form"]
+    witness = reconstruction["witness"]
+    compression = reconstruction["compression"]
+    identity_two = sp.eye(2)
+    expected_scalar = R(114, 125) + R(171, 250) * st
+    expected_compression = expected_scalar * identity_two
+
+    reporter.check(
+        f"{tag}_FORM",
+        form.shape == (8, 8) and form.free_symbols == {st}
+        and matrix_equal(form, form.H),
+        f"shape={form.shape}, free_symbols={sorted(map(str, form.free_symbols))}",
+    )
+    reporter.check(
+        f"{tag}_ISOMETRY",
+        matrix_equal(witness.H * witness, identity_two),
+        "X^dagger X=I_2",
+    )
+    reporter.check(
+        f"{tag}_COMPRESSION",
+        matrix_equal(compression, expected_compression),
+        f"X^dagger F_T X=({expected_scalar}) I_2",
+    )
+
+    points = (sp.Integer(0), R(1, 8), R(1, 2), sp.Integer(1))
+    point_results = []
+    point_ok = True
+    for point in points:
+        evaluated = sp.simplify(compression.subs(st, point))
+        scalar = sp.simplify(expected_scalar.subs(st, point))
+        determinant = sp.simplify(evaluated.det())
+        point_ok = bool(
+            point_ok
+            and determinant == scalar ** 2
+            and is_exact_pd_2x2(evaluated)
+        )
+        point_results.append(f"{point}:{determinant}")
+    reporter.check(
+        f"{tag}_RATIONAL_PD",
+        point_ok,
+        "det(s_t)=" + ",".join(point_results) + "; all PD",
+    )
+
+    slope = compression.applyfunc(lambda entry: sp.diff(entry, st))
+    gap = sp.expand(compression.subs(st, R(1, 2))
+                    - compression.subs(st, R(1, 8)))
+    reporter.check(
+        f"{tag}_TRANSPORT_RESPONSE",
+        matrix_equal(slope, R(171, 250) * identity_two)
+        and matrix_equal(gap, R(513, 2000) * identity_two)
+        and not matrix_equal(gap, sp.zeros(2)),
+        "slope=(171/250)I_2; gap[1/8->1/2]=(513/2000)I_2",
+    )
+
+
+def check_affine_admixture_lemma(reporter: Reporter) -> None:
+    """Construct a rank-two sensitive effect from any sensitive rank-one one.
+
+    For a generic Hermitian response Delta, P sees ``d != 0``.  The positive
+    choice epsilon*=d^2/[2(d^2+q^2)] lies in (0,1), makes P+epsilon*Q a
+    rank-two effect, and leaves the affine response nonzero with the sign of d.
+    """
+    d = sp.Symbol("d", real=True, nonzero=True)
+    q, x, y = sp.symbols("q x y", real=True)
+    epsilon = sp.Symbol("epsilon", real=True, positive=True)
+
+    delta = sp.Matrix([[d, x + I * y], [x - I * y, q]])
+    rank_one = sp.diag(1, 0)
+    added_ray = sp.diag(0, 1)
+    rank_two = rank_one + epsilon * added_ray
+    response = sp.expand(sp.trace(rank_two * delta))
+
+    reporter.check(
+        "AFFINE_RESPONSE_IDENTITY",
+        matrix_equal(delta, delta.H)
+        and sp.simplify(sp.trace(rank_one * delta) - d) == 0
+        and sp.simplify(response - (d + epsilon * q)) == 0,
+        "Tr[(P+epsilon Q)Delta]=d+epsilon q with Tr[P Delta]=d!=0",
+    )
+    reporter.check(
+        "GENERIC_RANK_TWO_PSD",
+        rank_one.rank() == 1 and rank_two.rank() == 2
+        and sp.simplify(rank_two.det() - epsilon) == 0
+        and epsilon.is_positive is True,
+        "P+epsilon Q has determinant epsilon>0 and rank 2",
+    )
+
+    sum_squares = d ** 2 + q ** 2
+    epsilon_star = sp.factor(d ** 2 / (2 * sum_squares))
+    effect_gap = sp.factor(1 - epsilon_star)
+    persisted = sp.factor(response.subs(epsilon, epsilon_star))
+    positive_numerator = sp.expand(2 * sum_squares + d * q)
+    positive_certificate = (
+        R(3, 2) * sum_squares + R(1, 2) * (d + q) ** 2)
+    expected_persisted = d * positive_numerator / (2 * sum_squares)
+    rank_two_star = rank_two.subs(epsilon, epsilon_star)
+
+    reporter.check(
+        "AFFINE_ADMIXTURE_EFFECT",
+        epsilon_star.is_positive is True
+        and effect_gap.is_positive is True
+        and rank_two_star.rank() == 2
+        and sp.simplify(rank_two_star.det() - epsilon_star) == 0,
+        "epsilon*=d^2/[2(d^2+q^2)] gives 0<epsilon*<1 and a rank-2 effect",
+    )
+    reporter.check(
+        "AFFINE_SENSITIVITY_PERSISTS",
+        sp.simplify(positive_numerator - positive_certificate) == 0
+        and positive_certificate.is_positive is True
+        and sp.simplify(persisted - expected_persisted) == 0,
+        "response=d[2(d^2+q^2)+dq]/[2(d^2+q^2)] is nonzero",
+    )
+
+
+def main() -> int:
+    reporter = Reporter()
+    try:
+        b170 = importlib.import_module(BLOCK170_MODULE)
+        reporter.check(
+            "BLOCK170_IMPORT",
+            Path(b170.__file__).resolve() == BLOCK170_PATH.resolve(),
+            str(Path(b170.__file__).resolve()),
+        )
+
+        fixtures = tuple(b170.PRIMARY)
+        reporter.check(
+            "BLOCK170_FIXTURES",
+            fixtures == (("8x4", 8, 4), ("12x4", 12, 4)),
+            f"PRIMARY={fixtures}",
+        )
+        reconstructions = [reconstruct_fixture(b170, fixture)
+                           for fixture in fixtures]
+        for reconstruction in reconstructions:
+            check_fixture(reconstruction, b170.ST, reporter)
+
+        reporter.check(
+            "CROSS_EXTENT_COMPRESSION",
+            matrix_equal(reconstructions[0]["compression"],
+                         reconstructions[1]["compression"]),
+            "8x4 and 12x4 give the same exact rank-2 affine compression",
+        )
+        check_affine_admixture_lemma(reporter)
+    except Exception as exc:  # fail closed and preserve a final TOTAL line
+        reporter.check(
+            "UNCAUGHT_EXCEPTION",
+            False,
+            f"{type(exc).__name__}: {exc}",
+        )
+
+    reporter.total()
+    return 1 if reporter.failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Block 178 — exact rank-two scalar transport counterexample

Stacked on #7331 after checking the parallel work. The two results are compatible: Block 177 proves the full displayed one-particle kernel is indefinite and conditionally propagates that through symmetric powers; this block finds a positive two-dimensional subspace inside that indefinite form.

At both committed 8x4 and 12x4 extents, the exact isometry X built from x0=(4e0+3e4)/5 and x2=(4e2+3e6)/5 gives X dagger X=I2 and

X dagger F_T(s_t) X = (114/125 + 171 s_t/250) I2.

The compression is rank two, positive definite for s_t greater than -4/3, and transport-sensitive with exact slope 171/250. Its half-trace changes by 513/2000 between s_t=1/8 and s_t=1/2. This directly satisfies the kill condition in Block 176 and refutes the older claim that every rank-two compression is blind or indefinite.

The scope is deliberately bounded. The result does not contradict the conditional whole-sector theorem in #7331, does not exclude determinant or exterior-power categories, and does not select a physical readout or derive the Born rule. Full N1-N8 no-go discipline is committed in the note.

Verification:
- primary exact runner: 12/12 PASS, cached with all five N5 resolution lines
- independent reconstruction: PASS=17 FAIL=0
- both extents agree symbolically
- exact source hygiene: zero float literals
- citation graph manifest refreshed: 5607 nodes, 16109 edges
- repository invariants with link enforcement: PASS

TOE status: zero axiom retirement, zero obligation retirement, zero percentage movement. The value is decisive pruning of a false route.