### PR TITLE
feat(nm2splt2y): 1-in 2-out at t vs t+1 on two-axis opposite y-probes: reverse fail then HOLD, face fails, composition fail

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,651 @@
+---
+claim_id: two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "1-in 2-out split at t versus t+1 on the four y-probes of the two-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py
+---
+
+# Two-Tick Composition Of One-In Two-Out Axis Split Reverse And Face On Four Y-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** 1-in 2-out axis split of simultaneous earliest incoming set `M`
+and outgoing dual `O` at each probe's formation tick `t` versus `t+1`,
+reverse/face from that split at each cut, and composition HOLD iff split
+at `τ0` equals split at `τ1` at `A,B,C,D`, on the four y-probes of the
+two-axis opposite seed in `B_3(0)={n:n·n<=9}`. Same process and y-probes
+as nm2ax. `M`, `O`, and split as nm2ax12. Process: two disjoint opposite
+pairs. Seed at tick 0: origin locks `+e_1`, `(0,1,0)` locks `−e_1`,
+`(0,0,1)` locks `+e_2`, `(0,1,1)` locks `−e_2`. The second pair is a new
+seed, not a formed child. Perp-step, incoming lock. Let `t(q)` be the
+formation tick of probe `q`. Let `τ0(q)=t(q)` and `τ1(q)=t(q)+1`. There
+is no global T. `M(q,τ)` is the set of earliest incoming nearest-neighbor
+steps at `q` using only records with tick `<= τ`. Seeds are a singleton
+seed letter. `O(q,τ)` is the outgoing dual of `M`: the set of `e` in
+`{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in `M(q+e,τ)`.
+Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Empty
+`O` at `t` fails split. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals
+`{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). 2-in 1-out is fail of this object,
+not UNDEFINED. Reverse HOLDs if and only if split HOLDs at `A` and at `B`.
+Face HOLDs if and only if split HOLDs at `C` and at `D`. Composition HOLD
+if and only if split at `τ0` equals split at `τ1` at `A`, at `B`, at `C`,
+and at `D`. This is not leftover of nm2ax12 `t+1`-only split reverse hold
+and face fail. This is not leftover of nmcover axis-cover. This is
+not leftover of nm2ax axis-cover. This is not
+leftover of frozen-`M` two-tick set equality. This is not leftover of
+reverse/face-bit composition as a substitute for equality of the four
+split reports. This is not leftover of leftover-of-`M` alone. This is not
+leftover of leftover-of-`O` alone. This is not leftover-empty fail. This
+is not leftover of exist-opposite of signed locks. This is not leftover of
+the 1-axis opposite two-site seed. This is not leftover of nmt2opp `M`
+frozen at `t`. This is not leftover of mixed #7188 fail/fail. The second
+pair is a new seed, not a formed child. Uniqueness is not required. Mixed
+remains a set. Occupancy of sites is not used. Displayed, not adopted. Do
+not write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cuts
+`τ0=t` and `τ1=t+1`. Axis is the unsigned lattice direction of a signed lock.
+Cover is the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and
+`Axis(O)`. Split is cover together with `|Axis(M)|=1`. Reverse and face are
+scored on split HOLD at the paired probes at each cut. Composition is
+equality of those four split reports across the two cuts. Named signs
+`{+,−}` are a coarser readout and are not used. A singleton unique lock
+letter is a different readout and is not used as the object. Existential
+opposite of signed locks is a different readout and is not used as the
+split reverse. Axis-cover without the one-axis incoming cardinality is a
+different readout and is not used. Frozen-`M` set equality is a different
+readout and is not used as the composition object. Reverse/face-bit
+equality is a different readout and is not used as the composition object.
+Occupancy of sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of 1-in 2-out axis split of M and O at t and at t+1 on the four y-probes of the two-axis opposite seed, empty O at t fails split so reverse fail and face fail at t, reverse hold and face fail at t+1 as nm2ax12, and composition fail because split at A,B,C changes from fail to hold; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face
+target_blocker_text: "display 1-in 2-out split at t versus t+1 on the four y-probes of the two-axis opposite seed, reverse/face at each cut, and composition HOLD iff split at t equals split at t+1"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep 1-in 2-out split two-tick composition displayed; do not write split into Admissibility, do not reduce to cover, do not reduce to frozen-M set equality, do not replace split equality by reverse/face-bit equality, do not replace split by existential opposite of signed locks, do not reprint nm2ax12 t+1-only reverse hold face fail as this two-tick report, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for 1-in 2-out split at t versus t+1 on the four y-probes of the two-axis opposite seed, reverse/face at each cut, and composition; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose 1-in
+2-out axis split of `M` and `O` is scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`,
+`C=(0,0,2)`, `D=(1,0,1)`. `A` is a seed. Same process and y-probes as
+nm2ax. `M`, `O`, and split as nm2ax12.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named 1-in 2-out axis split at `τ0=t` versus `τ1=t+1`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ0(q)=t(q)` and `τ1(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Empty `O` at `t` fails split. Empty O at t fails split. Duplicate steps collapse in
+the set. The construction does not require `M` or `O` to be a singleton. It
+does not sum either set. It does not replace `O` by `M`. It does not wait
+for a global later T. Occupancy of sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at a cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+If `q` is unformed at the cut, then cover is `UNDEFINED`. Overlapping axes
+fail. Incomplete union fails, including empty `O`. Axis is unsigned: `+e_i`
+and `−e_i` occupy the same axis.
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of this object, not UNDEFINED: cover HOLD with
+`|Axis(M)|=2` (hence `|Axis(O)|=1`) is split fail. Cover without the
+one-axis incoming cardinality is not this object. Unique letters are not
+this object. One-in one-out with leftover axis is cover fail and therefore
+split fail.
+
+Reverse 1-in 2-out at a cut holds if and only if split HOLDs at `A` and at
+`B` at that cut. Face 1-in 2-out at a cut holds if and only if split HOLDs
+at `C` and at `D` at that cut. Either side `UNDEFINED` is `UNDEFINED`. Else
+if both sides HOLD, reverse or face HOLDs. Else fail.
+
+Composition of split (displayed):
+
+```text
+composition HOLDs iff split(A,τ0)=split(A,τ1)
+and split(B,τ0)=split(B,τ1)
+and split(C,τ0)=split(C,τ1)
+and split(D,τ0)=split(D,τ1).
+```
+
+Any side `UNDEFINED` makes composition `UNDEFINED`. Else if some probe's
+split report changes from `t` to `t+1`, composition fails. Equality of the
+four `M` sets is a different object: those sets may stay equal while split
+changes because `O` fills in. Equality of reverse/face bits is a different
+object: those bits may match while some probe's split changes, and they
+may fail to match while the four split reports stay equal. This letter is
+equality of the four split reports.
+
+Admissibility is not edited. Split is not written into Admissibility. Do
+not write into Admissibility. Do not attach L1.
+
+## Theorem 1 — ticks, `M`, `O`, and split at `τ0=t` and at `τ1=t+1`
+
+On this process the four y-probes form. Earliest incoming `M` is frozen
+from `t` to `t+1`. Outgoing dual `O` is empty at `A`, `B`, and `C` at
+formation tick, and is `{−e_1}` at `D` at formation tick. Empty `O` at `t`
+fails split. At `t+1` the nm2ax12 HOLDING outgoing duals appear at `A`,
+`B`, and `C`, and `D` remains 1-in 1-out.
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=2
+M(A, τ0) = {−e_1}
+M(B, τ0) = {+e_1}
+M(C, τ0) = {+e_2}
+M(D, τ0) = {−e_3}
+M(A, τ1) = {−e_1}
+M(B, τ1) = {+e_1}
+M(C, τ1) = {+e_2}
+M(D, τ1) = {−e_3}
+O(A, τ0) = {}
+O(B, τ0) = {}
+O(C, τ0) = {}
+O(D, τ0) = {−e_1}
+O(A, τ1) = {+e_2, −e_3}
+O(B, τ1) = {+e_2, +e_3, −e_3}
+O(C, τ1) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ1) = {+e_1, −e_1}
+split(A, τ0) = fail
+split(B, τ0) = fail
+split(C, τ0) = fail
+split(D, τ0) = fail
+split(A, τ1) = hold
+split(B, τ1) = hold
+split(C, τ1) = hold
+split(D, τ1) = fail
+```
+
+`A` is a seed at tick 0. Mixed remains a set: `O(A,τ1)` has two outgoing
+steps and `O(B,τ1)` has three outgoing steps. Unique letters would assign
+`UNDEFINED` at mixed `O`. Here uniqueness is not required. At `τ0`, empty
+`O` at `A`, `B`, and `C` makes union of axes incomplete, so cover fails
+and split fails. At `D` at `τ0`, `Axis(M)={e_3}` and `Axis(O)={e_1}`, so
+leftover of the union is `{e_2}`: 1-in 1-out, cover fail, split fail. At
+`τ1`, `A`, `B`, and `C` are 1-in 2-out, so split HOLDs, and `D` remains
+1-in 1-out with leftover `{e_2}`, so split fails. 2-in 1-out is fail of
+this object, not UNDEFINED; that identity remains, and it is not the `D`
+report on this seed. O is not M. Frozen `M` is not this composition
+object.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`:
+
+```text
+new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+Compare to nm2ax12 `t+1` only. Same seed, same y-probes, same `M` and `O`
+at `τ1`, same split HOLD at `A`, `B`, and `C` and fail at `D`, reverse
+hold and face fail. That leftover does not score split at `t`, does not
+score reverse/face at `t`, and does not score two-tick split equality.
+Compare to 1-axis opposite two-site seed: that member forms `B` at tick 2
+and `D` at tick 3, has mixed `M(D,τ)`, and has cover HOLD at `D` from 2-in
+1-out. Here the second pair is a new seed, not a formed child.
+
+## Theorem 2 — reverse and face at `τ0` and at `τ1`
+
+Reverse 1-in 2-out holds if and only if split HOLDs at `A` and at `B`. At
+`τ0` both splits fail from empty `O`. Reverse fails. At `τ1` both splits
+HOLD. Reverse HOLDs. This is HOLD iff split, not leftover of nmcover
+axis-cover, not leftover-empty fail, and not exist-opposite.
+
+Reverse 1-in 2-out at τ0: fail
+Reverse 1-in 2-out at τ1: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Reverse fails at `t`
+and HOLDs at `t+1`. Frozen-`M` exist-opposite reverse HOLDs at both cuts
+because `M(A)={−e_1}` and `M(B)={+e_1}` are frozen. Cover reverse fails at
+`t` and HOLDs at `t+1`, which agrees on the bits by accident of empty `O`
+at `t` and complementary occupation at `t+1`. Those leftovers are not this
+display.
+
+Reverse fails at τ0.
+Reverse holds at τ1.
+
+Face 1-in 2-out holds if and only if split HOLDs at `C` and at `D`. At
+`τ0` split fails at `C` from empty `O` and fails at `D` from 1-in 1-out.
+Face fails. At `τ1` split HOLDs at `C` and fails at `D`. Face fails. The
+`D` failure at both cuts is cover fail from leftover `{e_2}` (1-in 1-out),
+which is fail of this object, not UNDEFINED.
+
+Face 1-in 2-out at τ0: fail
+Face 1-in 2-out at τ1: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Face fails at both cuts. Cover face fails at both cuts by the same `D`
+cover fail at `t+1` and by empty `O` at `C` at `t`. Split face fails
+because split fails at `D` at both cuts and at `C` at `t`. Exist-opposite
+face of signed `M` fails at both cuts. Exist-opposite face of signed `O`
+is `UNDEFINED` at `t` from empty `O` and HOLDs at `t+1`. Those leftovers
+are not this split face.
+
+Face fails at τ0.
+Face fails at τ1.
+
+## Theorem 3 — composition of split at `t` versus `t+1`
+
+Composition HOLD if and only if split at `τ0` equals split at `τ1` at
+`A`, at `B`, at `C`, and at `D`. Split at `A`, `B`, and `C` changes from
+fail to hold. Split at `D` stays fail. None is `UNDEFINED`.
+
+Composition of split at t versus t+1: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1. Composition fail is
+inequality of the four split reports, not inequality of the four `M`
+sets: those four `M` sets stay equal (frozen earliest incoming), so
+frozen-`M` two-tick composition HOLDs while this split composition fails.
+New six-neighbor records between `t` and `t+1` enter `O` and do not enter
+earliest `M`. Reverse/face-bit composition also fails here because reverse
+changes from fail to hold; that leftover is still a different object,
+because it scores two pair bits rather than the four split reports.
+
+This is not leftover of nm2ax12 `t+1`-only reverse hold and face fail:
+that display does not score split at `t`. This is not leftover of nmt2opp
+`M` frozen at `t` as a different seed. This is not leftover of mixed
+#7188 fail/fail. This is not leftover of the two-tick lock-count clock
+composition.
+
+Composition fails.
+
+## What this note does not claim
+
+- It does not select a unique incoming, outgoing, or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require split sides to be singletons.
+- It does not sum either set.
+- It does not replace split by leftover-empty fail.
+- It does not replace split by leftover of `M` alone.
+- It does not replace split by leftover of `O` alone.
+- It does not replace split by existential opposite of signed locks.
+- It does not replace split by axis-cover without `|Axis(M)|=1`.
+- It does not treat 2-in 1-out as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace composition of the four split reports by frozen-`M`
+  set equality.
+- It does not replace composition of the four split reports by
+  reverse/face-bit equality.
+- It does not replace split by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nm2ax12 `t+1`-only reverse hold and face fail as this
+  two-tick report.
+- It does not reprint nmcover axis-cover reverse hold face fail as this
+  split composition.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not reprint nmt2opp `M` frozen at `t` as this split display.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite seed process, 1-in 2-out axis split of `M` and `O` at `t`
+and at `t+1`, reverse/face from that split at each cut, and composition of
+those four split reports are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `2` |
+| `M` at `τ0=t` and at `τ1=t+1` | Theorem 1; frozen equal |
+| `O` at `τ0=t` and at `τ1=t+1` | Theorem 1; empty at `A,B,C` at `t`; HOLDING at `t+1` |
+| split at `τ0` | Theorem 1; fail at `A,B,C,D`; empty `O` at `t` fails split |
+| split at `τ1` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| reverse from 1-in 2-out at `τ0` and `τ1` | Theorem 2; `fail`, `hold` |
+| face from 1-in 2-out at `τ0` and `τ1` | Theorem 2; `fail`, `fail` |
+| composition of split at `t` versus `t+1` | Theorem 3; `fail` |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this split display |
+| leftover of exist-opposite HOLD | not this split display |
+| leftover of nmcover axis-cover | not this split display |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of frozen-`M` two-tick set equality | not this composition |
+| leftover of reverse/face-bit composition | not this composition |
+| leftover of nm2ax12 `t+1`-only split | not this two-tick report |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the two-tick lock-count clock | not this display |
+| 2-in 1-out scored as `UNDEFINED` | refused; fail of this object |
+| global later T | not used |
+| 1-in 2-out split as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: 1-in 2-out split at `t` versus `t+1` on the four y-probes of the two-axis opposite seed, reverse/face at each cut, and composition. |
+| V2 | Current main has no landed 1-in 2-out two-tick composition reverse/face report on these four y-probes of the two-axis opposite seed. |
+| V3 | Split reports at two cuts, the four reverse/face bits, and composition as split equality are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads unsigned 1-in 2-out split of own incoming and own outgoing at `t` and at `t+1` and scores equality of those four reports. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace split by leftover-empty fail, does not
+replace split by leftover of `M` alone or leftover of `O` alone, does not
+replace split by existential opposite of signed locks, does not replace
+split by nmcover axis-cover, does not replace split equality by frozen-`M`
+set equality, does not replace split equality by reverse/face-bit
+equality, does not identify this display with nm2ax12 `t+1` only, does not
+identify this display with the 1-axis opposite two-site seed, and does not
+identify it with nmt2opp frozen `M`. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2ax12 `t+1` only | reuse reverse hold and face fail at `t+1` | that leftover does not score split at `t`; reverse fails at `t` from empty `O` | ATTEMPTED |
+| frozen-`M` two-tick set equality | HOLD iff `M(t)=M(t+1)` at `A,B,C,D` | the four `M` sets stay equal, so that leftover HOLDs while split composition fails | ATTEMPTED |
+| reverse/face-bit composition | HOLD iff reverse/face bits match | those two pair bits fail here because reverse changes; the scored object is still the four split reports | ATTEMPTED |
+| nmcover axis-cover | score reverse/face as cover HOLD | cover reverse fails at `t` and HOLDs at `t+1` with split; 2-in 1-out is still cover HOLD and split fail | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover of the union is empty at `A` and at `B` at `t+1`, leftover reverse fails, while split reverse HOLDs at `t+1` | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` is frozen and is not `|Axis(M)|=1` cover of the pair | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | empty `O` at `t` makes leftover of `O` the full three axes; that is not this split | ATTEMPTED |
+| exist-opposite of signed `M` | reuse signed reverse hold and face fail of frozen `M` | exist-opposite reverse HOLDs at both cuts while split reverse fails at `t` | ATTEMPTED |
+| exist-opposite of signed `O` | score reverse/face inside `O` | empty `O` at `t` makes exist-opposite `UNDEFINED`; split reverse is fail, not `UNDEFINED` | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(A,τ1)` and mixed `O(B,τ1)` remain sets; split still reports hold at `A` at `t+1` and fail at `D` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | 2-in 1-out is fail of this object, not UNDEFINED; `D` here is 1-in 1-out cover fail, also not UNDEFINED | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(B)=2`, `t(D)=3`, mixed `M(D)`, cover HOLD at `D` | different seed; second pair is a new seed, not a formed child | ATTEMPTED |
+| nmt2opp `M` frozen at `t` | reuse 1-axis y-probe two-tick `M` | different seed and different letter; this letter is split equality | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores 1-in 2-out of own incoming and outgoing at two cuts | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports split reverse fail at `t` and hold at `t+1` | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace split by a `Z^3` sum | the construction does not sum; split is cover plus `|Axis(M)|=1` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ0(q)=t(q)` and `τ1(q)=t(q)+1` are per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by 1-in 2-out split | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of split with leftover of
+`M` alone, missing identification of split composition with frozen-`M` set
+equality, missing identification of split with leftover-empty fail, missing
+identification of split with existential opposite of signed locks, missing
+identification of split with nmcover axis-cover, missing identification of
+this seed with the 1-axis opposite two-site seed, missing identification of
+this two-tick report with nm2ax12 `t+1` only, and missing Record
+identification of split reverse are distinct open premises. This note claims
+no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ0=t` and
+`τ1=t+1`, unsigned axis, cover as complementary occupation of
+`{e_1,e_2,e_3}`, split as cover and `|Axis(M)|=1`, empty `O` at `t` fails
+split, 2-in 1-out as fail not `UNDEFINED`, composition as equality of the
+four split reports, four y-probes with seed `A`, second pair as a new seed
+not a formed child, and mixed remains a set are declared. No uniqueness of
+incoming locks, no six-neighbor lock union as the scored object, no
+lock-count clock, no frozen-`M` leftover as the composition object, no
+reverse/face-bit leftover as the composition object, no global later T, no
+formation attachment from already-recorded six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+split `hold`/`fail` reports at two cuts, and composition fail, do not close
+that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each unsigned lattice axis among `{e_1,e_2,e_3}` | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four split reports at two cuts, reverse/face at each cut, and composition | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for split reverse/face, a
+formation-rate rule, and a physical selector among 1-in 2-out axes. None
+is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Split two-tick composition should be refused as leftover
+because nm2ax12 already reported reverse hold and face fail at `t+1`;
+`M` is frozen so composition of `M` already answers two ticks; empty `O`
+at `t` should be `UNDEFINED` like unformed; cover already matches split
+at both cuts on this seed; leftover of `M` alone is frozen; exist-opposite
+of signed `M` already HOLDs reverse at both cuts; reverse/face-bit
+composition already fails; and 1-in 1-out at `D` should be `UNDEFINED`.
+
+**Answer:** nm2ax12 scores split at `t+1` only. This letter scores split at
+`t` and at `t+1`, reverse/face at each cut, and composition as equality of
+the four split reports. Those are extra reports, not a reprint. Frozen-`M`
+two-tick composition HOLDs because earliest incoming does not change; split
+composition fails because empty `O` at `t` fills in at `t+1` at `A`, `B`,
+and `C`. Empty `O` is empty, not `UNDEFINED`; unformed at `τ` is
+`UNDEFINED`. Cover HOLDs at `A`, `B`, and `C` at `t+1` and fails at `D`
+from leftover `{e_2}`. Split requires `|Axis(M)|=1` in addition to cover, so
+2-in 1-out is cover HOLD and split fail even when those bits agree on this
+seed. Exist-opposite reverse of signed `M` HOLDs at both cuts while split
+reverse fails at `t`. Reverse/face-bit composition scores two pair bits;
+this letter scores four split reports. `D` is formed at tick 2; 1-in 1-out
+is cover fail and split fail, not UNDEFINED. Reverse 1-in 2-out fails at
+`t` and HOLDs at `t+1`. Face fails at both cuts. Composition of split
+fails.
+
+### N8 — cross-cycle echo
+
+nm2ax12 reported 1-in 2-out reverse hold and face fail at `t+1` on these
+y-probes, with split HOLD at `A`, `B`, and `C` and fail at `D`. nm2ax
+reported axis-cover reverse hold and face fail at `t+1`. nsmopp #7208
+reported reverse hold and face hold from own incoming `M` on the 1-axis
+opposite two-site seed. The 1-axis 1-in 2-out split reported split HOLD at
+`A`, `B`, and `C`, split fail at `D` from 2-in 1-out, reverse hold, and
+face fail, with `t(B)=2` and `t(D)=3`. Frozen-`M` two-tick composition on
+this two-axis seed HOLDs. This note is not those displays: it reports 1-in
+2-out axis split of `M` and `O` at `τ0=t` and at `τ1=t+1` on the two-axis
+opposite seed, with `t(B)=1` and `t(D)=2`, split fail at all four probes at
+`t` from empty `O` or leftover `{e_2}`, split HOLD at `A`, `B`, and `C` and
+fail at `D` at `t+1`, reverse fail at `t` and hold at `t+1`, face fail at
+both cuts, and composition fail.
+
+**Gate disposition:** PASS for the 1-in 2-out two-tick reverse/face and
+composition reports above. FAIL / DO NOT SHIP for “the predicate equals
+the named sign,” “the predicate equals the unique singleton lock vector,”
+“the predicate equals six-neighbor lock union,” “the predicate equals
+leftover-empty fail,” “the predicate equals leftover of `M` alone,” “the
+predicate equals leftover of `O` alone,” “the predicate equals
+exist-opposite HOLD,” “the predicate equals nmcover axis-cover HOLD,”
+“the predicate equals nm2ax12 `t+1` only,” “the predicate equals frozen-`M`
+set equality,” “composition equals reverse/face-bit equality,” “the
+predicate equals the 1-axis opposite two-site seed,” “bits are
+Admissibility,” “2-in 1-out is UNDEFINED,” “reverse 1-in 2-out holds at
+`t`,” “reverse 1-in 2-out fails at `t+1`,” “face 1-in 2-out holds,” or
+“composition of split HOLDs.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t` and
+at `t+1`, reports unsigned axis of each, reports cover of the pair, reports
+the 1-in 2-out split at both cuts, scores reverse and face from split at
+each cut, scores composition as equality of the four split reports, lists
+new records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors, and checks Theorems 1--3. It also checks that split fails at
+all four probes at `t`, that empty `O` at `t` fails split, that split HOLDs
+at `A`, `B`, and `C` and fails at `D` at `t+1`, that reverse fails at `t`
+and HOLDs at `t+1`, that face fails at both cuts, that composition fails,
+that frozen-`M` two-tick composition HOLDs as a different leftover, that
+2-in 1-out is fail not `UNDEFINED`, that the 1-axis opposite two-site seed
+is a different member, that leftover-empty fail is a different reverse and
+face, that mixed sets remain sets, that unique-letter split is `UNDEFINED`
+at mixed `O`, that the construction does not sum, that a formation member
+from already-recorded six-neighbor locks is not attached, that the second
+pair is a new seed not a formed child, and that the display is not the
+two-tick lock-count clock composition. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.txt
@@ -1,0 +1,102 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py
+runner_sha256: 78a487daeaf249df5aa728eb1bf6373c70c647efbdde058762ec987d73b36576
+input_fingerprint_sha256: 3842b5a422e2bb549f99062b3f75b3a43230d08674a5fd31eb003a3f59129401
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.05
+status: ok
+----- stdout -----
+1-in 2-out axis split of M and O at t versus t+1 reverse/face composition
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: 1-in 2-out split at t versus t+1 on the four y-probes of the two-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: axis-identity
+PASS: cover-identity
+PASS: split-identity
+PASS: pair-bit-identity
+PASS: composition-identity
+PASS: leftover-empty-fail-contrast
+A t=0 M(t)={−e_1} O(t)={} split(t)=fail M(t+1)={−e_1} O(t+1)={+e_2, −e_3} split(t+1)=hold
+B t=1 M(t)={+e_1} O(t)={} split(t)=fail M(t+1)={+e_1} O(t+1)={+e_2, +e_3, −e_3} split(t+1)=hold
+C t=1 M(t)={+e_2} O(t)={} split(t)=fail M(t+1)={+e_2} O(t+1)={+e_1, −e_1, +e_3, −e_3} split(t+1)=hold
+D t=2 M(t)={−e_3} O(t)={−e_1} split(t)=fail M(t+1)={−e_3} O(t+1)={+e_1, −e_1} split(t+1)=fail
+split reverse t=fail t+1=hold
+split face t=fail t+1=fail
+composition=fail
+frozen-M composition leftover=HOLD
+bit-composition leftover=fail
+per_element: each unsigned lattice axis among {e_1,e_2,e_3} occupied by M or by O at a probe's t and t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four split reports at two cuts, reverse/face at each cut, and composition
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-at-t-and-t-plus-1  ({'A': ('{−e_1}', '{−e_1}'), 'B': ('{+e_1}', '{+e_1}'), 'C': ('{+e_2}', '{+e_2}'), 'D': ('{−e_3}', '{−e_3}')})
+PASS: theorem1-O-at-t-and-t-plus-1  ({'A': ('{}', '{+e_2, −e_3}'), 'B': ('{}', '{+e_2, +e_3, −e_3}'), 'C': ('{}', '{+e_1, −e_1, +e_3, −e_3}'), 'D': ('{−e_1}', '{+e_1, −e_1}')})
+PASS: theorem1-split-at-t-and-t-plus-1  ({'A': ('fail', 'hold'), 'B': ('fail', 'hold'), 'C': ('fail', 'hold'), 'D': ('fail', 'fail')})
+PASS: theorem1-empty-O-at-t-fails-split
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((0, 2, 0), (0, 1, -1)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-at-t-fail-and-t-plus-1-hold
+PASS: theorem2-face-at-t-and-t-plus-1-fail
+PASS: theorem3-composition-fail
+PASS: composition-is-split-equality-not-M-sets
+PASS: composition-is-not-reverse-face-bits
+PASS: two-in-one-out-is-fail-not-undefined
+PASS: d-is-one-in-one-out-not-cover
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-empty-plus-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-two-site-seed
+PASS: not-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-at-two-cuts
+PASS: note-reports-new-neighbors
+PASS: note-reports-split-reverse-face
+PASS: note-reports-composition-fail
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-exist-opposite
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-frozen-M-or-bit-composition
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: split-two-tick-composition-fail
+TOTAL: PASS=68 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py
@@ -1,0 +1,1429 @@
+#!/usr/bin/env python3
+"""1-in 2-out split at t versus t+1 reverse/face composition on two-axis opposite.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites: origin locks +e_1, (0,1,0) locks -e_1, (0,0,1) locks +e_2,
+and (0,1,1) locks -e_2. Two disjoint opposite pairs. Same process and
+y-probes as nm2ax. M, O, and split as nm2ax12. The second pair is a new
+seed, not a formed child of the first pair. A 6-NN step is allowed iff it
+is perpendicular to the parent lock axis. Newly formed sites lock the
+incoming step. Seeds keep their seed letters as a singleton. M(q, tau) is
+the set of earliest incoming nearest-neighbor steps at q using only records
+with tick <= tau. Unformed at tau => UNDEFINED. O(q, tau) is the outgoing
+dual of M: the set of e in {±e_1,±e_2,±e_3} such that q+e is formed and e
+is in M(q+e, tau). Unformed q at tau => UNDEFINED. Empty O is empty, not
+UNDEFINED. Empty O at t fails split. Axis(S) is the unsigned lattice
+directions of signed locks in S. Cover HOLDs at q iff Axis(M) intersect
+Axis(O) is empty and Axis(M) union Axis(O) equals {e_1,e_2,e_3}. UNDEFINED
+if M or O UNDEFINED. Else fail. Split HOLDs at q iff cover HOLDs and
+|Axis(M)|=1 (hence |Axis(O)|=2). 2-in 1-out is fail of this object, not
+UNDEFINED. tau0=t, tau1=t+1. Reverse HOLDs iff split at A and at B at that
+cut. Face likewise on C, D. Composition HOLD iff split at tau0 equals split
+at tau1 at A, B, C, and D. Uniqueness is not required. Occupancy of sites
+is not used. Named-sign lettering is not used. No larger host.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "1-in 2-out split at t versus t+1 on the four y-probes of the "
+    "two-axis opposite seed, reverse/face at each cut, and composition, "
+    "are reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast: {e_1,e_2,e_3} minus Axis(S). Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2).
+
+    2-in 1-out (cover HOLD with |Axis(M)|=2) is fail of this object, not
+    UNDEFINED. Empty O fails cover and therefore fails split.
+    """
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2, hence |Axis(O)|=1. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(split_a: str, split_b: str) -> str:
+    """Reverse HOLDs iff split at A and split at B."""
+    return pair_bit(split_a, split_b)
+
+
+def face_report(split_c: str, split_d: str) -> str:
+    """Face HOLDs iff split at C and split at D."""
+    return pair_bit(split_c, split_d)
+
+
+def composition_report(
+    split0: dict[str, str],
+    split1: dict[str, str],
+) -> str:
+    """HOLD iff split at t equals split at t+1 at A,B,C,D."""
+    for name in ("A", "B", "C", "D"):
+        if split0[name] == UNDEFINED or split1[name] == UNDEFINED:
+            return UNDEFINED
+        if split0[name] != split1[name]:
+            return "fail"
+    return "HOLD"
+
+
+def m_composition_report(
+    m0: dict[str, Incoming],
+    m1: dict[str, Incoming],
+) -> str:
+    """Leftover: HOLD iff M(t)=M(t+1) at A,B,C,D. Not this letter."""
+    for name in ("A", "B", "C", "D"):
+        if m0[name] == UNDEFINED or m1[name] == UNDEFINED:
+            return UNDEFINED
+        if m0[name] != m1[name]:
+            return "fail"
+    return "HOLD"
+
+
+def bit_composition_report(rev0: str, rev1: str, face0: str, face1: str) -> str:
+    """Leftover: HOLD iff reverse/face bits match. Not this letter."""
+    if rev0 == UNDEFINED or rev1 == UNDEFINED or face0 == UNDEFINED or face1 == UNDEFINED:
+        return UNDEFINED
+    if rev0 != rev1 or face0 != face1:
+        return "fail"
+    return "HOLD"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("1-in 2-out axis split of M and O at t versus t+1 reverse/face composition")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E2, E3) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "axis-identity",
+        axis_set(UNDEFINED) == UNDEFINED
+        and axis_set(frozenset({NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E1, NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E2, E3, NEG_E3})) == frozenset({E2, E3})
+        and axis_set(frozenset({E1, NEG_E1, E3, NEG_E3})) == frozenset({E1, E3}),
+    )
+    checks.check(
+        "cover-identity",
+        axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_cover(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_cover(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset()) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "hold"
+        and axis_cover(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1})) == "fail",
+    )
+    checks.check(
+        "split-identity",
+        axis_split(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_split(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_split(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_split(frozenset({NEG_E1}), frozenset()) == "fail"
+        and axis_split(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_split(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == "hold"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_split(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_in_one_out(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "fail"
+        and two_in_one_out(UNDEFINED, frozenset({E1})) == UNDEFINED,
+    )
+    checks.check(
+        "pair-bit-identity",
+        pair_bit(UNDEFINED, "hold") == UNDEFINED
+        and pair_bit("hold", UNDEFINED) == UNDEFINED
+        and pair_bit("hold", "hold") == "hold"
+        and pair_bit("hold", "fail") == "fail"
+        and pair_bit("fail", "hold") == "fail"
+        and pair_bit("fail", "fail") == "fail",
+    )
+    frozen_split = {"A": "fail", "B": "fail", "C": "fail", "D": "fail"}
+    changed_split = {"A": "hold", "B": "hold", "C": "hold", "D": "fail"}
+    checks.check(
+        "composition-identity",
+        composition_report(frozen_split, frozen_split) == "HOLD"
+        and composition_report(frozen_split, changed_split) == "fail"
+        and composition_report(
+            {"A": UNDEFINED, "B": "fail", "C": "fail", "D": "fail"},
+            frozen_split,
+        )
+        == UNDEFINED
+        and bit_composition_report("fail", "fail", "fail", "fail") == "HOLD"
+        and bit_composition_report("fail", "hold", "fail", "fail") == "fail",
+    )
+    checks.check(
+        "leftover-empty-fail-contrast",
+        leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and leftover_axis(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3}))
+        == frozenset()
+        and leftover_axis(frozenset({NEG_E3}), frozenset({E1, NEG_E1}))
+        == frozenset({E2})
+        and leftover_axis(frozenset({E2}), frozenset({E1})) == frozenset({E3}),
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m0: dict[str, AxisSet] = {}
+    axis_o0: dict[str, AxisSet] = {}
+    axis_m1: dict[str, AxisSet] = {}
+    axis_o1: dict[str, AxisSet] = {}
+    cover0: dict[str, str] = {}
+    cover1: dict[str, str] = {}
+    split0: dict[str, str] = {}
+    split1: dict[str, str] = {}
+    two_one0: dict[str, str] = {}
+    two_one1: dict[str, str] = {}
+    lx1: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        axis_m0[name] = axis_set(m0[name])
+        axis_o0[name] = axis_set(o0[name])
+        axis_m1[name] = axis_set(m1[name])
+        axis_o1[name] = axis_set(o1[name])
+        cover0[name] = axis_cover(m0[name], o0[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        split0[name] = axis_split(m0[name], o0[name])
+        split1[name] = axis_split(m1[name], o1[name])
+        two_one0[name] = two_in_one_out(m0[name], o0[name])
+        two_one1[name] = two_in_one_out(m1[name], o1[name])
+        lx1[name] = leftover_axis(m1[name], o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M(t)={lockset_display(m0[name])} "
+            f"O(t)={lockset_display(o0[name])} "
+            f"split(t)={split0[name]} "
+            f"M(t+1)={lockset_display(m1[name])} "
+            f"O(t+1)={lockset_display(o1[name])} "
+            f"split(t+1)={split1[name]}"
+        )
+
+    reverse0 = reverse_report(split0["A"], split0["B"])
+    reverse1 = reverse_report(split1["A"], split1["B"])
+    face0 = face_report(split0["C"], split0["D"])
+    face1 = face_report(split1["C"], split1["D"])
+    composition = composition_report(split0, split1)
+    m_composition = m_composition_report(m0, m1)
+    bit_composition = bit_composition_report(reverse0, reverse1, face0, face1)
+    cover_reverse0 = pair_bit(cover0["A"], cover0["B"])
+    cover_reverse1 = pair_bit(cover1["A"], cover1["B"])
+    cover_face0 = pair_bit(cover0["C"], cover0["D"])
+    cover_face1 = pair_bit(cover1["C"], cover1["D"])
+    leftover_reverse1 = leftover_match(lx1["A"], lx1["B"])
+    leftover_face1 = leftover_match(lx1["C"], lx1["D"])
+    m_exist_reverse0 = existential_opposite(m0["A"], m0["B"])
+    m_exist_reverse1 = existential_opposite(m1["A"], m1["B"])
+    m_exist_face0 = existential_opposite(m0["C"], m0["D"])
+    m_exist_face1 = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse0 = existential_opposite(o0["A"], o0["B"])
+    o_exist_reverse1 = existential_opposite(o1["A"], o1["B"])
+    o_exist_face0 = existential_opposite(o0["C"], o0["D"])
+    o_exist_face1 = existential_opposite(o1["C"], o1["D"])
+    unique_split_a1 = axis_split(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    one_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_o1 = {
+        name: outgoing_set(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    print(f"split reverse t={reverse0} t+1={reverse1}")
+    print(f"split face t={face0} t+1={face1}")
+    print(f"composition={composition}")
+    print(f"frozen-M composition leftover={m_composition}")
+    print(f"bit-composition leftover={bit_composition}")
+    print(
+        "per_element: each unsigned lattice axis among {e_1,e_2,e_3} "
+        "occupied by M or by O at a probe's t and t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four split reports at two cuts, reverse/face at each cut, and composition"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PAIR2] == 0
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["D"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(PAIR2, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and m0["A"] == frozenset({NEG_E1})
+        and m1["A"] == frozenset({NEG_E1}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-t-and-t-plus-1",
+        m0["A"] == frozenset({NEG_E1})
+        and m0["B"] == frozenset({E1})
+        and m0["C"] == frozenset({E2})
+        and m0["D"] == frozenset({NEG_E3})
+        and m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3}),
+        str(
+            {
+                name: (lockset_display(m0[name]), lockset_display(m1[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-O-at-t-and-t-plus-1",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1}),
+        str(
+            {
+                name: (lockset_display(o0[name]), lockset_display(o1[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-split-at-t-and-t-plus-1",
+        split0["A"] == "fail"
+        and split0["B"] == "fail"
+        and split0["C"] == "fail"
+        and split0["D"] == "fail"
+        and split1["A"] == "hold"
+        and split1["B"] == "hold"
+        and split1["C"] == "hold"
+        and split1["D"] == "fail"
+        and cover0["A"] == "fail"
+        and cover0["B"] == "fail"
+        and cover0["C"] == "fail"
+        and cover0["D"] == "fail"
+        and cover1["A"] == "hold"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "fail"
+        and two_one0["A"] == "fail"
+        and two_one1["D"] == "fail"
+        and split0["A"] != UNDEFINED
+        and split1["D"] != UNDEFINED,
+        str(
+            {
+                name: (split0[name], split1[name])
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-empty-O-at-t-fails-split",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and axis_split(m0["A"], o0["A"]) == "fail"
+        and axis_split(frozenset({NEG_E1}), frozenset()) == "fail"
+        and o0["A"] != UNDEFINED,
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"],
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((0, 2, 0), (0, 1, -1))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 2
+        and unique_letter(o1["A"]) == UNDEFINED
+        and isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and isinstance(m1["D"], frozenset)
+        and len(m1["D"]) == 1
+        and split1["D"] == "fail"
+        and split1["A"] == "hold"
+        and cover1["D"] == "fail",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and m0["A"] == frozenset({NEG_E1})
+        and m1["A"] == frozenset({NEG_E1}),
+    )
+    checks.check(
+        "theorem2-reverse-at-t-fail-and-t-plus-1-hold",
+        reverse0 == "fail"
+        and reverse1 == "hold"
+        and split0["A"] == "fail"
+        and split0["B"] == "fail"
+        and split1["A"] == "hold"
+        and split1["B"] == "hold"
+        and reverse0 != UNDEFINED
+        and reverse1 != "fail",
+    )
+    checks.check(
+        "theorem2-face-at-t-and-t-plus-1-fail",
+        face0 == "fail"
+        and face1 == "fail"
+        and split0["C"] == "fail"
+        and split0["D"] == "fail"
+        and split1["C"] == "hold"
+        and split1["D"] == "fail"
+        and face0 != UNDEFINED
+        and face1 != "hold",
+    )
+    checks.check(
+        "theorem3-composition-fail",
+        composition == "fail"
+        and split0["A"] != split1["A"]
+        and split0["B"] != split1["B"]
+        and split0["C"] != split1["C"]
+        and split0["D"] == split1["D"]
+        and split0["A"] != UNDEFINED
+        and split1["D"] != UNDEFINED,
+    )
+    checks.check(
+        "composition-is-split-equality-not-M-sets",
+        composition == "fail"
+        and m_composition == "HOLD"
+        and m0["A"] == m1["A"]
+        and m0["D"] == m1["D"]
+        and composition != m_composition
+        and composition_report(frozen_split, changed_split) == "fail"
+        and m_composition_report(m0, m1) == "HOLD",
+    )
+    checks.check(
+        "composition-is-not-reverse-face-bits",
+        composition == "fail"
+        and bit_composition == "fail"
+        and reverse0 != reverse1
+        and face0 == face1
+        and bit_composition_report("fail", "fail", "fail", "fail") == "HOLD"
+        and bit_composition_report("fail", "hold", "fail", "fail") == "fail",
+    )
+    checks.check(
+        "two-in-one-out-is-fail-not-undefined",
+        two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and two_one1["D"] == "fail"
+        and cover1["D"] == "fail"
+        and split1["D"] == "fail"
+        and split1["D"] != UNDEFINED
+        and face1 == "fail"
+        and face1 != UNDEFINED,
+    )
+    checks.check(
+        "d-is-one-in-one-out-not-cover",
+        cover1["D"] == "fail"
+        and two_one1["D"] == "fail"
+        and split1["D"] == "fail"
+        and axis_card(axis_m1["D"]) == "1"
+        and axis_card(axis_o1["D"]) == "1"
+        and lx1["D"] == frozenset({E2}),
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and one_cover["D"] == "hold"
+        and one_cover_face == "hold"
+        and one_split["D"] == "fail"
+        and one_split_face == "fail"
+        and cover1["D"] == "fail"
+        and cover_face1 == "fail"
+        and face1 == "fail"
+        and one_cover_face != cover_face1
+        and one_m1["D"] != m1["D"]
+        and one_o1["A"] != o1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse1 == "fail"
+        and leftover_face1 == "fail"
+        and lx1["A"] == frozenset()
+        and lx1["B"] == frozenset()
+        and lx1["C"] == frozenset()
+        and lx1["D"] == frozenset({E2})
+        and reverse1 == "hold"
+        and face1 == "fail"
+        and leftover_reverse1 != reverse1,
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse0 == "hold"
+        and m_exist_reverse1 == "hold"
+        and m_exist_face0 == "fail"
+        and m_exist_face1 == "fail"
+        and o_exist_reverse0 == UNDEFINED
+        and o_exist_face0 == UNDEFINED
+        and o_exist_reverse1 == "hold"
+        and o_exist_face1 == "hold"
+        and reverse0 == "fail"
+        and reverse1 == "hold"
+        and face0 == "fail"
+        and face1 == "fail"
+        and m_exist_reverse0 != reverse0
+        and o_exist_face1 != face1,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["D"]) == frozenset({NEG_E3})
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_split_a1 == UNDEFINED
+        and split1["A"] == "hold"
+        and split1["D"] == "fail",
+    )
+    checks.check(
+        "mutation-empty-plus-undefined",
+        axis_split(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_split(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and reverse0 == "fail"
+        and reverse1 == "hold",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(m1["D"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E1
+        and sum_of_set(m1["D"]) == NEG_E3
+        and sum_of_set(o1["A"]) == add(E2, NEG_E3)
+        and sum_of_set(o1["D"]) == ZERO
+        and axis_m1["D"] == frozenset({E3}),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E1 in m1["A"]
+        and NEG_E1 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and o0["A"] != m0["A"]
+        and axis_m1["A"] != axis_o1["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2}
+        and PAIR2 not in one_seeds
+        and one_ticks[PAIR2] == 1
+        and one_locks[PAIR2] == {E3}
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    x_m1 = {
+        name: incoming_set(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if X_PROBES[name] in ticks
+    }
+    perp_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            perp_ticks[PROBES[name]] + 1,
+            perp_ticks,
+            perp_locks,
+            perp_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in perp_ticks
+    }
+    same_m_a = incoming_set(
+        PROBES["A"],
+        same_ticks[PROBES["A"]] + 1,
+        same_ticks,
+        same_locks,
+        same_seeds,
+    )
+    zsym_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            zsym_ticks[PROBES[name]] + 1,
+            zsym_ticks,
+            zsym_locks,
+            zsym_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in zsym_ticks
+    }
+    ysym_ticks_count0 = sum(time == 0 for time in ysym_ticks.values())
+    checks.check(
+        "not-x-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and x_m1["A"] != m1["A"]
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse1 == "hold",
+    )
+    checks.check(
+        "not-same-lock-two-site-seed",
+        TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and same_m_a == frozenset({E1})
+        and m1["A"] == frozenset({NEG_E1})
+        and same_m_a != m1["A"],
+    )
+    checks.check(
+        "not-one-axis-or-y-symmetric-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and ysym_ticks_count0 == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-at-two-cuts",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ0) = {−e_1}" in note
+        and "M(B, τ0) = {+e_1}" in note
+        and "M(C, τ0) = {+e_2}" in note
+        and "M(D, τ0) = {−e_3}" in note
+        and "M(A, τ1) = {−e_1}" in note
+        and "M(B, τ1) = {+e_1}" in note
+        and "M(C, τ1) = {+e_2}" in note
+        and "M(D, τ1) = {−e_3}" in note
+        and "O(A, τ0) = {}" in note
+        and "O(B, τ0) = {}" in note
+        and "O(C, τ0) = {}" in note
+        and "O(D, τ0) = {−e_1}" in note
+        and "O(A, τ1) = {+e_2, −e_3}" in note
+        and "O(B, τ1) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ1) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ1) = {+e_1, −e_1}" in note
+        and "split(A, τ0) = fail" in note
+        and "split(B, τ0) = fail" in note
+        and "split(C, τ0) = fail" in note
+        and "split(D, τ0) = fail" in note
+        and "split(A, τ1) = hold" in note
+        and "split(B, τ1) = hold" in note
+        and "split(C, τ1) = hold" in note
+        and "split(D, τ1) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-split-reverse-face",
+        "Reverse 1-in 2-out at τ0: fail" in note
+        and "Reverse 1-in 2-out at τ1: hold" in note
+        and "Face 1-in 2-out at τ0: fail" in note
+        and "Face 1-in 2-out at τ1: fail" in note
+        and "Reverse fails at τ0." in note
+        and "Reverse holds at τ1." in note
+        and "Face fails at τ0." in note
+        and "Face fails at τ1." in note,
+    )
+    checks.check(
+        "note-reports-composition-fail",
+        "Composition of split at t versus t+1: fail" in note
+        and "Composition fails." in note
+        and "equality of the four split reports" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-exist-opposite",
+        "not leftover of nmcover axis-cover" in normalized_note
+        and "not leftover of the 1-axis opposite two-site seed" in normalized_note
+        and "2-in 1-out is fail of this object, not UNDEFINED" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "Empty O at t fails split" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-frozen-M-or-bit-composition",
+        "not leftover of frozen-`M` two-tick set equality" in normalized_note
+        and "not leftover of reverse/face-bit composition" in normalized_note
+        and "not leftover of nm2ax12 `t+1`-only split reverse hold" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not leftover of the two-tick lock-count clock composition"
+        in normalized_note
+        or "not reprint the two-tick lock-count clock composition" in normalized_note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse 1-in 2-out at τ1: hold" in note
+        and "Face 1-in 2-out at τ1: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ0(q)=t(q)" in note.replace(" ", "")
+        and "τ1(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_YPROBE_ONE_TWO_SPLIT_TWO_TICK_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "axis_cover" in defined_fns
+        and "axis_split" in defined_fns
+        and "two_in_one_out" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "composition_report" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "split-two-tick-composition-fail",
+        reverse0 == "fail"
+        and reverse1 == "hold"
+        and face0 == "fail"
+        and face1 == "fail"
+        and composition == "fail"
+        and m_composition == "HOLD"
+        and cover_reverse0 == "fail"
+        and cover_reverse1 == "hold"
+        and cover_face0 == "fail"
+        and cover_face1 == "fail"
+        and leftover_reverse1 == "fail"
+        and leftover_face1 == "fail"
+        and split0["A"] == "fail"
+        and split1["A"] == "hold"
+        and split1["D"] == "fail"
+        and two_one1["D"] == "fail"
+        and o_exist_face1 == "hold"
+        and o_exist_reverse0 == UNDEFINED,
+    )
+    _ = (
+        axis_m0,
+        axis_o0,
+        two_one0,
+        unique_split_a1,
+        one_cover_face,
+        one_split_face,
+        tau1,
+        cover_reverse0,
+        cover_face0,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Split two-tick on opposite y-probes: reverse fail at t HOLD at t+1, face fails at both, composition fail. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_yprobe_one_two_split_two_tick_composition_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.