### PR TITLE
feat(nm2orilefslz): signed leftover-axis det orientation of 1-in 2-out at t+1 on two-axis same-lock z-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,803 @@
+---
+claim_id: two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Signed leftover-axis det orientation at t+1 on the four z-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py
+---
+
+# Signed Leftover-Axis Determinant Orientation At t+1 Reverse And Face On Four Z-Probes Of The Two-Axis Same-Lock Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** signed leftover-axis det orientation of simultaneous earliest
+incoming set `M` and outgoing dual `O` at each probe's `τ=t+1`, and
+reverse/face from that sign, on the four z-probes of the two-axis
+same-lock seed in `B_3(0)={n:n·n<=9}`. Same process and z-probes as
+nm2slz. Orient as nm2orilefz: signed leftover axis `o_ℓ` and
+`det(m, e_pair, o_ℓ)`. Let `t(q)` be the formation tick of probe `q`.
+Let `τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest incoming
+nearest-neighbor steps at `q` using only records with tick `<= τ`.
+Seeds are a singleton seed letter. `O(q,τ)` is the outgoing dual of
+`M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed and
+`e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is
+empty, not `UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)`
+equals `{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs
+and `|Axis(M)|=1` (hence `|Axis(O)|=2`). Split HOLD required. When
+split HOLDs and `O` contains some `e` and `−e`, let `e_pair` be that
+`e` of smallest axis index. Leftover axis `ℓ` is the unique Axis not
+in `{axis(m), axis(e_pair)}`. Let `O_ℓ = O ∩ {± unit of ℓ}`. If
+`|O_ℓ|≠1`, Orient fails, not `UNDEFINED`. Else let `o_ℓ` be that signed
+vector. `Orient(q)` is the sign of the integer determinant of the 3×3
+matrix with columns `m`, `e_pair`, `o_ℓ`. If no opposite pair or split
+fails, Orient fails, not `UNDEFINED`. Reverse HOLDs if and only if
+`Orient(A)=Orient(B)` both `±1`. Face HOLDs if and only if
+`Orient(C)=Orient(D)` both `±1`. Cover and split do not score
+handedness. Neither pair is opposite. This is not leftover of
+nm2orilefz signed leftover reverse hold. This is not leftover of
+nm2slz axis-cover face hold. This is not leftover of nm2orichz
+unsigned leftover `+ℓ`. This is not leftover of nm2orionez lex-one
+signed outgoing. This is not leftover of nm2chiralz lexicographic
+`o1,o2` orientation. This is not leftover of nm2axz axis-cover. This
+is not leftover of nm2ax12z 1-in 2-out split. This is not leftover of
+leftover-of-`M` alone. This is not leftover of leftover-of-`O` alone.
+This is not leftover-empty fail of leftover axis. This is not leftover
+of nmunopp union. This is not leftover of nmt2opp `M` frozen at `t`.
+This is not leftover of nmot2opp two-tick composition. This is not
+leftover of nmoutopp untimed eventual-`O`. This is not leftover of
+mixed #7188 fail/fail. This is not leftover of the 1-axis same-lock
+two-site seed. This is not leftover of the two-axis opposite seed. The
+second pair is a new seed, not a formed child. Uniqueness is not
+required. Mixed remains a set. Displayed, not adopted. Do not write
+into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. The signed leftover-axis
+oriented frame is the integer sign of `det(m,e_pair,o_ℓ)` with unique
+signed incoming letter `m`, signed exist-opposite pair unit `e_pair` of
+smallest axis index in `O`, leftover axis `ℓ` the unique Axis not in
+`{axis(m), axis(e_pair)}`, and the unique signed vector `o_ℓ` in
+`O ∩ {± unit of ℓ}`, provided split HOLDs. Reverse and face are scored on
+equal `±1` signs at the paired probes. Named signs `{+,−}` of locks are a
+coarser readout and are not used as the object. A singleton unique
+outgoing lock letter is a different readout and is not used as the
+object. Presence of an opposite pair in `O` without the determinant sign
+is a different readout and is not used. Unsigned leftover unit `+ℓ` is a
+different readout and is not used. Lex-one signed outgoing letters per
+`Axis(O)` are a different readout and are not used. Lexicographic
+unsigned outgoing 2-plane `(o1,o2)` in axis order is a different readout
+and is not used. Existential opposite of signed locks across probes is a
+different readout and is not used. Axis-cover without the frame sign is
+a different readout and is not used. 1-in 2-out split without the frame
+sign is a different readout and is not used. Leftover-empty fail of
+unsigned leftover axis sets is a different readout and is not used. A
+`Z^3` sum of those locks is a different readout and is not used.
+Occupancy of sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of signed leftover-axis det orientation at t+1 on the four z-probes of the two-axis same-lock seed, Orient fail at A from overlapping e_2 split fail, Orient at B,C,D, reverse fail and face fail from equal +/-1 signs; uniqueness of outgoing locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face
+target_blocker_text: "display leftover axis with the signed O vector on that axis, not unsigned +l, reverse/face on the four z-probes of the two-axis same-lock seed, not nm2orilefz opposite reverse hold, not nm2slz cover face hold"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep signed leftover-axis det orientation at t+1 displayed; do not write Orient into Admissibility, do not reduce to unsigned leftover +l, do not reduce to lex-one signed outgoing, do not reduce to lexicographic o1,o2, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace Orient by presence of an opposite pair in O, do not replace Orient by existential opposite of signed locks, do not replace Orient by nm2orilefz opposite reverse hold, do not replace Orient by nm2slz axis-cover face hold, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for signed leftover-axis det orientation at t+1 on the four z-probes of the two-axis same-lock seed and reverse/face from that sign; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose
+signed leftover-axis frame of `M` and `O` is scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (1,0,1).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the second same-lock pair. Same process and
+z-probes as nm2slz.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint same-lock pairs recorded at formation tick 0. Origin
+locks `+e_1` and `(0,1,0)` locks `+e_1`. `(0,0,1)` locks `+e_2` and
+`(0,1,1)` locks `+e_2`. The second pair is a new seed, not a formed child
+of the first pair, and neither pair is opposite. This seed is not the
+1-axis same-lock two-site seed `{0,(0,1,0)}` with `+e_1/+e_1` alone. This
+seed is not the two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2`. This
+seed is not the perp two-site seed `+e_1/+e_2`. This seed is not the
+z-symmetric three-site seed `{0,(0,0,1),(0,0,-1)}`. This seed is not the
+y-symmetric three-site seed that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named signed leftover-axis frame of `M` and `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of z-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. Overlapping axes fail cover
+and therefore fail split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Signed leftover-axis oriented frame at the same cut:
+
+```text
+When split HOLDs and O contains some e and −e,
+e_pair is that e of smallest axis index.
+leftover axis ℓ is the unique Axis not in {axis(m), axis(e_pair)}.
+O_ℓ = O ∩ {± unit of ℓ}.
+If |O_ℓ|≠1, Orient fails, not UNDEFINED.
+Else o_ℓ is that signed vector.
+Orient(q) = sign of the integer determinant of columns (m, e_pair, o_ℓ).
+If no opposite pair or split fails, Orient fails, not UNDEFINED.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+The opposite-pair unit is the positive lattice unit of the smallest-index
+axis on which `O` contains both signs. The leftover letter is the unique
+signed vector of `O` on leftover axis `ℓ`, not the unsigned unit `+ℓ`.
+If leftover axis carries both signs, `|O_ℓ|=2` and Orient fails. Unique
+outgoing letters are not required. Mixed opposite signs occupy the pair
+axis as the pair. A vanishing determinant is fail. Sign of a nonzero
+integer determinant is `+1` or `−1`. Split HOLD required: overlapping
+axes at `A` is Orient fail, not UNDEFINED, even if `O` contains an
+opposite pair and a unique leftover sign.
+
+Reverse oriented frame holds if and only if `Orient(A)=Orient(B)` and both
+signs are `±1`. Face oriented frame holds if and only if
+`Orient(C)=Orient(D)` and both signs are `±1`. Either side `UNDEFINED` is
+`UNDEFINED`. Else if both sides are equal `±1`, reverse or face HOLDs.
+Else fail.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover reverse fails with this reverse, while
+cover face HOLDs and this face fails. Identifying split reverse with this
+reverse is refused: split reverse fails with this reverse, while split
+face HOLDs and this face fails. Identifying leftover-empty fail with this
+reverse is refused: leftover-empty bits agree here (`fail`/`fail`) and do
+not make Orient leftover-empty scoring; leftover-empty does not read
+`det(m,e_pair,o_ℓ)`. Identifying lexicographic `o1,o2` orientation with
+this face is refused: lexicographic face HOLDs with `+1,+1`, while this
+face fails. Identifying nm2orionez lex-one signed outgoing with this
+display is refused: lex-one is a different leftover letter. Identifying
+nm2orichz unsigned leftover `+ℓ` with this Orient is refused: unsigned
+leftover at `C` and at `D` is `+e_2` and yields `Orient=+1,−1`, while
+signed leftover is `−e_2` and yields `Orient=−1,+1`. Identifying
+nm2orilefz opposite reverse hold with this reverse is refused:
+nm2orilefz HOLDs reverse on the two-axis opposite seed; here reverse
+fails because split fails at `A`. Identifying nm2slz axis-cover face
+hold with this face is refused: nm2slz HOLDs face; this face fails.
+Identifying presence of an opposite pair in `O` with this reverse or
+face is refused: each of `A,B,C,D` has an opposite pair in `O`, so
+pair-presence reverse and face HOLD while this reverse and this face
+fail. Identifying a named sign of those locks with reverse or face is
+refused: named-sign lettering lost the axis.
+
+## Theorem 1 — ticks, `M`, `O`, split, pair, signed leftover, and Orient at `τ=t+1`
+
+On this process the four z-probes form. Compare to leftover axis: that
+leftover reports empty leftover at each probe and leftover reverse fail
+and leftover face fail. Compare to nm2slz cover: cover fails at `A` from
+overlapping `e_2`, HOLDs at `B,C,D`, reverse fail, and face hold. Compare
+to nm2orilefz signed leftover on the two-axis opposite seed: reverse
+hold and face fail, with `O(A)` missing `+e_2`. Compare to nm2chiralz
+lexicographic `o1,o2` orientation: face HOLDs on this member. Compare to
+nm2orichz unsigned leftover `+ℓ`: leftover at `C` and at `D` is unsigned
+`+e_2` and Orient is `+1,−1`. This display reads leftover axis with the
+signed `O` vector on that axis:
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=1
+M(A, τ) = {+e_2}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_3}
+M(D, τ) = {+e_1}
+O(A, τ) = {+e_1, −e_1, +e_2, +e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, −e_2}
+O(D, τ) = {−e_2, +e_3, −e_3}
+split(A) = fail
+split(B) = hold
+split(C) = hold
+split(D) = hold
+m(A) = +e_2
+pair(A) = +e_1
+leftover(A) = +e_3
+det(A) = −1
+Orient(A) = fail
+m(B) = +e_1
+pair(B) = +e_3
+leftover(B) = +e_2
+det(B) = −1
+Orient(B) = −1
+m(C) = +e_3
+pair(C) = +e_1
+leftover(C) = −e_2
+det(C) = −1
+Orient(C) = −1
+m(D) = +e_1
+pair(D) = +e_3
+leftover(D) = −e_2
+det(D) = +1
+Orient(D) = +1
+```
+
+`A` is a seed at tick 0 with seed letter `+e_2`. Mixed remains a set:
+`O(A,τ)` has four outgoing steps and `O(D,τ)` has three outgoing steps.
+Unique outgoing letters would assign `UNDEFINED` at mixed `O`. Here the
+same-lock partner of `A` is outgoing `+e_2`, so `Axis(M)` and `Axis(O)`
+overlap on `e_2`, cover fails, and split fails. Pair in `O` at `A` is
+still `+e_1` and signed leftover is still `+e_3` with integer
+`det=−1`, but split HOLD is required, so Orient at `A` is fail, not
+UNDEFINED, not `−1`. `M` is a singleton at each probe, so the unique
+signed `m` exists. At `B,C,D` split HOLDs, `O` contains an opposite
+pair, and `|O_ℓ|=1`, so Orient is the nonzero integer sign of
+`det(m,e_pair,o_ℓ)`. Cover and split HOLD at `C` and at `D` and do not
+score that `Orient(C)` and `Orient(D)` are opposite. Unsigned leftover
+`+ℓ` at `C` and at `D` is `+e_2` and yields `+1` and `−1`; signed
+leftover is `−e_2` and yields `−1` and `+1`. Lexicographic `o1,o2` at
+`B` and at `D` uses axis order `(e_2,e_3)` and yields `+1`; this pair
+at `B` and at `D` is `+e_3` with signed leftover `+e_2` at `B` and
+`−e_2` at `D`. If leftover axis carried both signs, `|O_ℓ|≠1` and
+Orient would fail; that does not occur on `B,C,D`. O is not M.
+
+On the 1-axis same-lock two-site seed, `A=(0,0,1)` is a formed child at
+tick 1 locking `+e_3`, split HOLDs at `A` and at `B` with Orient
+`−1,−1` so reverse HOLDs, and `C` is 2-in 1-out, so split fails at `C`
+and Orient at `C` is fail, not UNDEFINED. That is leftover of the first
+pair. Here both `(0,0,1)` and `(0,1,1)` are seeds of a second same-lock
+pair on a second axis. On the y-probes of this same seed, split HOLDs at
+`A` while `O(A)` has no opposite pair, so signed leftover-axis Orient
+fails, not UNDEFINED.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`:
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)
+new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)
+```
+
+`M` is frozen from `t` to `t+1`. At `t`, `O` at `A` is already `{+e_2}`
+from the same-lock partner, and `O` is empty at `B,C,D`. Split fails at
+each probe at `t`, and Orient is fail, not UNDEFINED.
+
+## Theorem 2 — reverse from oriented frame at `τ`
+
+Reverse oriented frame holds if and only if `Orient(A)=Orient(B)` both
+`±1`. `Orient(A)=fail` and `Orient(B)=−1`. Reverse fails. This is HOLD
+iff equal `±1` signs, not leftover of nm2orilefz signed leftover reverse
+hold, not leftover of nm2slz axis-cover, not leftover of nm2orichz
+unsigned leftover `+ℓ`, not leftover of nm2orionez lex-one signed
+outgoing, not leftover of nm2chiralz lexicographic `o1,o2`, not leftover
+of nm2axz axis-cover, not leftover of nm2ax12z 1-in 2-out split, not
+leftover-empty fail, and not exist-opposite.
+
+Reverse oriented frame at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Cover reverse fails
+because cover fails at `A`. Split reverse fails because split fails at
+`A`. Cover and split do not score handedness. Lexicographic reverse
+fails because lexicographic `Orient(A)=fail` and `Orient(B)=+1`. Signed
+leftover-axis reverse fails because `A` is not `±1`. Unsigned leftover
+reverse also fails on this member because unsigned leftover at `A` is
+likewise fail from split. Leftover-empty reverse fails because leftover
+of the union is empty at `A` and at `B`. Those leftover-empty bits
+agree with this reverse and do not make Orient leftover-empty scoring.
+Leftover of `M` reverse fails because leftover of `M` at `A` is
+`{e_1, e_3}` and at `B` is `{e_2, e_3}`: nonempty and unequal. Leftover
+of `O` reverse fails because leftover of `O` at `A` is empty and at `B`
+is `{e_1}`. Exist-opposite reverse of signed `M` fails. Exist-opposite
+reverse of signed `O` holds. Presence of an opposite pair in `O` at `A`
+and at `B` HOLDs, so pair-presence reverse HOLDs while this reverse
+fails. nm2orilefz reverse HOLDs on the two-axis opposite seed. 1-axis
+same-lock reverse HOLDs with `t(A)=1`. Those leftovers are not this
+display.
+
+Reverse fails.
+
+## Theorem 3 — face from oriented frame at `τ`
+
+Face oriented frame holds if and only if `Orient(C)=Orient(D)` both `±1`.
+`Orient(C)=−1` and `Orient(D)=+1`. Face fails.
+
+Face oriented frame at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Cover face HOLDs because cover HOLDs at `C` and at `D`. Split face HOLDs
+because split HOLDs at `C` and at `D`. Signed leftover-axis oriented face
+fails because the two frame signs are opposite. Unsigned leftover `+ℓ`
+face also fails, with opposite signs `+1` and `−1` rather than `−1` and
+`+1`. Lexicographic face HOLDs because both lexicographic signs are `+1`.
+Cover and split do not score handedness. Presence of an opposite pair in
+`O` HOLDs at `C` and at `D`, so pair-presence face HOLDs while this face
+fails. nm2slz axis-cover face HOLDs on this same seed. On the 1-axis
+same-lock two-site seed, cover face HOLDs while split face fails at `C`
+from 2-in 1-out, and Orient at `C` is fail, not UNDEFINED. This two-axis
+member is not leftover of that 1-axis split face fail. The four y-probes
+of this same seed give Orient fail at `A` from no opposite pair in `O`
+and Orient fail at `D` from split fail, so oriented face fails. The four
+x-probes give oriented reverse fail and oriented face fail. Those
+probe-direction readouts are not this z-probe display. Leftover-empty
+face fails because leftover of the union is empty at `C` and at `D`.
+Leftover of `M` at `C` is `{e_1, e_2}` and leftover of `M` at `D` is
+`{e_2, e_3}`: nonempty and unequal. Leftover of `O` at `C` is `{e_3}`
+and leftover of `O` at `D` is `{e_1}`: nonempty and unequal.
+Exist-opposite face of signed `M` fails. Exist-opposite face of signed
+`O` fails. Signed leftover-axis oriented face fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover HOLDs at `D` and split HOLDs at `D`. Orient at `D`
+is `+1`. Unsigned leftover at `D` is `+e_2` and Orient unsigned is `−1`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by unsigned leftover unit `+ℓ`.
+- It does not replace Orient by nm2orionez lex-one signed outgoing.
+- It does not replace Orient by lexicographic `o1,o2` orientation.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not replace Orient by nm2orilefz opposite reverse hold.
+- It does not replace Orient by nm2slz axis-cover face hold.
+- It does not treat split fail as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2axz axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2ax12z 1-in 2-out split reverse hold face hold as
+  this oriented display.
+- It does not reprint nm2chiralz lexicographic `o1,o2` reverse fail face
+  hold as this oriented display.
+- It does not reprint nm2orichz unsigned leftover `+ℓ` as this leftover
+  vector.
+- It does not reprint nm2orionez lex-one signed outgoing reverse fail face
+  hold as this oriented display.
+- It does not reprint nm2orilefz signed leftover reverse hold face fail as
+  this same-lock member.
+- It does not reprint nm2slz axis-cover reverse fail face hold as this
+  oriented display.
+- It does not reprint the 1-axis same-lock two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis same-lock seed process, signed leftover-axis det orientation at
+`t+1`, and the reverse/face bits from that sign are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis same-lock seed `+e_1/+e_1` and `+e_2/+e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `1` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; partner already outgoing at `A` |
+| split at `τ` | Theorem 1; fail at `A`, HOLD at `B,C,D` |
+| unique signed `m`, opposite pair in `O`, signed leftover `o_ℓ` | Theorem 1; singleton `M`, smallest-index pair, unique signed leftover |
+| integer `det(m,e_pair,o_ℓ)` | Theorem 1; `−1,−1,−1,+1` |
+| Orient at `τ` | Theorem 1; `fail,−1,−1,+1` |
+| reverse from oriented frame at `τ` | Theorem 2; `fail` |
+| face from oriented frame at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2axz axis-cover HOLD | not this oriented display |
+| leftover of nm2ax12z 1-in 2-out split HOLD | not this oriented display |
+| leftover of nm2slz axis-cover face HOLD | not this oriented display |
+| leftover of nm2chiralz lexicographic `o1,o2` | not this oriented display |
+| leftover of nm2orichz unsigned leftover `+ℓ` | not this leftover vector |
+| leftover of nm2orionez lex-one signed outgoing | not this oriented display |
+| leftover of nm2orilefz signed leftover reverse HOLD | not this same-lock member |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or x-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis same-lock two-site seed | not this display |
+| leftover of the two-axis opposite seed | not this display |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the transfer question: leftover axis with the signed `O` vector on that axis, not unsigned `+ℓ`, of `M` and `O` at `t+1` on the four z-probes of the two-axis same-lock seed, and reverse/face from that sign. |
+| V2 | Current main has no landed signed leftover-axis reverse/face of timed `M` and `O` on these four z-probes of the two-axis same-lock seed. |
+| V3 | Orient reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the integer sign of `det(m,e_pair,o_ℓ)` from the unique signed leftover vector in `O` at the same `t+1` cut, reverse fails from split fail at `A` while nm2orilefz reverse HOLDs, face fails while nm2slz cover face HOLDs, and Orient at `C` and at `D` differs from unsigned leftover `+ℓ`. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by unsigned leftover unit `+ℓ`, does not replace Orient by
+nm2orionez lex-one signed outgoing, does not replace Orient by nm2chiralz
+lexicographic `o1,o2`, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2axz axis-cover, does not
+replace Orient by nm2ax12z 1-in 2-out split, does not replace Orient by
+nm2orilefz opposite reverse hold, does not replace Orient by nm2slz
+axis-cover face hold, does not identify this display with the 1-axis
+same-lock two-site seed, and does not identify it with nmunopp union. No
+global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2chiralz lexicographic `o1,o2` | reuse lexicographic reverse fail and face hold | lexicographic face HOLDs (`+1,+1`) while this face fails (`−1,+1`); lexicographic reverse fails with this reverse | ATTEMPTED |
+| nm2orionez lex-one signed outgoing | reuse lex-one reverse fail and face hold | lex-one is a different leftover letter; this face fails | ATTEMPTED |
+| nm2orichz unsigned leftover `+ℓ` | reuse leftover unit `+ℓ` as the third column | unsigned leftover at `C` and at `D` is `+e_2` and Orient is `+1,−1`; signed leftover is `−e_2` and Orient is `−1,+1`; reverse/face bits agree and do not make leftover unsigned | ATTEMPTED |
+| nm2orilefz signed leftover | reuse opposite reverse hold and face fail | nm2orilefz reverse HOLDs with `Orient(A)=−1`; here `Orient(A)=fail` from overlapping `e_2` and reverse fails | ATTEMPTED |
+| nm2slz axis-cover | reuse cover reverse fail and cover face hold on these z-probes | cover face HOLDs while Orient face fails: `Orient(C)=−1` and `Orient(D)=+1` | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse hold and cover face hold | nm2axz is the opposite seed; here reverse fails and face fails | ATTEMPTED |
+| nm2ax12z 1-in 2-out split | reuse split reverse hold and split face hold | split reverse fails at `A`; split face HOLDs while Orient face fails; Cover and split do not score handedness | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails with Orient reverse and leftover face fails with Orient face; leftover-empty does not read `det(m,e_pair,o_ℓ)` | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_3}` and at `B` is `{e_2,e_3}`, nonempty unequal | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is empty and at `B` is `{e_1}` | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `O` HOLDs while Orient reverse fails; exist-opposite is a cross-probe boolean, not `det(m,e_pair,o_ℓ)` | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence HOLDs at `A` and at `B` and at `C` and at `D`, so those reverse and face HOLD while Orient reverse and face fail | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of signed incoming, pair unit, and signed leftover vector | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; pair is `+e_1`, leftover is `+e_3`, and Orient is fail from split | ATTEMPTED |
+| leftover axis with both signs | treat `|O_ℓ|=2` as defined by picking `+ℓ` | `|O_ℓ|≠1` is Orient fail, not UNDEFINED; unsigned leftover would still pick `+ℓ` | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | on split-HOLD probes they agree because each `M` letter is the positive unit; flipping `m` at a split-HOLD probe flips Orient while unsigned axis stays | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; none of these four probes is 2-in 1-out | ATTEMPTED |
+| overlapping axes as `UNDEFINED` | treat cover fail at `A` as unformed | split fail at `A` is Orient fail, not UNDEFINED | ATTEMPTED |
+| no opposite pair as `UNDEFINED` | treat missing `e` and `−e` in `O` as unformed | missing opposite pair is Orient fail, not UNDEFINED; y-probe `A` of this seed is the witness | ATTEMPTED |
+| 1-axis same-lock two-site seed | reuse `t(A)=1`, `t(C)=4`, reverse hold, Orient fail at `C` | different seed; second pair is a new seed, not a formed child; here `t(A)=0` and reverse fails | ATTEMPTED |
+| y-probe Orient | score the four y-probes on this seed | y-probe Orient fails at `A` from no opposite pair in `O`; this letter is the four z-probes | ATTEMPTED |
+| x-probe Orient | score the four x-probes on this seed | x-probe reverse fails at `A`; this letter is the four z-probes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores the signed leftover-axis oriented frame of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports Orient `fail,−1,−1,+1`, reverse fail, and face fail on the two-axis same-lock seed | ATTEMPTED |
+| two-axis opposite seed | reuse `+e_1/−e_1` and `+e_2/−e_2` | different seed; neither pair is opposite; this member is two disjoint same-lock pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum; mixed `O(A)` sums to `+e_2++e_3` while the pair is `+e_1` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with unsigned leftover unit `+ℓ`, missing
+identification of Orient with nm2orionez lex-one signed outgoing, missing
+identification of Orient with nm2chiralz lexicographic `o1,o2`, missing
+identification of Orient with nmcover axis-cover, missing identification of
+Orient with nm2axz axis-cover, missing identification of Orient with
+nm2ax12z 1-in 2-out split, missing identification of Orient with nm2orilefz
+opposite reverse hold, missing identification of Orient with nm2slz
+axis-cover face hold, missing identification of this seed with the
+1-axis same-lock two-site seed, and missing Record identification of Orient
+reverse are distinct open premises. This note claims no complete wall
+collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint same-lock seed pairs `+e_1/+e_1` and
+`+e_2/+e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, unique signed `m` when split HOLDs, smallest-index
+opposite pair in `O` when present, leftover axis the unique Axis not in
+`{axis(m), axis(e_pair)}`, leftover letter the unique signed vector of `O`
+on that axis, `|O_ℓ|≠1` as Orient fail not `UNDEFINED`, integer determinant
+sign, missing opposite pair as Orient fail not `UNDEFINED`, split fail as
+Orient fail not `UNDEFINED`, four z-probes with seed `A`, second pair as a
+new seed not a formed child, neither pair opposite, and mixed remains a set
+are declared. No uniqueness of outgoing locks, no six-neighbor lock union as
+the scored object, no lock-count clock, no global later T, no formation
+attachment from already-recorded six-neighbor locks, and no Admissibility
+rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+Orient `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | signed incoming letter, smallest-index opposite pair in `O`, signed leftover `O` vector on leftover axis | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four Orient reports, reverse/face from equal `±1` signs | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for Orient reverse/face, a
+formation-rate rule, and a physical selector among 1-in 2-out frames. None
+is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Orient reverse fail is only cover reverse, only split reverse,
+or only leftover-empty fail; lexicographic `o1,o2` already answers
+handedness; nm2orionez lex-one already answers signed leftover; nm2orichz
+unsigned leftover `+ℓ` already answers reverse because reverse and face
+bits agree; nm2orilefz already answers the leftover vector on z-probes;
+nm2slz already answers reverse/face on this seed; leftover of `M` alone
+already answers reverse; leftover of `O` alone already answers reverse;
+exist-opposite of signed `O` already answers reverse; pair-presence already
+answers reverse; the second pair is only the formed child `(0,0,1)` of the
+1-axis seed; unique outgoing letters should be required; and unsigned
+incoming axis already gives the same signs because each `M` letter is the
+positive unit.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Orient reverse fails because `Orient(A)=fail` from split
+fail at overlapping `e_2`, while Orient face fails because `Orient(C)=−1`
+and `Orient(D)=+1`. Cover reverse fails with this reverse, but cover face
+HOLDs while this face fails. Split reverse fails with this reverse, but
+split face HOLDs while this face fails. Cover and split do not score
+handedness. Lexicographic `o1,o2` reverse fails and face HOLDs with
+`+1,+1`; this reverse fails and this face fails. Unsigned leftover `+ℓ`
+at `C` and at `D` is `+e_2` and yields `+1` and `−1`; signed leftover is
+`−e_2` and yields `−1` and `+1`. Reverse and face bits of unsigned leftover
+agree with this member and do not make leftover unsigned. Presence of an
+opposite pair in `O` HOLDs at each of the four z-probes, so pair-presence
+reverse and face both HOLD, while this reverse and this face fail.
+nm2orilefz reverse HOLDs on the opposite seed with `O(A)` missing `+e_2`.
+nm2slz cover face HOLDs on this seed. Leftover of `M` alone at `A` is
+`{e_1,e_3}` and at `B` is `{e_2,e_3}`: nonempty unequal. Leftover of `O`
+alone at `A` is empty and at `B` is `{e_1}`. Exist-opposite reverse of
+signed `O` holds, but exist-opposite is a cross-probe boolean, not
+`det(m,e_pair,o_ℓ)`, and this reverse fails. Unique outgoing letters would
+assign `UNDEFINED` at mixed `O(A)`; the pair unit is `+e_1` and leftover
+is `+e_3`, while Orient is fail from split. Unsigned incoming axis agrees
+on split-HOLD probes because each unique `m` is the positive unit. The
+second pair is a new seed, not a formed child: `(0,0,1)` is recorded at
+tick 0 with lock `+e_2`, whereas the 1-axis child forms at tick 1 with
+lock `+e_3`. Reverse oriented frame is HOLD iff equal `±1` signs at `A`
+and at `B`, not leftover of nm2orilefz signed leftover.
+
+### N8 — cross-cycle echo
+
+nm2slz cover on this two-axis same-lock seed reported cover fail at `A`
+from overlapping `e_2`, cover HOLD at `B,C,D`, reverse fail, and face
+hold. nm2orilefz signed leftover on the two-axis opposite seed reported
+Orient `−1,−1,−1,+1`, reverse hold, and face fail. nm2axz cover on the
+opposite seed reported cover HOLD at each of the four z-probes, reverse
+hold, and face hold. nm2ax12z 1-in 2-out split on the opposite seed
+reported split HOLD at each of the four z-probes, reverse hold, and face
+hold. nm2chiralz lexicographic `o1,o2` on the opposite seed reported
+Orient `−1,+1,+1,+1`, reverse fail, and face hold. nm2orionez lex-one
+signed outgoing reported Orient `−1,+1,−1,−1`, reverse fail, and face
+hold. nm2orichz unsigned leftover `+ℓ` reported Orient `−1,−1,+1,−1`,
+reverse hold, and face fail. Leftover axis reported empty leftover at
+each of four z-probes, leftover reverse fail, and leftover face fail. The
+four y-probes of this same seed reported signed leftover-axis Orient fail
+at `A` from no opposite pair in `O`. This note is not those displays: it
+reports signed leftover-axis det orientation at `τ=t+1` on the two-axis
+same-lock seed, with `t(A)=0`, `t(B)=1`, `t(C)=1`, and `t(D)=1`,
+`Orient(A)=fail`, `Orient(B)=−1`, `Orient(C)=−1`, `Orient(D)=+1`, reverse
+fail, and face fail. Cover and split do not score handedness.
+
+**Gate disposition:** PASS for the signed leftover-axis `t+1` reverse/face
+reports above. FAIL / DO NOT SHIP for “the predicate equals the named
+sign,” “the predicate equals the unique singleton lock vector,” “the
+predicate equals six-neighbor lock union,” “the predicate equals
+leftover-empty fail,” “the predicate equals leftover of `M` alone,” “the
+predicate equals leftover of `O` alone,” “the predicate equals
+exist-opposite HOLD,” “the predicate equals opposite-pair presence in
+`O`,” “the predicate equals unsigned leftover unit `+ℓ`,” “the predicate
+equals nm2orionez lex-one HOLD,” “the predicate equals nm2chiralz
+lexicographic `o1,o2` HOLD,” “the predicate equals nmcover axis-cover
+HOLD,” “the predicate equals nm2axz axis-cover HOLD,” “the predicate
+equals nm2ax12z 1-in 2-out split HOLD,” “the predicate equals nm2orilefz
+signed leftover reverse HOLD,” “the predicate equals nm2slz axis-cover
+face HOLD,” “the predicate equals the 1-axis same-lock two-site seed,”
+“the predicate equals nmunopp union,” “bits are Admissibility,” “split
+fail is UNDEFINED,” “no opposite pair is UNDEFINED,” “`|O_ℓ|≠1` is
+UNDEFINED,” “reverse oriented frame holds,” or “face oriented frame
+holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis same-lock
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports split of the pair, reports the unique signed incoming letter, the
+smallest-index opposite pair in `O`, leftover axis, and signed leftover
+vector `o_ℓ`, reports the integer determinant and its sign, lists new
+records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors, and checks Theorems 1--3. It also checks that Orient is
+`fail,−1,−1,+1` at `A,B,C,D`, that reverse fails while pair-presence
+reverse HOLDs and nm2orilefz reverse HOLDs, that face fails while cover
+face, split face, pair-presence face, and lexicographic face HOLD, that
+unsigned leftover `+ℓ` differs at `C` and at `D`, that `|O_ℓ|≠1` is Orient
+fail not `UNDEFINED`, that split fail is Orient fail not `UNDEFINED`, that
+no opposite pair in `O` is Orient fail not `UNDEFINED`, that the 1-axis
+same-lock two-site seed is a different member with reverse HOLD, that
+leftover-empty fail is a different reverse object, that leftover of `M`
+alone and leftover of `O` alone are different objects, that mixed sets
+remain sets, that unique-letter Orient is `UNDEFINED` at mixed `O`, that
+the construction does not sum, that a formation member from already-recorded
+six-neighbor locks is not attached, that the second pair is a new seed not
+a formed child, that the y-probes and x-probes of this seed are not this
+letter, and that the display is not the two-tick lock-count clock
+composition. No runner cache is written.

--- a/logs/runner-cache/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,90 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py
+runner_sha256: bd0e8f5315b75caa92758acdaae578a29fc80cac54bd53e482c68f007cc49907
+input_fingerprint_sha256: baf6178b7f9fd2bde87a26c6b33741078c39f897015ca9ecd2e5c879e8ce2f1a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+signed leftover-axis det orientation reverse/face at t+1 on two-axis same-lock z-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Signed leftover-axis det orientation at t+1 on the four z-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+A t=0 M={+e_2} O={+e_1, −e_1, +e_2, +e_3} split=fail m=+e_2 pair=+e_1 leftover=+e_3 det=-1 Orient=fail
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} split=hold m=+e_1 pair=+e_3 leftover=+e_2 det=-1 Orient=−1
+C t=1 M={+e_3} O={+e_1, −e_1, −e_2} split=hold m=+e_3 pair=+e_1 leftover=−e_2 det=-1 Orient=−1
+D t=1 M={+e_1} O={−e_2, +e_3, −e_3} split=hold m=+e_1 pair=+e_3 leftover=−e_2 det=1 Orient=+1
+Orient reverse=fail face=fail
+split reverse=fail face=hold
+cover reverse=fail face=hold
+per_element: signed incoming letter, smallest-index opposite pair in O, and signed leftover O vector on leftover axis at a probe's t+1
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four Orient reports, reverse/face from equal +/-1 signs
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-O-split  ({'A': ('{+e_2}', 'fail'), 'B': ('{+e_1}', 'hold'), 'C': ('{+e_3}', 'hold'), 'D': ('{+e_1}', 'hold')})
+PASS: theorem1-Orient  ({'A': 'fail', 'B': '−1', 'C': '−1', 'D': '+1'})
+PASS: theorem1-mixed-O-unsigned-plane
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((1, 0, 1), (-1, 0, 1), (0, 0, 2)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 0, 2), (-1, 0, 2), (0, -1, 2)), 'D': ((1, -1, 1), (1, 0, 2), (1, 0, 0))})
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-orient-fail
+PASS: theorem3-face-orient-fail
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-same-lock-orient-reverse-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unsigned-incoming-axis-agrees-on-split-hold
+PASS: mutation-unsigned-leftover-plus-l-differs
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-y-probes-or-z-symmetric-or-perp
+PASS: not-opposite-or-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-Orient
+PASS: note-reports-new-neighbors
+PASS: note-reports-orient-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: orient-fail-not-split-hold
+TOTAL: PASS=58 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1585 @@
+#!/usr/bin/env python3
+"""Signed leftover-axis det orientation at t+1 on two-axis same-lock z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is four sites in two disjoint same-lock pairs: origin and (0,1,0) lock
++e_1; (0,0,1) and (0,1,1) lock +e_2. Neither pair is opposite. Same process
+and z-probes as nm2slz. Orient as nm2orilefz: signed leftover axis o_l and
+det(m, e_pair, o_l). Perp-step incoming lock. Unformed => UNDEFINED. Split
+HOLDs iff cover HOLDs and |Axis(M)|=1. Split HOLD required. When split
+HOLDs and O contains some e and -e, let e_pair be that e of smallest axis
+index. Leftover axis l is the unique Axis not in {axis(m), axis(e_pair)}.
+Let O_l = O intersect {+/- unit of l}. If |O_l| != 1, Orient fails, not
+UNDEFINED. Else let o_l be that signed vector. Orient is the sign of the
+integer determinant of columns (m, e_pair, o_l). If no opposite pair or
+split fails, Orient fails, not UNDEFINED. Reverse HOLDs iff
+Orient(A)=Orient(B) both +/-1. Face on C,D. Uniqueness of O is not
+required. Occupancy of sites is not used. No larger host. Displayed, not
+adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+FOUR_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    (PAIR2, E2),
+)
+TWO_AXIS_OPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Signed leftover-axis det orientation at t+1 on the four "
+    "z-probes of the two-axis same-lock seed, and reverse/face from that, "
+    "are reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = FOUR_SITE_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_axis_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e_pair)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def leftover_signed(outgoing: Outgoing, leftover_axis: Point) -> Point | str:
+    """Unique signed O vector on leftover axis. Fail if |O_l| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-leftover_axis[0], -leftover_axis[1], -leftover_axis[2])
+    occupied = outgoing & {leftover_axis, negative}
+    if len(occupied) != 1:
+        return "fail"
+    return next(iter(occupied))
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unsigned_leftover_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Unsigned leftover unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_axis_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, e_pair, o_l). Fail if |O_l| != 1 or no pair or split fails."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover_ax = leftover_axis_unit(signed_m, pair)
+    if leftover_ax == "fail" or not isinstance(leftover_ax, tuple):
+        return "fail"
+    leftover = leftover_signed(outgoing, leftover_ax)
+    if leftover == UNDEFINED:
+        return UNDEFINED
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Reverse HOLDs iff Orient(A)=Orient(B) both +/-1."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Face HOLDs iff Orient(C)=Orient(D) both +/-1."""
+    return pair_orient(orient_c, orient_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    pair = opposite_pair_unit(outgoing)
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover_ax = leftover_axis_unit(unsigned_m, pair)
+    if not isinstance(leftover_ax, tuple):
+        return "fail"
+    leftover = leftover_signed(outgoing, leftover_ax)
+    if not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("signed leftover-axis det orientation reverse/face at t+1 on two-axis same-lock z-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E1, E3) == -1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E3, E1, E2) == 1
+        and integer_det_columns(E3, E1, NEG_E2) == -1
+        and integer_det_columns(E1, E3, NEG_E2) == 1
+        and integer_det_columns(NEG_E2, E1, E3) == 1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == -1
+        and frame_orient(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3})) == 1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, NEG_E1, E3})) == 1
+        and frame_orient(frozenset({E1, NEG_E1}), frozenset({E2, E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3}))
+        == "fail"
+        and leftover_signed(frozenset({E1, NEG_E1, E3}), E3) == E3
+        and leftover_signed(frozenset({E1, NEG_E1, NEG_E2}), E2) == NEG_E2
+        and leftover_signed(frozenset({E1, NEG_E1, E3, NEG_E3}), E3) == "fail"
+        and leftover_signed(frozenset({E1, NEG_E1}), E3) == "fail"
+        and unsigned_leftover_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2}))
+        == 1
+        and unsigned_leftover_orient(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3}))
+        == -1
+        and unsigned_leftover_orient(
+            frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})
+        )
+        == -1
+        and lex_frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and lex_frame_orient(frozenset({E2}), frozenset({E1, E3})) == -1,
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(SAME_LOCK_SEEDS)
+    opp_ticks, opp_locks, opp_seeds = form(TWO_AXIS_OPP_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    two_site_ticks, two_site_locks, two_site_seeds = form(TWO_SITE_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m: dict[str, Point | str] = {}
+    plane: dict[str, tuple[Point, Point] | str] = {}
+    pair: dict[str, Point | str] = {}
+    leftover: dict[str, Point | str] = {}
+    det: dict[str, int | str] = {}
+    lex: dict[str, OrientVal] = {}
+    pair_present: dict[str, str] = {}
+    orient: dict[str, OrientVal] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1 = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1, ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1, ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m[name] = unique_signed_m(m1[name])
+        plane[name] = outgoing_plane(axis_o[name])
+        pair[name] = opposite_pair_unit(o1[name])
+        if isinstance(signed_m[name], tuple) and isinstance(pair[name], tuple):
+            leftover_ax = leftover_axis_unit(signed_m[name], pair[name])
+            if isinstance(leftover_ax, tuple):
+                leftover[name] = leftover_signed(o1[name], leftover_ax)
+            else:
+                leftover[name] = "fail"
+        else:
+            leftover[name] = "fail"
+        if (
+            isinstance(signed_m[name], tuple)
+            and isinstance(pair[name], tuple)
+            and isinstance(leftover[name], tuple)
+        ):
+            det[name] = integer_det_columns(
+                signed_m[name], pair[name], leftover[name]
+            )
+        else:
+            det[name] = "fail"
+        pair_present[name] = has_opposite_pair(o1[name])
+        lex[name] = lex_frame_orient(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"split={split[name]} "
+            f"m={LOCK_NAME[signed_m[name]] if isinstance(signed_m[name], tuple) else signed_m[name]} "
+            f"pair={LOCK_NAME[pair[name]] if isinstance(pair[name], tuple) else pair[name]} "
+            f"leftover={LOCK_NAME[leftover[name]] if isinstance(leftover[name], tuple) else leftover[name]} "
+            f"det={det[name]} "
+            f"Orient={orient_display(orient[name])}"
+        )
+
+    reverse = reverse_report(orient["A"], orient["B"])
+    face = face_report(orient["C"], orient["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unsigned_orient = {
+        name: unsigned_incoming_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    unsigned_leftover = {
+        name: unsigned_leftover_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    unique_o_orient_a = frame_orient(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = face_report(one_orient["C"], one_orient["D"])
+    print(f"Orient reverse={reverse} face={face}")
+    print(f"split reverse={split_reverse} face={split_face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: signed incoming letter, smallest-index opposite pair in O, "
+        "and signed leftover O vector on leftover axis at a probe's t+1"
+    )
+    print("per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites")
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: four Orient reports, reverse/face from equal +/-1 signs")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_a_parallel_blocked = ticks.get(add(E3, NEG_E2)) != 1
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_a_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[E3] == 0
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["D"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-split",
+        m1["A"] == frozenset({E2})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E1})
+        and o1["A"] == frozenset({E1, NEG_E1, E2, E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, NEG_E2})
+        and o1["D"] == frozenset({NEG_E2, E3, NEG_E3})
+        and split["A"] == "fail"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "hold"
+        and cover["A"] == "fail"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "hold",
+        str({name: (lockset_display(m1[name]), split[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Orient",
+        signed_m["A"] == E2
+        and signed_m["B"] == E1
+        and signed_m["C"] == E3
+        and signed_m["D"] == E1
+        and pair["A"] == E1
+        and pair["B"] == E3
+        and pair["C"] == E1
+        and pair["D"] == E3
+        and leftover["A"] == E3
+        and leftover["B"] == E2
+        and leftover["C"] == NEG_E2
+        and leftover["D"] == NEG_E2
+        and det["A"] == -1
+        and det["B"] == -1
+        and det["C"] == -1
+        and det["D"] == 1
+        and orient["A"] == "fail"
+        and orient["B"] == -1
+        and orient["C"] == -1
+        and orient["D"] == 1,
+        str({name: orient_display(orient[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-O-unsigned-plane",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 4
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["A"]) == frozenset({E2})
+        and axis_o["A"] == frozenset({E1, E2, E3})
+        and unique_o_orient_a == UNDEFINED
+        and orient["A"] == "fail"
+        and pair["A"] == E1
+        and E2 in o1["A"]
+        and E2 in m1["A"],
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and o0["A"] == frozenset({E2})
+        and all(o0[name] == frozenset() for name in ("B", "C", "D"))
+        and all(frame_orient(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 0, 2), (-1, 0, 2), (0, -1, 2))
+        and new_meet["D"] == ((1, -1, 1), (1, 0, 2), (1, 0, 0)),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and m1["A"] == frozenset({E2})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {E2}
+        and seed_map[ORIGIN] == seed_map[E2] == E1
+        and seed_map[E3] == seed_map[PAIR2] == E2
+        and add(seed_map[ORIGIN], seed_map[E2]) != ZERO
+        and add(seed_map[E3], seed_map[PAIR2]) != ZERO,
+    )
+    checks.check(
+        "theorem2-reverse-orient-fail",
+        reverse == "fail"
+        and orient["A"] == "fail"
+        and orient["B"] == -1
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and split_reverse == "fail"
+        and cover_reverse == "fail",
+    )
+    checks.check(
+        "theorem3-face-orient-fail",
+        face == "fail"
+        and orient["C"] == -1
+        and orient["D"] == 1
+        and face != UNDEFINED
+        and face != "hold"
+        and split_face == "hold"
+        and cover_face == "hold",
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split_reverse == "fail"
+        and cover_reverse == "fail"
+        and reverse == "fail"
+        and split_face == "hold"
+        and cover_face == "hold"
+        and face == "fail"
+        and face != split_face
+        and face != cover_face,
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and one_orient["C"] == "fail"
+        and one_split["C"] == "fail"
+        and one_cover["C"] == "hold"
+        and one_orient_face == "fail"
+        and one_split_face == "fail"
+        and one_cover_face == "hold",
+    )
+    checks.check(
+        "not-leftover-of-1-axis-same-lock-orient-reverse-hold",
+        one_ticks[PROBES["A"]] == 1
+        and one_ticks[PROBES["C"]] == 4
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["C"]] == 1
+        and one_orient["A"] == -1
+        and one_orient["B"] == -1
+        and reverse_report(one_orient["A"], one_orient["B"]) == "hold"
+        and one_orient["C"] == "fail"
+        and one_orient_face == "fail"
+        and face == "fail"
+        and reverse == "fail"
+        and one_m1["A"] != m1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and all(lx[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and leftover_reverse == reverse
+        and leftover_face == face
+        and cover_face == "hold"
+        and leftover_face != cover_face,
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m["A"] == frozenset({E1, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_o["A"] == frozenset()
+        and lx_o["B"] == frozenset({E1})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and o_exist_reverse != reverse
+        and pair_present["A"] == "hold"
+        and pair_present["B"] == "hold"
+        and pair_present["C"] == "hold"
+        and pair_present["D"] == "hold"
+        and pair_bit(pair_present["A"], pair_present["B"]) == "hold"
+        and pair_bit(pair_present["A"], pair_present["B"]) != reverse
+        and pair_bit(pair_present["C"], pair_present["D"]) == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) != face,
+    )
+    checks.check(
+        "mutation-unsigned-incoming-axis-agrees-on-split-hold",
+        unsigned_orient["A"] == "fail"
+        and unsigned_orient["B"] == -1
+        and unsigned_orient["C"] == -1
+        and unsigned_orient["D"] == 1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and unsigned_incoming_orient(frozenset({NEG_E2}), frozenset({E1, NEG_E1, E3}))
+        == -1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, NEG_E1, E3})) == 1
+        and orient["A"] == "fail",
+    )
+    checks.check(
+        "mutation-unsigned-leftover-plus-l-differs",
+        unsigned_leftover["A"] == "fail"
+        and unsigned_leftover["B"] == -1
+        and unsigned_leftover["C"] == 1
+        and unsigned_leftover["D"] == -1
+        and orient["A"] == "fail"
+        and orient["B"] == -1
+        and orient["C"] == -1
+        and orient["D"] == 1
+        and unsigned_leftover["C"] != orient["C"]
+        and unsigned_leftover["D"] != orient["D"]
+        and reverse_report(unsigned_leftover["A"], unsigned_leftover["B"]) == "fail"
+        and face_report(unsigned_leftover["C"], unsigned_leftover["D"]) == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and leftover["C"] == NEG_E2
+        and leftover["D"] == NEG_E2
+        and leftover_axis_unit(E3, E1) == E2
+        and leftover_axis_unit(E1, E3) == E2,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({E2})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED
+        and orient["A"] == "fail"
+        and orient["D"] == 1,
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == E2
+        and sum_of_set(o1["A"]) == add(E2, E3)
+        and axis_o["A"] == frozenset({E1, E2, E3})
+        and pair["A"] == E1
+        and leftover["A"] == E3,
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and E2 in m1["A"]
+        and E2 in o1["A"]
+        and o1["A"] != m1["A"]
+        and axis_m["A"] != axis_o["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    y_m1, y_o1 = probe_sides(Y_PROBES, ticks, locks, seed_map)
+    y_split = {name: axis_split(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_orient = {name: frame_orient(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_reverse = reverse_report(y_orient["A"], y_orient["B"])
+    y_face = face_report(y_orient["C"], y_orient["D"])
+    x_m1, x_o1 = probe_sides(X_PROBES, ticks, locks, seed_map)
+    x_orient = {name: frame_orient(x_m1[name], x_o1[name]) for name in ("A", "B", "C", "D")}
+    x_reverse = reverse_report(x_orient["A"], x_orient["B"])
+    x_face = face_report(x_orient["C"], x_orient["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    opp_m1, opp_o1 = probe_sides(PROBES, opp_ticks, opp_locks, opp_seeds)
+    opp_orient = {
+        name: frame_orient(opp_m1[name], opp_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    opp_reverse = reverse_report(opp_orient["A"], opp_orient["B"])
+    opp_face = face_report(opp_orient["C"], opp_orient["D"])
+    two_site_m_a = incoming_set(
+        PROBES["A"],
+        two_site_ticks[PROBES["A"]] + 1,
+        two_site_ticks,
+        two_site_locks,
+        two_site_seeds,
+    )
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-x-probes-or-y-probes-or-z-symmetric-or-perp",
+        FOUR_SITE_SEEDS != PERP_SEEDS
+        and FOUR_SITE_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and y_m1["A"] != m1["A"]
+        and y_split["A"] == "hold"
+        and y_orient["A"] == "fail"
+        and y_orient["B"] == -1
+        and y_reverse == "fail"
+        and y_split["D"] == "fail"
+        and y_orient["D"] == "fail"
+        and y_face == "fail"
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "not-opposite-or-one-axis-or-y-symmetric-seed",
+        FOUR_SITE_SEEDS != TWO_AXIS_OPP_SEEDS
+        and FOUR_SITE_SEEDS != SAME_LOCK_SEEDS
+        and FOUR_SITE_SEEDS != TWO_SITE_SEEDS
+        and FOUR_SITE_SEEDS != Y_SYMMETRIC_SEEDS
+        and two_site_m_a != m1["A"]
+        and opp_orient["A"] == -1
+        and opp_reverse == "hold"
+        and opp_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and isinstance(opp_o1["A"], frozenset)
+        and E2 not in opp_o1["A"]
+        and isinstance(o1["A"], frozenset)
+        and E2 in o1["A"]
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-Orient",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ) = {+e_2}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_3}" in note
+        and "M(D, τ) = {+e_1}" in note
+        and "O(A, τ) = {+e_1, −e_1, +e_2, +e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ) = {−e_2, +e_3, −e_3}" in note
+        and "split(A) = fail" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = hold" in note
+        and "m(A) = +e_2" in note
+        and "pair(A) = +e_1" in note
+        and "leftover(A) = +e_3" in note
+        and "det(A) = −1" in note
+        and "Orient(A) = fail" in note
+        and "m(B) = +e_1" in note
+        and "pair(B) = +e_3" in note
+        and "leftover(B) = +e_2" in note
+        and "det(B) = −1" in note
+        and "Orient(B) = −1" in note
+        and "m(C) = +e_3" in note
+        and "pair(C) = +e_1" in note
+        and "leftover(C) = −e_2" in note
+        and "det(C) = −1" in note
+        and "Orient(C) = −1" in note
+        and "m(D) = +e_1" in note
+        and "pair(D) = +e_3" in note
+        and "leftover(D) = −e_2" in note
+        and "det(D) = +1" in note
+        and "Orient(D) = +1" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)" in note,
+    )
+    checks.check(
+        "note-reports-orient-reverse-face",
+        "Reverse oriented frame at τ: fail" in note
+        and "Face oriented frame at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2orilefz signed leftover" in normalized_note
+        and "not leftover of nm2slz axis-cover" in normalized_note
+        and "not leftover of nm2axz axis-cover" in normalized_note
+        and "not leftover of nm2ax12z 1-in 2-out split" in normalized_note
+        and "not leftover of nm2chiralz lexicographic" in normalized_note
+        and "not leftover of nm2orichz unsigned leftover" in normalized_note
+        and "not leftover of nm2orionez lex-one" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "neither pair is opposite" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse oriented frame at τ: fail" in note
+        and "Face oriented frame at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_SAME_LOCK_ZPROBE_SIGNED_LEFTOVER_AXIS_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "opposite_pair_unit" in defined_fns
+        and "leftover_axis_unit" in defined_fns
+        and "leftover_signed" in defined_fns
+        and "unsigned_leftover_orient" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "orient-fail-not-split-hold",
+        reverse == "fail"
+        and face == "fail"
+        and split_reverse == "fail"
+        and cover_reverse == "fail"
+        and cover_face == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and one_orient_face == "fail"
+        and lex["A"] == "fail"
+        and lex["B"] == 1
+        and lex["C"] == 1
+        and lex["D"] == 1
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and face_report(lex["C"], lex["D"]) == "hold"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and opp_reverse == "hold",
+    )
+    _ = (
+        o0,
+        unique_o_orient_a,
+        one_cover_face,
+        one_split_face,
+        unsigned_orient,
+        perp_o1,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Signed leftover-axis same-lock z: reverse fails, face fails. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_same_lock_zprobe_signed_leftover_axis_det_orientation_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.