### PR TITLE
[physics-loop][gravity-source-quotient][bounded_theorem][bounded-support] localize axial boundary and metric-first escape

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/APPROACH_REGISTRY.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/APPROACH_REGISTRY.md
@@ -1,0 +1,13 @@
+# Approach Registry
+
+| Approach | Question | Disposition |
+|---|---|---|
+| raw axial odd matrix GNS | does Block 184 survive toward the IR? | bounded infeasible below `k*=0.0890875879245` |
+| scalar TT-only diagnostic | can the scalar hide the matrix issue? | yes; positive on coarse witnesses but has tiny nonzero critical overlap |
+| metric source quotient after inversion | can equal metric stresses be identified in raw `C`? | no; `ker M^dagger` is not in the covariance radical |
+| metric-first action reduction | can a physical metric restriction save the lane? | positive/source-faithful on declared axial atlas; physical selection open |
+| post-inversion Euclidean projection | is source projection equivalent to reduction? | no; `P Q^-1 P != (PQP)^-1` |
+| equal negative sign | does `mu=-1/1024` repair the action? | odd repair only; even cross-TT pole; not selected |
+| coefficient scan | can magnitude fitting rescue the one-parameter family? | deprioritized; `ker D` retains three even negative directions |
+| changed/nonlinear action | can geometry or blocking select a physical Hessian? | live, after reduction/source semantics are derived |
+| quantum/Record construction | can the positive physical kernel become a theory? | downstream; not attempted on the failed raw kernel |

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/ARTIFACT_PLAN.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/ARTIFACT_PLAN.md
@@ -1,0 +1,28 @@
+# Artifact Plan
+
+Pre-computation contract:
+
+1. Generalize the Block 184 odd edge/Ward symbol to axial momentum
+   `(k,0,0)` without changing the action, basis, or TT source.
+2. Sweep `k` from the static corner through `pi`, and for each value sweep the
+   complete temporal circle.
+3. Record action and Ward ranks, physical edge inertia, fifth-elementary gap,
+   bordered minimum singular value/determinant, covariance rank/gap, and TT
+   density extrema.
+4. Resolve endpoint/special-point degeneracies separately from open-interval
+   sign failures.
+5. If the route survives, identify a two-dimensional momentum certificate or
+   symmetry reduction; if it fails, localize the first boundary and state the
+   required action/axiom decision without overgeneralizing.
+6. Use early kill tests before packaging. Do not invoke `review-loop`.
+
+Execution status:
+
+1. completed;
+2. completed with an exact `L=71/72` boundary;
+3. completed, including source-visible and TT-near-dark diagnostics;
+4. completed;
+5. the route failed and was upgraded to a bivariate Bernstein certificate,
+   source-quotient test, constructive metric-first escape, and sign-flip
+   counterexample; and
+6. completed with a 9/9 baseline and nine isolated 8/1 mutations.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/ASSUMPTIONS_AND_IMPORTS.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/ASSUMPTIONS_AND_IMPORTS.md
@@ -1,0 +1,19 @@
+# Assumptions And Imports
+
+| Input | Role | Status / challenge |
+|---|---|---|
+| supplied reflected-curvature action at `mu=1/1024` | momentum-dependent odd edge symbol | unchanged repository input |
+| Block 184 orthonormal odd basis and cross-Ward border | conserved matrix construction | generalize in `k`; do not refit |
+| local TT covector | response probe | conserved on the axial family; not a Record instrument |
+| axial `y/z` reflection symmetry | fixed six-edge sector | valid for `(k,0,0)`; not a full momentum theorem |
+| dense two-variable scout | early sign/rank kill test | numerical support only unless upgraded to polynomial/interval proof |
+| Block 68 closed neutral Record-line carriers | physical source-fidelity discriminator | reflected `y/z` composite is tested at exact periodic momentum |
+| common line-metric image | constructive reduction candidate | reduction before inversion is tested; physical selection remains open |
+| `mu=-1/1024` | equal-magnitude sign counterfactual | diagnostic only; not independently selected |
+
+The minimal axioms do not select this action or guarantee momentum-uniform
+positivity.
+
+No continuum Einstein equation, Lorentzian signature, canonical ADM
+constraint, quantum state, Record instrument, observed constant, retained
+parent, or axiom authority is imported.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/CLAIM_STATUS_CERTIFICATE.md
@@ -1,0 +1,21 @@
+# Claim Status Certificate
+
+```yaml
+claim_type: bounded_theorem
+actual_current_surface_status: bounded-support
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+raw_full_source_matrix_gns_verdict: bounded_infeasible
+equal_magnitude_sign_flip_verdict: bounded_infeasible
+metric_first_reduction_status: constructive_positive_candidate
+physical_reduction_verdict: open
+gravity_verdict: open
+axiom_status: unchanged
+obligation_retirement: 0
+toe_percentage_movement: 0
+review_loop_disposition: not_run_by_user_instruction
+```
+
+The raw-edge and equal-sign-flip conclusions are narrow route decisions. The
+positive metric-first counterexample forbids a gravity no-go. An audit verdict
+has not been requested or applied.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/GOAL.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/GOAL.md
@@ -1,0 +1,31 @@
+# Goal
+
+Test the highest-leverage extension of Block 184 before attempting a costly
+full Brillouin-zone theorem: vary the spatial momentum along the symmetry
+axis and determine whether the positive conserved matrix measure survives.
+
+The scout must track the complete temporal circle, Ward/action ranks,
+smallest physical eigenvalue, bordered pole gap, TT covariance, and the
+approach to the static momentum corner. Special momentum degeneracies must be
+reported rather than hidden by excluding endpoints.
+
+Do not infer full gravity, Newtonian response, other sectors, quantum
+dynamics, Record instrumentation, refinement, axiom change, obligation
+retirement, or TOE movement from an axial scout.
+
+## Outcome
+
+The early kill fired. The raw odd edge covariance develops a source-visible
+infrared negative band and transition poles. The campaign then executed the
+highest-value discriminators rather than extending the failed raw route:
+
+- the raw covariance does not descend to common-metric source classes;
+- a metric-first reduction is positive and source-faithful on the declared
+  axial atlas;
+- projecting sources after raw inversion does not reproduce that reduction;
+- the equal-magnitude negative sign repairs the odd witness but creates an
+  even cross-TT pole; and
+- no axiom update is licensed.
+
+The next goal is to derive the metric-first constraint/source law from
+independent physics and then certify it beyond the axial odd sector.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/HANDOFF.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/HANDOFF.md
@@ -1,0 +1,27 @@
+# Handoff
+
+Block 185 overturns the extrapolation from Block 184's single momentum. For
+`mu=1/1024`, the axial odd edge kernel is globally rank-five PSD only above
+`k*=0.0890875879245`. It has a transition-pole shell and one infrared negative
+direction below that threshold.
+
+The decisive physical test uses two exact Ward-conserved odd sources with the
+same common-metric TT stress. At `L=72`, the local source gives `+262.795160`
+while the reflected closed-Record-line composite gives `-19528.101592`.
+Therefore the raw covariance neither defines a positive all-source GNS nor
+descends to metric-source equivalence classes.
+
+Do not call this a graviton ghost. Reducing the action to the common-metric
+image before inversion gives a positive two-dimensional odd quotient on the
+declared atlas and makes both sources agree at `262.795144`. The saving
+operation is a new physical constraint/source law; projection after raw
+inversion remains negative.
+
+Do not adopt `mu<0` as a sign fix. The equal-magnitude flip repairs the odd
+IR witness but produces a cross-TT-visible even pole at
+`theta=1.058285602655`, and the even `ker D` retains three coefficient-blind
+negative directions.
+
+The best next work is to derive the metric-first/common-metric reduction and
+`tau=M^dagger j` Record coupling independently, then run full-BZ and sector
+tests. No axiom or TOE percentage moved. `review-loop` was not invoked.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/LITERATURE_BRIDGES.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/LITERATURE_BRIDGES.md
@@ -1,0 +1,14 @@
+# Literature Bridges
+
+No external theorem is load bearing. The standard mathematical ideas are:
+
+- rank-one Hermitian updates and inertia continuity;
+- elementary symmetric polynomials on a one-null Hermitian fiber;
+- Bernstein positivity on a rectangle;
+- descent of a Hermitian form through a quotient only when the quotient
+  kernel lies in its radical; and
+- noncommutativity of reduction and inversion.
+
+A future physical reduction may compare with Dirac constraint reduction,
+Regge calculus phase space, and reflection-positive lattice constructions,
+but none is imported as authority here.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/NO_GO_LEDGER.md
@@ -1,0 +1,12 @@
+# No-Go Ledger
+
+| Bounded wall | Independent discriminator | Live escape |
+|---|---|---|
+| raw all-conserved-source edge GNS | bivariate sign boundary, exact border pole, and negative Record-source response | metric-first physical reduction or changed action |
+| raw covariance descent to metric source classes | `M^dagger r=M^dagger o` but `r^dag C r != o^dag C o` | couple through `tau=M^dagger j` before inversion |
+| post-inversion source projection | common projected source still gives `-4685.004` | reduce dynamics before inversion |
+| equal-magnitude negative sign repair | even cross-TT pole and coefficient-blind `ker D` negative directions | independently derived changed action/reduction |
+
+Not claimed: gravity failure, graviton ghost after physical reduction, no
+possible action, no quantum completion, axiom contradiction, or TOE closure.
+The complete N1--N8 discipline appears in the source note.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/OPPORTUNITY_QUEUE.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/OPPORTUNITY_QUEUE.md
@@ -1,0 +1,13 @@
+# Opportunity Queue
+
+1. Derive the common-metric constraint surface and source law before
+   inversion from local action/Record semantics rather than the hostile mode.
+2. Prove source transport through `tau=M^dagger j` and exact refinement.
+3. Certify the derived reduction on the `ky=kz` face, then the full
+   Brillouin zone and complementary reflection sectors.
+4. Compare the reduced quadratic law with the distinct nonlinear sourced
+   Regge Hessian; use geometry/blocking to select any changed action.
+5. Only after physical positivity, construct OS/positive-energy, quantum
+   state, unitary/open update, Record instrument, and cadence.
+6. Upgrade the floating Bernstein boundary to outward-rounded interval
+   arithmetic if audit retention needs an exact global axial certificate.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/PANEL_RETURN.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/PANEL_RETURN.md
@@ -1,0 +1,23 @@
+# Independent Panel Return
+
+The periodic portfolio panel ranked physical metric/source reduction first,
+action-sign derivation second, and quantum/Record construction only after a
+physical positive kernel exists.
+
+The reduction specialist found the same-stress `L=72` witness, proved that raw
+`C` cannot descend through `ker M^dagger`, and supplied the decisive
+constructive counterweight: metric-first reduction is positive and
+source-faithful on the declared atlas. It also found the even-sector pole that
+kills the equal-magnitude sign fit.
+
+The rank-stratified specialist independently derived the source-independent
+rank-one formula, the critical curve, the `L=71/72` determinant margins, and
+the bivariate Bernstein target. Its threshold agrees with the primary runner.
+
+Panel consensus:
+
+1. retire the raw full-source edge GNS route;
+2. do not label the result gravity failure;
+3. do not adopt a sign by positivity fitting;
+4. derive metric-first constraints and source coupling; and
+5. withhold axiom and TOE movement.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/PR_BACKLOG.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/PR_BACKLOG.md
@@ -1,0 +1,17 @@
+# PR Backlog
+
+Current block:
+
+- stacked on Block 184;
+- baseline runner 9/9;
+- nine isolated mutations each 8/1;
+- fresh source-identity-pinned cache;
+- audit verdict not requested;
+- `review-loop` not run by user instruction.
+
+Follow-on PRs should not modify this branch. They should start from the landed
+stack and preregister one of:
+
+1. independently derived metric/constraint/source reduction;
+2. full-BZ and complementary-sector certificate for that reduction; or
+3. nonlinear-action Hessian bridge with source and refinement transport.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/REVIEW_HISTORY.md
@@ -1,0 +1,39 @@
+# Review History
+
+## Local science review
+
+- Confirmed Block 184 and Block 185 use the same action, bases, Ward maps, and
+  TT source.
+- Independently reproduced the odd critical endpoints and exact `L=71/72`
+  phase witnesses.
+- Reproduced the same-stress Record-source non-descent witness in both full
+  pseudoinverse and odd Ward-border constructions.
+- Reproduced the metric-first positive reduction and the failure of
+  post-inversion projection.
+- Reproduced the equal-sign-flip source/Newtonian battery and even cross-TT
+  pole.
+- Applied N1--N8 no-go discipline; broad gravity language rejected.
+- Baseline: 9/9. Mutations: nine runs, each 8/1.
+- Rechecked open PRs during packaging. New PR #7343 is a Dirac--Kahler common
+  differential/patch-carrier result stacked on the orientation lane; it is
+  science- and file-disjoint from this gravity branch.
+- Citation graph: one node and four explicit parent/axiom edges added, for
+  staged-tree totals `5614/16120`.
+- Runner cache is fresh: runner SHA-256
+  `6c81ec601cbcb7d8a340a915cac7513b34e2e9aa5f85cd2f6aea9d4e8587b0ca`,
+  input fingerprint
+  `86865e19007f91ba69c61f1637c99eb35dac822d5697883ae82f817b164e263f`.
+- Repository invariants pass: `3972` rows, no link or class-F violations,
+  and the graph delta is explicitly acknowledged.
+- Strict audit lint exits zero with only inherited warnings/notices; staged
+  claim typing, vocabulary lint, Python compilation, cache check-only, and
+  diff hygiene pass.
+- The full audit pipeline passes graph construction, seeding,
+  classification, and effective-status computation, then stops at the
+  inherited dependency-policy epoch mismatch in stage 7. The run's generated
+  ledger residue was removed; no pipeline-generated file is staged.
+
+## External review status
+
+No `review-loop` was run, by explicit user instruction. No audit verdict was
+requested or applied. The branch remains stacked and unretained.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/ROUTE_PORTFOLIO.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/ROUTE_PORTFOLIO.md
@@ -1,0 +1,14 @@
+# Route Portfolio
+
+| Rank | Route | Terminal test | Kill condition |
+|---:|---|---|---|
+| 1 | derive metric-first physical constraint/source reduction | local, momentum-regular reduction selected independently of hostile modes; `tau=M^dagger j`; positive full-sector kernel | source coupling leaves metric classes, section is fitted/nonlocal/singular, or held-out sector fails |
+| 2 | full-BZ/sector certificate for the derived reduction | every physical momentum and sector, both TT modes, constraints, and static residue | any source-visible negative physical eigenvalue or pole |
+| 3 | changed action/Hessian from nonlinear geometry or blocking | sign and magnitude fixed independently with source/refinement transport | positivity is the only selection reason or new physical ghost appears |
+| 4 | OS/positive-energy and quantum/Record construction | action-selected state, local generator/update, CP instrument, and cadence | abstract GNS only or no operational Record map |
+| 5 | raw full-edge GNS | positive all-conserved-source form and source quotient descent | **stopped here** by the infrared and same-stress witnesses |
+| 6 | equal-magnitude negative sign | global sector repair with selected coefficient | **stopped here** by the even cross-TT pole and coefficient nonselection |
+
+More coefficient scans and raw GNS extensions are low leverage until route 1
+is physically derived. Quantum/Record dynamics remains downstream of the
+physical reduction.

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/STATE.yaml
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/STATE.yaml
@@ -1,0 +1,53 @@
+loop: toe-axiom-closure-block185-momentum-atlas-20260824
+mode: campaign
+target: best-honest-status
+runtime: remaining_4h_window
+started_at: 2026-08-24T09:24:05-04:00
+target_stop_at: 2026-08-24T10:39:22-04:00
+checkpoint_interval: 20m
+current_goal: "Checkpoint the axial source-quotient decision and hand off the physically derived metric-first reduction campaign."
+base_branch: physics-loop/toe-axiom-closure-block184-unitary-dilation-20260824
+science_branch: physics-loop/toe-axiom-closure-block185-momentum-atlas-20260824
+actual_current_surface_status: bounded-support
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+target_claim_type: bounded_theorem
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+cycle_count: 1
+block_count: 1
+active_route: metric_first_constraint_source_reduction_promoted
+approach_family_coverage:
+  axial_raw_odd_matrix_gns: completed_bounded_infeasible_below_kstar
+  same_metric_source_quotient: completed_raw_non_descent
+  metric_first_odd_reduction: completed_positive_on_declared_atlas
+  equal_magnitude_negative_sign: completed_bounded_infeasible_globally
+  even_sector_raw_matrix: completed_indefinite_with_sign_flip_pole
+  full_bz_physical_reduction: open
+  hamiltonian_quantum_record_refinement: open
+strongest_unresolved_proof_obligation: "Derive a local, momentum-regular common-metric/constraint reduction and Record coupling tau=M^dagger j from independent physics, then certify all sectors and momenta."
+hard_residual: "The metric-first reduction is a constructive positive candidate, but the action/axioms do not yet select it as the physical section or transport it through refinement and Records."
+files_touched:
+  - .claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/
+  - docs/ADMISSIBILITY_REFLECTED_CURVATURE_MOMENTUM_SOURCE_QUOTIENT_SIGN_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md
+  - scripts/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.py
+  - logs/runner-cache/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.txt
+open_imports:
+  - independent_constraint_and_source_reduction_selection
+  - full_brillouin_zone_and_sector_certificate
+  - nonlinear_action_hessian_bridge
+  - os_positive_energy_quantum_record_refinement
+no_go_routes:
+  - raw_full_edge_all_conserved_source_matrix_gns
+  - post_inversion_metric_source_projection
+  - equal_magnitude_negative_mu_global_sign_repair
+trace_gate_classification: upstream_support
+reachability_to_target: supports
+review_disposition: local_science_conformance_pass_inherited_pipeline_epoch_wall
+review_loop_disposition: not_run_by_user_instruction
+pr_status: ready_for_stacked_pr
+lock_owner: physics-loop-block185-momentum-atlas
+next_exact_action: "Derive the common-metric constraint/source reduction without reference to the hostile eigenvector, then run full-sector and off-axis early-kill tests before OS/quantum work."
+stop_condition: "This block has reached a scoped N1-N8 decision; checkpoint after reproducible packaging and handoff."
+completed_at: 2026-08-24T10:18:10-04:00

