### PR TITLE
feat(nm2simx): simultaneous M and O at t+1 on two-axis opposite x-probes: reverse HOLD, face HOLD

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,598 @@
+---
+claim_id: two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Simultaneous M and O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py
+---
+
+# Simultaneous Own-Incoming And Own-Outgoing At t+1 Reverse And Face On Four Two-Axis Opposite X-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** simultaneous earliest incoming set `M` and outgoing dual `O` at
+each probe's `τ=t+1`, their intersection, and reverse/face from simultaneous
+HOLD, on the four x-probes of the two-axis opposite seed in
+`B_3(0)={n:n·n<=9}`. Same perp-step incoming-lock process and x-probes as
+nm2axpx. Let `t(q)` be the formation tick of probe `q`. Let `τ(q)=t(q)+1`.
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q` using
+only records with tick `<= τ`. Seeds are a singleton seed letter. `O(q,τ)`
+is the outgoing dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that
+`q+e` is formed and `e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`.
+Empty `O` is empty, not `UNDEFINED`. Intersection is `M(q,τ) ∩ O(q,τ)`;
+unformed is `UNDEFINED`. Empty intersection is empty, not `UNDEFINED`.
+Simultaneous HOLDs at `q` if and only if both `M` and `O` are defined
+nonempty and `M ∩ O` is empty. `UNDEFINED` if `M` or `O` is `UNDEFINED`.
+Else fail. Reverse HOLDs if and only if simultaneous HOLDs at `A` and at
+`B`. Face HOLDs if and only if simultaneous HOLDs at `C` and at `D`. This is
+HOLD iff simultaneous, not leftover-empty fail of leftover axis. This is the
+first simultaneous display of `M` and `O` at `t+1` on the nm2axx cover-FAIL
+x-probe direction of the two-axis opposite seed. nm2axx cover reverse FAIL
+face FAIL (union misses e_2 at `A` and at `D`; axes still disjoint). nm2axpx
+forall-perp reverse HOLD face HOLD on these same probes is a different
+predicate. This is not leftover of nm2axx cover. This is not leftover of
+nm2axpx forall-perp. This is not leftover of nm2simz z-probe simultaneous.
+This is not leftover of leftover-empty fail. This is not leftover of
+leftover-of-`M` alone. This is not leftover of leftover-of-`O` alone. This
+is not leftover of nmsimopp exist-opposite of `M` and of `O` at `t+1`. This
+is not leftover of nmunopp union. This is not leftover of nmt2opp `M`
+frozen at `t`. This is not leftover of nmot2opp two-tick composition. This
+is not leftover of nmoutopp untimed eventual-`O`. This is not leftover of
+mixed #7188 fail/fail. Uniqueness is not required. Mixed remains a set.
+Occupancy of sites is not used. Occupancy `n` is not used. Displayed, not
+adopted. Do not write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Simultaneous is signed-letter disjointness of nonempty `M` and
+nonempty `O` at that same cut. Reverse and face are scored on simultaneous
+HOLD at the paired probes. Named signs `{+,−}` are a coarser readout and
+are not used. A singleton unique lock letter is a different readout and is
+not used as the object. Existential opposite of signed locks is a different
+readout and is not used as the simultaneous reverse. Unsigned axis-cover of
+`M` and `O` is a different readout and is not used. Forall-orthogonal of
+`M` versus `O` is a different readout and is not used. Leftover-empty fail
+of unsigned leftover axis sets is a different readout and is not used. A
+`Z^3` sum of those locks is a different readout and is not used. Occupancy
+of sites is not used. The construction does not use occupancy. A
+six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of simultaneous M and O at t+1 on the four x-probes of the two-axis opposite seed, empty intersection at each probe, reverse hold and face hold from simultaneous HOLD; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face
+target_blocker_text: "display simultaneous M and O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, HOLD iff simultaneous, not leftover-empty fail"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep simultaneous M and O at t+1 displayed; do not write simultaneous into Admissibility, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace simultaneous by existential opposite of signed locks, do not replace simultaneous by unsigned axis-cover, do not replace simultaneous by forall-perp, do not replace either set by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for simultaneous M and O at t+1 on the four x-probes of the two-axis opposite seed and reverse/face from that; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose
+simultaneous `M` and `O` is scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. `A` is not a seed. Same process and x-probes as nm2axpx.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. First pair:
+`L(0)=+e_1` and `L(0,1,0)=−e_1`. Second pair: `L(0,0,1)=+e_2` and
+`L(0,1,1)=−e_2`. The second pair is a new seed, not a formed child of the
+first pair. This seed is not the one-axis opposite two-site seed alone.
+This seed is not the perp two-site seed `+e_1/+e_2`. This seed is not the
+z-symmetric three-site seed `{0,(0,0,1),(0,0,-1)}`. This seed is not the
+y-symmetric three-site seed that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named simultaneous `M` and `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy of sites is not used. Occupancy `n` is not used. O is not M.
+
+Intersection at the same cut:
+
+```text
+(M ∩ O)(q,τ) = M(q,τ) ∩ O(q,τ).
+```
+
+If `q` is unformed at `τ`, then the intersection is `UNDEFINED`. Empty
+intersection is empty, not `UNDEFINED`.
+
+Simultaneous at a probe at the same cut:
+
+```text
+sim(q) HOLDs iff M and O are defined nonempty and M ∩ O is empty.
+```
+
+If `q` is unformed at `τ`, then simultaneous is `UNDEFINED`. Empty `M` or
+empty `O` fails. Nonempty overlapping letters fail. Simultaneous is signed
+letter disjointness: `+e_i` and `−e_i` are distinct letters. Unsigned
+axis-cover is a different object: opposite signs occupy the same axis, so
+letter-disjoint sets can fail cover. Leftover of the union of unsigned
+axes is `{e_1,e_2,e_3}` minus `(Axis(M) union Axis(O))`. Empty leftover is
+leftover fail of leftover axis; this display is HOLD iff simultaneous, not
+leftover-empty fail. Forall-perp is a different object: `{+e_1}` and
+`{−e_1}` are letter-disjoint and have integer dot `-1`.
+
+Reverse simultaneous holds if and only if simultaneous HOLDs at `A` and at
+`B`. Face simultaneous holds if and only if simultaneous HOLDs at `C` and
+at `D`. Either side `UNDEFINED` is `UNDEFINED`. Else if both sides HOLD,
+reverse or face HOLDs. Else fail.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Identifying leftover-empty fail with
+simultaneous reverse is refused: leftover-empty fail scores empty leftover
+axis as fail. Identifying unsigned axis-cover with simultaneous is refused:
+on this seed x-probe `A` has letter-disjoint nonempty `M` and `O` and fails
+complementary occupation of `{e_1,e_2,e_3}` because the union misses e_2.
+Identifying forall-perp with simultaneous is refused: integer-dot zero is
+not signed-letter disjointness.
+
+## Theorem 1 — ticks, `M`, `O`, intersection, and sim at `τ=t+1`
+
+On this process the four x-probes form. Compare to leftover axis: leftover
+of the unsigned-axis union is `{e_2}` at `A` and at `D` and empty at `B`
+and at `C`, so leftover reverse fail and leftover face fail. Compare to
+axis-cover on these x-probes: that leftover reports complementary unsigned
+axes HOLD at `B` and at `C` and FAIL at `A` and at `D` (union misses e_2;
+axes still disjoint), so cover reverse FAIL face FAIL. Compare to nm2axpx
+forall-perp: that leftover reports forall-perp HOLD at each probe. This
+display reads signed-letter simultaneous of those same timed sets:
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {−e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_1}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {−e_2, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+M(A, τ) ∩ O(A, τ) = {}
+M(B, τ) ∩ O(B, τ) = {}
+M(C, τ) ∩ O(C, τ) = {}
+M(D, τ) ∩ O(D, τ) = {}
+sim(A) = hold
+sim(B) = hold
+sim(C) = hold
+sim(D) = hold
+```
+
+`A` is not a seed. `A` is the site `(1,0,0)` forming at tick 2 with
+incoming `{−e_3}`. Mixed remains a set: `O(B,τ)` has three outgoing steps,
+`O(C,τ)` has three outgoing steps, and `O(D,τ)` has two outgoing steps on
+one axis. Unique letters would assign `UNDEFINED` at mixed `O` and would
+leave reverse and face `UNDEFINED`. Here uniqueness is not required. `M` is
+frozen from `t` to `t+1`. At `t`, `O` is empty at `A`, `B`, and `C`, so
+simultaneous fails at those probes; at `D`, `O(D,t)={−e_1}` is already
+nonempty and simultaneous HOLDs at the own-tick cut while cover still fails.
+At `τ=t+1`, `O` is nonempty at every scored probe, intersection is empty,
+and simultaneous HOLDs. At each probe, `M` and `O` are defined nonempty and
+disjoint as signed letters. Simultaneous therefore HOLDs at each probe.
+Leftover of the unsigned-axis union is `{e_2}` at `A` and at `D` and empty
+at `B` and at `C`; leftover-empty fail of that leftover is not this object.
+Axis-cover fails at `A` and at `D` because the union misses e_2; that
+unsigned complementary occupation is not this letter. Forall-perp HOLDs at
+each of these four x-probes; integer-dot zero is not this letter. O is not
+M.
+
+On the one-axis opposite two-site seed, `A=(1,0,0)` forms later than tick
+2. Here the second pair is seeded at tick 0, and `A` forms at tick 2.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+## Theorem 2 — reverse from simultaneous at `τ`
+
+Reverse simultaneous holds if and only if simultaneous HOLDs at `A` and at
+`B`. Both simultaneous reports HOLD. Reverse HOLDs. This is HOLD iff
+simultaneous, not leftover-empty fail.
+
+Reverse simultaneous at τ: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Leftover-empty reverse
+fails because leftover of the unsigned-axis union is `{e_2}` at `A` and
+empty at `B`. Simultaneous reverse HOLDs from signed-letter disjoint
+nonempty `M` and `O` at both reverse probes. Leftover-of-`M` reverse would
+fail because leftover of `M` at `A` is `{e_1, e_2}` and leftover of `M` at
+`B` is `{e_2, e_3}`: nonempty and unequal. Leftover-of-`O` reverse would
+fail because leftover of `O` at `A` is `{e_2, e_3}` and leftover of `O` at
+`B` is `{e_1}`: nonempty and unequal. Exist-opposite reverse of signed `M`
+fails. Exist-opposite reverse of signed `O` fails. Those leftovers are not
+this display. Unsigned axis-cover reverse FAILs on these x-probes because
+cover fails at `A`. Forall-perp reverse HOLDs on these x-probes; that is
+not this letter.
+
+Reverse holds.
+
+## Theorem 3 — face from simultaneous at `τ`
+
+Face simultaneous holds if and only if simultaneous HOLDs at `C` and at
+`D`. Both simultaneous reports HOLD. Face HOLDs.
+
+Face simultaneous at τ: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Leftover-empty face fails because leftover of the unsigned-axis union is
+empty at `C` and `{e_2}` at `D`. Simultaneous face HOLDs from signed-letter
+disjoint nonempty `M` and `O` at both face probes. Leftover-of-`M` face
+would fail because leftover of `M` at `C` is `{e_2, e_3}` and leftover of
+`M` at `D` is `{e_1, e_2}`: nonempty and unequal. Leftover of `O` at `C` is
+`{e_1}` and leftover of `O` at `D` is `{e_2, e_3}`: nonempty and unequal.
+Exist-opposite face of signed `M` fails and exist-opposite face of signed
+`O` fails. This display scores simultaneous of `M` and `O`, which HOLDs at
+`C` and at `D`, so face HOLDs.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Simultaneous HOLDs.
+
+On the same seed the four y-probes give simultaneous reverse hold and
+simultaneous face hold, but y-probe axis-cover face fails at `D`:
+`M(D)={−e_3}` and `O(D)={+e_1, −e_1}` are letter-disjoint and nonempty,
+yet `Axis(M) ∪ Axis(O) = {e_1, e_3}` misses `e_2`. The four z-probes give
+simultaneous reverse hold and simultaneous face hold, and z-probe
+axis-cover also HOLDs at each z-probe. Those probe-direction readouts are
+not this x-probe display. Letter-disjoint nonempty is not complementary
+axis-cover. Cover fail at `A` and at `D` is the split that this member
+first displays for simultaneous.
+
+Face holds.
+
+## What this note does not claim
+
+- It does not select a unique incoming, outgoing, or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require simultaneous sides to be singletons.
+- It does not sum either set.
+- It does not replace simultaneous by leftover-empty fail.
+- It does not replace simultaneous by leftover of `M` alone.
+- It does not replace simultaneous by leftover of `O` alone.
+- It does not replace simultaneous by existential opposite of signed locks.
+- It does not replace simultaneous by unsigned axis-cover of `M` and `O`.
+- It does not replace simultaneous by forall-perp of `M` versus `O`.
+- It does not replace simultaneous by 1-in 2-out axis split.
+- It does not replace `O` by `M`.
+- It does not replace simultaneous by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this simultaneous display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not treat the second opposite pair as a formed child of the first.
+- It does not score the y-probes or the z-probes as this letter.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite process, simultaneous `M` and `O` at `t+1`, and the
+reverse/face bits from simultaneous HOLD are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two disjoint opposite pairs `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual |
+| `M ∩ O` at `τ` | Theorem 1; empty at each probe |
+| sim at `τ` | Theorem 1; HOLD at each probe |
+| reverse from simultaneous at `τ` | Theorem 2; `hold` |
+| face from simultaneous at `τ` | Theorem 3; `hold` |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this simultaneous display |
+| leftover of nm2axx axis-cover FAIL | not this simultaneous display |
+| leftover of nm2axpx forall-perp HOLD | not this simultaneous display |
+| leftover of nm2simz z-probe simultaneous | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmsimopp exist-opposite HOLD | not this simultaneous display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| one-axis opposite leftover of the second pair | not this seed |
+| y-probe or z-probe simultaneous on this seed | not this letter |
+| global later T | not used |
+| simultaneous as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: simultaneous `M` and `O` at `t+1` on the four x-probes of the two-axis opposite seed, and reverse/face from that. |
+| V2 | Current main has no landed simultaneous reverse/face of timed `M` and `O` on these four x-probes of this two-axis opposite seed. |
+| V3 | Simultaneous reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads signed-letter disjointness of own incoming and own outgoing at the same `t+1` cut and scores HOLD iff simultaneous. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace simultaneous by leftover-empty fail, does not
+replace simultaneous by leftover of `M` alone or leftover of `O` alone,
+does not replace simultaneous by existential opposite of signed locks, does
+not replace simultaneous by unsigned axis-cover, does not replace
+simultaneous by forall-perp, does not identify this display with nmsimopp
+exist-opposite HOLD, and does not identify it with nmunopp union. No global
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover of the unsigned-axis union is `{e_2}` at `A` and at `D` and empty at `B` and at `C`, leftover reverse and face fail, while simultaneous HOLDs | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_2}` and at `B` is `{e_2,e_3}`, nonempty unequal, reverse would fail | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is `{e_2,e_3}` and at `B` is `{e_1}`, nonempty unequal, reverse would fail | ATTEMPTED |
+| nmsimopp exist-opposite | reuse signed reverse hold and face hold of `M` and of `O` | signed `M` reverse fails and signed `O` reverse fails; simultaneous reverse HOLDs from per-probe letter-disjoint nonempty `M` and `O` | ATTEMPTED |
+| nm2axx axis-cover | reuse complementary unsigned axes of `M` and `O` | cover reverse FAIL face FAIL because the union misses e_2 at `A` and at `D`; simultaneous HOLDs | ATTEMPTED |
+| nm2axpx forall-perp | reuse every integer dot `m·o=0` | `{+e_1}` and `{−e_1}` are letter-disjoint and have integer dot `-1`; forall-perp is not simultaneous | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters without a disjointness test against the pair | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(B,τ)`, `O(C,τ)`, and `O(D,τ)` remain sets; simultaneous still HOLDs; unique-letter reverse is `UNDEFINED` | ATTEMPTED |
+| exist-opposite of leftover axes | score `a+b=(0,0,0)` inside leftover axis vectors | leftover reverse is leftover-empty fail here; simultaneous reverse is HOLD iff simultaneous | ATTEMPTED |
+| same-tick-inclusive six-neighbor lock union | score locks of six-neighbors formed by `t(q)` | that leftover is neighbor locks; simultaneous is own `M` against own `O` | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores simultaneous of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports simultaneous HOLD and reverse hold face hold | ATTEMPTED |
+| one-axis leftover | treat `(0,0,1)` and `(0,1,1)` as formed children of `+e_1/−e_1` | those children lock `+e_3` at tick 1; here they are seeds locking `+e_2/−e_2` at tick 0 | ATTEMPTED |
+| y-probe simultaneous | score the four y-probes on this seed | y-probe `A` locks `−e_1` at tick 0; this letter is the four x-probes with non-seed `A` locking `−e_3` at tick 2 | ATTEMPTED |
+| z-probe simultaneous | score the four z-probes on this seed | z-probe `A` is a seed locking `+e_2`; this letter is the four x-probes | ATTEMPTED |
+| sum of a set | replace simultaneous by a `Z^3` sum | the construction does not sum; simultaneous is signed-letter disjointness of two sets | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by simultaneous | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of simultaneous with
+leftover of `M` alone, missing identification of simultaneous with
+leftover-empty fail, missing identification of simultaneous with
+existential opposite of signed locks, missing identification of
+simultaneous with unsigned axis-cover, missing identification of
+simultaneous with forall-perp, and missing Record identification of
+simultaneous reverse are distinct open premises. This note claims no
+complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite-pair seed locks `+e_1`, `−e_1`,
+`+e_2`, and `−e_2`, perpendicular step rule, incoming-step lock, own
+incoming set and own outgoing dual from records with tick `<= τ`, per-probe
+`τ=t+1`, simultaneous as defined nonempty disjoint `M` and `O`, HOLD iff
+simultaneous not leftover-empty fail, four x-probes with non-seed `A`, and
+mixed remains a set are declared. No uniqueness of incoming locks, no
+six-neighbor lock union as the scored object, no lock-count clock, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+simultaneous `hold`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each signed lock among `{±e_1,±e_2,±e_3}` in `M` or in `O` | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four sim reports, reverse/face from sim HOLD | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for simultaneous reverse/face,
+a formation-rate rule, and a physical selector among disjoint incoming and
+outgoing letters. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Simultaneous HOLD is only leftover empty; leftover-empty fail
+already answered three-axis occupation; leftover of `M` alone already gives
+a third direction; complementary occupation is only nm2axx cover; empty
+letter intersection is only nmsimopp; forall-perp already HOLDs on these
+x-probes; the second pair is only a child of the first pair; mixed `O`
+should make the predicate `UNDEFINED`; and empty `M` or empty `O` should be
+`UNDEFINED` like unformed.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that leftover as reverse fail and face
+fail. On these x-probes leftover of the unsigned-axis union is `{e_2}` at
+`A` and at `D` and empty at `B` and at `C`, so leftover reverse and face
+fail while simultaneous HOLDs. Simultaneous HOLDs when `M` and `O` are
+defined nonempty and signed-letter disjoint. Opposite signs on one axis
+are letter-disjoint and occupy that axis, so they can HOLD simultaneous
+and fail cover. On this seed, x-probe `A` HOLDs simultaneous with
+`M={−e_3}` and `O={+e_1}` and fails cover because the union misses e_2.
+x-probe `D` HOLDs simultaneous with mixed `O={+e_1, −e_1}` and fails cover
+for the same missing axis. Cover HOLDs at `B` and at `C`, but that is
+unsigned complementary axes, not this letter. Forall-perp also HOLDs at
+each of these four x-probes; `{+e_1}` and `{−e_1}` are letter-disjoint with
+integer dot `-1`, so simultaneous is not forall-perp. Leftover of `M`
+alone and leftover of `O` alone are nonempty one-sided leftovers and are
+unequal across reverse here. The second pair is seeded at tick 0 with
+`+e_2/−e_2`, not formed at tick 1 with `+e_3`. Mixed `O(B,τ)` remains a
+set and simultaneous at `B` HOLDs. Empty `M` or empty `O` fails by
+declaration, and is not `UNDEFINED`. Reverse simultaneous is HOLD iff
+simultaneous at `A` and at `B`, not leftover-empty fail.
+
+### N8 — cross-cycle echo
+
+nm2axx reported axis-cover of `M` versus `O` on these four x-probes with
+reverse fail and face fail because the union misses e_2; axes still
+disjoint. nm2axpx reported forall-orthogonal `M` versus `O` on these same
+four x-probes with reverse hold and face hold. nm2simz reported
+simultaneous `M` and `O` at `τ=t+1` on the four z-probes with reverse hold
+and face hold, where cover also HOLDs at each z-probe. Leftover axis
+reported leftover reverse fail and leftover face fail. This note is not
+those displays: it reports simultaneous `M` and `O` at `τ=t+1` on the four
+x-probes of the two-axis opposite seed, simultaneous HOLD at each of the
+four x-probes, reverse hold, and face hold, including where nm2axx cover
+fails. HOLD iff simultaneous, not leftover-empty fail, not axis-cover, not
+forall-perp, and not exist-opposite of `M` or of `O`.
+
+**Gate disposition:** PASS for the simultaneous `t+1` reverse/face reports
+above. FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the
+predicate equals the unique singleton lock vector,” “the predicate equals
+six-neighbor lock union,” “the predicate equals leftover-empty fail,” “the
+predicate equals leftover of `M` alone,” “the predicate equals leftover of
+`O` alone,” “the predicate equals nmsimopp exist-opposite HOLD,” “the
+predicate equals nm2axx axis-cover,” “the predicate equals nm2axpx
+forall-perp,” “the predicate equals nmunopp union,” “bits are
+Admissibility,” “simultaneous fails,” “reverse simultaneous fails,” or
+“face simultaneous fails.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each x-probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports the intersection of the pair, reports simultaneous of the pair,
+lists new records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors, and checks Theorems 1--3. It also checks that simultaneous
+HOLDs at each probe, that leftover-empty fail is a different reverse and
+face, that leftover of `M` alone and leftover of `O` alone are different
+objects, that mixed sets remain sets, that unique-letter simultaneous is
+`UNDEFINED` at mixed `O`, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not attached,
+that the second pair is a seed and not a formed child, that unsigned
+axis-cover is a different letter and FAILs reverse and face on these
+x-probes, that forall-perp is a different letter, and that the display is
+not the two-tick lock-count clock composition. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,97 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 9f9ab1dc73331d4c026458b1ae898e449c95946600b607262843f901215de7ed
+input_fingerprint_sha256: 07511b435f1df247d4c3bfa1b1e1c55454f904150f0a6fa341811eca82cf0f07
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+simultaneous M and O reverse/face at t+1 on two-axis opposite x-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Simultaneous M and O at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: intersection-identity
+PASS: simultaneous-identity
+PASS: pair-sim-identity
+PASS: leftover-empty-fail-contrast
+PASS: forall-perp-is-not-simultaneous
+A t=2 M={−e_3} O={+e_1} M∩O={} sim=hold
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} M∩O={} sim=hold
+C t=3 M={+e_1} O={−e_2, +e_3, −e_3} M∩O={} sim=hold
+D t=2 M={−e_3} O={+e_1, −e_1} M∩O={} sim=hold
+sim reverse=hold face=hold
+leftover-empty reverse=fail face=fail
+nm2axx cover reverse=fail face=fail
+per_element: each signed lock among {±e_1,±e_2,±e_3} in M or in O at a probe's t+1
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four sim reports, reverse/face from sim HOLD
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_3}', 'B': '{+e_1}', 'C': '{+e_1}', 'D': '{−e_3}'})
+PASS: theorem1-O-at-tau  ({'A': '{+e_1}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{−e_2, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-intersection-at-tau  ({'A': '{}', 'B': '{}', 'C': '{}', 'D': '{}'})
+PASS: theorem1-sim-hold  ({'A': 'hold', 'B': 'hold', 'C': 'hold', 'D': 'hold'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-O-empty-at-t-except-D
+PASS: theorem1-new-records-meet-6nn  ({'A': ((2, 0, 0),), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((2, -1, 0), (2, 0, 1), (2, 0, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-not-seed
+PASS: theorem2-reverse-sim-hold
+PASS: theorem3-face-sim-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-alone-differs
+PASS: mutation-leftover-of-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-empty-plus-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: not-y-probes-or-z-probes-or-perp
+PASS: mutation-axis-cover-is-not-this-letter
+PASS: mutation-forall-perp-is-not-this-letter
+PASS: not-nsopp-leftover-second-pair-is-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: empty-intersection-is-empty-not-undefined
+PASS: uniqueness-not-required
+PASS: note-claim-scope
+PASS: note-reports-M-O-intersection-sim
+PASS: note-reports-new-neighbors
+PASS: note-reports-sim-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-leftover-empty-fail
+PASS: note-not-axis-cover-or-exist-opposite-leftover
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-does-not-use-occupancy
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: sim-hold-not-leftover-empty-fail
+TOTAL: PASS=65 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1330 @@
+#!/usr/bin/env python3
+"""Simultaneous M and O at t+1 reverse/face on four x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and x-probes as nm2axpx.
+The second pair is a new seed, not a formed child of the first pair. A 6-NN
+step is allowed iff it is perpendicular to the parent lock axis. Newly formed
+sites lock the incoming step. Seeds keep their seed letters as a singleton.
+M(q, tau) is the set of earliest incoming nearest-neighbor steps at q using
+only records with tick <= tau. Unformed at tau => UNDEFINED. O(q, tau) is
+the outgoing dual of M: the set of e in {±e_1,±e_2,±e_3} such that q+e is
+formed and e is in M(q+e, tau). Unformed q at tau => UNDEFINED. Empty O is
+empty, not UNDEFINED. Intersection is M intersect O; unformed => UNDEFINED.
+Empty intersection is empty, not UNDEFINED. Simultaneous HOLDs at q iff both
+M and O are defined nonempty and M intersect O is empty. UNDEFINED if M or O
+UNDEFINED. Else fail. Reverse HOLDs iff simultaneous at A and at B. Face
+likewise on C, D. This is not leftover-empty fail. This is not unsigned
+axis-cover. This is not forall-perp. Uniqueness is not required. Occupancy
+of sites is not used. Named-sign lettering is not used. No larger host. Not
+leftover of M alone or of O alone. Not exist-opposite of signed locks.
+Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Simultaneous M and O at t+1 on the four x-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def intersection_set(left: Incoming, right: Outgoing) -> Incoming:
+    """M intersect O. Unformed on either side => UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("intersection sides must be lock sets or UNDEFINED")
+    return left & right
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast: {e_1,e_2,e_3} minus Axis(S). Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Unsigned-axis cover contrast. Not this simultaneous letter."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    if not incoming or not outgoing:
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def forall_orthogonal(left: Incoming, right: Incoming) -> str:
+    """nm2axpx leftover contrast: every m·o integer dot is 0. Not this letter."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if dot(a, b) != 0:
+                return "fail"
+    return "hold"
+
+
+def simultaneous(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff both defined nonempty and signed-letter intersection empty."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    if not incoming or not outgoing:
+        return "fail"
+    if incoming & outgoing:
+        return "fail"
+    return "hold"
+
+
+def pair_sim(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(sim_a: str, sim_b: str) -> str:
+    """Reverse HOLDs iff simultaneous at A and simultaneous at B."""
+    return pair_sim(sim_a, sim_b)
+
+
+def face_report(sim_c: str, sim_d: str) -> str:
+    """Face HOLDs iff simultaneous at C and simultaneous at D."""
+    return pair_sim(sim_c, sim_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def neighbor_lock_set(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    tau: int,
+) -> frozenset[Point]:
+    """Leftover contrast: locks of 6-NN formed by tau, site excluded."""
+    collected: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks or ticks[neighbor] > tau:
+            continue
+        collected.update(locks[neighbor])
+    return frozenset(collected)
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sim(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = simultaneous(
+            incoming_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+            outgoing_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+        )
+    return out
+
+
+def probe_cover(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = axis_cover(
+            incoming_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+            outgoing_set(
+                site, site_ticks[site] + 1, site_ticks, site_locks, site_seeds
+            ),
+        )
+    return out
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("simultaneous M and O reverse/face at t+1 on two-axis opposite x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "intersection-identity",
+        intersection_set(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and intersection_set(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and intersection_set(frozenset({E1, E2}), frozenset({E2, E3}))
+        == frozenset({E2})
+        and intersection_set(frozenset({NEG_E1}), frozenset({E2, NEG_E2, E3}))
+        == frozenset()
+        and intersection_set(frozenset(), frozenset({E1})) == frozenset(),
+    )
+    checks.check(
+        "simultaneous-identity",
+        simultaneous(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and simultaneous(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and simultaneous(frozenset(), frozenset({E2, E3})) == "fail"
+        and simultaneous(frozenset({NEG_E1}), frozenset()) == "fail"
+        and simultaneous(frozenset({NEG_E3}), frozenset({E1})) == "hold"
+        and simultaneous(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and simultaneous(frozenset({E1}), frozenset({E1, E2})) == "fail"
+        and simultaneous(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "hold"
+        and simultaneous(frozenset({E1}), frozenset({NEG_E1})) == "hold",
+    )
+    checks.check(
+        "pair-sim-identity",
+        pair_sim(UNDEFINED, "hold") == UNDEFINED
+        and pair_sim("hold", UNDEFINED) == UNDEFINED
+        and pair_sim("hold", "hold") == "hold"
+        and pair_sim("hold", "fail") == "fail"
+        and pair_sim("fail", "hold") == "fail"
+        and pair_sim("fail", "fail") == "fail",
+    )
+    checks.check(
+        "leftover-empty-fail-contrast",
+        leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and leftover_axis(frozenset({NEG_E3}), frozenset({E1})) == frozenset({E2})
+        and leftover_axis(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == frozenset(),
+    )
+    checks.check(
+        "forall-perp-is-not-simultaneous",
+        forall_orthogonal(frozenset({E1}), frozenset({NEG_E1})) == "fail"
+        and simultaneous(frozenset({E1}), frozenset({NEG_E1})) == "hold"
+        and frozenset({E1}).isdisjoint(frozenset({NEG_E1}))
+        and dot(E1, NEG_E1) == -1,
+    )
+
+    ticks, locks, seed_map = form()
+    twosite_ticks, twosite_locks, twosite_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, ysym_locks, ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    inter1: dict[str, Incoming] = {}
+    sim: dict[str, str] = {}
+    cover1: dict[str, str] = {}
+    fp1: dict[str, str] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        inter1[name] = intersection_set(m1[name], o1[name])
+        sim[name] = simultaneous(m1[name], o1[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        fp1[name] = forall_orthogonal(m1[name], o1[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"M∩O={lockset_display(inter1[name])} "
+            f"sim={sim[name]}"
+        )
+
+    reverse = reverse_report(sim["A"], sim["B"])
+    face = face_report(sim["C"], sim["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    cover_reverse = reverse_report(cover1["A"], cover1["B"])
+    cover_face = face_report(cover1["C"], cover1["D"])
+    fp_reverse = reverse_report(fp1["A"], fp1["B"])
+    fp_face = face_report(fp1["C"], fp1["D"])
+    unique_sim_a = simultaneous(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    unique_reverse = reverse_report(
+        simultaneous(unique_letter(m1["A"]), unique_letter(o1["A"])),
+        simultaneous(unique_letter(m1["B"]), unique_letter(o1["B"])),
+    )
+    unique_face = face_report(
+        simultaneous(unique_letter(m1["C"]), unique_letter(o1["C"])),
+        simultaneous(unique_letter(m1["D"]), unique_letter(o1["D"])),
+    )
+    leftover_neighbor_reverse = leftover_match(
+        leftover_of_one(neighbor_lock_set(PROBES["A"], ticks, locks, ticks[PROBES["A"]])),
+        leftover_of_one(neighbor_lock_set(PROBES["B"], ticks, locks, ticks[PROBES["B"]])),
+    )
+    print(f"sim reverse={reverse} face={face}")
+    print(f"leftover-empty reverse={leftover_reverse} face={leftover_face}")
+    print(f"nm2axx cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: each signed lock among {±e_1,±e_2,±e_3} in M or in O "
+        "at a probe's t+1"
+    )
+    print(
+        "per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four sim reports, reverse/face from sim HOLD")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and locks[PROBES["A"]] == {NEG_E3}
+        and locks[PROBES["B"]] == {E1}
+        and locks[PROBES["C"]] == {E1}
+        and locks[PROBES["D"]] == {NEG_E3}
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and incoming_set(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["C"], 2, ticks, locks, seed_map) == UNDEFINED
+        and simultaneous(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and simultaneous(
+            incoming_set(PROBES["A"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["A"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(PAIR2, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and PROBES["A"] not in seed_map
+        and m1["A"] == frozenset({NEG_E3}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E3})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E1})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({NEG_E2, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-intersection-at-tau",
+        inter1["A"] == frozenset()
+        and inter1["B"] == frozenset()
+        and inter1["C"] == frozenset()
+        and inter1["D"] == frozenset()
+        and all(
+            isinstance(m1[name], frozenset)
+            and isinstance(o1[name], frozenset)
+            and m1[name].isdisjoint(o1[name])
+            for name in ("A", "B", "C", "D")
+        ),
+        str({name: lockset_display(inter1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-sim-hold",
+        all(sim[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(
+            isinstance(m1[name], frozenset)
+            and isinstance(o1[name], frozenset)
+            and bool(m1[name])
+            and bool(o1[name])
+            and m1[name].isdisjoint(o1[name])
+            for name in ("A", "B", "C", "D")
+        ),
+        str({name: sim[name] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-O-empty-at-t-except-D",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and simultaneous(m0["A"], o0["A"]) == "fail"
+        and simultaneous(m0["B"], o0["B"]) == "fail"
+        and simultaneous(m0["C"], o0["C"]) == "fail"
+        and simultaneous(m0["D"], o0["D"]) == "hold"
+        and all(sim[name] == "hold" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0),)
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 1
+        and unique_letter(o1["A"]) == frozenset({E1})
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(o1["C"], frozenset)
+        and len(o1["C"]) == 3
+        and unique_letter(o1["C"]) == UNDEFINED
+        and isinstance(o1["D"], frozenset)
+        and len(o1["D"]) == 2
+        and unique_letter(o1["D"]) == UNDEFINED
+        and sim["B"] == "hold"
+        and sim["C"] == "hold"
+        and sim["D"] == "hold"
+        and sim["A"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and ticks[E1] == 2
+        and locks[E1] == {NEG_E3}
+        and m1["A"] == frozenset({NEG_E3})
+        and PROBES["A"] not in seed_map
+        and Y_PROBES["A"] != PROBES["A"]
+        and Z_PROBES["A"] != PROBES["A"],
+    )
+    checks.check(
+        "theorem2-reverse-sim-hold",
+        reverse == "hold"
+        and sim["A"] == "hold"
+        and sim["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail"
+        and cover_reverse == "fail",
+    )
+    checks.check(
+        "theorem3-face-sim-hold",
+        face == "hold"
+        and sim["C"] == "hold"
+        and sim["D"] == "hold"
+        and face != UNDEFINED
+        and face != "fail"
+        and cover_face == "fail",
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset({E2})
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and reverse == "hold"
+        and face == "hold"
+        and leftover_reverse != reverse
+        and leftover_face != face,
+    )
+    checks.check(
+        "mutation-leftover-of-M-alone-differs",
+        lx_m["A"] == frozenset({E1, E2})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_m["C"] == frozenset({E2, E3})
+        and lx_m["D"] == frozenset({E1, E2})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "mutation-leftover-of-O-alone-differs",
+        lx_o["A"] == frozenset({E2, E3})
+        and lx_o["B"] == frozenset({E1})
+        and lx_o["C"] == frozenset({E1})
+        and lx_o["D"] == frozenset({E2, E3})
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "fail"
+        and o_exist_face == "fail"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({NEG_E3})
+        and unique_letter(o1["A"]) == frozenset({E1})
+        and unique_sim_a == "hold"
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_reverse == UNDEFINED
+        and unique_face == UNDEFINED
+        and sim["A"] == "hold"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "mutation-empty-plus-undefined",
+        simultaneous(frozenset(), frozenset({E2, E3})) == "fail"
+        and simultaneous(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and reverse == "hold",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["D"], frozenset)
+        and isinstance(m1["A"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E3
+        and sum_of_set(m1["D"]) == NEG_E3
+        and sum_of_set(o1["D"]) == ZERO
+        and o1["D"] != frozenset()
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E3 in m1["A"]
+        and NEG_E3 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and inter1["A"] == frozenset(),
+    )
+    y_sim = probe_sim(Y_PROBES, ticks, locks, seed_map)
+    z_sim = probe_sim(Z_PROBES, ticks, locks, seed_map)
+    y_cover = probe_cover(Y_PROBES, ticks, locks, seed_map)
+    z_cover = probe_cover(Z_PROBES, ticks, locks, seed_map)
+    x_cover = cover1
+    perp_sim_map = probe_sim(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_sim = probe_sim(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    twosite_sim = probe_sim(PROBES, twosite_ticks, twosite_locks, twosite_seeds)
+    y_reverse = reverse_report(y_sim["A"], y_sim["B"])
+    y_face = face_report(y_sim["C"], y_sim["D"])
+    z_reverse = reverse_report(z_sim["A"], z_sim["B"])
+    z_face = face_report(z_sim["C"], z_sim["D"])
+    perp_reverse = reverse_report(perp_sim_map["A"], perp_sim_map["B"])
+    checks.check(
+        "not-y-probes-or-z-probes-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites
+        and ticks[Y_PROBES["A"]] == 0
+        and incoming_set(
+            Y_PROBES["A"], ticks[Y_PROBES["A"]] + 1, ticks, locks, seed_map
+        )
+        == frozenset({NEG_E1})
+        and y_cover["D"] == "fail"
+        and y_sim["D"] == "hold"
+        and y_reverse == "hold"
+        and y_face == "hold"
+        and ticks[Z_PROBES["A"]] == 0
+        and incoming_set(
+            Z_PROBES["A"], ticks[Z_PROBES["A"]] + 1, ticks, locks, seed_map
+        )
+        == frozenset({E2})
+        and all(z_cover[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(z_sim[name] == "hold" for name in ("A", "B", "C", "D"))
+        and z_reverse == "hold"
+        and z_face == "hold"
+        and m1["A"] != frozenset({NEG_E1})
+        and m1["A"] != frozenset({E2})
+        and perp_sim_map["B"] == "fail"
+        and perp_reverse == "fail"
+        and perp_reverse != reverse
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "mutation-axis-cover-is-not-this-letter",
+        cover1["A"] == "fail"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "fail"
+        and cover_reverse == "fail"
+        and cover_face == "fail"
+        and sim["A"] == "hold"
+        and sim["D"] == "hold"
+        and reverse == "hold"
+        and face == "hold"
+        and y_cover["D"] == "fail"
+        and y_sim["D"] == "hold"
+        and simultaneous(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "hold"
+        and axis_cover(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "fail",
+    )
+    checks.check(
+        "mutation-forall-perp-is-not-this-letter",
+        all(fp1[name] == "hold" for name in ("A", "B", "C", "D"))
+        and fp_reverse == "hold"
+        and fp_face == "hold"
+        and reverse == "hold"
+        and face == "hold"
+        and forall_orthogonal(frozenset({E1}), frozenset({NEG_E1})) == "fail"
+        and simultaneous(frozenset({E1}), frozenset({NEG_E1})) == "hold",
+    )
+    checks.check(
+        "not-nsopp-leftover-second-pair-is-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in twosite_ticks.values()) == 2
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and twosite_ticks[E3] == 1
+        and twosite_locks[E3] == {E3}
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2}
+        and twosite_ticks[PAIR2] == 1
+        and incoming_set(E3, 1, twosite_ticks, twosite_locks, twosite_seeds)
+        == frozenset({E3})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and zsym_ticks[E3] == 0
+        and zsym_locks[E3] == {NEG_E1}
+        and incoming_set(E3, 1, zsym_ticks, zsym_locks, zsym_seeds)
+        == frozenset({NEG_E1})
+        and twosite_ticks[PROBES["A"]] == 3
+        and ticks[PROBES["A"]] == 2
+        and twosite_sim["A"] == "hold"
+        and zsym_sim["A"] == "hold",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check(
+        "empty-intersection-is-empty-not-undefined",
+        all(
+            inter1[name] == frozenset() and inter1[name] != UNDEFINED
+            for name in ("A", "B", "C", "D")
+        ),
+    )
+    checks.check(
+        "uniqueness-not-required",
+        isinstance(o1["A"], frozenset)
+        and isinstance(o1["B"], frozenset)
+        and isinstance(o1["C"], frozenset)
+        and isinstance(o1["D"], frozenset)
+        and len(o1["A"]) == 1
+        and len(o1["B"]) == 3
+        and len(o1["C"]) == 3
+        and len(o1["D"]) == 2
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-intersection-sim",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_1}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {−e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "M(A, τ) ∩ O(A, τ) = {}" in note
+        and "M(B, τ) ∩ O(B, τ) = {}" in note
+        and "M(C, τ) ∩ O(C, τ) = {}" in note
+        and "M(D, τ) ∩ O(D, τ) = {}" in note
+        and "sim(A) = hold" in note
+        and "sim(B) = hold" in note
+        and "sim(C) = hold" in note
+        and "sim(D) = hold" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (2, 0, 0)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-sim-reverse-face",
+        "Reverse simultaneous at τ: hold" in note
+        and "Face simultaneous at τ: hold" in note
+        and "Reverse holds." in note
+        and "Face holds." in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-leftover-empty-fail",
+        "not leftover-empty fail" in normalized_note
+        and "HOLD iff simultaneous" in note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-not-axis-cover-or-exist-opposite-leftover",
+        "not leftover of nm2axx cover" in normalized_note
+        and "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover of nmsimopp exist-opposite of `M`" in normalized_note
+        and "not leftover of nm2axpx forall-perp" in normalized_note
+        and "union misses e_2" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse simultaneous at τ: hold" in note
+        and "Face simultaneous at τ: hold" in note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "Occupancy of sites is not used" in note
+        and "Occupancy `n` is not used" in note
+        and "does not use occupancy" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_XPROBE_SIMULTANEOUS_INCOMING_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "intersection_set" in defined_fns
+        and "simultaneous" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "sim-hold-not-leftover-empty-fail",
+        reverse == "hold"
+        and face == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and all(sim[name] == "hold" for name in ("A", "B", "C", "D"))
+        and cover_reverse == "fail"
+        and cover_face == "fail"
+        and sim["A"] == "hold"
+        and cover1["A"] == "fail"
+        and sim["D"] == "hold"
+        and cover1["D"] == "fail",
+    )
+    _ = (
+        leftover_neighbor_reverse,
+        ysym_ticks,
+        unique_sim_a,
+        axis_display,
+        x_cover,
+        ysym_locks,
+        ysym_seeds,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Simultaneous M and O at t+1 on opposite x-probes: reverse HOLD, face HOLD. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_xprobe_simultaneous_incoming_outgoing_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.