### PR TITLE
feat(nm2slm): incoming exist-opposite at t+1 on two-axis same-lock y-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,444 @@
+---
+claim_id: two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the own incoming *set* at t+1 on the four y-probes of the two-axis same-lock seed are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
+---
+
+# Own Incoming Set Existential Opposite Reverse And Face On Four Two-Axis Same-Lock Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from the probe's own incoming *set* `M(q,τ)` at
+each probe's `τ=t+1` on the four y-probes of the two-axis same-lock seed in
+`B_3(0)={n:n·n<=9}`. Let `t(q)` be the formation tick of probe `q`. Let
+`τ(q)=t(q)+1`. There is no global T. `M(q,τ)` is the set of earliest
+incoming nearest-neighbor steps at `q` using only records with tick `<= τ`.
+Seeds are a singleton seed letter. Mixed remains a set. Unformed at `τ` is
+`UNDEFINED`. Reverse HOLDs if and only if some lock in `M(A,τ)` is the
+vector opposite of some lock in `M(B,τ)`. Face HOLDs if and only if some
+lock in `M(C,τ)` is the vector opposite of some lock in `M(D,τ)`. Empty or
+`UNDEFINED` on either side is `UNDEFINED`; nonempty with no opposite pair
+fails. Unique `L` is not the object. This display does not use occupancy of
+sites as the letter: occupancy of sites is not used. This
+is not named-sign lettering. This is not a unique lock-vector leftover and
+not a sum leftover. This is not leftover of unique-L. This is not leftover
+of axis-cover of `M` and `O` at `t+1`. This is not leftover of exist-opposite
+of `O`. This is not leftover of 1-axis same-lock signed-M. This is not
+leftover of two-axis opposite signed-M. Neither pair is opposite.
+Uniqueness is not required. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py`](../scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse and face are scored on existence of an opposite pair in the
+own incoming sets at the per-probe cut `τ=t+1`. Named signs `{+,−}` are a
+coarser readout and are not used. A singleton unique lock letter is a
+different readout and is not used as the object: report `M`. A `Z^3` sum of
+those locks is a different readout and is not used. The construction does
+not sum. Occupancy of sites is not used. A six-neighbor star is not the
+letter. Axis-cover of `M` and `O` is a different readout and is not used as
+this reverse. Existential opposite of outgoing `O` is a different readout.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of M(q,τ) as the probe's own incoming set of earliest NN steps at t+1 on the four y-probes of the two-axis same-lock seed, mixed remains a set, with reverse fail and face fail from existential opposite; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face
+target_blocker_text: "display reverse and face from the own incoming set at t+1 on the four y-probes of the two-axis same-lock seed, compare to two-axis opposite signed-M, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not replace M by O, do not replace signed-M by axis-cover, do not replace this member by two-axis opposite, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for existential opposite of the own incoming set at t+1 on the four y-probes of the two-axis same-lock seed; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose own
+incoming sets are scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint same-lock pairs recorded at formation tick 0. Origin
+locks `+e_1` and `(0,1,0)` locks `+e_1`. `(0,0,1)` locks `+e_2` and
+`(0,1,1)` locks `+e_2`. The second pair is a new seed, not a formed child
+of the first pair, and neither pair is opposite. This seed is not the 1-axis
+same-lock two-site seed `{0,(0,1,0)}` with `+e_1/+e_1` alone. This seed is
+not the two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2`. This seed is
+not the y-symmetric three-site seed that also records `(0,-1,0)` at tick 0.
+This seed is not the x-axis same-lock seed `{0,(1,0,0)}` with `+e_2/+e_2`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named existential opposite from the own incoming set at `τ=t+1`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter. Duplicate incoming steps collapse in the set.
+The construction does not require `M` to be a singleton. It does not sum
+`M`. Occupancy of sites is not used. It does not wait for a global later T.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on existence
+of a pair of lock vectors that add to zero. They are not scored on `{+,−}`
+names and are not an occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in M(A,τ) and some b in M(B,τ) with a+b=(0,0,0)
+face     <=>  some c in M(C,τ) and some d in M(D,τ) with c+d=(0,0,0)
+```
+
+If `M(A,τ)` or `M(B,τ)` is empty or `UNDEFINED`, reverse is `UNDEFINED`.
+Else reverse fails if no such pair exists. If `M(C,τ)` or `M(D,τ)` is empty
+or `UNDEFINED`, face is `UNDEFINED`. Else face fails if no such pair exists.
+The report is one of `hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility. Do not write into Admissibility. Do not attach L1.
+
+## Theorem 1 — ticks and `M` at `τ=t+1`
+
+On this process the four y-probes form. Compare to two-axis opposite
+signed-M: the four-site seed with locks `+e_1/−e_1` and `+e_2/−e_2` reports
+`M(A,τ)={−e_1}` and `M(B,τ)={+e_1}`, so signed-M reverse HOLDs, while this
+same-lock member has `M(A,τ)={+e_1}` and `M(B,τ)={+e_1}`, so reverse fails.
+Compare to 1-axis same-lock signed-M: the two-site seed `{0,(0,1,0)}` with
+locks `+e_1/+e_1` reports reverse fail and face hold, with `t(D)=3` and
+mixed `M(D,τ)={−e_2,+e_3,−e_3}`. This two-axis same-lock member adds a
+second same-lock pair as a new seed. Face fails because `M(D,τ)={−e_3}`
+has no opposite of `M(C,τ)={+e_2}`.
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=2
+M(A, τ) = {+e_1}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_2}
+M(D, τ) = {−e_3}
+```
+
+`A` is a seed at tick 0. Earliest `M` is frozen from `t` to `τ=t+1` at each
+of the four probes: later records in the prefix do not add a new earliest
+incoming step. Uniqueness is not required. On this member each of the four
+scored sets happens to be a singleton. Mixed remains a set on the process:
+1-axis same-lock `M(D,τ)` is mixed. That mix is not this member.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse holds if and only if there exist `a` in `M(A,τ)` and `b` in
+`M(B,τ)` with `a+b=(0,0,0)`. Both sets are nonempty:
+`M(A,τ)={+e_1}` and `M(B,τ)={+e_1}`, so `+e_1+(+e_1)=(2,0,0)≠(0,0,0)`.
+No opposite pair exists. Reverse fails.
+
+Reverse exist-opposite at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Two-axis opposite
+signed-M reverse HOLDs from `{−e_1}` against `{+e_1}`. Axis-cover reverse
+of `M` and `O` HOLDs on this same member. Exist-opposite reverse of `O`
+HOLDs. Those leftovers are not this display. Signed-M reverse fails
+because neither pair of the two-axis same-lock seed is opposite.
+
+Reverse fails.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face holds if and only if there exist `c` in `M(C,τ)` and `d` in `M(D,τ)`
+with `c+d=(0,0,0)`. Both sets are nonempty: `M(C,τ)={+e_2}` and
+`M(D,τ)={−e_3}`, so `+e_2+(−e_3)=(0,1,−1)≠(0,0,0)`. No opposite pair
+exists. Face fails. Face is not `UNDEFINED`.
+
+Face exist-opposite at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `hold` and not `UNDEFINED`. Face fails. 1-axis same-lock
+signed-M face HOLDs from mixed `M(D,τ)={−e_2,+e_3,−e_3}` against
+`M(C,τ)={+e_2}`. Two-axis opposite signed-M face also fails from
+`M(D,τ)={−e_3}`. Axis-cover face of `M` and `O` fails on this member.
+Exist-opposite face of `O` HOLDs. Those leftovers are not this display.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the own incoming set to be a singleton.
+- It does not sum the own incoming set.
+- It does not replace `M` by `O`.
+- It does not replace signed-M exist-opposite by axis-cover of `M` and `O`.
+- It does not replace signed-M by leftover of unique-L.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint 1-axis same-lock signed-M reverse-fail face-hold as
+  this member.
+- It does not reprint two-axis opposite signed-M reverse-hold face-fail.
+- It does not reprint nsopp exist-opposite HOLD.
+- It does not reprint x-axis same-lock y-probe signed-M.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis same-lock four-site process, own incoming sets at `t+1`, and the
+reverse/face bits from existential opposite of signed `M` are displayed
+theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two disjoint same-lock pairs `+e_1/+e_1` and `+e_2/+e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| reverse from exist-opposite of `M` at `τ` | Theorem 2; `fail` |
+| face from exist-opposite of `M` at `τ` | Theorem 3; `fail` |
+| compare to two-axis opposite signed-M | Theorem 1; opposite reverse HOLDs from `{−e_1}` against `{+e_1}`; this member reverse-fails |
+| compare to 1-axis same-lock signed-M | Theorem 1; 1-axis reverse-fails and face-holds with mixed `M(D)`; this member face-fails |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of unique-L | not this display |
+| leftover of axis-cover of `M` and `O` | not this display |
+| leftover of exist-opposite of `O` | not this display |
+| leftover of 1-axis same-lock signed-M | not this display |
+| leftover of two-axis opposite signed-M | not this display |
+| leftover of nsopp exist-opposite HOLD | not this display |
+| leftover of x-axis same-lock y-probe signed-M | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| global later T | not used |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: own incoming set at `t+1` on the four y-probes of the two-axis same-lock seed, compared to two-axis opposite signed-M, and reverse/face from existential opposite. |
+| V2 | Current main has no landed own-incoming-set existential-opposite reverse/face report on these four two-axis same-lock y-probes. |
+| V3 | Own incoming sets at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the probe's own incoming set at `t+1` and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace signed-M by axis-cover, does not replace
+signed-M by exist-opposite of `O`, and does not identify this display with
+1-axis same-lock signed-M or with two-axis opposite. No global impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| two-axis opposite signed-M | reuse seed `+e_1/−e_1` and `+e_2/−e_2` | `M(A)` there is `{−e_1}` and reverse HOLDs; here `M(A)={+e_1}` and reverse fails | ATTEMPTED |
+| 1-axis same-lock signed-M | reuse seed `{0,(0,1,0)}` with `+e_1/+e_1` | 1-axis face HOLDs at mixed `M(D,τ)` with `t(D)=3`; here `t(D)=2`, `M(D)={−e_3}`, face fails | ATTEMPTED |
+| axis-cover of `M` and `O` | score complementary unsigned axes | cover reverse HOLDs and cover face fails on this member; signed-M reverse fails | ATTEMPTED |
+| exist-opposite of `O` | reuse signed reverse and face of `O` | O exist-opposite reverse hold and face hold; signed-M reverse fail and face fail | ATTEMPTED |
+| unique-L leftover | replace mixed sets by a singleton or `UNDEFINED` | unique-L happens to match because these four `M` are singletons; mixed remains a set on 1-axis `D` | ATTEMPTED |
+| sum of a set | replace `M` by a `Z^3` sum | the construction does not sum; sum of a singleton is that letter, not the set object | ATTEMPTED |
+| nsopp exist-opposite HOLD | reuse opposite `+e_1/−e_1` y-probes | that leftover has M exist-opposite reverse hold and face hold; this member fails both | ATTEMPTED |
+| x-axis same-lock y-probe | reuse seed `{0,(1,0,0)}` with `+e_2/+e_2` | different seed axis; `M(A)` there is not `{+e_1}` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores exist-opposite of own incoming at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member is two-axis same-lock with singleton `M(D)={−e_3}` | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of signed-M with
+axis-cover, missing identification of this member with two-axis opposite
+signed-M, missing identification of this member with 1-axis same-lock
+signed-M, and missing Record identification of exist-opposite reverse are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, four-site two-axis same-lock seed, perpendicular step
+rule, incoming-step lock, own incoming set from records with tick `<= τ`,
+per-probe `τ=t+1`, existential opposite, four y-probes with seed `A`, and
+mixed remains a set are declared. No uniqueness of incoming locks, no
+six-neighbor lock union as the scored object, no lock-count clock, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+exist-opposite reverse fail and face fail reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in an own incoming set | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four incoming sets plus reverse/face as hold, fail, or UNDEFINED | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Two-axis same-lock signed-M is still reverse HOLD because
+two-axis opposite HOLDs reverse and same-lock is only a sign flip; cover
+already HOLDs reverse on this member; 1-axis same-lock already answered
+signed-M; unique-L already matches the singletons; and exist-opposite of
+`O` already answered reverse/face.
+
+**Answer:** Reverse fails because `M(A,τ)={+e_1}` and `M(B,τ)={+e_1}` are
+not opposite. Two-axis opposite has `M(A,τ)={−e_1}` against
+`M(B,τ)={+e_1}` and reverse HOLDs. Axis-cover reverse HOLDs on this
+member while signed-M reverse fails. 1-axis same-lock reverse-fails and
+face-holds from mixed `M(D,τ)`; this member face-fails from singleton
+`M(D,τ)={−e_3}`. Unique-L matching singletons is not the object: mixed
+remains a set. Exist-opposite of `O` reverse-holds and face-holds, while
+signed-M reverse-fails and face-fails. Neither pair of this seed is
+opposite.
+
+### N8 — cross-cycle echo
+
+1-axis same-lock signed-M on `{0,(0,1,0)}` with `+e_1/+e_1` reports reverse
+fail and face hold with `t(D)=3`. Two-axis opposite reports reverse hold
+and face fail with opposite seed letters. Axis-cover of `M` and `O` on this
+same two-axis same-lock seed reports reverse hold and face fail. This note
+is not those displays: it reports own incoming sets at `τ=t+1` on two
+disjoint same-lock pairs, reverse fail, and face fail. Signed-M
+exist-opposite is not leftover of two-axis opposite and not leftover of
+axis-cover.
+
+**Gate disposition:** PASS for the own-incoming-set existential-opposite
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals the
+named sign,” “the predicate equals the unique singleton lock vector,” “the
+predicate equals the sum of the lock set,” “the predicate equals axis-cover
+of `M` and `O`,” “the predicate equals exist-opposite of `O`,” “the
+predicate equals 1-axis same-lock signed-M,” “the predicate equals two-axis
+opposite,” “bits are Admissibility,” “reverse exist-opposite HOLDs,” or
+“face exist-opposite HOLDs.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis same-lock
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set from the record prefix at that probe's `t+1`, scores reverse and face
+by existential opposite, compares to two-axis opposite signed-M and to
+1-axis same-lock signed-M, and checks Theorems 1--3. It also checks that
+signed-M reverse fails and face fails, that axis-cover reverse is a
+different reverse, that exist-opposite of `O` is a different object, that
+mixed sets remain sets, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not attached,
+and that the display is not the two-tick lock-count clock composition. No
+runner cache is written.

