### PR TITLE
feat(nm2ready): neighbor-read of M at t+1 on two-axis opposite y-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,321 @@
+---
+claim_id: two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of M at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
+---
+
+# Two-Axis Opposite Y-Probe Neighbor-Read Of M At t+1, Reverse And Face
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** Neighbor-read of M at t+1 on the four y-probes of the two-axis
+opposite seed, and reverse/face from that, are reported. Displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py)
+
+No runner cache is written.
+
+## Result Up Front
+
+On the finite Euclidean host `B_3(0)={n:n·n<=9}`, form records by the
+two-axis opposite seed, perp-step, incoming-lock process. Same process and
+y-probes as nm2axo. For each formed site `q` write `t(q)` for the formation
+tick and `τ(q)=t(q)+1`. There is no global T. `M(q,τ)` is the set of
+earliest incoming nearest-neighbor steps at `q` that can be assembled from
+records with tick at most `τ`. Mixed lock sets remain sets; uniqueness is
+not required. Unformed sites are `UNDEFINED`.
+
+Neighbor-read at a formed `q` HOLDs iff some formed six-neighbor `r=q+e`
+has `M(r,τ)` defined and equal to `M(q,τ)` as sets. Reverse HOLDs iff
+neighbor-read HOLDs at probes `A` and `B`. Face HOLDs iff neighbor-read
+HOLDs at probes `C` and `D`.
+
+On this seed and these y-probes the finite listing is:
+
+- t(A)=0, M(A, τ) = {−e_1}, neighbor-read(A) = fail
+- t(B)=1, M(B, τ) = {+e_1}, neighbor-read(B) = hold
+- t(C)=1, M(C, τ) = {+e_2}, neighbor-read(C) = fail
+- t(D)=2, M(D, τ) = {−e_3}, neighbor-read(D) = hold
+- Reverse neighbor-read at τ: fail
+- Face neighbor-read at τ: fail
+
+The face bit is displayed, not adopted. Do not write into Admissibility.
+Do not attach L1. This is not leftover of nm2axo timed-O exist-opposite on
+the same y-probes. This is not leftover of nm2readz z-probe neighbor-read.
+This is not leftover of R-style recovery of the incoming step from
+neighbors. No larger host is used.
+
+## Current Premise Boundary
+
+Quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+Admissibility determines a local distribution from nearest-neighbor
+conditions and does not supply the formation site, probability, or rate.
+
+The process below is an explicit finite display on `B_3(0)`. It is not a
+rewrite of Admissibility and is not a lattice-wide lettering rule.
+
+## Exact Objects
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`. The six nearest-neighbor
+steps are `±e_1,±e_2,±e_3`. The host is the Euclidean ball
+`B_3(0)={n:n·n<=9}`. No larger host is used.
+
+The two-axis opposite seed at tick 0 is two disjoint opposite pairs:
+
+- origin locks `+e_1`
+- `(0,1,0)` locks `−e_1`
+- `(0,0,1)` locks `+e_2`
+- `(0,1,1)` locks `−e_2`
+
+A parent with lock axis `e_i` may take a nearest-neighbor step `s` only
+when `s·e_i=0`. A newly formed child locks the incoming step. Seeds keep
+their seed letters as a singleton. If several parents first reach a child
+at the same tick, `M` is the set of those incoming steps.
+
+The four y-probes are `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`.
+These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`,
+`C=(2,0,0)`, `D=(1,1,0)`. Probe `A` is a seed. Formation and `M` are
+computed only from records on this host.
+
+For a site `q` and a tick bound `τ`, if `q` is unformed at `τ` then
+`M(q,τ)` and neighbor-read at `q` are `UNDEFINED`. Otherwise `M(q,τ)` is
+the earliest nonempty incoming set assembled from parents with formation
+tick at most `τ`. Neighbor-read HOLDs at formed `q` iff there exists a
+formed six-neighbor `r` with `M(r,τ)` defined and `M(r,τ)=M(q,τ)` as
+sets. Pair-read of two probe bits is `UNDEFINED` if either bit is
+`UNDEFINED`, HOLD if both HOLD, and fail otherwise. Reverse is pair-read
+of `A` and `B`. Face is pair-read of `C` and `D`. Occupancy of sites is
+not used. A six-neighbor star is not the letter.
+
+## Theorem 1 — Formation Ticks, M, And Neighbor-Read Bits
+
+**Claim.** On this host and seed, the four y-probes and their eventually
+formed six-neighbors have the ticks, lock sets, and neighbor-read bits
+listed below.
+
+**Proof.** Direct breadth-first formation with the perp-step rule yields
+four tick-0 seeds. Parallel steps from the origin along `±e_1` are blocked
+because those steps fail `s·e_i=0`. Probe ticks are t(A)=0, t(B)=1,
+t(C)=1, and t(D)=2.
+
+At each probe, `M` at `τ=t+1` equals `M` at formation: no earlier parent
+appears when the tick bound is raised by one, so the earliest incoming set
+is frozen.
+
+- A is the seed `(0,1,0)`, so M(A, τ) = {−e_1}.
+- B is first reached from `(0,1,1)` by `+e_1`, so M(B, τ) = {+e_1}.
+- C is first reached from `A` by `+e_2`, so M(C, τ) = {+e_2}.
+- D is first reached from `B` by `−e_3`, so M(D, τ) = {−e_3}.
+
+formed 6-NN of A at τ: (1, 1, 0)=UNDEFINED, (-1, 1, 0)=UNDEFINED, (0, 2, 0)={+e_2}, (0, 0, 0)={+e_1}, (0, 1, 1)={−e_2}, (0, 1, -1)={−e_3}
+
+formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)={−e_2}, (1, 2, 1)={+e_2}, (1, 0, 1)={+e_1}, (1, 1, 2)={+e_1, +e_3}, (1, 1, 0)={−e_3}
+
+formed 6-NN of C at τ: (1, 2, 0)={+e_1}, (-1, 2, 0)={−e_1}, (0, 1, 0)={−e_1}, (0, 2, 1)={+e_3}, (0, 2, -1)={+e_2, −e_3}
+
+formed 6-NN of D at τ: (2, 1, 0)={+e_1}, (0, 1, 0)={−e_1}, (1, 2, 0)={+e_1}, (1, 0, 0)={−e_3}, (1, 1, 1)={+e_1}, (1, 1, -1)={+e_1}
+
+matching 6-NN of A: none
+
+matching 6-NN of B: (1, 0, 1)
+
+matching 6-NN of C: none
+
+matching 6-NN of D: (1, 0, 0)
+
+None of the six-neighbors of `A` at `τ=1` carries `{−e_1}`, so
+neighbor-read(A) = fail. Sites `(1,1,0)` and `(-1,1,0)` do form later, at
+tick 2, and are `UNDEFINED` at `A`'s `τ`. The partner seed at the origin
+carries `{+e_1}`, unequal as a set. Site `(1,1,2)` is mixed
+`{+e_1, +e_3}` at `B`'s `τ`; mixed remains a set and is not equal to
+`{+e_1}`. The matching neighbor of `B` is `(1,0,1)`, whose lock set is the
+singleton `{+e_1}`, so neighbor-read(B) = hold without any uniqueness cut.
+None of the formed six-neighbors of `C` at `τ=2` equals `{+e_2}`: the mixed
+neighbor `(0,2,-1)` carries `{+e_2, −e_3}`, which remains a set and is not
+equal to `{+e_2}`, so neighbor-read(C) = fail. The matching neighbor of
+`D` is `(1,0,0)`, whose lock set is `{−e_3}`, so neighbor-read(D) = hold.
+`QED`
+
+## Theorem 2 — Reverse Neighbor-Read
+
+**Claim.** Reverse neighbor-read at `τ` is fail, not HOLD and not
+`UNDEFINED`.
+
+**Proof.** Reverse HOLDs iff neighbor-read HOLDs at `A` and at `B`. Both
+probes are formed, so the pair is not `UNDEFINED`. Theorem 1 gives
+neighbor-read(A) = fail and neighbor-read(B) = hold, hence
+Reverse neighbor-read at τ: fail.
+`QED`
+
+## Theorem 3 — Face Neighbor-Read, Displayed Not Adopted
+
+**Claim.** Face neighbor-read at `τ` is fail. The bit is displayed, not
+adopted.
+
+**Proof.** Face HOLDs iff neighbor-read HOLDs at `C` and at `D`. Theorem 1
+gives neighbor-read(C) = fail and neighbor-read(D) = hold, hence
+Face neighbor-read at τ: fail. The report is a finite listing on this
+seed and these four y-probes. It is displayed, not adopted as an
+Admissibility clause, as a lettering law, or as a uniqueness rule. Do not
+write into Admissibility. Do not attach L1.
+`QED`
+
+## Discriminators
+
+R-style leftover would recover an incoming step `e` at `q` from the
+presence of `−e` in `M(q+e,τ)`. On this seed that leftover is empty at
+each of the four y-probes. Neighbor-read instead compares whole lock sets.
+It fails at `A` and at `C` and HOLDs at `B` and at `D`, so it is not
+leftover of R-style.
+
+Timed-O leftover of nm2axo scores existential opposite of the probe's own
+outgoing dual `O` at the same cut. That leftover HOLDs reverse and HOLDs
+face on these same y-probes. Neighbor-read reverse fails and face fails,
+so the report is not leftover of nm2axo timed-O.
+
+The same y-probes on a two-site `±e_1` seed keep reverse fail and face
+fail, but `t(B)=2` and `t(D)=3` there with neighbor-read fail at `D`. The
+two-axis seed advances those ticks to `t(B)=1` and `t(D)=2` and HOLDs at
+`D`. The same two-axis opposite seed scored on z-probes returns reverse
+fail and face hold. On x-probes it returns reverse hold and face hold.
+The report is therefore not leftover of nm2readz z-probe neighbor-read
+and not leftover of x-probe neighbor-read.
+
+## Exact Target And Proof Obligations
+
+**Exact target:** report neighbor-read of `M` at `t+1` on the four y-probes
+of the two-axis opposite seed, and the reverse/face pair-read of those
+bits, on Euclidean `B_3(0)`.
+
+| Obligation | Disposition |
+|---|---|
+| name the seed, perp-step rule, host, and y-probes | displayed process, closed on `B_3(0)` |
+| list `t`, `M`, formed six-neighbor `M`, and neighbor-read bits | Theorem 1, finite listing |
+| reverse pair-read of `A` and `B` | Theorem 2, fail |
+| face pair-read of `C` and `D` | Theorem 3, fail, displayed not adopted |
+| adopt reverse or face as Admissibility | not claimed |
+| attach a uniqueness cut | not claimed |
+| lattice-wide lettering | not claimed; no global T |
+
+The proof-obligation graph is acyclic. The leaves are finite listings on
+a 123-site ball. No observational value is used.
+
+## No-Go Discipline Gate
+
+This note is a displayed finite report, not a negative law. Broad negative
+inference from the reverse fail, from the face fail, or from the `A` and
+`C` misses is **FAIL / DO NOT SHIP**.
+
+### N1 — materially distinct route scan
+
+Neighbor-read of whole lock sets, timed-O exist-opposite of outgoing
+duals, R-style leftover of the incoming step, z-probe neighbor-read,
+x-probe neighbor-read, unique-letter cuts, and a rewritten Admissibility
+rule are distinct objects. Only the first is executed here, and only on
+four y-probes. The others are named leftovers or out of scope. No
+universal negative is claimed, so a no-go is not shipped.
+
+### N2 — wall independence
+
+There is no shipped wall. Reverse fail and face fail are pair-reads of
+the four neighbor-read bits. Removing either pair changes the report
+without creating a law-level obstruction.
+
+### N3 — hidden-condition scan
+
+Load-bearing and explicit: two-axis opposite seed, perp-step
+`s·e_i=0`, incoming lock, Euclidean `B_3(0)`, `τ(q)=t(q)+1`, set equality
+of `M`, and the four named y-probes. No phrase such as "by construction"
+or "naturally" adds a further premise. Occupancy of sites is not used.
+
+### N4 — residual matching
+
+No prior negative is cited as evidence. The only linked premise document
+is the current axiom memo, used to quote Lattice, Qubit, Record, and the
+Admissibility non-supply of formation site. The listing is proved here.
+
+### N5 — resolution audit
+
+| Resolution | Executed? | Exact scope |
+|---|---:|---|
+| per element | yes | each earliest incoming lock set `M` at a probe and at formed six-neighbors, compared as sets at that probe's `t+1` |
+| per site | yes | y-probes `A,B,C,D` on Euclidean `B_3(0)` only |
+| per mode | no | no spectral or mode calculation is executed on this finite host |
+| per block | yes | four neighbor-read reports, reverse/face from those bits |
+| lattice-wide | checked and not executed | no lattice-wide lettering rule is claimed; no global T |
+
+### N6 — partial-closure paths
+
+Live extensions already named: other seeds, other probe axes, a uniqueness
+cut, R-style leftover, timed-O leftover, a larger host, or an
+Admissibility rewrite. None is closed by this listing, and none is
+dismissed as requiring a new axiom.
+
+### N7 — steelman
+
+The strongest objection to reading reverse fail or face fail as a law is
+decisive: both bits are pair-reads of two probe bits on one displayed
+seed. Timed-O exist-opposite on the same process HOLDs reverse and HOLDs
+face. Z-probe neighbor-read HOLDs face. That is why Theorem 3 is
+displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+Investment names `nm2readslz` and `nm2axo` mark nearby displayed
+processes. This note reuses the same two-axis opposite seed and y-probes
+as nm2axo only to report neighbor-read of `M` at `t+1`. It does not
+inherit timed-O exist-opposite HOLD, a same-lock partner match, or an
+incoming-step leftover as a theorem.
+
+**No-Go Discipline status:** FAIL / DO NOT SHIP for any negative
+Admissibility, lettering, or uniqueness claim. The positive finite listing
+in Theorems 1–3 remains a displayed bounded report.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite neighbor-read of M at t+1 on four y-probes, with reverse/face pair-read, on Euclidean B_3(0); displayed, not adopted."
+trace_class: upstream_support
+target_claim_id: two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face
+target_blocker_text: "report neighbor-read of M at t+1 on the two-axis opposite y-probes and the reverse/face pair of those bits"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep reverse/face displayed. Do not write into Admissibility. Do not attach L1."
+conditional_surface_status: "exact finite listing on B_3(0) for the declared seed and y-probes; law-level adoption remains open and is not claimed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice / Qubit / Record sentences | framework premise | linked current axiom memo |
+| Admissibility non-supply of formation site | framework boundary | quoted; process is displayed |
+| two-axis opposite seed, perp-step, incoming lock | declared process | explicit condition |
+| Euclidean `B_3(0)` | declared host | `{n:n·n<=9}`; no larger host |
+| neighbor-read, reverse, face | reported bits | Theorems 1–3 |
+| Admissibility rewrite, L1, uniqueness cut | residual | open and not claimed |
+
+Independent audit remains required before any effective status may change.

