### PR TITLE
feat(nm2oready): neighbor-read of O at t+1 on two-axis opposite y-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,497 @@
+---
+claim_id: two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of O at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py
+---
+
+# Neighbor-Read Of Own-Outgoing At t+1 Reverse And Face On Four Two-Axis Opposite Y-Probes
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** neighbor-read of the outgoing dual `O` at each probe's `τ=t+1`,
+and reverse/face from that neighbor-read, on the four y-probes of the
+two-axis opposite seed in `B_3(0)={n:n·n<=9}`. Same process and y-probes
+as nm2axo. Let `t(q)` be the formation tick of probe `q`. Let `τ(q)=t(q)+1`.
+There is no global T. `M(q,τ)` is the set of earliest incoming
+nearest-neighbor steps at `q` using only records with tick `<= τ`. Seeds
+are a singleton seed letter. `O(q,τ)` is the outgoing dual of `M`: the set
+of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in
+`M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not
+`UNDEFINED`. Neighbor-read HOLDs at formed `q` if and only if some formed
+6-NN `r` has `O(r,τ)` defined and equal to `O(q,τ)` as sets. Unformed `q`
+is `UNDEFINED`. Uniqueness is not required. Mixed remains a set. Reverse
+HOLDs if and only if neighbor-read HOLDs at `A` and at `B`. Face HOLDs if
+and only if neighbor-read HOLDs at `C` and at `D`. This is not leftover of
+nm2axo timed-O exist-opposite. This is not leftover of nm2simy simultaneous
+`M` and `O`. This is not leftover of nm2ready neighbor-read of M. This is
+not leftover of nm2oreadz z-probe neighbor-read of `O`. This is not leftover
+of R-style recovery of the outgoing step from neighbors. Occupancy of sites
+is not used. Named-sign lettering is not used. Displayed, not adopted. Do
+not write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Neighbor-read asks whether a formed six-neighbor recovers that
+outgoing set as a set, without being `O` itself. Reverse and face are
+scored on neighbor-read HOLD at the paired probes. Named signs `{+,−}` are
+a coarser readout and are not used. A singleton unique lock letter is a
+different readout and is not used as the object. Existential opposite of
+signed locks in `O` is a different readout and is not used. Simultaneous
+nonempty disjoint `M` and `O` is a different readout and is not used.
+Neighbor-read of `M` is a different readout and is not used. R-style
+recovery of signed steps from a neighbor's `O` is a different readout and
+is not used. A `Z^3` sum of those locks is a different readout and is not
+used. Occupancy of sites is not used. A six-neighbor star is not the letter.
+O is not M.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of neighbor-read of O at t+1 on the four y-probes of the two-axis opposite seed, neighbor-read bits at each probe, reverse fail and face fail from those bits; uniqueness of outgoing locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face
+target_blocker_text: "display neighbor-read of O at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, HOLD iff some formed 6-NN recovers O as a set"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep neighbor-read of O at t+1 displayed; do not write neighbor-read into Admissibility, do not reduce to neighbor-read of M, do not reduce to R-style recovery, do not reduce to timed-O exist-opposite or simultaneous M and O, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for neighbor-read of O at t+1 on the four y-probes of the two-axis opposite seed and reverse/face from that; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+neighbor-read of `O` is scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the first opposite pair.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. First pair:
+`L(0)=+e_1` and `L(0,1,0)=−e_1`. Second pair: `L(0,0,1)=+e_2` and
+`L(0,1,1)=−e_2`. The second pair is a new seed, not a formed child of the
+first pair. This seed is not the one-axis opposite two-site seed alone.
+This seed is not the perp two-site seed `+e_1/+e_2`. This seed is not the
+z-symmetric three-site seed `{0,(0,0,1),(0,0,-1)}`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named neighbor-read of `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum the set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Neighbor-read at a formed probe at the same cut:
+
+```text
+neighbor-read(q) HOLDs iff some formed 6-NN r has O(r,τ)
+defined and equal to O(q,τ) as sets.
+```
+
+If `q` is unformed at `τ`, then neighbor-read is `UNDEFINED`. Else if no
+formed six-neighbor recovers `O(q,τ)` as a set, neighbor-read fails. The
+probe is not counted as its own neighbor. Empty matching is fail, not
+`UNDEFINED`. Mixed remains a set: a mixed `O(q,τ)` may still match a mixed
+`O(r,τ)`.
+
+Reverse neighbor-read holds if and only if neighbor-read HOLDs at `A` and
+at `B`. Face neighbor-read holds if and only if neighbor-read HOLDs at `C`
+and at `D`. Either side `UNDEFINED` is `UNDEFINED`. Else if both sides HOLD,
+reverse or face HOLDs. Else fail.
+
+Identifying neighbor-read of `O` with neighbor-read of `M` is refused: the
+two bits disagree at `B` and at `D`. Identifying neighbor-read with R-style
+recovery of signed steps from a neighbor's `O` is refused: R-style recovers
+a different set. Identifying neighbor-read with nm2axo timed-O
+exist-opposite is refused: that leftover HOLDs reverse and HOLDs face.
+Identifying neighbor-read with nm2simy simultaneous `M` and `O` is refused:
+that leftover also HOLDs reverse and HOLDs face.
+
+## Theorem 1 — ticks, `O` at probes and formed 6-NN, neighbor-read bit
+
+On this process the four y-probes form. Compare to neighbor-read of `M`:
+that leftover reports fail at `A` and at `C` and hold at `B` and at `D`.
+This display reads whether a formed six-neighbor recovers the outgoing dual
+as a set:
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=2
+O(A, τ) = {+e_2, −e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+neighbor-read(A) = fail
+neighbor-read(B) = fail
+neighbor-read(C) = fail
+neighbor-read(D) = fail
+formed 6-NN of A at τ: (1, 1, 0)=UNDEFINED, (-1, 1, 0)=UNDEFINED, (0, 2, 0)={}, (0, 0, 0)={−e_2, −e_3}, (0, 1, 1)={+e_1, −e_1, +e_3}, (0, 1, -1)={}
+formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)={+e_1, −e_1, +e_3}, (1, 2, 1)={}, (1, 0, 1)={−e_2, +e_3, −e_3}, (1, 1, 2)={}, (1, 1, 0)={−e_1}
+formed 6-NN of C at τ: (1, 2, 0)={}, (-1, 2, 0)={}, (0, 1, 0)={+e_2, −e_3}, (0, 2, 1)={−e_2}, (0, 2, -1)={}
+formed 6-NN of D at τ: (2, 1, 0)={}, (0, 1, 0)={+e_2, −e_3}, (1, 2, 0)={−e_3}, (1, 0, 0)={+e_1}, (1, 1, 1)={+e_2, +e_3, −e_3}, (1, 1, -1)={+e_2, −e_3}
+matching 6-NN of A: none
+matching 6-NN of B: none
+matching 6-NN of C: none
+matching 6-NN of D: none
+```
+
+`A` is a seed at tick 0 with seed letter `−e_1`. The partner of that pair,
+the origin, is also a seed at tick 0 with seed letter `+e_1`. At `τ=1`
+those two seeds do not share an outgoing set: `O(A,τ)={+e_2, −e_3}` while
+`O(0,τ)={−e_2, −e_3}`. The second-pair seed `(0,1,1)` carries
+`{+e_1, −e_1, +e_3}`, also unequal. Empty `O` at a formed neighbor is
+defined empty, not `UNDEFINED`, and is not equal to nonempty probe `O`.
+Sites `(1,1,0)` and `(-1,1,0)` form later, at tick 2, and are `UNDEFINED`
+at `A`'s `τ`. Mixed remains a set: `O(A,τ)` has two outgoing steps, and
+unique letters would assign `UNDEFINED`; uniqueness is not required, and
+neighbor-read still fails because no formed six-neighbor equals that mixed
+set. At `t`, `O` is empty at `A`, `B`, and `C`, and is `{−e_1}` at `D`. At
+`τ=t+1`, `O` is nonempty and differs from the value at `t`. `M` is frozen
+from `t` to `t+1`; `O` is not. O is not M.
+
+On the one-axis opposite two-site seed, `t(B)=2` and `t(D)=3`, and
+`(0,0,1)` and `(0,1,1)` are formed children locking `+e_3`. Here both of
+those sites are seeds of a second opposite pair on a second axis, and the
+y-probe ticks are `t(B)=1` and `t(D)=2`. Neighbor-read of `O` on that
+leftover seed still fails at each y-probe, but the ticks and the second
+pair's lock letters differ.
+
+Empty matching is fail, not `UNDEFINED`. All four y-probes are formed, so
+neighbor-read is defined at each.
+
+## Theorem 2 — reverse from neighbor-read of `O` at `τ`
+
+Reverse neighbor-read holds if and only if neighbor-read HOLDs at `A` and
+at `B`. Neighbor-read fails at `A` and fails at `B`. Reverse fails. This is
+HOLD iff neighbor-read at both reverse probes, not leftover of neighbor-read
+of `M`, not leftover of nm2axo timed-O, and not leftover of nm2simy
+simultaneous.
+
+Reverse neighbor-read at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Neighbor-read of `M`
+also has reverse fail, but from a different pair of bits: fail at `A` and
+hold at `B`. Timed-O exist-opposite reverse HOLDs. Simultaneous reverse
+HOLDs. R-style recovery of `O` is unequal to `O` at each reverse probe.
+Those leftovers are not this display.
+
+Reverse fails.
+
+## Theorem 3 — face from neighbor-read of `O` at `τ`
+
+Face neighbor-read holds if and only if neighbor-read HOLDs at `C` and at
+`D`. Neighbor-read fails at `C` and at `D`. Face fails.
+
+Face neighbor-read at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Neighbor-read of `M` has face fail from fail at `C` and hold at `D`.
+Timed-O exist-opposite face HOLDs. Simultaneous face HOLDs. This display
+scores neighbor-read of `O`, which fails at `C` and at `D`, so face fails.
+
+On the same seed the four z-probes give neighbor-read hold at `A` and fail
+at `B`, `C`, and `D`, so reverse fail and face fail, but from hold at
+z-probe `A`, not fail at y-probe `A`. The four x-probes fail at each probe
+and have a different outgoing set at x-probe `A`. Those probe-direction
+readouts are not this y-probe display.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming or outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require neighbor-read sides to be singletons.
+- It does not sum either set.
+- It does not replace neighbor-read of `O` by neighbor-read of `M`.
+- It does not replace neighbor-read by R-style recovery of signed steps.
+- It does not replace neighbor-read by nm2axo timed-O exist-opposite.
+- It does not replace neighbor-read by nm2simy simultaneous `M` and `O`.
+- It does not replace `O` by `M`.
+- It does not replace neighbor-read by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nm2axo timed-O reverse hold and face hold.
+- It does not reprint nm2simy simultaneous reverse hold and face hold.
+- It does not reprint nm2ready neighbor-read of `M`.
+- It does not reprint nm2oreadz z-probe neighbor-read of `O`.
+- It does not treat the second opposite pair as a formed child of the first.
+- It does not score the z-probes or the x-probes as this letter.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite process, neighbor-read of `O` at `t+1`, and the reverse/face
+bits from that neighbor-read are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two disjoint opposite pairs `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `2` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual |
+| `O` at formed 6-NN | Theorem 1; reported at each eventually-formed neighbor |
+| neighbor-read bit at `τ` | Theorem 1; fail, fail, fail, fail |
+| reverse from neighbor-read at `τ` | Theorem 2; `fail` |
+| face from neighbor-read at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of nm2axo timed-O exist-opposite | not this neighbor-read display |
+| leftover of nm2simy simultaneous | not this neighbor-read display |
+| leftover of nm2ready neighbor-read of `M` | not this display |
+| leftover of nm2oreadz z-probe neighbor-read | not this display |
+| leftover of R-style recovery | not this display |
+| one-axis opposite leftover of the second pair | not this seed |
+| z-probe or x-probe neighbor-read on this seed | not this letter |
+| global later T | not used |
+| neighbor-read as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: neighbor-read of `O` at `t+1` on the four y-probes of the two-axis opposite seed, and reverse/face from that. |
+| V2 | Current main has no landed neighbor-read reverse/face of timed `O` on these four y-probes of this two-axis opposite seed. |
+| V3 | Neighbor-read reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads whether a formed six-neighbor recovers own outgoing as a set at the same `t+1` cut. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace neighbor-read of `O` by neighbor-read of `M`,
+does not replace neighbor-read by R-style recovery, and does not identify
+this display with timed-O exist-opposite or simultaneous `M` and `O`. No
+global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| neighbor-read of `M` | score reverse/face from equal incoming sets | neighbor-read of `M` is fail/hold/fail/hold; neighbor-read of `O` is fail/fail/fail/fail | ATTEMPTED |
+| R-style recovery | recover `e` by `(-e)` in `O(q+e)` | R-style of `O` is empty at `A`, `{−e_1}` at `B`, `{−e_2}` at `C`, `{+e_3}` at `D`; none equals `O` | ATTEMPTED |
+| nm2axo timed-O | reuse exist-opposite reverse hold and face hold | timed-O HOLDs reverse and HOLDs face; neighbor-read of `O` fails both | ATTEMPTED |
+| nm2simy simultaneous | reuse simultaneous reverse hold and face hold | simultaneous HOLDs at each y-probe; neighbor-read of `O` fails at each | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O` remains a set; neighbor-read still fails at each y-probe | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the outgoing set | ATTEMPTED |
+| z-probe neighbor-read | score the four z-probes on this seed | z-probe neighbor-read HOLDs at `A`; this letter fails at y-probe `A` | ATTEMPTED |
+| x-probe neighbor-read | score the four x-probes on this seed | x-probe `A` has `O={+e_1}` and `t=2`; y-probe `A` has `O={+e_2, −e_3}` and `t=0` | ATTEMPTED |
+| one-axis leftover | treat `(0,0,1)` and `(0,1,1)` as formed children of `+e_1/−e_1` | those children lock `+e_3` at tick 1; here they are seeds locking `+e_2/−e_2` at tick 0 | ATTEMPTED |
+| sum of a set | replace neighbor-read by a `Z^3` sum | the construction does not sum; equality is set equality of `O` | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by neighbor-read of `O` | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of neighbor-read of `O`
+with neighbor-read of `M`, missing identification with R-style recovery,
+missing identification with timed-O exist-opposite, and missing Record
+identification of neighbor-read reverse are distinct open premises. This
+note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite-pair seed locks `+e_1`, `−e_1`,
+`+e_2`, and `−e_2`, perpendicular step rule, incoming-step lock, own
+outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+neighbor-read as set equality of `O` at some formed six-neighbor, four
+y-probes with seed `A`, and mixed remains a set are declared. No uniqueness
+of outgoing locks, no six-neighbor lock union as the scored object, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+neighbor-read `hold`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each earliest outgoing lock set `O` at a probe and at formed 6-NN, compared as sets at the probe's `t+1` | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four neighbor-read reports, reverse/face from those bits | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for neighbor-read reverse/face,
+a formation-rate rule, and a physical selector among matching neighbors.
+None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Neighbor-read FAIL of `O` is only the partner seed not sharing
+a lock; neighbor-read of `M` already asked whether a neighbor recovers a
+lock set and already has reverse fail and face fail; R-style already
+recovers outgoing steps from neighbors; timed-O already uses `O`;
+simultaneous already uses `O`; empty `O` at a neighbor should be
+`UNDEFINED`; and reverse fail is only leftover of nm2ready reverse fail.
+
+**Answer:** The partner seed at the origin has `O={−e_2, −e_3}`, unequal to
+`O(A,τ)={+e_2, −e_3}`. Neighbor-read of `M` fails at `A` and `C` and HOLDs
+at `B` and `D`. Neighbor-read of `O` fails at each y-probe. R-style recovers
+`{ }` at `A`, `{−e_1}` at `B`, `{−e_2}` at `C`, and `{+e_3}` at `D`, none
+equal to `O`. Timed-O exist-opposite HOLDs reverse and HOLDs face from
+opposite pairs inside the probe's own `O`. Simultaneous HOLDs at each
+y-probe from nonempty disjoint `M` and `O`. Empty `O` at a formed neighbor
+is empty, not `UNDEFINED`, and does not match nonempty `O` at `τ`. Reverse
+fail of neighbor-read of `M` is fail at `A` with hold at `B`. Reverse fail
+here is fail at `A` with fail at `B`.
+
+### N8 — cross-cycle echo
+
+Investment names `nm2simy` and `nm2axo` mark nearby displayed processes.
+nm2axo reported timed-O exist-opposite HOLD at reverse and HOLD at face on
+these same y-probes. nm2simy reported simultaneous HOLD at each of those
+probes, reverse hold, and face hold. nm2ready reported neighbor-read of `M`
+fail at `A` and `C` and hold at `B` and `D`, reverse fail, and face fail.
+nm2oreadz reported neighbor-read of `O` hold only at z-probe `A`. This note
+is not those displays: it reports neighbor-read of `O` at `τ=t+1` on the
+four y-probes of the two-axis opposite seed, fail at each probe, reverse
+fail, and face fail.
+
+**Gate disposition:** PASS for the neighbor-read of `O` `t+1` reverse/face
+reports above. FAIL / DO NOT SHIP for “the predicate equals the named sign,”
+“the predicate equals the unique singleton lock vector,” “the predicate
+equals six-neighbor lock union,” “the predicate equals neighbor-read of
+`M`,” “the predicate equals R-style recovery,” “the predicate equals
+nm2axo timed-O,” “the predicate equals nm2simy simultaneous,” “bits are
+Admissibility,” “neighbor-read of `O` HOLDs at a y-probe,” “reverse
+neighbor-read HOLDs,” or “face neighbor-read HOLDs.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each y-probe's own outgoing dual
+from the record prefix at that probe's `t+1`, reads `O` at each eventually-
+formed six-neighbor at the same cut, reports neighbor-read as set equality
+at some formed six-neighbor, and checks Theorems 1--3. It also checks that
+neighbor-read fails at each y-probe, that neighbor-read of `M` is a
+different pattern, that R-style recovery is a different set, that timed-O
+exist-opposite HOLDs reverse and face, that simultaneous HOLDs reverse and
+face, that mixed sets remain sets, that unique-letter neighbor-read is not
+required at mixed `O`, that the construction does not sum, that a formation
+member from already-recorded six-neighbor locks is not attached, that the
+second pair is a seed and not a formed child, and that the display is not
+the z-probe or x-probe neighbor-read. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,80 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 30b0dcc1c5dc064d266714b6c1c571a1b2a4d990a6a4acc4ab3062d398e07eb8
+input_fingerprint_sha256: b768dfb97200d0ccdb1dae29bd86081921c9cdecb4e6be083b273781afe6e582
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+neighbor-read of O reverse/face at t+1 on two-axis opposite y-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of O at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: pair-read-identity
+PASS: neighbor-read-identity
+A t=0 O={+e_2, −e_3} neighbor-read=fail
+B t=1 O={+e_2, +e_3, −e_3} neighbor-read=fail
+C t=1 O={+e_1, −e_1, +e_3, −e_3} neighbor-read=fail
+D t=2 O={+e_1, −e_1} neighbor-read=fail
+neighbor-read reverse=fail face=fail
+per_element: each earliest outgoing lock set O at a probe and at formed 6-NN, compared as sets at the probe's t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-O-at-tau  ({'A': '{+e_2, −e_3}', 'B': '{+e_2, +e_3, −e_3}', 'C': '{+e_1, −e_1, +e_3, −e_3}', 'D': '{+e_1, −e_1}'})
+PASS: theorem1-O-not-frozen-from-t
+PASS: theorem1-O-is-not-M
+PASS: theorem1-formed-6nn-O-at-A
+PASS: theorem1-formed-6nn-O-at-B
+PASS: theorem1-formed-6nn-O-at-C
+PASS: theorem1-formed-6nn-O-at-D
+PASS: theorem1-neighbor-read-bits  ({'A': ('fail', ()), 'B': ('fail', ()), 'C': ('fail', ()), 'D': ('fail', ())})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-fail
+PASS: theorem3-face-fail
+PASS: mutation-r-style-differs
+PASS: mutation-neighbor-read-of-M-differs
+PASS: mutation-timed-O-and-simultaneous-differ
+PASS: mutation-unique-letter-mixed-O
+PASS: not-z-probes-or-x-probes-or-perp
+PASS: not-nsopp-leftover-second-pair-is-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-O-and-neighbor-read
+PASS: note-reports-formed-neighbors
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-timed-O-or-sim-or-M-leftover
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: neighbor-read-not-timed-O-or-sim
+TOTAL: PASS=50 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1057 @@
+#!/usr/bin/env python3
+"""Neighbor-read of O at t+1 reverse/face on four two-axis opposite y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and y-probes as nm2axo.
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Seeds keep their seed letters as
+a singleton. t(q) is the formation tick. tau = t(q)+1. M(q, tau) is the set
+of earliest incoming nearest-neighbor steps at q using only records with
+tick <= tau. O(q, tau) is the outgoing dual: e in {+/-e_i} with q+e formed
+and e in M(q+e, tau). Unformed at tau => UNDEFINED. Empty O is empty.
+Neighbor-read HOLDs at q iff some formed 6-NN r has O(r, tau) defined and
+equal to O(q, tau) as sets. Unformed q => UNDEFINED. Uniqueness is not
+required. Reverse HOLDs iff neighbor-read at A and at B. Face likewise on
+C, D. Occupancy of sites is not used. Named-sign lettering is not used. No
+larger host. This is not leftover of nm2axo timed-O exist-opposite. This is
+not leftover of nm2simy simultaneous M and O. This is not leftover of
+nm2ready neighbor-read of M. This is not leftover of nm2oreadz z-probe
+neighbor-read of O. This is not leftover of R-style recovery of the
+outgoing step from neighbors. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = Incoming
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of O at t+1 on the four y-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def neg(step: Point) -> Point:
+    return (-step[0], -step[1], -step[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def matching_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Formed 6-NN r with O(r, tau) defined and equal to O(site, tau)."""
+    own = outgoing_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff some formed 6-NN recovers O(q, tau) as a set. Unformed => UNDEFINED."""
+    matches = matching_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def matching_incoming_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with M(r, tau) equal to M(site, tau)."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_incoming(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of M. Not this letter."""
+    matches = matching_incoming_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def formed_neighbor_outgoing(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[tuple[Point, Outgoing], ...]:
+    """O(r, tau) at each eventually-formed 6-NN of site, including UNDEFINED."""
+    rows: list[tuple[Point, Outgoing]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        rows.append(
+            (neighbor, outgoing_set(neighbor, tau, ticks, locks, seed_map))
+        )
+    return tuple(rows)
+
+
+def r_style_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Leftover contrast: outgoing steps recovered as (-e) in O(q+e, tau)."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    recovered: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        other = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if neg(step) in other:
+            recovered.add(step)
+    return frozenset(recovered)
+
+
+def exist_opposite(left: Incoming, right: Incoming) -> str:
+    """nm2axo leftover: HOLD iff some pair from the two outgoing sets sums to 0."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("outgoing sets are not lock sets")
+    if not left or not right:
+        return UNDEFINED
+    for first in left:
+        for second in right:
+            if add(first, second) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def simultaneous_hold(incoming: Incoming, outgoing: Outgoing) -> str:
+    """nm2simy leftover: HOLD iff M and O defined nonempty and disjoint."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        raise TypeError("simultaneous sides are not lock sets")
+    if incoming and outgoing and incoming.isdisjoint(outgoing):
+        return "hold"
+    return "fail"
+
+
+def pair_read(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(read_a: str, read_b: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_read(read_a, read_b)
+
+
+def face_report(read_c: str, read_d: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_read(read_c, read_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def probe_reads(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = neighbor_read(
+            site,
+            site_ticks[site] + 1,
+            site_ticks,
+            site_locks,
+            site_seeds,
+        )
+    return out
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("neighbor-read of O reverse/face at t+1 on two-axis opposite y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "pair-read-identity",
+        pair_read(UNDEFINED, "hold") == UNDEFINED
+        and pair_read("hold", UNDEFINED) == UNDEFINED
+        and pair_read("hold", "hold") == "hold"
+        and pair_read("hold", "fail") == "fail"
+        and pair_read("fail", "hold") == "fail"
+        and pair_read("fail", "fail") == "fail",
+    )
+    checks.check(
+        "neighbor-read-identity",
+        neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and matching_neighbors(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and outgoing_set(PROBES["B"], -1, {}, {}, {}) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    twosite_ticks, twosite_locks, twosite_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+
+    tau1: dict[str, int] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    m1: dict[str, Incoming] = {}
+    reads: dict[str, str] = {}
+    reads_m: dict[str, str] = {}
+    matches: dict[str, tuple[Point, ...] | str] = {}
+    formed_o: dict[str, tuple[tuple[Point, Outgoing], ...]] = {}
+    r_style: dict[str, Outgoing] = {}
+    sim: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0 = ticks[site]
+        tau1[name] = ticks[site] + 1
+        o0[name] = outgoing_set(site, tau0, ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        reads[name] = neighbor_read(site, tau1[name], ticks, locks, seed_map)
+        reads_m[name] = neighbor_read_incoming(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        matches[name] = matching_neighbors(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        formed_o[name] = formed_neighbor_outgoing(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        r_style[name] = r_style_read(site, tau1[name], ticks, locks, seed_map)
+        sim[name] = simultaneous_hold(m1[name], o1[name])
+        print(
+            f"{name} t={ticks[site]} "
+            f"O={lockset_display(o1[name])} "
+            f"neighbor-read={reads[name]}"
+        )
+
+    reverse = reverse_report(reads["A"], reads["B"])
+    face = face_report(reads["C"], reads["D"])
+    timed_o_reverse = exist_opposite(o1["A"], o1["B"])
+    timed_o_face = exist_opposite(o1["C"], o1["D"])
+    sim_reverse = pair_read(sim["A"], sim["B"])
+    sim_face = pair_read(sim["C"], sim["D"])
+    print(f"neighbor-read reverse={reverse} face={face}")
+    print(
+        "per_element: each earliest outgoing lock set O at a probe and at "
+        "formed 6-NN, compared as sets at the probe's t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four neighbor-read reports, reverse/face from those bits")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["C"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-at-tau",
+        o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1}),
+        str({name: lockset_display(o1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-not-frozen-from-t",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and o1["A"] != o0["A"]
+        and o1["B"] != o0["B"]
+        and o1["C"] != o0["C"]
+        and o1["D"] != o0["D"],
+    )
+    checks.check(
+        "theorem1-O-is-not-M",
+        m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3})
+        and o1["A"] != m1["A"]
+        and o1["B"] != m1["B"]
+        and o1["C"] != m1["C"]
+        and o1["D"] != m1["D"],
+    )
+    checks.check(
+        "theorem1-formed-6nn-O-at-A",
+        formed_o["A"]
+        == (
+            ((1, 1, 0), UNDEFINED),
+            ((-1, 1, 0), UNDEFINED),
+            ((0, 2, 0), frozenset()),
+            ((0, 0, 0), frozenset({NEG_E2, NEG_E3})),
+            ((0, 1, 1), frozenset({E1, NEG_E1, E3})),
+            ((0, 1, -1), frozenset()),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-O-at-B",
+        formed_o["B"]
+        == (
+            ((2, 1, 1), UNDEFINED),
+            ((0, 1, 1), frozenset({E1, NEG_E1, E3})),
+            ((1, 2, 1), frozenset()),
+            ((1, 0, 1), frozenset({NEG_E2, E3, NEG_E3})),
+            ((1, 1, 2), frozenset()),
+            ((1, 1, 0), frozenset({NEG_E1})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-O-at-C",
+        formed_o["C"]
+        == (
+            ((1, 2, 0), frozenset()),
+            ((-1, 2, 0), frozenset()),
+            ((0, 1, 0), frozenset({E2, NEG_E3})),
+            ((0, 2, 1), frozenset({NEG_E2})),
+            ((0, 2, -1), frozenset()),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-O-at-D",
+        formed_o["D"]
+        == (
+            ((2, 1, 0), frozenset()),
+            ((0, 1, 0), frozenset({E2, NEG_E3})),
+            ((1, 2, 0), frozenset({NEG_E3})),
+            ((1, 0, 0), frozenset({E1})),
+            ((1, 1, 1), frozenset({E2, E3, NEG_E3})),
+            ((1, 1, -1), frozenset({E2, NEG_E3})),
+        ),
+    )
+    checks.check(
+        "theorem1-neighbor-read-bits",
+        reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail"
+        and matches["A"] == ()
+        and matches["B"] == ()
+        and matches["C"] == ()
+        and matches["D"] == (),
+        str({name: (reads[name], matches[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        o1["A"] == frozenset({E2, NEG_E3})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and reads["A"] == "fail"
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2}
+        and o1["A"] == frozenset({E2, NEG_E3}),
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse == "fail"
+        and reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reverse != UNDEFINED
+        and reverse != "hold",
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold",
+    )
+    checks.check(
+        "mutation-r-style-differs",
+        r_style["A"] == frozenset()
+        and r_style["B"] == frozenset({NEG_E1})
+        and r_style["C"] == frozenset({NEG_E2})
+        and r_style["D"] == frozenset({E3})
+        and r_style["A"] != o1["A"]
+        and r_style["B"] != o1["B"]
+        and r_style["C"] != o1["C"]
+        and r_style["D"] != o1["D"],
+    )
+    checks.check(
+        "mutation-neighbor-read-of-M-differs",
+        reads_m["A"] == "fail"
+        and reads_m["B"] == "hold"
+        and reads_m["C"] == "fail"
+        and reads_m["D"] == "hold"
+        and reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail"
+        and reads_m["B"] != reads["B"]
+        and reads_m["D"] != reads["D"],
+    )
+    checks.check(
+        "mutation-timed-O-and-simultaneous-differ",
+        timed_o_reverse == "hold"
+        and timed_o_face == "hold"
+        and sim["A"] == "hold"
+        and sim["B"] == "hold"
+        and sim["C"] == "hold"
+        and sim["D"] == "hold"
+        and sim_reverse == "hold"
+        and sim_face == "hold"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-unique-letter-mixed-O",
+        unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and reads["A"] == "fail",
+    )
+    z_reads = probe_reads(Z_PROBES, ticks, locks, seed_map)
+    x_reads = probe_reads(X_PROBES, ticks, locks, seed_map)
+    perp_reads = probe_reads(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_reads = probe_reads(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    twosite_reads = probe_reads(
+        PROBES, twosite_ticks, twosite_locks, twosite_seeds
+    )
+    x_o_a = outgoing_set(
+        X_PROBES["A"], ticks[X_PROBES["A"]] + 1, ticks, locks, seed_map
+    )
+    z_reverse = reverse_report(z_reads["A"], z_reads["B"])
+    z_face = face_report(z_reads["C"], z_reads["D"])
+    x_reverse = reverse_report(x_reads["A"], x_reads["B"])
+    x_face = face_report(x_reads["C"], x_reads["D"])
+    twosite_reverse = reverse_report(twosite_reads["A"], twosite_reads["B"])
+    twosite_face = face_report(twosite_reads["C"], twosite_reads["D"])
+    checks.check(
+        "not-z-probes-or-x-probes-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and z_reads["A"] == "hold"
+        and z_reads["B"] == "fail"
+        and z_reverse == "fail"
+        and z_face == "fail"
+        and x_reads["A"] == "fail"
+        and x_o_a == frozenset({E1})
+        and x_o_a != o1["A"]
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and perp_reads["A"] == "fail"
+        and reads["A"] == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and z_reads["A"] != reads["A"],
+    )
+    checks.check(
+        "not-nsopp-leftover-second-pair-is-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in twosite_ticks.values()) == 2
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and twosite_ticks[E3] == 1
+        and twosite_locks[E3] == {E3}
+        and twosite_ticks[PROBES["B"]] == 2
+        and twosite_ticks[PROBES["D"]] == 3
+        and twosite_reads["A"] == "fail"
+        and twosite_reverse == "fail"
+        and twosite_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and zsym_reads["A"] == "fail"
+        and zsym_reads["C"] == "fail"
+        and reads["A"] == "fail",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-O-and-neighbor-read",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "O(A, τ) = {+e_2, −e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "neighbor-read(A) = fail" in note
+        and "neighbor-read(B) = fail" in note
+        and "neighbor-read(C) = fail" in note
+        and "neighbor-read(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-formed-neighbors",
+        "formed 6-NN of A at τ: (1, 1, 0)=UNDEFINED, (-1, 1, 0)=UNDEFINED, (0, 2, 0)={}, (0, 0, 0)={−e_2, −e_3}, (0, 1, 1)={+e_1, −e_1, +e_3}, (0, 1, -1)={}"
+        in note
+        and "formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)={+e_1, −e_1, +e_3}, (1, 2, 1)={}, (1, 0, 1)={−e_2, +e_3, −e_3}, (1, 1, 2)={}, (1, 1, 0)={−e_1}"
+        in note
+        and "formed 6-NN of C at τ: (1, 2, 0)={}, (-1, 2, 0)={}, (0, 1, 0)={+e_2, −e_3}, (0, 2, 1)={−e_2}, (0, 2, -1)={}"
+        in note
+        and "formed 6-NN of D at τ: (2, 1, 0)={}, (0, 1, 0)={+e_2, −e_3}, (1, 2, 0)={−e_3}, (1, 0, 0)={+e_1}, (1, 1, 1)={+e_2, +e_3, −e_3}, (1, 1, -1)={+e_2, −e_3}"
+        in note
+        and "matching 6-NN of A: none" in note
+        and "matching 6-NN of B: none" in note
+        and "matching 6-NN of C: none" in note
+        and "matching 6-NN of D: none" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse neighbor-read at τ: fail" in note
+        and "Face neighbor-read at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-timed-O-or-sim-or-M-leftover",
+        "not leftover of nm2axo timed-O" in normalized_note
+        and "not leftover of nm2simy simultaneous" in normalized_note
+        and "not leftover of nm2ready neighbor-read of M" in normalized_note
+        and "not leftover of nm2oreadz z-probe" in normalized_note
+        and "not leftover of R-style" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_OUTGOING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "outgoing_set" in defined_fns
+        and "neighbor_read" in defined_fns
+        and "matching_neighbors" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "formed_neighbor_outgoing" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "neighbor-read-not-timed-O-or-sim",
+        reverse == "fail"
+        and face == "fail"
+        and reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail"
+        and timed_o_reverse == "hold"
+        and timed_o_face == "hold"
+        and sim_reverse == "hold"
+        and sim_face == "hold",
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Neighbor-read of O at t+1 on opposite y-probes: reverse fails, face fails. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_yprobe_neighbor_read_outgoing_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.