### PR TITLE
feat(nm2axmz): incoming exist-opposite at t+1 on two-axis opposite z-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,504 @@
+---
+claim_id: two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the own incoming *set* at t+1 on the four z-probes of the two-axis opposite seed are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
+---
+
+# Own Incoming Set Existential Opposite Reverse And Face On Four Z-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from the probe's own incoming *set* `M(q,τ)` at
+each probe's `τ=t+1` on the four z-probes of the two-axis opposite seed in
+`B_3(0)={n:n·n<=9}`. Process: two disjoint opposite pairs. Seed at tick 0:
+origin locks `+e_1`, `(0,1,0)` locks `−e_1`, `(0,0,1)` locks `+e_2`,
+`(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed child.
+Perp-step, incoming lock. Let `t(q)` be the formation tick of probe `q`.
+Let `τ(q)=t(q)+1`. There is no global T. `M(q,τ)` is the set of earliest
+incoming nearest-neighbor steps at `q` using only records with tick
+`<= τ`. Seeds are a singleton seed letter. Mixed remains a set. Unformed
+at `τ` is `UNDEFINED`. Reverse holds if and only if some lock in `M(A,τ)`
+is the vector opposite of some lock in `M(B,τ)`. Face holds if and only if
+some lock in `M(C,τ)` is the vector opposite of some lock in `M(D,τ)`.
+Empty or `UNDEFINED` on either side of a comparison is `UNDEFINED`;
+nonempty with no opposite pair fails. Unique `L` is not the object: report
+`M`. Occupancy of sites is not used. This is not named-sign lettering.
+This is not a unique lock-vector leftover and not a sum leftover. This is
+not leftover of unique-L. This is not leftover of nm2axz axis-cover of `M`
+and `O` on these same HOLDING-cover z-probes. This is not leftover of
+nmsimopp exist-opposite of `M` and of `O` at `t+1`. This is not leftover
+of timed `O` exist-opposite. This is not leftover of nm2axm y-probe
+signed-`M`. This is not leftover of nmt2opp `M` frozen at `t` as a
+different seed. This is not leftover of mixed #7188 fail/fail. Uniqueness
+of incoming locks is not required. Displayed, not adopted. Do not write
+into Admissibility. Do not attach L1. This note does not write existential
+opposite into Admissibility and does not attach a formation member from
+already-recorded six-neighbor locks. The six-neighbor star is not the
+letter.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming lock letters are unit nearest-neighbor
+steps. Reverse and face are scored on existence of an opposite pair in the
+own incoming sets at the per-probe cut `τ=t+1`. Named signs `{+,−}` are a
+coarser readout and are not used. A singleton unique lock-vector letter is a
+different readout and is not used as the object: report `M`. A `Z^3` sum of
+those locks is a different readout and is not used. The construction does
+not sum. Occupancy of sites is not used. A six-neighbor star is not the
+letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of M(q,τ) as the probe's own incoming set of earliest NN steps at τ=t+1 on the four z-probes of the two-axis opposite seed, mixed remains a set, with reverse fail and face fail from no opposite pair in signed M; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face
+target_blocker_text: "display reverse and face from the own incoming set at t+1 on the four z-probes of the two-axis opposite seed, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not replace M by O, do not replace exist-opposite by axis-cover, do not identify the report with 1-axis HOLDING M, do not identify it with y-probe signed-M, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for existential opposite of the own incoming set at t+1 on the four z-probes of the two-axis opposite seed; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose own
+incoming sets are scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (1,0,1).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the second opposite pair.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. The first
+pair is `{0, (0,1,0)}` with opposite locks `L(0)=+e_1` and
+`L(0,1,0)=−e_1`. The second pair is `{(0,0,1), (0,1,1)}` with opposite
+locks `L(0,0,1)=+e_2` and `L(0,1,1)=−e_2`. The second pair is a new seed,
+not a formed child of the first pair. This is not nsopp leftover: on the
+one-axis seed those two sites form at tick 1 with incoming `+e_3`. This
+seed is not the perp two-site seed `+e_1/+e_2`. This seed is not the
+z-symmetric three-site seed `{0,(0,0,1),(0,0,-1)}`. This seed is not the
+y-symmetric three-site seed that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named existential opposite from the own incoming set at `τ=t+1`
+
+Let `t(q)` be the formation tick of z-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter. Mixed remains a set. Unique `L(q)` is not used
+as the letter. Occupancy of sites is not used. Duplicate incoming steps
+collapse in the set. The construction does not require `M(q,τ)` to be a
+singleton. It does not sum `M(q,τ)`. It is not a unique lock-vector
+leftover and not a sum leftover. It is not leftover of unique-L. It is
+not leftover of nm2axz axis-cover of `M` and `O`. New records in `B_3(0)`
+between `t` and `t+1` that meet a probe's six-neighbors do not enter
+earliest `M`.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on existence
+of a pair of lock vectors that add to zero. They are not scored on `{+,−}`
+names.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in M(A,τ) and some b in M(B,τ) with a+b=(0,0,0)
+face     <=>  some c in M(C,τ) and some d in M(D,τ) with c+d=(0,0,0)
+```
+
+If `M(A,τ)` or `M(B,τ)` is empty or `UNDEFINED`, reverse is `UNDEFINED`.
+Else reverse fails if no such pair exists. If `M(C,τ)` or `M(D,τ)` is empty
+or `UNDEFINED`, face is `UNDEFINED`. Else face fails if no such pair exists.
+The report is one of `hold`, `fail`, or `UNDEFINED`. Either side
+`UNDEFINED` is `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility. Do not write into Admissibility. Do not attach L1.
+
+## Theorem 1 — ticks and `M` at `τ=t+1`
+
+On this process the four z-probes form. Own incoming sets at each probe's
+`τ=t+1` are frozen equal to `M` at `t`.
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=1
+M(A, τ) = {+e_2}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_3}
+M(D, τ) = {+e_1}
+```
+
+`A` is a seed at tick 0 with seed letter `+e_2`. The partner of that pair,
+`(0,1,1)`, is also a seed at tick 0 with seed letter `−e_2`. Mixed remains
+a set as a construction rule. On this two-axis seed each of `M(A,τ)`,
+`M(B,τ)`, `M(C,τ)`, and `M(D,τ)` is a singleton. Unique-L leftover would
+assign the same four letters. Here uniqueness is not required and the
+object is still the set `M`.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors:
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)
+new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)
+```
+
+Those new neighbors enter later outgoing duals and do not enter earliest
+`M`. Because `(0,1,1)` is a seed, it is not a new 6-NN of `A`.
+
+Compare to 1-axis HOLDING M. Same z-probes, same perp-step incoming lock,
+one opposite pair `{0,(0,1,0)}` with `+e_1/−e_1` only. On that 1-axis seed
+the runner reports `t(A)=1`, `t(B)=2`, `t(C)=4`, `t(D)=2`,
+`M(A,τ)={+e_3}`, `M(B,τ)={+e_1}`, mixed
+`M(C,τ)={+e_1, −e_1, +e_2}`, `M(D,τ)={+e_1}`, reverse fail, and 1-axis
+face hold. The two-axis seed advances `t(A)` from 1 to 0, `t(B)` from 2
+to 1, `t(C)` from 4 to 1, and `t(D)` from 2 to 1, replaces mixed `M(C,τ)`
+by `{+e_3}`, keeps reverse FAIL, and turns face from HOLD to fail.
+Reverse FAIL uses a singleton `M(A,τ)={+e_2}` against `{+e_1}`:
+`+e_2+(+e_1)` is not zero. Face fail uses singleton `M(C,τ)={+e_3}`
+against `M(D,τ)={+e_1}`: `+e_3+(+e_1)` is not zero.
+
+On the same two-axis seed, nm2axz axis-cover of `M` and `O` HOLDs at each
+of these four z-probes, with cover reverse HOLD and cover face HOLD. Signed
+own incoming `M` on those HOLDING-cover z-probes is this letter, and it
+fails both reverse and face.
+
+## Theorem 2 — reverse from exist-opposite of `M` at `τ`
+
+Reverse holds if and only if there exist `a` in `M(A,τ)` and `b` in
+`M(B,τ)` with `a+b=(0,0,0)`. Both sets are nonempty: `M(A,τ)={+e_2}` and
+`M(B,τ)={+e_1}`, so `+e_2+(+e_1)` is not zero. Reverse fails. Reverse FAIL
+uses a singleton `M(A,τ)`.
+
+Reverse exist-opposite at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Unique-L leftover also
+reports reverse fail from unique `L(A)=+e_2` and `L(B)=+e_1`. Axis-cover
+reverse HOLDs. Timed `O` exist-opposite reverse HOLDs. Y-probe signed-`M`
+reverse HOLDs. Those leftovers are not this display. Reverse fails because
+the pair from `M(A,τ)` and `M(B,τ)` is not opposite.
+
+Reverse fails.
+
+## Theorem 3 — face from exist-opposite of `M` at `τ`
+
+Face holds if and only if there exist `c` in `M(C,τ)` and `d` in `M(D,τ)`
+with `c+d=(0,0,0)`. Both sets are nonempty: `M(C,τ)={+e_3}` and
+`M(D,τ)={+e_1}`, so `+e_3+(+e_1)` is not zero. Face fails.
+
+Face exist-opposite at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `hold` and not `UNDEFINED`. Face fails. Unique-L leftover also
+reports face fail from unique `L(C)=+e_3` and `L(D)=+e_1`. Axis-cover face
+HOLDs, which is not this face fail. Timed `O` exist-opposite face fails by
+accident of the outgoing letters and is not this incoming-set report.
+1-axis HOLDING M face HOLDs, which is the discriminator. Y-probe signed-`M`
+face fails on a different probe set. Named-sign lettering lost the axis.
+Signed-`M` exist-opposite does not HOLD reverse or face on these
+HOLDING-cover z-probes: reverse fails and face fails.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the own incoming set to be a singleton.
+- It does not sum the own incoming set.
+- It does not use occupancy of sites as the letter.
+- It does not replace `M` by `O`.
+- It does not replace exist-opposite of signed `M` by axis-cover of `M` and
+  `O`.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not reprint 1-axis HOLDING M reverse fail and face hold as this
+  member.
+- It does not reprint nm2axm y-probe signed-`M` reverse hold and face fail.
+- It does not reprint nm2axz axis-cover reverse hold and face hold.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint timed `O` exist-opposite as this incoming-set report.
+- It does not reprint nmt2opp `M` frozen at `t` as this two-axis seed.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not treat the second pair as a formed child of nsopp leftover.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite-pair process, the own incoming sets at `t+1`, and the
+existential-opposite reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `1` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| reverse FAIL uses a singleton `M(A,τ)` | Theorem 1; yes; `{+e_2}` |
+| reverse from exist-opposite of `M` at `τ` | Theorem 2; `fail` |
+| face from exist-opposite of `M` at `τ` | Theorem 3; `fail` |
+| comparison to 1-axis HOLDING M | Theorem 1; 1-axis face hold, two-axis face fail |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of unique-L | not this display |
+| leftover of nm2axz axis-cover | not this display |
+| leftover of timed `O` exist-opposite | not this display |
+| leftover of nmsimopp exist-opposite of `M` and of `O` | not this display |
+| leftover of nm2axm y-probe signed-`M` | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| second pair as formed child | refused; new seed |
+| y-probe or x-probe signed-`M` on this seed | not this letter |
+| global later T | not used |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: own incoming set at `t+1` on the four z-probes of the two-axis opposite seed, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed own-incoming-set existential-opposite reverse/face report on these four z-probes of this two-axis opposite seed. |
+| V3 | Own incoming sets at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the probe's own incoming set at `t+1` and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not sum the lock set, does not replace `M` by `O`, does
+not replace exist-opposite by axis-cover, does not identify this display
+with 1-axis HOLDING M, does not identify it with y-probe signed-`M`, and
+does not identify it with timed `O` exist-opposite. No global impossibility
+is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| unique-L leftover | require a singleton `{v}` else `UNDEFINED` | on this seed `M` is already singleton at each probe, so unique-L reverse fail and face fail agree by accident; the object is still the set `M` | ATTEMPTED |
+| 1-axis HOLDING M | reuse reverse fail and face hold of own incoming `M` on these z-probes | 1-axis face HOLDs from mixed `M(C,τ)={+e_1, −e_1, +e_2}` against `{+e_1}`; two-axis face fails from `{+e_3}` against `{+e_1}` | ATTEMPTED |
+| nm2axz axis-cover | score reverse/face from complementary unsigned axes of `M` and `O` | cover reverse hold and face hold on these HOLDING-cover z-probes; signed-`M` reverse fail and face fail | ATTEMPTED |
+| timed `O` exist-opposite | score reverse/face inside `O(A,τ)` and `O(B,τ)` | timed `O` reverse HOLDs while signed-`M` reverse fails | ATTEMPTED |
+| nm2axm y-probe signed-`M` | reuse y-probe reverse hold and face fail | y-probe reverse HOLDs from `{−e_1}` against `{+e_1}`; this z-probe reverse fails from `{+e_2}` against `{+e_1}` | ATTEMPTED |
+| nmsimopp exist-opposite of `M` and of `O` | require both `M` and `O` exist-opposite | this display scores only own incoming `M` at `t+1` | ATTEMPTED |
+| sum of the same incoming sets | replace `M` by the `Z^3` sum | the construction does not sum; sum of a singleton agrees by accident and is not the letter | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | that leftover at `A` includes origin partner `+e_1` and pair partner `−e_2`; own incoming `M(A,τ)` is `{+e_2}` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; z-symmetric on these z-probes reports reverse hold and face hold | ATTEMPTED |
+| nsopp leftover child | treat `(0,0,1)` and `(0,1,1)` as formed children | they are tick-0 seeds with `+e_2/−e_2`, not tick-1 children with incoming `+e_3` | ATTEMPTED |
+| x-probe signed-`M` | score the four x-probes on this seed | x-probe `M(A,τ)={−e_3}` at tick 2; this letter is the four z-probes with seed `A` | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of signed-`M`
+exist-opposite with axis-cover, missing identification with 1-axis HOLDING
+M, missing identification with y-probe signed-`M`, and missing Record
+identification of exist-opposite reverse are distinct open premises. This
+note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-axis opposite seed locks `+e_1/−e_1` and `+e_2/−e_2`,
+perpendicular step rule, incoming-step lock, own incoming set from records
+with tick `<= τ`, per-probe `τ=t+1`, mixed remains a set, existential
+opposite, four z-probes with seed `A`, second pair is a new seed, and
+reverse/face as existence of a pair that sums to zero are declared. No
+uniqueness of incoming locks, no six-neighbor lock union as the scored
+object, no occupancy of sites as the letter, no named-sign reduction, no
+singleton leftover as the object, no sum leftover, no unique-L leftover, no
+axis-cover leftover, no timed-`O` leftover, no global later T, no formation
+attachment from already-recorded six-neighbor locks, and no Admissibility
+rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+exist-opposite reverse-fail and face-fail reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in an own incoming set | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four incoming sets and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** Signed-`M` exist-opposite should HOLD on these z-probes because
+nm2axz cover reverse HOLDs and face HOLDs; unique-L already gives the same
+four letters; y-probe signed-`M` already answered exist-opposite with reverse
+hold and face fail; 1-axis HOLDING M already answered these z-probes with
+reverse fail and face hold; timed `O` exist-opposite already HOLDs reverse;
+x-probes already give fail/fail; and empty `M` should be `UNDEFINED` like
+unformed.
+
+**Answer:** Cover HOLD is unsigned complementary occupation of `{e_1,e_2,e_3}`
+by `Axis(M)` and `Axis(O)` at one probe. Exist-opposite is a signed pair
+across two probes. Cover HOLDs both reverse and face on these z-probes;
+signed-`M` fails both. They disagree on the bits, so they are not the same
+object. Unique-L agrees because this seed happens to have singleton `M` at
+each of `A,B,C,D`; mixed remains a set as the construction, and uniqueness
+is not required. Y-probe signed-`M` reverse HOLDs from `{−e_1}` against
+`{+e_1}`; this z-probe reverse fails from `{+e_2}` against `{+e_1}`. 1-axis
+HOLDING M face HOLDs from mixed `M(C,τ)={+e_1, −e_1, +e_2}` against
+`{+e_1}`; two-axis face fails from `{+e_3}` against `{+e_1}`. That is the
+discriminator versus 1-axis HOLDING M. Timed `O` reverse HOLDs, so outgoing
+exist-opposite is not this incoming-set report. X-probes are different
+sites: `M(A,τ)={−e_3}` at tick 2, not seed `A` with `{+e_2}`. Empty `M` is
+`UNDEFINED` on a comparison side; unformed at `τ` is `UNDEFINED`. Reverse
+exist-opposite fails. Face fails. Signed-`M` exist-opposite does not HOLD
+either bit on these HOLDING-cover z-probes.
+
+### N8 — cross-cycle echo
+
+1-axis HOLDING M reported reverse fail and face hold from own incoming `M`
+on these same z-probes. nm2axm reported y-probe signed-`M` reverse hold and
+face fail. nm2axz reported axis-cover reverse hold and face hold on these
+z-probes. This note is not those displays: it reports exist-opposite of
+signed own incoming `M` at `τ=t+1` on the four z-probes of the two-axis
+opposite seed, reverse fail, and face fail. Discriminator versus 1-axis
+HOLDING M is face fail. Discriminator versus HOLDING cover is both bits.
+
+**Gate disposition:** PASS for the own-incoming-set existential-opposite
+`t+1` reverse/face reports above. FAIL / DO NOT SHIP for “the predicate
+equals the named sign,” “the predicate equals the unique singleton lock
+vector,” “the predicate equals the sum of the lock set,” “the predicate
+equals axis-cover,” “the predicate equals timed `O` exist-opposite,” “the
+predicate equals 1-axis HOLDING M,” “the predicate equals y-probe
+signed-`M`,” “bits are Admissibility,” “reverse exist-opposite holds,” or
+“face exist-opposite holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each z-probe's own earliest incoming
+set from the record prefix at that probe's `t+1`, scores reverse and face by
+existential opposite, lists new records in `B_3(0)` between `t` and `t+1`
+that meet a probe's six-neighbors, compares the same observables on the
+1-axis HOLDING M seed, and checks Theorems 1--3. It also checks that reverse
+fails and face fails, that mixed remains a set, that unique-L leftover is a
+different object even when letters agree, that nm2axz axis-cover leftover
+HOLDs both bits, that timed `O` exist-opposite reverse HOLDs, that the
+construction does not sum, that a formation member from already-recorded
+six-neighbor locks is not attached, that the second pair is a new seed, and
+that the display is not 1-axis HOLDING M and not y-probe signed-`M`. No
+runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.txt
@@ -1,0 +1,94 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
+runner_sha256: b8d4eff445c55ac59fbf09b62c39c34e4a3a8b28785281e96c58e1a77d58d3c7
+input_fingerprint_sha256: d36b509b551835f77a0d19caa7a471b48381c99ae165ee2465a87df44f6033bf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+two-axis opposite seed own incoming set exist-opposite reverse/face at t+1 on z-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the own incoming *set* at t+1 on the four z-probes of the two-axis opposite seed are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+PASS: own-incoming-set-identity
+A t=0 M={+e_2}
+B t=1 M={+e_1}
+C t=1 M={+e_3}
+D t=1 M={+e_1}
+exist-opposite reverse=fail face=fail
+1-axis HOLDING M reverse=fail face=hold t={1, 2, 4, 2}
+cover reverse=hold face=hold
+timed-O reverse=hold face=fail
+per_element: each lock vector in the probe's own incoming set M(q, t+1)
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four incoming sets plus reverse/face as hold, fail, or UNDEFINED
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-at-tau  ({'A': '{+e_2}', 'B': '{+e_1}', 'C': '{+e_3}', 'D': '{+e_1}'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((1, 0, 1), (-1, 0, 1), (0, 0, 2)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 0, 2), (-1, 0, 2), (0, -1, 2)), 'D': ((1, -1, 1), (1, 0, 2), (1, 0, 0))})
+PASS: theorem1-mixed-remains-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem1-reverse-fail-uses-singleton-M-A
+PASS: theorem1-compare-1-axis-HOLDING-M
+PASS: theorem2-reverse-exist-opposite-fail
+PASS: theorem3-face-exist-opposite-fail
+PASS: discriminator-vs-1-axis-HOLDING-M
+PASS: not-unique-L-leftover
+PASS: not-axis-cover-leftover
+PASS: not-timed-O-exist-opposite
+PASS: not-six-neighbor-lock-union
+PASS: not-x-probes-or-y-probes-or-perp
+PASS: not-y-symmetric-three-site-seed
+PASS: not-nsopp-leftover-child
+PASS: not-nnlock-named-sign
+PASS: incoming-locks-are-nn-steps
+PASS: uniqueness-not-required
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: mutation-empty-or-undefined-is-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: mutation-sum-is-not-the-letter
+PASS: note-claim-scope
+PASS: note-reports-ticks-and-incoming-sets
+PASS: note-reports-new-neighbors
+PASS: note-reports-exist-opposite-reverse-face
+PASS: note-compares-1-axis-HOLDING-M
+PASS: note-displayed-not-adopted
+PASS: note-not-sign-lettering
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-or-cover-leftover
+PASS: note-no-six-neighbor-star-as-letter
+PASS: note-not-nsopp-leftover-child
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: exist-opposite-fail-fail-not-cover-hold-hold
+TOTAL: PASS=61 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py
@@ -1,0 +1,1097 @@
+#!/usr/bin/env python3
+"""Own incoming set exist-opposite reverse/face on two-axis opposite z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. The second pair is a new seed, not
+a formed child of nsopp leftover. A 6-NN step is allowed iff it is
+perpendicular to the parent lock axis. Newly formed sites lock the incoming
+step. Seeds keep their seed letters as a singleton. M(q, tau) is the set of
+earliest incoming nearest-neighbor steps at q using only records with tick
+<= tau. Unformed at tau => UNDEFINED. Reverse HOLDs iff some a in M(A, tau)
+and some b in M(B, tau) have a+b=(0,0,0). Face likewise on C, D. Empty or
+UNDEFINED on either side is UNDEFINED; nonempty with no opposite pair fails.
+Same z-probes as nm2axz HOLDING-cover. Compare to 1-axis HOLDING M and to
+y-probe signed-M. Uniqueness is not required. Occupancy of sites is not
+used. Named-sign lettering is not used. No larger host. Not leftover of
+unique-L. Not leftover of axis-cover. Not leftover of timed O.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+Q_SEED: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (Q_SEED, NEG_E2),
+)
+ONE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from the own incoming *set* at t+1 on the "
+    "four z-probes of the two-axis opposite seed are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: Incoming) -> str:
+    if locks == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(locks, frozenset):
+        raise TypeError(f"lock set is not a lock set: {locks!r}")
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Outgoing dual of M. Contrast only; not this letter."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> Incoming:
+    """Unsigned lattice axes occupied by signed locks. Contrast only."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def axis_cover(incoming: Incoming, outgoing: Incoming) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. Contrast only."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def pair_cover(left: str, right: str) -> str:
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    UNDEFINED or empty on either side is UNDEFINED. Nonempty with no opposite
+    pair fails. Mixed remains a set. Does not sum. Does not require a singleton.
+    """
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        return UNDEFINED
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: Incoming, set_b: Incoming) -> str:
+    """Reverse iff some a in M(A, tau) and some b in M(B, tau) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: Incoming, set_d: Incoming) -> str:
+    """Face iff some c in M(C, tau) and some d in M(D, tau) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    """Unique-L leftover: UNDEFINED when mixed. Not this letter."""
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def neighbor_lock_set(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    tau: int,
+) -> frozenset[Point]:
+    """Leftover contrast: locks of 6-NN formed by tau, site excluded."""
+    collected: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks or ticks[neighbor] > tau:
+            continue
+        collected.update(locks[neighbor])
+    return frozenset(collected)
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: Incoming) -> Point | str:
+    if locks == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(locks, frozenset):
+        raise TypeError(f"lock set is not a lock set: {locks!r}")
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_incoming(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, Incoming]:
+    out: dict[str, Incoming] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = incoming_set(
+            site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+        )
+    return out
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("two-axis opposite seed own incoming set exist-opposite reverse/face at t+1 on z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == Q_SEED
+        and add(E2, E3) == Q_SEED
+        and add(E2, E1) != ZERO
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and in_ball(Q_SEED)
+        and not in_ball((4, 0, 0)),
+    )
+    set_a = frozenset({E2})
+    set_b = frozenset({E1})
+    set_c = frozenset({E3})
+    set_d = frozenset({E1})
+    one_set_c = frozenset({E1, NEG_E1, E2})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and existential_opposite(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and existential_opposite(frozenset(), frozenset({E3})) == UNDEFINED
+        and existential_opposite(frozenset({E3}), frozenset()) == UNDEFINED
+        and existential_opposite(frozenset(), frozenset()) == UNDEFINED
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(set_a, set_b) == "fail"
+        and existential_opposite(set_c, set_d) == "fail"
+        and existential_opposite(one_set_c, set_d) == "hold"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold",
+    )
+    checks.check(
+        "own-incoming-set-identity",
+        unique_letter(frozenset({E2})) == frozenset({E2})
+        and unique_letter(frozenset({E2, NEG_E2})) == UNDEFINED
+        and unique_letter(one_set_c) == UNDEFINED
+        and unique_letter(frozenset()) == UNDEFINED
+        and unique_letter(UNDEFINED) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, ysym_locks, ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o1: dict[str, Incoming] = {}
+    cover: dict[str, str] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    one_m1: dict[str, Incoming] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        cover[name] = axis_cover(m1[name], o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        one_m1[name] = incoming_set(
+            site, one_ticks[site] + 1, one_ticks, one_locks, one_seeds
+        )
+        print(f"{name} t={ticks[site]} M={set_display(m1[name])}")
+
+    reverse = reverse_report(m1["A"], m1["B"])
+    face = face_report(m1["C"], m1["D"])
+    unique_reverse = reverse_report(unique_letter(m1["A"]), unique_letter(m1["B"]))
+    unique_face = face_report(unique_letter(m1["C"]), unique_letter(m1["D"]))
+    cover_reverse = pair_cover(cover["A"], cover["B"])
+    cover_face = pair_cover(cover["C"], cover["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    one_reverse = reverse_report(one_m1["A"], one_m1["B"])
+    one_face = face_report(one_m1["C"], one_m1["D"])
+    neighbor_a = neighbor_lock_set(PROBES["A"], ticks, locks, ticks[PROBES["A"]])
+    neighbor_b = neighbor_lock_set(PROBES["B"], ticks, locks, ticks[PROBES["B"]])
+    neighbor_reverse = existential_opposite(neighbor_a, neighbor_b)
+    y_m1 = probe_incoming(Y_PROBES, ticks, locks, seed_map)
+    x_m1 = probe_incoming(X_PROBES, ticks, locks, seed_map)
+    y_reverse = reverse_report(y_m1["A"], y_m1["B"])
+    y_face = face_report(y_m1["C"], y_m1["D"])
+    x_reverse = reverse_report(x_m1["A"], x_m1["B"])
+    x_face = face_report(x_m1["C"], x_m1["D"])
+    print(f"exist-opposite reverse={reverse} face={face}")
+    print(
+        f"1-axis HOLDING M reverse={one_reverse} face={one_face} "
+        f"t={{{', '.join(str(one_ticks[PROBES[n]]) for n in ('A', 'B', 'C', 'D'))}}}"
+    )
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(f"timed-O reverse={o_exist_reverse} face={o_exist_face}")
+    print(
+        "per_element: each lock vector in the probe's own incoming set M(q, t+1)"
+    )
+    print(
+        "per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four incoming sets plus reverse/face as hold, fail, or UNDEFINED"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_a_parallel_blocked = ticks.get(add(E3, NEG_E2)) != 1
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(Q_SEED, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_a_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[E3] == 0
+        and ticks[Q_SEED] == 0
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and reverse_report(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            m1["B"],
+        )
+        == UNDEFINED
+        and incoming_set(PROBES["C"], 0, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["D"], 0, ticks, locks, seed_map) == UNDEFINED
+        and face_report(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            m1["D"],
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(Q_SEED, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and m1["A"] == frozenset({E2}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == set_a
+        and m1["B"] == set_b
+        and m1["C"] == set_c
+        and m1["D"] == set_d
+        and m1["A"] != UNDEFINED
+        and m1["D"] != UNDEFINED
+        and len(m1["A"]) == 1
+        and len(m1["D"]) == 1,
+        str({name: set_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 0, 2), (-1, 0, 2), (0, -1, 2))
+        and new_meet["D"] == ((1, -1, 1), (1, 0, 2), (1, 0, 0)),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-remains-a-set",
+        isinstance(m1["A"], frozenset)
+        and isinstance(m1["C"], frozenset)
+        and unique_letter(m1["C"]) == frozenset({E3})
+        and unique_letter(one_m1["C"]) == UNDEFINED
+        and isinstance(one_m1["C"], frozenset)
+        and len(one_m1["C"]) == 3,
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and m1["A"] == frozenset({E2})
+        and ticks[Q_SEED] == 0
+        and locks[Q_SEED] == {NEG_E2}
+        and Y_PROBES["A"] != PROBES["A"]
+        and X_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem1-reverse-fail-uses-singleton-M-A",
+        reverse == "fail"
+        and m1["A"] == set_a
+        and isinstance(m1["A"], frozenset)
+        and len(m1["A"]) == 1
+        and E2 in m1["A"]
+        and m1["B"] == set_b
+        and add(E2, E1) != ZERO,
+    )
+    checks.check(
+        "theorem1-compare-1-axis-HOLDING-M",
+        one_ticks[PROBES["A"]] == 1
+        and one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["C"]] == 4
+        and one_ticks[PROBES["D"]] == 2
+        and one_m1["A"] == frozenset({E3})
+        and one_m1["B"] == set_b
+        and one_m1["C"] == one_set_c
+        and one_m1["D"] == set_d
+        and one_reverse == "fail"
+        and one_face == "hold"
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["C"]] == 1
+        and m1["C"] != one_m1["C"]
+        and face != one_face,
+    )
+    checks.check(
+        "theorem2-reverse-exist-opposite-fail",
+        reverse == "fail"
+        and m1["A"] == set_a
+        and m1["B"] == set_b
+        and add(E2, E1) != ZERO
+        and reverse != UNDEFINED
+        and reverse != "hold",
+    )
+    checks.check(
+        "theorem3-face-exist-opposite-fail",
+        face == "fail"
+        and m1["C"] == set_c
+        and m1["D"] == set_d
+        and add(E3, E1) != ZERO
+        and face != UNDEFINED
+        and face != "hold",
+    )
+    checks.check(
+        "discriminator-vs-1-axis-HOLDING-M",
+        reverse == "fail"
+        and face == "fail"
+        and one_reverse == "fail"
+        and one_face == "hold"
+        and face != one_face
+        and m1["C"] == frozenset({E3})
+        and one_m1["C"] == one_set_c,
+    )
+    checks.check(
+        "not-unique-L-leftover",
+        unique_reverse == "fail"
+        and unique_face == "fail"
+        and reverse == unique_reverse
+        and face == unique_face
+        and unique_letter(m1["A"]) == frozenset({E2})
+        and unique_letter(m1["C"]) == frozenset({E3})
+        and unique_letter(one_m1["C"]) == UNDEFINED
+        and one_face != unique_face,
+    )
+    checks.check(
+        "not-axis-cover-leftover",
+        cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "hold"
+        and cover_reverse == "hold"
+        and cover_face == "hold"
+        and reverse != cover_reverse
+        and face != cover_face
+        and axis_cover(m1["A"], m1["B"]) == "fail",
+    )
+    checks.check(
+        "not-timed-O-exist-opposite",
+        o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and o_exist_reverse != reverse
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "not-six-neighbor-lock-union",
+        neighbor_reverse == "fail"
+        and reverse == "fail"
+        and E1 in neighbor_a
+        and NEG_E2 in neighbor_a
+        and E1 not in m1["A"]
+        and E2 in m1["A"]
+        and neighbor_a != m1["A"],
+    )
+    perp_m1 = probe_incoming(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_m1 = probe_incoming(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    ysym_ticks_count0 = sum(time == 0 for time in ysym_ticks.values())
+    perp_reverse = reverse_report(perp_m1["A"], perp_m1["B"])
+    perp_face = face_report(perp_m1["C"], perp_m1["D"])
+    zsym_reverse = reverse_report(zsym_m1["A"], zsym_m1["B"])
+    zsym_face = face_report(zsym_m1["C"], zsym_m1["D"])
+    checks.check(
+        "not-x-probes-or-y-probes-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and x_m1["A"] != m1["A"]
+        and y_m1["A"] != m1["A"]
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and y_reverse == "hold"
+        and y_face == "fail"
+        and perp_reverse == "fail"
+        and perp_face == "hold"
+        and zsym_reverse == "hold"
+        and zsym_face == "hold"
+        and reverse == "fail"
+        and face == "fail"
+        and y_reverse != reverse
+        and perp_face != face
+        and zsym_reverse != reverse,
+    )
+    checks.check(
+        "not-y-symmetric-three-site-seed",
+        TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and ysym_ticks_count0 == 3,
+    )
+    checks.check(
+        "not-nsopp-leftover-child",
+        TWO_AXIS_SEEDS != ONE_AXIS_SEEDS
+        and seed_map[E3] == E2
+        and seed_map[Q_SEED] == NEG_E2
+        and ticks[E3] == 0
+        and ticks[Q_SEED] == 0
+        and one_ticks[E3] == 1
+        and one_ticks[Q_SEED] == 1
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ticks.values()) == 4,
+    )
+    checks.check(
+        "not-nnlock-named-sign",
+        m1["A"] == frozenset({E2})
+        and named_sign(E2) == "+"
+        and named_sign(E1) == "+"
+        and m1["C"] == frozenset({E3})
+        and named_sign(E3) == "+"
+        and m1["A"] != named_sign(E2)
+        and m1["C"] != named_sign(E3),
+    )
+    checks.check(
+        "incoming-locks-are-nn-steps",
+        all(isinstance(m1[name], frozenset) and m1[name] <= set(NN) for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        len(m1["A"]) == 1
+        and len(m1["B"]) == 1
+        and len(m1["C"]) == 1
+        and len(m1["D"]) == 1
+        and reverse == "fail"
+        and face == "fail"
+        and unique_letter(one_m1["C"]) == UNDEFINED,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "mutation-empty-or-undefined-is-undefined",
+        reverse_report(frozenset(), m1["B"]) == UNDEFINED
+        and face_report(m1["C"], frozenset()) == UNDEFINED
+        and reverse_report(UNDEFINED, m1["B"]) == UNDEFINED
+        and face_report(m1["C"], UNDEFINED) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and reverse_report(set_a, set_b) == "fail"
+        and reverse_report(set_c, set_d) == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-sum-is-not-the-letter",
+        isinstance(m1["A"], frozenset)
+        and isinstance(m1["D"], frozenset)
+        and sum_of_set(m1["A"]) == E2
+        and sum_of_set(m1["B"]) == E1
+        and sum_of_set(m1["C"]) == E3
+        and sum_of_set(m1["D"]) == E1
+        and add(E2, E1) != ZERO
+        and add(E3, E1) != ZERO
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-and-incoming-sets",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ) = {+e_2}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_3}" in note
+        and "M(D, τ) = {+e_1}" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)" in note,
+    )
+    checks.check(
+        "note-reports-exist-opposite-reverse-face",
+        "Reverse exist-opposite at τ: fail" in note
+        and "Face exist-opposite at τ: fail" in note
+        and "Reverse fails." in note
+        and "Face fails." in note,
+    )
+    checks.check(
+        "note-compares-1-axis-HOLDING-M",
+        "Compare to 1-axis HOLDING M" in note
+        and "1-axis face hold" in normalized_note
+        and "two-axis seed advances" in normalized_note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-or-cover-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "not leftover of unique-L" in normalized_note
+        and "not leftover of nm2axz axis-cover" in normalized_note
+        and "not leftover of timed `O` exist-opposite" in normalized_note,
+    )
+    checks.check(
+        "note-no-six-neighbor-star-as-letter",
+        "six-neighbor star is not the letter" in normalized_note
+        and "own incoming set" in normalized_note,
+    )
+    checks.check(
+        "note-not-nsopp-leftover-child",
+        "not a formed child" in normalized_note
+        and "second pair is a new seed" in normalized_note
+        and "not leftover of mixed #7188 fail/fail" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_ZPROBE_OWN_INCOMING_SET_EXISTENTIAL_OPPOSITE_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "existential_opposite" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "exist-opposite-fail-fail-not-cover-hold-hold",
+        reverse == "fail"
+        and face == "fail"
+        and one_reverse == "fail"
+        and one_face == "hold"
+        and o_exist_reverse == "hold"
+        and cover_reverse == "hold"
+        and cover_face == "hold"
+        and y_reverse == "hold"
+        and y_face == "fail",
+    )
+    _ = (
+        neighbor_reverse,
+        x_reverse,
+        x_face,
+        ysym_locks,
+        ysym_seeds,
+        zsym_m1,
+        perp_m1,
+        zsym_face,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Signed-M exist-opposite on opposite z-probes: reverse fails, face fails. Discriminator vs 1-in 2-out HOLDING #7308. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_zprobe_own_incoming_set_existential_opposite_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.