### PR TITLE
feat(nm2splt3z): 1-in 2-out freeze t+1 vs t+2 on two-axis opposite z-probes: reverse HOLD, face HOLD, composition HOLD

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,712 @@
+---
+claim_id: two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "1-in 2-out split at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+---
+
+# One-In Two-Out Split At t+1 Versus t+2 Reverse And Face Composition On Four Z-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** 1-in 2-out split at t+1 versus t+2 on the four z-probes of the
+two-axis opposite seed, reverse/face at each cut, and composition, are
+reported. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py)
+
+Same process and z-probes as nm2axz. Let `t(q)` be the formation tick of
+probe `q`. Cuts are `τ1=t+1` and `τ2=t+2`. There is no global T.
+Do not score τ=t. `M(q,τ)` is the set of earliest incoming nearest-neighbor
+steps at `q` using only records with tick `<= τ`. Seeds are a singleton seed
+letter. `O(q,τ)` is the outgoing dual of `M`: the set of `e` in
+`{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in `M(q+e,τ)`.
+Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Axis of
+a defined lock set `S` is `Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at
+`q` if and only if `Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union
+`Axis(O)` equals `{e_1,e_2,e_3}`. `UNDEFINED` if `M` or `O` is
+`UNDEFINED`. Else fail. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). Empty O at t fails split as leftover of
+nm2splt2z and is not scored here. 2-in 1-out is fail of this object, not
+UNDEFINED. Reverse HOLDs if and only if split HOLDs at `A` and at `B` at
+that cut. Face HOLDs if and only if split HOLDs at `C` and at `D` at that
+cut. Composition HOLDs if and only if split at `τ1` equals split at `τ2` at
+`A`, `B`, `C`, and `D`. This is not leftover of nm2ax12z, which scores only
+`τ=t+1`. This is not leftover of nm2splt2z, which scores `τ=t` versus
+`t+1` from empty `O` at `t` and composition fail. This is not leftover of
+nmcover axis-cover. This is not leftover of nm2axz axis-cover. This is not
+leftover of leftover-of-`M` alone. This is not leftover of leftover-of-`O`
+alone. This is not leftover-empty fail of leftover axis. This is not leftover
+of nmunopp union. This is not leftover of nmt2opp `M` frozen at `t`. This
+is not leftover of nmot2opp two-tick composition of empty-then-HOLD `O`.
+This is not leftover of nmoutopp untimed eventual-`O`. This is not leftover
+of mixed #7188 fail/fail. This is not leftover of the 1-axis opposite
+two-site seed. This is not leftover of the same-lock two-site seed. This is
+not leftover of reverse/face bit composition as a substitute for the four
+split bits. This is not leftover of 2-in 1-out composition, which HOLDs
+here because 2-in 1-out fails at both cuts. This is not leftover of cover
+composition, which also HOLDs here without `|Axis(M)|=1`. The second pair
+is a new seed, not a formed child. Uniqueness is not required. Mixed remains
+a set. Displayed, not adopted. Do not write into Admissibility. Do not
+attach L1.
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on
+`B_3(0)={n:n·n<=9}` and the four named z-probes. Incoming lock letters are
+unit nearest-neighbor steps. `O` is the outgoing dual of those incoming
+sets at the per-probe cuts `τ1=t+1` and `τ2=t+2`. Axis is the unsigned
+lattice direction of a signed lock. Cover is the complementary occupation
+of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`. Split is cover together with
+`|Axis(M)|=1`. Reverse and face are scored on split HOLD at the paired
+probes at each cut. Composition is equality of the four split bits across
+the two cuts. Named signs `{+,−}` are a coarser readout and are not used.
+A singleton unique lock letter is a different readout and is not used as
+the object. Existential opposite of signed locks is a different readout
+and is not used as the split reverse. Axis-cover without the one-axis
+incoming cardinality is a different readout and is not used.
+Leftover-empty fail of unsigned leftover axis sets is a different readout
+and is not used. A `Z^3` sum of those locks is a different readout and is
+not used. Occupancy of sites is not used. A six-neighbor star is not the
+letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of 1-in 2-out split of M and O at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, HOLDING 3-split freeze with reverse hold, face hold, and composition hold; uniqueness of incoming locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face
+target_blocker_text: "display 1-in 2-out split at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition, not nm2splt2z t versus t+1, not cover, not exist-opposite"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep 1-in 2-out split at t+1 versus t+2 displayed; do not write split into Admissibility, do not score tau=t, do not reduce to cover, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace split by existential opposite of signed locks, do not replace composition by reverse/face bit stability, do not replace composition by 2-in 1-out composition, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for 1-in 2-out split at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose 1-in
+2-out axis split of `M` and `O` is scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (1,0,1).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the second opposite pair. Same process and
+z-probes as nm2axz.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named 1-in 2-out split of `M` and `O` at `τ1=t+1` and `τ2=t+2`
+
+Let `t(q)` be the formation tick of z-probe `q` when that tick is defined in
+`B_3(0)`. Cuts are `τ1=t+1` and `τ2=t+2`. There is no global T.
+Do not score τ=t.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `M` or `O` to be a singleton. It does not sum either set. It
+does not replace `O` by `M`. It does not wait for a global later T.
+Occupancy of sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at a cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+If `q` is unformed at that cut, then cover is `UNDEFINED`. Overlapping axes
+fail. Incomplete union fails. Axis is unsigned: `+e_i` and `−e_i` occupy
+the same axis.
+
+Split at a probe at a cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+Empty O at t fails split as leftover of nm2splt2z and is not scored here.
+2-in 1-out is fail of this object, not UNDEFINED: cover HOLD with
+`|Axis(M)|=2` (hence `|Axis(O)|=1`) is split fail. Cover without the
+one-axis incoming cardinality is not this object. Unique letters are not
+this object. One-in one-out with leftover axis is cover fail and therefore
+split fail.
+
+Reverse 1-in 2-out at a cut holds if and only if split HOLDs at `A` and at
+`B` at that cut. Face 1-in 2-out at a cut holds if and only if split HOLDs
+at `C` and at `D` at that cut. Either side `UNDEFINED` is `UNDEFINED`. Else
+if both sides HOLD, reverse or face HOLDs. Else fail.
+
+Composition HOLDs if and only if split at `τ1` equals split at `τ2` at
+`A`, `B`, `C`, and `D`. Else fail. Reverse/face bit stability is a leftover
+predicate and is not this composition. 2-in 1-out composition is a leftover
+predicate and is not this composition. Cover composition is a leftover
+predicate and is not this composition.
+
+Identifying a named sign of those locks with reverse or face is refused:
+named-sign lettering lost the axis. Identifying leftover-empty fail with
+split reverse is refused: leftover-empty fail scores empty leftover as
+fail. Identifying axis-cover reverse/face of the 1-axis opposite two-site
+seed with this reverse/face is refused. Identifying nm2ax12z split reverse
+hold and face hold at `t+1` only with this freeze is refused: that leftover
+does not score `τ=t+2`. Identifying nm2splt2z composition fail at `t`
+versus `t+1` with this freeze is refused: Do not score τ=t. Identifying
+exist-opposite of signed `O` with split reverse is refused: exist-opposite
+face of signed `O` fails while split face HOLDs.
+
+## Theorem 1 — ticks, `M`, `O`, and split at `τ1=t+1` and `τ2=t+2`
+
+On this process the four z-probes form. Compare to the 1-axis opposite
+two-site seed: that member forms `A` at tick 1 as a child locking `+e_3`,
+forms `B` at tick 2, forms `C` at tick 4 with mixed 2-in 1-out `M` at
+`t+1`, and forms `D` at tick 2. Here the second pair is a new seed, not a
+formed child, so `(0,0,1)` is already recorded at tick 0 with lock `+e_2`
+and `(0,1,1)` is already recorded at tick 0 with lock `−e_2`. This display
+reads the 1-in 2-out split of timed `M` and `O` at `τ1=t+1` and `τ2=t+2`.
+Do not score τ=t.
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=1
+M(A, τ1) = {+e_2}
+M(B, τ1) = {+e_1}
+M(C, τ1) = {+e_3}
+M(D, τ1) = {+e_1}
+M(A, τ2) = {+e_2}
+M(B, τ2) = {+e_1}
+M(C, τ2) = {+e_3}
+M(D, τ2) = {+e_1}
+O(A, τ1) = {+e_1, −e_1, +e_3}
+O(B, τ1) = {+e_2, +e_3, −e_3}
+O(C, τ1) = {+e_1, −e_1, −e_2}
+O(D, τ1) = {−e_2, +e_3, −e_3}
+O(A, τ2) = {+e_1, −e_1, +e_3}
+O(B, τ2) = {+e_2, +e_3, −e_3}
+O(C, τ2) = {+e_1, −e_1, −e_2}
+O(D, τ2) = {−e_2, +e_3, −e_3}
+Axis(M)(A, τ2) = {e_2}
+Axis(O)(A, τ2) = {e_1, e_3}
+Axis(M)(B, τ2) = {e_1}
+Axis(O)(B, τ2) = {e_2, e_3}
+Axis(M)(C, τ2) = {e_3}
+Axis(O)(C, τ2) = {e_1, e_2}
+Axis(M)(D, τ2) = {e_1}
+Axis(O)(D, τ2) = {e_2, e_3}
+|Axis(M)|(A, τ2) = 1
+|Axis(O)|(A, τ2) = 2
+|Axis(M)|(B, τ2) = 1
+|Axis(O)|(B, τ2) = 2
+|Axis(M)|(C, τ2) = 1
+|Axis(O)|(C, τ2) = 2
+|Axis(M)|(D, τ2) = 1
+|Axis(O)|(D, τ2) = 2
+cover(A, τ1) = hold
+cover(B, τ1) = hold
+cover(C, τ1) = hold
+cover(D, τ1) = hold
+cover(A, τ2) = hold
+cover(B, τ2) = hold
+cover(C, τ2) = hold
+cover(D, τ2) = hold
+split(A, τ1) = hold
+split(B, τ1) = hold
+split(C, τ1) = hold
+split(D, τ1) = hold
+split(A, τ2) = hold
+split(B, τ2) = hold
+split(C, τ2) = hold
+split(D, τ2) = hold
+```
+
+`A` is a seed at tick 0 with seed letter `+e_2`. `M` is frozen from `t+1`
+to `t+2` at each probe. `O` is nonempty at `τ1` and frozen equal at `τ2`.
+Mixed remains a set: `O(A,τ1)` has three outgoing steps and `O(D,τ1)` has
+three outgoing steps. Unique letters would assign `UNDEFINED` at mixed `O`.
+Here uniqueness is not required. At each probe at both cuts, `Axis(M)` and
+`Axis(O)` are complementary: their union is `{e_1,e_2,e_3}` and their
+intersection is empty. Cover therefore HOLDs at each probe at both cuts,
+and split HOLDs because `|Axis(M)|=1`. 2-in 1-out is fail of this object,
+not UNDEFINED; that identity remains, and it is not the report at any of
+these four probes at either cut. Leftover of the union is empty at each
+probe at both cuts; leftover-empty fail of that leftover is not this
+object. O is not M.
+
+Investment nm2axz cover on these four z-probes at `t+1`: cover HOLDs at
+every probe. Investment nm2ax12z split on these four z-probes at `t+1`:
+split HOLDs at every probe, reverse hold, face hold. Those leftovers do not
+score `τ=t+2`. Investment nm2splt2z composition of split at `t` versus
+`t+1` fails from empty `O` at `t`. Do not score τ=t. This note is the
+first display of split at `t+1` versus `t+2` now that `O` is nonempty. The
+HOLDING 3-split freezes.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` at `τ1` and do not enter earliest `M`. Site
+`(0,1,1)` is a seed, so it is not a new 6-NN of `A`. Between `t+1` and
+`t+2` a new 6-NN of `A` forms at `(0,-1,1)` with incoming `{+e_3}`. The
+step from `A` to that site is `−e_2`, which is not in that incoming set,
+so the new neighbor does not enter `O`. `O` therefore freezes.
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)
+new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)
+new 6-NN of A at t(A)+2: (0, -1, 1)
+new 6-NN of B at t(B)+2: none
+new 6-NN of C at t(C)+2: none
+new 6-NN of D at t(D)+2: none
+```
+
+## Theorem 2 — reverse and face at `τ1` and at `τ2`
+
+Reverse 1-in 2-out holds if and only if split HOLDs at `A` and at `B` at
+that cut. Face 1-in 2-out holds if and only if split HOLDs at `C` and at
+`D` at that cut.
+
+Reverse 1-in 2-out at τ1: hold
+Reverse 1-in 2-out at τ2: hold
+Face 1-in 2-out at τ1: hold
+Face 1-in 2-out at τ2: hold
+
+At `τ1` every split HOLDs from nonempty complementary `O`, so reverse
+HOLDs and face HOLDs. At `τ2` the same four split bits HOLD, so reverse
+HOLDs and face HOLDs. Cover reverse and cover face HOLD at both cuts.
+Leftover-empty reverse fails at both cuts because leftover of the union is
+empty. Leftover of `M` reverse fails because leftover of `M` at `A` is
+`{e_1, e_3}` and at `B` is `{e_2, e_3}`: nonempty and unequal. Leftover of
+`O` reverse fails because leftover of `O` at `A` is `{e_2}` and at `B` is
+`{e_1}`: nonempty and unequal. Exist-opposite reverse of signed `M` fails.
+Exist-opposite reverse of signed `O` holds at both cuts. Exist-opposite
+face of signed `O` fails. Those leftovers are not this display.
+
+Leftover of nm2splt2z at `τ=t` is reverse fail and face fail from empty
+`O`. Do not score τ=t.
+
+The four y-probes of this same seed give split reverse hold and split face
+fail at `t+1` and the same bits at `t+2`. The four x-probes give split
+reverse fail and split face fail at both cuts. Those probe-direction
+readouts are not this z-probe display.
+
+## Theorem 3 — composition hold / fail
+
+Composition HOLDs if and only if split at `τ1` equals split at `τ2` at
+`A`, `B`, `C`, and `D`. Each probe reports hold at `τ1` and hold at `τ2`.
+The bits are equal. Composition holds.
+
+Composition of split bits: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Reverse/face bit composition also HOLDs on this member because reverse
+stays hold and face stays hold. That leftover is not this letter:
+composition is equality of the four split bits, not equality of the two
+reverse/face bits. 2-in 1-out composition HOLDs because 2-in 1-out fails at
+both cuts at every probe. Cover composition HOLDs because cover HOLDs at
+both cuts; cover without `|Axis(M)|=1` is not this object. Frozen `M` is
+equal at the two cuts and is not this composition. Frozen `O` is equal at
+the two cuts and is not this composition by itself: the letter is 1-in
+2-out split of `M` and `O`. nmot2opp scores exist-opposite of `O`.
+nm2ax12z scores only `t+1`. nm2splt2z scores `t` versus `t+1` with
+composition fail from empty `O` at `t`. Mixed #7188 two-tick composition
+reported fail/fail with composition HOLD. This member reports hold then
+hold, with composition hold. This is not the two-tick lock-count clock
+composition.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover HOLDs at `D` at both cuts and split HOLDs at `D`
+at both cuts.
+
+Composition holds.
+
+## What this note does not claim
+
+- It does not select a unique incoming, outgoing, or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require split sides to be singletons.
+- It does not sum either set.
+- It does not replace split by leftover-empty fail.
+- It does not replace split by leftover of `M` alone.
+- It does not replace split by leftover of `O` alone.
+- It does not replace split by existential opposite of signed locks.
+- It does not replace split by axis-cover without `|Axis(M)|=1`.
+- It does not treat 2-in 1-out as `UNDEFINED`.
+- It does not score `τ=t`.
+- It does not treat empty `O` at `t` as this letter.
+- It does not replace `O` by `M`.
+- It does not replace split by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  split display.
+- It does not reprint nm2axz axis-cover reverse hold face hold as this
+  split display.
+- It does not reprint nm2ax12z 1-in 2-out at `t+1` only as this freeze.
+- It does not reprint nm2splt2z composition fail at `t` versus `t+1`.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this split display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not replace composition by reverse/face bit stability.
+- It does not replace composition by 2-in 1-out composition.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite seed process, 1-in 2-out split of `M` and `O` at `t+1`
+versus `t+2`, reverse/face at each cut, and composition of those split bits
+are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `1` |
+| `M` at `τ1=t+1` and `τ2=t+2` | Theorem 1; frozen equal |
+| `O` at `τ1=t+1` | Theorem 1; HOLDING outgoing dual |
+| `O` at `τ2=t+2` | Theorem 1; frozen equal to `τ1` |
+| split at `τ1` | Theorem 1; HOLD at each probe |
+| split at `τ2` | Theorem 1; HOLD at each probe; freeze |
+| reverse at `τ1` and at `τ2` | Theorem 2; hold then hold |
+| face at `τ1` and at `τ2` | Theorem 2; hold then hold |
+| composition of split bits | Theorem 3; hold |
+| unique incoming lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this split display |
+| leftover of exist-opposite HOLD | not this split display |
+| leftover of nmcover axis-cover HOLD | not this split display |
+| leftover of nm2axz axis-cover HOLD | not this split display |
+| leftover of nm2ax12z `t+1` only | not this freeze |
+| leftover of nm2splt2z `t` versus `t+1` | not this freeze; Do not score τ=t |
+| y-probe or x-probe split on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| leftover of reverse/face bit composition | not this display |
+| leftover of 2-in 1-out composition | not this display; that leftover HOLDs |
+| leftover of cover composition | not this display; that leftover HOLDs |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display |
+| 2-in 1-out scored as `UNDEFINED` | refused; fail of this object |
+| empty `O` at `t` as this letter | refused; Do not score τ=t |
+| global later T | not used |
+| 1-in 2-out split as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: 1-in 2-out split at `t+1` versus `t+2` on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition. |
+| V2 | Current main has no landed 1-in 2-out split at `t+1` versus `t+2` reverse/face composition on these four z-probes of the two-axis opposite seed. |
+| V3 | Split reports at two cuts, the four reverse/face bits, and composition are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads unsigned 1-in 2-out split of own incoming and own outgoing at `t+1` and at `t+2` and scores composition as equality of those four split bits. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace split by leftover-empty fail, does not
+replace split by leftover of `M` alone or leftover of `O` alone, does not
+replace split by existential opposite of signed locks, does not replace
+split by nmcover axis-cover, does not replace split by nm2axz axis-cover,
+does not replace this freeze by nm2ax12z at `t+1` only, does not replace
+this freeze by nm2splt2z at `t` versus `t+1`, does not identify this
+display with the 1-axis opposite two-site seed, and does not identify it
+with nmunopp union. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2splt2z `t` versus `t+1` | reuse composition fail from empty `O` at `t` | Do not score τ=t; here `O` is nonempty and the HOLDING 3-split freezes | ATTEMPTED |
+| nm2ax12z `t+1` only | reuse split reverse hold and face hold at `t+1` | that leftover does not score `τ=t+2`; here freeze of those bits is the letter | ATTEMPTED |
+| nmcover axis-cover | score reverse/face as cover HOLD | on the 1-axis opposite two-site seed cover HOLDs at every z-probe at `t+1` so cover face HOLDs, while split face fails at `C` from 2-in 1-out; cover without `|Axis(M)|=1` is not this object | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse hold and cover face hold on these z-probes | cover HOLDs at `t+1` and split HOLDs at `t+1` because `|Axis(M)|=1`; 2-in 1-out remains cover HOLD and split fail on the 1-axis z-probes; neither leftover scores freeze at `t+2` as this 1-in 2-out object | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover of the union is empty at each probe at both cuts, leftover reverse and face fail, while split reverse and face HOLD | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_3}` and at `B` is `{e_2,e_3}`, nonempty unequal, reverse would fail | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is `{e_2}` and at `B` is `{e_1}`, nonempty unequal, reverse would fail | ATTEMPTED |
+| exist-opposite | reuse signed reverse/face of `O` | exist-opposite face of signed `O` fails while split face HOLDs | ATTEMPTED |
+| reverse/face bit composition | score composition on reverse/face bits | those bits also freeze here, but the letter is equality of the four split bits | ATTEMPTED |
+| 2-in 1-out composition | score composition on 2-in 1-out bits | 2-in 1-out fails at both cuts, so that leftover HOLDs; it is not 1-in 2-out | ATTEMPTED |
+| cover composition | score composition on cover bits | cover also freezes; cover without `|Axis(M)|=1` is not this object | ATTEMPTED |
+| nmot2opp `O` two-tick | reuse exist-opposite of `O` at `t` versus `t+1` | empty then HOLD `O` with `UNDEFINED` then hold is not HOLDING split freeze | ATTEMPTED |
+| nmt2opp `M` two-tick | reuse frozen `M` | `M` is frozen; this letter is split of `M` and `O` | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; split is unsigned 1-in 2-out of `M` and `O` | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(A,τ1)` remains a set; split still HOLDs at both cuts | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | 2-in 1-out is fail of this object, not UNDEFINED; none of these four probes is 2-in 1-out | ATTEMPTED |
+| empty `O` as this letter | treat empty outgoing at `t` as the freeze | Do not score τ=t; empty O at t fails split as leftover of nm2splt2z | ATTEMPTED |
+| new 6-NN enters `O` | treat `(0,-1,1)` as a new outgoing of `A` at `t+2` | that neighbor locks `{+e_3}`; step `−e_2` from `A` is not in its incoming set | ATTEMPTED |
+| letter intersection as split | score reverse/face inside `M ∩ O` | letter intersection empty is not 1-in 2-out; opposite signs can share an axis | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(A)=1`, `t(C)=4`, mixed `M(C)`, split fail at `C` | different seed; second pair is a new seed, not a formed child; here `t(A)=0` and split HOLDs at `C` at both cuts | ATTEMPTED |
+| y-probe split | score the four y-probes on this seed | y-probe face fails at `D`; this letter is the four z-probes | ATTEMPTED |
+| x-probe split | score the four x-probes on this seed | x-probe reverse fails at `A`; this letter is the four z-probes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores 1-in 2-out of own incoming and outgoing at `t+1` versus `t+2` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports hold then hold, with composition hold | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace split by a `Z^3` sum | the construction does not sum; split is cover plus `|Axis(M)|=1` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | cuts are `τ1=t+1` and `τ2=t+2` per probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by 1-in 2-out split | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of split with leftover of
+`M` alone, missing identification of split with leftover-empty fail, missing
+identification of split with existential opposite of signed locks, missing
+identification of split with nmcover axis-cover, missing identification of
+split with nm2axz axis-cover, missing identification of this freeze with
+nm2ax12z at `t+1` only, missing identification of this freeze with
+nm2splt2z at `t` versus `t+1`, missing identification of this seed with the
+1-axis opposite two-site seed, and missing Record identification of split
+reverse are distinct open premises. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe cuts
+`τ1=t+1` and `τ2=t+2`, unsigned axis, cover as complementary occupation of
+`{e_1,e_2,e_3}`, split as cover and `|Axis(M)|=1`, Do not score τ=t,
+2-in 1-out as fail not `UNDEFINED`, four z-probes with seed `A`,
+second pair as a new seed not a formed child, mixed remains a set, and
+composition as equality of the four split bits are declared. No uniqueness
+of incoming locks, no six-neighbor lock union as the scored object, no
+lock-count clock, no global later T, no formation attachment from
+already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+split `hold` reports and composition hold do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | each unsigned lattice axis among `{e_1,e_2,e_3}` | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four split reports at t+1 and at t+2 plus reverse/face/composition | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for split reverse/face, a
+formation-rate rule, and a physical selector among 1-in 2-out axes. None
+is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** New 6-NN of `A` at `t+2` must enter `O`, so freeze fails;
+empty `O` at `t` is the letter; composition of reverse/face bits is the
+letter; cover freeze is this letter; 2-in 1-out composition HOLD means
+split composition HOLD; nm2ax12z already displayed split reverse hold and
+face hold; nm2splt2z already displayed two-tick composition; leftover of
+`M` alone already answers reverse; and exist-opposite already answers
+reverse.
+
+**Answer:** The new 6-NN `(0,-1,1)` locks `{+e_3}`; the step from `A` is
+`−e_2`, which is not in that incoming set, so it does not enter `O`. `O`
+is frozen. Do not score τ=t. Empty O at t fails split as leftover of
+nm2splt2z. Split bits stay hold at each of `A`, `B`, `C`, and `D`, so
+composition of those four bits HOLDs. Reverse/face bit composition also
+HOLDs on this member, but it is a leftover predicate. Cover also freezes,
+but cover without `|Axis(M)|=1` is not this object. 2-in 1-out fails at
+both cuts, so 2-in 1-out composition HOLDs as a leftover. nm2ax12z scores
+only `t+1`. nm2splt2z scores `t` versus `t+1` with composition fail.
+Leftover of `M` alone at `A` is `{e_1,e_3}` and at `B` is `{e_2,e_3}`:
+nonempty unequal, so leftover-of-`M` reverse fails while split reverse
+HOLDs. Exist-opposite face of signed `O` fails while split face HOLDs.
+Reverse 1-in 2-out is HOLD iff split at `A` and at `B` at that cut, not
+leftover of nm2ax12z or nm2splt2z.
+
+### N8 — cross-cycle echo
+
+nsmopp #7208 reported reverse hold and face hold from own incoming `M` on
+the 1-axis opposite two-site seed. nmcover axis-cover on that seed reported
+cover HOLD at each of the four z-probes, reverse hold, and face hold, with
+split face fail from 2-in 1-out at `C`. nm2axz cover on this two-axis seed
+reported cover HOLD at each of the four z-probes, reverse hold, and face
+hold, with `|Axis(M)|=1` at each probe. nm2ax12z reported 1-in 2-out split
+HOLD at `t+1` on these four z-probes, reverse hold, and face hold, without
+scoring `τ=t+2`. nm2splt2z reported 1-in 2-out split fail at `t` from empty
+`O` and HOLD at `t+1`, reverse fail then hold, face fail then hold, and
+composition fail. The four y-probes of this same seed reported split reverse
+hold and split face fail at `t+1`, frozen at `t+2`. nmot2opp reported empty
+then HOLD `O` with exist-opposite `UNDEFINED` then hold. This note is not
+those displays: it reports 1-in 2-out split at `t+1` versus `t+2` on the
+two-axis opposite seed, with `t(A)=0`, `t(B)=1`, `t(C)=1`, and `t(D)=1`,
+split HOLD at `τ1`, split HOLD at `τ2`, reverse hold then hold, face hold
+then hold, and composition hold. Do not score τ=t.
+
+**Gate disposition:** PASS for the 1-in 2-out `t+1` versus `t+2` reverse/face
+and composition reports above. FAIL / DO NOT SHIP for “the predicate equals
+the named sign,” “the predicate equals the unique singleton lock vector,”
+“the predicate equals six-neighbor lock union,” “the predicate equals
+leftover-empty fail,” “the predicate equals leftover of `M` alone,” “the
+predicate equals leftover of `O` alone,” “the predicate equals
+exist-opposite HOLD,” “the predicate equals nmcover axis-cover HOLD,” “the
+predicate equals nm2axz axis-cover HOLD,” “the predicate equals nm2ax12z
+at `t+1` only,” “the predicate equals nm2splt2z at `t` versus `t+1`,”
+“the predicate equals the 1-axis opposite two-site seed,” “the predicate
+equals nmunopp union,” “the predicate equals 2-in 1-out composition HOLD,”
+“bits are Admissibility,” “2-in 1-out is UNDEFINED,” “score `τ=t`,”
+“composition fail,” or “split fails at `τ2`.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1` and
+at that probe's `t+2`, reports unsigned axis of each, reports cover of the
+pair, reports `|Axis(M)|` and the 1-in 2-out split at each cut, lists new
+records in `B_3(0)` between `t` and `t+1` and between `t+1` and `t+2` that
+meet a probe's six-neighbors, reports reverse and face at each cut, reports
+composition of the four split bits, and checks Theorems 1--3. It also
+checks that Do not score τ=t, that leftover empty O at t fails split and
+makes nm2splt2z composition fail, that split HOLDs at `A`, `B`, `C`, and
+`D` at `t+1` and at `t+2`, that 2-in 1-out is fail not `UNDEFINED`, that
+2-in 1-out composition HOLDs as a leftover, that the 1-axis opposite
+two-site seed is a different member with split face fail at `C`, that
+leftover-empty fail is a different reverse and face, that leftover of `M`
+alone and leftover of `O` alone are different objects, that mixed sets
+remain sets, that unique-letter split is `UNDEFINED` at mixed `O`, that
+the new 6-NN of `A` at `t+2` does not enter `O`, that the construction does
+not sum, that a formation member from already-recorded six-neighbor locks
+is not attached, that the second pair is a new seed not a formed child,
+that the y-probes and x-probes of this seed are not this letter, and that
+the display is not the two-tick lock-count clock composition. No runner
+cache is written.

--- a/logs/runner-cache/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.txt
@@ -1,0 +1,100 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+runner_sha256: b4096a858d9535486fb8ee106041a4fbd7cf9c3163b5826ca221002b77276496
+input_fingerprint_sha256: 57db852cf56f1e333fc47c406e8e83a4588b14c8538f7a4af609d17258c8aa72
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+1-in 2-out split at t+1 versus t+2 reverse/face composition on two-axis opposite z-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: 1-in 2-out split at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: axis-identity
+PASS: cover-identity
+PASS: split-identity
+PASS: pair-bit-identity
+PASS: composition-identity
+PASS: leftover-empty-fail-contrast
+A t=0 τ1=1 M1={+e_2} O1={+e_1, −e_1, +e_3} cover1=hold split1=hold τ2=2 M2={+e_2} O2={+e_1, −e_1, +e_3} Axis(M)={e_2} Axis(O)={e_1, e_3} |Axis(M)|=1 |Axis(O)|=2 cover2=hold split2=hold
+B t=1 τ1=2 M1={+e_1} O1={+e_2, +e_3, −e_3} cover1=hold split1=hold τ2=3 M2={+e_1} O2={+e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} |Axis(M)|=1 |Axis(O)|=2 cover2=hold split2=hold
+C t=1 τ1=2 M1={+e_3} O1={+e_1, −e_1, −e_2} cover1=hold split1=hold τ2=3 M2={+e_3} O2={+e_1, −e_1, −e_2} Axis(M)={e_3} Axis(O)={e_1, e_2} |Axis(M)|=1 |Axis(O)|=2 cover2=hold split2=hold
+D t=1 τ1=2 M1={+e_1} O1={−e_2, +e_3, −e_3} cover1=hold split1=hold τ2=3 M2={+e_1} O2={−e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} |Axis(M)|=1 |Axis(O)|=2 cover2=hold split2=hold
+split reverse τ1=hold τ2=hold face τ1=hold τ2=hold
+composition=hold
+cover reverse=hold face=hold
+leftover-empty reverse=fail face=fail
+per_element: each unsigned lattice axis among {e_1,e_2,e_3} occupied by M or by O at a probe's t+1 or t+2
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four split reports at t+1 and at t+2 plus reverse/face/composition
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: incoming-set-seed-singleton
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-at-tau1-and-tau2  ({'A': ('{+e_2}', '{+e_2}'), 'B': ('{+e_1}', '{+e_1}'), 'C': ('{+e_3}', '{+e_3}'), 'D': ('{+e_1}', '{+e_1}')})
+PASS: theorem1-O-frozen-at-tau1-and-tau2  ({'A': ('{+e_1, −e_1, +e_3}', '{+e_1, −e_1, +e_3}'), 'B': ('{+e_2, +e_3, −e_3}', '{+e_2, +e_3, −e_3}'), 'C': ('{+e_1, −e_1, −e_2}', '{+e_1, −e_1, −e_2}'), 'D': ('{−e_2, +e_3, −e_3}', '{−e_2, +e_3, −e_3}')})
+PASS: theorem1-Axis-M-and-O  ({'A': ('{e_2}', '{e_1, e_3}'), 'B': ('{e_1}', '{e_2, e_3}'), 'C': ('{e_3}', '{e_1, e_2}'), 'D': ('{e_1}', '{e_2, e_3}')})
+PASS: theorem1-cover-and-axis-card  ({'A': ('hold', 'hold', '1', '2'), 'B': ('hold', 'hold', '1', '2'), 'C': ('hold', 'hold', '1', '2'), 'D': ('hold', 'hold', '1', '2')})
+PASS: theorem1-split-at-tau1-and-tau2  ({'A': ('hold', 'hold'), 'B': ('hold', 'hold'), 'C': ('hold', 'hold'), 'D': ('hold', 'hold')})
+PASS: leftover-empty-O-at-t-fails-split-not-scored
+PASS: theorem1-M-frozen-from-tplus1
+PASS: theorem1-new-records-meet-6nn  ({'t+1': {'A': ((1, 0, 1), (-1, 0, 1), (0, 0, 2)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 0, 2), (-1, 0, 2), (0, -1, 2)), 'D': ((1, -1, 1), (1, 0, 2), (1, 0, 0))}, 't+2': {'A': ((0, -1, 1),), 'B': (), 'C': (), 'D': ()}})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-and-face-at-each-cut
+PASS: theorem3-composition-hold  ({'composition': 'hold', 'leftover_rf': 'hold', 'two_one': 'hold', 'cover': 'hold', 'leftover_t': 'fail'})
+PASS: two-in-one-out-is-fail-not-undefined
+PASS: d-is-one-in-two-out-cover-and-split
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-alone-differs
+PASS: mutation-leftover-of-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-empty-plus-undefined
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-y-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-two-site-seed
+PASS: not-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-Axis-cover-split
+PASS: note-reports-new-neighbors
+PASS: note-reports-split-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-exist-opposite
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: split-hold-not-leftover-empty
+TOTAL: PASS=67 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py
@@ -1,0 +1,1669 @@
+#!/usr/bin/env python3
+"""1-in 2-out split at t+1 versus t+2 reverse/face composition on two-axis z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites: origin locks +e_1, (0,1,0) locks -e_1, (0,0,1) locks +e_2,
+and (0,1,1) locks -e_2. Two disjoint opposite pairs. Same process and
+z-probes as nm2axz. The second pair is a new seed, not a formed child of the
+first pair. A 6-NN step is allowed iff it is perpendicular to the parent
+lock axis. Newly formed sites lock the incoming step. Seeds keep their seed
+letters as a singleton. t(q) is the formation tick. tau1 = t+1. tau2 = t+2.
+No global T. Do not score tau=t. M(q, tau) is the set of earliest incoming
+nearest-neighbor steps at q using only records with tick <= tau. Unformed
+at tau => UNDEFINED. O(q, tau) is the outgoing dual of M: the set of e in
+{±e_1,±e_2,±e_3} such that q+e is formed and e is in M(q+e, tau). Unformed
+q at tau => UNDEFINED. Empty O is empty, not UNDEFINED. Axis(S) is the
+unsigned lattice directions of signed locks in S. Cover HOLDs at q iff
+Axis(M) intersect Axis(O) is empty and Axis(M) union Axis(O) equals
+{e_1,e_2,e_3}. UNDEFINED if M or O UNDEFINED. Else fail. Split HOLDs at q
+iff cover HOLDs and |Axis(M)|=1 (hence |Axis(O)|=2). Empty O at t fails
+split as leftover of nm2splt2z and is not scored here. 2-in 1-out is fail
+of this object, not UNDEFINED. Reverse HOLDs iff split at A and at B at
+that cut. Face likewise on C, D. Composition HOLDs iff split at tau1
+equals split at tau2 at A, B, C, and D. Uniqueness is not required.
+Occupancy of sites is not used. Named-sign lettering is not used. No
+larger host. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "1-in 2-out split at t+1 versus t+2 on the four z-probes of the "
+    "two-axis opposite seed, reverse/face at each cut, and "
+    "composition, are reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast: {e_1,e_2,e_3} minus Axis(S). Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2).
+
+    2-in 1-out (cover HOLD with |Axis(M)|=2) is fail of this object, not
+    UNDEFINED.
+    """
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2, hence |Axis(O)|=1. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(split_a: str, split_b: str) -> str:
+    """Reverse HOLDs iff split at A and split at B."""
+    return pair_bit(split_a, split_b)
+
+
+def face_report(split_c: str, split_d: str) -> str:
+    """Face HOLDs iff split at C and split at D."""
+    return pair_bit(split_c, split_d)
+
+
+def composition_report(
+    split0_a: str,
+    split1_a: str,
+    split0_b: str,
+    split1_b: str,
+    split0_c: str,
+    split1_c: str,
+    split0_d: str,
+    split1_d: str,
+) -> str:
+    """HOLD iff split bits at tau1 equal bits at tau2 at A, B, C, and D."""
+    if (
+        split0_a == split1_a
+        and split0_b == split1_b
+        and split0_c == split1_c
+        and split0_d == split1_d
+    ):
+        return "hold"
+    return "fail"
+
+
+def leftover_bit_composition(rev0: str, rev1: str, face0: str, face1: str) -> str:
+    """Leftover: score composition on reverse/face bits, not on the four split bits."""
+    if rev0 != rev1 or face0 != face1:
+        return "fail"
+    return "hold"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+    offset: int = 1,
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+offset and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + offset:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("1-in 2-out split at t+1 versus t+2 reverse/face composition on two-axis opposite z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "axis-identity",
+        axis_set(UNDEFINED) == UNDEFINED
+        and axis_set(frozenset({NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E1, NEG_E1})) == frozenset({E1})
+        and axis_set(frozenset({E2, E3, NEG_E3})) == frozenset({E2, E3})
+        and axis_set(frozenset({E1, NEG_E1, E3, NEG_E3})) == frozenset({E1, E3}),
+    )
+    checks.check(
+        "cover-identity",
+        axis_cover(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_cover(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_cover(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset()) == "fail"
+        and axis_cover(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == "hold"
+        and axis_cover(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "hold"
+        and axis_cover(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1, E2, E3})) == "fail"
+        and axis_cover(frozenset({E1}), frozenset({E1})) == "fail",
+    )
+    checks.check(
+        "split-identity",
+        axis_split(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and axis_split(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and axis_split(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_split(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "hold"
+        and axis_split(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == "hold"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E1}), frozenset({E2})) == "fail"
+        and axis_split(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_in_one_out(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3})) == "fail"
+        and two_in_one_out(UNDEFINED, frozenset({E1})) == UNDEFINED,
+    )
+    checks.check(
+        "pair-bit-identity",
+        pair_bit(UNDEFINED, "hold") == UNDEFINED
+        and pair_bit("hold", UNDEFINED) == UNDEFINED
+        and pair_bit("hold", "hold") == "hold"
+        and pair_bit("hold", "fail") == "fail"
+        and pair_bit("fail", "hold") == "fail"
+        and pair_bit("fail", "fail") == "fail",
+    )
+    checks.check(
+        "composition-identity",
+        composition_report(
+            "hold", "hold", "hold", "hold", "hold", "hold", "hold", "hold"
+        )
+        == "hold"
+        and composition_report(
+            "fail", "fail", "fail", "fail", "fail", "fail", "fail", "fail"
+        )
+        == "hold"
+        and composition_report(
+            UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED,
+            UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED,
+        )
+        == "hold"
+        and composition_report(
+            "fail", "hold", "fail", "hold", "fail", "hold", "fail", "hold"
+        )
+        == "fail"
+        and composition_report(
+            "hold", "hold", "hold", "hold", "hold", "hold", "fail", "hold"
+        )
+        == "fail"
+        and leftover_bit_composition("fail", "fail", "fail", "fail") == "hold"
+        and leftover_bit_composition("fail", "hold", "fail", "hold") == "fail"
+        and leftover_bit_composition("hold", "hold", "fail", "fail") == "hold",
+    )
+    checks.check(
+        "leftover-empty-fail-contrast",
+        leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and leftover_axis(frozenset({NEG_E1}), frozenset({E2, E3, NEG_E3}))
+        == frozenset()
+        and leftover_axis(frozenset({NEG_E3}), frozenset({E1, NEG_E1}))
+        == frozenset({E2})
+        and leftover_axis(frozenset({E2}), frozenset({E1})) == frozenset({E3}),
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau1: dict[str, int] = {}
+    tau2: dict[str, int] = {}
+    m_t: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    m2: dict[str, Incoming] = {}
+    o_t: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    o2: dict[str, Outgoing] = {}
+    axis_m1: dict[str, AxisSet] = {}
+    axis_o1: dict[str, AxisSet] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover_t: dict[str, str] = {}
+    cover1: dict[str, str] = {}
+    cover: dict[str, str] = {}
+    split_t: dict[str, str] = {}
+    split1: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one_t: dict[str, str] = {}
+    two_one1: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    lx1: dict[str, AxisSet] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    new_meet2: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau1[name] = ticks[site] + 1
+        tau2[name] = ticks[site] + 2
+        m_t[name] = incoming_set(site, ticks[site], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        m2[name] = incoming_set(site, tau2[name], ticks, locks, seed_map)
+        o_t[name] = outgoing_set(site, ticks[site], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        o2[name] = outgoing_set(site, tau2[name], ticks, locks, seed_map)
+        axis_m1[name] = axis_set(m1[name])
+        axis_o1[name] = axis_set(o1[name])
+        axis_m[name] = axis_set(m2[name])
+        axis_o[name] = axis_set(o2[name])
+        cover_t[name] = axis_cover(m_t[name], o_t[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        cover[name] = axis_cover(m2[name], o2[name])
+        split_t[name] = axis_split(m_t[name], o_t[name])
+        split1[name] = axis_split(m1[name], o1[name])
+        split[name] = axis_split(m2[name], o2[name])
+        two_one_t[name] = two_in_one_out(m_t[name], o_t[name])
+        two_one1[name] = two_in_one_out(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m2[name], o2[name])
+        lx1[name] = leftover_axis(m1[name], o1[name])
+        lx[name] = leftover_axis(m2[name], o2[name])
+        lx_m[name] = leftover_of_one(m2[name])
+        lx_o[name] = leftover_of_one(o2[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks, 1)
+        new_meet2[name] = new_records_meeting_six_nn(site, ticks, 2)
+        print(
+            f"{name} t={ticks[site]} "
+            f"τ1={tau1[name]} "
+            f"M1={lockset_display(m1[name])} "
+            f"O1={lockset_display(o1[name])} "
+            f"cover1={cover1[name]} split1={split1[name]} "
+            f"τ2={tau2[name]} "
+            f"M2={lockset_display(m2[name])} "
+            f"O2={lockset_display(o2[name])} "
+            f"Axis(M)={axis_display(axis_m[name])} "
+            f"Axis(O)={axis_display(axis_o[name])} "
+            f"|Axis(M)|={axis_card(axis_m[name])} "
+            f"|Axis(O)|={axis_card(axis_o[name])} "
+            f"cover2={cover[name]} split2={split[name]}"
+        )
+
+    reverse_t = reverse_report(split_t["A"], split_t["B"])
+    reverse1 = reverse_report(split1["A"], split1["B"])
+    reverse2 = reverse_report(split["A"], split["B"])
+    face_t = face_report(split_t["C"], split_t["D"])
+    face1 = face_report(split1["C"], split1["D"])
+    face2 = face_report(split["C"], split["D"])
+    reverse = reverse2
+    face = face2
+    composition = composition_report(
+        split1["A"],
+        split["A"],
+        split1["B"],
+        split["B"],
+        split1["C"],
+        split["C"],
+        split1["D"],
+        split["D"],
+    )
+    leftover_t_composition = composition_report(
+        split_t["A"],
+        split1["A"],
+        split_t["B"],
+        split1["B"],
+        split_t["C"],
+        split1["C"],
+        split_t["D"],
+        split1["D"],
+    )
+    leftover_rf_composition = leftover_bit_composition(
+        reverse1, reverse2, face1, face2
+    )
+    leftover_t_rf_composition = leftover_bit_composition(
+        reverse_t, reverse1, face_t, face1
+    )
+    two_one_composition = composition_report(
+        two_one1["A"],
+        two_one["A"],
+        two_one1["B"],
+        two_one["B"],
+        two_one1["C"],
+        two_one["C"],
+        two_one1["D"],
+        two_one["D"],
+    )
+    cover_composition = composition_report(
+        cover1["A"],
+        cover["A"],
+        cover1["B"],
+        cover["B"],
+        cover1["C"],
+        cover["C"],
+        cover1["D"],
+        cover["D"],
+    )
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m2["A"], m2["B"])
+    m_exist_face = existential_opposite(m2["C"], m2["D"])
+    o_exist_reverse = existential_opposite(o2["A"], o2["B"])
+    o_exist_face = existential_opposite(o2["C"], o2["D"])
+    unique_split_a = axis_split(unique_letter(m2["A"]), unique_letter(o2["A"]))
+    one_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_o1 = {
+        name: outgoing_set(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    print(f"split reverse τ1={reverse1} τ2={reverse2} face τ1={face1} τ2={face2}")
+    print(f"composition={composition}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(f"leftover-empty reverse={leftover_reverse} face={leftover_face}")
+    print(
+        "per_element: each unsigned lattice axis among {e_1,e_2,e_3} "
+        "occupied by M or by O at a probe's t+1 or t+2"
+    )
+    print(
+        "per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print(
+        "per_block: four split reports at t+1 and at t+2 plus reverse/face/composition"
+    )
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PAIR2] == 0
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and axis_split(
+            incoming_set(PROBES["D"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "incoming-set-seed-singleton",
+        incoming_set(ORIGIN, 0, ticks, locks, seed_map) == frozenset({E1})
+        and incoming_set(E2, 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and incoming_set(E3, 1, ticks, locks, seed_map) == frozenset({E2})
+        and incoming_set(PAIR2, 1, ticks, locks, seed_map) == frozenset({NEG_E2})
+        and m1["A"] == frozenset({E2}),
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-at-tau1-and-tau2",
+        m1["A"] == frozenset({E2})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E1})
+        and m2["A"] == frozenset({E2})
+        and m2["B"] == frozenset({E1})
+        and m2["C"] == frozenset({E3})
+        and m2["D"] == frozenset({E1})
+        and m1["A"] == m2["A"]
+        and m1["B"] == m2["B"]
+        and m1["C"] == m2["C"]
+        and m1["D"] == m2["D"],
+        str({name: (lockset_display(m1[name]), lockset_display(m2[name])) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-O-frozen-at-tau1-and-tau2",
+        o1["A"] == frozenset({E1, NEG_E1, E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, NEG_E2})
+        and o1["D"] == frozenset({NEG_E2, E3, NEG_E3})
+        and o2["A"] == o1["A"]
+        and o2["B"] == o1["B"]
+        and o2["C"] == o1["C"]
+        and o2["D"] == o1["D"]
+        and o1["A"] != UNDEFINED
+        and o2["A"] != frozenset(),
+        str({name: (lockset_display(o1[name]), lockset_display(o2[name])) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Axis-M-and-O",
+        axis_m["A"] == frozenset({E2})
+        and axis_o["A"] == frozenset({E1, E3})
+        and axis_m["B"] == frozenset({E1})
+        and axis_o["B"] == frozenset({E2, E3})
+        and axis_m["C"] == frozenset({E3})
+        and axis_o["C"] == frozenset({E1, E2})
+        and axis_m["D"] == frozenset({E1})
+        and axis_o["D"] == frozenset({E2, E3})
+        and axis_m1["A"] == axis_m["A"]
+        and axis_o1["A"] == axis_o["A"],
+        str(
+            {
+                name: (axis_display(axis_m[name]), axis_display(axis_o[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-cover-and-axis-card",
+        cover1["A"] == "hold"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "hold"
+        and cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "hold"
+        and axis_card(axis_m["A"]) == "1"
+        and axis_card(axis_m["B"]) == "1"
+        and axis_card(axis_m["C"]) == "1"
+        and axis_card(axis_m["D"]) == "1"
+        and axis_card(axis_o["A"]) == "2"
+        and axis_card(axis_o["B"]) == "2"
+        and axis_card(axis_o["C"]) == "2"
+        and axis_card(axis_o["D"]) == "2"
+        and all(lx[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(lx1[name] == frozenset() for name in ("A", "B", "C", "D")),
+        str(
+            {
+                name: (
+                    cover1[name],
+                    cover[name],
+                    axis_card(axis_m[name]),
+                    axis_card(axis_o[name]),
+                )
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-split-at-tau1-and-tau2",
+        split1["A"] == "hold"
+        and split1["B"] == "hold"
+        and split1["C"] == "hold"
+        and split1["D"] == "hold"
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "hold"
+        and two_one1["A"] == "fail"
+        and two_one["A"] == "fail"
+        and two_one["B"] == "fail"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and split1["A"] != UNDEFINED
+        and split["D"] != UNDEFINED
+        and split["D"] != "fail",
+        str(
+            {
+                name: (split1[name], split[name])
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "leftover-empty-O-at-t-fails-split-not-scored",
+        all(o_t[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(split_t[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(split_t[name] != UNDEFINED for name in ("A", "B", "C", "D"))
+        and leftover_t_composition == "fail"
+        and leftover_t_rf_composition == "fail"
+        and "Do not score τ=t" in note
+        and axis_split(frozenset({E2}), frozenset()) == "fail"
+        and axis_cover(frozenset({E2}), frozenset()) == "fail",
+    )
+    checks.check(
+        "theorem1-M-frozen-from-tplus1",
+        m1["A"] == m2["A"]
+        and m1["B"] == m2["B"]
+        and m1["C"] == m2["C"]
+        and m1["D"] == m2["D"]
+        and m_t["A"] == m1["A"],
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 0, 2), (-1, 0, 2), (0, -1, 2))
+        and new_meet["D"] == ((1, -1, 1), (1, 0, 2), (1, 0, 0))
+        and new_meet2["A"] == ((0, -1, 1),)
+        and new_meet2["B"] == ()
+        and new_meet2["C"] == ()
+        and new_meet2["D"] == ()
+        and incoming_set((0, -1, 1), tau2["A"], ticks, locks, seed_map)
+        == frozenset({E3})
+        and NEG_E2
+        not in incoming_set((0, -1, 1), tau2["A"], ticks, locks, seed_map),
+        str({"t+1": new_meet, "t+2": new_meet2}),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        isinstance(o2["A"], frozenset)
+        and len(o2["A"]) == 3
+        and unique_letter(o2["A"]) == UNDEFINED
+        and isinstance(o2["D"], frozenset)
+        and len(o2["D"]) == 3
+        and unique_letter(o2["D"]) == UNDEFINED
+        and isinstance(m2["D"], frozenset)
+        and len(m2["D"]) == 1
+        and split["D"] == "hold"
+        and split["A"] == "hold"
+        and cover["D"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and m1["A"] == frozenset({E2})
+        and m2["A"] == frozenset({E2}),
+    )
+    checks.check(
+        "theorem2-reverse-and-face-at-each-cut",
+        reverse1 == "hold"
+        and reverse2 == "hold"
+        and face1 == "hold"
+        and face2 == "hold"
+        and reverse1 != UNDEFINED
+        and face1 != UNDEFINED
+        and reverse2 != UNDEFINED
+        and face2 != UNDEFINED
+        and split1["A"] == "hold"
+        and split1["B"] == "hold"
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and split1["C"] == "hold"
+        and split1["D"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "hold"
+        and reverse_t == "fail"
+        and face_t == "fail",
+    )
+    checks.check(
+        "theorem3-composition-hold",
+        composition == "hold"
+        and split1["A"] == split["A"]
+        and split1["B"] == split["B"]
+        and split1["C"] == split["C"]
+        and split1["D"] == split["D"]
+        and leftover_rf_composition == "hold"
+        and two_one_composition == "hold"
+        and cover_composition == "hold"
+        and leftover_t_composition == "fail"
+        and leftover_t_composition != composition
+        and composition != UNDEFINED,
+        str(
+            {
+                "composition": composition,
+                "leftover_rf": leftover_rf_composition,
+                "two_one": two_one_composition,
+                "cover": cover_composition,
+                "leftover_t": leftover_t_composition,
+            }
+        ),
+    )
+    checks.check(
+        "two-in-one-out-is-fail-not-undefined",
+        two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and two_one["A"] == "fail"
+        and two_one["B"] == "fail"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and cover["D"] == "hold"
+        and split["D"] == "hold"
+        and split["D"] != UNDEFINED
+        and one_split["C"] == "fail"
+        and one_cover["C"] == "hold"
+        and two_in_one_out(one_m1["C"], one_o1["C"]) == "hold"
+        and face == "hold"
+        and face != UNDEFINED,
+    )
+    checks.check(
+        "d-is-one-in-two-out-cover-and-split",
+        cover["D"] == "hold"
+        and two_one["D"] == "fail"
+        and split["D"] == "hold"
+        and axis_card(axis_m["D"]) == "1"
+        and axis_card(axis_o["D"]) == "2"
+        and lx["D"] == frozenset(),
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["A"]] == 1
+        and one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["C"]] == 4
+        and one_ticks[PROBES["D"]] == 2
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and one_cover["C"] == "hold"
+        and one_cover["D"] == "hold"
+        and one_cover_face == "hold"
+        and one_split["C"] == "fail"
+        and one_split["D"] == "hold"
+        and one_split_face == "fail"
+        and cover["D"] == "hold"
+        and cover_face == "hold"
+        and split["D"] == "hold"
+        and face == "hold"
+        and one_split_face != face
+        and one_m1["A"] != m1["A"]
+        and one_m1["C"] != m1["C"]
+        and one_o1["A"] != o1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset()
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset()
+        and reverse == "hold"
+        and face == "hold"
+        and leftover_reverse != reverse
+        and leftover_face != face,
+    )
+    checks.check(
+        "mutation-leftover-of-M-alone-differs",
+        lx_m["A"] == frozenset({E1, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_m["C"] == frozenset({E1, E2})
+        and lx_m["D"] == frozenset({E2, E3})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and reverse_m_alone != reverse
+        and face_m_alone != face,
+    )
+    checks.check(
+        "mutation-leftover-of-O-alone-differs",
+        lx_o["A"] == frozenset({E2})
+        and lx_o["B"] == frozenset({E1})
+        and lx_o["C"] == frozenset({E3})
+        and lx_o["D"] == frozenset({E1})
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and reverse_o_alone != reverse
+        and face_o_alone != face,
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and m_exist_reverse != reverse
+        and o_exist_face != face
+        and axis_split(m2["A"], m2["B"]) == "fail"
+        and axis_split(m2["C"], m2["D"]) == "fail",
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m2["A"]) == frozenset({E2})
+        and unique_letter(o2["A"]) == UNDEFINED
+        and unique_letter(m2["D"]) == frozenset({E1})
+        and unique_letter(o2["D"]) == UNDEFINED
+        and unique_split_a == UNDEFINED
+        and split["A"] == "hold"
+        and split["D"] == "hold",
+    )
+    checks.check(
+        "mutation-empty-plus-undefined",
+        axis_split(frozenset(), frozenset({E2, E3})) == "fail"
+        and axis_split(UNDEFINED, frozenset({E1})) == UNDEFINED
+        and reverse == "hold",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(m2["D"], frozenset)
+        and isinstance(o2["A"], frozenset)
+        and sum_of_set(m2["A"]) == E2
+        and sum_of_set(m2["D"]) == E1
+        and sum_of_set(o2["A"]) == E3
+        and sum_of_set(o2["D"]) == NEG_E2
+        and axis_m["D"] == frozenset({E1}),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m2["A"], frozenset)
+        and isinstance(o2["A"], frozenset)
+        and E2 in m2["A"]
+        and E2 not in o2["A"]
+        and o2["A"] != m2["A"]
+        and axis_m["A"] != axis_o["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2}
+        and PAIR2 not in one_seeds
+        and one_ticks[PAIR2] == 1
+        and one_locks[PAIR2] == {E3}
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    y_m1 = {
+        name: incoming_set(
+            Y_PROBES[name],
+            ticks[Y_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if Y_PROBES[name] in ticks
+    }
+    y_o1 = {
+        name: outgoing_set(
+            Y_PROBES[name],
+            ticks[Y_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if Y_PROBES[name] in ticks
+    }
+    y_split = {name: axis_split(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_face = pair_bit(y_split["C"], y_split["D"])
+    y_m2 = {
+        name: incoming_set(
+            Y_PROBES[name],
+            ticks[Y_PROBES[name]] + 2,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if Y_PROBES[name] in ticks
+    }
+    y_o2 = {
+        name: outgoing_set(
+            Y_PROBES[name],
+            ticks[Y_PROBES[name]] + 2,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if Y_PROBES[name] in ticks
+    }
+    y_split2 = {name: axis_split(y_m2[name], y_o2[name]) for name in ("A", "B", "C", "D")}
+    y_composition = composition_report(
+        y_split["A"],
+        y_split2["A"],
+        y_split["B"],
+        y_split2["B"],
+        y_split["C"],
+        y_split2["C"],
+        y_split["D"],
+        y_split2["D"],
+    )
+    y_reverse = pair_bit(y_split["A"], y_split["B"])
+    x_m1 = {
+        name: incoming_set(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if X_PROBES[name] in ticks
+    }
+    x_o1 = {
+        name: outgoing_set(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+        if X_PROBES[name] in ticks
+    }
+    x_split = {name: axis_split(x_m1[name], x_o1[name]) for name in ("A", "B", "C", "D")}
+    x_reverse = pair_bit(x_split["A"], x_split["B"])
+    x_face = pair_bit(x_split["C"], x_split["D"])
+    perp_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            perp_ticks[PROBES[name]] + 1,
+            perp_ticks,
+            perp_locks,
+            perp_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in perp_ticks
+    }
+    same_m_a = incoming_set(
+        PROBES["A"],
+        same_ticks[PROBES["A"]] + 1,
+        same_ticks,
+        same_locks,
+        same_seeds,
+    )
+    zsym_m1 = {
+        name: incoming_set(
+            PROBES[name],
+            zsym_ticks[PROBES[name]] + 1,
+            zsym_ticks,
+            zsym_locks,
+            zsym_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+        if PROBES[name] in zsym_ticks
+    }
+    ysym_ticks_count0 = sum(time == 0 for time in ysym_ticks.values())
+    checks.check(
+        "not-x-probes-or-y-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and x_m1["A"] != m1["A"]
+        and y_m1["A"] != m1["A"]
+        and y_split["D"] == "fail"
+        and y_face == "fail"
+        and y_reverse == "hold"
+        and y_composition == "hold"
+        and y_face != face
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "not-same-lock-two-site-seed",
+        TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and same_m_a != m1["A"]
+        and m1["A"] == frozenset({E2}),
+    )
+    checks.check(
+        "not-one-axis-or-y-symmetric-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and ysym_ticks_count0 == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Axis-cover-split",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ1) = {+e_2}" in note
+        and "M(A, τ2) = {+e_2}" in note
+        and "M(B, τ1) = {+e_1}" in note
+        and "M(B, τ2) = {+e_1}" in note
+        and "M(C, τ1) = {+e_3}" in note
+        and "M(C, τ2) = {+e_3}" in note
+        and "M(D, τ1) = {+e_1}" in note
+        and "M(D, τ2) = {+e_1}" in note
+        and "O(A, τ1) = {+e_1, −e_1, +e_3}" in note
+        and "O(B, τ1) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ1) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ1) = {−e_2, +e_3, −e_3}" in note
+        and "O(A, τ2) = {+e_1, −e_1, +e_3}" in note
+        and "O(B, τ2) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ2) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ2) = {−e_2, +e_3, −e_3}" in note
+        and "split(A, τ1) = hold" in note
+        and "split(B, τ1) = hold" in note
+        and "split(C, τ1) = hold" in note
+        and "split(D, τ1) = hold" in note
+        and "split(A, τ2) = hold" in note
+        and "split(B, τ2) = hold" in note
+        and "split(C, τ2) = hold" in note
+        and "split(D, τ2) = hold" in note
+        and "Do not score τ=t" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)" in note
+        and "new 6-NN of A at t(A)+2: (0, -1, 1)" in note
+        and "new 6-NN of B at t(B)+2: none" in note
+        and "new 6-NN of C at t(C)+2: none" in note
+        and "new 6-NN of D at t(D)+2: none" in note,
+    )
+    checks.check(
+        "note-reports-split-reverse-face",
+        "Reverse 1-in 2-out at τ1: hold" in note
+        and "Reverse 1-in 2-out at τ2: hold" in note
+        and "Face 1-in 2-out at τ1: hold" in note
+        and "Face 1-in 2-out at τ2: hold" in note
+        and "Composition of split bits: hold" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-exist-opposite",
+        "not leftover of nmcover axis-cover" in normalized_note
+        and "not leftover of the 1-axis opposite two-site seed" in normalized_note
+        and "not leftover of nm2ax12z" in normalized_note
+        and "not leftover of nm2splt2z" in normalized_note
+        and "2-in 1-out is fail of this object, not UNDEFINED" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse 1-in 2-out at τ1: hold" in note
+        and "Face 1-in 2-out at τ1: hold" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ1=t+1" in note.replace(" ", "")
+        and "τ2=t+2" in note.replace(" ", "")
+        and "Do not score τ=t" in note,
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_ZPROBE_ONE_TWO_SPLIT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "axis_cover" in defined_fns
+        and "axis_split" in defined_fns
+        and "two_in_one_out" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "composition_report" in defined_fns
+        and "leftover_bit_composition" in defined_fns
+        and "new_records_meeting_six_nn" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "split-hold-not-leftover-empty",
+        reverse == "hold"
+        and face == "hold"
+        and reverse1 == "hold"
+        and face1 == "hold"
+        and cover_reverse == "hold"
+        and cover_face == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and split["A"] == "hold"
+        and split["D"] == "hold"
+        and cover["D"] == "hold"
+        and two_one["D"] == "fail"
+        and two_one["C"] == "fail"
+        and one_split_face == "fail"
+        and o_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and composition == "hold"
+        and leftover_t_composition == "fail"
+        and two_one_composition == "hold"
+        and leftover_rf_composition == "hold"
+        and existential_opposite(o_t["A"], o_t["B"]) == UNDEFINED
+        and reverse_t != UNDEFINED,
+    )
+    _ = (
+        o_t,
+        unique_split_a,
+        one_cover_face,
+        one_split_face,
+        axis_m1,
+        axis_o1,
+        lx1,
+        y_composition,
+        leftover_rf_composition,
+        two_one_composition,
+        cover_composition,
+        leftover_t_composition,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. HOLDING 1-in 2-out (#7308) freezes at t+1 vs t+2 now that O is nonempty: reverse HOLD at both cuts, face HOLD at both, composition HOLD. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_zprobe_one_two_split_tplus1_tplus2_composition_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.