--- a/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/TRACE_GATE.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block185-momentum-atlas-20260824/TRACE_GATE.md
@@ -1,0 +1,15 @@
+# Trace Gate
+
+```yaml
+trace_gate_classification: upstream_support
+reachability_to_target: supports
+raw_full_source_route: stopped
+metric_first_reduction_route: promoted
+strongest_unresolved_proof_obligation: derive physical constraint/source selection and certify it over all momenta and sectors
+next_trace_action: derive tau=M^dagger j and reduction before inversion from local physics, then full-BZ/sector and OS tests
+toe_movement: 0
+axiom_change: none
+```
+
+The campaign resolves the Block 184 momentum extension and sharpens the
+Block 180 physical-section blocker. It does not reach a retained theory node.

--- a/docs/ADMISSIBILITY_REFLECTED_CURVATURE_MOMENTUM_SOURCE_QUOTIENT_SIGN_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md
+++ b/docs/ADMISSIBILITY_REFLECTED_CURVATURE_MOMENTUM_SOURCE_QUOTIENT_SIGN_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md
@@ -1,0 +1,437 @@
+---
+claim_id: admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_bounded_theorem_note_2026-08-24
+claim_type: bounded_theorem
+claim_scope: "For the supplied twenty-two-edge reflected-curvature quadratic action family Q_mu=Q_union+mu D(-q)^T D(q), the y/z-odd six-edge Ward quotient on axial momentum (k,0,0,theta) has a source-independent rank-one update O_mu=O_0-mu r(theta)r(theta)^dagger. At mu=1/1024, a reconstructed degree-(5,4) bivariate fifth-elementary polynomial and Bernstein certificate localize the full-temporal-circle PSD threshold to k*=0.0890875879243, with a transition pole shell and one negative physical direction below it. On the exact L=72 static mode, a local TT edge source and a reflected closed-Record-line composite have the same common-metric stress and exact Ward conservation but opposite-sign raw covariance responses, so the raw covariance does not descend to common-metric source classes. Reducing the action to the common-metric image before inversion gives a positive, representative-independent odd metric quotient on the declared numerical atlas; projecting sources after raw inversion does not. The counterfactual mu=-1/1024 repairs the tested odd infrared fiber and retains the inherited source/Newtonian gates, but develops a cross-TT-visible even-sector unit-circle pole. These are bounded numerical/algebraic route decisions for this action family. A canonical physical reduction, other action, full Brillouin zone, nonlinear gravity, quantum/Record dynamics, axiom amendment, obligation retirement, and TOE percentage movement are not claimed."
+parents:
+  - admissibility_reflected_curvature_action_glued_matrix_gns_unitary_boundary_bounded_theorem_note_2026-08-24
+  - admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_bounded_theorem_note_2026-08-14
+  - admissibility_cycle713_record_stress_block44_ir_reflected_carrier_boundary_bounded_theorem_note_2026-08-13
+upstream_dependencies:
+  - minimal_axioms
+  - admissibility_reflected_curvature_action_glued_matrix_gns_unitary_boundary_bounded_theorem_note_2026-08-24
+  - admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_bounded_theorem_note_2026-08-14
+  - admissibility_cycle713_record_stress_block44_ir_reflected_carrier_boundary_bounded_theorem_note_2026-08-13
+runner: scripts/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.py
+---
+
+# Reflected-Curvature Momentum, Source-Quotient, And Sign Boundary
+
+**Type:** `bounded_theorem`
+
+**Status:** bounded numerical/algebraic support; unaudited; no axiom is
+amended.
+
+**RAW_FULL_SOURCE_MATRIX_GNS_VERDICT: BOUNDED_INFEASIBLE.**
+
+**EQUAL_MAGNITUDE_SIGN_FLIP_VERDICT: BOUNDED_INFEASIBLE.**
+
+**PHYSICAL_REDUCTION_VERDICT: OPEN.**
+
+**GRAVITY_VERDICT: OPEN.**
+
+TOE accounting: **zero obligation retirement, zero percentage movement, and
+no axiom is amended**. The result changes the gravity portfolio substantially,
+but it does not complete or positively retain a gravity theory.
+
+## Result Up Front
+
+Block 184 proved a positive rank-five matrix density at one spatial momentum,
+`k=pi/2`, in the odd sector of the `y <-> z` reflection. Extending the same
+literal action and Ward border toward the infrared finds that this momentum
+was not representative.
+
+For
+
+\[
+ Q_\mu(q)=Q_{\rm union}(q)+\mu D(-q)^T D(q),
+ \qquad O_\mu(q)=-Q_\mu(q),                              \tag{1}
+\]
+
+the axial odd restriction obeys
+
+\[
+ O_\mu(k,\theta)=O_0(k,\theta)-\mu r(\theta)r(\theta)^\dagger, \tag{2}
+\]
+
+where, in the committed odd edge basis,
+
+\[
+ r(\theta)=
+ \begin{pmatrix}
+ 1+e^{-i\theta}&\sqrt2&0&0&-\sqrt2e^{-i\theta}&0
+ \end{pmatrix}^{T},                                    \tag{3}
+\]
+
+and `||r||^2=6+2 cos(theta)` lies between four and eight. The update is
+rank one, is independent of `k`, and is orthogonal to the Ward column. Thus
+positive `mu` is literally a negative-semidefinite update of the covariance
+kernel on one conserved direction; it can create at most one new negative
+physical eigenvalue.
+
+At `mu=1/1024`, the complete axial odd phase boundary is
+
+\[
+ k_c(0)=0.0884184579426,
+ \qquad
+ k_c(\pi)=0.0890875879243.                              \tag{4}
+\]
+
+The latter is the global full-temporal-circle threshold. Above it, the odd
+kernel is positive semidefinite of rank five for every temporal frequency.
+Between the two endpoints, the temporal circle contains a pair of bordered
+unit-circle poles. Below `k_c(0)`, one conserved odd direction is negative at
+every temporal frequency. The exact periodic controls make the distinction
+concrete:
+
+| periodic length | `k=2 pi/L` | static minimum physical eigenvalue | role |
+|---:|---:|---:|---|
+| `71` | `0.0884955677068` | `+5.29743e-6` | static positive, but temporal pole at `theta=0.691266304413` |
+| `72` | `0.0872664625997` | `-7.92636e-5` | inside the all-frequency negative band |
+
+This does not by itself prove a graviton ghost. The negative direction is
+dominated by the reflected relative-orientation sector, and a concrete
+common-metric reduction removes it. But it does refute the physical use of the
+*raw* full-edge inverse for all conserved sources.
+
+## The Decisive Source-Fidelity Test
+
+Let `M(q)` be the supplied line-metric map. At the static `L=72` momentum,
+compare the local TT edge source
+
+\[
+ o=e_y-e_z                                                   \tag{5}
+\]
+
+with the reflection-odd composite of four closed transverse Record-line
+sources
+
+\[
+ r_R={j_{+y}+j_{-y}-j_{+z}-j_{-z}\over2\sqrt2}.             \tag{6}
+\]
+
+Each `j` uses the repository's coefficient-two diagonal edge convention. The
+four lines and their oppositely weighted partners are displaced in the `x`
+direction, so they share the same nonzero Fourier multiplier
+`L(1-exp(i k))`. Reflection supplies the `z` pair from the `y` pair without a
+new source rule.
+
+Both sources are exactly odd and Ward-conserved, and
+
+\[
+ M^\dagger r_R=M^\dagger o,
+ \qquad
+ d=r_R-o\in\ker M^\dagger.                                \tag{7}
+\]
+
+Yet the raw Ward-bordered covariance gives
+
+\[
+ o^\dagger C o=+262.79515955,
+ \qquad
+ r_R^\dagger C r_R=-19528.1015920,
+ \qquad
+ d^\dagger C d=-19790.5978933.                            \tag{8}
+\]
+
+For a Hermitian form to descend from edge sources to common-metric source
+classes, `ker M^dagger` must lie in its radical. Equation (8) directly
+disproves that condition. Therefore one cannot first build the raw covariance
+and then declare the relative directions to be auxiliary. If Record edge
+microstructure is physical, `d` is a Ward-conserved negative-norm source of
+this candidate. If only common-metric stress is physical, the calculation is
+a source-interface failure that demands a reduction or selected section.
+
+The local TT scalar is a particularly dangerous diagnostic by itself. On the
+`L=72` temporal grid it stays positive and has
+
+\[
+ k^2 C_{TT}(k,0)=2.00129959,                               \tag{9}
+\]
+
+which looks like the expected infrared pole. It nevertheless has a small but
+nonzero overlap, approximately `9.67e-6`, with the static critical mode and
+therefore develops an extremely narrow simple pole at `k_c(0)`. The scalar
+channel hides most of the matrix failure; it does not remove it.
+
+## Constructive Escape: Reduce Before Inversion
+
+The strongest steelman is constructive. Let `B_o` span the three odd metric
+coordinates
+
+\[
+ h_{yy}-h_{zz},\qquad h_{xy}-h_{xz},\qquad h_{yt}-h_{zt}, \tag{10}
+\]
+
+and define
+
+\[
+ M_o(q)=M_{\rm line}(q)B_o.                               \tag{11}
+\]
+
+The odd edge Ward column lies in `im M_o`. Pull it back to a three-coordinate
+metric gauge vector and let `Z_m` span its orthogonal complement. Reducing the
+action *before* inversion gives
+
+\[
+ H_m(q)=Z_m^\dagger M_o(q)^\dagger[-Q_\mu(q)]M_o(q)Z_m.   \tag{12}
+\]
+
+This two-dimensional kernel was positive semidefinite on the declared
+`41 x 65` axial atlas from `k=0.001` through `pi` and `theta=0` through `pi`;
+the smallest sampled eigenvalue was `2.4999998e-7`. At `L=72`, both source
+representatives in (5)--(6) reduce to the same stress and give
+
+\[
+ C_{TT,\mathrm{metric}}=262.79514446.                    \tag{13}
+\]
+
+The result is independent of `mu` on this common-metric image because the
+added curvature rows annihilate it. This is an explicit positive route, not a
+claim that no physical reduction exists.
+
+The order of operations is load bearing. Orthogonally projecting `o` and
+`r_R` to the same metric-image edge vector but retaining the already inverted
+raw covariance gives `-4685.00374`, not (13). In symbols,
+
+\[
+ P Q^{-1}P\ne(PQP)^{-1}.                                 \tag{14}
+\]
+
+Consequently the metric-first construction is new constraint/reduction law
+data. It cannot be obtained by relabeling Block 184's raw GNS after the fact.
+It remains to derive why the common-metric image, its source map, and its
+constraint elimination are the physically selected objects.
+
+## Why Flipping The Sign Is Not The Answer
+
+The equal-magnitude counterfactual `mu=-1/1024` is informative. On the axial
+odd sector it changes (2) into a positive rank-one update. It repairs the
+`L=72` odd minimum, makes both source responses positive, retains exact Ward,
+reflection, and Hermiticity, solves all 6,528 inherited closed neutral
+Record-source modes, and preserves the static `k^2 h_tt -> 2` residue.
+
+Those successes do not select the sign or magnitude. The same counterfactual
+changes the zero-mode action inertia from `(7-,5+,10 zero)` to
+`(10-,2+,10 zero)`, changes a held-out curvature response by an order-one
+amount, and fails in the complementary even sector.
+
+At `k=pi/2`, the even edge/gauge dimensions are `16/3`. For
+`mu=-1/1024`, a physical eigenvalue crosses zero at
+
+\[
+ \theta_*=1.058285602655.                                \tag{15}
+\]
+
+The quotient inertia changes from `(3-,10+)` to `(4-,9+)`; at the root it is
+`(3-,9+,1 zero)` and the 19-by-19 Ward border has minimum singular value about
+`6.1e-15`. The supplied cross-TT source has nonzero null-mode overlap
+`4.56621e-4`, and its response changes from approximately `+518` to `-517`
+across a `2e-7` frequency bracket.
+
+Moreover, inside the even conserved quotient, the kernel of `D` has dimension
+eleven and inertia `(3-,8+)` at the three declared temporal controls. Those
+three negative directions are invisible to every coefficient multiplying
+`D^dagger D`. Thus the one-parameter curvature coefficient cannot make the
+raw all-conserved-source edge form positive even when a larger negative
+magnitude removes the particular crossing in (15).
+
+The sign flip is therefore a diagnostic of the relative edge band, not a
+derived action repair.
+
+## Trace And Claim Status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+trace_class: upstream_support
+target_claim_id: admissibility_regge_tt_record_observable_inverse_amplification_refinement_gate_bounded_theorem_note_2026-08-23
+target_blocker_text: "the originally promised terminal route verdict is blocked until a physical reduction/section (or an inner product inducing one) and directed state/source/observable refinement law are supplied"
+source_of_blocker_text: frontier_question
+reachability_to_target: supports
+artifact_role: theorem
+raw_full_source_matrix_gns_verdict: bounded_infeasible
+equal_magnitude_sign_flip_verdict: bounded_infeasible
+physical_reduction_verdict: open
+gravity_verdict: open
+next_trace_action: "derive the metric-first/common-metric constraint reduction and Record coupling tau=M^dagger j from independent local physics, then certify every sector over the full Brillouin zone before returning to OS, quantum, Record, and refinement construction"
+conditional_surface_status: null
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Inputs, Types, And Non-Imports
+
+The result extends [Block 184's action-glued matrix
+GNS](ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_GLUED_MATRIX_GNS_UNITARY_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md)
+using the supplied flat quadratic 22-edge reflected action from [Block
+74](ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_RECORD_SOURCE_TWO_STEP_TRANSFER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md),
+not the distinct nonlinear 15-edge sourced Regge action in the neighboring
+gravity lane. It consumes the exact Ward maps, line-metric map, local TT rows,
+and the [Block 68 closed neutral Record-line source
+convention](ADMISSIBILITY_CYCLE713_RECORD_STRESS_BLOCK44_IR_REFLECTED_CARRIER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-13.md)
+from typed parents. It does not promote any parent to retained status.
+
+No observed constant, continuum Einstein theorem, Lorentzian signature,
+canonical lapse/shift constraint, positive-energy state, quantum commutator,
+Record instrument, clock, refinement map, nonlinear background, audit verdict,
+or axiom amendment is imported. `mu=1/1024`, its equal-magnitude sign flip,
+the axial ray, and the declared numerical grids are finite-probe inputs rather
+than empirical fits.
+
+The [minimal axioms](MINIMAL_AXIOMS_2026-06-29.md) are contextual. They
+expressly say that Admissibility does not choose a Hamiltonian or transfer
+operator. They also do not choose this quadratic action, a metric-first
+section, a physical source quotient, or the coefficient `mu`. No tension with
+the axioms has been established.
+
+## Polynomial And Numerical Certificate
+
+With one exact Ward null, define
+
+\[
+ \Delta_\mu(k,\theta)=e_5(O_\mu)
+ =\sum_{a=1}^{6}\det O_\mu[\widehat a,\widehat a].        \tag{16}
+\]
+
+It is the product of the five physical eigenvalues. On the axial odd sector,
+`Delta_mu` is a degree-five polynomial in `cos(k)` and degree four in
+`cos(theta)`. A 32-by-32 Fourier reconstruction agrees with held-out direct
+determinants at relative error below `1e-12`. Transforming the reconstructed
+polynomial to Bernstein form on
+
+\[
+ \cos k\in[-1,\cos k_c(\pi)],\qquad
+ \cos\theta\in[-1,1]                                   \tag{17}
+\]
+
+gives nonnegative coefficients up to a `1e-10` floating boundary residue;
+the smallest nonboundary positive coefficient is about `3.5e-8`. Because the
+interior Bernstein basis functions are positive and the threshold corner is
+simple, the physical inertia cannot change above (4). Direct quotient spectra
+on a held-out grid provide an implementation-disjoint cross-check.
+
+The certificate is bounded numerical/algebraic, not exact interval arithmetic.
+An outward-rounded high-precision interval transform would strengthen the one
+floating boundary coefficient into an exact interval theorem without changing
+the route decision.
+
+## No-Go Discipline
+
+### N1 — Alternative-route enumeration
+
+The campaign compared nine distinct continuations: raw all-source GNS;
+TT-only GNS; common-metric restriction before inversion; post-inversion source
+projection; stationary Schur/Dirac elimination; `mu=0` with relative modes
+left null; the equal negative sign; a changed curvature/action family; and a
+connection/holonomy or Lorentzian quantum construction. Only the first and the
+equal-magnitude sign fit are stopped here. Metric-first reduction is a positive
+counterexample to a broad gravity no-go.
+
+### N2 — Wall-independence audit
+
+The odd infrared wall is seen independently in the physical quotient
+eigenvalue, the fifth-elementary polynomial, the Ward-border singular value,
+and an exact periodic Record-source response. Source non-descent is checked by
+the common-metric pullback rather than inferred from the hostile eigenvector.
+The sign-flip failure is independently in the even sector and uses a cross-TT
+source. No single eigensolver or source convention carries the conclusion.
+
+### N3 — Hidden-wall scan
+
+The result keeps open the action signature, physical source cone, canonical
+constraint surface, lapse/shift typing, nonlinear background, boundary state,
+positive-energy condition, time contour, off-axis momenta, refinement, and
+Record clock. It does not assume that every edge coordinate is a graviton or
+that every conserved edge covector is a licensed matter source.
+
+### N4 — Residual matching
+
+The bounded negative conclusion matches the computed residual exactly: the
+raw full-edge inverse cannot be a positive form for all conserved sources and
+cannot descend to metric source classes; the tested sign flip is not a global
+repair. The surviving residual is constructive: derive and certify the
+metric-first physical reduction and its source/Record transport.
+
+### N5 — Execution resolutions
+
+`per_element`: all six odd edge coordinates, all sixteen even edge
+coordinates, their one/three Ward columns, and the two same-stress source
+representatives are checked.
+
+`per_site`: exact `L=71` and `L=72` periodic closed neutral line witnesses are
+checked; arbitrary inhomogeneous lattices are not.
+
+`per_mode`: the full temporal circle is certified on the safe axial odd domain,
+and explicit odd/even pole locations are resolved below it.
+
+`per_block`: the supplied action, source quotient, metric-first escape,
+equal-magnitude sign counterfactual, 6,528 inherited source solves, and static
+residue are separated.
+
+`lattice_wide`: not executed—there is no full Brillouin-zone, nonlinear,
+refinement, quantum Record, or gravity theorem.
+
+### N6 — Rhetoric audit
+
+The permitted language is “source-visible negative mode of the unreduced edge
+covariance,” “raw full-source route failure,” and “physical reduction open.”
+“Gravity fails,” “graviton ghost,” “no physical action,” and “axiom
+contradiction” are not licensed.
+
+### N7 — Partial-closure path scan
+
+The common-metric reduction is positive and source-faithful on the declared
+atlas, the local TT response retains the expected static residue, and the
+negative-sign counterfactual shows that the odd obstruction is action
+sensitive. These are real positive seams. They prevent the raw-edge failure
+from being inflated into a theory-wide negative result.
+
+### N8 — Cross-cycle echo
+
+Blocks 180--184 independently identified source-representative ambiguity,
+stationary-section poles, and the difference between a positive kinematic GNS
+and a physical boundary law. The present same-stress witness resolves that
+open question at one exact periodic mode, while the metric-first construction
+recovers the previously named escape. The result generalizes the route map; it
+does not merely repeat an earlier negative sample.
+
+**N1--N8 status: PASS.**
+
+## Decision And Next Campaign
+
+The highest-leverage next campaign is not more raw GNS work and not coefficient
+scanning. It is to derive the common-metric/constraint reduction from
+independent local physics:
+
+1. identify the canonical presymplectic or constraint surface before
+   inversion;
+2. prove that Record matter couples only through
+   `tau=M^dagger j`, including refinement transport;
+3. eliminate gauge, lapse/shift, and relative-orientation variables without a
+   momentum-fitted or singular section;
+4. certify the resulting physical kernel over the full Brillouin zone and
+   both reflection sectors; and
+5. only then construct OS/positive-energy, quantum state, unitary dynamics,
+   and operational Record instrumentation.
+
+If this reduction cannot be derived and unreduced Record edge modes are
+instead declared physical, equation (8) is a genuine ghost of that candidate
+edge theory and the action must change. That decision is downstream law work,
+not an axiom amendment.
+
+## TOE Lane Accounting
+
+| TOE lane | repository | physical | autonomous | movement |
+|---|---:|---:|---:|---:|
+| operational / Records | 95% | 92% | 50% | `0` |
+| causal order / time | 76% | 72% | 41% | `0` |
+| inertia / matter | 95% | 96% | 75% | `0` |
+| gravity / source / resources | 70% | 45% | 29% | `0` |
+| Born / history | 84% | 63% | 34% | `0` |
+
+The percentage map is unchanged because no retained obligation is retired.
+The route confidence changed materially: the raw full-source GNS and the
+equal-magnitude sign fit are demoted, while metric-first constraint reduction
+is promoted to the dominant gravity seam.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16116,
- "node_count": 5613,
+ "edge_count": 16120,
+ "node_count": 5614,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -925,6 +925,10 @@
   "admissibility_reflected_curvature_gravity_physical_reconstruction_cut_gate_boundary_bounded_theorem_note_2026-08-14": {
    "deps_hash": "cb785bbdf571",
    "out_degree": 6
+  },
+  "admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_bounded_theorem_note_2026-08-24": {
+   "deps_hash": "f622a1405a62",
+   "out_degree": 4
   },
   "admissibility_reflected_curvature_weyl_feshbach_reflection_radical_boundary_bounded_theorem_note_2026-08-24": {
    "deps_hash": "c8eee4235fc9",

--- a/logs/runner-cache/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.txt
+++ b/logs/runner-cache/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.py
+runner_sha256: 6c81ec601cbcb7d8a340a915cac7513b34e2e9aa5f85cd2f6aea9d4e8587b0ca
+input_fingerprint_sha256: 86865e19007f91ba69c61f1637c99eb35dac822d5697883ae82f817b164e263f
+timeout_sec: 240
+exit_code: 0
+elapsed_sec: 8.22
+status: ok
+----- stdout -----
+[PASS] supplied-action-sector-source-binding: the literal mu=1/1024 action, both y/z sectors, and supplied Record carriers are bound w...
+       edges=22; odd=(22, 6)/(4, 1); even=(22, 16)/(4, 3)
+[PASS] global-axial-odd-rank-five-phase-boundary: a degree-(5,4) bivariate Bernstein certificate localizes the full-circle PSD boundary
+       k0=0.088418457942407; k*=0.089087587924519; Bernstein min=-9.66e-11; rank1=8.0e-14; heldout=2.75e-13
+[PASS] periodic-ir-negative-band-and-transition-pole: L=72 lies in the all-frequency negative band while L=71 carries an exact temporal unit-c...
+       L72 min=-7.926e-05; L71 static=5.297e-06; theta_pole=0.691266304426; sigma=3.54e-15
+[PASS] same-metric-record-source-quotient-obstruction: two Ward-conserved odd sources with identical metric stress have opposite-sign covarianc...
+       M^T(r-o)=1.45e-16; oCo=262.795160; rCr=-19528.101592; dCd=-19790.597894
+[PASS] tt-newtonian-subchannel-hides-but-does-not-remove-pole: the sampled local TT density stays positive with k^2 C near two, yet its tiny nonzero po...
+       rho=[0.503010,262.795160]; k2C=2.001299586; overlap=9.669e-06; sides=-198.27/708.23
+[PASS] metric-first-reduction-constructive-escape: restricting the action before inversion gives a positive source-faithful odd metric quot...
+       grid min=2.500e-07; M-gauge=2.09e-14; reduced o/r=262.795144/262.795144; P C P=-4685.004
+[PASS] equal-magnitude-negative-sign-odd-repair-counterfactual: mu=-1/1024 repairs the odd IR sign while preserving Ward, source solves, and the static ...
+       zero inertia=(10, 2, 10); 6528 residual=1.07e-10; odd min=2.284e-03; o/r=262.795/522.154
+[PASS] even-sector-sign-flip-and-curvature-null-wall: the equal sign flip creates a cross-TT-visible even pole and cannot alter three curvatur...
+       theta=1.058285602655056; sigma=5.17e-15; overlap=4.566e-04; C sides=518.41/-517.18; kerD=((3, 8, 0), (3, 8, 0), (3, 8, 0))
+[PASS] no-go-discipline-axiom-and-toe-boundary: the two route failures are bounded while physical reduction, changed action, gravity, an...
+       raw full-source GNS and the tested sign flip stop; selected TT/constraint sections, other actions, nonlinear gravity, and Record dynamics remain live
+AXIAL_PHASE_CERTIFICATE: in the odd sector k>=0.0890875879243 is rank-five PSD on the full temporal circle; a transition shell and an infrared negative band lie below
+SOURCE_QUOTIENT_CERTIFICATE: at L=72, M^T r=M^T o and both sources are Ward-conserved, but r^dag C r<0<o^dag C o, so the raw covariance does not descend to metric-source classes
+METRIC_REDUCTION_CERTIFICATE: reducing the action to the common-metric image before inversion restores representative independence and a positive tested odd quotient; projecting sources after raw inversion does not
+SIGN_COUNTERFACTUAL_CERTIFICATE: mu=-1/1024 repairs the tested odd infrared fiber and retains the inherited source/Newtonian gates, but creates a cross-TT-visible even-sector unit-circle pole
+CURVATURE_NULL_CERTIFICATE: on the tested even fibers, ker D within the conserved quotient has inertia (3-,8+), so changing only the coefficient of D^dag D cannot make the raw full-source form positive
+PHYSICAL_DECISION: derive a source/constraint section or a different action from independent physics before returning to quantum GNS and Record construction
+N5_CERTIFICATE: the execution resolutions below state exactly what this runner did and did not resolve
+per_element: checked all six odd edge coordinates, all sixteen even edge coordinates, their one/three Ward columns, and two equal-metric source representatives
+per_site: checked closed neutral Record-line pairs on the exact L=71 and L=72 periodic witnesses; no arbitrary inhomogeneous lattice is claimed
+per_mode: certified the full axial odd temporal circle above the global threshold and localized odd/even unit-circle poles below it
+per_block: checked the supplied action, source quotient, equal-magnitude sign counterfactual, inherited 6528-source battery, and static residue
+lattice_wide: checked and not executed — no off-axis full Brillouin zone, nonlinear background, canonical reduction, refinement, quantum Record, or gravity theorem is claimed
+RAW_FULL_SOURCE_MATRIX_GNS_VERDICT: BOUNDED_INFEASIBLE; EQUAL_MAGNITUDE_SIGN_FLIP_VERDICT: BOUNDED_INFEASIBLE; PHYSICAL_REDUCTION_VERDICT: OPEN; GRAVITY_VERDICT: OPEN
+TOE_MOVEMENT: obligations=0 percentages=0 axioms_amended=0
+elapsed_sec=4.67
+TOTAL: PASS=9 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.py
+++ b/scripts/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.py
@@ -1,0 +1,978 @@
+#!/usr/bin/env python3
+"""Block 185: axial momentum, source quotient, and action-sign boundary.
+
+The runner extends Block 184's y/z-odd matrix GNS probe over axial spatial
+momentum.  It certifies the infrared sign boundary, tests two Ward-conserved
+edge representatives of the same common-metric TT stress, and challenges the
+equal-magnitude action-sign flip in the complementary even sector.
+
+This is a bounded numerical/algebraic result for the supplied quadratic
+twenty-two-edge action family.  It does not claim gravity failure, select a
+physical constraint reduction, amend an axiom, retire an obligation, or move
+a TOE percentage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import os
+from pathlib import Path
+import sys
+import time
+
+import numpy as np
+from numpy.polynomial import Polynomial, chebyshev
+from scipy.linalg import null_space
+from scipy.optimize import brentq
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import admissibility_cycle713_record_stress_block44_ir_reflected_carrier_boundary_2026_08_13 as block68  # noqa: E402
+import admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_2026_08_14 as block74  # noqa: E402
+import admissibility_reflected_curvature_action_glued_matrix_gns_unitary_boundary_2026_08_24 as block184  # noqa: E402
+
+
+block48 = block74.block48
+block49 = block74.block49
+NOTE_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_REFLECTED_CURVATURE_MOMENTUM_SOURCE_QUOTIENT_SIGN_"
+    "BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+PARENT_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_GLUED_MATRIX_GNS_UNITARY_"
+    "BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md"
+)
+SOURCE_PARENT_PATH = ROOT / "docs" / (
+    "ADMISSIBILITY_CYCLE713_RECORD_STRESS_BLOCK44_IR_REFLECTED_CARRIER_"
+    "BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+
+AUDIT_TIMEOUT_SEC = 240
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_REFLECTED_CURVATURE_MOMENTUM_SOURCE_QUOTIENT_SIGN_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md",
+    "docs/ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_GLUED_MATRIX_GNS_UNITARY_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-24.md",
+    "docs/ADMISSIBILITY_REFLECTED_CURVATURE_ACTION_RECORD_SOURCE_TWO_STEP_TRANSFER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-14.md",
+    "docs/ADMISSIBILITY_CYCLE713_RECORD_STRESS_BLOCK44_IR_REFLECTED_CARRIER_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-08-13.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/audit/data/axiom_premise_nodes.json",
+    "scripts/admissibility_reflected_curvature_momentum_source_quotient_sign_boundary_2026_08_24.py",
+    "scripts/admissibility_reflected_curvature_action_glued_matrix_gns_unitary_boundary_2026_08_24.py",
+    "scripts/admissibility_reflected_curvature_action_record_source_two_step_transfer_boundary_2026_08_14.py",
+    "scripts/admissibility_cycle713_record_stress_block44_ir_reflected_carrier_boundary_2026_08_13.py",
+)
+
+MUTATIONS = (
+    "action_input",
+    "threshold_input",
+    "periodic_input",
+    "source_input",
+    "tt_input",
+    "reduction_input",
+    "repair_input",
+    "even_input",
+    "note_boundary",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, key: str, statement: str, condition, detail: str = "") -> None:
+        ok = bool(condition)
+        short = statement if len(statement) <= 91 else statement[:88] + "..."
+        print(f"[{'PASS' if ok else 'FAIL'}] {key}: {short}")
+        if detail:
+            clipped = detail if len(detail) <= 190 else detail[:187] + "..."
+            print(f"       {clipped}")
+        self.passed += int(ok)
+        self.failed += int(not ok)
+
+
+@dataclass(frozen=True)
+class Sector:
+    edge_basis: np.ndarray
+    gauge_basis: np.ndarray
+
+
+@dataclass(frozen=True)
+class PhysicalFiber:
+    operator: np.ndarray
+    right: np.ndarray
+    left: np.ndarray
+    quotient: np.ndarray
+    reduced: np.ndarray
+    bordered: np.ndarray
+    covariance: np.ndarray
+
+
+@dataclass(frozen=True)
+class AxialPolynomialCertificate:
+    coefficients: np.ndarray
+    bernstein_safe: np.ndarray
+    relative_reconstruction: float
+    k_zero: float
+    k_global: float
+    safe_grid_minimum: float
+    rank_one_residual: float
+    rank_one_ward: float
+    rank_one_norm_range: tuple[float, float]
+
+
+def flat(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").lower().split())
+
+
+def inertia_values(values: np.ndarray, tolerance: float = 1.0e-9) -> tuple[int, int, int]:
+    values = np.asarray(values, dtype=float)
+    return (
+        int(np.sum(values < -tolerance)),
+        int(np.sum(values > tolerance)),
+        int(np.sum(np.abs(values) <= tolerance)),
+    )
+
+
+def sector(union, sign: int) -> Sector:
+    edge_swap = block48.swap_matrix_for_directions(tuple(union.directions))
+    edge_basis = block48.sign_basis(edge_swap, sign)
+    gauge_swap = np.eye(4)
+    gauge_swap[[1, 2]] = gauge_swap[[2, 1]]
+    gauge_basis = block48.sign_basis(gauge_swap, sign)
+    return Sector(edge_basis=edge_basis, gauge_basis=gauge_basis)
+
+
+def physical_fiber(
+    union,
+    selected: Sector,
+    momentum: np.ndarray,
+    mu: float,
+) -> PhysicalFiber:
+    q = np.asarray(momentum, dtype=complex)
+    edge = selected.edge_basis
+    gauge = selected.gauge_basis
+    operator = edge.T @ (-block74.cross_action_symbol(union, q, mu)) @ edge
+    right = edge.T @ block48.union_gauge_map(union, q) @ gauge
+    left = edge.T @ block48.union_gauge_map(union, -q) @ gauge
+    quotient = null_space(right.conj().T, rcond=1.0e-11)
+    reduced = quotient.conj().T @ operator @ quotient
+    reduced = 0.5 * (reduced + reduced.conj().T)
+    zero = np.zeros((gauge.shape[1], gauge.shape[1]), dtype=complex)
+    bordered = np.block([[operator, left], [right.T, zero]])
+    covariance = np.linalg.inv(bordered)[: edge.shape[1], : edge.shape[1]]
+    covariance = 0.5 * (covariance + covariance.conj().T)
+    return PhysicalFiber(
+        operator=operator,
+        right=right,
+        left=left,
+        quotient=quotient,
+        reduced=reduced,
+        bordered=bordered,
+        covariance=covariance,
+    )
+
+
+def fifth_elementary(matrix: np.ndarray) -> float:
+    value = sum(
+        np.linalg.det(np.delete(np.delete(matrix, index, axis=0), index, axis=1))
+        for index in range(matrix.shape[0])
+    )
+    return float(value.real)
+
+
+def odd_e5(union, odd: Sector, wave_number: float, frequency: float, mu: float) -> float:
+    q = np.asarray((wave_number, 0.0, 0.0, frequency), dtype=complex)
+    operator = odd.edge_basis.T @ (-block74.cross_action_symbol(union, q, mu)) @ odd.edge_basis
+    return fifth_elementary(operator)
+
+
+def chebyshev_to_power(coefficients: np.ndarray) -> np.ndarray:
+    degree_x, degree_y = np.asarray(coefficients.shape) - 1
+    first = np.zeros_like(coefficients)
+    for y_index in range(degree_y + 1):
+        values = chebyshev.cheb2poly(coefficients[:, y_index])
+        first[: len(values), y_index] = values
+    power = np.zeros_like(coefficients)
+    for x_index in range(degree_x + 1):
+        values = chebyshev.cheb2poly(first[x_index, :])
+        power[x_index, : len(values)] = values
+    return power
+
+
+def transform_rectangle(
+    power: np.ndarray,
+    x_low: float,
+    x_high: float,
+    y_low: float = -1.0,
+    y_high: float = 1.0,
+) -> np.ndarray:
+    first = np.zeros_like(power)
+    for y_index in range(power.shape[1]):
+        transformed = Polynomial(power[:, y_index])(
+            Polynomial((x_low, x_high - x_low))
+        ).coef
+        first[: len(transformed), y_index] = transformed
+    result = np.zeros_like(power)
+    for x_index in range(power.shape[0]):
+        transformed = Polynomial(first[x_index, :])(
+            Polynomial((y_low, y_high - y_low))
+        ).coef
+        result[x_index, : len(transformed)] = transformed
+    return result
+
+
+def power_to_bernstein(power: np.ndarray) -> np.ndarray:
+    degree_x, degree_y = np.asarray(power.shape) - 1
+    bernstein = np.zeros_like(power)
+    for x_index in range(degree_x + 1):
+        for y_index in range(degree_y + 1):
+            bernstein[x_index, y_index] = sum(
+                power[x_power, y_power]
+                * math.comb(x_index, x_power)
+                / math.comb(degree_x, x_power)
+                * math.comb(y_index, y_power)
+                / math.comb(degree_y, y_power)
+                for x_power in range(x_index + 1)
+                for y_power in range(y_index + 1)
+            )
+    return bernstein
+
+
+def axial_polynomial_certificate(
+    union, odd: Sector, mutation: str
+) -> AxialPolynomialCertificate:
+    count_x = 32
+    count_y = 32
+    degree_x = 5
+    degree_y = 4
+    sampled = np.asarray(
+        [
+            [
+                odd_e5(
+                    union,
+                    odd,
+                    2.0 * np.pi * x_index / count_x,
+                    2.0 * np.pi * y_index / count_y,
+                    block74.MU,
+                )
+                for y_index in range(count_y)
+            ]
+            for x_index in range(count_x)
+        ]
+    )
+    fourier = np.fft.fft2(sampled) / (count_x * count_y)
+    coefficients = np.zeros((degree_x + 1, degree_y + 1))
+    for x_index in range(degree_x + 1):
+        x_slots = (0,) if x_index == 0 else (x_index, (-x_index) % count_x)
+        for y_index in range(degree_y + 1):
+            y_slots = (0,) if y_index == 0 else (y_index, (-y_index) % count_y)
+            coefficients[x_index, y_index] = float(
+                sum(fourier[left, right] for left in x_slots for right in y_slots).real
+            )
+
+    controls = (
+        (0.123, 0.456),
+        (0.777, 2.222),
+        (1.2, 3.1),
+        (2.9, 1.7),
+    )
+    reconstruction = max(
+        abs(
+            chebyshev.chebval2d(np.cos(wave), np.cos(frequency), coefficients)
+            - odd_e5(union, odd, wave, frequency, block74.MU)
+        )
+        for wave, frequency in controls
+    )
+    scale = max(float(np.max(np.abs(sampled))), np.finfo(float).tiny)
+
+    k_zero = brentq(
+        lambda wave: odd_e5(union, odd, wave, 0.0, block74.MU),
+        0.08,
+        0.10,
+        xtol=1.0e-14,
+    )
+    k_global = brentq(
+        lambda wave: odd_e5(union, odd, wave, np.pi, block74.MU),
+        0.08,
+        0.10,
+        xtol=1.0e-14,
+    )
+    certified_boundary = k_global - (0.002 if mutation == "threshold_input" else 0.0)
+    power = chebyshev_to_power(coefficients)
+    rectangle = transform_rectangle(power, -1.0, np.cos(certified_boundary))
+    bernstein_safe = power_to_bernstein(rectangle)
+
+    safe_grid_minimum = np.inf
+    for wave in np.linspace(k_global + 1.0e-5, np.pi, 19):
+        for frequency in np.linspace(0.0, np.pi, 17):
+            fiber = physical_fiber(
+                union,
+                odd,
+                np.asarray((wave, 0.0, 0.0, frequency)),
+                block74.MU,
+            )
+            safe_grid_minimum = min(
+                safe_grid_minimum, float(np.linalg.eigvalsh(fiber.reduced)[0])
+            )
+    rank_one_residual = 0.0
+    rank_one_ward = 0.0
+    norm_values = []
+    for frequency in (0.0, 0.7, np.pi):
+        momentum = np.asarray((0.3, 0.0, 0.0, frequency), dtype=complex)
+        baseline = (
+            odd.edge_basis.T
+            @ (-block74.cross_action_symbol(union, momentum, 0.0))
+            @ odd.edge_basis
+        )
+        supplied = (
+            odd.edge_basis.T
+            @ (-block74.cross_action_symbol(union, momentum, block74.MU))
+            @ odd.edge_basis
+        )
+        update = (baseline - supplied) / block74.MU
+        vector = np.asarray(
+            (
+                1.0 + np.exp(-1.0j * frequency),
+                np.sqrt(2.0),
+                0.0,
+                0.0,
+                -np.sqrt(2.0) * np.exp(-1.0j * frequency),
+                0.0,
+            ),
+            dtype=complex,
+        )
+        expected = np.outer(vector, vector.conj())
+        rank_one_residual = max(
+            rank_one_residual,
+            float(np.linalg.norm(update - expected) / np.linalg.norm(expected)),
+        )
+        ward = (
+            odd.edge_basis.T
+            @ block48.union_gauge_map(union, momentum)
+            @ odd.gauge_basis
+        )
+        rank_one_ward = max(
+            rank_one_ward, float(np.linalg.norm(vector.conj() @ ward))
+        )
+        norm_values.append(float(np.vdot(vector, vector).real))
+
+    return AxialPolynomialCertificate(
+        coefficients=coefficients,
+        bernstein_safe=bernstein_safe,
+        relative_reconstruction=float(reconstruction / scale),
+        k_zero=float(k_zero),
+        k_global=float(k_global),
+        safe_grid_minimum=float(safe_grid_minimum),
+        rank_one_residual=rank_one_residual,
+        rank_one_ward=rank_one_ward,
+        rank_one_norm_range=(min(norm_values), max(norm_values)),
+    )
+
+
+def periodic_phase_data(union, odd: Sector, mutation: str) -> dict[str, float | tuple[int, int, int]]:
+    hostile_length = 70 if mutation == "periodic_input" else 72
+    hostile_k = 2.0 * np.pi / hostile_length
+    safe_k = 2.0 * np.pi / 71.0
+    hostile = physical_fiber(
+        union, odd, np.asarray((hostile_k, 0.0, 0.0, 0.0)), block74.MU
+    )
+    safe_static = physical_fiber(
+        union, odd, np.asarray((safe_k, 0.0, 0.0, 0.0)), block74.MU
+    )
+
+    transition_frequency = brentq(
+        lambda frequency: float(
+            np.linalg.eigvalsh(
+                physical_fiber(
+                    union,
+                    odd,
+                    np.asarray((safe_k, 0.0, 0.0, frequency)),
+                    block74.MU,
+                ).reduced
+            )[0]
+        ),
+        0.0,
+        np.pi,
+        xtol=1.0e-14,
+    )
+    transition = physical_fiber(
+        union,
+        odd,
+        np.asarray((safe_k, 0.0, 0.0, transition_frequency)),
+        block74.MU,
+    )
+    hostile_values = np.linalg.eigvalsh(hostile.reduced)
+    safe_values = np.linalg.eigvalsh(safe_static.reduced)
+    transition_values = np.linalg.eigvalsh(transition.reduced)
+    return {
+        "hostile_length": float(hostile_length),
+        "hostile_k": hostile_k,
+        "safe_k": safe_k,
+        "hostile_minimum": float(hostile_values[0]),
+        "safe_minimum": float(safe_values[0]),
+        "hostile_inertia": inertia_values(hostile_values),
+        "safe_inertia": inertia_values(safe_values),
+        "transition_frequency": float(transition_frequency),
+        "transition_eigenvalue": float(transition_values[np.argmin(np.abs(transition_values))]),
+        "transition_border_singular": float(
+            np.linalg.svd(transition.bordered, compute_uv=False)[-1]
+        ),
+    }
+
+
+def record_edge_source(union, direction: tuple[int, int, int]) -> np.ndarray:
+    edge_index = {value: slot for slot, value in enumerate(union.directions)}
+    carrier = block68.canonical_carrier(
+        tuple(union.directions), np.asarray(direction, dtype=int)
+    )
+    if carrier is None:
+        raise AssertionError("the reflected union must carry every signed Record ray")
+    edge, _offset = carrier
+    source = np.zeros(len(union.directions), dtype=complex)
+    source[edge_index[edge]] = 2.0
+    return source
+
+
+def source_quotient_data(union, odd: Sector, mutation: str) -> dict[str, float]:
+    local = block74.local_tt_observables(union, "")[0]
+    record = (
+        record_edge_source(union, (0, 1, 0))
+        + record_edge_source(union, (0, -1, 0))
+        - record_edge_source(union, (0, 0, 1))
+        - record_edge_source(union, (0, 0, -1))
+    ) / (2.0 * np.sqrt(2.0))
+    if mutation == "source_input":
+        record = record + 0.1 * local
+
+    wave_number = 2.0 * np.pi / 72.0
+    momentum = np.asarray((wave_number, 0.0, 0.0, 0.0), dtype=complex)
+    fiber = physical_fiber(union, odd, momentum, block74.MU)
+    local_odd = odd.edge_basis.T @ local
+    record_odd = odd.edge_basis.T @ record
+    difference = record - local
+    difference_odd = record_odd - local_odd
+    metric = block48.metric_coefficients(np.asarray(union.directions, dtype=float))
+    gauge = block48.union_gauge_map(union, momentum)
+    projector = odd.edge_basis @ odd.edge_basis.T
+    multiplier = 72.0 * (1.0 - np.exp(1.0j * wave_number))
+
+    def response(source: np.ndarray) -> float:
+        return float(np.vdot(source, fiber.covariance @ source).real)
+
+    return {
+        "local_odd_residual": float(np.linalg.norm(local - projector @ local)),
+        "record_odd_residual": float(np.linalg.norm(record - projector @ record)),
+        "metric_match": float(np.linalg.norm(metric.T @ difference)),
+        "local_ward": float(np.linalg.norm(local.conj() @ gauge)),
+        "record_ward": float(np.linalg.norm(record.conj() @ gauge)),
+        "line_multiplier": float(abs(multiplier)),
+        "local_response": response(local_odd),
+        "record_response": response(record_odd),
+        "difference_response": response(difference_odd),
+        "cross_response": float(
+            np.vdot(local_odd, fiber.covariance @ record_odd).real
+        ),
+        "scaled_record_response": float(abs(multiplier) ** 2 * response(record_odd)),
+    }
+
+
+def tt_visibility_data(union, odd: Sector, mutation: str) -> dict[str, float]:
+    source = odd.edge_basis.T @ block74.local_tt_observables(union, "")[0]
+    if mutation == "tt_input":
+        source = source + 0.01 * odd.edge_basis.T @ record_edge_source(
+            union, (0, 1, 0)
+        )
+    wave_number = 2.0 * np.pi / 72.0
+    densities = []
+    for frequency in np.linspace(0.0, 2.0 * np.pi, 256, endpoint=False):
+        fiber = physical_fiber(
+            union,
+            odd,
+            np.asarray((wave_number, 0.0, 0.0, frequency)),
+            block74.MU,
+        )
+        densities.append(float(np.vdot(source, fiber.covariance @ source).real))
+
+    critical = brentq(
+        lambda wave: float(
+            np.linalg.eigvalsh(
+                physical_fiber(
+                    union,
+                    odd,
+                    np.asarray((wave, 0.0, 0.0, 0.0)),
+                    block74.MU,
+                ).reduced
+            )[0]
+        ),
+        0.08,
+        0.10,
+        xtol=1.0e-14,
+    )
+    at_root = physical_fiber(
+        union, odd, np.asarray((critical, 0.0, 0.0, 0.0)), block74.MU
+    )
+    root_values, root_vectors = np.linalg.eigh(at_root.reduced)
+    root_slot = int(np.argmin(np.abs(root_values)))
+    root_edge = at_root.quotient @ root_vectors[:, root_slot]
+    overlap = float(abs(np.vdot(source, root_edge)))
+
+    nearby = []
+    for offset in (-3.0e-12, 3.0e-12):
+        fiber = physical_fiber(
+            union,
+            odd,
+            np.asarray((critical + offset, 0.0, 0.0, 0.0)),
+            block74.MU,
+        )
+        nearby.append(float(np.vdot(source, fiber.covariance @ source).real))
+    return {
+        "density_minimum": min(densities),
+        "density_maximum": max(densities),
+        "static_residue": wave_number**2 * densities[0],
+        "critical": float(critical),
+        "critical_overlap": overlap,
+        "below_response": nearby[0],
+        "above_response": nearby[1],
+    }
+
+
+def odd_metric_basis() -> np.ndarray:
+    basis = np.zeros((len(block48.HCOMPS), 3), dtype=float)
+    root_two = np.sqrt(2.0)
+    basis[block48.HCOMPS.index((1, 1)), 0] = 1.0 / root_two
+    basis[block48.HCOMPS.index((2, 2)), 0] = -1.0 / root_two
+    basis[block48.HCOMPS.index((0, 1)), 1] = 1.0 / root_two
+    basis[block48.HCOMPS.index((0, 2)), 1] = -1.0 / root_two
+    basis[block48.HCOMPS.index((1, 3)), 2] = 1.0 / root_two
+    basis[block48.HCOMPS.index((2, 3)), 2] = -1.0 / root_two
+    return basis
+
+
+def metric_reduction_data(union, odd: Sector, mutation: str) -> dict[str, float]:
+    metric_basis = odd_metric_basis()
+    maximum_gauge_lift = 0.0
+    minimum_reduced = np.inf
+    for wave_number in np.linspace(0.001, np.pi, 41):
+        for frequency in np.linspace(0.0, np.pi, 65):
+            momentum = np.asarray(
+                (wave_number, 0.0, 0.0, frequency), dtype=complex
+            )
+            metric = block49.union_line_metric_map(union, momentum) @ metric_basis
+            gauge = block48.union_gauge_map(union, momentum) @ odd.gauge_basis
+            metric_gauge = np.linalg.lstsq(metric, gauge, rcond=None)[0]
+            maximum_gauge_lift = max(
+                maximum_gauge_lift,
+                float(np.linalg.norm(metric @ metric_gauge - gauge)),
+            )
+            quotient = null_space(metric_gauge.conj().T, rcond=1.0e-11)
+            operator = -block74.cross_action_symbol(union, momentum, block74.MU)
+            reduced = quotient.conj().T @ metric.conj().T @ operator @ metric @ quotient
+            reduced = 0.5 * (reduced + reduced.conj().T)
+            minimum_reduced = min(
+                minimum_reduced, float(np.linalg.eigvalsh(reduced)[0])
+            )
+
+    wave_number = 2.0 * np.pi / 72.0
+    momentum = np.asarray((wave_number, 0.0, 0.0, 0.0), dtype=complex)
+    metric = block49.union_line_metric_map(union, momentum) @ metric_basis
+    gauge = block48.union_gauge_map(union, momentum) @ odd.gauge_basis
+    metric_gauge = np.linalg.lstsq(metric, gauge, rcond=None)[0]
+    quotient = null_space(metric_gauge.conj().T, rcond=1.0e-11)
+    operator = -block74.cross_action_symbol(union, momentum, block74.MU)
+    reduced = quotient.conj().T @ metric.conj().T @ operator @ metric @ quotient
+    reduced = 0.5 * (reduced + reduced.conj().T)
+
+    local = block74.local_tt_observables(union, "")[0]
+    record = (
+        record_edge_source(union, (0, 1, 0))
+        + record_edge_source(union, (0, -1, 0))
+        - record_edge_source(union, (0, 0, 1))
+        - record_edge_source(union, (0, 0, -1))
+    ) / (2.0 * np.sqrt(2.0))
+    local_stress = quotient.conj().T @ metric.conj().T @ local
+    record_stress = quotient.conj().T @ metric.conj().T @ record
+    local_response = float(
+        np.vdot(local_stress, np.linalg.solve(reduced, local_stress)).real
+    )
+    record_response = float(
+        np.vdot(record_stress, np.linalg.solve(reduced, record_stress)).real
+    )
+
+    raw = physical_fiber(union, odd, momentum, block74.MU)
+    odd_metric = odd.edge_basis.T @ metric
+    projector = odd_metric @ np.linalg.pinv(odd_metric, rcond=1.0e-11)
+    projected_local = projector @ (odd.edge_basis.T @ local)
+    projected_record = projector @ (odd.edge_basis.T @ record)
+    post_inversion_response = float(
+        np.vdot(projected_local, raw.covariance @ projected_local).real
+    )
+    if mutation == "reduction_input":
+        local_response = post_inversion_response
+
+    return {
+        "maximum_gauge_lift": maximum_gauge_lift,
+        "minimum_reduced": minimum_reduced,
+        "stress_match": float(np.linalg.norm(local_stress - record_stress)),
+        "local_response": local_response,
+        "record_response": record_response,
+        "projected_source_match": float(
+            np.linalg.norm(projected_local - projected_record)
+        ),
+        "post_inversion_response": post_inversion_response,
+        "l72_reduced_minimum": float(np.linalg.eigvalsh(reduced)[0]),
+    }
+
+
+def repair_data(union, odd: Sector, mutation: str) -> dict[str, object]:
+    repair_mu = block74.MU if mutation == "repair_input" else -block74.MU
+    structural = block74.structural_certificate(union, repair_mu, "")
+    sources = block74.source_certificate(
+        union, (repair_mu, 2.0 * repair_mu), False, ""
+    )
+    static = block74.static_source_certificate(union, repair_mu, "")
+    wave_number = 2.0 * np.pi / 72.0
+    fiber = physical_fiber(
+        union,
+        odd,
+        np.asarray((wave_number, 0.0, 0.0, 0.0)),
+        repair_mu,
+    )
+    local = odd.edge_basis.T @ block74.local_tt_observables(union, "")[0]
+    record = odd.edge_basis.T @ (
+        (
+            record_edge_source(union, (0, 1, 0))
+            + record_edge_source(union, (0, -1, 0))
+            - record_edge_source(union, (0, 0, 1))
+            - record_edge_source(union, (0, 0, -1))
+        )
+        / (2.0 * np.sqrt(2.0))
+    )
+    return {
+        "mu": repair_mu,
+        "zero_inertia": structural["zero_inertia"],
+        "nullities": structural["nullities"],
+        "ward": structural["ward"],
+        "reflection": structural["reflection"],
+        "hermiticity": structural["hermiticity"],
+        "source_samples": sources.samples,
+        "source_nullities": sources.nullities,
+        "source_ward": sources.maximum_ward,
+        "source_residuals": sources.maximum_relative_residual,
+        "selection_ratio": sources.selection_ratio,
+        "static_residues": static["residues"],
+        "static_nonmetric": static["nonmetric"],
+        "odd_minimum": float(np.linalg.eigvalsh(fiber.reduced)[0]),
+        "local_response": float(np.vdot(local, fiber.covariance @ local).real),
+        "record_response": float(np.vdot(record, fiber.covariance @ record).real),
+    }
+
+
+def even_counterexample_data(union, even: Sector, mutation: str) -> dict[str, object]:
+    mu = -block74.MU
+
+    def indexed_eigenvalue(frequency: float) -> float:
+        fiber = physical_fiber(
+            union,
+            even,
+            np.asarray((np.pi / 2.0, 0.0, 0.0, frequency)),
+            mu,
+        )
+        return float(np.linalg.eigvalsh(fiber.reduced)[3])
+
+    root = brentq(indexed_eigenvalue, 1.05, 1.07, xtol=1.0e-14)
+    root_fiber = physical_fiber(
+        union,
+        even,
+        np.asarray((np.pi / 2.0, 0.0, 0.0, root)),
+        mu,
+    )
+    root_values, root_vectors = np.linalg.eigh(root_fiber.reduced)
+    root_edge = root_fiber.quotient @ root_vectors[:, 3]
+    source = even.edge_basis.T @ block74.local_tt_observables(union, "")[1]
+    if mutation == "even_input":
+        source = np.zeros_like(source)
+
+    side_inertias = []
+    responses = []
+    for offset in (-1.0e-7, 1.0e-7):
+        fiber = physical_fiber(
+            union,
+            even,
+            np.asarray((np.pi / 2.0, 0.0, 0.0, root + offset)),
+            mu,
+        )
+        side_inertias.append(
+            inertia_values(np.linalg.eigvalsh(fiber.reduced), tolerance=1.0e-11)
+        )
+        responses.append(float(np.vdot(source, fiber.covariance @ source).real))
+
+    curvature_null_inertias = []
+    for frequency in (0.0, root, np.pi):
+        q = np.asarray((np.pi / 2.0, 0.0, 0.0, frequency), dtype=complex)
+        fiber = physical_fiber(union, even, q, 0.0)
+        curvature = (
+            block49.centered_curvature_intertwiner(union, q)
+            @ even.edge_basis
+            @ fiber.quotient
+        )
+        kernel = null_space(curvature, rcond=1.0e-11)
+        restricted = kernel.conj().T @ fiber.reduced @ kernel
+        restricted = 0.5 * (restricted + restricted.conj().T)
+        curvature_null_inertias.append(inertia_values(np.linalg.eigvalsh(restricted)))
+
+    return {
+        "root": float(root),
+        "root_eigenvalue": float(root_values[3]),
+        "root_border_singular": float(
+            np.linalg.svd(root_fiber.bordered, compute_uv=False)[-1]
+        ),
+        "root_inertia": inertia_values(root_values),
+        "side_inertias": tuple(side_inertias),
+        "source_overlap": float(abs(np.vdot(source, root_edge))),
+        "responses": tuple(responses),
+        "curvature_null_inertias": tuple(curvature_null_inertias),
+    }
+
+
+def main() -> int:
+    started = time.perf_counter()
+    mutation = os.environ.get("TOE_MUTATION", "")
+    if mutation and mutation not in MUTATIONS:
+        raise ValueError(f"unknown TOE_MUTATION={mutation!r}")
+
+    checks = Checks()
+    union = block48.build_reflection_union()
+    odd = sector(union, -1)
+    even = sector(union, +1)
+    binding_mu = 2.0 * block74.MU if mutation == "action_input" else block74.MU
+    binding_gate = (
+        binding_mu == 1.0 / 1024.0
+        and len(union.directions) == 22
+        and odd.edge_basis.shape == (22, 6)
+        and odd.gauge_basis.shape == (4, 1)
+        and even.edge_basis.shape == (22, 16)
+        and even.gauge_basis.shape == (4, 3)
+        and NOTE_PATH.exists()
+        and AXIOM_PATH.exists()
+        and PARENT_PATH.exists()
+        and SOURCE_PARENT_PATH.exists()
+    )
+    checks.check(
+        "supplied-action-sector-source-binding",
+        "the literal mu=1/1024 action, both y/z sectors, and supplied Record carriers are bound without fitting",
+        binding_gate,
+        f"edges={len(union.directions)}; odd={odd.edge_basis.shape}/{odd.gauge_basis.shape}; even={even.edge_basis.shape}/{even.gauge_basis.shape}",
+    )
+
+    polynomial = axial_polynomial_certificate(union, odd, mutation)
+    polynomial_gate = (
+        polynomial.relative_reconstruction < 1.0e-11
+        and 0.08841 < polynomial.k_zero < 0.08843
+        and 0.08908 < polynomial.k_global < 0.08910
+        and polynomial.k_global > polynomial.k_zero
+        and np.min(polynomial.bernstein_safe) > -1.0e-7
+        and np.max(polynomial.bernstein_safe) > 700.0
+        and polynomial.safe_grid_minimum > 1.0e-7
+        and polynomial.rank_one_residual < 1.0e-12
+        and polynomial.rank_one_ward < 1.0e-12
+        and abs(polynomial.rank_one_norm_range[0] - 4.0) < 1.0e-12
+        and abs(polynomial.rank_one_norm_range[1] - 8.0) < 1.0e-12
+    )
+    checks.check(
+        "global-axial-odd-rank-five-phase-boundary",
+        "a degree-(5,4) bivariate Bernstein certificate localizes the full-circle PSD boundary",
+        polynomial_gate,
+        f"k0={polynomial.k_zero:.15f}; k*={polynomial.k_global:.15f}; Bernstein min={np.min(polynomial.bernstein_safe):.2e}; rank1={polynomial.rank_one_residual:.1e}; heldout={polynomial.relative_reconstruction:.2e}",
+    )
+
+    periodic = periodic_phase_data(union, odd, mutation)
+    periodic_gate = (
+        periodic["hostile_length"] == 72.0
+        and periodic["hostile_inertia"] == (1, 4, 0)
+        and periodic["safe_inertia"] == (0, 5, 0)
+        and periodic["hostile_minimum"] < -7.0e-5
+        and periodic["safe_minimum"] > 5.0e-6
+        and 0.6912 < periodic["transition_frequency"] < 0.6914
+        and abs(periodic["transition_eigenvalue"]) < 1.0e-12
+        and periodic["transition_border_singular"] < 1.0e-10
+    )
+    checks.check(
+        "periodic-ir-negative-band-and-transition-pole",
+        "L=72 lies in the all-frequency negative band while L=71 carries an exact temporal unit-circle pole",
+        periodic_gate,
+        f"L72 min={periodic['hostile_minimum']:.3e}; L71 static={periodic['safe_minimum']:.3e}; theta_pole={periodic['transition_frequency']:.12f}; sigma={periodic['transition_border_singular']:.2e}",
+    )
+
+    source = source_quotient_data(union, odd, mutation)
+    source_gate = (
+        source["local_odd_residual"] < 1.0e-12
+        and source["record_odd_residual"] < 1.0e-12
+        and source["metric_match"] < 1.0e-12
+        and source["local_ward"] < 1.0e-12
+        and source["record_ward"] < 1.0e-12
+        and source["line_multiplier"] > 6.0
+        and source["local_response"] > 250.0
+        and source["record_response"] < -19000.0
+        and source["difference_response"] < -19000.0
+        and abs(source["cross_response"] - source["local_response"]) < 0.2
+        and source["scaled_record_response"] < -7.0e5
+    )
+    checks.check(
+        "same-metric-record-source-quotient-obstruction",
+        "two Ward-conserved odd sources with identical metric stress have opposite-sign covariance responses",
+        source_gate,
+        f"M^T(r-o)={source['metric_match']:.2e}; oCo={source['local_response']:.6f}; rCr={source['record_response']:.6f}; dCd={source['difference_response']:.6f}",
+    )
+
+    tt = tt_visibility_data(union, odd, mutation)
+    tt_gate = (
+        tt["density_minimum"] > 0.50
+        and tt["density_maximum"] > 260.0
+        and 2.001 < tt["static_residue"] < 2.002
+        and abs(tt["critical"] - polynomial.k_zero) < 1.0e-11
+        and tt["critical_overlap"] > 8.0e-6
+        and tt["below_response"] < -100.0
+        and tt["above_response"] > 500.0
+    )
+    checks.check(
+        "tt-newtonian-subchannel-hides-but-does-not-remove-pole",
+        "the sampled local TT density stays positive with k^2 C near two, yet its tiny nonzero pole overlap is resolved",
+        tt_gate,
+        f"rho=[{tt['density_minimum']:.6f},{tt['density_maximum']:.6f}]; k2C={tt['static_residue']:.9f}; overlap={tt['critical_overlap']:.3e}; sides={tt['below_response']:.2f}/{tt['above_response']:.2f}",
+    )
+
+    reduction = metric_reduction_data(union, odd, mutation)
+    reduction_gate = (
+        reduction["maximum_gauge_lift"] < 3.0e-13
+        and reduction["minimum_reduced"] > 2.0e-7
+        and reduction["stress_match"] < 1.0e-12
+        and 262.7 < reduction["local_response"] < 262.9
+        and abs(reduction["local_response"] - reduction["record_response"]) < 1.0e-10
+        and reduction["projected_source_match"] < 1.0e-12
+        and reduction["post_inversion_response"] < -4600.0
+        and reduction["l72_reduced_minimum"] > 0.0018
+    )
+    checks.check(
+        "metric-first-reduction-constructive-escape",
+        "restricting the action before inversion gives a positive source-faithful odd metric quotient on the declared atlas",
+        reduction_gate,
+        f"grid min={reduction['minimum_reduced']:.3e}; M-gauge={reduction['maximum_gauge_lift']:.2e}; reduced o/r={reduction['local_response']:.6f}/{reduction['record_response']:.6f}; P C P={reduction['post_inversion_response']:.3f}",
+    )
+
+    repair = repair_data(union, odd, mutation)
+    repair_gate = (
+        repair["mu"] == -1.0 / 1024.0
+        and repair["zero_inertia"] == (10, 2, 10)
+        and repair["nullities"] == (4,)
+        and repair["ward"] < 2.0e-13
+        and repair["reflection"] < 1.0e-13
+        and repair["hermiticity"] < 1.0e-13
+        and repair["source_samples"] == 6528
+        and repair["source_nullities"] == (4,)
+        and repair["source_ward"] < 1.0e-12
+        and max(repair["source_residuals"]) < 1.2e-10
+        and repair["selection_ratio"] < -0.6
+        and max(abs(value - 2.0) for value in repair["static_residues"][:4]) < 0.002
+        and repair["odd_minimum"] > 0.002
+        and repair["local_response"] > 250.0
+        and repair["record_response"] > 500.0
+    )
+    checks.check(
+        "equal-magnitude-negative-sign-odd-repair-counterfactual",
+        "mu=-1/1024 repairs the odd IR sign while preserving Ward, source solves, and the static residue",
+        repair_gate,
+        f"zero inertia={repair['zero_inertia']}; 6528 residual={max(repair['source_residuals']):.2e}; odd min={repair['odd_minimum']:.3e}; o/r={repair['local_response']:.3f}/{repair['record_response']:.3f}",
+    )
+
+    even = even_counterexample_data(union, even, mutation)
+    even_gate = (
+        1.0582 < even["root"] < 1.0584
+        and abs(even["root_eigenvalue"]) < 1.0e-11
+        and even["root_border_singular"] < 1.0e-10
+        and even["root_inertia"] == (3, 9, 1)
+        and even["side_inertias"] == ((3, 10, 0), (4, 9, 0))
+        and even["source_overlap"] > 4.0e-4
+        and even["responses"][0] > 500.0
+        and even["responses"][1] < -500.0
+        and even["curvature_null_inertias"] == ((3, 8, 0),) * 3
+    )
+    checks.check(
+        "even-sector-sign-flip-and-curvature-null-wall",
+        "the equal sign flip creates a cross-TT-visible even pole and cannot alter three curvature-null negative directions",
+        even_gate,
+        f"theta={even['root']:.15f}; sigma={even['root_border_singular']:.2e}; overlap={even['source_overlap']:.3e}; C sides={even['responses'][0]:.2f}/{even['responses'][1]:.2f}; kerD={even['curvature_null_inertias']}",
+    )
+
+    note = flat(NOTE_PATH)
+    if mutation == "note_boundary":
+        note = note.replace("gravity_verdict: open", "gravity_verdict: closed")
+    axiom = flat(AXIOM_PATH)
+    scope_gate = (
+        "raw_full_source_matrix_gns_verdict: bounded_infeasible" in note
+        and "equal_magnitude_sign_flip_verdict: bounded_infeasible" in note
+        and "physical_reduction_verdict: open" in note
+        and "gravity_verdict: open" in note
+        and "no axiom is amended" in note
+        and "zero obligation retirement" in note
+        and all(f"### n{index}" in note for index in range(1, 9))
+        and "n1--n8 status: pass" in note
+        and "choose a hamiltonian or transfer operator" in axiom
+    )
+    checks.check(
+        "no-go-discipline-axiom-and-toe-boundary",
+        "the two route failures are bounded while physical reduction, changed action, gravity, and axioms remain open",
+        scope_gate,
+        "raw full-source GNS and the tested sign flip stop; selected TT/constraint sections, other actions, nonlinear gravity, and Record dynamics remain live",
+    )
+
+    print(
+        "AXIAL_PHASE_CERTIFICATE: in the odd sector k>=0.0890875879243 is rank-five PSD on the full temporal circle; a transition shell and an infrared negative band lie below"
+    )
+    print(
+        "SOURCE_QUOTIENT_CERTIFICATE: at L=72, M^T r=M^T o and both sources are Ward-conserved, but r^dag C r<0<o^dag C o, so the raw covariance does not descend to metric-source classes"
+    )
+    print(
+        "METRIC_REDUCTION_CERTIFICATE: reducing the action to the common-metric image before inversion restores representative independence and a positive tested odd quotient; projecting sources after raw inversion does not"
+    )
+    print(
+        "SIGN_COUNTERFACTUAL_CERTIFICATE: mu=-1/1024 repairs the tested odd infrared fiber and retains the inherited source/Newtonian gates, but creates a cross-TT-visible even-sector unit-circle pole"
+    )
+    print(
+        "CURVATURE_NULL_CERTIFICATE: on the tested even fibers, ker D within the conserved quotient has inertia (3-,8+), so changing only the coefficient of D^dag D cannot make the raw full-source form positive"
+    )
+    print(
+        "PHYSICAL_DECISION: derive a source/constraint section or a different action from independent physics before returning to quantum GNS and Record construction"
+    )
+    print(
+        "N5_CERTIFICATE: the execution resolutions below state exactly what this runner did and did not resolve"
+    )
+    print(
+        "per_element: checked all six odd edge coordinates, all sixteen even edge coordinates, their one/three Ward columns, and two equal-metric source representatives"
+    )
+    print(
+        "per_site: checked closed neutral Record-line pairs on the exact L=71 and L=72 periodic witnesses; no arbitrary inhomogeneous lattice is claimed"
+    )
+    print(
+        "per_mode: certified the full axial odd temporal circle above the global threshold and localized odd/even unit-circle poles below it"
+    )
+    print(
+        "per_block: checked the supplied action, source quotient, equal-magnitude sign counterfactual, inherited 6528-source battery, and static residue"
+    )
+    print(
+        "lattice_wide: checked and not executed — no off-axis full Brillouin zone, nonlinear background, canonical reduction, refinement, quantum Record, or gravity theorem is claimed"
+    )
+    print(
+        "RAW_FULL_SOURCE_MATRIX_GNS_VERDICT: BOUNDED_INFEASIBLE; EQUAL_MAGNITUDE_SIGN_FLIP_VERDICT: BOUNDED_INFEASIBLE; PHYSICAL_REDUCTION_VERDICT: OPEN; GRAVITY_VERDICT: OPEN"
+    )
+    print("TOE_MOVEMENT: obligations=0 percentages=0 axioms_amended=0")
+    print(f"elapsed_sec={time.perf_counter() - started:.2f}")
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

Block 185 localizes the supplied reflected-curvature gravity source boundary. The raw full-source covariance does not descend to the common-metric source quotient, and an equal-magnitude sign flip only moves the obstruction into a TT-visible even-sector pole. Reducing to the common physical metric before inversion is positive on the declared axial atlas and gives representation-independent same-stress response.

## Scope

- bounded-support upstream result; no retained or broad gravity claim
- no minimal-axiom edit
- metric-first reduction remains to be independently derived and tested over the full Brillouin zone
- `review-loop` intentionally not run

## Reproduction

- baseline runner: 9/9
- nine one-at-a-time mutations: each 8/1
- independent math/physics/panel reproductions recorded in the campaign pack
- cache, citation/link invariants, strict audit lint, staged typing, vocabulary, Python compilation, and diff hygiene pass
- full audit pipeline reaches stage 7, then stops at the inherited dependency-policy epoch mismatch