### PR TITLE
feat(nm2oricyclrdy): neighbor-read of cyclic lex-largest Orient at t+1 on two-axis opposite y-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,398 @@
+---
+claim_id: two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of the cyclic lex-largest orientation at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
+---
+
+# Neighbor-Read Of Cyclic Lex-Largest Orientation At t+1 Reverse And Face On Four Y-Probes Of The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** Neighbor-read of the cyclic lex-largest orientation at t+1 on the four
+y-probes of the two-axis opposite seed, and reverse/face from that, are
+reported. Displayed, not adopted.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py)
+
+No runner cache is written.
+
+## Result Up Front
+
+On the finite Euclidean host `B_3(0)={n:n·n<=9}`, form records by the
+two-axis opposite seed, perp-step, incoming-lock process. Same process and
+y-probes as nm2ax. For each formed site `q` write `t(q)` for the formation
+tick and `τ(q)=t(q)+1`. There is no global T. `M`, `O`, and split are as
+nm2ax12. Orient as nm2oricyclz: cyclic next/prev lex-largest outgoing
+determinant orientation of the 1-in 2-out frame. Unformed sites are
+`UNDEFINED`.
+
+Neighbor-read HOLDs at a formed `q` iff `Orient(q)` is `±1` and some formed
+six-neighbor `r=q+e` has `Orient(r)=Orient(q)` at the same `τ`. If Orient
+fails at `q`, neighbor-read fails, not `UNDEFINED`. Uniqueness is not
+required. Reverse HOLDs iff neighbor-read HOLDs at probes `A` and `B`. Face
+HOLDs iff neighbor-read HOLDs at probes `C` and `D`. Cover and split do not
+score handedness.
+
+On this seed and these y-probes the finite listing is:
+
+- t(A)=0, M(A, τ) = {−e_1}, O(A, τ) = {+e_2, −e_3}, split(A) = hold, i(A) = 1, o_next(A) = +e_2, o_prev(A) = −e_3, det(A) = +1, Orient(A) = +1, neighbor-read(A) = hold
+- t(B)=1, M(B, τ) = {+e_1}, O(B, τ) = {+e_2, +e_3, −e_3}, split(B) = hold, i(B) = 1, o_next(B) = +e_2, o_prev(B) = −e_3, det(B) = −1, Orient(B) = −1, neighbor-read(B) = fail
+- t(C)=1, M(C, τ) = {+e_2}, O(C, τ) = {+e_1, −e_1, +e_3, −e_3}, split(C) = hold, i(C) = 2, o_next(C) = −e_3, o_prev(C) = −e_1, det(C) = +1, Orient(C) = +1, neighbor-read(C) = hold
+- t(D)=2, M(D, τ) = {−e_3}, O(D, τ) = {+e_1, −e_1}, split(D) = fail, i(D) = 3, o_next(D) = −e_1, o_prev(D) = fail, det(D) = fail, Orient(D) = fail, neighbor-read(D) = fail
+- Reverse neighbor-read at τ: fail
+- Face neighbor-read at τ: fail
+
+The face bit is displayed, not adopted. Do not write into Admissibility.
+Do not attach L1. This is not leftover of nm2oricycy equal `±1` Orient
+signs, not leftover of nm2oricyclz z-probe Orient HOLDING reverse and face,
+not leftover of nm2sready neighbor-read of the 1-in 2-out split, not
+leftover of nm2ready neighbor-read of M, not leftover of nm2oready
+neighbor-read of O, not leftover of nm2ax axis-cover, not leftover of
+nm2ax12 1-in 2-out split, not leftover of lexicographic `o1,o2`, not leftover
+of cyclic lex-smallest, not leftover of nm2orioney lex-one, not leftover of
+leftover-of-`M` alone, not leftover of leftover-of-`O` alone, not
+leftover-empty fail, not leftover of mixed #7188 fail/fail, and not the
+two-tick lock-count clock composition. The second pair is a new seed, not a
+formed child. O is not M. No larger host is used.
+
+## Current Premise Boundary
+
+Quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+When present, a record locks exactly one admissible local possibility.
+
+Admissibility determines a local distribution from nearest-neighbor
+conditions and does not supply the formation site, probability, or rate.
+
+The process below is an explicit finite display on `B_3(0)`. It is not a
+rewrite of Admissibility and is not a lattice-wide lettering rule.
+
+## Exact Objects
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`. The six nearest-neighbor
+steps are `±e_1,±e_2,±e_3`. The host is the Euclidean ball
+`B_3(0)={n:n·n<=9}`. No larger host is used.
+
+The two-axis opposite seed at tick 0 is two disjoint opposite pairs:
+
+- origin locks `+e_1`
+- `(0,1,0)` locks `−e_1`
+- `(0,0,1)` locks `+e_2`
+- `(0,1,1)` locks `−e_2`
+
+The second pair is a new seed, not a formed child of the first pair. A
+parent with lock axis `e_i` may take a nearest-neighbor step `s` only when
+`s·e_i=0`. A newly formed child locks the incoming step. Seeds keep their
+seed letters as a singleton. If several parents first reach a child at the
+same tick, `M` is the set of those incoming steps.
+
+The four y-probes are `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`.
+These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`,
+`C=(2,0,0)`, `D=(1,1,0)`. Probe `A` is a seed. Formation, `M`, and `O` are
+computed only from records on this host.
+
+For a site `q` and a tick bound `τ`, if `q` is unformed at `τ` then `M`,
+`O`, Orient, and neighbor-read at `q` are `UNDEFINED`. Otherwise `M(q,τ)` is
+the earliest nonempty incoming set assembled from parents with formation
+tick at most `τ`, and
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+Empty `O` is empty, not `UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs iff `Axis(M)` intersect
+`Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals `{e_1,e_2,e_3}`.
+Split HOLDs iff cover HOLDs and `|Axis(M)|=1` (hence `|Axis(O)|=2`). Split
+HOLD required. When split HOLDs, `m` is the unique vector in `M`. Let `i`
+in `{1,2,3}` be the axis index of `m`. `e_next = e_{i+1}` with `3+1→1`.
+`e_prev = e_{i-1}` with `1−1→3`. `O_next = O ∩ {±e_next}`. `O_prev =
+O ∩ {±e_prev}`. If either slot is empty, Orient fails, not `UNDEFINED`.
+Order `+e < −e`. `o_next` is the lex-largest vector in `O_next` (hence `−e`
+if both signs). `o_prev` likewise. `Orient(q)` is the sign of the integer
+determinant of columns `m`, `o_next`, `o_prev`. If split fails, Orient
+fails, not `UNDEFINED`.
+
+Neighbor-read HOLDs at formed `q` iff `Orient(q)` is `±1` and there exists a
+formed six-neighbor `r` with `Orient(r)=Orient(q)` at the same `τ`. If
+Orient fails at `q`, neighbor-read fails, not `UNDEFINED`. Mixed remains a
+set. Uniqueness is not required. Pair-read of two probe bits is
+`UNDEFINED` if either bit is `UNDEFINED`, HOLD if both HOLD, and fail
+otherwise. Reverse is pair-read of `A` and `B`. Face is pair-read of `C`
+and `D`. Occupancy of sites is not used.
+
+## Theorem 1 — Formation Ticks, M, O, Orient, And Neighbor-Read Bits
+
+**Claim.** On this host and seed, the four y-probes have the ticks, lock
+sets, cyclic lex-largest Orient signs, and neighbor-read bits listed below.
+
+**Proof.** Direct breadth-first formation with the perp-step rule yields
+four tick-0 seeds. Parallel steps from the origin along `±e_1` are blocked
+because those steps fail `s·e_i=0`. Probe ticks are t(A)=0, t(B)=1,
+t(C)=1, and t(D)=2.
+
+At each probe, `M` at `τ=t+1` equals `M` at formation. `O` is assembled from
+neighbors that are formed by that same cut. Orient is the cyclic next/prev
+lex-largest determinant sign of nm2oricyclz at that same cut.
+
+- A is the seed `(0,1,0)`, so M(A, τ) = {−e_1}, O(A, τ) = {+e_2, −e_3}, split(A) = hold, i(A) = 1, o_next(A) = +e_2, o_prev(A) = −e_3, det(A) = +1, Orient(A) = +1, neighbor-read(A) = hold.
+- B is first reached from `(0,1,1)` by `+e_1`, so M(B, τ) = {+e_1}, O(B, τ) = {+e_2, +e_3, −e_3}, split(B) = hold, i(B) = 1, o_next(B) = +e_2, o_prev(B) = −e_3, det(B) = −1, Orient(B) = −1, neighbor-read(B) = fail.
+- C is first reached from `A` by `+e_2`, so M(C, τ) = {+e_2}, O(C, τ) = {+e_1, −e_1, +e_3, −e_3}, split(C) = hold, i(C) = 2, o_next(C) = −e_3, o_prev(C) = −e_1, det(C) = +1, Orient(C) = +1, neighbor-read(C) = hold.
+- D is first reached from `B` by `−e_3` at tick 2, so M(D, τ) = {−e_3}, O(D, τ) = {+e_1, −e_1}, split(D) = fail, i(D) = 3, o_next(D) = −e_1, o_prev(D) = fail, det(D) = fail, Orient(D) = fail, neighbor-read(D) = fail.
+
+new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)
+
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+
+new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)
+
+new 6-NN of D at t(D)+1: (2, 1, 0)
+
+formed 6-NN of A at τ: (1, 1, 0) M=UNDEFINED O=UNDEFINED Orient=UNDEFINED neighbor-read=UNDEFINED, (-1, 1, 0) M=UNDEFINED O=UNDEFINED Orient=UNDEFINED neighbor-read=UNDEFINED, (0, 2, 0) M={+e_2} O={} Orient=fail neighbor-read=fail, (0, 0, 0) M={+e_1} O={−e_2, −e_3} Orient=+1 neighbor-read=hold, (0, 1, 1) M={−e_2} O={+e_1, −e_1, +e_3} Orient=+1 neighbor-read=hold, (0, 1, -1) M={−e_3} O={} Orient=fail neighbor-read=fail
+
+formed 6-NN of B at τ: (2, 1, 1) M=UNDEFINED O=UNDEFINED Orient=UNDEFINED neighbor-read=UNDEFINED, (0, 1, 1) M={−e_2} O={+e_1, −e_1, +e_3} Orient=+1 neighbor-read=hold, (1, 2, 1) M={+e_2} O={} Orient=fail neighbor-read=fail, (1, 0, 1) M={+e_1} O={−e_2, +e_3, −e_3} Orient=+1 neighbor-read=fail, (1, 1, 2) M={+e_1, +e_3} O={} Orient=fail neighbor-read=fail, (1, 1, 0) M={−e_3} O={−e_1} Orient=fail neighbor-read=fail
+
+formed 6-NN of C at τ: (1, 2, 0) M={+e_1} O={} Orient=fail neighbor-read=fail, (-1, 2, 0) M={−e_1} O={} Orient=fail neighbor-read=fail, (0, 1, 0) M={−e_1} O={+e_2, −e_3} Orient=+1 neighbor-read=hold, (0, 2, 1) M={+e_3} O={−e_2} Orient=fail neighbor-read=fail, (0, 2, -1) M={+e_2, −e_3} O={} Orient=fail neighbor-read=fail
+
+formed 6-NN of D at τ: (2, 1, 0) M={+e_1} O={} Orient=fail neighbor-read=fail, (0, 1, 0) M={−e_1} O={+e_2, −e_3} Orient=+1 neighbor-read=hold, (1, 2, 0) M={+e_1} O={−e_3} Orient=fail neighbor-read=fail, (1, 0, 0) M={−e_3} O={+e_1} Orient=fail neighbor-read=fail, (1, 1, 1) M={+e_1} O={+e_2, +e_3, −e_3} Orient=−1 neighbor-read=fail, (1, 1, -1) M={+e_1} O={+e_2, −e_3} Orient=−1 neighbor-read=fail
+
+matching 6-NN of A: (0, 0, 0), (0, 1, 1)
+
+matching 6-NN of B: none
+
+matching 6-NN of C: (0, 1, 0)
+
+matching 6-NN of D: none
+
+The matching neighbors of `A` are the origin and the second-pair seed
+`(0,1,1)`. Both carry Orient `+1` at `A`'s `τ`, equal to `Orient(A)=+1`,
+so neighbor-read(A) = hold. Sites `(1,1,0)` and `(-1,1,0)` do form later
+and are `UNDEFINED` at `A`'s `τ`. Site `C=(0,2,0)` is formed at `A`'s `τ`
+with empty `O`, so Orient fails there.
+
+`B` has Orient `−1` because lex-largest on the mixed `e_3` slot of
+`O(B,τ)={+e_2,+e_3,−e_3}` selects `−e_3`, and `det(+e_1,+e_2,−e_3)=−1`.
+No formed six-neighbor at `B`'s `τ` recovers Orient `−1`. Neighbor
+`(1,0,1)` has the same unsigned 1-in 2-out axes, so split neighbor-read
+HOLDs there, but its Orient is `+1`. Therefore neighbor-read(B) = fail
+even though split(B) = hold and Orient(B) is `±1`. This is the first
+display of neighbor-read of cyclic lex-largest Orient on these y-probes,
+and it is not leftover of nm2sready neighbor-read of the 1-in 2-out split
+and not leftover of nm2oricycy equal-sign reverse of Orient.
+
+`C` has Orient `+1`. The matching neighbor is seed `A=(0,1,0)`, so
+neighbor-read(C) = hold. Split HOLDs at `C` with no matching unsigned-axis
+neighbor, so split neighbor-read fails at `C` while this neighbor-read
+HOLDs.
+
+Split fails at `D` from cover fail with leftover `{e_2}` (1-in 1-out).
+Empty `O_prev` on `e_2` makes Orient fail, not `UNDEFINED`. Neighbor-read(D)
+is therefore fail, not `UNDEFINED`. Mixed remains a set at `C`'s outgoing
+`{+e_1,−e_1,+e_3,−e_3}` and at `B`'s mixed `e_3` slot.
+`QED`
+
+## Theorem 2 — Reverse Neighbor-Read
+
+**Claim.** Reverse neighbor-read at `τ` is fail, not hold and not
+`UNDEFINED`.
+
+**Proof.** Reverse HOLDs iff neighbor-read HOLDs at `A` and at `B`. Both
+probes are formed, so the pair is not `UNDEFINED`. Theorem 1 gives
+neighbor-read(A) = hold and neighbor-read(B) = fail, hence
+Reverse neighbor-read at τ: fail. Equal-sign reverse of Orient also fails,
+because `Orient(A)=+1` and `Orient(B)=−1`, but that is a different
+predicate: neighbor-read reverse fails because `B` has no matching
+neighbor, while neighbor-read at `A` HOLDs. Neighbor-read of split reverse
+HOLDs. Cover reverse HOLDs. Cover and split do not score handedness.
+`QED`
+
+## Theorem 3 — Face Neighbor-Read, Displayed Not Adopted
+
+**Claim.** Face neighbor-read at `τ` is fail, not hold and not
+`UNDEFINED`. The bit is displayed, not adopted.
+
+**Proof.** Face HOLDs iff neighbor-read HOLDs at `C` and at `D`. Theorem 1
+gives neighbor-read(C) = hold and neighbor-read(D) = fail, hence
+Face neighbor-read at τ: fail. The report is a finite listing on this
+seed and these four y-probes. It is displayed, not adopted as an
+Admissibility clause, as a lettering law, or as a uniqueness rule. Do not
+write into Admissibility. Do not attach L1.
+`QED`
+
+## Discriminators
+
+Neighbor-read of `M` as signed sets fails at `A` and at `C`, and HOLDs at
+`B` and at `D`. Neighbor-read of `O` as signed sets fails at every
+y-probe. Neighbor-read of the 1-in 2-out split HOLDs at `A` and at `B` and
+fails at `C` and at `D`, so that reverse HOLDs. The present letter HOLDs at
+`A` and at `C` and fails at `B` and at `D`, so reverse fails. It is
+therefore not leftover of nm2ready neighbor-read of M, not leftover of
+nm2oready neighbor-read of O, and not leftover of nm2sready neighbor-read
+of the 1-in 2-out split.
+
+nm2oricycy reverse fail face fail scores equal `±1` Orient signs, not
+neighbor-read. Here neighbor-read HOLDs at `A` while Orient(A) disagrees
+with Orient(B), and neighbor-read HOLDs at `C` while Orient(D) fails.
+nm2oricyclz HOLDING reverse and face is the four z-probes of this seed
+under Orient equality; neighbor-read of that same Orient fails at every
+z-probe. Cyclic lex-smallest reverse HOLDs with Orient `+1` at `A` and at
+`B`; this Orient at `B` is `−1`, and matching 6-NN of A under lex-smallest
+is only the origin, not also `(0,1,1)`. Lex-one reverse HOLDs. Leftover of
+`M` alone reverse HOLDs. Leftover of `O` alone reverse HOLDs.
+
+The same y-probes on a two-site `±e_1` seed form `B` at tick 2 and `D` at
+tick 3 and treat `(0,0,1)` as a formed child, not a seed. A perpendicular
+two-site seed and a z-symmetric three-site seed do not reproduce this
+listing.
+
+## Exact Target And Proof Obligations
+
+**Exact target:** report neighbor-read of the cyclic lex-largest orientation
+at `t+1` on the four y-probes of the two-axis opposite seed, and the
+reverse/face pair-read of those bits, on Euclidean `B_3(0)`.
+
+| Obligation | Disposition |
+|---|---|
+| name the seed, perp-step rule, host, and y-probes | displayed process, closed on `B_3(0)` |
+| list `t`, `M`, `O`, Orient, formed six-neighbor bits, and neighbor-read | Theorem 1, finite listing |
+| reverse pair-read of `A` and `B` | Theorem 2, fail |
+| face pair-read of `C` and `D` | Theorem 3, fail, displayed not adopted |
+| adopt reverse or face as Admissibility | not claimed |
+| attach a uniqueness cut | not claimed |
+| lattice-wide lettering | not claimed; no global T |
+
+The proof-obligation graph is acyclic. The leaves are finite listings on
+a 123-site ball. No observational value is used.
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: neighbor-read of cyclic next/prev lex-largest Orient at `t+1` on the four y-probes of the two-axis opposite seed, and reverse/face from that. |
+| V2 | Current main has no landed neighbor-read of cyclic lex-largest Orient reverse/face on these four y-probes. |
+| V3 | Four neighbor-read reports and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because neighbor-read HOLDs at `A` and at `C` while failing at `B`, split neighbor-read reverse HOLDs, and equal-sign Orient reverse fails for a different reason. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-Go Discipline Gate
+
+This note is a displayed finite report, not a negative law. Broad negative
+inference from the reverse fail, from the face fail, or from leftover
+signed-set misses is **FAIL / DO NOT SHIP**.
+
+### N1 — materially distinct routes
+
+Neighbor-read of cyclic lex-largest Orient, neighbor-read of `M`,
+neighbor-read of `O`, neighbor-read of split, equal-sign reverse of Orient,
+axis-cover without neighbor-read, unique-letter cuts, cyclic lex-smallest,
+and a rewritten Admissibility rule are distinct objects. Only the first is
+executed here, and only on four y-probes. The others are named leftovers or
+out of scope. No universal negative is claimed, so a no-go is not shipped.
+
+### N2 — wall independence
+
+There is no shipped wall. Reverse fail and face fail are pair-reads of
+the four neighbor-read bits. Removing either pair changes the report
+without creating a law-level obstruction.
+
+### N3 — hidden-condition scan
+
+Load-bearing and explicit: two-axis opposite seed, perp-step
+`s·e_i=0`, incoming lock, Euclidean `B_3(0)`, `τ(q)=t(q)+1`, cyclic
+lex-largest Orient of `M` and `O` as nm2oricyclz, neighbor-read of that
+sign against formed six-neighbors at the same `τ`, and the four named
+y-probes. No phrase such as "by construction" or "naturally" adds a
+further premise. Occupancy of sites is not used.
+
+### N4 — residual matching
+
+No prior negative is cited as evidence. The only linked premise document
+is the current axiom memo, used to quote Lattice, Qubit, Record, and the
+Admissibility non-supply of formation site. The listing is proved here.
+
+### N5 — resolution audit
+
+| Resolution | Executed? | Exact scope |
+|---|---:|---|
+| per element | yes | cyclic lex-largest Orient of `M` and `O` at a probe and at formed six-neighbors, compared as `±1` signs at that probe's `t+1` |
+| per site | yes | y-probes `A,B,C,D` on Euclidean `B_3(0)` only |
+| per mode | no | no spectral or mode calculation is executed on this finite host |
+| per block | yes | four neighbor-read reports, reverse/face from those bits |
+| lattice-wide | checked and not executed | no lattice-wide lettering rule is claimed; no global T |
+
+### N6 — partial-closure paths
+
+Live extensions already named: other seeds, other probe axes, a uniqueness
+cut, signed-set leftover, a larger host, or an Admissibility rewrite. None
+is closed by this listing, and none is dismissed as requiring a new axiom.
+
+### N7 — steelman
+
+The strongest objection to reading reverse fail and face fail as a law is
+decisive: both bits are pair-reads of probe reports on one displayed seed.
+Neighbor-read of `M` fails at `A`, neighbor-read of `O` fails at `A` and at
+`B`, and neighbor-read of split HOLDs reverse. Equal-sign Orient reverse
+fails because `A` is `+1` and `B` is `−1`, while this reverse fails because
+`B` has no matching neighbor. That is why Theorem 3 is displayed, not
+adopted.
+
+### N8 — cross-cycle echo
+
+Investment names `nm2ax`, `nm2ax12`, `nm2oricyclz`, `nm2oricycy`,
+`nm2sready`, `nm2ready`, and `nm2oready` mark nearby displayed processes.
+This note reuses the same two-axis opposite seed and y-probes only to
+report neighbor-read of cyclic lex-largest Orient at `t+1`. It does not
+inherit an Orient-equality reverse, a split neighbor-read, or a signed-set
+neighbor-read as a theorem.
+
+**No-Go Discipline status:** FAIL / DO NOT SHIP for any negative
+Admissibility, lettering, or uniqueness claim. The positive finite listing
+in Theorems 1–3 remains a displayed bounded report.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite neighbor-read of cyclic lex-largest Orient at t+1 on four y-probes, with reverse/face pair-read, on Euclidean B_3(0); displayed, not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face
+target_blocker_text: "report neighbor-read of cyclic lex-largest Orient at t+1 on the two-axis opposite y-probes and the reverse/face pair of those bits"
+source_of_blocker_text: handoff
+reachability_to_target: supports
+artifact_role: theorem
+next_trace_action: "Keep reverse/face displayed. Do not write into Admissibility. Do not attach L1."
+conditional_surface_status: "exact finite listing on B_3(0) for the declared seed and y-probes; law-level adoption remains open and is not claimed"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Imports And Claim Boundary
+
+| Item | Role | Status |
+|---|---|---|
+| current Lattice / Qubit / Record sentences | framework premise | linked current axiom memo |
+| Admissibility non-supply of formation site | framework boundary | quoted; process is displayed |
+| two-axis opposite seed, perp-step, incoming lock | declared process | explicit condition |
+| Euclidean `B_3(0)` | declared host | `{n:n·n<=9}`; no larger host |
+| neighbor-read of cyclic lex-largest Orient, reverse, face | reported bits | Theorems 1–3 |
+| Admissibility rewrite, L1, uniqueness cut | residual | open and not claimed |
+
+Independent audit remains required before any effective status may change.

