### PR TITLE
feat(nm2sreadz): neighbor-read of 1-in 2-out split at t+1 on two-axis opposite z-probes: reverse HOLD, face HOLD

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,336 @@
+---
+claim_id: two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of the 1-in 2-out split at t+1 on the four z-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py
+---
+
+# Two-Axis Opposite Z-Probe Neighbor-Read Of The 1-In 2-Out Split At t+1, Reverse And Face
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** Neighbor-read of the 1-in 2-out split at t+1 on the four z-probes of the
+two-axis opposite seed, and reverse/face from that, are reported. Displayed, not
+adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py)
+
+No runner cache is written.
+
+## Result Up Front
+
+On the finite Euclidean host `B_3(0)={n:n·n<=9}`, form records by the
+two-axis opposite seed, perp-step, incoming-lock process. Same process and
+z-probes as nm2axz. For each formed site `q` write `t(q)` for the formation
+tick and `τ(q)=t(q)+1`. There is no global T. `M`, `O`, and split are as
+nm2ax12z. Unformed sites are `UNDEFINED`.
+
+Neighbor-read of the split HOLDs at a formed `q` iff split HOLDs at `q` and
+some formed six-neighbor `r=q+e` has split HOLD and
+`Axis(M(r,τ))=Axis(M(q,τ))` and `Axis(O(r,τ))=Axis(O(q,τ))`. If split fails
+at `q`, neighbor-read fails, not `UNDEFINED`. Uniqueness is not required.
+Reverse HOLDs iff neighbor-read HOLDs at probes `A` and `B`. Face HOLDs iff
+neighbor-read HOLDs at probes `C` and `D`.
+
+On this seed and these z-probes the finite listing is:
+
+- t(A)=0, M(A, τ) = {+e_2}, O(A, τ) = {+e_1, −e_1, +e_3}, Axis(M)(A, τ) = {e_2}, Axis(O)(A, τ) = {e_1, e_3}, split(A) = hold, neighbor-read(A) = hold
+- t(B)=1, M(B, τ) = {+e_1}, O(B, τ) = {+e_2, +e_3, −e_3}, Axis(M)(B, τ) = {e_1}, Axis(O)(B, τ) = {e_2, e_3}, split(B) = hold, neighbor-read(B) = hold
+- t(C)=1, M(C, τ) = {+e_3}, O(C, τ) = {+e_1, −e_1, −e_2}, Axis(M)(C, τ) = {e_3}, Axis(O)(C, τ) = {e_1, e_2}, split(C) = hold, neighbor-read(C) = hold
+- t(D)=1, M(D, τ) = {+e_1}, O(D, τ) = {−e_2, +e_3, −e_3}, Axis(M)(D, τ) = {e_1}, Axis(O)(D, τ) = {e_2, e_3}, split(D) = hold, neighbor-read(D) = hold
+- Reverse neighbor-read at τ: hold
+- Face neighbor-read at τ: hold
+
+The face bit is displayed, not adopted. Do not write into Admissibility.
+Do not attach L1. This is not leftover of nm2readz neighbor-read of M, not
+leftover of nm2oreadz neighbor-read of O, not leftover of signed (M, O) set
+equality, and not leftover of nm2ax12z 1-in 2-out split without neighbor-read.
+No larger host is used.
+
+## Current Premise Boundary
+
+Quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+Admissibility determines a local distribution from nearest-neighbor
+conditions and does not supply the formation site, probability, or rate.
+
+The process below is an explicit finite display on `B_3(0)`. It is not a
+rewrite of Admissibility and is not a lattice-wide lettering rule.
+
+## Exact Objects
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`. The six nearest-neighbor
+steps are `±e_1,±e_2,±e_3`. The host is the Euclidean ball
+`B_3(0)={n:n·n<=9}`. No larger host is used.
+
+The two-axis opposite seed at tick 0 is two disjoint opposite pairs:
+
+- origin locks `+e_1`
+- `(0,1,0)` locks `−e_1`
+- `(0,0,1)` locks `+e_2`
+- `(0,1,1)` locks `−e_2`
+
+The second pair is a new seed, not a formed child of the first pair. A
+parent with lock axis `e_i` may take a nearest-neighbor step `s` only when
+`s·e_i=0`. A newly formed child locks the incoming step. Seeds keep their
+seed letters as a singleton. If several parents first reach a child at the
+same tick, `M` is the set of those incoming steps.
+
+The four z-probes are `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(1,0,1)`.
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`,
+`C=(2,0,0)`, `D=(1,1,0)`. Probe `A` is a seed. Formation, `M`, and `O` are
+computed only from records on this host.
+
+For a site `q` and a tick bound `τ`, if `q` is unformed at `τ` then `M`,
+`O`, split, and neighbor-read at `q` are `UNDEFINED`. Otherwise `M(q,τ)` is
+the earliest nonempty incoming set assembled from parents with formation
+tick at most `τ`, and
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+Empty `O` is empty, not `UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs iff `Axis(M)` intersect
+`Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals `{e_1,e_2,e_3}`.
+Split HOLDs iff cover HOLDs and `|Axis(M)|=1` (hence `|Axis(O)|=2`). 2-in
+1-out is fail of this object, not UNDEFINED.
+
+Neighbor-read HOLDs at formed `q` iff split HOLDs at `q` and there exists a
+formed six-neighbor `r` with split HOLD and the same unsigned axis
+assignment: `Axis(M(r,τ))=Axis(M(q,τ))` and `Axis(O(r,τ))=Axis(O(q,τ))`.
+If split fails at `q`, neighbor-read fails, not `UNDEFINED`. Mixed remains
+a set. Uniqueness is not required. Pair-read of two probe bits is
+`UNDEFINED` if either bit is `UNDEFINED`, HOLD if both HOLD, and fail
+otherwise. Reverse is pair-read of `A` and `B`. Face is pair-read of `C`
+and `D`. Occupancy of sites is not used.
+
+## Theorem 1 — Formation Ticks, M, O, Split, And Neighbor-Read Bits
+
+**Claim.** On this host and seed, the four z-probes and their eventually
+formed six-neighbors have the ticks, lock sets, split bits, and
+neighbor-read bits listed below.
+
+**Proof.** Direct breadth-first formation with the perp-step rule yields
+four tick-0 seeds. Parallel steps from the origin along `±e_1` are blocked
+because those steps fail `s·e_i=0`. Probe ticks are t(A)=0, t(B)=1,
+t(C)=1, and t(D)=1.
+
+At each probe, `M` at `τ=t+1` equals `M` at formation. `O` is assembled from
+neighbors that are formed by that same cut.
+
+- A is the seed `(0,0,1)`, so M(A, τ) = {+e_2}, O(A, τ) = {+e_1, −e_1, +e_3}, Axis(M)(A, τ) = {e_2}, Axis(O)(A, τ) = {e_1, e_3}, split(A) = hold.
+- B is first reached from `(0,1,1)` by `+e_1`, so M(B, τ) = {+e_1}, O(B, τ) = {+e_2, +e_3, −e_3}, Axis(M)(B, τ) = {e_1}, Axis(O)(B, τ) = {e_2, e_3}, split(B) = hold.
+- C is first reached from `A` by `+e_3`, so M(C, τ) = {+e_3}, O(C, τ) = {+e_1, −e_1, −e_2}, Axis(M)(C, τ) = {e_3}, Axis(O)(C, τ) = {e_1, e_2}, split(C) = hold.
+- D is first reached from `A` by `+e_1`, so M(D, τ) = {+e_1}, O(D, τ) = {−e_2, +e_3, −e_3}, Axis(M)(D, τ) = {e_1}, Axis(O)(D, τ) = {e_2, e_3}, split(D) = hold.
+
+formed 6-NN of A at τ: (1, 0, 1) M={+e_1} O={} split=fail neighbor-read=fail, (-1, 0, 1) M={−e_1} O={} split=fail neighbor-read=fail, (0, 1, 1) M={−e_2} O={+e_1, −e_1, +e_3} split=hold neighbor-read=hold, (0, -1, 1) M=UNDEFINED O=UNDEFINED split=UNDEFINED neighbor-read=UNDEFINED, (0, 0, 2) M={+e_3} O={} split=fail neighbor-read=fail, (0, 0, 0) M={+e_1} O={−e_2, −e_3} split=hold neighbor-read=hold
+
+formed 6-NN of B at τ: (2, 1, 1) M=UNDEFINED O=UNDEFINED split=UNDEFINED neighbor-read=UNDEFINED, (0, 1, 1) M={−e_2} O={+e_1, −e_1, +e_3} split=hold neighbor-read=hold, (1, 2, 1) M={+e_2} O={} split=fail neighbor-read=fail, (1, 0, 1) M={+e_1} O={−e_2, +e_3, −e_3} split=hold neighbor-read=hold, (1, 1, 2) M={+e_1, +e_3} O={} split=fail neighbor-read=fail, (1, 1, 0) M={−e_3} O={−e_1} split=fail neighbor-read=fail
+
+formed 6-NN of C at τ: (1, 0, 2) M={+e_1, +e_3} O={} split=fail neighbor-read=fail, (-1, 0, 2) M={−e_1, +e_3} O={} split=fail neighbor-read=fail, (0, 1, 2) M={+e_3} O={+e_1, −e_1, +e_2} split=hold neighbor-read=hold, (0, -1, 2) M={−e_2} O={} split=fail neighbor-read=fail, (0, 0, 1) M={+e_2} O={+e_1, −e_1, +e_3} split=hold neighbor-read=hold
+
+formed 6-NN of D at τ: (2, 0, 1) M=UNDEFINED O=UNDEFINED split=UNDEFINED neighbor-read=UNDEFINED, (0, 0, 1) M={+e_2} O={+e_1, −e_1, +e_3} split=hold neighbor-read=hold, (1, 1, 1) M={+e_1} O={+e_2, +e_3, −e_3} split=hold neighbor-read=hold, (1, -1, 1) M={−e_2} O={} split=fail neighbor-read=fail, (1, 0, 2) M={+e_1, +e_3} O={} split=fail neighbor-read=fail, (1, 0, 0) M={−e_3} O={} split=fail neighbor-read=fail
+
+matching 6-NN of A: (0, 1, 1)
+
+matching 6-NN of B: (1, 0, 1)
+
+matching 6-NN of C: (0, 1, 2)
+
+matching 6-NN of D: (1, 1, 1)
+
+The matching neighbor of `A` is the other seed of the second pair,
+`(0,1,1)`. That site carries `M={−e_2}`, which is not equal to
+`M(A,τ)={+e_2}` as signed sets, but `Axis(M)={e_2}` and
+`Axis(O)={e_1,e_3}` agree, so neighbor-read(A) = hold without any
+uniqueness cut. Site `(0,-1,1)` does form later, at tick 2, and is
+`UNDEFINED` at `A`'s `τ`. Site `(1,0,1)` is formed at `A`'s `τ` with empty
+`O`, so split fails there and neighbor-read is fail, not `UNDEFINED`.
+
+The matching neighbor of `B` is `D`. `M` agrees as `{+e_1}`, but
+`O(B,τ)={+e_2,+e_3,−e_3}` is not equal to `O(D,τ)={−e_2,+e_3,−e_3}` as
+signed sets. The unsigned axes agree: `Axis(M)={e_1}` and
+`Axis(O)={e_2,e_3}`, so neighbor-read(B) = hold. Likewise
+neighbor-read(C) = hold by `(0,1,2)` and neighbor-read(D) = hold by `B`.
+Site `(1,1,2)` is mixed `{+e_1,+e_3}` at `B`'s `τ`; mixed remains a set
+and does not recover a 1-in 2-out assignment.
+`QED`
+
+## Theorem 2 — Reverse Neighbor-Read
+
+**Claim.** Reverse neighbor-read at `τ` is hold, not fail and not
+`UNDEFINED`.
+
+**Proof.** Reverse HOLDs iff neighbor-read HOLDs at `A` and at `B`. Both
+probes are formed, so the pair is not `UNDEFINED`. Theorem 1 gives
+neighbor-read(A) = hold and neighbor-read(B) = hold, hence
+Reverse neighbor-read at τ: hold.
+`QED`
+
+## Theorem 3 — Face Neighbor-Read, Displayed Not Adopted
+
+**Claim.** Face neighbor-read at `τ` is hold. The bit is displayed, not
+adopted.
+
+**Proof.** Face HOLDs iff neighbor-read HOLDs at `C` and at `D`. Theorem 1
+gives both HOLD, hence Face neighbor-read at τ: hold. The report is a
+finite listing on this seed and these four z-probes. It is displayed, not
+adopted as an Admissibility clause, as a lettering law, or as a uniqueness
+rule. Do not write into Admissibility. Do not attach L1.
+`QED`
+
+## Discriminators
+
+Neighbor-read of `M` as signed sets fails at `A` and HOLDs at `B`, `C`,
+and `D`. Neighbor-read of `O` as signed sets HOLDs at `A` and fails at
+`B`, `C`, and `D`. Signed `(M, O)` set equality fails at every z-probe:
+no formed six-neighbor recovers both lock sets as sets. The present
+letter recovers the unsigned 1-in 2-out axis assignment, so reverse and
+face HOLD. It is therefore not leftover of nm2readz neighbor-read of M
+and not leftover of nm2oreadz neighbor-read of O.
+
+The same z-probes on a two-site `±e_1` seed reverse/face as hold/fail.
+A perpendicular two-site seed and a z-symmetric three-site seed do not
+reproduce hold/hold. The same two-axis opposite seed scored on x-probes
+or y-probes returns a different reverse/face pair. The report is
+therefore not leftover of nm2ax12z 1-in 2-out split without neighbor-read.
+
+## Exact Target And Proof Obligations
+
+**Exact target:** report neighbor-read of the 1-in 2-out split at `t+1` on
+the four z-probes of the two-axis opposite seed, and the reverse/face
+pair-read of those bits, on Euclidean `B_3(0)`.
+
+| Obligation | Disposition |
+|---|---|
+| name the seed, perp-step rule, host, and z-probes | displayed process, closed on `B_3(0)` |
+| list `t`, `M`, `O`, split, formed six-neighbor bits, and neighbor-read | Theorem 1, finite listing |
+| reverse pair-read of `A` and `B` | Theorem 2, hold |
+| face pair-read of `C` and `D` | Theorem 3, hold, displayed not adopted |
+| adopt reverse or face as Admissibility | not claimed |
+| attach a uniqueness cut | not claimed |
+| lattice-wide lettering | not claimed; no global T |
+
+The proof-obligation graph is acyclic. The leaves are finite listings on
+a 123-site ball. No observational value is used.
+
+## No-Go Discipline Gate
+
+This note is a displayed finite report, not a negative law. Broad negative
+inference from the reverse hold, from the face hold, or from leftover
+signed-set misses is **FAIL / DO NOT SHIP**.
+
+### N1 — materially distinct route scan
+
+Neighbor-read of the unsigned 1-in 2-out assignment, neighbor-read of `M`,
+neighbor-read of `O`, signed `(M, O)` set equality, axis-cover without
+`|Axis(M)|=1`, unique-letter cuts, and a rewritten Admissibility rule are
+distinct objects. Only the first is executed here, and only on four
+z-probes. The others are named leftovers or out of scope. No universal
+negative is claimed, so a no-go is not shipped.
+
+### N2 — wall independence
+
+There is no shipped wall. Reverse hold and face hold are pair-reads of
+the four neighbor-read bits. Removing either pair changes the report
+without creating a law-level obstruction.
+
+### N3 — hidden-condition scan
+
+Load-bearing and explicit: two-axis opposite seed, perp-step
+`s·e_i=0`, incoming lock, Euclidean `B_3(0)`, `τ(q)=t(q)+1`, split HOLD
+together with unsigned axis equality of `M` and of `O`, and the four named
+z-probes. No phrase such as "by construction" or "naturally" adds a
+further premise. Occupancy of sites is not used.
+
+### N4 — residual matching
+
+No prior negative is cited as evidence. The only linked premise document
+is the current axiom memo, used to quote Lattice, Qubit, Record, and the
+Admissibility non-supply of formation site. The listing is proved here.
+
+### N5 — resolution audit
+
+| Resolution | Executed? | Exact scope |
+|---|---:|---|
+| per element | yes | each 1-in 2-out axis assignment of `M` and `O` at a probe and at formed six-neighbors, compared as unsigned axes at that probe's `t+1` |
+| per site | yes | z-probes `A,B,C,D` on Euclidean `B_3(0)` only |
+| per mode | no | no spectral or mode calculation is executed on this finite host |
+| per block | yes | four neighbor-read reports, reverse/face from those bits |
+| lattice-wide | checked and not executed | no lattice-wide lettering rule is claimed; no global T |
+
+### N6 — partial-closure paths
+
+Live extensions already named: other seeds, other probe axes, a uniqueness
+cut, signed-set leftover, a larger host, or an Admissibility rewrite. None
+is closed by this listing, and none is dismissed as requiring a new axiom.
+
+### N7 — steelman
+
+The strongest objection to reading reverse HOLD and face HOLD as a law is
+decisive: both bits are pair-reads of probe reports on one displayed seed.
+Neighbor-read of `M` fails at `A`, neighbor-read of `O` fails at `B`, and
+signed `(M, O)` equality fails at every z-probe. That is why Theorem 3 is
+displayed, not adopted.
+
+### N8 — cross-cycle echo
+
+Investment names `nm2axz`, `nm2ax12z`, `nm2readz`, and `nm2oreadz` mark
+nearby displayed processes. This note reuses the same two-axis opposite
+seed and z-probes only to report neighbor-read of the 1-in 2-out split at
+`t+1`. It does not inherit an axis-cover claim, a split-without-read
+claim, or a signed-set neighbor-read as a theorem.
+
+**No-Go Discipline status:** FAIL / DO NOT SHIP for any negative
+Admissibility, lettering, or uniqueness claim. The positive finite listing
+in Theorems 1–3 remains a displayed bounded report.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite neighbor-read of the 1-in 2-out split at t+1 on four z-probes, with reverse/face pair-read, on Euclidean B_3(0); displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face
+target_blocker_text: "report neighbor-read of the 1-in 2-out split at t+1 on the two-axis opposite z-probes and the reverse/face pair of those bits"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep reverse/face displayed. Do not write into Admissibility. Do not attach L1."
+conditional_surface_status: "exact finite listing on B_3(0) for the declared seed and z-probes; law-level adoption remains open and is not claimed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice / Qubit / Record sentences | framework premise | linked current axiom memo |
+| Admissibility non-supply of formation site | framework boundary | quoted; process is displayed |
+| two-axis opposite seed, perp-step, incoming lock | declared process | explicit condition |
+| Euclidean `B_3(0)` | declared host | `{n:n·n<=9}`; no larger host |
+| neighbor-read of the 1-in 2-out split, reverse, face | reported bits | Theorems 1–3 |
+| Admissibility rewrite, L1, uniqueness cut | residual | open and not claimed |
+
+Independent audit remains required before any effective status may change.

