### PR TITLE
feat(nm2oricyclrdz): neighbor-read of cyclic lex-largest Orient at t+1 on two-axis opposite z-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,606 @@
+---
+claim_id: two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of the cyclic lex-largest orientation at t+1 on the four z-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
+---
+
+# Neighbor-Read Of Cyclic Lex-Largest Orientation At t+1 Reverse And Face On Four Z-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** neighbor-read of the cyclic next/prev lex-largest outgoing
+determinant orientation of the 1-in 2-out frame of simultaneous earliest
+incoming set `M` and outgoing dual `O` at each probe's `τ=t+1`, and
+reverse/face from that neighbor-read, on the four z-probes of the two-axis
+opposite seed in `B_3(0)={n:n·n<=9}`. Same process and z-probes as nm2axz.
+Orient as nm2oricyclz. Let `t(q)` be the formation tick of probe `q`. Let
+`τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest incoming nearest-neighbor
+steps at `q` using only records with tick `<= τ`. Seeds are a singleton
+seed letter. `O(q,τ)` is the outgoing dual of `M`: the set of `e` in
+`{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in `M(q+e,τ)`.
+Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Split
+HOLDs at `q` if and only if cover HOLDs and `|Axis(M)|=1`. When split
+HOLDs, `m` is unique in `M`. `e_next = e_{i+1}` with `3+1→1`. `e_prev =
+e_{i-1}` with `1−1→3`. Order `+e < −e`. `o_next` is the lex-largest vector
+in `O ∩ {±e_next}`. `o_prev` likewise. `Orient(q)` is the sign of the
+integer determinant of columns `m`, `o_next`, `o_prev`. If split fails,
+Orient fails, not `UNDEFINED`. Neighbor-read HOLDs at `q` if and only if
+`Orient(q)` is `±1` and some formed 6-NN `r` has `Orient(r)=Orient(q)` both
+`±1` at the same cut `τ(q)`. If Orient fails at `q`, neighbor-read fails,
+not `UNDEFINED`. Unformed `q` is `UNDEFINED`. Uniqueness is not required.
+Mixed remains a set. Reverse HOLDs if and only if neighbor-read HOLDs at
+`A` and at `B`. Face HOLDs if and only if neighbor-read HOLDs at `C` and
+at `D`. This is not leftover of nm2oricyclz cyclic lex-largest Orient
+reverse hold and face hold. This is not leftover of nm2oreadz neighbor-read
+of O. This is not leftover of nm2readz neighbor-read of M. This is not
+leftover of nm2axz axis-cover. This is not leftover of nm2ax12z 1-in 2-out
+split. This is not leftover of nm2orichz leftover-axis. This is not leftover
+of cyclic lex-smallest. Occupancy of sites is not used. Named-sign
+lettering is not used. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named z-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Orient is the cyclic next/prev lex-largest outgoing determinant of
+the 1-in 2-out frame. Neighbor-read asks whether a formed six-neighbor
+recovers that same `±1` Orient sign at the same cut, without being the
+probe itself. Reverse and face are scored on neighbor-read HOLD at the
+paired probes. Named signs `{+,−}` are a coarser readout and are not used.
+A singleton unique lock letter is a different readout and is not used as
+the object. Axis-cover of `M` and `O` is a different readout and is not
+used. 1-in 2-out split is a different readout and is not used. Equal Orient
+signs at `A` and at `B` are a different readout and are not used as this
+reverse. Neighbor-read of `O` is a different readout and is not used.
+Neighbor-read of `M` is a different readout and is not used. Leftover-axis
+Orient is a different readout and is not used. Cyclic lex-smallest Orient
+is a different readout and is not used. A `Z^3` sum of those locks is a
+different readout and is not used. Occupancy of sites is not used. A
+six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of neighbor-read of cyclic lex-largest Orient at t+1 on the four z-probes of the two-axis opposite seed, neighbor-read bits at each probe, reverse fail and face fail from those bits; uniqueness of outgoing locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face
+target_blocker_text: "display neighbor-read of cyclic lex-largest Orient at t+1 on the four z-probes of the two-axis opposite seed, HOLD iff some formed 6-NN recovers the same Orient sign"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep neighbor-read of cyclic lex-largest Orient at t+1 displayed; do not write neighbor-read into Admissibility, do not reduce to neighbor-read of O or of M, do not reduce to nm2oricyclz equal-sign reverse, do not reduce to leftover-axis neighbor-read, do not reduce to cyclic lex-smallest neighbor-read, do not reduce to axis-cover or 1-in 2-out split, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for neighbor-read of cyclic lex-largest Orient at t+1 on the four z-probes of the two-axis opposite seed and reverse/face from that; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four z-probes are the only sites whose
+neighbor-read of cyclic lex-largest Orient is scored:
+
+```text
+A = (0,0,1),  B = (1,1,1),  C = (0,0,2),  D = (1,0,1).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the second opposite pair. Same process and
+z-probes as nm2axz.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named neighbor-read of cyclic lex-largest Orient at `τ=t+1`
+
+Let `t(q)` be the formation tick of z-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover HOLDs iff `Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union
+`Axis(O)` equals `{e_1,e_2,e_3}`. Split HOLDs iff cover HOLDs and
+`|Axis(M)|=1`. Cover and split do not score handedness.
+
+Oriented frame at the same cut, as nm2oricyclz:
+
+```text
+When split HOLDs, m is the unique signed letter in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1. e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}. O_prev = O ∩ {±e_prev}.
+If either is empty, Orient fails, not UNDEFINED.
+Order +e < −e. o_next is lex-largest in O_next (hence −e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+Neighbor-read at a probe at the same cut:
+
+```text
+neighbor-read(q) HOLDs iff Orient(q) is ±1 and some formed 6-NN r
+has Orient(r, τ(q)) = Orient(q) both ±1.
+```
+
+If `q` is unformed at `τ`, then neighbor-read is `UNDEFINED`. If Orient
+fails at `q`, neighbor-read fails, not `UNDEFINED`. Else if no formed
+six-neighbor recovers the same `±1` sign, neighbor-read fails. The probe
+is not counted as its own neighbor. Empty matching is fail, not
+`UNDEFINED`. Mixed remains a set: mixed `O` may still define a sign, and
+that sign may still fail to match any neighbor.
+
+Reverse neighbor-read holds if and only if neighbor-read HOLDs at `A` and
+at `B`. Face neighbor-read holds if and only if neighbor-read HOLDs at `C`
+and at `D`. Either side `UNDEFINED` is `UNDEFINED`. Else if both sides HOLD,
+reverse or face HOLDs. Else fail.
+
+Identifying neighbor-read of Orient with neighbor-read of `O` is refused:
+neighbor-read of `O` HOLDs at `A` from the partner seed sharing the outgoing
+set, while neighbor-read of Orient fails at `A` because that partner has
+the opposite sign. Identifying neighbor-read of Orient with neighbor-read
+of `M` is refused: neighbor-read of `M` HOLDs at `B`, `C`, and `D`.
+Identifying this reverse with nm2oricyclz equal-sign reverse is refused:
+Orient reverse HOLDs from `Orient(A)=Orient(B)=−1`, while this reverse
+fails because neither reverse probe has a matching neighbor. Identifying
+this reverse with leftover-axis neighbor-read is refused: leftover-axis
+neighbor-read HOLDs at `B`, `C`, and `D` and leftover-axis face HOLDs.
+Identifying this reverse with cyclic lex-smallest neighbor-read is refused:
+lex-smallest neighbor-read HOLDs at `A` from the origin matching `+1`.
+Identifying neighbor-read with axis-cover or 1-in 2-out split is refused:
+those objects HOLD at each of these four z-probes.
+
+## Theorem 1 — ticks, `M`, `O`, Orient, neighbor-read at `τ=t+1`
+
+On this process the four z-probes form. Compare to nm2oricyclz: that leftover
+reports Orient `−1,−1,+1,+1`, reverse hold, and face hold from equal `±1`
+signs. Compare to nm2oreadz: that leftover reports neighbor-read of `O`
+hold at `A` and fail at `B`, `C`, and `D`. This display reads whether a
+formed six-neighbor recovers the cyclic lex-largest Orient sign:
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=1
+M(A, τ) = {+e_2}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_3}
+M(D, τ) = {+e_1}
+O(A, τ) = {+e_1, −e_1, +e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, −e_2}
+O(D, τ) = {−e_2, +e_3, −e_3}
+Orient(A) = −1
+Orient(B) = −1
+Orient(C) = +1
+Orient(D) = +1
+neighbor-read(A) = fail
+neighbor-read(B) = fail
+neighbor-read(C) = fail
+neighbor-read(D) = fail
+formed 6-NN of A at τ: (1, 0, 1)=fail, (-1, 0, 1)=fail, (0, 1, 1)=+1, (0, -1, 1)=UNDEFINED, (0, 0, 2)=fail, (0, 0, 0)=+1
+formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)=+1, (1, 2, 1)=fail, (1, 0, 1)=+1, (1, 1, 2)=fail, (1, 1, 0)=fail
+formed 6-NN of C at τ: (1, 0, 2)=fail, (-1, 0, 2)=fail, (0, 1, 2)=−1, (0, -1, 2)=fail, (0, 0, 1)=−1
+formed 6-NN of D at τ: (2, 0, 1)=UNDEFINED, (0, 0, 1)=−1, (1, 1, 1)=−1, (1, -1, 1)=fail, (1, 0, 2)=fail, (1, 0, 0)=fail
+matching 6-NN of A: none
+matching 6-NN of B: none
+matching 6-NN of C: none
+matching 6-NN of D: none
+```
+
+`A` is a seed at tick 0 with seed letter `+e_2`. The partner of that pair,
+`(0,1,1)`, is also a seed at tick 0 with seed letter `−e_2`. At `τ=1` those
+two seeds share the same outgoing set `{+e_1, −e_1, +e_3}`, so neighbor-read
+of `O` HOLDs at `A`. They do not share Orient: flipping `m` from `+e_2` to
+`−e_2` flips the determinant, so Orient at the partner is `+1` while Orient
+at `A` is `−1`. Origin `(0,0,0)` also reports Orient `+1`. No formed
+six-neighbor recovers `−1` at `A`. Mixed remains a set: `O(A,τ)` has three
+outgoing steps and still defines Orient `−1`. Unique letters would assign
+`UNDEFINED` at mixed `O`. Here uniqueness is not required. At `t`, `O` is
+empty at each probe, split fails, Orient fails, and neighbor-read fails,
+not `UNDEFINED`. `M` is frozen from `t` to `t+1`; `O` is not. O is not M.
+
+On the 1-axis opposite two-site seed, `A=(0,0,1)` is a formed child at
+tick 1 locking `+e_3`, neighbor-read of cyclic Orient HOLDs at `A` from
+the origin, and reverse HOLDs. That is leftover of the first pair. Here
+both `(0,0,1)` and `(0,1,1)` are seeds of a second opposite pair on a
+second axis, and neighbor-read fails at `A`.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`:
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)
+new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)
+```
+
+Those new six-neighbors have empty `O` at the probe cut, so their Orient
+fails and they do not match.
+
+## Theorem 2 — reverse from neighbor-read of Orient at `τ`
+
+Reverse neighbor-read holds if and only if neighbor-read HOLDs at `A` and
+at `B`. Neighbor-read fails at `A` and at `B`. Reverse fails. This is HOLD
+iff neighbor-read at both reverse probes, not leftover of nm2oricyclz
+equal-sign reverse, not leftover of nm2oreadz neighbor-read of O.
+
+Reverse neighbor-read at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. nm2oricyclz Orient
+reverse HOLDs because `Orient(A)=−1` and `Orient(B)=−1`. Cover reverse
+HOLDs. Split reverse HOLDs. Neighbor-read of `O` reverse fails from hold
+at `A` with fail at `B`. Neighbor-read of `M` reverse fails from fail at
+`A` with hold at `B`. Leftover-axis neighbor-read reverse fails from fail
+at `A` with hold at `B`. Cyclic lex-smallest neighbor-read reverse fails
+from hold at `A` with fail at `B`. Those leftovers are not this display.
+
+Reverse fails.
+
+## Theorem 3 — face from neighbor-read of Orient at `τ`
+
+Face neighbor-read holds if and only if neighbor-read HOLDs at `C` and at
+`D`. Neighbor-read fails at `C` and at `D`. Face fails.
+
+Face neighbor-read at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+nm2oricyclz Orient face HOLDs because both signs are `+1`. Cover face HOLDs.
+Split face HOLDs. Neighbor-read of `M` has face hold. Leftover-axis
+neighbor-read has face hold. Neighbor-read of `O` has face fail, but from
+a different object: set equality of `O`, not equal Orient signs. At `C`,
+formed neighbors report Orient `−1` at `(0,1,2)` and at `A`, opposite to
+`Orient(C)=+1`. At `D`, formed neighbors report Orient `−1` at `A` and at
+`B`, opposite to `Orient(D)=+1`.
+
+On the same seed the four y-probes give neighbor-read hold at `A` and at
+`C` and fail at `B` and at `D`, so reverse fail and face fail, but from
+hold at y-probe `A`, not fail at z-probe `A`. The four x-probes fail at
+each probe from Orient fail at `A` and at `D`. Those probe-direction
+readouts are not this z-probe display.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require neighbor-read sides to be singletons.
+- It does not sum either set.
+- It does not replace neighbor-read of Orient by neighbor-read of `O`.
+- It does not replace neighbor-read of Orient by neighbor-read of `M`.
+- It does not replace neighbor-read by nm2oricyclz equal-sign reverse.
+- It does not replace neighbor-read by leftover-axis neighbor-read.
+- It does not replace neighbor-read by cyclic lex-smallest neighbor-read.
+- It does not replace neighbor-read by axis-cover of `M` and `O`.
+- It does not replace neighbor-read by 1-in 2-out split.
+- It does not treat Orient fail as `UNDEFINED`.
+- It does not treat empty matching as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace neighbor-read by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nm2oricyclz Orient reverse hold and face hold.
+- It does not reprint nm2oreadz neighbor-read of `O`.
+- It does not reprint nm2readz neighbor-read of `M`.
+- It does not reprint nm2axz axis-cover reverse hold and face hold.
+- It does not reprint nm2ax12z 1-in 2-out reverse hold and face hold.
+- It does not reprint nm2orichz leftover-axis reverse hold and face fail.
+- It does not treat the second opposite pair as a formed child of the first.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four z-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis opposite process, neighbor-read of cyclic lex-largest Orient at
+`t+1`, and the reverse/face bits from that neighbor-read are displayed
+theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two disjoint opposite pairs `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `1` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual |
+| Orient at `τ` | Theorem 1; `−1`, `−1`, `+1`, `+1` |
+| Orient at formed 6-NN | Theorem 1; reported at each eventually-formed neighbor |
+| neighbor-read bit at `τ` | Theorem 1; fail, fail, fail, fail |
+| reverse from neighbor-read at `τ` | Theorem 2; `fail` |
+| face from neighbor-read at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of nm2oricyclz equal-sign reverse | not this neighbor-read display |
+| leftover of nm2oreadz neighbor-read of `O` | not this display |
+| leftover of nm2readz neighbor-read of `M` | not this display |
+| leftover of nm2axz axis-cover | not this neighbor-read display |
+| leftover of nm2ax12z 1-in 2-out | not this neighbor-read display |
+| leftover of nm2orichz leftover-axis | not this display |
+| leftover of cyclic lex-smallest | not this display |
+| one-axis opposite leftover of the second pair | not this seed |
+| y-probe or x-probe neighbor-read on this seed | not this letter |
+| global later T | not used |
+| neighbor-read as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: can a formed six-neighbor recover the same cyclic lex-largest Orient sign at `t+1` on the four z-probes of the two-axis opposite seed, and reverse/face from that. |
+| V2 | Current main has no landed neighbor-read reverse/face of cyclic lex-largest Orient on these four z-probes of this two-axis opposite seed. |
+| V3 | Neighbor-read reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads whether a formed six-neighbor recovers the same `±1` Orient sign at the same `t+1` cut: the partner seed shares `O` and flips Orient, so neighbor-read of `O` HOLDs at `A` while this fails at every z-probe. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique lock, does not replace neighbor-read of Orient by neighbor-read of
+`O` or of `M`, does not replace it by nm2oricyclz equal-sign reverse, and
+does not identify this display with leftover-axis neighbor-read, cyclic
+lex-smallest neighbor-read, axis-cover, or 1-in 2-out split. No global
+impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2oricyclz equal-sign reverse | reuse Orient reverse hold and face hold | Orient reverse HOLDs from `−1,−1` and face HOLDs from `+1,+1`; this reverse fails and this face fails because no formed 6-NN recovers the same sign | ATTEMPTED |
+| nm2oreadz neighbor-read of `O` | score reverse/face from equal outgoing sets | neighbor-read of `O` HOLDs at `A` from partner seed `(0,1,1)`; this fails at `A` because that partner has Orient `+1` | ATTEMPTED |
+| nm2readz neighbor-read of `M` | score reverse/face from equal incoming sets | neighbor-read of `M` is fail/hold/hold/hold and face hold; this is fail/fail/fail/fail and face fail | ATTEMPTED |
+| leftover-axis neighbor-read | score neighbor-read of leftover-axis Orient | leftover-axis neighbor-read is fail/hold/hold/hold and face hold; this face fails | ATTEMPTED |
+| cyclic lex-smallest neighbor-read | reuse same cyclic axes with `+e` if both signs | lex-smallest neighbor-read HOLDs at `A` from origin matching `+1`; this fails at `A` | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse hold and face hold | cover HOLDs at each z-probe; neighbor-read of Orient fails at each z-probe | ATTEMPTED |
+| nm2ax12z 1-in 2-out | reuse split reverse hold and face hold | split HOLDs at each z-probe; Cover and split do not score handedness | ATTEMPTED |
+| unique signed `|O_i|=1` | replace mixed `O` by unique letters | unique signed Orient fails at each probe, so that neighbor-read fails from Orient fail, not from unmatched `±1` signs | ATTEMPTED |
+| unique letter | replace mixed sets by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; Orient is `−1`, not `UNDEFINED`; neighbor-read still fails | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis and the frame | ATTEMPTED |
+| y-probe neighbor-read | score the four y-probes on this seed | y-probe neighbor-read HOLDs at `A`; this letter fails at z-probe `A` | ATTEMPTED |
+| x-probe neighbor-read | score the four x-probes on this seed | x-probe neighbor-read fails at `A` from Orient fail; this letter has Orient `−1` at z-probe `A` | ATTEMPTED |
+| 1-axis leftover | treat `(0,0,1)` and `(0,1,1)` as formed children of `+e_1/−e_1` | those children lock `+e_3` at tick 1; here they are seeds locking `+e_2/−e_2` at tick 0; 1-axis neighbor-read reverse HOLDs | ATTEMPTED |
+| Orient fail as `UNDEFINED` | treat split fail as unformed | Orient fail is neighbor-read fail, not UNDEFINED; at `t`, empty `O` makes Orient fail and neighbor-read fail | ATTEMPTED |
+| empty matching as `UNDEFINED` | treat no matching neighbor as unformed | empty matching is fail, not UNDEFINED | ATTEMPTED |
+| sum of a set | replace neighbor-read by a `Z^3` sum | the construction does not sum; equality is equality of `±1` signs | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by neighbor-read of Orient | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of neighbor-read of Orient
+with neighbor-read of `O`, missing identification with neighbor-read of `M`,
+missing identification with nm2oricyclz equal-sign reverse, missing
+identification with leftover-axis neighbor-read, missing identification
+with cyclic lex-smallest neighbor-read, missing identification with
+axis-cover, and missing Record identification of neighbor-read reverse are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite-pair seed locks `+e_1`, `−e_1`,
+`+e_2`, and `−e_2`, perpendicular step rule, incoming-step lock, own
+incoming set and own outgoing dual from records with tick `<= τ`, per-probe
+`τ=t+1`, cyclic next/prev lex-largest Orient of the 1-in 2-out frame,
+neighbor-read as equal `±1` Orient at some formed six-neighbor at the same
+cut, Orient fail as neighbor-read fail not `UNDEFINED`, four z-probes with
+seed `A`, and mixed remains a set are declared. No uniqueness of outgoing
+locks, no six-neighbor lock union as the scored object, no global later T,
+no formation attachment from already-recorded six-neighbor locks, and no
+Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+neighbor-read `hold`/`fail` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | cyclic lex-largest Orient at a probe and at formed 6-NN, compared as `±1` signs at the probe's `t+1` | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four neighbor-read reports, reverse/face from those bits | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for neighbor-read reverse/face,
+a formation-rate rule, and a physical selector among matching neighbors.
+None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Neighbor-read of Orient must HOLD at `A` because the partner
+seed shares `O`; neighbor-read of `O` already asked whether a neighbor
+recovers a lock set; nm2oricyclz already answered reverse HOLD from equal
+signs; leftover-axis neighbor-read already HOLDs at `B`, `C`, and `D`;
+cyclic lex-smallest already HOLDs at `A`; y-probe neighbor-read already
+HOLDs at `A`; cover and split already HOLD reverse and face; empty `O` at
+a neighbor should be `UNDEFINED`; and reverse fail is only leftover of
+nm2oreadz reverse fail.
+
+**Answer:** The partner seed `(0,1,1)` matches `O(A,τ)` as a set of three
+outgoing steps and reports Orient `+1`, opposite to `Orient(A)=−1`, because
+`m` flips from `+e_2` to `−e_2`. Neighbor-read of `O` HOLDs at `A`.
+Neighbor-read of Orient fails at every z-probe. nm2oricyclz reverse HOLDs
+from equal signs at `A` and at `B` without asking a neighbor. Leftover-axis
+neighbor-read HOLDs at `B` from `D` matching `−1`, and leftover-axis face
+HOLDs; this face fails. Cyclic lex-smallest neighbor-read HOLDs at `A` from
+origin matching `+1`; this fails at `A`. Y-probe neighbor-read HOLDs at `A`;
+this z-probe letter fails at `A`. Cover and split HOLD reverse and face
+without cyclic signed columns. Empty `O` at a formed neighbor is Orient
+fail, not `UNDEFINED`, and does not match a `±1` probe sign. Reverse fail
+of neighbor-read of `O` is hold at `A` with fail at `B`. Reverse fail here
+is fail at `A` with fail at `B`.
+
+### N8 — cross-cycle echo
+
+nm2oricyclz reported cyclic lex-largest Orient `−1,−1,+1,+1`, reverse hold,
+and face hold. nm2oreadz reported neighbor-read of `O` hold only at `A`,
+reverse fail, and face fail. nm2readz reported neighbor-read of `M` fail at
+`A` and hold at `B`, `C`, and `D`, reverse fail, and face hold. nm2axz
+reported axis-cover HOLD at each of four z-probes, reverse hold, and face
+hold. nm2ax12z reported 1-in 2-out split HOLD at each of those probes,
+reverse hold, and face hold. nm2orichz leftover-axis reported Orient
+`−1,−1,+1,−1`, reverse hold, and face fail. Cyclic lex-smallest on the same
+seed reports Orient `+1,+1,−1,−1` and neighbor-read hold at `A`. The four
+y-probes of this same seed report neighbor-read hold at `A`. This note is
+not those displays: it reports neighbor-read of cyclic lex-largest Orient
+at `τ=t+1` on the four z-probes of the two-axis opposite seed, fail at each
+probe, reverse fail, and face fail.
+
+**Gate disposition:** PASS for the neighbor-read of cyclic lex-largest Orient
+`t+1` reverse/face reports above. FAIL / DO NOT SHIP for “the predicate
+equals the named sign,” “the predicate equals the unique singleton lock
+vector,” “the predicate equals six-neighbor lock union,” “the predicate
+equals neighbor-read of `O`,” “the predicate equals neighbor-read of `M`,”
+“the predicate equals nm2oricyclz equal-sign reverse,” “the predicate
+equals leftover-axis neighbor-read,” “the predicate equals cyclic
+lex-smallest neighbor-read,” “the predicate equals nm2axz axis-cover,”
+“the predicate equals nm2ax12z 1-in 2-out,” “bits are Admissibility,”
+“neighbor-read of Orient HOLDs at `A`,” “reverse neighbor-read HOLDs,” or
+“face neighbor-read HOLDs.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each z-probe's own cyclic
+lex-largest Orient from the record prefix at that probe's `t+1`, reads
+Orient at each eventually-formed six-neighbor at the same cut, reports
+neighbor-read as equal `±1` signs at some formed six-neighbor, and checks
+Theorems 1--3. It also checks that neighbor-read fails at each of `A,B,C,D`,
+that neighbor-read of `O` HOLDs at `A`, that neighbor-read of `M` is a
+different pattern, that leftover-axis neighbor-read HOLDs at `B,C,D`, that
+cyclic lex-smallest neighbor-read HOLDs at `A`, that Orient fail is
+neighbor-read fail not `UNDEFINED`, that mixed sets remain sets, that
+unique-letter Orient is not required at mixed `O`, that the construction
+does not sum, that a formation member from already-recorded six-neighbor
+locks is not attached, that the second pair is a seed and not a formed
+child, that the 1-axis opposite two-site seed is a different member with
+neighbor-read reverse hold, and that the display is not the y-probe or
+x-probe neighbor-read. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,82 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 4c47ed88d9da6f28682e435d0c0f78900a14df919e6584a1fc3311004a8aa00f
+input_fingerprint_sha256: 9a4b104173459c4feadd58ef287489b990d934764aa0517b18ecb2968f6dc5ca
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+neighbor-read of cyclic lex-largest Orient reverse/face at t+1 on two-axis opposite z-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of the cyclic lex-largest orientation at t+1 on the four z-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: pair-read-identity
+PASS: orient-identity
+PASS: neighbor-read-identity
+A t=0 M={+e_2} O={+e_1, −e_1, +e_3} Orient=−1 neighbor-read=fail
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} Orient=−1 neighbor-read=fail
+C t=1 M={+e_3} O={+e_1, −e_1, −e_2} Orient=+1 neighbor-read=fail
+D t=1 M={+e_1} O={−e_2, +e_3, −e_3} Orient=+1 neighbor-read=fail
+neighbor-read reverse=fail face=fail
+per_element: cyclic lex-largest Orient at a probe and at formed 6-NN, compared as +/-1 signs at the probe's t+1
+per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-O-Orient  ({'A': '−1', 'B': '−1', 'C': '+1', 'D': '+1'})
+PASS: theorem1-formed-6nn-orients-A
+PASS: theorem1-formed-6nn-orients-B
+PASS: theorem1-formed-6nn-orients-C
+PASS: theorem1-formed-6nn-orients-D
+PASS: theorem1-neighbor-read-bits  ({'A': ('fail', ()), 'B': ('fail', ()), 'C': ('fail', ()), 'D': ('fail', ())})
+PASS: theorem1-mixed-stays-a-set
+PASS: theorem1-A-is-seed
+PASS: theorem1-M-frozen-O-empty-at-t
+PASS: theorem1-new-records-meet-6nn
+PASS: theorem2-reverse-fail
+PASS: theorem3-face-fail
+PASS: orient-fail-is-neighbor-read-fail-not-undefined
+PASS: mutation-neighbor-read-of-O-differs
+PASS: mutation-neighbor-read-of-M-differs
+PASS: mutation-leftover-axis-neighbor-read-differs
+PASS: mutation-cyclic-lex-smallest-neighbor-read-differs
+PASS: not-x-probes-or-y-probes-or-perp
+PASS: not-nsopp-leftover-second-pair-is-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-Orient-and-neighbor-read
+PASS: note-reports-formed-neighbors
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split-or-O-leftover
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: neighbor-read-not-cover-or-split-or-orient-reverse
+TOTAL: PASS=52 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1491 @@
+#!/usr/bin/env python3
+"""Neighbor-read of cyclic lex-largest Orient at t+1 reverse/face on four z-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and z-probes as nm2axz.
+Perp-step incoming lock. Orient as nm2oricyclz: cyclic next/prev lex-largest
+outgoing determinant of the 1-in 2-out frame at tau=t+1. Neighbor-read HOLDs
+at q iff Orient(q) is +/-1 and some formed 6-NN r has Orient(r)=Orient(q)
+both +/-1. If Orient fails at q, neighbor-read fails, not UNDEFINED.
+Unformed q => UNDEFINED. Uniqueness is not required. Reverse HOLDs iff
+neighbor-read at A and at B. Face on C, D. Occupancy of sites is not used.
+Named-sign lettering is not used. No larger host. Displayed, not adopted.
+Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = Incoming
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of the cyclic lex-largest orientation at "
+    "t+1 on the four z-probes of the two-axis opposite seed, and "
+    "reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def neg(step: Point) -> Point:
+    return (-step[0], -step[1], -step[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        occupied.add(axis_of_letter(lock))
+    return frozenset(occupied)
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1 or len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def axis_index(lock: Point) -> int | str:
+    axis = axis_of_letter(lock)
+    if axis == E1:
+        return 1
+    if axis == E2:
+        return 2
+    if axis == E3:
+        return 3
+    return "fail"
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    idx = axis_index(signed_m)
+    if idx == "fail" or not isinstance(idx, int):
+        return "fail"
+    e_next = AXES[idx % 3]
+    e_prev = AXES[idx - 2]
+    return e_next, e_prev
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def cyclic_signed_outgoing(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = True
+) -> tuple[Point, Point] | str:
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    o_next = picker(outgoing, units[0])
+    o_prev = picker(outgoing, units[1])
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def _sign_det(signed_m: Point, col2: Point, col3: Point) -> OrientVal:
+    det = integer_det_columns(signed_m, col2, col3)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-largest cyclic slots."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return _sign_det(signed_m, plane[0], plane[1])
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: leftover-axis Orient. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail" or not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    return _sign_det(signed_m, pair, leftover)
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return _sign_det(signed_m, plane[0], plane[1])
+
+
+def cyclic_lex_smallest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: same cyclic axes, lex-smallest (+e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return _sign_det(signed_m, plane[0], plane[1])
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: lexicographic unsigned o1,o2."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return _sign_det(signed_m, plane[0], plane[1])
+
+
+def orient_at(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    orient_fn=frame_orient,
+) -> OrientVal:
+    incoming = incoming_set(site, tau, ticks, locks, seed_map)
+    outgoing = outgoing_set(site, tau, ticks, locks, seed_map)
+    return orient_fn(incoming, outgoing)
+
+
+def matching_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    orient_fn=frame_orient,
+) -> tuple[Point, ...] | str:
+    """Formed 6-NN r with Orient(r, tau)=Orient(site, tau) both +/-1."""
+    own = orient_at(site, tau, ticks, locks, seed_map, orient_fn)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own not in (1, -1):
+        return ()
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = orient_at(neighbor, tau, ticks, locks, seed_map, orient_fn)
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    orient_fn=frame_orient,
+) -> str:
+    """HOLD iff some formed 6-NN recovers the same +/-1 Orient. Orient fail => fail."""
+    own = orient_at(site, tau, ticks, locks, seed_map, orient_fn)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own not in (1, -1):
+        return "fail"
+    matches = matching_neighbors(site, tau, ticks, locks, seed_map, orient_fn)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def formed_neighbor_orients(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    orient_fn=frame_orient,
+) -> tuple[tuple[Point, OrientVal], ...]:
+    """Orient at each eventually-formed 6-NN of site, including UNDEFINED."""
+    rows: list[tuple[Point, OrientVal]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        rows.append(
+            (neighbor, orient_at(neighbor, tau, ticks, locks, seed_map, orient_fn))
+        )
+    return tuple(rows)
+
+
+def matching_outgoing_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with O(r, tau)=O(site, tau)."""
+    own = outgoing_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_outgoing(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of O. Not this letter."""
+    matches = matching_outgoing_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def matching_incoming_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with M(r, tau)=M(site, tau)."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_incoming(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of M. Not this letter."""
+    matches = matching_incoming_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def pair_read(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED. Else fail."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(read_a: str, read_b: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_read(read_a, read_b)
+
+
+def face_report(read_c: str, read_d: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_read(read_c, read_d)
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def probe_reads(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+    orient_fn=frame_orient,
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            out[name] = UNDEFINED
+            continue
+        out[name] = neighbor_read(
+            site,
+            site_ticks[site] + 1,
+            site_ticks,
+            site_locks,
+            site_seeds,
+            orient_fn,
+        )
+    return out
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print(
+        "neighbor-read of cyclic lex-largest Orient reverse/face at t+1 "
+        "on two-axis opposite z-probes"
+    )
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(E2, NEG_E2) == ZERO
+        and add(E3, NEG_E3) == ZERO
+        and add(E3, E2) == PAIR2
+        and dot(E1, E2) == 0
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "pair-read-identity",
+        pair_read(UNDEFINED, "hold") == UNDEFINED
+        and pair_read("hold", UNDEFINED) == UNDEFINED
+        and pair_read("hold", "hold") == "hold"
+        and pair_read("hold", "fail") == "fail"
+        and pair_read("fail", "hold") == "fail"
+        and pair_read("fail", "fail") == "fail",
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and frame_orient(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3})) == 1
+        and cyclic_units(E2) == (E3, E1)
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1,
+    )
+    checks.check(
+        "neighbor-read-identity",
+        neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and matching_neighbors(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], -1, {}, {}, {}),
+            outgoing_set(PROBES["B"], -1, {}, {}, {}),
+        )
+        == UNDEFINED
+        and neighbor_read(
+            ORIGIN,
+            0,
+            {ORIGIN: 0},
+            {ORIGIN: {E1}},
+            {ORIGIN: E1},
+        )
+        == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    twosite_ticks, twosite_locks, twosite_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+
+    tau1: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    split: dict[str, str] = {}
+    cover: dict[str, str] = {}
+    orient: dict[str, OrientVal] = {}
+    reads: dict[str, str] = {}
+    reads_o: dict[str, str] = {}
+    reads_m: dict[str, str] = {}
+    reads_left: dict[str, str] = {}
+    reads_small: dict[str, str] = {}
+    matches: dict[str, tuple[Point, ...] | str] = {}
+    formed_or: dict[str, tuple[tuple[Point, OrientVal], ...]] = {}
+    unique_signed: dict[str, OrientVal] = {}
+    leftover_or: dict[str, OrientVal] = {}
+    small_or: dict[str, OrientVal] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0 = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0, ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0, ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        split[name] = axis_split(m1[name], o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        leftover_or[name] = leftover_pair_orient(m1[name], o1[name])
+        unique_signed[name] = unique_signed_orient(m1[name], o1[name])
+        small_or[name] = cyclic_lex_smallest_orient(m1[name], o1[name])
+        reads[name] = neighbor_read(site, tau1[name], ticks, locks, seed_map)
+        reads_o[name] = neighbor_read_outgoing(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_m[name] = neighbor_read_incoming(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_left[name] = neighbor_read(
+            site, tau1[name], ticks, locks, seed_map, leftover_pair_orient
+        )
+        reads_small[name] = neighbor_read(
+            site, tau1[name], ticks, locks, seed_map, cyclic_lex_smallest_orient
+        )
+        matches[name] = matching_neighbors(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        formed_or[name] = formed_neighbor_orients(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"Orient={orient_display(orient[name])} "
+            f"neighbor-read={reads[name]}"
+        )
+
+    reverse = reverse_report(reads["A"], reads["B"])
+    face = face_report(reads["C"], reads["D"])
+    orient_reverse = pair_orient(orient["A"], orient["B"])
+    orient_face = pair_orient(orient["C"], orient["D"])
+    cover_reverse = pair_read(cover["A"], cover["B"])
+    cover_face = pair_read(cover["C"], cover["D"])
+    split_reverse = pair_read(split["A"], split["B"])
+    split_face = pair_read(split["C"], split["D"])
+    print(f"neighbor-read reverse={reverse} face={face}")
+    print(
+        "per_element: cyclic lex-largest Orient at a probe and at formed "
+        "6-NN, compared as +/-1 signs at the probe's t+1"
+    )
+    print(
+        "per_site: scored only at z-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print(
+        "per_mode: no spectral or mode calculation is executed on this finite host"
+    )
+    print("per_block: four neighbor-read reports, reverse/face from those bits")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["C"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 0, ticks, locks, seed_map) == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-Orient",
+        m1["A"] == frozenset({E2})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E1})
+        and o1["A"] == frozenset({E1, NEG_E1, E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, NEG_E2})
+        and o1["D"] == frozenset({NEG_E2, E3, NEG_E3})
+        and orient["A"] == -1
+        and orient["B"] == -1
+        and orient["C"] == 1
+        and orient["D"] == 1
+        and all(split[name] == "hold" for name in ("A", "B", "C", "D")),
+        str({name: orient_display(orient[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-formed-6nn-orients-A",
+        formed_or["A"]
+        == (
+            ((1, 0, 1), "fail"),
+            ((-1, 0, 1), "fail"),
+            ((0, 1, 1), 1),
+            ((0, -1, 1), UNDEFINED),
+            ((0, 0, 2), "fail"),
+            ((0, 0, 0), 1),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-orients-B",
+        formed_or["B"]
+        == (
+            ((2, 1, 1), UNDEFINED),
+            ((0, 1, 1), 1),
+            ((1, 2, 1), "fail"),
+            ((1, 0, 1), 1),
+            ((1, 1, 2), "fail"),
+            ((1, 1, 0), "fail"),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-orients-C",
+        formed_or["C"]
+        == (
+            ((1, 0, 2), "fail"),
+            ((-1, 0, 2), "fail"),
+            ((0, 1, 2), -1),
+            ((0, -1, 2), "fail"),
+            ((0, 0, 1), -1),
+        ),
+    )
+    checks.check(
+        "theorem1-formed-6nn-orients-D",
+        formed_or["D"]
+        == (
+            ((2, 0, 1), UNDEFINED),
+            ((0, 0, 1), -1),
+            ((1, 1, 1), -1),
+            ((1, -1, 1), "fail"),
+            ((1, 0, 2), "fail"),
+            ((1, 0, 0), "fail"),
+        ),
+    )
+    checks.check(
+        "theorem1-neighbor-read-bits",
+        reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail"
+        and matches["A"] == ()
+        and matches["B"] == ()
+        and matches["C"] == ()
+        and matches["D"] == (),
+        str({name: (reads[name], matches[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-stays-a-set",
+        o1["A"] == frozenset({E1, NEG_E1, E3})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and orient["A"] == -1
+        and reads["A"] == "fail",
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2}
+        and orient_at(PAIR2, 1, ticks, locks, seed_map) == 1
+        and orient["A"] == -1,
+    )
+    checks.check(
+        "theorem1-M-frozen-O-empty-at-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and all(o0[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(frame_orient(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D"))
+        and neighbor_read(PROBES["A"], ticks[PROBES["A"]], ticks, locks, seed_map)
+        == "fail",
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 0, 2), (-1, 0, 2), (0, -1, 2))
+        and new_meet["D"] == ((1, -1, 1), (1, 0, 2), (1, 0, 0)),
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse == "fail"
+        and reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and orient_reverse == "hold"
+        and cover_reverse == "hold"
+        and split_reverse == "hold",
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and orient_face == "hold"
+        and cover_face == "hold"
+        and split_face == "hold",
+    )
+    checks.check(
+        "orient-fail-is-neighbor-read-fail-not-undefined",
+        frame_orient(frozenset({E2}), frozenset()) == "fail"
+        and neighbor_read(PROBES["A"], ticks[PROBES["A"]], ticks, locks, seed_map)
+        == "fail"
+        and unique_signed["A"] == "fail"
+        and unique_signed["B"] == "fail"
+        and unique_signed["C"] == "fail"
+        and unique_signed["D"] == "fail"
+        and neighbor_read(
+            PROBES["A"], tau1["A"], ticks, locks, seed_map, unique_signed_orient
+        )
+        == "fail",
+    )
+    checks.check(
+        "mutation-neighbor-read-of-O-differs",
+        reads_o["A"] == "hold"
+        and reads_o["B"] == "fail"
+        and reads_o["C"] == "fail"
+        and reads_o["D"] == "fail"
+        and reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reverse_report(reads_o["A"], reads_o["B"]) == "fail"
+        and face_report(reads_o["C"], reads_o["D"]) == "fail"
+        and reads_o["A"] != reads["A"],
+    )
+    checks.check(
+        "mutation-neighbor-read-of-M-differs",
+        reads_m["A"] == "fail"
+        and reads_m["B"] == "hold"
+        and reads_m["C"] == "hold"
+        and reads_m["D"] == "hold"
+        and face_report(reads_m["C"], reads_m["D"]) == "hold"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-leftover-axis-neighbor-read-differs",
+        leftover_or["A"] == -1
+        and leftover_or["B"] == -1
+        and leftover_or["C"] == 1
+        and leftover_or["D"] == -1
+        and reads_left["A"] == "fail"
+        and reads_left["B"] == "hold"
+        and reads_left["C"] == "hold"
+        and reads_left["D"] == "hold"
+        and reverse_report(reads_left["A"], reads_left["B"]) == "fail"
+        and face_report(reads_left["C"], reads_left["D"]) == "hold"
+        and face_report(reads_left["C"], reads_left["D"]) != face,
+    )
+    checks.check(
+        "mutation-cyclic-lex-smallest-neighbor-read-differs",
+        small_or["A"] == 1
+        and small_or["B"] == 1
+        and small_or["C"] == -1
+        and small_or["D"] == -1
+        and reads_small["A"] == "hold"
+        and reads_small["B"] == "fail"
+        and reads_small["C"] == "fail"
+        and reads_small["D"] == "fail"
+        and reads_small["A"] != reads["A"],
+    )
+    y_reads = probe_reads(Y_PROBES, ticks, locks, seed_map)
+    x_reads = probe_reads(X_PROBES, ticks, locks, seed_map)
+    perp_reads = probe_reads(PROBES, perp_ticks, perp_locks, perp_seeds)
+    zsym_reads = probe_reads(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    twosite_reads = probe_reads(
+        PROBES, twosite_ticks, twosite_locks, twosite_seeds
+    )
+    y_reverse = reverse_report(y_reads["A"], y_reads["B"])
+    y_face = face_report(y_reads["C"], y_reads["D"])
+    x_reverse = reverse_report(x_reads["A"], x_reads["B"])
+    x_face = face_report(x_reads["C"], x_reads["D"])
+    twosite_reverse = reverse_report(twosite_reads["A"], twosite_reads["B"])
+    twosite_face = face_report(twosite_reads["C"], twosite_reads["D"])
+    checks.check(
+        "not-x-probes-or-y-probes-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and y_reads["A"] == "hold"
+        and y_reads["B"] == "fail"
+        and y_reads["C"] == "hold"
+        and y_reads["D"] == "fail"
+        and y_reverse == "fail"
+        and y_face == "fail"
+        and x_reads["A"] == "fail"
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and perp_reads["A"] == "hold"
+        and reads["A"] == "fail"
+        and y_reads["A"] != reads["A"]
+        and perp_reads["A"] != reads["A"],
+    )
+    checks.check(
+        "not-nsopp-leftover-second-pair-is-seed",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in twosite_ticks.values()) == 2
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and twosite_ticks[E3] == 1
+        and twosite_locks[E3] == {E3}
+        and twosite_reads["A"] == "hold"
+        and twosite_reverse == "hold"
+        and twosite_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and twosite_reverse != reverse
+        and zsym_reads["A"] == "fail",
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Orient-and-neighbor-read",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ) = {+e_2}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_3}" in note
+        and "M(D, τ) = {+e_1}" in note
+        and "O(A, τ) = {+e_1, −e_1, +e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ) = {−e_2, +e_3, −e_3}" in note
+        and "Orient(A) = −1" in note
+        and "Orient(B) = −1" in note
+        and "Orient(C) = +1" in note
+        and "Orient(D) = +1" in note
+        and "neighbor-read(A) = fail" in note
+        and "neighbor-read(B) = fail" in note
+        and "neighbor-read(C) = fail" in note
+        and "neighbor-read(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-formed-neighbors",
+        "formed 6-NN of A at τ: (1, 0, 1)=fail, (-1, 0, 1)=fail, (0, 1, 1)=+1, (0, -1, 1)=UNDEFINED, (0, 0, 2)=fail, (0, 0, 0)=+1"
+        in note
+        and "formed 6-NN of B at τ: (2, 1, 1)=UNDEFINED, (0, 1, 1)=+1, (1, 2, 1)=fail, (1, 0, 1)=+1, (1, 1, 2)=fail, (1, 1, 0)=fail"
+        in note
+        and "formed 6-NN of C at τ: (1, 0, 2)=fail, (-1, 0, 2)=fail, (0, 1, 2)=−1, (0, -1, 2)=fail, (0, 0, 1)=−1"
+        in note
+        and "formed 6-NN of D at τ: (2, 0, 1)=UNDEFINED, (0, 0, 1)=−1, (1, 1, 1)=−1, (1, -1, 1)=fail, (1, 0, 2)=fail, (1, 0, 0)=fail"
+        in note
+        and "matching 6-NN of A: none" in note
+        and "matching 6-NN of B: none" in note
+        and "matching 6-NN of C: none" in note
+        and "matching 6-NN of D: none" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse neighbor-read at τ: fail" in note
+        and "Face neighbor-read at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split-or-O-leftover",
+        "not leftover of nm2axz axis-cover" in normalized_note
+        and "not leftover of nm2ax12z 1-in 2-out" in normalized_note
+        and "not leftover of nm2oricyclz" in normalized_note
+        and "not leftover of nm2oreadz neighbor-read of O" in normalized_note
+        and "not leftover of nm2readz neighbor-read of M" in normalized_note
+        and "not leftover of nm2orichz leftover-axis" in normalized_note
+        and "not leftover of cyclic lex-smallest" in normalized_note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_ZPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "frame_orient" in defined_fns
+        and "neighbor_read" in defined_fns
+        and "matching_neighbors" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "formed_neighbor_orients" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "neighbor-read-not-cover-or-split-or-orient-reverse",
+        reverse == "fail"
+        and face == "fail"
+        and orient_reverse == "hold"
+        and orient_face == "hold"
+        and cover_reverse == "hold"
+        and split_reverse == "hold"
+        and reads["A"] == "fail"
+        and reads["B"] == "fail"
+        and reads["C"] == "fail"
+        and reads["D"] == "fail",
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Neighbor-read of Orient signs fails reverse and face; the 3-split is neighbor-readable, the handedness sign is site-local. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_zprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.