--- a/logs/runner-cache/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,97 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
+runner_sha256: b91f009290bda20c4366aa70a9c7600b2651d3f7545297f3f4f28bbbf26e7ea0
+input_fingerprint_sha256: 61d1e87423cf0217a59ace87c63909120227587281bf95e3c3f32e3c286a1126
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+neighbor-read of cyclic lex-largest Orient reverse/face at t+1 on two-axis opposite y-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of the cyclic lex-largest orientation at t+1 on the four y-probes of the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: cyclic-next-prev-identity
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+PASS: neighbor-read-identity
+A t=0 M={−e_1} O={+e_2, −e_3} split=hold i=1 o_next=+e_2 o_prev=−e_3 det=1 Orient=+1 neighbor-read=hold
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} split=hold i=1 o_next=+e_2 o_prev=−e_3 det=-1 Orient=−1 neighbor-read=fail
+C t=1 M={+e_2} O={+e_1, −e_1, +e_3, −e_3} split=hold i=2 o_next=−e_3 o_prev=−e_1 det=1 Orient=+1 neighbor-read=hold
+D t=2 M={−e_3} O={+e_1, −e_1} split=fail i=3 o_next=−e_1 o_prev=fail det=fail Orient=fail neighbor-read=fail
+neighbor-read reverse=fail face=fail
+Orient reverse=fail face=fail
+split reverse=hold face=fail
+cover reverse=hold face=fail
+per_element: cyclic lex-largest Orient of M and O at a probe and at formed 6-NN, compared as +/-1 signs at the probe's t+1
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports, reverse/face from those bits
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 2})
+PASS: theorem1-M-O-split  ({'A': ('{−e_1}', 'hold'), 'B': ('{+e_1}', 'hold'), 'C': ('{+e_2}', 'hold'), 'D': ('{−e_3}', 'fail')})
+PASS: theorem1-Orient  ({'A': '+1', 'B': '−1', 'C': '+1', 'D': 'fail'})
+PASS: theorem1-neighbor-read  ({'A': ('hold', '(0, 0, 0), (0, 1, 1)'), 'B': ('fail', 'none'), 'C': ('hold', '(0, 1, 0)'), 'D': ('fail', 'none')})
+PASS: theorem1-formed-6nn-A
+PASS: theorem1-mixed-O-lex-largest-slot
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((0, 2, 0), (0, 1, -1)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-neighbor-read-fail
+PASS: theorem3-face-neighbor-read-fail
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: empty-cyclic-slot-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-lex-smallest-cyclic-differs
+PASS: mutation-lex-one-and-unsigned-plane-differ
+PASS: mutation-leftover-signed-and-unsigned-differ
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-z-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-or-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-Orient
+PASS: note-reports-new-neighbors
+PASS: note-reports-orient-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: orient-cyclic-lex-largest-not-smallest-or-lex-one
+TOTAL: PASS=64 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,2231 @@
+#!/usr/bin/env python3
+"""Neighbor-read of cyclic lex-largest Orient at t+1 reverse/face on y-probes.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process and y-probes as nm2ax.
+Perp-step incoming lock. M, O, split as nm2ax12. Orient as nm2oricyclz:
+cyclic next/prev lex-largest outgoing determinant orientation of the 1-in
+2-out frame. t(q) is the formation tick. tau = t(q)+1. Unformed =>
+UNDEFINED. Neighbor-read HOLDs at q iff Orient(q) is +/-1 and some formed
+6-NN r has Orient(r)=Orient(q) at the same tau. If Orient fails at q,
+neighbor-read fails, not UNDEFINED. Uniqueness is not required. Reverse
+HOLDs iff neighbor-read at A and at B. Face likewise on C, D. Occupancy of
+sites is not used. No larger host. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+SlotVal = Point | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+AXIS_INDEX = {E1: 1, E2: 2, E3: 3}
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of the cyclic lex-largest orientation at t+1 on the four "
+    "y-probes of the two-axis opposite seed, and reverse/face from that, are "
+    "reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def negate(lock: Point) -> Point:
+    return (-lock[0], -lock[1], -lock[2])
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def slot_display(value: SlotVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if isinstance(value, tuple) and value in LOCK_NAME:
+        return LOCK_NAME[value]
+    raise TypeError(f"slot is not a lock or fail: {value!r}")
+
+
+def index_display(value: int | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if isinstance(value, int):
+        return str(value)
+    raise TypeError(f"axis index is not an index or fail: {value!r}")
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def sign_of_det(det: int) -> OrientVal:
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def axis_index_of(lock: Point) -> int:
+    axis = axis_of_letter(lock)
+    if axis not in AXIS_INDEX:
+        raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+    return AXIS_INDEX[axis]
+
+
+def cyclic_next_prev(index: int) -> tuple[Point, Point]:
+    """e_next = e_{i+1} with 3+1->1; e_prev = e_{i-1} with 1-1->3."""
+    if index not in (1, 2, 3):
+        raise ValueError(f"axis index is not in {{1,2,3}}: {index!r}")
+    next_index = 1 if index == 3 else index + 1
+    prev_index = 3 if index == 1 else index - 1
+    return AXES[next_index - 1], AXES[prev_index - 1]
+
+
+def axis_slot(outgoing: Outgoing, axis: Point) -> Incoming:
+    """O intersect {+/- axis}. UNDEFINED if O is unformed."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    return frozenset(outgoing & {axis, negate(axis)})
+
+
+def lex_largest_signed(slot: Incoming) -> SlotVal:
+    """Lex-largest under +e < -e. Empty is fail. Hence -e if both signs."""
+    if slot == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(slot, frozenset) or not slot:
+        return "fail"
+    axis = axis_of_letter(next(iter(slot)))
+    negative = negate(axis)
+    if negative in slot:
+        return negative
+    if axis in slot:
+        return axis
+    return "fail"
+
+
+def lex_smallest_signed(slot: Incoming) -> SlotVal:
+    """Lex-smallest under +e < -e. Mutation: +e if both signs. Not this letter."""
+    if slot == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(slot, frozenset) or not slot:
+        return "fail"
+    axis = axis_of_letter(next(iter(slot)))
+    negative = negate(axis)
+    if axis in slot:
+        return axis
+    if negative in slot:
+        return negative
+    return "fail"
+
+
+def cyclic_index(incoming: Incoming) -> int | str:
+    """Axis index i of unique m. Fail if M is not a singleton."""
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    return axis_index_of(signed_m)
+
+
+def cyclic_slots(
+    incoming: Incoming,
+    outgoing: Outgoing,
+    *,
+    largest: bool = True,
+) -> tuple[int | str, SlotVal, SlotVal]:
+    """i, o_next, o_prev from unique m and lex choice on cyclic O slots."""
+    index = cyclic_index(incoming)
+    if index == UNDEFINED:
+        return UNDEFINED, UNDEFINED, UNDEFINED
+    if index == "fail" or not isinstance(index, int):
+        return "fail", "fail", "fail"
+    e_next, e_prev = cyclic_next_prev(index)
+    picker = lex_largest_signed if largest else lex_smallest_signed
+    o_next = picker(axis_slot(outgoing, e_next))
+    o_prev = picker(axis_slot(outgoing, e_prev))
+    return index, o_next, o_prev
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3. Mutation: unsigned."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        occupied = outgoing & {axis, negate(axis)}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i. Not cyclic."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        occupied = outgoing & {axis, negate(axis)}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negate(axis))
+    return picked[0], picked[1]
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        if axis in outgoing and negate(axis) in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_axis_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e_pair)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def leftover_signed(outgoing: Outgoing, leftover_ax: Point) -> Point | str:
+    """Unique signed O vector on leftover axis. Fail if |O_l| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    occupied = outgoing & {leftover_ax, negate(leftover_ax)}
+    if len(occupied) != 1:
+        return "fail"
+    return next(iter(occupied))
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def det_orient(col1: Point, col2: Point, col3: Point) -> OrientVal:
+    return sign_of_det(integer_det_columns(col1, col2, col3))
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic unsigned o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return det_orient(signed_m, plane[0], plane[1])
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e_pair, o_l). Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail" or not isinstance(pair, tuple):
+        return "fail"
+    leftover_ax = leftover_axis_unit(signed_m, pair)
+    if leftover_ax == "fail" or not isinstance(leftover_ax, tuple):
+        return "fail"
+    leftover = leftover_signed(outgoing, leftover_ax)
+    if leftover == UNDEFINED:
+        return UNDEFINED
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    return det_orient(signed_m, pair, leftover)
+
+
+def unsigned_leftover_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Unsigned leftover unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail" or not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_axis_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    return det_orient(signed_m, pair, leftover)
+
+
+def lex_one_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: lex-one signed O_i in axis order, not cyclic next/prev."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = lex_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return det_orient(signed_m, plane[0], plane[1])
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane. Fail if an opposite pair occupies O_i."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return det_orient(signed_m, plane[0], plane[1])
+
+
+def lex_smallest_cyclic_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: cyclic next/prev with lex-smallest. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    _index, o_next, o_prev = cyclic_slots(incoming, outgoing, largest=False)
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return det_orient(signed_m, o_next, o_prev)
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-largest cyclic slots.
+
+    Fail if split fails or a cyclic slot is empty, not UNDEFINED.
+    """
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    _index, o_next, o_prev = cyclic_slots(incoming, outgoing, largest=True)
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return det_orient(signed_m, o_next, o_prev)
+
+
+def matching_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    *,
+    orient_fn=frame_orient,
+) -> tuple[Point, ...] | str:
+    """Formed 6-NN r with Orient(r, tau) equal to Orient(site, tau) both +/-1.
+
+    If Orient fails at site, return the empty tuple (fail, not UNDEFINED).
+    Unformed site => UNDEFINED.
+    """
+    own_m = incoming_set(site, tau, ticks, locks, seed_map)
+    own_o = outgoing_set(site, tau, ticks, locks, seed_map)
+    own = orient_fn(own_m, own_o)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own not in (1, -1):
+        return ()
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other_m = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        other_o = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        other = orient_fn(other_m, other_o)
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    *,
+    orient_fn=frame_orient,
+) -> str:
+    """HOLD iff Orient is +/-1 and a formed 6-NN recovers that same sign.
+
+    Unformed => UNDEFINED. Orient fail => fail, not UNDEFINED.
+    """
+    matches = matching_neighbors(
+        site, tau, ticks, locks, seed_map, orient_fn=orient_fn
+    )
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def matching_incoming_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with M(r, tau) equal to M(site, tau)."""
+    own = incoming_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_incoming(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of M. Not this letter."""
+    matches = matching_incoming_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def matching_outgoing_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: formed 6-NN r with O(r, tau) equal to O(site, tau)."""
+    own = outgoing_set(site, tau, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(own, frozenset):
+        raise TypeError(f"lock set is not a lock set: {own!r}")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if other == UNDEFINED:
+            continue
+        if not isinstance(other, frozenset):
+            raise TypeError(f"lock set is not a lock set: {other!r}")
+        if other == own:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_outgoing(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of O. Not this letter."""
+    matches = matching_outgoing_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def matching_split_neighbors(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, ...] | str:
+    """Leftover contrast: neighbor-read of the 1-in 2-out split. Not this letter."""
+    own_m = incoming_set(site, tau, ticks, locks, seed_map)
+    own_o = outgoing_set(site, tau, ticks, locks, seed_map)
+    split = axis_split(own_m, own_o)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return ()
+    axes_m = axis_set(own_m)
+    axes_o = axis_set(own_o)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        other_m = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        other_o = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        if axis_split(other_m, other_o) != "hold":
+            continue
+        if axis_set(other_m) == axes_m and axis_set(other_o) == axes_o:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def neighbor_read_split(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover contrast: neighbor-read of split. Not this letter."""
+    matches = matching_split_neighbors(site, tau, ticks, locks, seed_map)
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if matches:
+        return "hold"
+    return "fail"
+
+
+def formed_neighbor_rows(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[tuple[Point, Incoming, Outgoing, OrientVal, str], ...]:
+    """M, O, Orient, neighbor-read at each eventually-formed 6-NN, same tau."""
+    rows: list[tuple[Point, Incoming, Outgoing, OrientVal, str]] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor not in ticks:
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        outgoing = outgoing_set(neighbor, tau, ticks, locks, seed_map)
+        rows.append(
+            (
+                neighbor,
+                incoming,
+                outgoing,
+                frame_orient(incoming, outgoing),
+                neighbor_read(neighbor, tau, ticks, locks, seed_map),
+            )
+        )
+    return tuple(rows)
+
+
+def match_display(matches: tuple[Point, ...] | str) -> str:
+    if matches == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(matches, tuple):
+        raise TypeError(f"matching neighbors are not a tuple: {matches!r}")
+    if not matches:
+        return "none"
+    return ", ".join(str(site) for site in matches)
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1. Leftover contrast."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(read_a: str, read_b: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_bit(read_a, read_b)
+
+
+def face_report(read_c: str, read_d: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_bit(read_c, read_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print(
+        "neighbor-read of cyclic lex-largest Orient reverse/face at t+1 "
+        "on two-axis opposite y-probes"
+    )
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "cyclic-next-prev-identity",
+        cyclic_next_prev(1) == (E2, E3)
+        and cyclic_next_prev(2) == (E3, E1)
+        and cyclic_next_prev(3) == (E1, E2)
+        and axis_index_of(NEG_E1) == 1
+        and axis_index_of(E2) == 2
+        and axis_index_of(NEG_E3) == 3
+        and lex_largest_signed(frozenset({E2, NEG_E2})) == NEG_E2
+        and lex_smallest_signed(frozenset({E2, NEG_E2})) == E2
+        and lex_largest_signed(frozenset({E2})) == E2
+        and lex_largest_signed(frozenset()) == "fail"
+        and lex_largest_signed(frozenset({E3, NEG_E3})) == NEG_E3
+        and lex_smallest_signed(frozenset({E3, NEG_E3})) == E3,
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(NEG_E1, E2, NEG_E3) == 1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E2, NEG_E3, NEG_E1) == 1
+        and integer_det_columns(E2, E3, E1) == 1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({NEG_E1}), frozenset({E2, NEG_E3})) == 1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})) == 1
+        and frame_orient(frozenset({NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and lex_smallest_cyclic_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == 1
+        and lex_smallest_cyclic_orient(
+            frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3})
+        )
+        == 1
+        and lex_one_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and lex_one_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3, NEG_E3}))
+        == -1
+        and leftover_pair_orient(frozenset({NEG_E1}), frozenset({E2, NEG_E3}))
+        == "fail"
+        and leftover_pair_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and unique_signed_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == "fail"
+        and unique_signed_orient(frozenset({NEG_E1}), frozenset({E2, NEG_E3})) == 1
+        and lex_frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and lex_frame_orient(frozenset({NEG_E1}), frozenset({E2, NEG_E3})) == -1,
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail"
+        and pair_bit("hold", "hold") == "hold"
+        and pair_bit("hold", "fail") == "fail"
+        and pair_bit(UNDEFINED, "hold") == UNDEFINED,
+    )
+    checks.check(
+        "neighbor-read-identity",
+        neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and matching_neighbors(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and neighbor_read(PROBES["B"], -1, {}, {}, {}) == UNDEFINED
+        and frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED,
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m: dict[str, Point | str] = {}
+    index: dict[str, int | str] = {}
+    o_next: dict[str, SlotVal] = {}
+    o_prev: dict[str, SlotVal] = {}
+    det: dict[str, int | str] = {}
+    lex: dict[str, OrientVal] = {}
+    lex_small: dict[str, OrientVal] = {}
+    lex_one: dict[str, OrientVal] = {}
+    leftover: dict[str, OrientVal] = {}
+    unique_s: dict[str, OrientVal] = {}
+    pair_present: dict[str, str] = {}
+    orient: dict[str, OrientVal] = {}
+    reads: dict[str, str] = {}
+    reads_m: dict[str, str] = {}
+    reads_o: dict[str, str] = {}
+    reads_split: dict[str, str] = {}
+    reads_small: dict[str, str] = {}
+    matches: dict[str, tuple[Point, ...] | str] = {}
+    formed: dict[str, tuple[tuple[Point, Incoming, Outgoing, OrientVal, str], ...]] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    tau1: dict[str, int] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m[name] = unique_signed_m(m1[name])
+        index[name], o_next[name], o_prev[name] = cyclic_slots(m1[name], o1[name])
+        if (
+            isinstance(signed_m[name], tuple)
+            and isinstance(o_next[name], tuple)
+            and isinstance(o_prev[name], tuple)
+        ):
+            det[name] = integer_det_columns(
+                signed_m[name], o_next[name], o_prev[name]
+            )
+        else:
+            det[name] = "fail"
+        pair_present[name] = has_opposite_pair(o1[name])
+        lex[name] = lex_frame_orient(m1[name], o1[name])
+        lex_small[name] = lex_smallest_cyclic_orient(m1[name], o1[name])
+        lex_one[name] = lex_one_orient(m1[name], o1[name])
+        leftover[name] = leftover_pair_orient(m1[name], o1[name])
+        unique_s[name] = unique_signed_orient(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        reads[name] = neighbor_read(site, tau1[name], ticks, locks, seed_map)
+        reads_m[name] = neighbor_read_incoming(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_o[name] = neighbor_read_outgoing(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_split[name] = neighbor_read_split(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        reads_small[name] = neighbor_read(
+            site,
+            tau1[name],
+            ticks,
+            locks,
+            seed_map,
+            orient_fn=lex_smallest_cyclic_orient,
+        )
+        matches[name] = matching_neighbors(site, tau1[name], ticks, locks, seed_map)
+        formed[name] = formed_neighbor_rows(
+            site, tau1[name], ticks, locks, seed_map
+        )
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"split={split[name]} "
+            f"i={index_display(index[name])} "
+            f"o_next={slot_display(o_next[name])} "
+            f"o_prev={slot_display(o_prev[name])} "
+            f"det={det[name]} "
+            f"Orient={orient_display(orient[name])} "
+            f"neighbor-read={reads[name]}"
+        )
+
+    reverse = reverse_report(reads["A"], reads["B"])
+    face = face_report(reads["C"], reads["D"])
+    orient_reverse = pair_orient(orient["A"], orient["B"])
+    orient_face = pair_orient(orient["C"], orient["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unique_o_orient_a = frame_orient(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {
+        name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_split = {
+        name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = pair_orient(one_orient["C"], one_orient["D"])
+    one_orient_reverse = pair_orient(one_orient["A"], one_orient["B"])
+    one_reads = {
+        name: neighbor_read(
+            PROBES[name],
+            one_ticks[PROBES[name]] + 1,
+            one_ticks,
+            one_locks,
+            one_seeds,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    one_nread_reverse = reverse_report(one_reads["A"], one_reads["B"])
+    one_nread_face = face_report(one_reads["C"], one_reads["D"])
+    print(f"neighbor-read reverse={reverse} face={face}")
+    print(f"Orient reverse={orient_reverse} face={orient_face}")
+    print(f"split reverse={split_reverse} face={split_face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: cyclic lex-largest Orient of M and O at a probe and at "
+        "formed 6-NN, compared as +/-1 signs at the probe's t+1"
+    )
+    print(
+        "per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites"
+    )
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: four neighbor-read reports, reverse/face from those bits")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["C"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 0, ticks, locks, seed_map) == UNDEFINED
+        and neighbor_read(PROBES["D"], 1, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-split",
+        m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E3})
+        and o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1})
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and cover["A"] == "hold"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail",
+        str(
+            {
+                name: (lockset_display(m1[name]), split[name])
+                for name in ("A", "B", "C", "D")
+            }
+        ),
+    )
+    checks.check(
+        "theorem1-Orient",
+        signed_m["A"] == NEG_E1
+        and signed_m["B"] == E1
+        and signed_m["C"] == E2
+        and signed_m["D"] == NEG_E3
+        and index["A"] == 1
+        and index["B"] == 1
+        and index["C"] == 2
+        and index["D"] == 3
+        and o_next["A"] == E2
+        and o_prev["A"] == NEG_E3
+        and o_next["B"] == E2
+        and o_prev["B"] == NEG_E3
+        and o_next["C"] == NEG_E3
+        and o_prev["C"] == NEG_E1
+        and o_next["D"] == NEG_E1
+        and o_prev["D"] == "fail"
+        and det["A"] == 1
+        and det["B"] == -1
+        and det["C"] == 1
+        and det["D"] == "fail"
+        and orient["A"] == 1
+        and orient["B"] == -1
+        and orient["C"] == 1
+        and orient["D"] == "fail",
+        str({name: orient_display(orient[name]) for name in ("A", "B", "C", "D")}),
+    )
+    empty: Incoming = frozenset()
+    checks.check(
+        "theorem1-neighbor-read",
+        reads["A"] == "hold"
+        and reads["B"] == "fail"
+        and reads["C"] == "hold"
+        and reads["D"] == "fail"
+        and matches["A"] == ((0, 0, 0), (0, 1, 1))
+        and matches["B"] == ()
+        and matches["C"] == ((0, 1, 0),)
+        and matches["D"] == ()
+        and match_display(matches["A"]) == "(0, 0, 0), (0, 1, 1)"
+        and match_display(matches["B"]) == "none"
+        and match_display(matches["C"]) == "(0, 1, 0)"
+        and match_display(matches["D"]) == "none",
+        str({name: (reads[name], match_display(matches[name])) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-formed-6nn-A",
+        formed["A"]
+        == (
+            ((1, 1, 0), UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED),
+            ((-1, 1, 0), UNDEFINED, UNDEFINED, UNDEFINED, UNDEFINED),
+            ((0, 2, 0), frozenset({E2}), empty, "fail", "fail"),
+            (
+                (0, 0, 0),
+                frozenset({E1}),
+                frozenset({NEG_E2, NEG_E3}),
+                1,
+                "hold",
+            ),
+            (
+                (0, 1, 1),
+                frozenset({NEG_E2}),
+                frozenset({E1, NEG_E1, E3}),
+                1,
+                "hold",
+            ),
+            ((0, 1, -1), frozenset({NEG_E3}), empty, "fail", "fail"),
+        ),
+    )
+    checks.check(
+        "theorem1-mixed-O-lex-largest-slot",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 2
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and unique_letter(o1["B"]) == UNDEFINED
+        and o_prev["B"] == NEG_E3
+        and lex_smallest_signed(axis_slot(o1["B"], E3)) == E3
+        and unique_o_orient_a == UNDEFINED
+        and orient["A"] == 1
+        and unique_s["A"] == 1
+        and unique_s["B"] == "fail",
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and frame_orient(m0["A"], o0["A"]) == "fail"
+        and frame_orient(m0["B"], o0["B"]) == "fail"
+        and frame_orient(m0["C"], o0["C"]) == "fail"
+        and frame_orient(m0["D"], o0["D"]) == "fail",
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((0, 2, 0), (0, 1, -1))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and m1["A"] == frozenset({NEG_E1})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem2-reverse-neighbor-read-fail",
+        reverse == "fail"
+        and reads["A"] == "hold"
+        and reads["B"] == "fail"
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and orient_reverse == "fail"
+        and split_reverse == "hold"
+        and cover_reverse == "hold"
+        and reverse_report(reads_split["A"], reads_split["B"]) == "hold",
+    )
+    checks.check(
+        "theorem3-face-neighbor-read-fail",
+        face == "fail"
+        and reads["C"] == "hold"
+        and reads["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and orient_face == "fail"
+        and split_face == "fail"
+        and cover_face == "fail"
+        and reverse_report(reads_split["C"], reads_split["D"]) == "fail",
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split_reverse == "hold"
+        and cover_reverse == "hold"
+        and reverse == "fail"
+        and split_face == "fail"
+        and cover_face == "fail"
+        and face == "fail"
+        and reverse != split_reverse
+        and reverse != cover_reverse
+        and lex["A"] == -1
+        and lex["B"] == 1
+        and pair_orient(lex["A"], lex["B"]) == "fail",
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and one_orient["C"] == 1
+        and one_split["C"] == "hold"
+        and one_cover["C"] == "hold"
+        and one_orient["D"] == "fail"
+        and one_split["D"] == "fail"
+        and one_cover["D"] == "hold"
+        and one_orient_face == "fail"
+        and one_split_face == "fail"
+        and one_cover_face == "hold"
+        and o_prev["D"] == "fail"
+        and split["D"] == "fail"
+        and orient["D"] != UNDEFINED,
+    )
+    checks.check(
+        "empty-cyclic-slot-is-orient-fail-not-undefined",
+        lex_largest_signed(axis_slot(o1["D"], E2)) == "fail"
+        and o_prev["D"] == "fail"
+        and frame_orient(m1["D"], o1["D"]) == "fail"
+        and split["D"] == "fail"
+        and leftover_axis(m1["D"], o1["D"]) == frozenset({E2}),
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["A"]] == 0
+        and one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["C"]] == 1
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 2
+        and one_orient["A"] == 1
+        and one_orient["B"] == -1
+        and one_orient_reverse == "fail"
+        and one_orient["D"] == "fail"
+        and one_orient_face == "fail"
+        and one_cover_face == "hold"
+        and cover_face == "fail"
+        and one_cover_face != cover_face
+        and one_m1["D"] != m1["D"]
+        and one_o1["A"] != o1["A"]
+        and lex_smallest_cyclic_orient(one_m1["A"], one_o1["A"]) == -1
+        and lex_small["A"] == 1
+        and one_nread_reverse != UNDEFINED
+        and one_nread_face != UNDEFINED
+        and ticks[PROBES["D"]] != one_ticks[PROBES["D"]],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset()
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and leftover_reverse == reverse
+        and leftover_face == face
+        and orient["A"] == 1
+        and orient["B"] == -1
+        and leftover_axis(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m["A"] == frozenset({E2, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_o["A"] == frozenset({E1})
+        and lx_o["B"] == frozenset({E1})
+        and reverse_m_alone == "hold"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "hold"
+        and face_o_alone == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and reverse_m_alone != reverse
+        and reverse_o_alone != reverse,
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "hold"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and reverse == "fail"
+        and face == "fail"
+        and m_exist_reverse != reverse
+        and o_exist_face != face
+        and pair_present["A"] == "fail"
+        and pair_present["B"] == "hold"
+        and pair_present["C"] == "hold"
+        and pair_present["D"] == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) != face
+        and pair_bit(pair_present["A"], pair_present["B"]) == "fail",
+    )
+    checks.check(
+        "mutation-lex-smallest-cyclic-differs",
+        lex_small["A"] == 1
+        and lex_small["B"] == 1
+        and lex_small["C"] == 1
+        and lex_small["D"] == "fail"
+        and pair_orient(lex_small["A"], lex_small["B"]) == "hold"
+        and pair_orient(lex_small["C"], lex_small["D"]) == "fail"
+        and reverse == "fail"
+        and pair_orient(lex_small["A"], lex_small["B"]) != reverse
+        and o_prev["B"] == NEG_E3
+        and lex_smallest_signed(axis_slot(o1["B"], E3)) == E3
+        and orient["B"] == -1
+        and lex_small["B"] == 1,
+    )
+    checks.check(
+        "mutation-lex-one-and-unsigned-plane-differ",
+        lex_one["A"] == 1
+        and lex_one["B"] == 1
+        and lex_one["C"] == -1
+        and lex_one["D"] == "fail"
+        and pair_orient(lex_one["A"], lex_one["B"]) == "hold"
+        and lex["A"] == -1
+        and lex["B"] == 1
+        and lex["C"] == -1
+        and lex["D"] == "fail"
+        and pair_orient(lex["A"], lex["B"]) == "fail"
+        and orient["A"] == 1
+        and orient["B"] == -1
+        and orient["C"] == 1
+        and lex_one["C"] != orient["C"]
+        and lex["A"] != orient["A"]
+        and pair_orient(lex_one["A"], lex_one["B"]) != reverse,
+    )
+    checks.check(
+        "mutation-leftover-signed-and-unsigned-differ",
+        leftover["A"] == "fail"
+        and leftover["B"] == -1
+        and leftover["C"] == "fail"
+        and leftover["D"] == "fail"
+        and unsigned_leftover_orient(m1["A"], o1["A"]) == "fail"
+        and unsigned_leftover_orient(m1["B"], o1["B"]) == -1
+        and unsigned_leftover_orient(m1["C"], o1["C"]) == -1
+        and unsigned_leftover_orient(m1["D"], o1["D"]) == "fail"
+        and orient["A"] == 1
+        and leftover["A"] != orient["A"]
+        and unsigned_leftover_orient(m1["C"], o1["C"]) != orient["C"]
+        and pair_orient(leftover["A"], leftover["B"]) == "fail",
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED
+        and unique_s["B"] == "fail"
+        and unique_s["C"] == "fail"
+        and orient["A"] == 1
+        and orient["B"] == -1
+        and orient["B"] != UNDEFINED,
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E1
+        and sum_of_set(o1["A"]) == add(E2, NEG_E3)
+        and sum_of_set(o1["B"]) == E2
+        and axis_o["A"] == frozenset({E2, E3})
+        and o_next["A"] == E2
+        and o_prev["A"] == NEG_E3,
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E1 in m1["A"]
+        and NEG_E1 not in o1["A"]
+        and E2 in o1["A"]
+        and E2 not in m1["A"]
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    z_m1, z_o1 = probe_sides(Z_PROBES, ticks, locks, seed_map)
+    z_split = {name: axis_split(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")}
+    z_orient = {
+        name: frame_orient(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    z_reverse = pair_orient(z_orient["A"], z_orient["B"])
+    z_face = pair_orient(z_orient["C"], z_orient["D"])
+    z_reads = {
+        name: neighbor_read(
+            Z_PROBES[name],
+            ticks[Z_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    z_nread_reverse = reverse_report(z_reads["A"], z_reads["B"])
+    z_nread_face = face_report(z_reads["C"], z_reads["D"])
+    x_m1, x_o1 = probe_sides(X_PROBES, ticks, locks, seed_map)
+    x_orient = {
+        name: frame_orient(x_m1[name], x_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    x_reverse = pair_orient(x_orient["A"], x_orient["B"])
+    x_face = pair_orient(x_orient["C"], x_orient["D"])
+    x_reads = {
+        name: neighbor_read(
+            X_PROBES[name],
+            ticks[X_PROBES[name]] + 1,
+            ticks,
+            locks,
+            seed_map,
+        )
+        for name in ("A", "B", "C", "D")
+    }
+    x_nread_reverse = reverse_report(x_reads["A"], x_reads["B"])
+    x_nread_face = face_report(x_reads["C"], x_reads["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    same_m_a = incoming_set(
+        PROBES["A"], same_ticks[PROBES["A"]] + 1, same_ticks, same_locks, same_seeds
+    )
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-x-probes-or-z-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and z_m1["A"] != m1["A"]
+        and z_split["A"] == "hold"
+        and z_orient["A"] == -1
+        and z_orient["B"] == -1
+        and z_orient["C"] == 1
+        and z_orient["D"] == 1
+        and z_reverse == "hold"
+        and z_face == "hold"
+        and z_split["D"] == "hold"
+        and x_orient["A"] == "fail"
+        and x_orient["B"] == -1
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse == "fail"
+        and face == "fail"
+        and z_reverse != reverse
+        and z_face != face
+        and z_nread_reverse == "fail"
+        and z_nread_face == "fail"
+        and z_reads["A"] == "fail"
+        and z_reads["C"] == "fail"
+        and reads["A"] == "hold"
+        and reads["C"] == "hold"
+        and x_nread_reverse == "fail"
+        and x_nread_face == "fail",
+    )
+    checks.check(
+        "not-same-lock-or-one-axis-or-y-symmetric-seed",
+        TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and same_m_a != m1["A"]
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-Orient",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_1}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_2, −e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "split(A) = hold" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = fail" in note
+        and "i(A) = 1" in note
+        and "o_next(A) = +e_2" in note
+        and "o_prev(A) = −e_3" in note
+        and "det(A) = +1" in note
+        and "Orient(A) = +1" in note
+        and "i(B) = 1" in note
+        and "o_next(B) = +e_2" in note
+        and "o_prev(B) = −e_3" in note
+        and "det(B) = −1" in note
+        and "Orient(B) = −1" in note
+        and "i(C) = 2" in note
+        and "o_next(C) = −e_3" in note
+        and "o_prev(C) = −e_1" in note
+        and "det(C) = +1" in note
+        and "Orient(C) = +1" in note
+        and "i(D) = 3" in note
+        and "o_next(D) = −e_1" in note
+        and "o_prev(D) = fail" in note
+        and "det(D) = fail" in note
+        and "Orient(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (0, 2, 0), (0, 1, -1)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-orient-reverse-face",
+        "Reverse neighbor-read at τ: fail" in note
+        and "Face neighbor-read at τ: fail" in note
+        and "neighbor-read(A) = hold" in note
+        and "neighbor-read(B) = fail" in note
+        and "neighbor-read(C) = hold" in note
+        and "neighbor-read(D) = fail" in note
+        and "matching 6-NN of A: (0, 0, 0), (0, 1, 1)" in note
+        and "matching 6-NN of B: none" in note
+        and "matching 6-NN of C: (0, 1, 0)" in note
+        and "matching 6-NN of D: none" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2ax axis-cover" in normalized_note
+        and "not leftover of nm2ax12 1-in 2-out split" in normalized_note
+        and "not leftover of lexicographic" in normalized_note
+        and "not leftover of cyclic lex-smallest" in normalized_note
+        and "not leftover of nm2orioney lex-one" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse neighbor-read at τ: fail" in note
+        and "Face neighbor-read at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index_n}" in note for index_n in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_LEX_LARGEST_ORIENT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "cyclic_next_prev" in defined_fns
+        and "lex_largest_signed" in defined_fns
+        and "lex_smallest_cyclic_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "neighbor_read" in defined_fns
+        and "matching_neighbors" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "orient-cyclic-lex-largest-not-smallest-or-lex-one",
+        reverse == "fail"
+        and face == "fail"
+        and split_reverse == "hold"
+        and cover_reverse == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and one_orient_face == "fail"
+        and lex_small["A"] == 1
+        and lex_small["B"] == 1
+        and pair_orient(lex_small["A"], lex_small["B"]) == "hold"
+        and lex_one["A"] == 1
+        and lex_one["B"] == 1
+        and lex_one["C"] == -1
+        and pair_orient(lex_one["A"], lex_one["B"]) == "hold"
+        and lex["A"] == -1
+        and lex["B"] == 1
+        and leftover["A"] == "fail"
+        and orient["A"] == 1
+        and leftover["A"] != orient["A"]
+        and z_reverse == "hold"
+        and z_face == "hold"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and o_exist_face != face
+        and reads_split["A"] == "hold"
+        and reads_split["B"] == "hold"
+        and reverse_report(reads_split["A"], reads_split["B"]) == "hold"
+        and reverse_report(reads_split["A"], reads_split["B"]) != reverse
+        and reads_m["A"] == "fail"
+        and reads_o["A"] == "fail"
+        and reads_o["B"] == "fail"
+        and reads_small["A"] == "hold"
+        and reads_small["B"] == "fail"
+        and matches["A"] == ((0, 0, 0), (0, 1, 1))
+        and matching_neighbors(
+            PROBES["A"],
+            tau1["A"],
+            ticks,
+            locks,
+            seed_map,
+            orient_fn=lex_smallest_cyclic_orient,
+        )
+        == ((0, 0, 0),),
+    )
+    _ = (
+        o0,
+        unique_o_orient_a,
+        one_cover_face,
+        one_split_face,
+        perp_o1,
+        unique_s,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Neighbor-read of cyclic Orient on y: reverse fails, face fails. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_yprobe_neighbor_read_cyclic_lex_largest_orient_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.