--- a/logs/runner-cache/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,79 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py
+runner_sha256: d10e70502c8af2d60e00c3ffb201cf973fa6d5d746623b3e53817c12622b7827
+input_fingerprint_sha256: ce83b1723a7b3499f2e4b87f33567d88c9028aca1094642a9a5a37ed8b3f74b3
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+neighbor-read of 1-in 2-out split reverse/face at t+1 on z-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of the 1-in 2-out split at t+1 on the four z-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: pair-read-identity
+PASS: neighbor-read-identity
+A t=0 M={+e_2} O={+e_1, −e_1, +e_3} Axis(M)={e_2} Axis(O)={e_1, e_3} split=hold neighbor-read=hold
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} split=hold neighbor-read=hold
+C t=1 M={+e_3} O={+e_1, −e_1, −e_2} Axis(M)={e_3} Axis(O)={e_1, e_2} split=hold neighbor-read=hold
+D t=1 M={+e_1} O={−e_2, +e_3, −e_3} Axis(M)={e_1} Axis(O)={e_2, e_3} split=hold neighbor-read=hold
+neighbor-read reverse=hold face=hold
+per_element: each 1-in 2-out axis assignment of M and O at a probe and at formed 6-NN, compared as unsigned axes at the probe's t+1
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-O-at-tau  ({'A': ('{+e_2}', '{+e_1, −e_1, +e_3}'), 'B': ('{+e_1}', '{+e_2, +e_3, −e_3}'), 'C': ('{+e_3}', '{+e_1, −e_1, −e_2}'), 'D': ('{+e_1}', '{−e_2, +e_3, −e_3}')})
+PASS: theorem1-axis-split
+PASS: theorem1-formed-6nn-A
+PASS: theorem1-formed-6nn-B
+PASS: theorem1-formed-6nn-C
+PASS: theorem1-formed-6nn-D
+PASS: theorem1-neighbor-read-bits  ({'A': ('hold', ((0, 1, 1),)), 'B': ('hold', ((1, 0, 1),)), 'C': ('hold', ((0, 1, 2),)), 'D': ('hold', ((1, 1, 1),))})
+PASS: theorem1-split-fail-is-fail-not-undefined
+PASS: theorem1-axis-match-not-signed-sets
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-hold
+PASS: theorem3-face-hold
+PASS: mutation-signed-pair-fails
+PASS: mutation-M-read-differs
+PASS: mutation-O-read-differs
+PASS: not-x-probes-or-y-probes-or-perp
+PASS: not-nsopp-leftover-second-pair-is-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-nread
+PASS: note-reports-formed-neighbors
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-m-or-o-or-signed-leftover
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: neighbor-read-not-m-or-o-read
+TOTAL: PASS=49 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1286 @@
+#!/usr/bin/env python3
+"""Neighbor-read of the 1-in 2-out split at t+1 reverse/face on z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and z-probes as nm2axz.
+A 6-NN step is allowed iff it is perpendicular to the parent lock axis.
+Newly formed sites lock the incoming step. Seeds keep their seed letters as
+a singleton. t(q) is the formation tick. tau = t(q)+1. M, O, and split are
+as nm2ax12z. Unformed at tau => UNDEFINED. Neighbor-read of split HOLDs at
+q iff split HOLDs at q and some formed 6-NN r has split HOLD and
+Axis(M(r, tau)) = Axis(M(q, tau)) and Axis(O(r, tau)) = Axis(O(q, tau)).
+If split fails at q, neighbor-read fails, not UNDEFINED. Uniqueness is not
+required. Reverse HOLDs iff neighbor-read at A and at B. Face likewise on
+C, D. Occupancy of sites is not used. Named-sign lettering is not used.
+No larger host. This is not leftover of neighbor-read of M, not leftover of
+neighbor-read of O, and not leftover of signed (M, O) set equality.
+Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "\u2212e_1",
+    E2: "+e_2",
+    NEG_E2: "\u2212e_2",
+    E3: "+e_3",
+    NEG_E3: "\u2212e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of the 1-in 2-out split at t+1 on the four z-probes of the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def neg(step: Point) -> Point:
+    return (-step[0], -step[1], -step[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2).
+
+    2-in 1-out (cover HOLD with |Axis(M)|=2) is fail of this object, not
+    UNDEFINED.
+    """
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def matching_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Formed 6-NN r recovering the same 1-in 2-out axis assignment.
+
+    If split fails at site, return the empty tuple (fail, not UNDEFINED).
+    Unformed site => UNDEFINED.
+    """
+    own_m = incoming_set(site, tau, ticks, locks, seed_map)
+    own_o = outgoing_set(site, tau, ticks, locks, seed_map)
+    split = axis_split(own_m, own_o)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return ()
+    axes_m = axis_set(own_m)
+    axes_o = axis_set(own_o)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other_m = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        other_o = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if axis_split(other_m, other_o) != "hold":
+            continue
+        if axis_set(other_m) == axes_m and axis_set(other_o) == axes_o:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLDs and a formed 6-NN recovers the same 1+2 axes.
+
+    Unformed => UNDEFINED. Split fail => fail, not UNDEFINED.
+    """
+    matches = matching_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def formed_neighbor_rows(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[tuple[Point, Incoming, Outgoing, str, str], ...]:
+    """M, O, split, neighbor-read at each eventually-formed 6-NN, same tau."""
+    rows: list[tuple[Point, Incoming, Outgoing, str, str]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        outgoing = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        rows.append(
+            (
+                neighbor,
+                incoming,
+                outgoing,
+                axis_split(incoming, outgoing),
+                neighbor_read(neighbor, tau, ticks, locks, seed_map),
+            )
+        )
+    return tuple(rows)
+
+
+def matching_incoming_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with M(r, tau) equal to M(site, tau)."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_incoming(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of M. Not this letter."""
+    matches = matching_incoming_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def matching_outgoing_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with O(r, tau) equal to O(site, tau)."""
+    own = outgoing_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_outgoing(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of O. Not this letter."""
+    matches = matching_outgoing_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def signed_pair_matches(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: split HOLD plus M and O equal as signed sets."""
+    own_m = incoming_set(site, tau, ticks, locks, seed_map)
+    own_o = outgoing_set(site, tau, ticks, locks, seed_map)
+    split = axis_split(own_m, own_o)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return ()
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other_m = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        other_o = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if axis_split(other_m, other_o) != "hold":
+            continue
+        if other_m == own_m and other_o == own_o:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def signed_pair_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: signed (M, O) recovery. Not this letter."""
+    matches = signed_pair_matches(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def pair_read(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def reverse_report(read_a: str, read_b: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_read(read_a, read_b)
+
+
+def face_report(read_c: str, read_d: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_read(read_c, read_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def probe_reads(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = neighbor_read(
+            site,
+            site_ticks[site] + 1,
+            site_ticks,
+            site_locks,
+            site_seeds,
+        )
+    return out
+
+
+def match_display(matches: tuple[Point, ...] | str) -> str:
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if not matches:
+        return "none"
+    return ", ".join(str(site) for site in matches)
+
+
+def formed_line(
+    rows: tuple[tuple[Point, Incoming, Outgoing, str, str], ...],
+) -> str:
+    parts: list[str] = []
+    for neighbor, incoming, outgoing, split, read in rows:
+        parts.append(
+            f"{neighbor} M={lockset_display(incoming)} "
+            f"O={lockset_display(outgoing)} split={split} "
+            f"neighbor-read={read}"
+        )
+    return ", ".join(parts)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("neighbor-read of 1-in 2-out split reverse/face at t+1 on z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == PAIR2
+        and neg(E1) == NEG_E1
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "pair-read-identity",
+        pair_read(UNDEFINED, "hold") == UNDEFINED
+        and pair_read("hold", UNDEFINED) == UNDEFINED
+        and pair_read("hold", "hold") == "hold"
+        and pair_read("hold", "fail") == "fail"
+        and pair_read("fail", "hold") == "fail"
+        and pair_read("fail", "fail") == "fail",
+    )
+    checks.check(
+        "neighbor-read-identity",
+        neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and matching_neighbors(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and incoming_set(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and outgoing_set(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and axis_split(UNDEFINED, UNDEFINED) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    twosite_ticks, twosite_locks, twosite_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+
+    tau1: dict[str, int] = {}
+    m1: dict[str, Incoming] = {}
+    o1: dict[str, Outgoing] = {}
+    split: dict[str, str] = {}
+    reads: dict[str, str] = {}
+    reads_m: dict[str, str] = {}
+    reads_o: dict[str, str] = {}
+    reads_signed: dict[str, str] = {}
+    matches: dict[str, tuple[Point, ...] | str] = {}
+    formed: dict[str, tuple[tuple[Point, Incoming, Outgoing, str, str], ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau1[name] = ticks[site] + 1
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        split[name] = axis_split(m1[name], o1[name])
+        reads[name] = neighbor_read(site, tau1[name], ticks, locks, seed_map)
+        reads_m[name] = neighbor_read_incoming(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_o[name] = neighbor_read_outgoing(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_signed[name] = signed_pair_read(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        matches[name] = matching_neighbors(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        formed[name] = formed_neighbor_rows(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"Axis(M)={axis_display(axis_set(m1[name]))} "
+            f"Axis(O)={axis_display(axis_set(o1[name]))} "
+            f"split={split[name]} "
+            f"neighbor-read={reads[name]}"
+        )
+
+    reverse = reverse_report(reads["A"], reads["B"])
+    face = face_report(reads["C"], reads["D"])
+    print(f"neighbor-read reverse={reverse} face={face}")
+    print(
+        "per_element: each 1-in 2-out axis assignment of M and O at a probe "
+        "and at formed 6-NN, compared as unsigned axes at the probe's t+1"
+    )
+    print(
+        "per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four neighbor-read reports, reverse/face from those bits")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["C"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 0, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-at-tau",
+        m1["A"] == frozenset({E2})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E1})
+        and o1["A"] == frozenset({E1, NEG_E1, E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, NEG_E2})
+        and o1["D"] == frozenset({NEG_E2, E3, NEG_E3}),
+        str(
+            {
+                name: (lockset_display(m1[name]), lockset_display(o1[name]))
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-axis-split",
+        axis_set(m1["A"]) == frozenset({E2})
+        and axis_set(o1["A"]) == frozenset({E1, E3})
+        and axis_set(m1["B"]) == frozenset({E1})
+        and axis_set(o1["B"]) == frozenset({E2, E3})
+        and axis_set(m1["C"]) == frozenset({E3})
+        and axis_set(o1["C"]) == frozenset({E1, E2})
+        and axis_set(m1["D"]) == frozenset({E1})
+        and axis_set(o1["D"]) == frozenset({E2, E3})
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "hold",
+    )
+    empty: Incoming = frozenset()
+    checks.check(
+        "theorem1-formed-6nn-A",
+        formed["A"]
+        == (
+            ((1, 0, 1), frozenset({E1}), empty, "fail", "fail"),
+            ((-1, 0, 1), frozenset({NEG_E1}), empty, "fail", "fail"),
+            (
+                (0, 1, 1),
+                frozenset({NEG_E2}),
+                frozenset({E1, NEG_E1, E3}),
+                "hold",
+                "hold",
+            ),
+            ((0, -1, 1), UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED),
+            ((0, 0, 2), frozenset({E3}), empty, "fail", "fail"),
+            (
+                (0, 0, 0),
+                frozenset({E1}),
+                frozenset({NEG_E2, NEG_E3}),
+                "hold",
+                "hold",
+            ),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-B",
+        formed["B"]
+        == (
+            ((2, 1, 1), UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED),
+            (
+                (0, 1, 1),
+                frozenset({NEG_E2}),
+                frozenset({E1, NEG_E1, E3}),
+                "hold",
+                "hold",
+            ),
+            ((1, 2, 1), frozenset({E2}), empty, "fail", "fail"),
+            (
+                (1, 0, 1),
+                frozenset({E1}),
+                frozenset({NEG_E2, E3, NEG_E3}),
+                "hold",
+                "hold",
+            ),
+            ((1, 1, 2), frozenset({E1, E3}), empty, "fail", "fail"),
+            ((1, 1, 0), frozenset({NEG_E3}), frozenset({NEG_E1}), "fail", "fail"),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-C",
+        formed["C"]
+        == (
+            ((1, 0, 2), frozenset({E1, E3}), empty, "fail", "fail"),
+            ((-1, 0, 2), frozenset({NEG_E1, E3}), empty, "fail", "fail"),
+            (
+                (0, 1, 2),
+                frozenset({E3}),
+                frozenset({E1, NEG_E1, E2}),
+                "hold",
+                "hold",
+            ),
+            ((0, -1, 2), frozenset({NEG_E2}), empty, "fail", "fail"),
+            (
+                (0, 0, 1),
+                frozenset({E2}),
+                frozenset({E1, NEG_E1, E3}),
+                "hold",
+                "hold",
+            ),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-D",
+        formed["D"]
+        == (
+            ((2, 0, 1), UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED),
+            (
+                (0, 0, 1),
+                frozenset({E2}),
+                frozenset({E1, NEG_E1, E3}),
+                "hold",
+                "hold",
+            ),
+            (
+                (1, 1, 1),
+                frozenset({E1}),
+                frozenset({E2, E3, NEG_E3}),
+                "hold",
+                "hold",
+            ),
+            ((1, -1, 1), frozenset({NEG_E2}), empty, "fail", "fail"),
+            ((1, 0, 2), frozenset({E1, E3}), empty, "fail", "fail"),
+            ((1, 0, 0), frozenset({NEG_E3}), empty, "fail", "fail"),
+        ),
+    )
+    checks.check(
+        "theorem1-neighbor-read-bits",
+        reads["A"] == "hold"
+        and reads["B"] == "hold"
+        and reads["C"] == "hold"
+        and reads["D"] == "hold"
+        and matches["A"] == ((0, 1, 1),)
+        and matches["B"] == ((1, 0, 1),)
+        and matches["C"] == ((0, 1, 2),)
+        and matches["D"] == ((1, 1, 1),),
+        str({name: (reads[name], matches[name]) for name in ("A", "B", "C", "D")}),
+    )
+    d_at_a_tau = neighbor_read((1, 0, 1), tau1["A"], ticks, locks, seed_map)
+    checks.check(
+        "theorem1-split-fail-is-fail-not-undefined",
+        axis_split(
+            incoming_set((1, 0, 1), tau1["A"], ticks, locks, seed_map),
+            outgoing_set((1, 0, 1), tau1["A"], ticks, locks, seed_map),
+        )
+        == "fail"
+        and d_at_a_tau == "fail"
+        and d_at_a_tau != UNDEFINED
+        and neighbor_read((0, -1, 1), tau1["A"], ticks, locks, seed_map)
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-axis-match-not-signed-sets",
+        m1["A"] == frozenset({E2})
+        and incoming_set(PAIR2, tau1["A"], ticks, locks, seed_map)
+        == frozenset({NEG_E2})
+        and m1["A"] != incoming_set(PAIR2, tau1["A"], ticks, locks, seed_map)
+        and axis_set(m1["A"])
+        == axis_set(incoming_set(PAIR2, tau1["A"], ticks, locks, seed_map))
+        and o1["B"] != o1["D"]
+        and axis_set(o1["B"]) == axis_set(o1["D"])
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["A"]) == frozenset({E2})
+        and reads["A"] == "hold"
+        and reads["B"] == "hold",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and m1["A"] == frozenset({E2})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem2-reverse-hold",
+        reverse == "hold"
+        and reads["A"] == "hold"
+        and reads["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail",
+    )
+    checks.check(
+        "theorem3-face-hold",
+        face == "hold"
+        and reads["C"] == "hold"
+        and reads["D"] == "hold"
+        and face != UNDEFINED
+        and face != "fail",
+    )
+    checks.check(
+        "mutation-signed-pair-fails",
+        reads_signed["A"] == "fail"
+        and reads_signed["B"] == "fail"
+        and reads_signed["C"] == "fail"
+        and reads_signed["D"] == "fail"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    checks.check(
+        "mutation-M-read-differs",
+        reads_m["A"] == "fail"
+        and reads_m["B"] == "hold"
+        and reads_m["C"] == "hold"
+        and reads_m["D"] == "hold"
+        and reads["A"] == "hold"
+        and reverse == "hold",
+    )
+    checks.check(
+        "mutation-O-read-differs",
+        reads_o["A"] == "hold"
+        and reads_o["B"] == "fail"
+        and reads_o["C"] == "fail"
+        and reads_o["D"] == "fail"
+        and reads["B"] == "hold"
+        and reverse == "hold"
+        and face == "hold",
+    )
+    y_reads = probe_reads(Y_PROBES, ticks, locks, seed_map)
+    x_reads = probe_reads(X_PROBES, ticks, locks, seed_map)
+    perp_reads = probe_reads(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_reads = probe_reads(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    twosite_reads = probe_reads(
+        PROBES, twosite_ticks, twosite_locks, twosite_seeds
+    )
+    y_reverse = reverse_report(y_reads["A"], y_reads["B"])
+    y_face = face_report(y_reads["C"], y_reads["D"])
+    x_reverse = reverse_report(x_reads["A"], x_reads["B"])
+    x_face = face_report(x_reads["C"], x_reads["D"])
+    twosite_reverse = reverse_report(twosite_reads["A"], twosite_reads["B"])
+    twosite_face = face_report(twosite_reads["C"], twosite_reads["D"])
+    perp_reverse = reverse_report(perp_reads["A"], perp_reads["B"])
+    perp_face = face_report(perp_reads["C"], perp_reads["D"])
+    checks.check(
+        "not-x-probes-or-y-probes-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and y_reads["C"] == "fail"
+        and y_reads["D"] == "fail"
+        and y_reverse == "hold"
+        and y_face == "fail"
+        and x_reads["A"] == "fail"
+        and x_reads["D"] == "fail"
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and perp_reverse == "fail"
+        and perp_face == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and x_reverse != reverse
+        and y_face != face,
+    )
+    checks.check(
+        "not-nsopp-leftover-second-pair-is-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in twosite_ticks.values()) == 2
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and twosite_ticks[E3] == 1
+        and twosite_locks[E3] == {E3}
+        and twosite_reverse == "hold"
+        and twosite_face == "fail"
+        and reverse == "hold"
+        and face == "hold"
+        and twosite_face != face
+        and zsym_reads["A"] == "fail"
+        and zsym_reads["C"] == "fail",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-nread",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ) = {+e_2}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_3}" in note
+        and "M(D, τ) = {+e_1}" in note
+        and "O(A, τ) = {+e_1, \u2212e_1, +e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, \u2212e_3}" in note
+        and "O(C, τ) = {+e_1, \u2212e_1, \u2212e_2}" in note
+        and "O(D, τ) = {\u2212e_2, +e_3, \u2212e_3}" in note
+        and "Axis(M)(A, τ) = {e_2}" in note
+        and "Axis(O)(A, τ) = {e_1, e_3}" in note
+        and "Axis(M)(B, τ) = {e_1}" in note
+        and "Axis(O)(B, τ) = {e_2, e_3}" in note
+        and "Axis(M)(C, τ) = {e_3}" in note
+        and "Axis(O)(C, τ) = {e_1, e_2}" in note
+        and "Axis(M)(D, τ) = {e_1}" in note
+        and "Axis(O)(D, τ) = {e_2, e_3}" in note
+        and "split(A) = hold" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = hold" in note
+        and "neighbor-read(A) = hold" in note
+        and "neighbor-read(B) = hold" in note
+        and "neighbor-read(C) = hold" in note
+        and "neighbor-read(D) = hold" in note,
+    )
+    checks.check(
+        "note-reports-formed-neighbors",
+        "formed 6-NN of A at τ: " + formed_line(formed["A"]) in note
+        and "formed 6-NN of B at τ: " + formed_line(formed["B"]) in note
+        and "formed 6-NN of C at τ: " + formed_line(formed["C"]) in note
+        and "formed 6-NN of D at τ: " + formed_line(formed["D"]) in note
+        and "matching 6-NN of A: (0, 1, 1)" in note
+        and "matching 6-NN of B: (1, 0, 1)" in note
+        and "matching 6-NN of C: (0, 1, 2)" in note
+        and "matching 6-NN of D: (1, 1, 1)" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse neighbor-read at τ: hold" in note
+        and "Face neighbor-read at τ: hold" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-m-or-o-or-signed-leftover",
+        "not leftover of nm2readz neighbor-read of M" in normalized_note
+        and "not leftover of nm2oreadz neighbor-read of O" in normalized_note
+        and "not leftover of signed (M, O) set equality" in normalized_note
+        and "not leftover of nm2ax12z 1-in 2-out split without neighbor-read"
+        in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in allowed_retained for line in allowed_retained)
+        and all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_ONE_TWO_SPLIT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "neighbor_read" in defined_fns
+        and "matching_neighbors" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "formed_neighbor_rows" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "neighbor-read-not-m-or-o-read",
+        reverse == "hold"
+        and face == "hold"
+        and reads["A"] == "hold"
+        and reads["B"] == "hold"
+        and reads["C"] == "hold"
+        and reads["D"] == "hold"
+        and reads_m["A"] == "fail"
+        and reads_o["B"] == "fail"
+        and reads_signed["A"] == "fail",
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Neighbor-read of the HOLDING 3-split axis assignment: reverse HOLD, face HOLD. Not leftover of M-read or O-read. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_zprobe_neighbor_read_one_two_split_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.