### PR TITLE
feat(nm2axox): outgoing exist-opposite at t+1 on two-axis opposite x-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,522 @@
+---
+claim_id: two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Reverse and face from the own outgoing *set* at t+1 on the four x-probes of the two-axis opposite seed are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py
+---
+
+# Own Outgoing Set Existential Opposite At t+1 Reverse And Face On Four X-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** reverse and face from the probe's own outgoing *set* `O(q,τ)` at
+each probe's `τ=t+1` on the four x-probes of the two-axis opposite seed in
+`B_3(0)={n:n·n<=9}`. Same process and x-probes as nm2axx. Process: two
+disjoint opposite pairs. Seed at tick 0: origin locks `+e_1`, `(0,1,0)`
+locks `−e_1`, `(0,0,1)` locks `+e_2`, `(0,1,1)` locks `−e_2`. The second
+pair is a new seed, not a formed child. Perp-step, incoming lock. Let
+`t(q)` be the formation tick of probe `q`. Let `τ(q)=t(q)+1`. There is no
+global T. `M(q,τ)` is the set of earliest incoming nearest-neighbor steps
+at `q` using only records with tick `<= τ`. Seeds are a singleton seed
+letter. `O(q,τ)` is the outgoing dual of `M`: the set of `e` in
+`{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in `M(q+e,τ)`.
+Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Reverse
+holds if and only if some lock in `O(A,τ)` is the vector opposite of some
+lock in `O(B,τ)`. Face holds if and only if some lock in `O(C,τ)` is the
+vector opposite of some lock in `O(D,τ)`. Empty or `UNDEFINED` on either
+side of a comparison is `UNDEFINED`; nonempty with no opposite pair fails.
+nm2axo O HOLDING on y-probes. nm2axx cover FAIL/FAIL on x-probes.
+Discriminator: does signed O still HOLD where cover fails? It does not:
+reverse fails and face fails. This is not leftover of axis-cover FAIL/FAIL
+of `M` and `O` at `t+1`. This is not leftover of M exist-opposite. This is
+not leftover of unique-L. This is not leftover of nm2axo y-probe HOLD/HOLD.
+This is not leftover of nmoutopp untimed eventual-`O`. Uniqueness is not
+required. Mixed remains a set. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1. This note does not write existential
+opposite into Admissibility and does not attach a formation member from
+already-recorded six-neighbor locks. This display does not use occupancy.
+Mixed remains a set. Unique `L` is not the object. The six-neighbor star is
+not the letter. Occupancy of sites is not used. This is not named-sign
+lettering. This is not a unique lock-vector leftover and not a sum leftover.
+O is not M.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Reverse and face are scored on existence of an opposite pair in the
+own outgoing sets at that same cut. Named signs `{+,−}` are a coarser
+readout and are not used. A singleton unique lock-vector letter is a
+different readout and is not used as the object: report `O`. A `Z^3` sum of
+those locks is a different readout and is not used. The construction does
+not sum. Occupancy of sites is not used. A six-neighbor star is not the
+letter. O is not M.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of O(q, tau) as the probe's own outgoing dual of M at t+1 on the four x-probes of the two-axis opposite seed, mixed remains a set, with reverse fail and face fail from existential opposite; uniqueness of outgoing locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face
+target_blocker_text: "display reverse and face from the own outgoing set at t+1 on the four x-probes of the two-axis opposite seed, or UNDEFINED"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep reverse and face displayed; do not write existential opposite into Admissibility, do not reduce to named sign, do not require a singleton lock vector, do not sum the lock set, do not identify the sets with unique-L leftover, do not identify the sets with axis-cover FAIL/FAIL, do not identify the sets with M exist-opposite, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for existential opposite of the own outgoing set at t+1 on the four x-probes of the two-axis opposite seed, reverse fail and face fail; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose own
+outgoing sets at `τ=t+1` are scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are the nsopp x-probes. These are not the y-probes `A=(0,1,0)`,
+`B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`. These are not the z-probes
+`A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(1,0,1)`. `A` is not a seed.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. The first
+pair is `{0, (0,1,0)}` with opposite locks `L(0)=+e_1` and
+`L(0,1,0)=−e_1`. The second pair is `{(0,0,1), (0,1,1)}` with opposite
+locks `L(0,0,1)=+e_2` and `L(0,1,1)=−e_2`. The second pair is a new seed,
+not a formed child of the first pair. This is not nsopp leftover: on the
+one-axis seed those two sites form at tick 1 with incoming `+e_3`. This
+seed is not the perp two-site seed `+e_1/+e_2`. This seed is not the
+z-symmetric three-site seed `{0,(0,0,1),(0,0,-1)}`. This seed is not the
+y-symmetric three-site seed that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named existential opposite from the own outgoing set at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum `O`. Unique `L(q)` is not
+used as the letter. This display does not use a six-neighbor star. Occupancy
+of sites is not used. It is not a unique lock-vector leftover and not a sum
+leftover. It is not leftover of unique-L. It is not leftover of M
+exist-opposite. It is not leftover of axis-cover. O is not M.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Reverse and face are scored on existence
+of a pair of lock vectors that add to zero. They are not scored on `{+,−}`
+names and are not an occupancy-kernel inner product.
+
+Reverse and face (displayed):
+
+```text
+reverse  <=>  some a in O(A,τ) and some b in O(B,τ) with a+b=(0,0,0)
+face     <=>  some c in O(C,τ) and some d in O(D,τ) with c+d=(0,0,0)
+```
+
+If `O(A,τ)` or `O(B,τ)` is empty or `UNDEFINED`, reverse is `UNDEFINED`. Else
+reverse fails if no such pair exists. If `O(C,τ)` or `O(D,τ)` is empty or
+`UNDEFINED`, face is `UNDEFINED`. Else face fails if no such pair exists.
+The report is one of `hold`, `fail`, or `UNDEFINED`.
+
+Admissibility is not edited. Existential opposite is not written into
+Admissibility. Do not write into Admissibility. Do not attach L1.
+
+## Theorem 1 — ticks, `M`, and `O` at `τ=t+1`
+
+On this process the four x-probes form. Those ticks locate the earliest
+incoming set and the outgoing dual at the per-probe cut `τ=t+1`. They are
+not occupancy kernels and are not a global later T.
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {−e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_1}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {−e_2, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+```
+
+`A` is not a seed. `A` is the site `(1,0,0)` forming at tick 2 with
+incoming `{−e_3}`. Mixed remains a set: `O(B,τ)` has three outgoing
+steps, `O(C,τ)` has three, and `O(D,τ)` has two. `O(A,τ)` is a singleton
+`{+e_1}`. Unique letters would assign `UNDEFINED` at mixed `O(B)`, `O(C)`,
+and `O(D)`. Here uniqueness is not required. `M` is frozen from `t` to
+`t+1`. O is not M. `M` and `O` are disjoint at each of the four probes.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+At `t`, `O(A,t)`, `O(B,t)`, and `O(C,t)` are empty, while `O(D,t)={−e_1}`.
+Empty `O` at `t` is not this letter. This display reads `O` at `τ=t+1`.
+
+Compare to #7167 1-axis. Same x-probes, same perp-step incoming lock, one
+opposite pair `{0,(0,1,0)}` with `+e_1/−e_1` only. On that 1-axis seed the
+runner reports `t(A)=3`, `t(B)=2`, `t(C)=4`, `t(D)=3`, and the same
+outgoing sets at `t+1`. The two-axis seed advances `t(A)` from 3 to 2,
+`t(B)` from 2 to 1, `t(C)` from 4 to 3, and `t(D)` from 3 to 2 because
+`(0,0,1)` and `(0,1,1)` are seeds rather than formed children. Reverse of
+1-axis `O` fails. Face of 1-axis `O` fails. Tick advance is not identity of
+the letter: the scored object is signed `O` at each probe's own `t+1`.
+
+Axis-cover of `M` and `O` at this same cut fails at `A`, HOLDs at `B`,
+HOLDs at `C`, and fails at `D` because `Axis(M)∪Axis(O)` at `A` and at `D`
+misses `e_2`. That leftover of axis-cover reports reverse fail and face
+fail. Cover HOLDs at `B` and at `C`. This display scores signed
+exist-opposite of `O` alone. Cover HOLD at `B` is not exist-opposite HOLD.
+
+## Theorem 2 — reverse hold / fail / UNDEFINED
+
+Reverse of `O` at `τ` holds if and only if there exist `a` in `O(A,τ)` and
+`b` in `O(B,τ)` with `a+b=(0,0,0)`. Both sets are nonempty:
+`O(A,τ)={+e_1}` and `O(B,τ)={+e_2, +e_3, −e_3}`. No pair adds to zero:
+`+e_1` has no opposite in `O(B,τ)`. Reverse fails.
+
+Reverse of O at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Unique-L leftover of
+`O` reports reverse `UNDEFINED` because `O(B,τ)` is mixed. M exist-opposite
+reverse fails from `−e_3` in `M(A,τ)` against `+e_1` in `M(B,τ)`. Those
+incoming letters are disjoint from `O` at each reverse probe. Axis-cover
+reverse fails from cover fail at `A`, while cover HOLDs at `B`. Reverse
+fails here because a pair from `O(A,τ)` and `O(B,τ)` is not opposite.
+Y-probe exist-opposite reverse HOLDs on this same seed from
+`O(A,τ)={+e_2, −e_3}` against `O(B,τ)={+e_2, +e_3, −e_3}`.
+
+Reverse fails.
+
+## Theorem 3 — face hold / fail / UNDEFINED
+
+Face of `O` at `τ` holds if and only if there exist `c` in `O(C,τ)` and
+`d` in `O(D,τ)` with `c+d=(0,0,0)`. Both sets are nonempty:
+`O(C,τ)={−e_2, +e_3, −e_3}` and `O(D,τ)={+e_1, −e_1}`. No pair adds to
+zero: `±e_1` at `D` has no opposite in `O(C,τ)`, and `−e_2` at `C` has no
+opposite in `O(D,τ)`. Face fails.
+
+Face of O at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `hold` and not `UNDEFINED`. Face fails. Unique-L leftover of
+`O` reports face `UNDEFINED` from mixed outgoing sets at `C` and at `D`.
+M exist-opposite face fails because `M(C,τ)={+e_1}` has no opposite in
+`M(D,τ)={−e_3}`. Axis-cover face fails because cover fails at `D`, while
+cover HOLDs at `C`. Exist-opposite face of signed `O` also fails, but from
+the signed pair `{−e_2, +e_3, −e_3}` against `{+e_1, −e_1}`, not from the
+unsigned leftover `{e_2}` at `D`. Named-sign lettering lost the axis in
+mixed `{+,−}` at `B`, `C`, and `D`. Y-probe exist-opposite face HOLDs on
+this same seed. Face already fails at each probe's own `t+1` from the own
+outgoing set.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require the own outgoing set to be a singleton.
+- It does not sum the own outgoing set.
+- It does not use occupancy of sites as the letter.
+- It does not score reverse or face as an occupancy-kernel inner product.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint unique-L letters on these x-probes as the object.
+- It does not reprint M exist-opposite as the letter.
+- It does not reprint axis-cover of `M` and `O` as the letter.
+- It does not reprint y-probe HOLD/HOLD as this x-probe letter.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not treat the second pair as a formed child of nsopp leftover.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite-pair process, the own outgoing sets at `t+1`, and the
+existential-opposite reverse/face predicates are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; outgoing dual |
+| compare O to M | Theorem 1; disjoint at each probe; O is not M |
+| reverse from exist-opposite of `O` at `τ` | Theorem 2; `fail` |
+| face from exist-opposite of `O` at `τ` | Theorem 3; `fail` |
+| comparison to #7167 1-axis | Theorem 1; 1-axis ticks `3,2,4,3`; same `O` sets |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of unique-L | not this display |
+| leftover of M exist-opposite | not this display |
+| leftover of axis-cover | not this display |
+| leftover of nm2axo y-probe HOLD/HOLD | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| second pair as formed child | refused; new seed |
+| global later T | not used |
+| existential opposite as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the discriminator: own outgoing set at `t+1` on the four x-probes of the two-axis opposite seed, reverse/face or `UNDEFINED`. |
+| V2 | Current main has no landed timed own-outgoing-set existential-opposite reverse/face report on these four x-probes of the two-axis opposite seed. |
+| V3 | Own outgoing sets at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the probe's own outgoing dual of `M` at `t+1` and scores existence of an opposite pair. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not sum the lock set, does not reprint unique-L, does not
+reprint M exist-opposite as the letter, does not reprint axis-cover as the
+letter, does not use a six-neighbor star, and does not use occupancy of
+sites. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| leftover of axis-cover | score reverse/face as complementary unsigned axes of `M` and `O` | axis-cover reverse fails and face fails, but cover HOLDs at `B` and at `C`; this reverse fails from `{+e_1}` against `{+e_2,+e_3,−e_3}` | ATTEMPTED |
+| leftover of M exist-opposite | reuse signed reverse/face of `M` at `τ` | M reverse fails and M face fails from `{−e_3}` against `{+e_1}` and `{+e_1}` against `{−e_3}`; those incoming sets are disjoint from `O` | ATTEMPTED |
+| unique-L leftover | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(B,τ)` remains a set; unique-letter reverse of `O` is `UNDEFINED` while reverse fails | ATTEMPTED |
+| sum of the same outgoing sets | replace `O` by the `Z^3` sum | the construction does not sum; sum of mixed `O(B,τ)` cancels to `+e_2` while `O(B,τ)` stays a three-element set | ATTEMPTED |
+| nm2axo y-probes | score `A=(0,1,0)`, `C=(0,2,0)` | leftover; y-probe reverse HOLDs and face HOLDs while x-probe reverse fails and face fails | ATTEMPTED |
+| z-probes on the same process | score `A=(0,0,1)`, `C=(0,0,2)` | leftover; z-probe reverse HOLDs and face fails; `O(A)` there is `{+e_1,−e_1,+e_3}`, not `{+e_1}` | ATTEMPTED |
+| nmsimopp one-axis simultaneous | reuse 1-axis `M` and `O` together at `t+1` | different seed; two-axis advances ticks from `3,2,4,3` to `2,1,3,2` | ATTEMPTED |
+| nmoutopp untimed eventual-`O` | wait for all later children | `τ(q)=t(q)+1` is per-probe; no untimed eventual set | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is a different signed letter; this display reads `O` alone | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| occupancy of sites | assign one letter from occupancy | occupancy of sites is not used | ATTEMPTED |
+| occupancy-kernel inner product | score an occupancy inner product | different object; not an occupancy-kernel inner product | ATTEMPTED |
+| same-tick-inclusive six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | this display does not use a six-neighbor star | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores exist-opposite of own outgoing at `t+1` | ATTEMPTED |
+| nsopp leftover child | treat `(0,0,1)` and `(0,1,1)` as formed children | they are tick-0 seeds with `+e_2/−e_2`, not tick-1 children with incoming `+e_3` | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by existential opposite | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of this display with
+axis-cover, missing identification of this display with M exist-opposite,
+and missing Record identification of exist-opposite reverse are distinct
+open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two-axis opposite seed locks `+e_1/−e_1` and `+e_2/−e_2`,
+perpendicular step rule, incoming-step lock, own outgoing dual from records
+with tick `<= τ`, per-probe `τ=t+1`, four x-probes with `A` not a seed,
+second pair is a new seed, mixed remains a set, and reverse/face as existence
+of a pair that sums to zero are declared. No uniqueness of outgoing locks, no
+occupancy of sites, no named-sign reduction, no singleton leftover as the
+object, no sum leftover, no unique-L leftover, no M exist-opposite leftover,
+no leftover of axis-cover, no six-neighbor star as the letter, no global
+later T, no formation attachment from already-recorded six-neighbor locks,
+and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+`fail`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each lock vector in an own outgoing set at `t+1` | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four outgoing sets and two reverse/face comparisons | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for reverse/face, a
+formation-rate rule, and a physical selector among `{±e_i}`. None is taken
+here.
+
+### N7 — hostile steelman
+
+**Steelman:** The own outgoing set at `t+1` is leftover of unique-L because
+`O(A)` is already a singleton `{+e_1}`; the sets should be replaced by their
+sums; axis-cover already answered FAIL/FAIL; M exist-opposite already
+answered signed FAIL/FAIL; y-probe HOLD/HOLD already answered timed `O`;
+named signs should suffice because they keep orientation; and occupancy of
+sites should track that vector.
+
+**Answer:** The named construction reports outgoing sets `{+e_1}`,
+`{+e_2, +e_3, −e_3}`, `{−e_2, +e_3, −e_3}`, `{+e_1, −e_1}` at `A,B,C,D`
+from the probe's own outgoing dual of `M` at `τ=t+1`. Mixed remains a set.
+The construction does not sum. Occupancy of sites is not used. Named signs
+lost the axis. No pair from `O(A,τ)` and `O(B,τ)` is opposite, so reverse
+fails. No pair from `O(C,τ)` and `O(D,τ)` is opposite, so face fails.
+Unique-L leftover of `O` reports reverse `UNDEFINED` and face `UNDEFINED`
+from mixed outgoing sets at `B`, `C`, and `D`. M exist-opposite reports
+reverse fail and face fail from incoming sets that are disjoint from `O`
+at each probe. Axis-cover reports reverse fail and face fail from incomplete
+unsigned union at `A` and at `D`, while cover HOLDs at `B` and at `C`.
+Y-probe exist-opposite HOLDs reverse and face on this same seed. Fail from
+outgoing `{+e_1}` at reverse and `{−e_2,+e_3,−e_3}` at face, while cover
+HOLDs at `B` and at `C` and y-probe O HOLDs, is a discriminator. The sets
+are not those leftovers. The bits remain displayed. Outgoing-lock uniqueness
+is not required. O is not M.
+
+### N8 — cross-cycle echo
+
+#7167 1-axis on these x-probes reports the same `O` sets with later ticks
+`3,2,4,3` and reverse fail, face fail. Axis-cover on these x-probes reports
+reverse fail and face fail from leftover `{e_2}` at `A` and at `D`, while
+cover HOLDs at `B` and at `C`. M exist-opposite on this seed reports reverse
+fail and face fail from incoming `{−e_3}` against `{+e_1}`. Unique lock-vector
+lettering of the outgoing sets would report reverse `UNDEFINED` and face
+`UNDEFINED` because reverse and face mix at `B`, `C`, and `D`. nm2axo y-probe
+exist-opposite reports reverse hold and face hold. A sum leftover of the
+same lists would replace mixed `O(B,τ)` by `+e_2` after cancelling `+e_3`
+and `−e_3`. This note is not those displays: mixed remains a set, the
+construction does not sum, the letter is the own outgoing set at `t+1` on
+the four x-probes of the two-axis opposite seed, reverse fails, and face
+fails.
+
+**Gate disposition:** PASS for the own-outgoing-set existential-opposite
+`t+1` reverse/face reports above. FAIL / DO NOT SHIP for “the predicate
+equals the named sign,” “the predicate equals the unique singleton lock
+vector,” “the predicate equals the sum of the lock set,” “the predicate
+equals leftover of axis-cover,” “the predicate equals leftover of M
+exist-opposite,” “bits are Admissibility,” “the letter is occupancy of
+sites,” “the sets equal unique-L leftover,” “reverse holds,” or “face
+holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own outgoing dual of
+the incoming set from the record prefix at that probe's `t+1`, scores
+reverse and face by existential opposite, compares the same observables on
+the #7167 1-axis seed, and checks Theorems 1--3. It also checks that mixed
+sets remain sets, that unique-letter reverse of `O` is `UNDEFINED`, that
+axis-cover HOLDs at `B` and at `C` while this reverse fails, that M is
+disjoint from `O`, that y-probe exist-opposite HOLDs on this same seed,
+that the construction does not sum, that a formation member from
+already-recorded six-neighbor locks is not attached, that the second pair
+is a new seed, and that the display is not leftover of axis-cover. No runner
+cache is written.

--- a/logs/runner-cache/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,96 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py
+runner_sha256: fefeaaf3d6fd0613461110d2417b12a74ba2915f00cb84e9bb1de0bd75df78f6
+input_fingerprint_sha256: ce73590b11d166d32dfe7caddae05b7b97017d3ca3c9aa4fb247db943429ba1b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+two-axis opposite seed own outgoing set exist-opposite reverse/face at t+1
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Reverse and face from the own outgoing *set* at t+1 on the four x-probes of the two-axis opposite seed are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: existential-opposite-identity
+A t=2 M={−e_3} O={+e_1}
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3}
+C t=3 M={+e_1} O={−e_2, +e_3, −e_3}
+D t=2 M={−e_3} O={+e_1, −e_1}
+O reverse=fail face=fail
+M reverse=fail face=fail
+cover reverse=fail face=fail
+per_element: each lock vector in the probe's own outgoing set O(q, tau)
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four outgoing sets at t+1 plus reverse/face as hold, fail, or UNDEFINED
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_3}', 'B': '{+e_1}', 'C': '{+e_1}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_1}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{−e_2, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((2, 0, 0),), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((2, -1, 0), (2, 0, 1), (2, 0, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-not-seed
+PASS: theorem1-compare-7167-1-axis
+PASS: theorem2-reverse-fail  (fail)
+PASS: theorem3-face-fail  (fail)
+PASS: discriminator-O-fail-where-cover-fail
+PASS: not-M-exist-opposite-letter
+PASS: not-unique-L-leftover
+PASS: O-is-not-M
+PASS: not-y-probes-or-z-symmetric-or-perp
+PASS: not-z-probes
+PASS: not-y-symmetric-three-site-seed
+PASS: not-nsopp-leftover-child
+PASS: not-nnlock-named-sign
+PASS: outgoing-locks-are-nn-steps
+PASS: uniqueness-not-required
+PASS: two-axis-opposite-lock-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: empty-O-is-empty-not-undefined
+PASS: mutation-empty-or-undefined-is-undefined
+PASS: mutation-no-opposite-pair-fails
+PASS: mutation-unique-L-outgoing-would-be-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: O-at-t-is-not-this-tplus1-letter
+PASS: note-claim-scope
+PASS: note-reports-ticks-and-outgoing-sets
+PASS: note-reports-new-neighbors
+PASS: note-reports-fail-fail
+PASS: note-displayed-not-adopted
+PASS: note-not-axis-cover-or-M-leftover
+PASS: note-not-sign-lettering
+PASS: note-does-not-attach-formation-member
+PASS: note-not-unique-or-sum-or-star-leftover
+PASS: note-no-six-neighbor-star-as-letter
+PASS: note-not-nsopp-leftover-child
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: source-letter-from-own-outgoing-set-existential-opposite
+TOTAL: PASS=64 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1185 @@
+#!/usr/bin/env python3
+"""Own outgoing set exist-opposite at t+1 reverse/face on two-axis x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and x-probes as nm2axx.
+The second pair is a new seed, not a formed child. A 6-NN step is allowed
+iff it is perpendicular to the parent lock axis. Newly formed sites lock the
+incoming step. Seeds keep their seed letters as a singleton. t(q) is the
+formation tick. tau = t+1. M(q, tau) is the set of earliest incoming
+nearest-neighbor steps at q using only records with tick <= tau. Unformed
+at tau => UNDEFINED. O(q, tau) is the outgoing dual of M: the set of e in
+{±e_1,±e_2,±e_3} such that q+e is formed and e is in M(q+e, tau). Unformed
+q at tau => UNDEFINED. Empty O is empty, not UNDEFINED. Reverse HOLDs iff
+some a in O(A, tau) and some b in O(B, tau) have a+b=(0,0,0). Face likewise
+on C, D. Empty or UNDEFINED on either side is UNDEFINED; nonempty with no
+opposite pair fails. Uniqueness is not required. Occupancy of sites is not
+used. Named-sign lettering is not used. No unique P_+. No 6-NN star. No
+Cl(3,0). No Dijkstra. No Gram. No larger host. Not leftover of axis-cover
+FAIL/FAIL. Not leftover of M exist-opposite. Not leftover of unique-L.
+Not leftover of y-probe O HOLD/HOLD.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+Q_SEED: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+POSITIVE_LOCKS = frozenset({E1, E2, E3})
+NEGATIVE_LOCKS = frozenset({NEG_E1, NEG_E2, NEG_E3})
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (Q_SEED, NEG_E2),
+)
+ONE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Reverse and face from the own outgoing *set* at t+1 on the "
+    "four x-probes of the two-axis opposite seed are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def named_sign(lock: Point) -> str:
+    """Named sign of a lock vector. Contrast only; not the scored predicate."""
+    if lock in POSITIVE_LOCKS:
+        return "+"
+    if lock in NEGATIVE_LOCKS:
+        return "-"
+    raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    """Unique-L leftover: UNDEFINED when mixed. Not this letter."""
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Hold iff some lock in left is the vector opposite of some lock in right.
+
+    UNDEFINED or empty on either side is UNDEFINED. Nonempty with no opposite
+    pair fails. Mixed remains a set. Does not sum. Does not require a singleton.
+    """
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        return UNDEFINED
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def reverse_report(set_a: Incoming, set_b: Incoming) -> str:
+    """Reverse iff some a in O(A, tau) and some b in O(B, tau) have a+b=(0,0,0)."""
+    return existential_opposite(set_a, set_b)
+
+
+def face_report(set_c: Incoming, set_d: Incoming) -> str:
+    """Face iff some c in O(C, tau) and some d in O(D, tau) have c+d=(0,0,0)."""
+    return existential_opposite(set_c, set_d)
+
+
+def axis_set(value: Incoming) -> frozenset[Point] | str:
+    """Unsigned axes of a lock set. Contrast only; not this letter."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        occupied.add(axis_of_letter(lock))
+    return frozenset(occupied)
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Axis-cover leftover contrast. Not this reverse."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def pair_cover(left: str, right: str) -> str:
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: Incoming) -> Point | str:
+    """Z^3 sum leftover of a lock set. Contrast only; not this letter."""
+    if locks == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(locks, frozenset):
+        raise TypeError(f"lock set is not a lock set: {locks!r}")
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("two-axis opposite seed own outgoing set exist-opposite reverse/face at t+1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E2, E3) == Q_SEED
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and in_ball(Q_SEED)
+        and not in_ball((4, 0, 0)),
+    )
+    out_a = frozenset({E1})
+    out_b = frozenset({E2, E3, NEG_E3})
+    out_c = frozenset({NEG_E2, E3, NEG_E3})
+    out_d = frozenset({E1, NEG_E1})
+    set_a = frozenset({NEG_E3})
+    set_b = frozenset({E1})
+    set_c = frozenset({E1})
+    set_d = frozenset({NEG_E3})
+    hold_a = frozenset({E2, NEG_E3})
+    hold_b = frozenset({E2, E3, NEG_E3})
+    checks.check(
+        "existential-opposite-identity",
+        existential_opposite(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and existential_opposite(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and existential_opposite(frozenset(), frozenset({E3})) == UNDEFINED
+        and existential_opposite(frozenset({E3}), frozenset()) == UNDEFINED
+        and existential_opposite(frozenset(), frozenset()) == UNDEFINED
+        and existential_opposite(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and existential_opposite(frozenset({NEG_E1}), frozenset({E1})) == "hold"
+        and existential_opposite(frozenset({E2}), frozenset({NEG_E3})) == "fail"
+        and existential_opposite(hold_a, hold_b) == "hold"
+        and existential_opposite(out_a, out_b) == "fail"
+        and existential_opposite(out_c, out_d) == "fail"
+        and existential_opposite(frozenset({NEG_E2}), frozenset({E2})) == "hold",
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, ysym_locks, ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    one_m1: dict[str, Incoming] = {}
+    one_o1: dict[str, Outgoing] = {}
+    cover: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        one_m1[name] = incoming_set(
+            site, one_ticks[site] + 1, one_ticks, one_locks, one_seeds
+        )
+        one_o1[name] = outgoing_set(
+            site, one_ticks[site] + 1, one_ticks, one_locks, one_seeds
+        )
+        cover[name] = axis_cover(m1[name], o1[name])
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])}"
+        )
+
+    reverse = reverse_report(o1["A"], o1["B"])
+    face = face_report(o1["C"], o1["D"])
+    reverse_m = reverse_report(m1["A"], m1["B"])
+    face_m = face_report(m1["C"], m1["D"])
+    cover_reverse = pair_cover(cover["A"], cover["B"])
+    cover_face = pair_cover(cover["C"], cover["D"])
+    unique_out_reverse = reverse_report(unique_letter(o1["A"]), unique_letter(o1["B"]))
+    unique_out_face = face_report(unique_letter(o1["C"]), unique_letter(o1["D"]))
+    unique_m_reverse = reverse_report(unique_letter(m1["A"]), unique_letter(m1["B"]))
+    unique_m_face = face_report(unique_letter(m1["C"]), unique_letter(m1["D"]))
+    one_reverse = reverse_report(one_o1["A"], one_o1["B"])
+    one_face = face_report(one_o1["C"], one_o1["D"])
+    print(f"O reverse={reverse} face={face}")
+    print(f"M reverse={reverse_m} face={face_m}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: each lock vector in the probe's own outgoing set O(q, tau)"
+    )
+    print(
+        "per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four outgoing sets at t+1 plus reverse/face as hold, fail, or UNDEFINED"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(Q_SEED, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[E3] == 0
+        and ticks[Q_SEED] == 0
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and reverse_report(
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+            o1["B"],
+        )
+        == UNDEFINED
+        and outgoing_set(PROBES["C"], 2, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(Q_SEED, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and m1["A"] == frozenset({NEG_E3}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == set_a
+        and m1["B"] == set_b
+        and m1["C"] == set_c
+        and m1["D"] == set_d,
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == out_a
+        and o1["B"] == out_b
+        and o1["C"] == out_c
+        and o1["D"] == out_d
+        and o1["A"] != UNDEFINED
+        and o1["D"] != UNDEFINED
+        and isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 1
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and isinstance(o1["C"], frozenset)
+        and len(o1["C"]) == 3
+        and isinstance(o1["D"], frozenset)
+        and len(o1["D"]) == 2,
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0),)
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 1
+        and unique_letter(o1["A"]) == frozenset({E1})
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(o1["C"], frozenset)
+        and len(o1["C"]) == 3
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and o1["A"] != UNDEFINED
+        and o1["D"] != UNDEFINED,
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and ticks[E1] == 2
+        and locks[E1] == {NEG_E3}
+        and m1["A"] == frozenset({NEG_E3})
+        and E1 not in seed_map
+        and Y_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem1-compare-7167-1-axis",
+        one_ticks[PROBES["A"]] == 3
+        and one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["C"]] == 4
+        and one_ticks[PROBES["D"]] == 3
+        and one_o1["A"] == frozenset({E1})
+        and one_o1["B"] == o1["B"]
+        and one_o1["C"] == o1["C"]
+        and one_o1["D"] == o1["D"]
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and ticks[PROBES["A"]] != one_ticks[PROBES["A"]]
+        and ticks[PROBES["D"]] != one_ticks[PROBES["D"]]
+        and one_reverse == "fail"
+        and one_face == "fail",
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse == "fail"
+        and o1["A"] == out_a
+        and o1["B"] == out_b
+        and E1 in o1["A"]
+        and NEG_E1 not in o1["B"]
+        and E2 in o1["B"]
+        and E3 in o1["B"]
+        and NEG_E3 in o1["B"]
+        and reverse != "hold"
+        and reverse != UNDEFINED,
+        reverse,
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face == "fail"
+        and o1["C"] == out_c
+        and o1["D"] == out_d
+        and NEG_E2 in o1["C"]
+        and E2 not in o1["D"]
+        and E1 in o1["D"]
+        and NEG_E1 in o1["D"]
+        and face != "hold"
+        and face != UNDEFINED,
+        face,
+    )
+    checks.check(
+        "discriminator-O-fail-where-cover-fail",
+        reverse == "fail"
+        and face == "fail"
+        and cover["A"] == "fail"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail"
+        and cover_reverse == "fail"
+        and cover_face == "fail"
+        and cover["B"] != reverse
+        and cover["C"] != face,
+    )
+    checks.check(
+        "not-M-exist-opposite-letter",
+        reverse_m == "fail"
+        and face_m == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and o1["A"] != m1["A"]
+        and o1["B"] != m1["B"]
+        and o1["C"] != m1["C"]
+        and o1["D"] != m1["D"]
+        and NEG_E3 in m1["A"]
+        and NEG_E3 not in o1["A"]
+        and E1 in m1["B"]
+        and E1 not in o1["B"],
+    )
+    checks.check(
+        "not-unique-L-leftover",
+        unique_out_reverse == UNDEFINED
+        and unique_out_face == UNDEFINED
+        and unique_m_reverse == "fail"
+        and unique_m_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and reverse != unique_out_reverse
+        and face != unique_out_face
+        and unique_letter(o1["A"]) == frozenset({E1}),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E3 in m1["A"]
+        and NEG_E3 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and o1["B"] != m1["B"]
+        and o1["C"] != m1["C"]
+        and o1["D"] != m1["D"]
+        and m1["A"].isdisjoint(o1["A"])
+        and m1["B"].isdisjoint(o1["B"])
+        and m1["C"].isdisjoint(o1["C"])
+        and m1["D"].isdisjoint(o1["D"]),
+    )
+    y_o1 = {
+        name: outgoing_set(
+            Y_PROBES[name],
+            ticks[Y_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if Y_PROBES[name] in ticks
+    }
+    z_o1 = {
+        name: outgoing_set(
+            Z_PROBES[name],
+            ticks[Z_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if Z_PROBES[name] in ticks
+    }
+    perp_o1 = {
+        name: outgoing_set(
+            PROBES[name],
+            perp_ticks[PROBES[name]] + 1,
+            perp_ticks,
+            perp_locks,
+            perp_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in perp_ticks
+    }
+    zsym_o1 = {
+        name: outgoing_set(
+            PROBES[name],
+            zsym_ticks[PROBES[name]] + 1,
+            zsym_ticks,
+            zsym_locks,
+            zsym_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in zsym_ticks
+    }
+    y_reverse = reverse_report(y_o1["A"], y_o1["B"])
+    y_face = face_report(y_o1["C"], y_o1["D"])
+    z_reverse = reverse_report(z_o1["A"], z_o1["B"])
+    z_face = face_report(z_o1["C"], z_o1["D"])
+    zsym_reverse = reverse_report(zsym_o1["A"], zsym_o1["B"])
+    zsym_face = face_report(zsym_o1["C"], zsym_o1["D"])
+    ysym_ticks_count0 = sum(time == 0 for time in ysym_ticks.values())
+    checks.check(
+        "not-y-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != y_probe_sites
+        and y_o1["A"] != o1["A"]
+        and zsym_o1["B"] != o1["B"]
+        and perp_o1["B"] != o1["B"]
+        and y_reverse == "hold"
+        and y_face == "hold"
+        and y_reverse != reverse
+        and y_face != face
+        and zsym_face == "hold"
+        and zsym_face != face
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "not-z-probes",
+        probe_sites != z_probe_sites
+        and z_o1["A"] != o1["A"]
+        and z_reverse == "hold"
+        and z_face == "fail"
+        and z_reverse != reverse,
+    )
+    checks.check(
+        "not-y-symmetric-three-site-seed",
+        TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and ysym_ticks_count0 == 3,
+    )
+    checks.check(
+        "not-nsopp-leftover-child",
+        TWO_AXIS_SEEDS != ONE_AXIS_SEEDS
+        and seed_map[E3] == E2
+        and seed_map[Q_SEED] == NEG_E2
+        and ticks[E3] == 0
+        and ticks[Q_SEED] == 0
+        and one_ticks[E3] == 1
+        and one_ticks[Q_SEED] == 1
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ticks.values()) == 4,
+    )
+    checks.check(
+        "not-nnlock-named-sign",
+        o1["A"] == frozenset({E1})
+        and named_sign(NEG_E3) == "-"
+        and named_sign(E1) == "+"
+        and named_sign(E2) == "+"
+        and o1["A"] != named_sign(E1)
+        and m1["A"] != named_sign(NEG_E3),
+    )
+    checks.check(
+        "outgoing-locks-are-nn-steps",
+        all(
+            isinstance(o1[name], frozenset) and o1[name] <= set(NN)
+            for name in ("A", "B", "C", "D")
+        ),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 1
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and isinstance(o1["C"], frozenset)
+        and len(o1["C"]) == 3
+        and isinstance(o1["D"], frozenset)
+        and len(o1["D"]) == 2
+        and reverse == "fail"
+        and face == "fail"
+        and reverse != UNDEFINED
+        and face != UNDEFINED,
+    )
+    checks.check(
+        "two-axis-opposite-lock-seed",
+        ticks[ORIGIN] == 0
+        and locks[ORIGIN] == {E1}
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and ticks[Q_SEED] == 0
+        and locks[Q_SEED] == {NEG_E2}
+        and add(E1, NEG_E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    unformed = (3, 0, 0)
+    checks.check(
+        "empty-O-is-empty-not-undefined",
+        outgoing_set(unformed, 0, ticks, locks, seed_map) == UNDEFINED
+        and unformed not in ticks
+        and isinstance(o1["A"], frozenset)
+        and o1["A"]
+        and existential_opposite(frozenset(), o1["B"]) == UNDEFINED
+        and outgoing_set(PROBES["A"], tau1["A"], ticks, locks, seed_map) != UNDEFINED
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset(),
+    )
+    checks.check(
+        "mutation-empty-or-undefined-is-undefined",
+        reverse_report(frozenset(), o1["B"]) == UNDEFINED
+        and face_report(o1["C"], frozenset()) == UNDEFINED
+        and reverse_report(UNDEFINED, o1["B"]) == UNDEFINED
+        and face_report(o1["C"], UNDEFINED) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-no-opposite-pair-fails",
+        reverse_report(frozenset({E1}), frozenset({E1, E3})) == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-unique-L-outgoing-would-be-undefined",
+        unique_out_face == UNDEFINED
+        and unique_out_reverse == UNDEFINED
+        and unique_m_face == "fail"
+        and unique_m_reverse == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        sum_of_set(o1["A"]) == E1
+        and sum_of_set(o1["B"]) == E2
+        and sum_of_set(o1["C"]) == NEG_E2
+        and sum_of_set(o1["D"]) == ZERO
+        and o1["B"] != frozenset({E2})
+        and o1["D"] != frozenset()
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "O-at-t-is-not-this-tplus1-letter",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and o0["A"] != o1["A"]
+        and o0["D"] != o1["D"],
+    )
+
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-ticks-and-outgoing-sets",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_1}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {−e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (2, 0, 0)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)" in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-fail-fail",
+        "Reverse of O at τ: fail" in note
+        and "Face of O at τ: fail" in note
+        and "hold" in note
+        and "fail" in note
+        and "UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-axis-cover-or-M-leftover",
+        "not leftover of axis-cover" in normalized_note
+        and "not leftover of M exist-opposite" in normalized_note
+        and "O is not M" in note
+        and "own outgoing set" in normalized_note,
+    )
+    checks.check(
+        "note-not-sign-lettering",
+        "not named-sign lettering" in normalized_note
+        and "lost the axis" in normalized_note,
+    )
+    checks.check(
+        "note-does-not-attach-formation-member",
+        "does not attach a formation member from already-recorded six-neighbor locks"
+        in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-unique-or-sum-or-star-leftover",
+        "not a unique lock-vector leftover" in normalized_note
+        and "not a sum leftover" in normalized_note
+        and "does not sum" in normalized_note
+        and "not leftover of unique-L" in normalized_note
+        and "Face fails." in note
+        and "Reverse fails." in note,
+    )
+    checks.check(
+        "note-no-six-neighbor-star-as-letter",
+        "does not use a six-neighbor star" in normalized_note
+        and "O is not M" in note
+        and "own outgoing set" in normalized_note,
+    )
+    checks.check(
+        "note-not-nsopp-leftover-child",
+        "not a formed child" in normalized_note
+        and "second pair is a new seed" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_XPROBE_OWN_OUTGOING_SET_EXISTENTIAL_OPPOSITE_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "existential_opposite" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "source-letter-from-own-outgoing-set-existential-opposite",
+        "outgoing_set" in defined_fns
+        and "existential_opposite" in defined_fns
+        and "unique_vector_letter" not in defined_fns
+        and "sum_letter" not in defined_fns
+        and not any("occup" in name for name in defined_fns)
+        and "inner_product" not in defined_fns,
+    )
+    _ = (
+        z_face,
+        o0,
+        ysym_locks,
+        ysym_seeds,
+        one_m1,
+        one_face,
+        cover_reverse,
+        zsym_reverse,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Signed-O exist-opposite on opposite x-probes: reverse fails, face fails. Discriminator vs timed-O HOLDING y #7310. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_xprobe_own_outgoing_set_existential_opposite_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.