--- a/logs/runner-cache/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,78 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 0f4e9ea481cb0aa20bf7162b8b48b048b1b6be7c908336ae151540792b2e34ec
+input_fingerprint_sha256: 00525b5c51c894096095579dab285ac9e62aa94474e3957868c67ca0140ea298
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+neighbor-read of M reverse/face at t+1 on two-axis opposite y-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of M at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: pair-read-identity
+PASS: neighbor-read-identity
+A t=0 M={−e_1} neighbor-read=fail
+B t=1 M={+e_1} neighbor-read=hold
+C t=1 M={+e_2} neighbor-read=fail
+D t=2 M={−e_3} neighbor-read=hold
+neighbor-read reverse=fail face=fail
+per_element: each earliest incoming lock set M at a probe and at formed 6-NN, compared as sets at the probe's t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-at-tau  ({'A': '{−e_1}', 'B': '{+e_1}', 'C': '{+e_2}', 'D': '{−e_3}'})
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-formed-6nn-M-at-A
+PASS: theorem1-formed-6nn-M-at-B
+PASS: theorem1-formed-6nn-M-at-C
+PASS: theorem1-formed-6nn-M-at-D
+PASS: theorem1-neighbor-read-bits  ({'A': ('fail', ()), 'B': ('hold', ((1, 0, 1),)), 'C': ('fail', ()), 'D': ('hold', ((1, 0, 0),))})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-fail
+PASS: theorem3-face-fail
+PASS: mutation-r-style-differs
+PASS: mutation-timed-O-differs
+PASS: mutation-unique-letter-mixed-neighbor
+PASS: not-z-probes-or-x-probes-or-perp
+PASS: not-nsopp-leftover-second-pair-is-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-and-neighbor-read
+PASS: note-reports-formed-neighbors
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-timed-O-or-zprobe-leftover
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: neighbor-read-not-timed-O
+TOTAL: PASS=48 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,965 @@
+#!/usr/bin/env python3
+"""Neighbor-read of M at t+1 reverse/face on four two-axis opposite y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and y-probes as nm2axo.
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Seeds keep their seed letters as
+a singleton. t(q) is the formation tick. tau = t(q)+1. M(q, tau) is the set
+of earliest incoming nearest-neighbor steps at q using only records with
+tick <= tau. Unformed at tau => UNDEFINED. For formed neighbor r = q+e,
+report M(r, tau). Neighbor-read HOLDs at q iff some formed 6-NN r has
+M(r, tau) defined and equal to M(q, tau) as sets. Unformed q => UNDEFINED.
+Mixed remains a set. Uniqueness is not required. Reverse HOLDs iff
+neighbor-read at A and at B. Face likewise on C, D. Occupancy of sites is
+not used. Named-sign lettering is not used. No larger host. This is not
+leftover of nm2axo timed-O exist-opposite. This is not leftover of
+nm2readz z-probe neighbor-read. This is not R-style recovery of the
+incoming step from neighbors. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of M at t+1 on the four y-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def neg(step: Point) -> Point:
+    return (-step[0], -step[1], -step[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def matching_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Formed 6-NN r with M(r, tau) defined and equal to M(site, tau)."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff some formed 6-NN recovers M(q, tau) as a set. Unformed => UNDEFINED."""
+    matches = matching_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def formed_neighbor_incoming(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[tuple[Point, Incoming], ...]:
+    """M(r, tau) at each eventually-formed 6-NN of site, including UNDEFINED."""
+    rows: list[tuple[Point, Incoming]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        rows.append(
+            (neighbor, incoming_set(neighbor, tau, ticks, locks, seed_map))
+        )
+    return tuple(rows)
+
+
+def r_style_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Leftover contrast: incoming steps recovered as (-e) in M(q+e, tau)."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    recovered: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if neg(step) in other:
+            recovered.add(step)
+    return frozenset(recovered)
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Leftover contrast: own outgoing dual O of M at tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    found: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if step in other:
+            found.add(step)
+    return frozenset(found)
+
+
+def exist_opposite(left: Incoming, right: Incoming) -> str:
+    """nm2axo leftover: HOLD iff some pair from the two outgoing sets sums to 0."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("outgoing sets are not lock sets")
+    if not left or not right:
+        return UNDEFINED
+    for first in left:
+        for second in right:
+            if add(first, second) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def pair_read(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(read_a: str, read_b: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_read(read_a, read_b)
+
+
+def face_report(read_c: str, read_d: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_read(read_c, read_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def probe_reads(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = neighbor_read(
+            site,
+            site_ticks[site] + 1,
+            site_ticks,
+            site_locks,
+            site_seeds,
+        )
+    return out
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("neighbor-read of M reverse/face at t+1 on two-axis opposite y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "pair-read-identity",
+        pair_read(UNDEFINED, "hold") == UNDEFINED
+        and pair_read("hold", UNDEFINED) == UNDEFINED
+        and pair_read("hold", "hold") == "hold"
+        and pair_read("hold", "fail") == "fail"
+        and pair_read("fail", "hold") == "fail"
+        and pair_read("fail", "fail") == "fail",
+    )
+    checks.check(
+        "neighbor-read-identity",
+        neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and matching_neighbors(PROBES["B"], -1, {}, {}, {}) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    twosite_ticks, twosite_locks, twosite_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    reads: dict[str, str] = {}
+    matches: dict[str, tuple[Point, ...] | str] = {}
+    formed_m: dict[str, tuple[tuple[Point, Incoming], ...]] = {}
+    r_style: dict[str, Incoming] = {}
+    outgoing: dict[str, Incoming] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0 = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0, ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        reads[name] = neighbor_read(site, tau1[name], ticks, locks, seed_map)
+        matches[name] = matching_neighbors(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        formed_m[name] = formed_neighbor_incoming(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        r_style[name] = r_style_read(site, tau1[name], ticks, locks, seed_map)
+        outgoing[name] = outgoing_set(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"neighbor-read={reads[name]}"
+        )
+
+    reverse = reverse_report(reads["A"], reads["B"])
+    face = face_report(reads["C"], reads["D"])
+    timed_o_reverse = exist_opposite(outgoing["A"], outgoing["B"])
+    timed_o_face = exist_opposite(outgoing["C"], outgoing["D"])
+    print(f"neighbor-read reverse={reverse} face={face}")
+    print(
+        "per_element: each earliest incoming lock set M at a probe and at "
+        "formed 6-NN, compared as sets at the probe's t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four neighbor-read reports, reverse/face from those bits")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["C"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau",
+        m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3}),
+        str({name: lockset_display(m1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-A",
+        formed_m["A"]
+        == (
+            ((1, 1, 0), UNDEFINED),
+            ((-1, 1, 0), UNDEFINED),
+            ((0, 2, 0), frozenset({E2})),
+            ((0, 0, 0), frozenset({E1})),
+            ((0, 1, 1), frozenset({NEG_E2})),
+            ((0, 1, -1), frozenset({NEG_E3})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-B",
+        formed_m["B"]
+        == (
+            ((2, 1, 1), UNDEFINED),
+            ((0, 1, 1), frozenset({NEG_E2})),
+            ((1, 2, 1), frozenset({E2})),
+            ((1, 0, 1), frozenset({E1})),
+            ((1, 1, 2), frozenset({E1, E3})),
+            ((1, 1, 0), frozenset({NEG_E3})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-C",
+        formed_m["C"]
+        == (
+            ((1, 2, 0), frozenset({E1})),
+            ((-1, 2, 0), frozenset({NEG_E1})),
+            ((0, 1, 0), frozenset({NEG_E1})),
+            ((0, 2, 1), frozenset({E3})),
+            ((0, 2, -1), frozenset({E2, NEG_E3})),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-M-at-D",
+        formed_m["D"]
+        == (
+            ((2, 1, 0), frozenset({E1})),
+            ((0, 1, 0), frozenset({NEG_E1})),
+            ((1, 2, 0), frozenset({E1})),
+            ((1, 0, 0), frozenset({NEG_E3})),
+            ((1, 1, 1), frozenset({E1})),
+            ((1, 1, -1), frozenset({E1})),
+        ),
+    )
+    checks.check(
+        "theorem1-neighbor-read-bits",
+        reads["A"] == "fail"
+        and reads["B"] == "hold"
+        and reads["C"] == "fail"
+        and reads["D"] == "hold"
+        and matches["A"] == ()
+        and matches["B"] == ((1, 0, 1),)
+        and matches["C"] == ()
+        and matches["D"] == ((1, 0, 0),),
+        str({name: (reads[name], matches[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        incoming_set((1, 1, 2), tau1["B"], ticks, locks, seed_map)
+        == frozenset({E1, E3})
+        and unique_letter(
+            incoming_set((1, 1, 2), tau1["B"], ticks, locks, seed_map)
+        )
+        == UNDEFINED
+        and reads["B"] == "hold"
+        and incoming_set((0, 2, -1), tau1["C"], ticks, locks, seed_map)
+        == frozenset({E2, NEG_E3})
+        and unique_letter(
+            incoming_set((0, 2, -1), tau1["C"], ticks, locks, seed_map)
+        )
+        == UNDEFINED
+        and reads["C"] == "fail",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and m1["A"] == frozenset({NEG_E1})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse == "fail"
+        and reads["A"] == "fail"
+        and reads["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "hold",
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "hold"
+        and face != UNDEFINED
+        and face != "hold",
+    )
+    checks.check(
+        "mutation-r-style-differs",
+        r_style["A"] == frozenset()
+        and r_style["B"] == frozenset()
+        and r_style["C"] == frozenset()
+        and r_style["D"] == frozenset()
+        and reads["B"] == "hold"
+        and reads["D"] == "hold",
+    )
+    checks.check(
+        "mutation-timed-O-differs",
+        outgoing["A"] == frozenset({E2, NEG_E3})
+        and outgoing["B"] == frozenset({E2, E3, NEG_E3})
+        and outgoing["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and outgoing["D"] == frozenset({E1, NEG_E1})
+        and timed_o_reverse == "hold"
+        and timed_o_face == "hold"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-unique-letter-mixed-neighbor",
+        unique_letter(
+            incoming_set((1, 1, 2), tau1["B"], ticks, locks, seed_map)
+        )
+        == UNDEFINED
+        and unique_letter(m1["B"]) == frozenset({E1})
+        and reads["B"] == "hold"
+        and unique_letter(
+            incoming_set((0, 2, -1), tau1["C"], ticks, locks, seed_map)
+        )
+        == UNDEFINED
+        and unique_letter(m1["C"]) == frozenset({E2})
+        and reads["C"] == "fail",
+    )
+    z_reads = probe_reads(Z_PROBES, ticks, locks, seed_map)
+    x_reads = probe_reads(X_PROBES, ticks, locks, seed_map)
+    perp_reads = probe_reads(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_reads = probe_reads(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    twosite_reads = probe_reads(
+        PROBES, twosite_ticks, twosite_locks, twosite_seeds
+    )
+    z_reverse = reverse_report(z_reads["A"], z_reads["B"])
+    z_face = face_report(z_reads["C"], z_reads["D"])
+    x_reverse = reverse_report(x_reads["A"], x_reads["B"])
+    x_face = face_report(x_reads["C"], x_reads["D"])
+    twosite_reverse = reverse_report(twosite_reads["A"], twosite_reads["B"])
+    twosite_face = face_report(twosite_reads["C"], twosite_reads["D"])
+    checks.check(
+        "not-z-probes-or-x-probes-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and z_reads["A"] == "fail"
+        and z_reads["C"] == "hold"
+        and z_reverse == "fail"
+        and z_face == "hold"
+        and x_reverse == "hold"
+        and x_face == "hold"
+        and perp_reads["B"] == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and z_face != face
+        and x_reverse != reverse,
+    )
+    checks.check(
+        "not-nsopp-leftover-second-pair-is-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in twosite_ticks.values()) == 2
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and twosite_ticks[E3] == 1
+        and twosite_locks[E3] == {E3}
+        and twosite_ticks[PROBES["B"]] == 2
+        and twosite_ticks[PROBES["D"]] == 3
+        and twosite_reads["D"] == "fail"
+        and twosite_reverse == "fail"
+        and twosite_face == "fail"
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and reads["D"] == "hold"
+        and reverse == "fail"
+        and face == "fail"
+        and zsym_reads["A"] == "hold"
+        and zsym_reads["C"] == "fail",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-and-neighbor-read",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "neighbor-read(A) = fail" in note
+        and "neighbor-read(B) = hold" in note
+        and "neighbor-read(C) = fail" in note
+        and "neighbor-read(D) = hold" in note,
+    )
+    checks.check(
+        "note-reports-formed-neighbors",
+        "formed 6-NN of A at τ: (1, 1, 0)=UNDEFINED, (-1, 1, 0)=UNDEFINED, (0, 2, 0)={+e_2}, (0, 0, 0)={+e_1}, (0, 1, 1)={−e_2}, (0, 1, -1)={−e_3}"
+        in note
+        and "formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)={−e_2}, (1, 2, 1)={+e_2}, (1, 0, 1)={+e_1}, (1, 1, 2)={+e_1, +e_3}, (1, 1, 0)={−e_3}"
+        in note
+        and "formed 6-NN of C at τ: (1, 2, 0)={+e_1}, (-1, 2, 0)={−e_1}, (0, 1, 0)={−e_1}, (0, 2, 1)={+e_3}, (0, 2, -1)={+e_2, −e_3}"
+        in note
+        and "formed 6-NN of D at τ: (2, 1, 0)={+e_1}, (0, 1, 0)={−e_1}, (1, 2, 0)={+e_1}, (1, 0, 0)={−e_3}, (1, 1, 1)={+e_1}, (1, 1, -1)={+e_1}"
+        in note
+        and "matching 6-NN of A: none" in note
+        and "matching 6-NN of B: (1, 0, 1)" in note
+        and "matching 6-NN of C: none" in note
+        and "matching 6-NN of D: (1, 0, 0)" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse neighbor-read at τ: fail" in note
+        and "Face neighbor-read at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-timed-O-or-zprobe-leftover",
+        "not leftover of nm2axo timed-O" in normalized_note
+        and "not leftover of nm2readz z-probe neighbor-read" in normalized_note
+        and "not leftover of R-style" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_INCOMING_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "neighbor_read" in defined_fns
+        and "matching_neighbors" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "formed_neighbor_incoming" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "neighbor-read-not-timed-O",
+        reverse == "fail"
+        and face == "fail"
+        and reads["A"] == "fail"
+        and reads["B"] == "hold"
+        and reads["C"] == "fail"
+        and reads["D"] == "hold"
+        and timed_o_reverse == "hold"
+        and timed_o_face == "hold",
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Neighbor-read of M at t+1 on opposite y-probes: reverse fails, face fails. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_yprobe_neighbor_read_incoming_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.