--- a/logs/runner-cache/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.txt
@@ -1,0 +1,90 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
+runner_sha256: 67700bb6338f8996c97803d06fd718a8ba8045b7ea8c197e29f5d9b9d9d174d0
+input_fingerprint_sha256: 36ce2fb64742227cd6985d18a26b39d96126163af195cc53a3a52c1b545b6a2c
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+own incoming set exist-opposite reverse/face at t+1
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the own incoming *set* at t+1 on the four y-probes of the two-axis same-lock seed are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+A t=0 M={+e_1} exist-M-side={+e_1}
+B t=1 M={+e_1} exist-M-side={+e_1}
+C t=1 M={+e_2} exist-M-side={+e_2}
+D t=2 M={−e_3} exist-M-side={−e_3}
+exist-M reverse=fail face=fail
+two-axis-opposite reverse=hold face=fail
+1-axis same-lock reverse=fail face=hold
+cover reverse=hold face=fail
+per_element: each lock vector in the probe's own incoming set M(q, tau)
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four incoming sets plus reverse/face as hold, fail, or UNDEFINED
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: neither-pair-is-opposite
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{+e_1}', 'B': '{+e_1}', 'C': '{+e_2}', 'D': '{−e_3}'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-A-is-seed
+PASS: theorem1-mixed-remains-a-set
+PASS: theorem2-reverse-exist-opposite-fail  (fail)
+PASS: theorem3-face-exist-opposite-fail  (fail)
+PASS: compare-two-axis-opposite-signed-M
+PASS: compare-1-axis-same-lock-signed-M
+PASS: not-axis-cover-of-M-and-O
+PASS: not-exist-opposite-of-O
+PASS: not-unique-L-as-object
+PASS: not-nsopp-exist-opposite-hold
+PASS: not-x-probes-or-x-axis-same-or-ysym
+PASS: not-nnlock-named-sign
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: mutation-empty-or-undefined-is-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: mutation-sum-is-not-the-set
+PASS: note-claim-scope
+PASS: note-reports-ticks-and-incoming-sets
+PASS: note-reports-exist-opposite-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-two-axis-opposite-or-1-axis
+PASS: note-not-cover-or-O-or-unique-L
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-no-global-T
+PASS: note-not-sign-lettering
+PASS: note-does-not-use-occupancy
+PASS: note-not-ndot-or-occupancy-inner-product
+PASS: note-does-not-attach-formation-member
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-own-incoming-set-existential-opposite
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
@@ -1,0 +1,973 @@
+#!/usr/bin/env python3
+"""Own incoming set exist-opposite reverse/face on two-axis same-lock y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites in two disjoint same-lock pairs: origin and (0,1,0) lock
++e_1; (0,0,1) and (0,1,1) lock +e_2. Neither pair is opposite. A 6-NN step
+is allowed iff it is perpendicular to the parent lock axis. Newly formed
+sites lock the incoming step. Seeds keep their seed letters as a singleton.
+M(q, tau) is the set of earliest incoming nearest-neighbor steps at q using
+only records with tick <= tau. Unformed at tau => UNDEFINED. Reverse HOLDs
+iff some a in M(A, tau) and some b in M(B, tau) have a+b=(0,0,0). Face
+likewise on C, D. Empty or UNDEFINED on either side is UNDEFINED; nonempty
+with no opposite pair fails. Compare to two-axis opposite signed-M.
+Uniqueness is not required. Occupancy of sites is not used. Named-sign
+lettering is not used. No larger host. Not leftover of unique-L. Not
+leftover of axis-cover. Not leftover of exist-opposite of O. Not leftover
+of 1-axis same-lock signed-M. Displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+FOUR_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    ((0, 1, 1), E2),
+)
+ONE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+TWO_AXIS_OPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    ((0, 1, 1), NEG_E2),
+)
+NSOPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+X_AXIS_SAME_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E2),
+    (E1, E2),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from the own incoming *set* at t+1 on the "
+    "four y-probes of the two-axis same-lock seed are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = FOUR_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Outgoing dual of M. Leftover comparator only. Unformed => UNDEFINED."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> Incoming:
+    """Unsigned lattice axes occupied by signed locks. Leftover comparator."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def axis_cover(incoming: Incoming, outgoing: Incoming) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. Leftover comparator."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def pair_cover(left: str, right: str) -> str:
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: Incoming, set_b: Incoming) -> str:
+    """Reverse iff some a in M(A, tau) and some b in M(B, tau) have a+b=0."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: Incoming, set_d: Incoming) -> str:
+    """Face iff some c in M(C, tau) and some d in M(D, tau) have c+d=0."""
+    return existential_opposite(set_c, set_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def sum_of_set(locks: Incoming) -> Point | str:
+    if locks == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(locks, frozenset):
+        raise TypeError("sum needs a lock set")
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def probe_incoming(
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> dict[str, Incoming]:
+    report: dict[str, Incoming] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau = ticks[site] + 1
+        report[name] = incoming_set(site, tau, ticks, locks, seed_map)
+    return report
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("own incoming set exist-opposite reverse/face at t+1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E1, E1) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and existential_opposite(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and existential_opposite(frozenset(), frozenset({E3})) == UNDEFINED
+        and existential_opposite(frozenset({E3}), frozenset()) == UNDEFINED
+        and existential_opposite(frozenset(), frozenset()) == UNDEFINED
+        and existential_opposite(frozenset({E1}), frozenset({E1})) == "fail"
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold"
+        and existential_opposite(frozenset({E2}), frozenset({NEG_E3})) == "fail"
+        and existential_opposite(frozenset({E2}), frozenset({NEG_E2, E3, NEG_E3}))
+        == "hold",
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SEEDS)
+    opp_ticks, opp_locks, opp_seeds = form(TWO_AXIS_OPP_SEEDS)
+    nsopp_ticks, nsopp_locks, nsopp_seeds = form(NSOPP_SEEDS)
+    xsame_ticks, xsame_locks, xsame_seeds = form(X_AXIS_SAME_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o1: dict[str, Incoming] = {}
+    cover: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        cover[name] = axis_cover(m1[name], o1[name])
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"exist-M-side={lockset_display(m1[name])}"
+        )
+
+    reverse = reverse_report(m1["A"], m1["B"])
+    face = face_report(m1["C"], m1["D"])
+    o_reverse = reverse_report(o1["A"], o1["B"])
+    o_face = face_report(o1["C"], o1["D"])
+    cover_reverse = pair_cover(cover["A"], cover["B"])
+    cover_face = pair_cover(cover["C"], cover["D"])
+    unique_reverse = reverse_report(unique_letter(m1["A"]), unique_letter(m1["B"]))
+    unique_face = face_report(unique_letter(m1["C"]), unique_letter(m1["D"]))
+
+    one_m = probe_incoming(one_ticks, one_locks, one_seeds)
+    one_reverse = reverse_report(one_m["A"], one_m["B"])
+    one_face = face_report(one_m["C"], one_m["D"])
+    opp_m = probe_incoming(opp_ticks, opp_locks, opp_seeds)
+    opp_reverse = reverse_report(opp_m["A"], opp_m["B"])
+    opp_face = face_report(opp_m["C"], opp_m["D"])
+    nsopp_m = probe_incoming(nsopp_ticks, nsopp_locks, nsopp_seeds)
+    nsopp_reverse = reverse_report(nsopp_m["A"], nsopp_m["B"])
+    nsopp_face = face_report(nsopp_m["C"], nsopp_m["D"])
+    xsame_m = probe_incoming(xsame_ticks, xsame_locks, xsame_seeds)
+
+    print(f"exist-M reverse={reverse} face={face}")
+    print(f"two-axis-opposite reverse={opp_reverse} face={opp_face}")
+    print(f"1-axis same-lock reverse={one_reverse} face={one_face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: each lock vector in the probe's own incoming set M(q, tau)"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four incoming sets plus reverse/face as hold, fail, or UNDEFINED"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED
+        and reverse_report(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            m1["B"],
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set((0, 1, 1), 1, ticks, locks, seed_map) == frozenset({E2})
+        and FOUR_SITE_SEEDS
+        == ((ORIGIN, E1), (E2, E1), (E3, E2), ((0, 1, 1), E2)),
+    )
+    checks.check(
+        "neither-pair-is-opposite",
+        seed_map[ORIGIN] == seed_map[E2] == E1
+        and seed_map[E3] == seed_map[(0, 1, 1)] == E2
+        and add(seed_map[ORIGIN], seed_map[E2]) != ZERO
+        and add(seed_map[E3], seed_map[(0, 1, 1)]) != ZERO
+        and FOUR_SITE_SEEDS != TWO_AXIS_OPP_SEEDS,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and E2 in seed_map
+        and seed_map[E2] == E1
+        and m1["A"] == frozenset({E1}),
+    )
+    checks.check(
+        "theorem1-mixed-remains-a-set",
+        isinstance(m1["A"], frozenset)
+        and isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 1
+        and unique_letter(m1["D"]) == frozenset({NEG_E3})
+        and isinstance(one_m["D"], frozenset)
+        and len(one_m["D"]) == 3
+        and unique_letter(one_m["D"]) == UNDEFINED
+        and one_m["D"] == frozenset({NEG_E2, E3, NEG_E3}),
+    )
+    checks.check(
+        "theorem2-reverse-exist-opposite-fail",
+        reverse == "fail"
+        and m1["A"] == frozenset({E1})
+        and m1["B"] == frozenset({E1})
+        and add(E1, E1) != ZERO
+        and reverse != UNDEFINED
+        and reverse != "hold",
+        reverse,
+    )
+    checks.check(
+        "theorem3-face-exist-opposite-fail",
+        face == "fail"
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3})
+        and add(E2, NEG_E3) != ZERO
+        and face != UNDEFINED
+        and face != "hold",
+        face,
+    )
+    checks.check(
+        "compare-two-axis-opposite-signed-M",
+        opp_m["A"] == frozenset({NEG_E1})
+        and opp_m["B"] == frozenset({E1})
+        and opp_m["C"] == frozenset({E2})
+        and opp_m["D"] == frozenset({NEG_E3})
+        and opp_reverse == "hold"
+        and opp_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and m1["A"] != opp_m["A"],
+    )
+    checks.check(
+        "compare-1-axis-same-lock-signed-M",
+        one_m["A"] == frozenset({E1})
+        and one_m["B"] == frozenset({E1})
+        and one_m["C"] == frozenset({E2})
+        and one_m["D"] == frozenset({NEG_E2, E3, NEG_E3})
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and one_reverse == "fail"
+        and one_face == "hold"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "not-axis-cover-of-M-and-O",
+        cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and cover_reverse == "hold"
+        and cover_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and reverse != cover_reverse,
+    )
+    checks.check(
+        "not-exist-opposite-of-O",
+        o_reverse == "hold"
+        and o_face == "hold"
+        and reverse == "fail"
+        and face == "fail"
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "not-unique-L-as-object",
+        unique_reverse == "fail"
+        and unique_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and unique_letter(one_m["D"]) == UNDEFINED
+        and one_face == "hold",
+    )
+    checks.check(
+        "not-nsopp-exist-opposite-hold",
+        FOUR_SITE_SEEDS != NSOPP_SEEDS
+        and nsopp_reverse == "hold"
+        and nsopp_face == "hold"
+        and reverse == "fail"
+        and face == "fail"
+        and nsopp_m["A"] == frozenset({NEG_E1}),
+    )
+    x_m1 = {
+        name: incoming_set(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if X_PROBES[name] in ticks
+    }
+    checks.check(
+        "not-x-probes-or-x-axis-same-or-ysym",
+        FOUR_SITE_SEEDS != X_AXIS_SAME_SEEDS
+        and FOUR_SITE_SEEDS != Y_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and x_m1["A"] != m1["A"]
+        and xsame_m["A"] != m1["A"]
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check(
+        "not-nnlock-named-sign",
+        m1["A"] == frozenset({E1})
+        and named_sign(E1) == "+"
+        and m1["C"] == frozenset({E2})
+        and named_sign(E2) == "+"
+        and m1["A"] != named_sign(E1)
+        and m1["C"] != named_sign(E2),
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(
+            isinstance(m1[name], frozenset) and m1[name] <= set(NN)
+            for name in ("A", "B", "C", "D")
+        ),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        isinstance(m1["A"], frozenset)
+        and len(m1["A"]) == 1
+        and isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 1
+        and isinstance(one_m["D"], frozenset)
+        and len(one_m["D"]) == 3
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "mutation-empty-or-undefined-is-undefined",
+        reverse_report(frozenset(), m1["B"]) == UNDEFINED
+        and face_report(m1["C"], frozenset()) == UNDEFINED
+        and reverse_report(UNDEFINED, m1["B"]) == UNDEFINED
+        and face_report(m1["C"], UNDEFINED) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-sum-is-not-the-set",
+        sum_of_set(m1["A"]) == E1
+        and sum_of_set(m1["B"]) == E1
+        and sum_of_set(m1["C"]) == E2
+        and sum_of_set(m1["D"]) == NEG_E3
+        and m1["A"] == frozenset({E1})
+        and reverse == "fail",
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-and-incoming-sets",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {+e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_3}" in note,
+    )
+    checks.check(
+        "note-reports-exist-opposite-reverse-face",
+        "Reverse exist-opposite at τ: fail" in note
+        and "Face exist-opposite at τ: fail" in note
+        and "Reverse fails." in note
+        and "Face fails." in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-two-axis-opposite-or-1-axis",
+        "not leftover of two-axis opposite signed-M" in normalized_note
+        and "not leftover of 1-axis same-lock signed-M" in normalized_note
+        and "neither pair is opposite" in normalized_note,
+    )
+    checks.check(
+        "note-not-cover-or-O-or-unique-L",
+        "not leftover of axis-cover of `M` and `O`" in normalized_note
+        and "not leftover of exist-opposite of `O`" in normalized_note
+        and "not leftover of unique-L" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "occupancy of sites is not used" in normalized_note
+        and "own incoming set" in normalized_note
+        and "mixed remains a set" in normalized_note,
+    )
+    checks.check(
+        "note-not-ndot-or-occupancy-inner-product",
+        "not an occupancy-kernel inner product" in normalized_note
+        and "occupancy of sites is not used" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_SAME_LOCK_YPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "existential_opposite" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "source-letter-from-own-incoming-set-existential-opposite",
+        "incoming_set" in defined_fns
+        and "existential_opposite" in defined_fns
+        and reverse == "fail"
+        and face == "fail"
+        and opp_reverse == "hold",
+    )
+    _ = (
+        AXIS_NAME,
+        nsopp_face,
+        unique_face,
+        xsame_m,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Signed-M exist-opposite on same-lock y-probes: reverse fails, face fails. Discriminator vs timed-O HOLDING #7311. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_same_lock_yprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.