### PR TITLE
feat(nm2oricht2z): opposite-pair 1-in 2-out frame orientation freeze t+1 vs t+2 on two-axis opposite z-probes: reverse HOLD, face fails, composition HOLD

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,767 @@
+---
+claim_id: two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Opposite-pair orientation at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+---
+
+# Opposite-Pair Orientation Freeze t+1 Versus t+2 Reverse And Face On Four Z-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** opposite-pair orientation of the 1-in 2-out frame of simultaneous
+earliest incoming set `M` and outgoing dual `O` at each probe's `τ1=t+1`
+and `τ2=t+2`, reverse/face from that sign at each cut, and composition of
+Orient, on the four z-probes of the two-axis opposite seed in
+`B_3(0)={n:n·n<=9}`. Same process and z-probes as nm2axz. Orient as
+nm2orichz at each cut. `M` and `O` as nm2ax12z. Let `t(q)` be the
+formation tick of probe `q`. Cuts are local: `τ1=t+1`, `τ2=t+2`.
+There is no global T. Do not score τ=t. `M(q,τ)` is the set of earliest
+incoming nearest-neighbor steps at `q` using only records with tick
+`<= τ`. Seeds are a singleton seed letter. `O(q,τ)` is the outgoing dual
+of `M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed
+and `e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is
+empty, not `UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)`
+equals `{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). Split HOLD required. When `M` is
+singleton `{m}` and `O` contains some `e` and `−e`, let `o_pair` be that
+`e` of smallest axis index, leftover axis `ℓ` the unique Axis not in
+`{axis(m), axis(e)}`, oriented as the unit `+ℓ`. `Orient(q,τ)` is the
+sign of the integer determinant of the 3×3 matrix with columns `m`, `e`,
+`+ℓ`. If no opposite pair in `O`, fail, not `UNDEFINED`. Else fail, not
+`UNDEFINED`, if split fails. Reverse HOLDs if and only if
+`Orient(A)=Orient(B)` both `±1` at that cut. Face HOLDs if and only if
+`Orient(C)=Orient(D)` both `±1` at that cut. Composition HOLDs if and
+only if `Orient` at `τ1` equals `Orient` at `τ2` at `A,B,C,D`. Cover and
+split do not score handedness. This is not leftover of nm2orichz
+opposite-pair orientation at `t+1` alone. This is not leftover of
+nm2simt2z simultaneous `M` and `O` freeze. This is not leftover of
+nm2chiralz lexicographic `o1,o2` orientation. This is not leftover of
+nm2axz axis-cover. This is not leftover of nm2ax12z 1-in 2-out split.
+This is not leftover of leftover-of-`M` alone. This is not leftover of
+leftover-of-`O` alone. This is not leftover-empty fail of leftover axis.
+This is not leftover of nmunopp union. This is not leftover of nmt2opp
+`M` frozen at `t`. This is not leftover of nmot2opp two-tick composition.
+This is not leftover of nmoutopp untimed eventual-`O`. This is not
+leftover of mixed #7188 fail/fail. This is not leftover of the 1-axis
+opposite two-site seed. This is not leftover of the same-lock two-site
+seed. The second pair is a new seed, not a formed child. Uniqueness is
+not required. Mixed remains a set. Displayed, not adopted. Do not write
+into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cuts
+`τ1=t+1` and `τ2=t+2`. Axis is the unsigned lattice direction of a signed
+lock. Cover is the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)`
+and `Axis(O)`. Split is cover together with `|Axis(M)|=1`. The opposite-pair
+oriented frame is the integer sign of `det(m,e,+ℓ)` with unique signed
+incoming letter `m`, signed exist-opposite pair unit `e` of smallest axis
+index in `O`, and leftover unit `+ℓ`. Reverse and face are scored on equal
+`±1` signs at the paired probes at each cut. Composition is equality of
+those four Orient reports across the two cuts. Named signs `{+,−}` of locks
+are a coarser readout and are not used as the object. A singleton unique
+outgoing lock letter is a different readout and is not used as the object.
+Presence of an opposite pair in `O` without the determinant sign is a
+different readout and is not used. Lexicographic unsigned outgoing 2-plane
+`(o1,o2)` in axis order is a different readout and is not used.
+Existential opposite of signed locks across probes is a different readout
+and is not used. Axis-cover without the frame sign is a different readout
+and is not used. 1-in 2-out split without the frame sign is a different
+readout and is not used. Simultaneous `M` and `O` freeze is a different
+readout and is not used. Leftover-empty fail of unsigned leftover axis
+sets is a different readout and is not used. A `Z^3` sum of those locks
+is a different readout and is not used. Occupancy of sites is not used. A
+six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of opposite-pair orientation of the 1-in 2-out frame of M and O at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, Orient at A,B,C,D at each cut, reverse hold and face fail at each cut, composition hold; uniqueness of outgoing locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face
+target_blocker_text: "display opposite-pair orientation freeze t+1 versus t+2 reverse/face composition on the four z-probes of the two-axis opposite seed"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep opposite-pair orientation of the 1-in 2-out frame of M and O at t+1 versus t+2 displayed; do not write Orient into Admissibility, do not reduce to nm2orichz t+1 alone, do not reduce to nm2simt2z M-and-O freeze, do not reduce to lexicographic o1,o2, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace Orient by presence of an opposite pair in O, do not replace Orient by existential opposite of signed locks, do not replace Orient by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for opposite-pair orientation of the 1-in 2-out frame of M and O at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose
+opposite-pair 1-in 2-out frame of `M` and `O` is scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (1,0,1).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the second opposite pair. Same process and
+z-probes as nm2axz.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named opposite-pair 1-in 2-out frame of `M` and `O` at `τ1` and `τ2`
+
+Let `t(q)` be the formation tick of z-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ1(q)=t(q)+1` and `τ2(q)=t(q)+2`. There is no global T.
+Do not score `τ=t`.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at a cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at a cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Opposite-pair oriented frame at a cut, as nm2orichz:
+
+```text
+When M is singleton {m} and O contains some e and −e,
+o_pair is that e of smallest axis index.
+leftover axis ℓ is the unique Axis not in {axis(m), axis(e)},
+oriented as the unit +ℓ.
+Orient(q,τ) = sign of the integer determinant of columns (m, e, +ℓ).
+If no opposite pair in O, fail, not UNDEFINED.
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+The opposite-pair unit is the positive lattice unit of the smallest-index
+axis on which `O` contains both signs. Unique outgoing letters are not
+required. Mixed opposite signs occupy that axis as the pair. A vanishing
+determinant is fail. Sign of a nonzero integer determinant is `+1` or `−1`.
+Split HOLD required: 2-in 1-out is Orient fail, not UNDEFINED, even if `O`
+contains an opposite pair.
+
+Reverse oriented frame at a cut holds if and only if `Orient(A)=Orient(B)`
+and both signs are `±1`. Face oriented frame at a cut holds if and only if
+`Orient(C)=Orient(D)` and both signs are `±1`. Either side `UNDEFINED` is
+`UNDEFINED`. Else if both sides are equal `±1`, reverse or face HOLDs.
+Else fail.
+
+Composition holds if and only if `Orient(q,τ1)=Orient(q,τ2)` at each of
+`A,B,C,D`. Either side `UNDEFINED` is `UNDEFINED`. Else if the four signs
+agree across the two cuts, composition HOLDs. Else fail.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover HOLDs reverse and face while this face
+fails. Identifying split reverse with this reverse is refused: split HOLDs
+reverse and face while this face fails. Identifying leftover-empty fail
+with this reverse is refused: leftover-empty fail scores empty leftover as
+reverse fail, while this reverse HOLDs. Identifying lexicographic
+`o1,o2` orientation with this reverse is refused: lexicographic reverse
+fails with `Orient_lex(A)=−1` and `Orient_lex(B)=+1`, while this reverse
+HOLDs. Identifying presence of an opposite pair in `O` with this face is
+refused: each of `C` and `D` has an opposite pair in `O`, so pair-presence
+face HOLDs while this face fails. Identifying nm2simt2z `M` and `O` freeze
+with this composition is refused: that letter is equality of lock sets,
+not equality of `det(m,e,+ℓ)` signs. Identifying a named sign of those
+locks with reverse or face is refused: named-sign lettering lost the axis.
+
+## Theorem 1 — ticks, `M`, `O`, and Orient at `τ1` and `τ2`
+
+On this process the four z-probes form. Compare to leftover axis: that
+leftover reports empty leftover at each probe and leftover reverse fail
+and leftover face fail. Compare to nm2axz cover and nm2ax12z split: both
+HOLD reverse and face on this member. Compare to nm2chiralz lexicographic
+`o1,o2` orientation: reverse fails and face HOLDs on this member. Compare
+to nm2orichz: that letter is the `t+1` cut alone. This display reads the
+opposite-pair oriented frame of those same timed sets at both cuts:
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=1
+M(A, τ1) = {+e_2}
+M(B, τ1) = {+e_1}
+M(C, τ1) = {+e_3}
+M(D, τ1) = {+e_1}
+O(A, τ1) = {+e_1, −e_1, +e_3}
+O(B, τ1) = {+e_2, +e_3, −e_3}
+O(C, τ1) = {+e_1, −e_1, −e_2}
+O(D, τ1) = {−e_2, +e_3, −e_3}
+Orient(A, τ1) = −1
+Orient(B, τ1) = −1
+Orient(C, τ1) = +1
+Orient(D, τ1) = −1
+M(A, τ2) = {+e_2}
+M(B, τ2) = {+e_1}
+M(C, τ2) = {+e_3}
+M(D, τ2) = {+e_1}
+O(A, τ2) = {+e_1, −e_1, +e_3}
+O(B, τ2) = {+e_2, +e_3, −e_3}
+O(C, τ2) = {+e_1, −e_1, −e_2}
+O(D, τ2) = {−e_2, +e_3, −e_3}
+Orient(A, τ2) = −1
+Orient(B, τ2) = −1
+Orient(C, τ2) = +1
+Orient(D, τ2) = −1
+```
+
+`A` is a seed at tick 0 with seed letter `+e_2`. Mixed remains a set:
+`O(A,τ1)` has three outgoing steps and `O(D,τ1)` has three outgoing steps.
+Unique outgoing letters would assign `UNDEFINED` at mixed `O`. Here the
+opposite pair in `O` is the signed exist-opposite pair of smallest axis
+index, so mixed opposite signs occupy that axis as the pair and Orient is
+defined. `M` is a singleton at each probe, so the unique signed `m`
+exists. At each probe at each cut split HOLDs and `O` contains an opposite
+pair, so Orient is the nonzero integer sign of `det(m,e,+ℓ)`, not fail.
+Cover and split HOLD at each probe and do not score that `Orient(C)` and
+`Orient(D)` are opposite. Lexicographic `o1,o2` at `B` and at `D` uses
+axis order `(e_2,e_3)` and yields `+1`; this pair at `B` and at `D` is
+`+e_3` with leftover `+e_2` and yields `−1`. O is not M.
+
+On the 1-axis opposite two-site seed, `A=(0,0,1)` is a formed child at
+tick 1 locking `+e_3`, and `C` is 2-in 1-out, so split fails at `C` and
+Orient at `C` is fail, not UNDEFINED, even if one asks only for an
+opposite pair in `O`. That is leftover of the first pair. Here both
+`(0,0,1)` and `(0,1,1)` are seeds of a second opposite pair on a second
+axis. On the y-probes of this same seed, split HOLDs at `A` while `O(A)`
+has no opposite pair, so opposite-pair Orient fails, not UNDEFINED, while
+lexicographic `o1,o2` at that y-probe is defined.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`. The `t+2` neighbor of `A` forms with
+earliest incoming `+e_3`, so `−e_2` does not enter `O(A,τ2)`:
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)
+new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)
+new 6-NN of A at t(A)+2: (0, -1, 1)
+new 6-NN of B at t(B)+2: none
+new 6-NN of C at t(C)+2: none
+new 6-NN of D at t(D)+2: none
+```
+
+`M` is frozen from `t` to `t+1` and from `t+1` to `t+2`. At `t`, `O` is
+empty at each probe, split fails, and Orient is fail, not UNDEFINED.
+Do not score `τ=t`.
+
+## Theorem 2 — reverse and face from oriented frame at `τ1` and `τ2`
+
+Reverse oriented frame holds if and only if `Orient(A)=Orient(B)` both
+`±1`. At `τ1`, `Orient(A)=−1` and `Orient(B)=−1`. Reverse HOLDs. At `τ2`,
+`Orient(A)=−1` and `Orient(B)=−1`. Reverse HOLDs. This is HOLD iff equal
+`±1` signs, not leftover of nm2chiralz lexicographic `o1,o2`, not leftover
+of nm2axz axis-cover, not leftover of nm2ax12z 1-in 2-out split, not
+leftover-empty fail, and not exist-opposite.
+
+Reverse oriented frame at τ1: hold
+Reverse oriented frame at τ2: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Cover reverse HOLDs
+because cover HOLDs at `A` and at `B`. Split reverse HOLDs because split
+HOLDs at `A` and at `B`. Cover and split do not score handedness.
+Lexicographic reverse fails because lexicographic `Orient(A)=−1` and
+`Orient(B)=+1`. Opposite-pair reverse HOLDs because both signs are `−1`.
+Leftover-empty reverse fails because leftover of the union is empty at `A`
+and at `B`. Leftover of `M` reverse fails because leftover of `M` at `A`
+is `{e_1, e_3}` and at `B` is `{e_2, e_3}`: nonempty and unequal. Leftover
+of `O` reverse fails because leftover of `O` at `A` is `{e_2}` and at `B`
+is `{e_1}`: nonempty and unequal. Exist-opposite reverse of signed `M`
+fails. Exist-opposite reverse of signed `O` holds. Presence of an
+opposite pair in `O` at `A` and at `B` HOLDs. Those leftovers are not
+this display.
+
+Face oriented frame holds if and only if `Orient(C)=Orient(D)` both `±1`.
+At `τ1`, `Orient(C)=+1` and `Orient(D)=−1`. Face fails. At `τ2`,
+`Orient(C)=+1` and `Orient(D)=−1`. Face fails.
+
+Face oriented frame at τ1: fail
+Face oriented frame at τ2: fail
+
+Cover face HOLDs because cover HOLDs at `C` and at `D`. Split face HOLDs
+because split HOLDs at `C` and at `D`. Opposite-pair oriented face fails
+because the two frame signs are opposite. Lexicographic face HOLDs because
+both lexicographic signs are `+1`. Cover and split do not score
+handedness. Presence of an opposite pair in `O` HOLDs at `C` and at `D`,
+so pair-presence face HOLDs while this face fails. On the 1-axis opposite
+two-site seed, cover face HOLDs while split face fails at `C` from 2-in
+1-out, and Orient at `C` is fail, not UNDEFINED. This two-axis member is
+not leftover of that 1-axis split face fail. The four y-probes of this
+same seed give Orient fail at `A` from no opposite pair in `O` and Orient
+fail at `D` from split fail, so oriented reverse fails and oriented face
+fails. The four x-probes give oriented reverse fail and oriented face
+fail. Those probe-direction readouts are not this z-probe display.
+Leftover-empty face fails because leftover of the union is empty at `C`
+and at `D`. Leftover of `M` at `C` is `{e_1, e_2}` and leftover of `M` at
+`D` is `{e_2, e_3}`: nonempty and unequal. Leftover of `O` at `C` is
+`{e_3}` and leftover of `O` at `D` is `{e_1}`: nonempty and unequal.
+Exist-opposite face of signed `M` fails. Exist-opposite face of signed
+`O` fails. Opposite-pair oriented face fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover HOLDs at `D` and split HOLDs at `D`. Orient at `D`
+is `−1` at both cuts.
+
+Reverse holds at both cuts. Face fails at both cuts.
+
+## Theorem 3 — composition of Orient at `τ1` versus `τ2`
+
+Composition HOLDs if and only if `Orient` at `τ1` equals `Orient` at `τ2`
+at `A,B,C,D`. `Orient(A,τ1)=Orient(A,τ2)=−1`,
+`Orient(B,τ1)=Orient(B,τ2)=−1`, `Orient(C,τ1)=Orient(C,τ2)=+1`,
+`Orient(D,τ1)=Orient(D,τ2)=−1`. Composition HOLDs.
+
+Composition of Orient: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+The reverse-only orientation of nm2orichz (reverse HOLD, face fail at
+`t+1`) freezes at `t+2`: the four signs are unchanged. That freeze is
+the present letter. It is not leftover of nm2orichz, which scores only
+one cut. It is not leftover of nm2simt2z, which scores equality of `M`
+and of `O` rather than equality of Orient. On this member `M` and `O`
+also freeze, so simultaneous freeze HOLDs as a leftover; the scored
+object remains the four Orient signs. Bit-stability of reverse HOLD and
+face fail is a leftover predicate: those bits can agree while a probe
+sign flips, which composition of Orient would fail. Composition of
+Orient at `τ=t` versus `τ=t+1` fails because Orient is fail at formation
+and `±1` at `t+1`. Do not score `τ=t`.
+
+## What this note does not claim
+
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by lexicographic `o1,o2` orientation.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not replace Orient composition by nm2simt2z `M` and `O` freeze.
+- It does not treat split fail as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2axz axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2ax12z 1-in 2-out split reverse hold face hold as
+  this oriented display.
+- It does not reprint nm2chiralz lexicographic `o1,o2` reverse fail face
+  hold as this oriented display.
+- It does not reprint nm2orichz opposite-pair orientation at `t+1` alone.
+- It does not reprint nm2simt2z simultaneous `M` and `O` freeze as this
+  Orient composition.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite seed process, opposite-pair orientation of the 1-in 2-out
+frame of `M` and `O` at `t+1` versus `t+2`, reverse/face at each cut, and
+composition of Orient are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `1` |
+| `M` at `τ1` and at `τ2` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ1` and at `τ2` | Theorem 1; HOLDING outgoing dual, freeze |
+| unique signed `m`, opposite pair in `O`, leftover `+ℓ` | Theorem 1; singleton `M`, smallest-index pair, leftover unit |
+| integer `det(m,e,+ℓ)` at both cuts | Theorem 1; `−1,−1,+1,−1` at each cut |
+| Orient at `τ1` | Theorem 1; `−1,−1,+1,−1` |
+| Orient at `τ2` | Theorem 1; `−1,−1,+1,−1` |
+| reverse from oriented frame at `τ1` and at `τ2` | Theorem 2; `hold` at each cut |
+| face from oriented frame at `τ1` and at `τ2` | Theorem 2; `fail` at each cut |
+| composition of Orient | Theorem 3; `hold` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2axz axis-cover HOLD | not this oriented display |
+| leftover of nm2ax12z 1-in 2-out split HOLD | not this oriented display |
+| leftover of nm2chiralz lexicographic `o1,o2` | not this oriented display |
+| leftover of nm2orichz `t+1` alone | not this freeze letter |
+| leftover of nm2simt2z `M` and `O` freeze | not this Orient composition |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or x-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| score at `τ=t` | refused |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: does the reverse-only opposite-pair orientation of nm2orichz freeze from `t+1` to `t+2` on the four z-probes of the two-axis opposite seed. |
+| V2 | Current main has no landed opposite-pair-frame reverse/face composition of timed `M` and `O` at `t+1` versus `t+2` on these four z-probes of the two-axis opposite seed. |
+| V3 | Orient reports at two cuts, the reverse/face bits at each cut, and composition are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the integer sign of `det(m,e,+ℓ)` at two local cuts and reports that reverse HOLDs, face fails, and the four signs freeze, while lexicographic reverse fails, cover/split/pair-presence HOLD face, and nm2simt2z scores lock-set equality rather than Orient equality. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by nm2chiralz lexicographic `o1,o2`, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2axz axis-cover, does not
+replace Orient by nm2ax12z 1-in 2-out split, does not replace this freeze
+by nm2orichz `t+1` alone, does not replace Orient composition by nm2simt2z
+`M` and `O` freeze, does not identify this display with the 1-axis opposite
+two-site seed, and does not identify it with nmunopp union. No global
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2orichz `t+1` alone | reuse reverse hold and face fail at one cut | that letter has no `t+2` cut and no Orient composition | ATTEMPTED |
+| nm2simt2z `M` and `O` freeze | score equality of lock sets | simultaneous freeze HOLDs here as leftover; composition of this letter is equality of Orient signs | ATTEMPTED |
+| reverse/face bit-stability | score reverse and face bits equal across cuts | those bits can agree while a probe sign flips; composition of Orient would then fail | ATTEMPTED |
+| nm2chiralz lexicographic `o1,o2` | reuse lexicographic reverse fail and face hold | lexicographic reverse fails (`−1,+1`) while this reverse HOLDs (`−1,−1`); lexicographic face HOLDs while this face fails | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse hold and cover face hold on these z-probes | cover face HOLDs while Orient face fails: `Orient(C)=+1` and `Orient(D)=−1` | ATTEMPTED |
+| nm2ax12z 1-in 2-out split | reuse split reverse hold and split face hold | split face HOLDs while Orient face fails; Cover and split do not score handedness | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails while Orient reverse HOLDs; leftover face fails with Orient face | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_3}` and at `B` is `{e_2,e_3}`, nonempty unequal; leftover reverse fails while Orient reverse HOLDs | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is `{e_2}` and at `B` is `{e_1}`, nonempty unequal; leftover reverse fails while Orient reverse HOLDs | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `M` fails while Orient reverse HOLDs; exist-opposite is a cross-probe boolean, not `det(m,e,+ℓ)` | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence HOLDs at `C` and at `D`, so that face HOLDs while Orient face fails | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of signed incoming, pair unit, and leftover unit | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; pair is `+e_1` and Orient is `−1` | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | on this member they agree because each `M` letter is the positive unit; flipping `m` at `A` to `−e_2` flips Orient to `+1` while unsigned axis stays `e_2` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; none of these four probes is 2-in 1-out | ATTEMPTED |
+| no opposite pair as `UNDEFINED` | treat missing `e` and `−e` in `O` as unformed | missing opposite pair is Orient fail, not UNDEFINED; y-probe `A` of this seed is the witness | ATTEMPTED |
+| score at `τ=t` | compose Orient at formation versus `t+1` | leftover of nmot2opp; Orient is fail at `t` and `±1` at `t+1`; Do not score `τ=t` | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(A)=1`, `t(C)=4`, mixed `M(C)`, Orient fail at `C` | different seed; second pair is a new seed, not a formed child; here `t(A)=0` and Orient at `C` is `+1` | ATTEMPTED |
+| y-probe Orient | score the four y-probes on this seed | y-probe Orient fails at `A` from no opposite pair in `O`; this letter is the four z-probes | ATTEMPTED |
+| x-probe Orient | score the four x-probes on this seed | x-probe reverse fails at `A`; this letter is the four z-probes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores the opposite-pair oriented frame of own incoming and outgoing at `t+1` versus `t+2` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports Orient `−1,−1,+1,−1`, reverse hold, and face fail at both cuts | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum; mixed `O(A)` sums to `+e_3` while the pair is `+e_1` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ1(q)=t(q)+1` and `τ2(q)=t(q)+2` are per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with nm2chiralz lexicographic `o1,o2`, missing
+identification of Orient with nmcover axis-cover, missing identification of
+Orient with nm2axz axis-cover, missing identification of Orient with
+nm2ax12z 1-in 2-out split, missing identification of this freeze with
+nm2orichz `t+1` alone, missing identification of Orient composition with
+nm2simt2z `M` and `O` freeze, missing identification of this seed with the
+1-axis opposite two-site seed, and missing Record identification of Orient
+reverse are distinct open premises. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ1=t+1`
+and `τ2=t+2`, unsigned axis, cover as complementary occupation of
+`{e_1,e_2,e_3}`, split as cover and `|Axis(M)|=1`, unique signed `m` when
+split HOLDs, smallest-index opposite pair in `O` when present, leftover
+unit `+ℓ`, integer determinant sign, missing opposite pair as Orient fail
+not `UNDEFINED`, split fail as Orient fail not `UNDEFINED`, four z-probes
+with seed `A`, second pair as a new seed not a formed child, mixed remains
+a set, and composition as equality of Orient at the two cuts are declared.
+No uniqueness of outgoing locks, no six-neighbor lock union as the scored
+object, no lock-count clock, no global later T, no formation attachment
+from already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+Orient `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | signed incoming letter, smallest-index opposite pair in `O`, leftover `+axis` among `{e_1,e_2,e_3}` at a probe's `t+1` and `t+2` | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four Orient reports at `t+1` and `t+2`, reverse/face at each cut, composition | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for Orient reverse/face, a
+formation-rate rule, a later cut `t+3`, and a physical selector among 1-in
+2-out frames. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Orient reverse hold is only cover reverse, only split reverse,
+or only presence of an opposite pair in `O`; lexicographic `o1,o2` already
+answers handedness; leftover-empty fail already answers reverse; leftover
+of `M` alone already answers reverse; leftover of `O` alone already answers
+reverse; exist-opposite of signed `O` already answers reverse; the second
+pair is only the formed child `(0,0,1)` of the 1-axis seed; unique outgoing
+letters should be required; unsigned incoming axis already gives the same
+signs because each `M` letter is the positive unit; because `M` and `O`
+freeze, composition is nm2simt2z; because reverse HOLD and face fail at
+both cuts, composition is only bit-stability; and nm2orichz already
+answered reverse-only orientation.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Orient reverse HOLDs because `Orient(A)=−1` and
+`Orient(B)=−1`, while Orient face fails because `Orient(C)=+1` and
+`Orient(D)=−1`, at both cuts. Cover and split HOLD reverse and face on
+this member and do not score those opposite face signs. Lexicographic
+`o1,o2` reverse fails with `−1,+1` and face HOLDs with `+1,+1`; this
+reverse HOLDs and this face fails. Presence of an opposite pair in `O`
+HOLDs at each of the four z-probes, so pair-presence reverse and face both
+HOLD, while this face fails. Leftover of `M` alone at `A` is `{e_1,e_3}`
+and at `B` is `{e_2,e_3}`: nonempty unequal, so leftover-of-`M` reverse
+fails while Orient reverse HOLDs. Leftover of `O` alone at `A` is `{e_2}`
+and at `B` is `{e_1}`: leftover-of-`O` reverse fails. Exist-opposite
+reverse of signed `O` holds with this reverse, but exist-opposite is a
+cross-probe boolean, not `det(m,e,+ℓ)`. Unique outgoing letters would
+assign `UNDEFINED` at mixed `O(A)`; the pair unit is `+e_1`. Unsigned
+incoming axis agrees on this member because each unique `m` is the
+positive unit, and flipping `m` at `A` to `−e_2` flips Orient to `+1`
+while `Axis(M)` stays `{e_2}`. The second pair is a new seed, not a formed
+child: `(0,0,1)` is recorded at tick 0 with lock `+e_2`, whereas the
+1-axis child forms at tick 1 with lock `+e_3`. nm2orichz scores only
+`τ=t+1`. nm2simt2z scores equality of `M` and of `O`. Reverse/face
+bit-stability can HOLD while a probe sign flips. Reverse oriented frame
+is HOLD iff equal `±1` signs at `A` and at `B` at that cut, not leftover
+of nm2chiralz lexicographic `o1,o2`. Composition of Orient: hold.
+
+### N8 — cross-cycle echo
+
+nm2axz cover on this two-axis seed reported cover HOLD at each of the four
+z-probes, reverse hold, and face hold. nm2ax12z 1-in 2-out split on the
+same seed reported split HOLD at each of the four z-probes, reverse hold,
+and face hold. nm2chiralz lexicographic `o1,o2` on the same seed reported
+Orient `−1,+1,+1,+1`, reverse fail, and face hold. nm2orichz reported
+opposite-pair Orient `−1,−1,+1,−1`, reverse hold, and face fail at `t+1`
+alone. nm2simt2z reported simultaneous `M` and `O` freeze from `t+1` to
+`t+2` with reverse hold and face hold. Leftover axis reported empty
+leftover at each of four z-probes, leftover reverse fail, and leftover
+face fail. The four y-probes of this same seed reported split reverse hold
+and split face fail, and opposite-pair Orient fail at `A` from no opposite
+pair in `O`. This note is not those displays: it reports opposite-pair
+orientation of the 1-in 2-out frame of `M` and `O` at `τ1=t+1` versus
+`τ2=t+2` on the two-axis opposite seed, with `t(A)=0`, `t(B)=1`,
+`t(C)=1`, and `t(D)=1`, `Orient=−1,−1,+1,−1` at both cuts, reverse hold at
+both cuts, face fail at both cuts, and composition hold. Cover and split
+do not score handedness.
+
+**Gate disposition:** PASS for the opposite-pair-frame `t+1` versus `t+2`
+reverse/face reports and displayed composition above. FAIL / DO NOT SHIP
+for “the predicate equals the named sign,” “the predicate equals the unique
+singleton lock vector,” “the predicate equals six-neighbor lock union,”
+“the predicate equals leftover-empty fail,” “the predicate equals leftover
+of `M` alone,” “the predicate equals leftover of `O` alone,” “the
+predicate equals exist-opposite HOLD,” “the predicate equals opposite-pair
+presence in `O`,” “the predicate equals nm2chiralz lexicographic `o1,o2`
+HOLD,” “the predicate equals nmcover axis-cover HOLD,” “the predicate
+equals nm2axz axis-cover HOLD,” “the predicate equals nm2ax12z 1-in 2-out
+split HOLD,” “the predicate equals nm2orichz `t+1` alone,” “the predicate
+equals nm2simt2z `M` and `O` freeze,” “the predicate equals the 1-axis
+opposite two-site seed,” “the predicate equals nmunopp union,” “bits are
+Admissibility,” “split fail is UNDEFINED,” “no opposite pair is
+UNDEFINED,” “reverse oriented frame fails,” “face oriented frame holds,”
+or “composition of Orient fails.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1` and
+`t+2`, reports the unique signed incoming letter, the smallest-index
+opposite pair in `O`, leftover unit `+ℓ`, the integer determinant and its
+sign at both cuts, lists new records in `B_3(0)` between `t` and `t+1` and
+between `t+1` and `t+2` that meet a probe's six-neighbors, and checks
+Theorems 1--3. It also checks that Orient is `−1,−1,+1,−1` at `A,B,C,D` at
+both cuts, that reverse HOLDs at both cuts while leftover reverse fails
+and lexicographic reverse fails, that face fails at both cuts while cover
+face, split face, and pair-presence face HOLD, that composition HOLDs,
+that split fail is Orient fail not `UNDEFINED`, that no opposite pair in
+`O` is Orient fail not `UNDEFINED`, that the 1-axis opposite two-site seed
+is a different member with Orient fail at `C`, that leftover-empty fail is
+a different reverse, that leftover of `M` alone and leftover of `O` alone
+are different objects, that mixed sets remain sets, that unique-letter
+Orient is `UNDEFINED` at mixed `O`, that the construction does not sum,
+that a formation member from already-recorded six-neighbor locks is not
+attached, that the second pair is a new seed not a formed child, that the
+y-probes and x-probes of this seed are not this letter, that `τ=t` is not
+scored, and that the display is not the two-tick lock-count clock
+composition. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.txt
@@ -1,0 +1,91 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+runner_sha256: 2a9ed205f76ebd6693effe34d8be970423bb23a75988b0b5fbb6fd34494c24cf
+input_fingerprint_sha256: 9f3ba1924fff6a2bd123d33a923470acb987bdb7ac39897b095129cf8a4c22db
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+opposite-pair orientation freeze t+1 versus t+2 reverse/face composition on two-axis opposite z-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Opposite-pair orientation at t+1 versus t+2 on the four z-probes of the two-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+PASS: composition-identity
+A t=0 M(tau1)={+e_2} O(tau1)={+e_1, −e_1, +e_3} Orient(tau1)=−1 M(tau2)={+e_2} O(tau2)={+e_1, −e_1, +e_3} Orient(tau2)=−1
+B t=1 M(tau1)={+e_1} O(tau1)={+e_2, +e_3, −e_3} Orient(tau1)=−1 M(tau2)={+e_1} O(tau2)={+e_2, +e_3, −e_3} Orient(tau2)=−1
+C t=1 M(tau1)={+e_3} O(tau1)={+e_1, −e_1, −e_2} Orient(tau1)=+1 M(tau2)={+e_3} O(tau2)={+e_1, −e_1, −e_2} Orient(tau2)=+1
+D t=1 M(tau1)={+e_1} O(tau1)={−e_2, +e_3, −e_3} Orient(tau1)=−1 M(tau2)={+e_1} O(tau2)={−e_2, +e_3, −e_3} Orient(tau2)=−1
+Orient reverse tau1=hold tau2=hold
+Orient face tau1=fail tau2=fail
+Orient composition=hold
+per_element: signed incoming letter, smallest-index opposite pair in O, and leftover +axis among {e_1,e_2,e_3} at a probe's t+1 and t+2
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four Orient reports at t+1 and t+2, reverse/face at each cut, composition
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-O-Orient-at-tau1  ({'A': '−1', 'B': '−1', 'C': '+1', 'D': '−1'})
+PASS: theorem1-M-O-Orient-at-tau2  ({'A': '−1', 'B': '−1', 'C': '+1', 'D': '−1'})
+PASS: do-not-score-tau-t
+PASS: theorem1-new-records-meet-6nn  ({'A': (((1, 0, 1), (-1, 0, 1), (0, 0, 2)), ((0, -1, 1),)), 'B': (((1, 2, 1), (1, 1, 2), (1, 1, 0)), ()), 'C': (((1, 0, 2), (-1, 0, 2), (0, -1, 2)), ()), 'D': (((1, -1, 1), (1, 0, 2), (1, 0, 0)), ())})
+PASS: theorem1-new-tplus2-neighbor-does-not-enter-O
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-tau1-and-tau2-hold
+PASS: theorem2-face-tau1-and-tau2-fail
+PASS: theorem3-composition-hold  (hold)
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unsigned-incoming-axis-agrees-here
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-y-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-or-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-Orient-at-both-cuts
+PASS: note-reports-new-neighbors
+PASS: note-reports-orient-reverse-face-composition
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split-or-sim-freeze
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: orient-fail-not-split-hold
+TOTAL: PASS=59 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py
@@ -1,0 +1,1670 @@
+#!/usr/bin/env python3
+"""Opposite-pair orientation freeze t+1 versus t+2 reverse/face composition.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and z-probes as nm2axz.
+Perp-step incoming lock. M and O as nm2ax12z. Unformed => UNDEFINED. Split
+HOLDs iff cover HOLDs and |Axis(M)|=1. Split HOLD required. When M is
+singleton {m} and O contains some e and -e, let o_pair be that e of
+smallest axis index, leftover axis l the unique Axis not in {axis(m),
+axis(e)}, oriented as the unit +l. Orient as nm2orichz at each cut: the
+sign of the integer determinant of columns (m, e, +l). If no opposite pair
+in O, fail, not UNDEFINED. Else fail, not UNDEFINED, if split fails.
+t(q)=formation tick. tau1=t+1, tau2=t+2. No global T. Do not score tau=t.
+Reverse/face from Orient at each cut. Reverse HOLDs iff Orient(A)=Orient(B)
+both +/-1. Face on C,D. Composition HOLD iff Orient at tau1 equals Orient
+at tau2 at A,B,C,D. Uniqueness of O is not required. Occupancy of sites is
+not used. No larger host. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Opposite-pair orientation at t+1 versus t+2 on the four z-probes of "
+    "the two-axis opposite seed, reverse/face at each cut, and "
+    "composition, are reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, e, +l). Fail if split fails or O has no opposite pair."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Reverse HOLDs iff Orient(A)=Orient(B) both +/-1."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Face HOLDs iff Orient(C)=Orient(D) both +/-1."""
+    return pair_orient(orient_c, orient_d)
+
+
+def composition_report(
+    left_a: OrientVal,
+    right_a: OrientVal,
+    left_b: OrientVal,
+    right_b: OrientVal,
+    left_c: OrientVal,
+    right_c: OrientVal,
+    left_d: OrientVal,
+    right_d: OrientVal,
+) -> str:
+    """HOLD iff Orient at tau1 equals Orient at tau2 at A, B, C, and D."""
+    sides = (left_a, right_a, left_b, right_b, left_c, right_c, left_d, right_d)
+    if any(side == UNDEFINED for side in sides):
+        return UNDEFINED
+    if (
+        left_a == right_a
+        and left_b == right_b
+        and left_c == right_c
+        and left_d == right_d
+    ):
+        return "hold"
+    return "fail"
+
+
+def leftover_bit_composition(rev1: str, rev2: str, face1: str, face2: str) -> str:
+    """Leftover: score composition on reverse/face bits, not Orient equality."""
+    if any(bit == UNDEFINED for bit in (rev1, rev2, face1, face2)):
+        return UNDEFINED
+    if rev1 != rev2 or face1 != face2:
+        return "fail"
+    return "hold"
+
+
+def leftover_mo_composition(
+    m1_a: Incoming,
+    m2_a: Incoming,
+    o1_a: Outgoing,
+    o2_a: Outgoing,
+    m1_b: Incoming,
+    m2_b: Incoming,
+    o1_b: Outgoing,
+    o2_b: Outgoing,
+    m1_c: Incoming,
+    m2_c: Incoming,
+    o1_c: Outgoing,
+    o2_c: Outgoing,
+    m1_d: Incoming,
+    m2_d: Incoming,
+    o1_d: Outgoing,
+    o2_d: Outgoing,
+) -> str:
+    """Leftover of nm2simt2z: M and O freeze, not Orient equality."""
+    sides = (
+        m1_a,
+        m2_a,
+        o1_a,
+        o2_a,
+        m1_b,
+        m2_b,
+        o1_b,
+        o2_b,
+        m1_c,
+        m2_c,
+        o1_c,
+        o2_c,
+        m1_d,
+        m2_d,
+        o1_d,
+        o2_d,
+    )
+    if any(side == UNDEFINED for side in sides):
+        return UNDEFINED
+    if (
+        m1_a == m2_a
+        and o1_a == o2_a
+        and m1_b == m2_b
+        and o1_b == o2_b
+        and m1_c == m2_c
+        and o1_c == o2_c
+        and m1_d == m2_d
+        and o1_d == o2_d
+    ):
+        return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+    offset: int = 1,
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+offset and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + offset:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    pair = opposite_pair_unit(outgoing)
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(unsigned_m, pair)
+    if not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def probe_sides_at(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+    offset: int,
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + offset
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("opposite-pair orientation freeze t+1 versus t+2 reverse/face composition on two-axis opposite z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E1, E3) == -1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E3, E1, E2) == 1
+        and integer_det_columns(NEG_E2, E1, E3) == 1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, NEG_E1, E3})) == 1
+        and frame_orient(frozenset({E1, NEG_E1}), frozenset({E2, E3})) == "fail"
+        and lex_frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and lex_frame_orient(frozenset({E2}), frozenset({E1, E3})) == -1,
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+    checks.check(
+        "composition-identity",
+        composition_report(-1, -1, -1, -1, 1, 1, -1, -1) == "hold"
+        and composition_report(-1, -1, -1, -1, 1, -1, -1, -1) == "fail"
+        and composition_report(-1, "fail", -1, -1, 1, 1, -1, -1) == "fail"
+        and composition_report("fail", "fail", "fail", "fail", "fail", "fail", "fail", "fail")
+        == "hold"
+        and composition_report(UNDEFINED, -1, -1, -1, 1, 1, -1, -1) == UNDEFINED
+        and leftover_bit_composition("hold", "hold", "fail", "fail") == "hold"
+        and leftover_bit_composition("hold", "hold", "fail", "hold") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    tau2: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    m2: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    o2: dict[str, Outgoing] = {}
+    axis_m1: dict[str, AxisSet] = {}
+    axis_o1: dict[str, AxisSet] = {}
+    cover1: dict[str, str] = {}
+    cover2: dict[str, str] = {}
+    split0: dict[str, str] = {}
+    split1: dict[str, str] = {}
+    split2: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m1: dict[str, Point | str] = {}
+    signed_m2: dict[str, Point | str] = {}
+    pair1: dict[str, Point | str] = {}
+    pair2: dict[str, Point | str] = {}
+    leftover1: dict[str, Point | str] = {}
+    leftover2: dict[str, Point | str] = {}
+    det1: dict[str, int | str] = {}
+    det2: dict[str, int | str] = {}
+    lex1: dict[str, OrientVal] = {}
+    lex2: dict[str, OrientVal] = {}
+    pair_present1: dict[str, str] = {}
+    pair_present2: dict[str, str] = {}
+    orient0: dict[str, OrientVal] = {}
+    orient1: dict[str, OrientVal] = {}
+    orient2: dict[str, OrientVal] = {}
+    lx1: dict[str, AxisSet] = {}
+    lx_m1: dict[str, AxisSet] = {}
+    lx_o1: dict[str, AxisSet] = {}
+    new_meet1: dict[str, tuple[Point, ...]] = {}
+    new_meet2: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        tau2[name] = ticks[site] + 2
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        m2[name] = incoming_set(site, tau2[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        o2[name] = outgoing_set(site, tau2[name], ticks, locks, seed_map)
+        axis_m1[name] = axis_set(m1[name])
+        axis_o1[name] = axis_set(o1[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        cover2[name] = axis_cover(m2[name], o2[name])
+        split0[name] = axis_split(m0[name], o0[name])
+        split1[name] = axis_split(m1[name], o1[name])
+        split2[name] = axis_split(m2[name], o2[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m1[name] = unique_signed_m(m1[name])
+        signed_m2[name] = unique_signed_m(m2[name])
+        pair1[name] = opposite_pair_unit(o1[name])
+        pair2[name] = opposite_pair_unit(o2[name])
+        if isinstance(signed_m1[name], tuple) and isinstance(pair1[name], tuple):
+            leftover1[name] = leftover_unit(signed_m1[name], pair1[name])
+        else:
+            leftover1[name] = "fail"
+        if isinstance(signed_m2[name], tuple) and isinstance(pair2[name], tuple):
+            leftover2[name] = leftover_unit(signed_m2[name], pair2[name])
+        else:
+            leftover2[name] = "fail"
+        if (
+            isinstance(signed_m1[name], tuple)
+            and isinstance(pair1[name], tuple)
+            and isinstance(leftover1[name], tuple)
+        ):
+            det1[name] = integer_det_columns(
+                signed_m1[name], pair1[name], leftover1[name]
+            )
+        else:
+            det1[name] = "fail"
+        if (
+            isinstance(signed_m2[name], tuple)
+            and isinstance(pair2[name], tuple)
+            and isinstance(leftover2[name], tuple)
+        ):
+            det2[name] = integer_det_columns(
+                signed_m2[name], pair2[name], leftover2[name]
+            )
+        else:
+            det2[name] = "fail"
+        pair_present1[name] = has_opposite_pair(o1[name])
+        pair_present2[name] = has_opposite_pair(o2[name])
+        lex1[name] = lex_frame_orient(m1[name], o1[name])
+        lex2[name] = lex_frame_orient(m2[name], o2[name])
+        orient0[name] = frame_orient(m0[name], o0[name])
+        orient1[name] = frame_orient(m1[name], o1[name])
+        orient2[name] = frame_orient(m2[name], o2[name])
+        lx1[name] = leftover_axis(m1[name], o1[name])
+        lx_m1[name] = leftover_of_one(m1[name])
+        lx_o1[name] = leftover_of_one(o1[name])
+        new_meet1[name] = new_records_meeting_six_nn(site, ticks, 1)
+        new_meet2[name] = new_records_meeting_six_nn(site, ticks, 2)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M(tau1)={lockset_display(m1[name])} "
+            f"O(tau1)={lockset_display(o1[name])} "
+            f"Orient(tau1)={orient_display(orient1[name])} "
+            f"M(tau2)={lockset_display(m2[name])} "
+            f"O(tau2)={lockset_display(o2[name])} "
+            f"Orient(tau2)={orient_display(orient2[name])}"
+        )
+
+    reverse1 = reverse_report(orient1["A"], orient1["B"])
+    reverse2 = reverse_report(orient2["A"], orient2["B"])
+    face1 = face_report(orient1["C"], orient1["D"])
+    face2 = face_report(orient2["C"], orient2["D"])
+    reverse0 = reverse_report(orient0["A"], orient0["B"])
+    face0 = face_report(orient0["C"], orient0["D"])
+    composition = composition_report(
+        orient1["A"], orient2["A"],
+        orient1["B"], orient2["B"],
+        orient1["C"], orient2["C"],
+        orient1["D"], orient2["D"],
+    )
+    leftover_t_tplus1_composition = composition_report(
+        orient0["A"], orient1["A"],
+        orient0["B"], orient1["B"],
+        orient0["C"], orient1["C"],
+        orient0["D"], orient1["D"],
+    )
+    leftover_bits = leftover_bit_composition(reverse1, reverse2, face1, face2)
+    leftover_mo = leftover_mo_composition(
+        m1["A"], m2["A"], o1["A"], o2["A"],
+        m1["B"], m2["B"], o1["B"], o2["B"],
+        m1["C"], m2["C"], o1["C"], o2["C"],
+        m1["D"], m2["D"], o1["D"], o2["D"],
+    )
+    cover_reverse1 = pair_bit(cover1["A"], cover1["B"])
+    cover_face1 = pair_bit(cover1["C"], cover1["D"])
+    split_reverse1 = pair_bit(split1["A"], split1["B"])
+    split_face1 = pair_bit(split1["C"], split1["D"])
+    leftover_reverse = leftover_match(lx1["A"], lx1["B"])
+    leftover_face = leftover_match(lx1["C"], lx1["D"])
+    reverse_m_alone = leftover_match(lx_m1["A"], lx_m1["B"])
+    face_m_alone = leftover_match(lx_m1["C"], lx_m1["D"])
+    reverse_o_alone = leftover_match(lx_o1["A"], lx_o1["B"])
+    face_o_alone = leftover_match(lx_o1["C"], lx_o1["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unsigned_orient1 = {
+        name: unsigned_incoming_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    unique_o_orient_a = frame_orient(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = face_report(one_orient["C"], one_orient["D"])
+    print(f"Orient reverse tau1={reverse1} tau2={reverse2}")
+    print(f"Orient face tau1={face1} tau2={face2}")
+    print(f"Orient composition={composition}")
+    print(
+        "per_element: signed incoming letter, smallest-index opposite pair in O, "
+        "and leftover +axis among {e_1,e_2,e_3} at a probe's t+1 and t+2"
+    )
+    print("per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites")
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: four Orient reports at t+1 and t+2, reverse/face at each cut, composition")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["D"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-Orient-at-tau1",
+        m1["A"] == frozenset({E2})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E1})
+        and o1["A"] == frozenset({E1, NEG_E1, E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, NEG_E2})
+        and o1["D"] == frozenset({NEG_E2, E3, NEG_E3})
+        and all(split1[name] == "hold" for name in ("A", "B", "C", "D"))
+        and signed_m1["A"] == E2
+        and signed_m1["B"] == E1
+        and signed_m1["C"] == E3
+        and signed_m1["D"] == E1
+        and pair1["A"] == E1
+        and pair1["B"] == E3
+        and pair1["C"] == E1
+        and pair1["D"] == E3
+        and leftover1["A"] == E3
+        and leftover1["B"] == E2
+        and leftover1["C"] == E2
+        and leftover1["D"] == E2
+        and det1["A"] == -1
+        and det1["B"] == -1
+        and det1["C"] == 1
+        and det1["D"] == -1
+        and orient1["A"] == -1
+        and orient1["B"] == -1
+        and orient1["C"] == 1
+        and orient1["D"] == -1,
+        str({name: orient_display(orient1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-Orient-at-tau2",
+        m2["A"] == m1["A"]
+        and m2["B"] == m1["B"]
+        and m2["C"] == m1["C"]
+        and m2["D"] == m1["D"]
+        and o2["A"] == o1["A"]
+        and o2["B"] == o1["B"]
+        and o2["C"] == o1["C"]
+        and o2["D"] == o1["D"]
+        and all(split2[name] == "hold" for name in ("A", "B", "C", "D"))
+        and signed_m2["A"] == signed_m1["A"]
+        and pair2["A"] == pair1["A"]
+        and leftover2["A"] == leftover1["A"]
+        and det2["A"] == det1["A"]
+        and det2["B"] == det1["B"]
+        and det2["C"] == det1["C"]
+        and det2["D"] == det1["D"]
+        and orient2["A"] == -1
+        and orient2["B"] == -1
+        and orient2["C"] == 1
+        and orient2["D"] == -1
+        and orient2["A"] == orient1["A"]
+        and orient2["B"] == orient1["B"]
+        and orient2["C"] == orient1["C"]
+        and orient2["D"] == orient1["D"],
+        str({name: orient_display(orient2[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "do-not-score-tau-t",
+        all(o0[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(orient0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(split0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and reverse0 == "fail"
+        and face0 == "fail"
+        and leftover_t_tplus1_composition == "fail"
+        and reverse1 == "hold"
+        and face1 == "fail",
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet1["A"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet1["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet1["C"] == ((1, 0, 2), (-1, 0, 2), (0, -1, 2))
+        and new_meet1["D"] == ((1, -1, 1), (1, 0, 2), (1, 0, 0))
+        and new_meet2["A"] == ((0, -1, 1),)
+        and new_meet2["B"] == ()
+        and new_meet2["C"] == ()
+        and new_meet2["D"] == (),
+        str({name: (new_meet1[name], new_meet2[name]) for name in ("A", "B", "C", "D")}),
+    )
+    child_of_a_tplus2 = (0, -1, 1)
+    checks.check(
+        "theorem1-new-tplus2-neighbor-does-not-enter-O",
+        child_of_a_tplus2 in new_meet2["A"]
+        and ticks[child_of_a_tplus2] == ticks[PROBES["A"]] + 2
+        and incoming_set(child_of_a_tplus2, tau2["A"], ticks, locks, seed_map)
+        == frozenset({E3})
+        and NEG_E2 not in o2["A"]
+        and o2["A"] == o1["A"]
+        and orient2["A"] == orient1["A"],
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and m1["A"] == frozenset({E2})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem2-reverse-tau1-and-tau2-hold",
+        reverse1 == "hold"
+        and reverse2 == "hold"
+        and orient1["A"] == -1
+        and orient1["B"] == -1
+        and orient2["A"] == -1
+        and orient2["B"] == -1
+        and reverse1 != UNDEFINED
+        and reverse2 != "fail"
+        and split_reverse1 == "hold"
+        and cover_reverse1 == "hold",
+    )
+    checks.check(
+        "theorem2-face-tau1-and-tau2-fail",
+        face1 == "fail"
+        and face2 == "fail"
+        and orient1["C"] == 1
+        and orient1["D"] == -1
+        and orient2["C"] == 1
+        and orient2["D"] == -1
+        and face1 != UNDEFINED
+        and face1 != "hold"
+        and split_face1 == "hold"
+        and cover_face1 == "hold",
+    )
+    checks.check(
+        "theorem3-composition-hold",
+        composition == "hold"
+        and leftover_mo == "hold"
+        and leftover_bits == "hold"
+        and leftover_t_tplus1_composition == "fail"
+        and leftover_t_tplus1_composition != composition
+        and orient1["A"] == orient2["A"]
+        and orient1["B"] == orient2["B"]
+        and orient1["C"] == orient2["C"]
+        and orient1["D"] == orient2["D"],
+        composition,
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split_reverse1 == "hold"
+        and cover_reverse1 == "hold"
+        and reverse1 == "hold"
+        and split_face1 == "hold"
+        and cover_face1 == "hold"
+        and face1 == "fail"
+        and face1 != split_face1
+        and face1 != cover_face1
+        and reverse2 == "hold"
+        and face2 == "fail",
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and one_orient["C"] == "fail"
+        and one_split["C"] == "fail"
+        and one_cover["C"] == "hold"
+        and one_orient_face == "fail"
+        and one_split_face == "fail"
+        and one_cover_face == "hold",
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["A"]] == 1
+        and one_ticks[PROBES["C"]] == 4
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["C"]] == 1
+        and one_orient["C"] == "fail"
+        and one_orient_face == "fail"
+        and face1 == "fail"
+        and reverse1 == "hold"
+        and one_m1["A"] != m1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and all(lx1[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and leftover_reverse != reverse1
+        and leftover_face == face1,
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m1["A"] == frozenset({E1, E3})
+        and lx_m1["B"] == frozenset({E2, E3})
+        and lx_o1["A"] == frozenset({E2})
+        and lx_o1["B"] == frozenset({E1})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse1 == "hold"
+        and face1 == "fail",
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and reverse1 == "hold"
+        and face1 == "fail"
+        and m_exist_reverse != reverse1
+        and pair_present1["A"] == "hold"
+        and pair_present1["B"] == "hold"
+        and pair_present1["C"] == "hold"
+        and pair_present1["D"] == "hold"
+        and pair_present2["A"] == "hold"
+        and pair_bit(pair_present1["C"], pair_present1["D"]) == "hold"
+        and pair_bit(pair_present1["C"], pair_present1["D"]) != face1,
+    )
+    checks.check(
+        "mutation-unsigned-incoming-axis-agrees-here",
+        unsigned_orient1["A"] == -1
+        and unsigned_orient1["B"] == -1
+        and unsigned_orient1["C"] == 1
+        and unsigned_orient1["D"] == -1
+        and frame_orient(frozenset({NEG_E2}), o1["A"]) == 1
+        and unsigned_incoming_orient(frozenset({NEG_E2}), o1["A"]) == -1
+        and orient1["A"] == -1,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({E2})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED
+        and orient1["A"] == -1
+        and orient1["D"] == -1
+        and unique_letter(o2["A"]) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == E2
+        and sum_of_set(o1["A"]) == E3
+        and axis_o1["A"] == frozenset({E1, E3})
+        and pair1["A"] == E1
+        and leftover1["A"] == E3,
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and E2 in m1["A"]
+        and E2 not in o1["A"]
+        and o1["A"] != m1["A"]
+        and o2["A"] != m2["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet1["A"],
+    )
+    y_m1, y_o1 = probe_sides_at(Y_PROBES, ticks, locks, seed_map, 1)
+    y_m2, y_o2 = probe_sides_at(Y_PROBES, ticks, locks, seed_map, 2)
+    y_orient1 = {name: frame_orient(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_orient2 = {name: frame_orient(y_m2[name], y_o2[name]) for name in ("A", "B", "C", "D")}
+    y_face1 = face_report(y_orient1["C"], y_orient1["D"])
+    y_reverse1 = reverse_report(y_orient1["A"], y_orient1["B"])
+    x_m1, x_o1 = probe_sides_at(X_PROBES, ticks, locks, seed_map, 1)
+    x_orient1 = {name: frame_orient(x_m1[name], x_o1[name]) for name in ("A", "B", "C", "D")}
+    x_reverse1 = reverse_report(x_orient1["A"], x_orient1["B"])
+    x_face1 = face_report(x_orient1["C"], x_orient1["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    same_m_a = incoming_set(
+        PROBES["A"], same_ticks[PROBES["A"]] + 1, same_ticks, same_locks, same_seeds
+    )
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-x-probes-or-y-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and y_m1["A"] != m1["A"]
+        and y_orient1["A"] == "fail"
+        and y_orient1["D"] == "fail"
+        and y_face1 == "fail"
+        and y_reverse1 == "fail"
+        and y_orient2["A"] == y_orient1["A"]
+        and x_reverse1 == "fail"
+        and x_face1 == "fail"
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse1 == "hold"
+        and face1 == "fail",
+    )
+    checks.check(
+        "not-same-lock-or-one-axis-or-y-symmetric-seed",
+        TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and same_m_a != m1["A"]
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Orient-at-both-cuts",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ1) = {+e_2}" in note
+        and "M(B, τ1) = {+e_1}" in note
+        and "M(C, τ1) = {+e_3}" in note
+        and "M(D, τ1) = {+e_1}" in note
+        and "O(A, τ1) = {+e_1, −e_1, +e_3}" in note
+        and "O(B, τ1) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ1) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ1) = {−e_2, +e_3, −e_3}" in note
+        and "Orient(A, τ1) = −1" in note
+        and "Orient(B, τ1) = −1" in note
+        and "Orient(C, τ1) = +1" in note
+        and "Orient(D, τ1) = −1" in note
+        and "M(A, τ2) = {+e_2}" in note
+        and "M(B, τ2) = {+e_1}" in note
+        and "M(C, τ2) = {+e_3}" in note
+        and "M(D, τ2) = {+e_1}" in note
+        and "O(A, τ2) = {+e_1, −e_1, +e_3}" in note
+        and "O(B, τ2) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ2) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ2) = {−e_2, +e_3, −e_3}" in note
+        and "Orient(A, τ2) = −1" in note
+        and "Orient(B, τ2) = −1" in note
+        and "Orient(C, τ2) = +1" in note
+        and "Orient(D, τ2) = −1" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)" in note
+        and "new 6-NN of A at t(A)+2: (0, -1, 1)" in note
+        and "new 6-NN of B at t(B)+2: none" in note
+        and "new 6-NN of C at t(C)+2: none" in note
+        and "new 6-NN of D at t(D)+2: none" in note,
+    )
+    checks.check(
+        "note-reports-orient-reverse-face-composition",
+        "Reverse oriented frame at τ1: hold" in note
+        and "Reverse oriented frame at τ2: hold" in note
+        and "Face oriented frame at τ1: fail" in note
+        and "Face oriented frame at τ2: fail" in note
+        and "Composition of Orient: hold" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split-or-sim-freeze",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2orichz" in normalized_note
+        and "not leftover of nm2simt2z" in normalized_note
+        and "not leftover of nm2chiralz lexicographic" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse oriented frame at τ1: hold" in note
+        and "Face oriented frame at τ1: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "Do not score τ=t" in note
+        and "τ1=t+1" in note.replace(" ", "")
+        and "τ2=t+2" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_ZPROBE_OPPOSITE_PAIR_FRAME_ORIENTATION_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "opposite_pair_unit" in defined_fns
+        and "leftover_unit" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "composition_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "orient-fail-not-split-hold",
+        reverse1 == "hold"
+        and face1 == "fail"
+        and reverse2 == "hold"
+        and face2 == "fail"
+        and split_reverse1 == "hold"
+        and cover_reverse1 == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and one_orient_face == "fail"
+        and lex1["A"] == -1
+        and lex1["B"] == 1
+        and lex1["C"] == 1
+        and lex1["D"] == 1
+        and lex2["A"] == lex1["A"]
+        and reverse_report(lex1["A"], lex1["B"]) == "fail"
+        and face_report(lex1["C"], lex1["D"]) == "hold"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and leftover_mo == "hold"
+        and leftover_bits == "hold",
+    )
+    _ = (
+        o0,
+        unique_o_orient_a,
+        one_cover_face,
+        one_split_face,
+        unsigned_orient1,
+        axis_m1,
+        leftover_bits,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Opposite-pair orientation freeze: reverse HOLD at both cuts, face fails at both (C=+1, D=-1), composition HOLD. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_zprobe_opposite_pair_frame_orientation_tplus1_tplus2_composition_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.