### PR TITLE
feat(nm2readx): neighbor-read of M at t+1 on two-axis opposite x-probes: reverse HOLD, face HOLD

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,519 @@
+---
+claim_id: two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of M at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
+---
+
+# Neighbor-Read Of Incoming M At t+1 Reverse And Face On Four Two-Axis Opposite X-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** neighbor-read of earliest incoming set `M` at each probe's
+`τ=t+1`, and reverse/face from that neighbor-read, on the four x-probes of
+the two-axis opposite seed in `B_3(0)={n:n·n<=9}`, no global T. Same process
+and x-probes as nm2axpx. Let `t(q)` be the formation tick of probe `q`. Let
+`τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest incoming nearest-neighbor
+steps at `q` using only records with tick `<= τ`. Seeds are a singleton seed
+letter. Unformed at `τ` is `UNDEFINED`. For a formed neighbor `r=q+e`,
+report `M(r,τ)`. Neighbor-read HOLDs at `q` if and only if some formed
+six-neighbor `r` has `M(r,τ)` defined and equal to `M(q,τ)` as sets.
+Unformed `q` is `UNDEFINED`. Reverse HOLDs if and only if neighbor-read
+HOLDs at `A` and at `B`. Face HOLDs if and only if neighbor-read HOLDs at
+`C` and at `D`. This is the first neighbor-read of `M` at `t+1` on the
+nm2axpx forall-perp HOLD x-probe direction of the two-axis opposite seed.
+This is not leftover of nm2axpx forall-perp. This is not leftover of nm2axx
+axis-cover. This is not leftover of two-axis same-lock z-probe
+neighbor-read. This is not leftover of two-axis same-lock x-probe
+neighbor-read. This is not leftover of R-style recovery of the incoming
+step from neighbors. Uniqueness is not required. Mixed remains a set.
+Occupancy `n` is not used. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. Neighbor-read compares those incoming sets as sets at a formed
+six-neighbor. Reverse and face are scored on neighbor-read HOLD at the
+paired probes. Named signs `{+,−}` are a coarser readout and are not used.
+A singleton unique lock letter is a different readout and is not used as
+the object. R-style recovery of the incoming step as `−e` in `M(q+e,τ)` is
+a different readout and is not used. Forall-perp of `M` versus outgoing
+dual `O` is a different readout and is not used. Axis-cover of `M` and `O`
+is a different readout and is not used. Occupancy of sites is not used.
+This display does not use occupancy. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of neighbor-read of M at t+1 on the four x-probes of the two-axis opposite seed, HOLD at A from matching D, HOLD at B,C,D, reverse hold and face hold from those bits; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face
+target_blocker_text: "display neighbor-read of M at t+1 on the four x-probes of the two-axis opposite seed, compare to nm2axpx forall-perp and to same-lock neighbor-read, HOLD iff some formed 6-NN recovers M as a set"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep neighbor-read of M at t+1 displayed; do not write the bits into Admissibility, do not reduce to R-style recovery, do not reduce to nm2axpx forall-perp, do not reduce to nm2axx cover leftover, do not replace the display by two-axis same-lock neighbor-read, do not require a unique letter, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for neighbor-read of M at t+1 on the four x-probes of the two-axis opposite seed and reverse/face from that; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose
+neighbor-read of `M` is scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. `A` is not a seed. Same process and x-probes as nm2axpx.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. The first
+pair is `{0, (0,1,0)}` with opposite locks `L(0)=+e_1` and `L(0,1,0)=−e_1`.
+The second pair is `{(0,0,1), (0,1,1)}` with opposite locks `L(0,0,1)=+e_2`
+and `L(0,1,1)=−e_2`. The second pair is a new seed, not a formed child of
+the first pair. On the one-axis opposite two-site process the sites
+`(0,0,1)` and `(0,1,1)` form at tick 1 locking `+e_3`; here they are seeds
+at tick 0 locking `+e_2` and `−e_2`. This seed is not the two-axis same-lock
+seed `+e_1/+e_1` and `+e_2/+e_2`. This seed is not the perp two-site seed
+`+e_1/+e_2`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named neighbor-read of `M` at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+Neighbor-read at a formed probe at the same cut:
+
+```text
+neighbor-read(q) HOLDs iff some formed 6-NN r has M(r,τ)
+defined and equal to M(q,τ) as sets.
+```
+
+If `q` is unformed at `τ`, then neighbor-read is `UNDEFINED`. Empty match
+fails. Mixed remains a set: equality is set equality, not a unique-letter
+reduction. Occupancy of sites is not used. The construction does not require
+`M` to be a singleton. It does not sum the set. It does not wait for a
+global later T.
+
+R-style recovery is a different object: the set of steps `e` such that
+`−e` lies in `M(q+e,τ)`. Forall-perp of `M` versus outgoing dual `O` is a
+different object. Axis-cover of `M` and `O` is a different object.
+
+Reverse neighbor-read holds if and only if neighbor-read HOLDs at `A` and
+at `B`. Face neighbor-read holds if and only if neighbor-read HOLDs at `C`
+and at `D`. Either side `UNDEFINED` is `UNDEFINED`. Else if both sides HOLD,
+reverse or face HOLDs. Else fail.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the set. Identifying R-style recovery with
+neighbor-read is refused: at `A`, R-style is `{−e_1}` while `M(A,τ)={−e_3}`;
+at `C`, R-style is `{+e_3}` while `M(C,τ)={+e_1}`; at `B` and at `D`,
+R-style is empty while neighbor-read HOLDs. Identifying nm2axpx forall-perp
+with this reverse/face is refused: forall-perp scores every incoming letter
+against every outgoing dual letter at one probe; neighbor-read scores
+set-equality of own incoming `M` at a formed six-neighbor. Identifying
+nm2axx axis-cover with this reverse/face is refused: nm2axx cover fails at
+`A` and at `D` and fails reverse and face; this member HOLDs at each
+x-probe and HOLDs reverse and face. Identifying two-axis same-lock z-probe
+neighbor-read with this reverse is refused: that leftover has seed `A` at
+tick 0 with `M={+e_2}`; here `A` is not a seed, `t(A)=2`, and
+`M(A,τ)={−e_3}`. Identifying two-axis same-lock x-probe neighbor-read with
+this reverse is refused: same-lock x-probes also HOLD reverse and face, but
+`M((0,1,1),τ)` there is `{+e_2}` while here it is `{−e_2}`, and
+`M((0,1,0),τ)` there is `{+e_1}` while here it is `{−e_1}`.
+
+## Theorem 1 — ticks, `M` at probes and at formed 6-NN, and neighbor-read bit
+
+On this process the four x-probes form. Incoming is frozen at formation:
+`M(q,t+1)=M(q,t)` at every scored probe. Compare to nm2axpx forall-perp:
+that leftover HOLDs reverse and face by scoring integer dots of `M` versus
+`O`. Here `M` is read at the same cut `τ=t+1` and scored by set-equality
+at a formed six-neighbor. Neighbor-read HOLDs at `A`, at `B`, at `C`, and
+at `D`. Reverse HOLDs. Face HOLDs. The match at `A` is `D=(1,1,0)` with
+the same letter `{−e_3}`. The match at `D` is `A=(1,0,0)` with the same
+letter `{−e_3}`.
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {−e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_3}
+neighbor-read(A) = hold
+neighbor-read(B) = hold
+neighbor-read(C) = hold
+neighbor-read(D) = hold
+formed 6-NN of A at τ: (2, 0, 0)={+e_1}, (0, 0, 0)={+e_1}, (1, 1, 0)={−e_3}, (1, -1, 0)={+e_1}, (1, 0, 1)={+e_1}, (1, 0, -1)={+e_1}
+formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)={−e_2}, (1, 2, 1)={+e_2}, (1, 0, 1)={+e_1}, (1, 1, 2)={+e_1, +e_3}, (1, 1, 0)={−e_3}
+formed 6-NN of C at τ: (1, 0, 0)={−e_3}, (2, 1, 0)={+e_1}, (2, -1, 0)={−e_2, −e_3}, (2, 0, 1)={+e_2, +e_3, −e_3}, (2, 0, -1)={−e_3}
+formed 6-NN of D at τ: (2, 1, 0)={+e_1}, (0, 1, 0)={−e_1}, (1, 2, 0)={+e_1}, (1, 0, 0)={−e_3}, (1, 1, 1)={+e_1}, (1, 1, -1)={+e_1}
+matching 6-NN of A: (1, 1, 0)
+matching 6-NN of B: (1, 0, 1)
+matching 6-NN of C: (2, 1, 0)
+matching 6-NN of D: (1, 0, 0)
+```
+
+`A` is not a seed. `A` is the site `(1,0,0)` forming at tick 2 with
+incoming `{−e_3}`. Mixed remains a set: `M((1,1,2),τ)` at `B`'s cut is
+`{+e_1, +e_3}`, and `M((2,0,1),τ)` at `C`'s cut is `{+e_2, +e_3, −e_3}`.
+Unique letters would assign `UNDEFINED` at those mixed neighbors. Here
+uniqueness is not required. `M` is frozen from `t` to `τ=t+1` at each of
+the four x-probes. Unformed six-neighbors remain `UNDEFINED` at the cut
+and do not match.
+
+On the two-axis same-lock seed with the same x-probes, neighbor-read also
+HOLDs reverse and face with the same ticks and the same probe letters, but
+the formed neighbor `(0,1,1)` of `B` locks `{+e_2}` and the formed
+neighbor `(0,1,0)` of `D` locks `{+e_1}`. Here those neighbors lock
+`{−e_2}` and `{−e_1}` because the pairs are opposite. That leftover is
+not this display.
+
+On the two-axis same-lock z-probes, `A=(0,0,1)` is a seed at tick 0 with
+`M={+e_2}`, and neighbor-read HOLDs reverse and face from the same-lock
+partner seed. Here `A` is not a seed.
+
+On the two-axis opposite z-probes, neighbor-read fails at `A` because the
+partner seed `(0,1,1)` locks `−e_2`, unequal to `M(A,τ)={+e_2}`. That
+leftover fails reverse. This member HOLDs reverse on the x-probes.
+
+On the 1-axis same-lock two-site seed, `t(A)=3` with mixed `M`,
+neighbor-read fails at `A` and at `D`, and reverse and face fail. That is
+leftover of the first pair. Here the second pair is a new opposite seed,
+`t(A)=2`, and reverse and face HOLD.
+
+## Theorem 2 — reverse from neighbor-read at `τ`
+
+Reverse neighbor-read holds if and only if neighbor-read HOLDs at `A` and
+at `B`. Neighbor-read HOLDs at `A` and HOLDs at `B`. Reverse HOLDs.
+
+Reverse neighbor-read at τ: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Two-axis opposite
+z-probe neighbor-read reverse fails because neighbor-read fails at seed
+`A`. Two-axis opposite y-probe neighbor-read reverse fails. nm2axx
+axis-cover reverse fails because cover fails at `A` from a union that
+misses e_2. R-style recovery at `A` is `{−e_1}`, not equal to
+`M(A,τ)={−e_3}`, and R-style at `B` is empty. Those leftovers are not
+this display.
+
+Reverse holds.
+
+## Theorem 3 — face from neighbor-read at `τ`
+
+Face neighbor-read holds if and only if neighbor-read HOLDs at `C` and at
+`D`. Both neighbor-reads HOLD. Face HOLDs.
+
+Face neighbor-read at τ: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `fail` and not `UNDEFINED`. Face holds.
+
+On the same seed the four y-probes give reverse fail and face fail. The
+four z-probes give reverse fail and face hold, with seed `A` at tick 0.
+Those probe-direction readouts are not this x-probe display.
+
+nm2axx cover face fails because cover fails at `D`. 1-axis same-lock face
+fails. Two-site opposite leftover face fails. Z-symmetric leftover fails
+at `A` and HOLDs face. Those leftovers are not this display.
+
+Face holds.
+
+## What this note does not claim
+
+- It does not select a unique incoming lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require neighbor-read sides to be singletons.
+- It does not sum the incoming set.
+- It does not replace neighbor-read by R-style recovery.
+- It does not replace neighbor-read by nm2axpx forall-perp.
+- It does not replace neighbor-read by nm2axx axis-cover.
+- It does not replace neighbor-read by two-axis same-lock z-probe neighbor-read.
+- It does not replace neighbor-read by two-axis same-lock x-probe neighbor-read.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint 1-axis same-lock neighbor-read as this member.
+- It does not reprint two-axis opposite y-probe neighbor-read.
+- It does not reprint two-axis opposite z-probe neighbor-read.
+- It does not treat the second opposite pair as a formed child of the first.
+- It does not score the y-probes or the z-probes as this letter.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite four-site process, neighbor-read of `M` at `t+1`, and the
+reverse/face bits from that neighbor-read are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `M` at formed 6-NN | Theorem 1; `D` matches `A` on `{−e_3}` |
+| neighbor-read bit at `τ` | Theorem 1; HOLD at `A`,`B`,`C`,`D` |
+| reverse from neighbor-read at `τ` | Theorem 2; `hold` |
+| face from neighbor-read at `τ` | Theorem 3; `hold` |
+| compare to nm2axpx forall-perp | Theorem 1; forall-perp HOLDs reverse/face by `M` versus `O` dots; this member HOLDs by set-equality of `M` at a formed 6-NN |
+| compare to nm2axx cover | Theorem 1; cover reverse FAIL face FAIL; neighbor-read reverse HOLD face HOLD |
+| compare to two-axis same-lock z-probe neighbor-read | Theorem 1; same-lock z has seed `A` at tick 0 with `M={+e_2}`; here `t(A)=2` and `M={−e_3}` |
+| compare to two-axis same-lock x-probe neighbor-read | Theorem 1; same-lock x HOLDs reverse/face but neighbor `M` at `(0,1,1)` and `(0,1,0)` differs by sign |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of nm2axpx forall-perp | not this neighbor-read display |
+| leftover of nm2axx axis-cover | not this display |
+| leftover of two-axis same-lock z-probe neighbor-read | not this display |
+| leftover of two-axis same-lock x-probe neighbor-read | not this display |
+| leftover of R-style | not this display |
+| leftover of 1-axis same-lock neighbor-read | not this display |
+| leftover of y-probe neighbor-read | not this display |
+| leftover of z-probe neighbor-read | not this display |
+| global later T | not used |
+| neighbor-read as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: neighbor-read of `M` at `t+1` on the four x-probes of the two-axis opposite seed, compared to nm2axpx forall-perp and to same-lock neighbor-read, and reverse/face from those bits. |
+| V2 | Current main has no landed neighbor-read reverse/face of timed `M` on these four two-axis opposite x-probes. |
+| V3 | Neighbor-read reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads set-equality of own incoming `M` at a formed six-neighbor at the same `t+1` cut. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace neighbor-read by R-style recovery, does not
+replace neighbor-read by nm2axpx forall-perp, does not replace neighbor-read
+by nm2axx axis-cover, and does not identify this display with two-axis
+same-lock neighbor-read. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2axpx forall-perp | score every `m·o=0` of `M` versus `O` | forall-perp is incoming-versus-outgoing integer dots at one probe; neighbor-read is set-equality of `M` at a formed 6-NN; `O(A,τ)={+e_1}` is not `M(A,τ)={−e_3}` | ATTEMPTED |
+| nm2axx axis-cover | reuse cover of `M` and `O` | cover fails at `A` and at `D` and fails reverse and face; neighbor-read HOLDs at each x-probe and HOLDs reverse and face | ATTEMPTED |
+| two-axis same-lock z-probe neighbor-read | reuse seed `+e_1/+e_1` and `+e_2/+e_2` on z-probes | that leftover has seed `A` at tick 0 with `M={+e_2}`; here `A` is not a seed, `t(A)=2`, and `M={−e_3}` | ATTEMPTED |
+| two-axis same-lock x-probe neighbor-read | reuse same-lock pairs on these x-probes | same-lock x HOLDs reverse/face, but `M((0,1,1),τ)={+e_2}` and `M((0,1,0),τ)={+e_1}` there; here those neighbors lock `{−e_2}` and `{−e_1}` | ATTEMPTED |
+| R-style recovery | recover incoming as `−e` in `M(q+e,τ)` | R-style at `A` is `{−e_1}` unequal to `{−e_3}`; at `C` is `{+e_3}` unequal to `{+e_1}`; at `B` and at `D` it is empty while neighbor-read HOLDs | ATTEMPTED |
+| 1-axis same-lock neighbor-read | reuse seed `{0,(0,1,0)}` with `+e_1/+e_1` | 1-axis fails reverse and face with `t(A)=3`; here `t(A)=2` and reverse and face HOLD | ATTEMPTED |
+| two-site opposite leftover | reuse opposite `+e_1/−e_1` without the second pair | that leftover fails reverse and face; this member HOLDs face from four opposite seeds | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed neighbor `M((1,1,2),τ)={+e_1,+e_3}` remains a set; unique-letter is `UNDEFINED` while neighbor-read HOLDs at `B` | ATTEMPTED |
+| y-probe neighbor-read | score the four y-probes on this seed | y-probe reverse fails and face fails; this letter is the four x-probes | ATTEMPTED |
+| z-probe neighbor-read | score the four z-probes on this seed | z-probe reverse fails because seed `A` has partner letter `−e_2`; this letter has non-seed `A` at tick 2 | ATTEMPTED |
+| z-symmetric leftover | reuse seed `{0,(0,0,1),(0,0,-1)}` | that leftover fails at `A`; this member HOLDs at `A` | ATTEMPTED |
+| perp two-site leftover | reuse seed `{0,(0,1,0)}` with `+e_1/+e_2` | perp fails at each x-probe; this member HOLDs reverse and face | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the set | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by neighbor-read | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of neighbor-read with
+R-style recovery, missing identification of neighbor-read with nm2axpx
+forall-perp, missing identification of neighbor-read with nm2axx
+axis-cover, missing identification of this member with two-axis same-lock
+neighbor-read, and missing Record identification of neighbor-read reverse
+are distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite pairs with locks `+e_1`, `−e_1`,
+`+e_2`, and `−e_2`, perpendicular step rule, incoming-step lock, own
+incoming set from records with tick `<= τ`, per-probe `τ=t+1`,
+neighbor-read as set-equality of `M` at a formed six-neighbor, four
+x-probes with non-seed `A`, reverse as neighbor-read at `A` and `B`, face
+as neighbor-read at `C` and `D`, and mixed remains a set are declared. No
+uniqueness of incoming locks, no R-style recovery as the scored object, no
+forall-perp as the scored object, no axis-cover as the scored object, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+neighbor-read reverse hold and face hold reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each earliest incoming lock set `M` at a probe and at formed 6-NN | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four neighbor-read reports, reverse/face from those bits | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for neighbor-read reverse/face,
+a formation-rate rule, and a physical selector among matching six-neighbors.
+None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Two-axis opposite neighbor-read on x-probes is leftover of
+nm2axpx forall-perp because the same process and probes already HOLD reverse
+and face; leftover of two-axis same-lock x-probe neighbor-read because only
+a sign of two seed letters changed; leftover of nm2axx cover with the union
+demand dropped; leftover of R-style because some neighbor already carries
+an opposite step; and uniqueness of `M` already answers the match.
+
+**Answer:** Forall-perp pairs every incoming letter with every outgoing dual
+letter at one probe. Neighbor-read asks whether some formed six-neighbor
+carries the same incoming set. `O(A,τ)={+e_1}` is not `M(A,τ)={−e_3}`.
+Same-lock x-probes HOLD reverse and face with the same probe letters, but
+`M((0,1,1),τ)` and `M((0,1,0),τ)` differ by sign because the pairs are
+opposite here. nm2axx cover reverse FAIL face FAIL because the union misses
+e_2 at `A` and at `D`; neighbor-read reverse HOLD face HOLD. R-style at `A`
+is `{−e_1}`, not `{−e_3}`. Mixed neighbor `M((1,1,2),τ)={+e_1,+e_3}` remains
+a set; uniqueness is not required. Reverse neighbor-read is HOLD iff
+neighbor-read at `A` and at `B`, not leftover of forall-perp and not
+leftover of same-lock x-probe neighbor-read.
+
+### N8 — cross-cycle echo
+
+nm2axpx reported forall-orthogonal `M` versus `O` on these four x-probes
+with reverse hold and face hold. nm2axx reported axis-cover of `M` versus
+`O` on these four x-probes with reverse fail and face fail because the
+union misses e_2. nm2readslz reported neighbor-read of `M` on two-axis
+same-lock z-probes with reverse hold and face hold from seed `A` at tick 0.
+Two-axis opposite z-probe neighbor-read reports fail at `A`, HOLD at
+`B`,`C`,`D`, reverse fail, and face hold. Two-axis opposite y-probes report
+reverse fail and face fail. This note is not those displays: it reports
+neighbor-read of `M` at `τ=t+1` on two disjoint opposite pairs with
+x-probes, HOLD at `A`,`B`,`C`,`D`, reverse hold, and face hold. HOLD iff
+some formed 6-NN recovers `M` as a set, not leftover of nm2axpx forall-perp,
+and not leftover of same-lock neighbor-read.
+
+**Gate disposition:** PASS for the neighbor-read `t+1` reverse/face reports
+above. FAIL / DO NOT SHIP for “the predicate equals the named sign,” “the
+predicate equals the unique singleton lock vector,” “the predicate equals
+R-style recovery,” “the predicate equals nm2axpx forall-perp,” “the
+predicate equals nm2axx axis-cover,” “the predicate equals two-axis
+same-lock neighbor-read,” “bits are Admissibility,” “neighbor-read fails at
+`A`,” “neighbor-read fails at `D`,” “reverse neighbor-read fails,” or “face
+neighbor-read fails.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each x-probe's own earliest incoming
+set from the record prefix at that probe's `t+1`, reports `M` at each formed
+six-neighbor, reports neighbor-read as set-equality of those incoming sets,
+lists matching six-neighbors, compares to two-axis same-lock neighbor-read
+and to opposite z-probe neighbor-read, and checks Theorems 1--3. It also
+checks that neighbor-read HOLDs at `A` from matching `D`, that R-style
+recovery is a different object, that mixed sets remain sets, that
+unique-letter is `UNDEFINED` at mixed neighbors, that the construction does
+not sum, that a formation member from already-recorded six-neighbor locks
+is not attached, and that the display is not leftover of nm2axpx forall-perp
+or of nm2axx axis-cover. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,88 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
+runner_sha256: f098869f7ead20ffe7bfd662701780421791ab26bcd2a4f13b5bb2f21e00719e
+input_fingerprint_sha256: 3dd368cd5e86c3fc10658a05479fede0fb3c602f1cd0d0cbc8c223b679e1aade
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+neighbor-read of M reverse/face at t+1 on two-axis opposite x-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of M at t+1 on the four x-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: pair-read-identity
+PASS: neighbor-read-identity
+A t=2 M={−e_3} neighbor-read=hold
+B t=1 M={+e_1} neighbor-read=hold
+C t=3 M={+e_1} neighbor-read=hold
+D t=2 M={−e_3} neighbor-read=hold
+neighbor-read reverse=hold face=hold
+same-lock x-probe neighbor-read reverse=hold face=hold
+nm2readslz same-lock z-probe neighbor-read reverse=hold face=hold A=hold
+opposite z-probe neighbor-read reverse=fail face=hold A=fail
+per_element: each earliest incoming lock set M at a probe and at formed 6-NN, compared as sets at the probe's t+1
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: pairs-are-opposite
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_3}', 'B': '{+e_1}', 'C': '{+e_1}', 'D': '{−e_3}'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-formed-6nn-M-at-A
+PASS: theorem1-formed-6nn-M-at-B
+PASS: theorem1-formed-6nn-M-at-C
+PASS: theorem1-formed-6nn-M-at-D
+PASS: theorem1-neighbor-read-bits  ({'A': ('hold', ((1, 1, 0),)), 'B': ('hold', ((1, 0, 1),)), 'C': ('hold', ((2, 1, 0),)), 'D': ('hold', ((1, 0, 0),))})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-not-seed
+PASS: compare-same-lock-x-neighbor-read
+PASS: compare-nm2readslz-same-lock-z-neighbor-read
+PASS: compare-opposite-z-neighbor-read
+PASS: compare-1-axis-same-lock-x-neighbor-read
+PASS: theorem2-reverse-hold
+PASS: theorem3-face-hold
+PASS: mutation-r-style-differs
+PASS: mutation-unique-letter-mixed-neighbor
+PASS: not-y-probes-or-z-probes-or-perp
+PASS: not-nsopp-leftover-second-pair-is-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-and-neighbor-read
+PASS: note-reports-formed-neighbors
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-same-lock-or-r-style-leftover
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-does-not-use-occupancy
+PASS: note-uniqueness-not-required
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: neighbor-read-not-cover-or-same-lock-z
+TOTAL: PASS=55 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1090 @@
+#!/usr/bin/env python3
+"""Neighbor-read of M at t+1 reverse/face on two-axis opposite x-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and x-probes as nm2axpx.
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Seeds keep their seed letters as
+a singleton. The second pair is a new seed, not a formed child of the first
+pair. t(q) is the formation tick. tau = t(q)+1. M(q, tau) is the set of
+earliest incoming nearest-neighbor steps at q using only records with tick
+<= tau. Unformed at tau => UNDEFINED. For formed neighbor r = q+e, report
+M(r, tau). Neighbor-read HOLDs at q iff some formed 6-NN r has M(r, tau)
+defined and equal to M(q, tau) as sets. Unformed q => UNDEFINED. Mixed
+remains a set. Uniqueness is not required. Reverse HOLDs iff neighbor-read
+at A and at B. Face likewise on C, D. Occupancy n is not used. Named-sign
+lettering is not used. No larger host. This is not leftover
+of nm2axpx forall-perp. This is not leftover of nm2axx axis-cover. This is
+not leftover of two-axis same-lock z-probe neighbor-read. This is not
+leftover of two-axis same-lock x-probe neighbor-read. This is not leftover
+of R-style recovery of the incoming step from neighbors. Displayed, not
+adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+YZ: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+BALL_SQ = 9
+TWO_AXIS_OPPOSITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (YZ, NEG_E2),
+)
+FOUR_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    (YZ, E2),
+)
+ONE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+NSPAR_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E1, NEG_E1),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of M at t+1 on the four x-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def neg(step: Point) -> Point:
+    return (-step[0], -step[1], -step[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def formed_display(rows: tuple[tuple[Point, Incoming], ...]) -> str:
+    return ", ".join(
+        f"{neighbor}={lockset_display(incoming)}" for neighbor, incoming in rows
+    )
+
+
+def matching_display(matches: tuple[Point, ...] | str) -> str:
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    return ", ".join(str(site) for site in matches)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_OPPOSITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def matching_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Formed 6-NN r with M(r, tau) defined and equal to M(site, tau)."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff some formed 6-NN recovers M(q, tau) as a set. Unformed => UNDEFINED."""
+    matches = matching_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def formed_neighbor_incoming(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[tuple[Point, Incoming], ...]:
+    """M(r, tau) at each eventually-formed 6-NN of site, including UNDEFINED."""
+    rows: list[tuple[Point, Incoming]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        rows.append(
+            (neighbor, incoming_set(neighbor, tau, ticks, locks, seed_map))
+        )
+    return tuple(rows)
+
+
+def r_style_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Recover incoming as steps e with -e in M(q+e, tau). Different object."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    recovered: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if neg(step) in other:
+            recovered.add(step)
+    return frozenset(recovered)
+
+
+def pair_read(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(read_a: str, read_b: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_read(read_a, read_b)
+
+
+def face_report(read_c: str, read_d: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_read(read_c, read_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def probe_reads(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = neighbor_read(
+            site,
+            site_ticks[site] + 1,
+            site_ticks,
+            site_locks,
+            site_seeds,
+        )
+    return out
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("neighbor-read of M reverse/face at t+1 on two-axis opposite x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == YZ
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "pair-read-identity",
+        pair_read(UNDEFINED, "hold") == UNDEFINED
+        and pair_read("hold", UNDEFINED) == UNDEFINED
+        and pair_read("hold", "hold") == "hold"
+        and pair_read("hold", "fail") == "fail"
+        and pair_read("fail", "hold") == "fail"
+        and pair_read("fail", "fail") == "fail",
+    )
+    checks.check(
+        "neighbor-read-identity",
+        neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and matching_neighbors(PROBES["B"], -1, {}, {}, {}) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SEEDS)
+    sl_ticks, sl_locks, sl_seeds = form(FOUR_SITE_SEEDS)
+    twosite_ticks, twosite_locks, twosite_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    one_axis_ticks, one_axis_locks, one_axis_seeds = form(TWO_SITE_SEEDS)
+
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    reads: dict[str, str] = {}
+    matches: dict[str, tuple[Point, ...] | str] = {}
+    formed_m: dict[str, tuple[tuple[Point, Incoming], ...]] = {}
+    r_style: dict[str, Incoming] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0 = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0, ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        reads[name] = neighbor_read(site, tau1[name], ticks, locks, seed_map)
+        matches[name] = matching_neighbors(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        formed_m[name] = formed_neighbor_incoming(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        r_style[name] = r_style_read(site, tau1[name], ticks, locks, seed_map)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"neighbor-read={reads[name]}"
+        )
+
+    reverse = reverse_report(reads["A"], reads["B"])
+    face = face_report(reads["C"], reads["D"])
+    sl_x_reads = probe_reads(PROBES, sl_ticks, sl_locks, sl_seeds)
+    sl_x_reverse = reverse_report(sl_x_reads["A"], sl_x_reads["B"])
+    sl_x_face = face_report(sl_x_reads["C"], sl_x_reads["D"])
+    sl_z_reads = probe_reads(Z_PROBES, sl_ticks, sl_locks, sl_seeds)
+    sl_z_reverse = reverse_report(sl_z_reads["A"], sl_z_reads["B"])
+    sl_z_face = face_report(sl_z_reads["C"], sl_z_reads["D"])
+    opp_z_reads = probe_reads(Z_PROBES, ticks, locks, seed_map)
+    opp_z_reverse = reverse_report(opp_z_reads["A"], opp_z_reads["B"])
+    opp_z_face = face_report(opp_z_reads["C"], opp_z_reads["D"])
+    print(f"neighbor-read reverse={reverse} face={face}")
+    print(
+        f"same-lock x-probe neighbor-read reverse={sl_x_reverse} "
+        f"face={sl_x_face}"
+    )
+    print(
+        f"nm2readslz same-lock z-probe neighbor-read reverse={sl_z_reverse} "
+        f"face={sl_z_face} A={sl_z_reads['A']}"
+    )
+    print(
+        f"opposite z-probe neighbor-read reverse={opp_z_reverse} "
+        f"face={opp_z_face} A={opp_z_reads['A']}"
+    )
+    print(
+        "per_element: each earliest incoming lock set M at a probe and at "
+        "formed 6-NN, compared as sets at the probe's t+1"
+    )
+    print(
+        "per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four neighbor-read reports, reverse/face from those bits")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["A"], 1, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["C"], 2, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(YZ, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and TWO_AXIS_OPPOSITE_SEEDS
+        == ((ORIGIN, E1), (E2, NEG_E1), (E3, E2), (YZ, NEG_E2)),
+    )
+    checks.check(
+        "pairs-are-opposite",
+        seed_map[ORIGIN] == E1
+        and seed_map[E2] == NEG_E1
+        and seed_map[E3] == E2
+        and seed_map[YZ] == NEG_E2
+        and add(seed_map[ORIGIN], seed_map[E2]) == ZERO
+        and add(seed_map[E3], seed_map[YZ]) == ZERO
+        and TWO_AXIS_OPPOSITE_SEEDS != FOUR_SITE_SEEDS,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E3})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-A",
+        formed_m["A"]
+        == (
+            ((2, 0, 0), frozenset({E1})),
+            ((0, 0, 0), frozenset({E1})),
+            ((1, 1, 0), frozenset({NEG_E3})),
+            ((1, -1, 0), frozenset({E1})),
+            ((1, 0, 1), frozenset({E1})),
+            ((1, 0, -1), frozenset({E1})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-B",
+        formed_m["B"]
+        == (
+            ((2, 1, 1), UNDEFINED),
+            ((0, 1, 1), frozenset({NEG_E2})),
+            ((1, 2, 1), frozenset({E2})),
+            ((1, 0, 1), frozenset({E1})),
+            ((1, 1, 2), frozenset({E1, E3})),
+            ((1, 1, 0), frozenset({NEG_E3})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-C",
+        formed_m["C"]
+        == (
+            ((1, 0, 0), frozenset({NEG_E3})),
+            ((2, 1, 0), frozenset({E1})),
+            ((2, -1, 0), frozenset({NEG_E2, NEG_E3})),
+            ((2, 0, 1), frozenset({E2, E3, NEG_E3})),
+            ((2, 0, -1), frozenset({NEG_E3})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-D",
+        formed_m["D"]
+        == (
+            ((2, 1, 0), frozenset({E1})),
+            ((0, 1, 0), frozenset({NEG_E1})),
+            ((1, 2, 0), frozenset({E1})),
+            ((1, 0, 0), frozenset({NEG_E3})),
+            ((1, 1, 1), frozenset({E1})),
+            ((1, 1, -1), frozenset({E1})),
+        ),
+    )
+    checks.check(
+        "theorem1-neighbor-read-bits",
+        reads["A"] == "hold"
+        and reads["B"] == "hold"
+        and reads["C"] == "hold"
+        and reads["D"] == "hold"
+        and matches["A"] == ((1, 1, 0),)
+        and matches["B"] == ((1, 0, 1),)
+        and matches["C"] == ((2, 1, 0),)
+        and matches["D"] == ((1, 0, 0),),
+        str({name: (reads[name], matches[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        incoming_set((1, 1, 2), tau1["B"], ticks, locks, seed_map)
+        == frozenset({E1, E3})
+        and unique_letter(
+            incoming_set((1, 1, 2), tau1["B"], ticks, locks, seed_map)
+        )
+        == UNDEFINED
+        and reads["B"] == "hold"
+        and incoming_set((2, -1, 0), tau1["C"], ticks, locks, seed_map)
+        == frozenset({NEG_E2, NEG_E3})
+        and incoming_set((2, 0, 1), tau1["C"], ticks, locks, seed_map)
+        == frozenset({E2, E3, NEG_E3})
+        and unique_letter(
+            incoming_set((2, 0, 1), tau1["C"], ticks, locks, seed_map)
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and ticks[E1] == 2
+        and E1 not in seed_map
+        and m1["A"] == frozenset({NEG_E3})
+        and Y_PROBES["A"] != PROBES["A"]
+        and Z_PROBES["A"] != PROBES["A"],
+    )
+    sl_b_partner = incoming_set(
+        YZ, sl_ticks[PROBES["B"]] + 1, sl_ticks, sl_locks, sl_seeds
+    )
+    sl_d_partner = incoming_set(
+        E2, sl_ticks[PROBES["D"]] + 1, sl_ticks, sl_locks, sl_seeds
+    )
+    checks.check(
+        "compare-same-lock-x-neighbor-read",
+        sl_x_reads["A"] == "hold"
+        and sl_x_reads["B"] == "hold"
+        and sl_x_reads["C"] == "hold"
+        and sl_x_reads["D"] == "hold"
+        and sl_x_reverse == "hold"
+        and sl_x_face == "hold"
+        and sl_b_partner == frozenset({E2})
+        and formed_m["B"][1][1] == frozenset({NEG_E2})
+        and sl_d_partner == frozenset({E1})
+        and formed_m["D"][1][1] == frozenset({NEG_E1})
+        and FOUR_SITE_SEEDS != TWO_AXIS_OPPOSITE_SEEDS,
+    )
+    checks.check(
+        "compare-nm2readslz-same-lock-z-neighbor-read",
+        sl_z_reads["A"] == "hold"
+        and sl_z_reads["B"] == "hold"
+        and sl_z_reads["C"] == "hold"
+        and sl_z_reads["D"] == "hold"
+        and sl_z_reverse == "hold"
+        and sl_z_face == "hold"
+        and sl_ticks[Z_PROBES["A"]] == 0
+        and ticks[PROBES["A"]] == 2
+        and Z_PROBES["A"] in sl_seeds
+        and PROBES["A"] not in seed_map
+        and incoming_set(
+            Z_PROBES["A"], sl_ticks[Z_PROBES["A"]] + 1, sl_ticks, sl_locks, sl_seeds
+        )
+        == frozenset({E2})
+        and m1["A"] == frozenset({NEG_E3}),
+    )
+    checks.check(
+        "compare-opposite-z-neighbor-read",
+        opp_z_reads["A"] == "fail"
+        and opp_z_reads["B"] == "hold"
+        and opp_z_reads["C"] == "hold"
+        and opp_z_reads["D"] == "hold"
+        and opp_z_reverse == "fail"
+        and opp_z_face == "hold"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    one_reads = probe_reads(PROBES, one_ticks, one_locks, one_seeds)
+    one_reverse = reverse_report(one_reads["A"], one_reads["B"])
+    one_face = face_report(one_reads["C"], one_reads["D"])
+    checks.check(
+        "compare-1-axis-same-lock-x-neighbor-read",
+        one_reads["A"] == "fail"
+        and one_reads["C"] == "hold"
+        and one_reads["D"] == "fail"
+        and one_reverse == "fail"
+        and one_face == "fail"
+        and one_ticks[PROBES["A"]] == 3
+        and ticks[PROBES["A"]] == 2
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse == "hold"
+        and reads["A"] == "hold"
+        and reads["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail",
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face == "hold"
+        and reads["C"] == "hold"
+        and reads["D"] == "hold"
+        and face != UNDEFINED
+        and face != "fail",
+    )
+    checks.check(
+        "mutation-r-style-differs",
+        r_style["A"] == frozenset({NEG_E1})
+        and r_style["B"] == frozenset()
+        and r_style["C"] == frozenset({E3})
+        and r_style["D"] == frozenset()
+        and r_style["A"] != m1["A"]
+        and r_style["C"] != m1["C"]
+        and reads["A"] == "hold"
+        and reads["C"] == "hold",
+    )
+    checks.check(
+        "mutation-unique-letter-mixed-neighbor",
+        unique_letter(
+            incoming_set((1, 1, 2), tau1["B"], ticks, locks, seed_map)
+        )
+        == UNDEFINED
+        and unique_letter(m1["B"]) == frozenset({E1})
+        and unique_letter(m1["A"]) == frozenset({NEG_E3})
+        and reads["A"] == "hold"
+        and reads["B"] == "hold",
+    )
+    y_reads = probe_reads(Y_PROBES, ticks, locks, seed_map)
+    z_reads = probe_reads(Z_PROBES, ticks, locks, seed_map)
+    perp_reads = probe_reads(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_reads = probe_reads(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    twosite_reads = probe_reads(
+        PROBES, twosite_ticks, twosite_locks, twosite_seeds
+    )
+    y_reverse = reverse_report(y_reads["A"], y_reads["B"])
+    y_face = face_report(y_reads["C"], y_reads["D"])
+    z_reverse = reverse_report(z_reads["A"], z_reads["B"])
+    z_face = face_report(z_reads["C"], z_reads["D"])
+    twosite_reverse = reverse_report(twosite_reads["A"], twosite_reads["B"])
+    twosite_face = face_report(twosite_reads["C"], twosite_reads["D"])
+    checks.check(
+        "not-y-probes-or-z-probes-or-perp",
+        TWO_AXIS_OPPOSITE_SEEDS != PERP_SEEDS
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites
+        and y_reads["A"] == "fail"
+        and y_reads["C"] == "fail"
+        and y_reverse == "fail"
+        and y_face == "fail"
+        and z_reverse == "fail"
+        and z_face == "hold"
+        and ticks[Y_PROBES["A"]] == 0
+        and ticks[Z_PROBES["A"]] == 0
+        and ticks[PROBES["A"]] == 2
+        and m1["A"] == frozenset({NEG_E3})
+        and incoming_set(
+            Y_PROBES["A"], ticks[Y_PROBES["A"]] + 1, ticks, locks, seed_map
+        )
+        == frozenset({NEG_E1})
+        and perp_reads["A"] == "fail"
+        and perp_reads["B"] == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and y_face != face,
+    )
+    checks.check(
+        "not-nsopp-leftover-second-pair-is-seed",
+        TWO_AXIS_OPPOSITE_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != Z_SYMMETRIC_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != Y_SYMMETRIC_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != NSPAR_SEEDS
+        and TWO_AXIS_OPPOSITE_SEEDS != FOUR_SITE_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in twosite_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and twosite_ticks[E3] == 1
+        and twosite_locks[E3] == {E3}
+        and twosite_reads["A"] == "fail"
+        and twosite_reads["C"] == "hold"
+        and twosite_reverse == "fail"
+        and twosite_face == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and zsym_reads["A"] == "fail"
+        and zsym_reads["C"] == "hold"
+        and one_axis_ticks[E3] == 1
+        and one_axis_locks[E3] == {E3}
+        and E3 not in one_axis_seeds
+        and E3 in seed_map
+        and YZ in seed_map,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-and-neighbor-read",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "neighbor-read(A) = hold" in note
+        and "neighbor-read(B) = hold" in note
+        and "neighbor-read(C) = hold" in note
+        and "neighbor-read(D) = hold" in note,
+    )
+    checks.check(
+        "note-reports-formed-neighbors",
+        "formed 6-NN of A at τ: (2, 0, 0)={+e_1}, (0, 0, 0)={+e_1}, (1, 1, 0)={−e_3}, (1, -1, 0)={+e_1}, (1, 0, 1)={+e_1}, (1, 0, -1)={+e_1}"
+        in note
+        and "formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)={−e_2}, (1, 2, 1)={+e_2}, (1, 0, 1)={+e_1}, (1, 1, 2)={+e_1, +e_3}, (1, 1, 0)={−e_3}"
+        in note
+        and "formed 6-NN of C at τ: (1, 0, 0)={−e_3}, (2, 1, 0)={+e_1}, (2, -1, 0)={−e_2, −e_3}, (2, 0, 1)={+e_2, +e_3, −e_3}, (2, 0, -1)={−e_3}"
+        in note
+        and "formed 6-NN of D at τ: (2, 1, 0)={+e_1}, (0, 1, 0)={−e_1}, (1, 2, 0)={+e_1}, (1, 0, 0)={−e_3}, (1, 1, 1)={+e_1}, (1, 1, -1)={+e_1}"
+        in note
+        and "matching 6-NN of A: (1, 1, 0)" in note
+        and "matching 6-NN of B: (1, 0, 1)" in note
+        and "matching 6-NN of C: (2, 1, 0)" in note
+        and "matching 6-NN of D: (1, 0, 0)" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse neighbor-read at τ: hold" in note
+        and "Face neighbor-read at τ: hold" in note
+        and "Reverse holds." in note
+        and "Face holds." in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-same-lock-or-r-style-leftover",
+        "not leftover of nm2axpx forall-perp" in normalized_note
+        and "not leftover of nm2axx axis-cover" in normalized_note
+        and "not leftover of two-axis same-lock z-probe neighbor-read"
+        in normalized_note
+        and "not leftover of two-axis same-lock x-probe neighbor-read"
+        in normalized_note
+        and "not leftover of R-style" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-does-not-use-occupancy",
+        "does not use occupancy" in normalized_note
+        and "Occupancy `n` is not used" in note
+        and "neighbor-read" in normalized_note,
+    )
+    checks.check(
+        "note-uniqueness-not-required",
+        "Uniqueness is not required." in normalized_note
+        and "Mixed remains a set." in note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_XPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "neighbor_read" in defined_fns
+        and "matching_neighbors" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "formed_neighbor_incoming" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "neighbor-read-not-cover-or-same-lock-z",
+        reverse == "hold"
+        and face == "hold"
+        and reads["A"] == "hold"
+        and reads["B"] == "hold"
+        and reads["C"] == "hold"
+        and reads["D"] == "hold"
+        and sl_z_reverse == "hold"
+        and ticks[PROBES["A"]] != sl_ticks[Z_PROBES["A"]]
+        and formed_m["B"][1][1] == frozenset({NEG_E2})
+        and sl_b_partner == frozenset({E2}),
+    )
+    _ = (formed_display, matching_display, z_reads, ysym_ticks)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Neighbor-read of M at t+1 on opposite x-probes: reverse HOLD, face HOLD. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_xprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.