### PR TITLE
feat(nm2ocyccslx): cyclic lex-smallest det orientation of 1-in 2-out at t+1 on two-axis same-lock x-probes: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,815 @@
+---
+claim_id: two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Cyclic lex-smallest Orient at t+1 on the four x-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py
+---
+
+# Cyclic Lex-Smallest Orient At t+1 Reverse And Face On Four X-Probes Of The Two-Axis Same-Lock Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** cyclic lex-smallest Orient of the 1-in 2-out frame of
+simultaneous earliest incoming set `M` and outgoing dual `O` at each
+probe's `τ=t+1`, and reverse/face from that sign, on the four x-probes of
+the two-axis same-lock seed in `B_3(0)={n:n·n<=9}`. Same process and
+x-probes as nm2slpx. `M`, `O`, split as nm2sl12. Orient as nm2oricyccz.
+Let `t(q)` be the formation tick of probe `q`. Let
+`τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest incoming nearest-neighbor
+steps at `q` using only records with tick `<= τ`. Seeds are a singleton
+seed letter. `O(q,τ)` is the outgoing dual of `M`: the set of `e` in
+`{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in `M(q+e,τ)`.
+Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Axis
+of a defined lock set `S` is `Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs
+at `q` if and only if `Axis(M)` intersect `Axis(O)` is empty and `Axis(M)`
+union `Axis(O)` equals `{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if
+cover HOLDs and `|Axis(M)|=1` (hence `|Axis(O)|=2`). Split HOLD required.
+When split HOLDs, `m` is the unique vector in `M`. Let `i` in `{1,2,3}` be
+the axis index of `m`. `e_next = e_{i+1}` with `3+1→1`. `e_prev = e_{i-1}`
+with `1−1→3`. `O_next = O ∩ {±e_next}` and `O_prev = O ∩ {±e_prev}`. If
+either empty, Orient fails, not `UNDEFINED`. Order `+e < −e`. `o_next` is
+the lex-smallest vector in `O_next` (hence `+e` if both signs). `o_prev`
+likewise. `Orient(q)` is the sign of the integer determinant of the 3×3
+matrix with columns `m`, `o_next`, `o_prev`. If split fails, Orient fails,
+not `UNDEFINED`. Reverse HOLDs if and only if `Orient(A)=Orient(B)` both
+`±1`. Face HOLDs if and only if `Orient(C)=Orient(D)` both `±1`. Cover and
+split do not score handedness. This is not leftover of nm2oricyccz cyclic
+next/prev lex-smallest on the two-axis opposite z-probes. This is not
+leftover of nm2oricyclslx lex-largest cyclic on these same-lock x-probes.
+This is not leftover of nm2oricyccx lex-smallest on opposite x-probes.
+This is not leftover of nm2orionez lex-one signed outgoing letters. This
+is not leftover of nm2orilef signed leftover-axis. This is not leftover of
+nm2orichz unsigned leftover-axis `+ℓ`. This is not leftover of nm2oridetz
+unique `|O_i|=1` signed outgoing letters. This is not leftover of
+nm2chiralz lexicographic unsigned `o1,o2`. This is not leftover of nm2slx
+axis-cover.
+This is not leftover of nm2sl12 1-in 2-out split. This is not leftover of
+leftover-of-`M` alone. This is not leftover of leftover-of-`O` alone. This
+is not leftover-empty fail of leftover axis. This is not leftover of nmunopp
+union. This is not leftover of nmt2opp `M` frozen at `t`. This is not
+leftover of nmot2opp two-tick composition. This is not leftover of nmoutopp
+untimed eventual-`O`. This is not leftover of mixed #7188 fail/fail. This
+is not leftover of the 1-axis same-lock two-site seed. This is not leftover
+of the two-axis opposite seed. The second pair is a new seed, not a formed
+child. A is not a seed. Uniqueness is not required. Mixed remains a set.
+Displayed, not adopted. Do not write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. The cyclic lex-smallest
+oriented frame is the integer sign of `det(m,o_next,o_prev)` with unique
+signed incoming letter `m`, cyclic axes from `Axis(M)`, and lex-smallest
+signed outgoing letters on those axes under `+e < −e`. Reverse and face are
+scored on equal `±1` signs at the paired probes. Named signs `{+,−}` of
+locks are a coarser readout and are not used as the object. A singleton
+unique outgoing lock letter is a different readout and is not used as the
+object. Lex-one signed outgoing letters ordered by `e1<e2<e3` are a
+different readout and are not used. Lex-smallest cyclic letters are a
+different readout and are not used. Unsigned leftover unit `+ℓ` is a
+different readout and is not used. Unique signed letters requiring
+`|O_i|=1` are a different readout and are not used. Signed leftover-axis
+`det(m,e_pair,o_ℓ)` is a different readout and is not used. Existential
+opposite of signed locks is a different readout and is not used. Axis-cover
+without the frame sign is a different readout and is not used. 1-in 2-out
+split without the frame sign is a different readout and is not used.
+Leftover-empty fail of unsigned leftover axis sets is a different readout
+and is not used. A `Z^3` sum of those locks is a different readout and is
+not used. Occupancy of sites is not used. A six-neighbor star is not the
+letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of cyclic lex-smallest Orient of the 1-in 2-out frame of M and O at t+1 on the four x-probes of the two-axis same-lock seed, Orient fail,+1,-1,fail, reverse fail and face fail from equal +/-1 signs; uniqueness of outgoing locks is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face
+target_blocker_text: "display cyclic lex-smallest Orient reverse/face on the four x-probes of the two-axis same-lock seed, cyclic from Axis(M), not lex-largest, not lex-one, not leftover-axis, not cover, not split"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep cyclic lex-smallest Orient of the 1-in 2-out frame of M and O at t+1 displayed; do not write Orient into Admissibility, do not reduce to lex-one signed outgoing, do not reduce to lex-largest cyclic, do not reduce to signed leftover-axis, do not reduce to unsigned leftover +l, do not reduce to unique |O_i|=1, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace Orient by presence of an opposite pair in O, do not replace Orient by existential opposite of signed locks, do not replace Orient by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for cyclic lex-smallest Orient of the 1-in 2-out frame of M and O at t+1 on the four x-probes of the two-axis same-lock seed and reverse/face from that sign; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose cyclic
+next/prev lex-smallest orientation of `M` and `O` is scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`,
+`C=(0,0,2)`, `D=(1,0,1)`. A is not a seed. Same process and x-probes as
+nm2slpx.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint same-lock pairs recorded at formation tick 0. Origin
+locks `+e_1` and `(0,1,0)` locks `+e_1`. The second pair is a new seed, not
+a formed child: `(0,0,1)` locks `+e_2` and `(0,1,1)` locks `+e_2`. Four
+sites form at tick 0. This seed is not the nsopp one-axis two-site seed
+`{0,(0,1,0)}` with locks `+e_1/−e_1`. This seed is not the 1-axis same-lock
+two-site seed with both sites locking `+e_1`. This seed is not the
+two-axis opposite seed that would lock the second pair as `+e_2/−e_2`.
+This seed is not the nnseed two-site seed `+e_1/+e_2`. This seed is not the
+y-axis opposite `±e_2` seed.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named cyclic next/prev lex-smallest 1-in 2-out frame of `M` and `O` at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Cyclic next/prev lex-smallest oriented frame at the same cut:
+
+```text
+When split HOLDs, m is the unique vector in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1.
+e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}.
+O_prev = O ∩ {±e_prev}.
+If either empty, Orient fails, not UNDEFINED.
+Order +e < −e.
+o_next is the lex-smallest vector in O_next (hence +e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+If split fails, fail, not UNDEFINED.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+Unique outgoing letters are not required. Mixed opposite signs occupy a
+cyclic axis as the lex-smallest `+e`. A vanishing determinant is fail. Sign
+of a nonzero integer determinant is `+1` or `−1`. Split HOLD required:
+cover fail or 2-in 1-out is Orient fail, not UNDEFINED, even if `O_next`
+is nonempty. Empty `O_next` or empty `O_prev` is Orient fail, not
+`UNDEFINED`.
+
+Reverse oriented frame holds if and only if `Orient(A)=Orient(B)` and both
+signs are `±1`. Face oriented frame holds if and only if
+`Orient(C)=Orient(D)` and both signs are `±1`. Either side `UNDEFINED` is
+`UNDEFINED`. Else if both sides are equal `±1`, reverse or face HOLDs.
+Else fail.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover and split fail reverse here, but they do
+not report that cyclic `o_prev` at `B` is `+e_3` with `Orient(B)=+1`.
+Identifying split reverse with this reverse is
+refused on the same handedness gap. Identifying leftover-empty fail with
+this reverse is refused: leftover-empty fail scores empty leftover as
+reverse fail, and does not read `det(m,o_next,o_prev)`. Identifying
+lexicographic `o1,o2` or lex-one signed outgoing orientation with this
+reverse is refused: lex-one at `B` is `+1` and at `C` is `−1`, the same
+signs as this cyclic letter on these x-probes, from axis-order of
+`Axis(O)` rather than cyclic slots of `Axis(M)`. Identifying lex-largest
+cyclic letters with this letter is refused: lex-largest at `B` is `−1`
+and at `C` is `+1`. Identifying unsigned leftover-axis `+ℓ` with this
+letter is refused: unsigned leftover at `C` is `+e_2` with Orient `−1`,
+matching this sign at `C` while leftover reverse and leftover face fail
+from leftover Orient fail at `A` and at `D`; signed leftover-axis at `C`
+is `+1` while this Orient at `C` is `−1`. Unsigned cyclic `+e_next,+e_prev`
+at `C` is `+1` while this Orient at `C` is `−1`.
+Identifying signed leftover-axis `det(m,e_pair,o_ℓ)` with this letter is
+refused: leftover requires an opposite pair in `O`, so leftover of
+`M={+e_2}` and `O={+e_1,+e_3}` fails while cyclic Orient is `+1`; on the
+y-probes of this seed leftover Orient at y-probe `A` fails while cyclic
+Orient is `−1`. Identifying presence of an opposite pair in `O` with this
+face is refused: pair-presence is a boolean HOLD/fail and does not read
+the cyclic letters; on the two-axis opposite seed, `O(D)` is
+`{+e_1,−e_1}` so pair-presence face HOLDs, while here `O(D)` is `{+e_1}`
+and pair-presence face fails. Identifying a named sign of those locks
+with reverse or face is refused: named-sign lettering lost the axis.
+
+## Theorem 1 — ticks, `M`, `O`, split, `i`, `o_next`, `o_prev`, and Orient at `τ=t+1`
+
+On this process the four x-probes form. Cover of timed `M` and `O` fails at
+`A` and at `D` because leftover axis `{e_2}` is missing from the union.
+`|Axis(M)|=1` at each of the four x-probes, so split equals cover on this
+member. Compare to leftover axis: leftover of the union is `{e_2}` at `A`
+and at `D` and empty at `B` and at `C`, leftover reverse fail and leftover
+face fail. Compare to nm2slx cover and nm2sl12 split: both fail reverse
+and face on this member. Compare to nm2orichz unsigned leftover `+ℓ`:
+unsigned Orient at `C` is `−1` while signed leftover-axis at `C` is `+1`.
+Compare to nm2orionez lex-one: lex-one at `B` is `+1` and at `C` is
+`−1`, the same signs as this letter on these x-probes from axis-order.
+Compare to lex-largest cyclic: lex-largest at `B` is `−1` and at
+`C` is `+1`. Compare to nm2oricyccz: that opposite-seed z-probe display
+has reverse hold and face hold. Compare to nm2oricyccx: that opposite-seed
+x-probe display has `O(D)={+e_1,−e_1}` while here `O(D)={+e_1}`. This display reads the cyclic next/prev
+lex-smallest oriented frame of those same timed sets on the same-lock seed:
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {−e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {−e_3}
+O(A, τ) = {+e_1}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {−e_2, +e_3, −e_3}
+O(D, τ) = {+e_1}
+split(A) = fail
+split(B) = hold
+split(C) = hold
+split(D) = fail
+i(A) = 3
+o_next(A) = +e_1
+o_prev(A) = fail
+det(A) = fail
+Orient(A) = fail
+i(B) = 1
+o_next(B) = +e_2
+o_prev(B) = +e_3
+det(B) = 1
+Orient(B) = +1
+i(C) = 1
+o_next(C) = −e_2
+o_prev(C) = +e_3
+det(C) = -1
+Orient(C) = −1
+i(D) = 3
+o_next(D) = +e_1
+o_prev(D) = fail
+det(D) = fail
+Orient(D) = fail
+```
+
+A is not a seed. `A` forms at tick 2 by the incoming step `−e_3`. Mixed
+remains a set: `O(B,τ)` has three outgoing steps and `O(C,τ)` has three.
+Unique outgoing letters would assign `UNDEFINED` at mixed `O`. Unique
+`|O_i|=1` signed outgoing Orient fails at `B` because `|O ∩ {±e_3}|=2`.
+Here `i` is the axis index of unique `m`, `e_next` and `e_prev` are the
+cyclic neighbors of that axis, and the outgoing letters are lex-smallest
+under `+e < −e`. At `B`, `i=1` so `e_next=e_2` and `e_prev=e_3`,
+`O_next={+e_2}` and `O_prev={+e_3,−e_3}`, hence `o_next=+e_2`,
+`o_prev=+e_3`, and `det(+e_1,+e_2,+e_3)=1`. At `C`, `i=1` so the same
+cyclic axes, `O_next={−e_2}` and `O_prev={+e_3,−e_3}`, hence
+`o_next=−e_2`, `o_prev=+e_3`, and `det(+e_1,−e_2,+e_3)=-1`. Lex-one at
+`B` would pick `+e_3` as the lex-smallest letter on `e_3` and yield `+1`,
+the same sign as this cyclic letter at `B`. Lex-largest cyclic at `B`
+yields `−1`. At `A` unique `m` is
+`−e_3` so `i=3`, `O_next={+e_1}`, and `O_prev` is empty, split fails, and
+Orient fails, not `UNDEFINED`. At `D` unique `m` is `−e_3` so `i=3`,
+`O_next={+e_1}`, `O_prev` is empty, split fails, and Orient fails, not
+`UNDEFINED`. Cover and split do not score that `Orient(C)=−1`. O is not M.
+
+On the 1-axis same-lock two-site seed, cover reverse HOLDs on these
+x-probes while split reverse fails from 2-in 1-out, and Orient reverse
+fails. That is leftover of the first pair. Here both `(0,0,1)` and
+`(0,1,1)` are seeds of a second same-lock pair on a second axis. On the
+y-probes of this same seed, cyclic reverse fails because `Orient` at
+y-probe `A` is `−1` and at y-probe `B` is `+1`, while this x-probe reverse
+fails. Signed leftover at y-probe `A` fails because `O` has no opposite
+pair, so leftover is not cyclic. On the z-probes of this same seed,
+cyclic reverse fails and face HOLDs (`Orient(C)=−1` and `Orient(D)=−1`),
+while this x-probe face fails. Those probe-direction readouts are not
+this x-probe display.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+`M` is frozen from `t` to `t+1`. At `t`, `O` is empty at `A`, `B`, `C`,
+and `D`. Split at `t` fails and Orient is fail, not UNDEFINED.
+
+## Theorem 2 — reverse from oriented frame at `τ`
+
+Reverse oriented frame holds if and only if `Orient(A)=Orient(B)` both
+`±1`. `Orient(A)=fail` and `Orient(B)=+1`. Reverse fails. This is HOLD iff
+equal `±1` signs, not leftover of nm2oricyclz opposite-z cyclic, not
+leftover of nm2orionez lex-one, not leftover of nm2slx axis-cover, not
+leftover of nm2sl12 1-in 2-out split, not leftover-empty fail, and not
+exist-opposite.
+
+Reverse oriented frame at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Cover reverse fails
+because cover fails at `A`. Split reverse fails because split fails at
+`A`. Cover and split do not score handedness. Unsigned leftover reverse
+also fails, because unsigned leftover at `A` fails with split, but
+unsigned leftover at `C` is not this letter. Lex-one reverse fails
+because lex-one at `A` fails and lex-one at `B` is `+1`, the same sign
+as cyclic lex-smallest at `B` from axis-order of `Axis(O)`. Lex-largest
+cyclic at `B` is `−1`, not this `+1`. Leftover-empty reverse fails because leftover of the
+union at `B` is empty while leftover at `A` is `{e_2}`. Leftover of `M`
+reverse fails because leftover of `M` at `A` is `{e_1, e_2}` and at `B`
+is `{e_2, e_3}`: nonempty and unequal. Leftover of `O` reverse fails
+because leftover of `O` at `A` is `{e_2, e_3}` and at `B` is `{e_1}`:
+nonempty and unequal. Exist-opposite reverse of signed `M` fails.
+Exist-opposite reverse of signed `O` fails. Presence of an opposite pair
+in `O` fails at `A` and HOLDs at `B`. Y-probe cyclic reverse fails on this
+same seed from `−1,+1`. Those leftovers are not this display.
+
+Reverse fails.
+
+## Theorem 3 — face from oriented frame at `τ`
+
+Face oriented frame holds if and only if `Orient(C)=Orient(D)` both `±1`.
+`Orient(C)=−1` and `Orient(D)=fail`. Face fails.
+
+Face oriented frame at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Cover face fails because cover fails at `D`. Split face fails because
+split fails at `D`. Opposite-pair oriented face with unsigned leftover
+`+ℓ` also fails, and unsigned leftover Orient at `C` is `−1`, matching
+this Orient at `C`, while signed leftover-axis at `C` is `+1`. Lex-one
+face fails because lex-one at `C` is `−1` and lex-one at `D` fails,
+matching this face from axis-order columns. Lex-largest cyclic face fails
+because lex-largest at `C` is `+1` and at `D` fails. Cover and split do
+not score handedness. Presence of an opposite pair in `O` HOLDs at `C`
+and fails at `D`, so pair-presence face fails with this face, but
+pair-presence is a boolean and does not report `Orient(C)=−1`. On the two-axis opposite seed,
+pair-presence face HOLDs because `O(D)` contains `±e_1`. On the 1-axis
+same-lock two-site seed, cover reverse HOLDs while split reverse fails
+from 2-in 1-out; this two-axis member is not leftover of that 1-axis split
+reverse fail. The four y-probes of this same seed give cyclic reverse fail
+and face fail. The four z-probes give cyclic reverse fail and face HOLD.
+Those probe-direction readouts are not this x-probe display.
+Leftover-empty face fails because leftover of the union is empty at `C`
+and `{e_2}` at `D`. Leftover of `M` at `C` is `{e_2, e_3}` and leftover of
+`M` at `D` is `{e_1, e_2}`: nonempty and unequal. Leftover of `O` at `C`
+is `{e_1}` and leftover of `O` at `D` is `{e_2, e_3}`: nonempty and
+unequal. Exist-opposite face of signed `M` fails. Exist-opposite face of
+signed `O` fails. Cyclic next/prev lex-smallest oriented face fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Split fails at `A` and at `D`. Orient at `A` is fail.
+Orient at `C` is `−1`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not select a unique outgoing lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by unsigned leftover unit `+ℓ`.
+- It does not replace Orient by signed leftover-axis `det(m,e_pair,o_ℓ)`.
+- It does not replace Orient by lexicographic `o1,o2` orientation.
+- It does not replace Orient by lex-one signed outgoing letters.
+- It does not replace Orient by lex-largest cyclic next/prev letters.
+- It does not replace Orient by unique `|O_i|=1` signed outgoing letters.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not treat split fail as `UNDEFINED`.
+- It does not treat empty `O_next` or empty `O_prev` as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nm2slx axis-cover reverse fail face fail as this
+  oriented display.
+- It does not reprint nm2sl12 1-in 2-out split reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2oricyccz cyclic next/prev lex-smallest on the
+  two-axis opposite z-probes as this same-lock x-probe member.
+- It does not reprint nm2oricyclslx lex-largest reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orilef signed leftover-axis as this cyclic letter.
+- It does not reprint nm2orichz unsigned leftover-axis `+ℓ` as this letter.
+- It does not reprint nm2orionez lex-one reverse fail face hold on
+  z-probes as this x-probe display.
+- It does not reprint nm2chiralz lexicographic `o1,o2` as this letter.
+- It does not reprint the 1-axis same-lock two-site seed as this member.
+- It does not reprint the two-axis opposite seed as this member.
+- It does not score the y-probes or the z-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition. This is
+  not the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+two-axis same-lock seed process, cyclic next/prev lex-smallest orientation of
+the 1-in 2-out frame of `M` and `O` at `t+1`, and the reverse/face bits from
+that sign are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis same-lock seed `+e_1/+e_1` and `+e_2/+e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual |
+| split at `τ` | Theorem 1; fail at `A,D`, hold at `B,C` |
+| unique signed `m`, axis index `i`, cyclic `o_next`, `o_prev` | Theorem 1; `i=3` at `A`, `o_prev` fail at `A`; `i=1`, `o_next=+e_2`, `o_prev=−e_3` at `B`; `i=1`, `o_next=−e_2`, `o_prev=−e_3` at `C`; `i=3`, `o_prev` fail at `D` |
+| integer `det(m,o_next,o_prev)` | Theorem 1; fail, `−1`, `+1`, fail |
+| Orient at `τ` | Theorem 1; fail, `−1`, `+1`, fail |
+| reverse from oriented frame at `τ` | Theorem 2; `fail` |
+| face from oriented frame at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nm2slx axis-cover FAIL | not this oriented display |
+| leftover of nm2sl12 1-in 2-out split FAIL | not this oriented display |
+| leftover of nm2oricyclz opposite-z cyclic | not this oriented display |
+| leftover of nm2orilef signed leftover-axis | not this oriented display |
+| leftover of nm2orichz unsigned leftover `+ℓ` | not this oriented display |
+| leftover of nm2orionez lex-one | not this oriented display |
+| leftover of lex-largest cyclic next/prev | not this oriented display |
+| leftover of nm2oridetz unique `|O_i|=1` | not this oriented display |
+| leftover of nm2chiralz lexicographic `o1,o2` | not this oriented display |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or z-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis same-lock two-site seed | not this display |
+| leftover of the two-axis opposite seed | not this display |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| empty `O_next` or empty `O_prev` scored as `UNDEFINED` | refused; Orient fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: cyclic next/prev lex-smallest outgoing determinant orientation of the 1-in 2-out frame of `M` and `O` at `t+1` on the four x-probes of the two-axis same-lock seed, cyclic from `Axis(M)` with lex-smallest letters not lex-one, and reverse/face from that sign. |
+| V2 | Current main has no landed cyclic next/prev lex-smallest-frame reverse/face of timed `M` and `O` on these four x-probes of the two-axis same-lock seed. |
+| V3 | Orient reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the integer sign of `det(m,o_next,o_prev)` from cyclic lex-smallest outgoing letters at the same `t+1` cut, reverse fails, face fails, `Orient(B)=+1` while nm2oricyclslx lex-largest at `B` is `−1`, unsigned cyclic at `C` is `+1` while this Orient at `C` is `−1`, unique signed face fails, and z-probe face HOLDs while this face fails. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by unsigned leftover unit `+ℓ`, does not replace Orient by signed
+leftover-axis, does not replace Orient by nm2orionez lex-one, does not
+replace Orient by lex-largest cyclic, does not replace Orient by
+nm2oridetz unique `|O_i|=1`, does not replace Orient by nm2chiralz
+lexicographic `o1,o2`, does not replace Orient by nm2slx axis-cover, does
+not replace Orient by nm2sl12 1-in 2-out split, does not identify this
+display with nm2oricyccz, does not identify this display with
+nm2oricyclslx, does not identify this seed with the 1-axis
+same-lock two-site seed, and does not identify it with nmunopp union. No
+global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| nm2orichz unsigned leftover `+ℓ` | reuse leftover unit `+ℓ` in place of cyclic letters | unsigned leftover at `C` is `+e_2` with Orient `−1`, matching this sign at `C`; leftover reverse/face fail from fail at `A`/`D` and do not report cyclic columns | ATTEMPTED |
+| nm2orionez lex-one | reuse lex-smallest signed letter per Axis(`O`) in `e1<e2<e3` order | lex-one at `B` is `+1` and at `C` is `−1`, the same signs as this letter, from axis-order of `Axis(O)` not cyclic slots of `Axis(M)` | ATTEMPTED |
+| nm2oricyclslx lex-largest cyclic | reuse cyclic axes with lex-largest letters | lex-largest at `B` is `−1` and at `C` is `+1`; this letter at `B` is `+1` and at `C` is `−1` | ATTEMPTED |
+| nm2orilef signed leftover-axis | reuse `det(m,e_pair,o_ℓ)` requiring an opposite pair in `O` | leftover of `M={+e_2}` and `O={+e_1,+e_3}` fails while cyclic Orient is `+1`; y-probe leftover at `A` fails while cyclic at y-probe `A` is `−1` | ATTEMPTED |
+| nm2oridetz unique `|O_i|=1` | require a unique signed letter on each Axis(`O`) | mixed `O(B,τ)` has `|O ∩ {±e_3}|=2`, so unique-outgoing Orient fails at `B` while cyclic Orient is `+1` | ATTEMPTED |
+| nm2chiralz lexicographic `o1,o2` | reuse unsigned axis units of Axis(`O`) | unsigned axis units at `B` are `(e_2,e_3)` with Orient `+1`; at `C` unsigned cyclic `+e_2,+e_3` is `+1` while this Orient at `C` is `−1` | ATTEMPTED |
+| nm2slx axis-cover | reuse cover reverse fail and cover face fail on these x-probes | cover does not report `Orient(C)=−1`; Cover and split do not score handedness | ATTEMPTED |
+| nm2sl12 1-in 2-out split | reuse split reverse fail and split face fail | split face fails with this face, but split does not read `det(m,o_next,o_prev)` | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails because leftover at `B` is empty; leftover does not read cyclic letters | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_2}` and at `B` is `{e_2,e_3}`, nonempty unequal | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is `{e_2,e_3}` and at `B` is `{e_1}`, nonempty unequal | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `M` fails and of signed `O` fails; exist-opposite is a cross-probe boolean, not `det(m,o_next,o_prev)` | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence HOLDs at `C` and fails at `D`; on the opposite seed pair-presence face HOLDs because `O(D)={+e_1,−e_1}`; pair-presence does not report `Orient(C)=−1` | ATTEMPTED |
+| nm2oricyccz opposite-z cyclic | reuse opposite-seed z-probe Orient reverse hold and face hold | opposite z-probes and opposite seed; this letter is same-lock x-probes with reverse fail and face fail | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of signed incoming and cyclic lex-smallest outgoing | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(B,τ)` remains a set; `o_prev` is `+e_3` and Orient is `+1` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; none of these four probes is 2-in 1-out | ATTEMPTED |
+| empty `O_prev` as `UNDEFINED` | treat missing cyclic slice as unformed | empty `O_prev` is Orient fail, not UNDEFINED; x-probe `A` is the witness | ATTEMPTED |
+| 1-axis same-lock two-site seed | reuse first-pair x-probe cover reverse hold | different seed; second pair is a new seed, not a formed child; 1-axis cover reverse HOLDs while this reverse fails | ATTEMPTED |
+| y-probe Orient | score the four y-probes on this seed | y-probe cyclic reverse fails from `−1,+1`; this letter is the four x-probes with Orient fail at `A` | ATTEMPTED |
+| z-probe Orient | score the four z-probes on this seed | z-probe cyclic face HOLDs; this letter is the four x-probes with face fail | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores the cyclic next/prev lex-smallest oriented frame of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports Orient fail, `+1`, `−1`, fail | ATTEMPTED |
+| two-axis opposite seed | reuse `+e_1/−e_1` and `+e_2/−e_2` | different seed; this member is two disjoint same-lock pairs; opposite `O(D)` is `{+e_1,−e_1}` | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum; mixed `O(B)` sums to `+e_2` while `o_prev` is `+e_3` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with unsigned leftover unit `+ℓ`, missing
+identification of Orient with signed leftover-axis, missing identification of
+Orient with nm2orionez lex-one, missing identification of Orient with
+lex-largest cyclic, missing identification of Orient with nm2oridetz unique
+`|O_i|=1`, missing identification of Orient with nm2chiralz lexicographic
+`o1,o2`, missing identification of Orient with nm2slx axis-cover, missing
+identification of Orient with nm2sl12 1-in 2-out split, missing
+identification of this seed with the 1-axis same-lock two-site seed, missing
+identification of this seed with the two-axis opposite seed, and missing
+Record identification of Orient reverse are distinct open premises. This
+note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint same-lock seed pairs `+e_1/+e_1` and
+`+e_2/+e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, unique signed `m` when split HOLDs, cyclic
+next/prev axes from `Axis(M)`, lex-smallest signed letters on those axes
+under `+e < −e`, integer determinant sign, empty cyclic slice as Orient
+fail not `UNDEFINED`, split fail as Orient fail not `UNDEFINED`, four
+x-probes with formed-child `A`, second pair as a new seed not a formed
+child, and mixed remains a set are declared. No uniqueness of outgoing
+locks, no six-neighbor lock union as the scored object, no lock-count
+clock, no global later T, no formation attachment from already-recorded
+six-neighbor locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+Orient `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | unique signed incoming letter, cyclic next/prev axes from `Axis(M)`, lex-smallest outgoing letters on those axes among `{e_1,e_2,e_3}` | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four Orient reports, reverse/face from equal `±1` signs | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for Orient reverse/face, a
+formation-rate rule, and a physical selector among 1-in 2-out frames. None
+is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Orient reverse fail is only cover reverse or only split
+reverse; unsigned leftover `+ℓ` already answers handedness because reverse
+and face bits agree; lex-one already answers handedness; leftover-empty
+fail already answers reverse; leftover of `M` alone already answers
+reverse; leftover of `O` alone already answers reverse; exist-opposite of
+signed `O` already answers reverse; pair-presence already answers face;
+signed leftover-axis already displayed the letter on these x-probes because
+the reverse/face bits agree; nm2oricyclz already displayed the letter;
+the second pair is only the formed child of the 1-axis seed; unique
+outgoing letters should be required; y-probe cyclic reverse fail already
+displayed the letter; and z-probe cyclic face HOLD already displayed the
+letter.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Orient reverse fails because `Orient(A)=fail` and
+`Orient(B)=+1`, while Orient face fails because `Orient(C)=−1` and
+`Orient(D)=fail`. Cover and split fail reverse and face on this member and
+do not score that cyclic `o_prev` at `B` is `+e_3` with `Orient(B)=+1`.
+Unsigned leftover `+ℓ` at `C` is `+e_2` with unsigned Orient `−1`, matching
+this sign at `C`. Lex-one at `B` is `+1` and at `C` is `−1`, the same
+signs as this cyclic letter from axis-order of `Axis(O)`. Lex-largest
+cyclic at `B` is `−1` and at `C` is `+1`. Signed leftover-axis at `C` is
+`+1` while this Orient at `C` is `−1`; leftover of `M={+e_2}` and
+`O={+e_1,+e_3}` fails while cyclic Orient is `+1`, and y-probe leftover
+at `A` fails while cyclic at y-probe `A` is `−1`. Presence of an opposite
+pair in `O` HOLDs at `C` and fails at `D`; on the two-axis opposite seed
+pair-presence face HOLDs because `O(D)={+e_1,−e_1}`. Pair-presence is a
+boolean, not `det(m,o_next,o_prev)`. Leftover of `M` alone at `A` is
+`{e_1,e_2}` and at `B` is `{e_2,e_3}`: nonempty unequal. Leftover of `O`
+alone at `A` is `{e_2,e_3}` and at `B` is `{e_1}`. Exist-opposite reverse
+of signed `O` fails with this reverse, but exist-opposite is a
+cross-probe boolean, not `det(m,o_next,o_prev)`. Unique outgoing letters
+would assign `UNDEFINED` at mixed `O(B)`; unique `|O_i|=1` Orient fails
+at `B` while this Orient is `+1`. The second pair is a new seed, not a
+formed child: `(0,0,1)` is recorded at tick 0 with lock `+e_2`, whereas
+the 1-axis child forms at tick 1 with lock `+e_3`. Y-probe cyclic reverse
+fails from `−1,+1`; this letter is the four x-probes with Orient fail at
+`A`. Z-probe cyclic face HOLDs; this letter is the four x-probes with
+face fail. nm2oricyccz used the opposite seed and the z-probes with
+reverse hold. Reverse oriented frame is HOLD iff equal `±1` signs at `A`
+and at `B`, not leftover of nm2oricyclslx lex-largest.
+
+### N8 — cross-cycle echo
+
+nm2slx cover on this two-axis same-lock seed reported cover fail at `A`
+and at `D`, reverse fail, and face fail. nm2sl12 1-in 2-out split on the
+same seed reported split fail at `A` and at `D`, reverse fail, and face
+fail. nm2oricyccz cyclic next/prev lex-smallest on the two-axis opposite
+z-probes is a different seed and a different probe direction, with reverse
+hold and face hold. nm2oricyclslx lex-largest on these same x-probes
+reports Orient fail, `−1`, `+1`, fail. nm2orichz
+unsigned leftover-axis `+ℓ` on z-probes reported reverse hold and face
+fail, using leftover unit `+ℓ` rather than cyclic letters. nm2orionez
+lex-one on z-probes reported reverse fail and face hold. The four
+z-probes of this same seed under cyclic lex-smallest report reverse fail
+and face HOLD. The four y-probes of this same seed report cyclic reverse
+fail and face fail. This note is not those displays: it reports cyclic
+lex-smallest Orient of the 1-in 2-out frame of `M` and `O`
+at `τ=t+1` on the two-axis same-lock seed x-probes, with `t(A)=2`,
+`t(B)=1`, `t(C)=3`, and `t(D)=2`, `Orient(A)=fail`, `Orient(B)=+1`,
+`Orient(C)=−1`, `Orient(D)=fail`, reverse fail, and face fail. Cover and
+split do not score handedness.
+
+**Gate disposition:** PASS for the cyclic next/prev lex-smallest-frame
+`t+1` reverse/face reports above. FAIL / DO NOT SHIP for “the predicate
+equals the named sign,” “the predicate equals the unique singleton lock
+vector,” “the predicate equals six-neighbor lock union,” “the predicate
+equals leftover-empty fail,” “the predicate equals leftover of `M`
+alone,” “the predicate equals leftover of `O` alone,” “the predicate
+equals exist-opposite HOLD,” “the predicate equals opposite-pair presence
+in `O`,” “the predicate equals unsigned leftover unit `+ℓ`,” “the
+predicate equals signed leftover-axis,” “the predicate equals nm2orionez
+lex-one,” “the predicate equals lex-largest cyclic next/prev,” “the
+predicate equals nm2oridetz unique `|O_i|=1`,” “the predicate equals
+nm2chiralz lexicographic `o1,o2` HOLD,” “the predicate equals nm2slx
+axis-cover FAIL,” “the predicate equals nm2sl12 1-in 2-out split FAIL,”
+“the predicate equals nm2oricyclz,” “the predicate equals the 1-axis
+same-lock two-site seed,” “the predicate equals the two-axis opposite
+seed,” “the predicate equals nmunopp union,” “bits are Admissibility,”
+“split fail is UNDEFINED,” “empty `O_prev` is UNDEFINED,” “reverse
+oriented frame holds,” or “face oriented frame holds.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis same-lock
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`,
+reports split of the pair, reports the unique signed incoming letter, the
+axis index `i`, and the cyclic lex-smallest outgoing letters `o_next` and
+`o_prev`, reports the integer determinant and its sign, lists new records
+in `B_3(0)` between `t` and `t+1` that meet a probe's six-neighbors, and
+checks Theorems 1--3. It also checks that Orient is fail, `+1`, `−1`, fail
+at `A,B,C,D`, that reverse fails, that face fails, that unsigned leftover
+Orient at `C` is `−1` matching this Orient at `C`, that lex-largest cyclic
+at `B` is `−1` while this Orient at `B` is `+1`, that lex-one at `B` is
+`+1` matching this Orient at `B` from axis-order, that split fail is
+Orient fail not `UNDEFINED`, that empty `O_prev` is Orient fail not
+`UNDEFINED`, that the 1-axis same-lock two-site seed is a different
+member, that the two-axis opposite seed is a different member, that
+leftover-empty fail is a different reverse, that leftover of `M` alone
+and leftover of `O` alone are different objects, that mixed sets remain
+sets, that unique-letter Orient is `UNDEFINED` at mixed `O`, that the
+construction does not sum, that a formation member from already-recorded
+six-neighbor locks is not attached, that the second pair is a new seed not
+a formed child, that the y-probes of this seed give cyclic reverse fail
+from `−1,+1`, that the z-probes of this seed give cyclic face HOLD, and
+that the display is not the two-tick lock-count clock composition. No
+runner cache is written.

--- a/logs/runner-cache/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 1c3e0a251c1de155d3e8f3a08ba857e165a3079490a8c749a4f318fad7ffad3a
+input_fingerprint_sha256: 84a1b2a6ac60feb152e1602dff7ec0466079e97864c94bd1ad094a7a9ab632b5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+cyclic lex-smallest Orient reverse/face at t+1 on two-axis same-lock x-probes
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Cyclic lex-smallest Orient at t+1 on the four x-probes of the two-axis same-lock seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+A t=2 M={−e_3} O={+e_1} split=fail i=3 o_next=+e_1 o_prev=fail det=fail Orient=fail
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} split=hold i=1 o_next=+e_2 o_prev=+e_3 det=+1 Orient=+1
+C t=3 M={+e_1} O={−e_2, +e_3, −e_3} split=hold i=1 o_next=−e_2 o_prev=+e_3 det=−1 Orient=−1
+D t=2 M={−e_3} O={+e_1} split=fail i=3 o_next=+e_1 o_prev=fail det=fail Orient=fail
+Orient reverse=fail face=fail
+split reverse=fail face=fail
+cover reverse=fail face=fail
+per_element: unique signed incoming letter, cyclic next/prev axes from Axis(M), and lex-smallest outgoing letters on those axes at a probe's t+1
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four Orient reports, reverse/face from equal +/-1 signs
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-O-split  ({'A': ('{−e_3}', 'fail'), 'B': ('{+e_1}', 'hold'), 'C': ('{+e_1}', 'hold'), 'D': ('{−e_3}', 'fail')})
+PASS: theorem1-Orient  ({'A': 'fail', 'B': '+1', 'C': '−1', 'D': 'fail'})
+PASS: theorem1-mixed-O-lex-smallest-prev
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((2, 0, 0),), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((2, -1, 0), (2, 0, 1), (2, 0, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-A-is-not-seed
+PASS: theorem2-reverse-orient-fail
+PASS: theorem3-face-orient-fail
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-cover-reverse-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-and-pair-presence-differ
+PASS: mutation-unsigned-leftover-differs-at-C
+PASS: mutation-lex-one-matches-signs-lex-largest-cyclic-differs
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-y-probes-or-z-probes-or-z-symmetric-or-perp
+PASS: not-opposite-or-one-axis-or-y-symmetric-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-Orient
+PASS: note-reports-new-neighbors
+PASS: note-reports-orient-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split-or-lex-one
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: orient-fail-not-split-hold
+TOTAL: PASS=57 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1795 @@
+#!/usr/bin/env python3
+"""Cyclic lex-smallest Orient at t+1 of the 1-in 2-out frame.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint same-lock pairs: origin locks +e_1, (0,1,0) locks +e_1,
+(0,0,1) locks +e_2, (0,1,1) locks +e_2. Same process and x-probes as
+nm2slpx. Perp-step incoming lock. M, O, split as nm2sl12. Orient as
+nm2oricyccz. Unformed => UNDEFINED. Split HOLDs iff cover HOLDs and
+|Axis(M)|=1. Split HOLD required. When split HOLDs, m is the unique vector
+in M. Let i in {1,2,3} be the axis index of m. e_next = e_{i+1} with
+3+1->1. e_prev = e_{i-1} with 1-1->3. O_next = O intersect {+/-e_next},
+O_prev = O intersect {+/-e_prev}. If either empty, Orient fails, not
+UNDEFINED. Order +e < -e. o_next is the lex-smallest vector in O_next
+(hence +e if both signs). o_prev likewise. Orient is the sign of the
+integer determinant of columns m, o_next, o_prev. If split fails, Orient
+fails, not UNDEFINED. Reverse HOLDs iff Orient(A)=Orient(B) both +/-1.
+Face on C,D. Uniqueness of O is not required. Occupancy of sites is not
+used. No larger host. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+YZ: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+    (E3, E2),
+    (YZ, E2),
+)
+ONE_AXIS_SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+TWO_AXIS_OPPOSITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (YZ, NEG_E2),
+)
+NSOPP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Cyclic lex-smallest Orient at t+1 on the four x-probes of the two-axis "
+    "same-lock seed, and reverse/face from that, are reported. Displayed, not "
+    "adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def letter_display(value: Point | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple):
+        raise TypeError(f"letter is not a lock or fail: {value!r}")
+    return LOCK_NAME[value]
+
+
+def index_display(value: int | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, int):
+        raise TypeError(f"axis index is not an index or fail: {value!r}")
+    return str(value)
+
+
+def det_display(value: int | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == -1:
+        return "−1"
+    if value == 1:
+        return "+1"
+    if isinstance(value, int):
+        return str(value)
+    raise TypeError(f"det is not an integer or fail: {value!r}")
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SAME_LOCK_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def axis_index_i(signed_m: Point | str) -> int | str:
+    """Axis index i in {1,2,3} of unique m. Fail if m is not unique."""
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    axis = axis_of_letter(signed_m)
+    if axis not in AXES:
+        return "fail"
+    return AXES.index(axis) + 1
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    """e_next, e_prev cyclic from Axis(m). 3+1->1 and 1-1->3."""
+    axis = axis_of_letter(signed_m)
+    if axis not in AXES:
+        return "fail"
+    i = AXES.index(axis)
+    return AXES[(i + 1) % 3], AXES[(i - 1) % 3]
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-largest signed letter in O intersect {+/-axis}. Order +e < -e."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-smallest signed letter in O intersect {+/-axis}. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def leftover_signed(
+    signed_m: Point, pair_unit: Point, outgoing: Outgoing
+) -> Point | str:
+    """Signed O vector on leftover axis. Fail if |O_l| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axis = leftover_unit(signed_m, pair_unit)
+    if axis == "fail" or not isinstance(axis, tuple):
+        return "fail"
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = tuple(vec for vec in (axis, negative) if vec in outgoing)
+    if len(occupied) != 1:
+        return "fail"
+    return occupied[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negative)
+    return picked[0], picked[1]
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def sign_of_det(col1: Point, col2: Point, col3: Point) -> OrientVal:
+    det = integer_det_columns(col1, col2, col3)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_signed_letter(
+    incoming: Incoming, outgoing: Outgoing, axis: Point, *, largest: bool
+) -> Point | str:
+    """Signed cyclic letter on one cyclic axis. Independent of split."""
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    return picker(outgoing, axis)
+
+
+def cyclic_next_prev(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = False
+) -> tuple[Point, Point] | str:
+    """(o_next, o_prev). Fail if either cyclic slice is empty."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    o_next = cyclic_signed_letter(incoming, outgoing, units[0], largest=largest)
+    o_prev = cyclic_signed_letter(incoming, outgoing, units[1], largest=largest)
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lex-one signed outgoing orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = lex_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return sign_of_det(signed_m, plane[0], plane[1])
+
+
+def unique_outgoing_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Unique |O_i|=1 signed outgoing orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return sign_of_det(signed_m, plane[0], plane[1])
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Signed leftover-axis orientation (nm2orilef). Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail" or not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_signed(signed_m, pair, outgoing)
+    if leftover == UNDEFINED:
+        return UNDEFINED
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    return sign_of_det(signed_m, pair, leftover)
+
+
+def unsigned_leftover_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Unsigned leftover +l orientation (nm2orichz). Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail" or not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    return sign_of_det(signed_m, pair, leftover)
+
+
+def cyclic_lex_largest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Cyclic next/prev with lex-largest letters. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_next_prev(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return sign_of_det(signed_m, plane[0], plane[1])
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-smallest cyclic letters."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_next_prev(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return sign_of_det(signed_m, plane[0], plane[1])
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Reverse HOLDs iff Orient(A)=Orient(B) both +/-1."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Face HOLDs iff Orient(C)=Orient(D) both +/-1."""
+    return pair_orient(orient_c, orient_d)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("cyclic lex-smallest Orient reverse/face at t+1 on two-axis same-lock x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != z_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == YZ
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E1, NEG_E2, NEG_E3) == 1
+        and integer_det_columns(E2, E3, E1) == 1
+        and integer_det_columns(E3, NEG_E1, NEG_E2) == 1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E1}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E2, E3})) == "fail"
+        and frame_orient(frozenset({E1}), frozenset({E2})) == "fail"
+        and frame_orient(frozenset({NEG_E3}), frozenset({E1})) == "fail"
+        and frame_orient(frozenset({E1, E2}), frozenset({E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and leftover_pair_orient(frozenset({E2}), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == 1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and lex_frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and cyclic_lex_largest_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == -1
+        and frame_orient(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3})) == -1
+        and lex_frame_orient(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == -1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1
+        and lex_smallest_on_axis(frozenset({E1, NEG_E1}), E1) == E1
+        and cyclic_units(E1) == (E2, E3)
+        and cyclic_units(E2) == (E3, E1)
+        and cyclic_units(E3) == (E1, E2)
+        and cyclic_units(NEG_E3) == (E1, E2),
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(ONE_AXIS_SAME_LOCK_SEEDS)
+    opp_ticks, opp_locks, opp_seeds = form(TWO_AXIS_OPPOSITE_SEEDS)
+    nsopp_ticks, nsopp_locks, nsopp_seeds = form(NSOPP_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    tau0: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m: dict[str, Point | str] = {}
+    index_i: dict[str, int | str] = {}
+    units: dict[str, tuple[Point, Point] | str] = {}
+    o_next: dict[str, Point | str] = {}
+    o_prev: dict[str, Point | str] = {}
+    plane: dict[str, tuple[Point, Point] | str] = {}
+    det: dict[str, int | str] = {}
+    lex: dict[str, OrientVal] = {}
+    unique_o: dict[str, OrientVal] = {}
+    leftover_o: dict[str, OrientVal] = {}
+    unsigned_o: dict[str, OrientVal] = {}
+    largest: dict[str, OrientVal] = {}
+    pair: dict[str, Point | str] = {}
+    pair_present: dict[str, str] = {}
+    orient: dict[str, OrientVal] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1 = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1, ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1, ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m[name] = unique_signed_m(m1[name])
+        index_i[name] = axis_index_i(signed_m[name])
+        if isinstance(signed_m[name], tuple):
+            units[name] = cyclic_units(signed_m[name])
+        else:
+            units[name] = "fail"
+        if isinstance(units[name], tuple):
+            o_next[name] = lex_smallest_on_axis(o1[name], units[name][0])
+            o_prev[name] = lex_smallest_on_axis(o1[name], units[name][1])
+        else:
+            o_next[name] = "fail"
+            o_prev[name] = "fail"
+        plane[name] = cyclic_next_prev(m1[name], o1[name], largest=False)
+        if isinstance(signed_m[name], tuple) and isinstance(plane[name], tuple):
+            det[name] = integer_det_columns(
+                signed_m[name], plane[name][0], plane[name][1]
+            )
+        else:
+            det[name] = "fail"
+        pair[name] = opposite_pair_unit(o1[name])
+        pair_present[name] = has_opposite_pair(o1[name])
+        lex[name] = lex_frame_orient(m1[name], o1[name])
+        unique_o[name] = unique_outgoing_orient(m1[name], o1[name])
+        leftover_o[name] = leftover_pair_orient(m1[name], o1[name])
+        unsigned_o[name] = unsigned_leftover_orient(m1[name], o1[name])
+        largest[name] = cyclic_lex_largest_orient(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"split={split[name]} "
+            f"i={index_display(index_i[name])} "
+            f"o_next={letter_display(o_next[name])} "
+            f"o_prev={letter_display(o_prev[name])} "
+            f"det={det_display(det[name])} "
+            f"Orient={orient_display(orient[name])}"
+        )
+
+    reverse = reverse_report(orient["A"], orient["B"])
+    face = face_report(orient["C"], orient["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    lex_reverse = reverse_report(lex["A"], lex["B"])
+    lex_face = face_report(lex["C"], lex["D"])
+    leftover_orient_reverse = reverse_report(leftover_o["A"], leftover_o["B"])
+    leftover_orient_face = face_report(leftover_o["C"], leftover_o["D"])
+    unsigned_reverse = reverse_report(unsigned_o["A"], unsigned_o["B"])
+    unsigned_face = face_report(unsigned_o["C"], unsigned_o["D"])
+    largest_reverse = reverse_report(largest["A"], largest["B"])
+    largest_face = face_report(largest["C"], largest["D"])
+    unique_reverse = reverse_report(unique_o["A"], unique_o["B"])
+    unique_face = face_report(unique_o["C"], unique_o["D"])
+    unique_letter_o_b = frame_orient(unique_letter(m1["B"]), unique_letter(o1["B"]))
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_reverse = pair_bit(one_cover["A"], one_cover["B"])
+    one_split_reverse = pair_bit(one_split["A"], one_split["B"])
+    one_orient_reverse = reverse_report(one_orient["A"], one_orient["B"])
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = face_report(one_orient["C"], one_orient["D"])
+    print(f"Orient reverse={reverse} face={face}")
+    print(f"split reverse={split_reverse} face={split_face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: unique signed incoming letter, cyclic next/prev axes from Axis(M), "
+        "and lex-smallest outgoing letters on those axes at a probe's t+1"
+    )
+    print("per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites")
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: four Orient reports, reverse/face from equal +/-1 signs")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    seed_partner_parallel_blocked = all(
+        ticks.get(add(E2, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(YZ, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and seed_partner_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[ORIGIN] == 0
+        and ticks[E2] == 0
+        and ticks[E3] == 0
+        and ticks[YZ] == 0
+        and locks[ORIGIN] == {E1}
+        and locks[E2] == {E1}
+        and locks[E3] == {E2}
+        and locks[YZ] == {E2}
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["A"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["A"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["C"], 2, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 2, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["D"], 1, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 1, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-split",
+        m1["A"] == frozenset({NEG_E3})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({NEG_E3})
+        and o1["A"] == frozenset({E1})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({NEG_E2, E3, NEG_E3})
+        and o1["D"] == frozenset({E1})
+        and split["A"] == "fail"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and cover["A"] == "fail"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail",
+        str({name: (lockset_display(m1[name]), split[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Orient",
+        signed_m["A"] == NEG_E3
+        and signed_m["B"] == E1
+        and signed_m["C"] == E1
+        and signed_m["D"] == NEG_E3
+        and index_i["A"] == 3
+        and index_i["B"] == 1
+        and index_i["C"] == 1
+        and index_i["D"] == 3
+        and o_next["A"] == E1
+        and o_prev["A"] == "fail"
+        and o_next["B"] == E2
+        and o_prev["B"] == E3
+        and o_next["C"] == NEG_E2
+        and o_prev["C"] == E3
+        and o_next["D"] == E1
+        and o_prev["D"] == "fail"
+        and det["A"] == "fail"
+        and det["B"] == 1
+        and det["C"] == -1
+        and det["D"] == "fail"
+        and orient["A"] == "fail"
+        and orient["B"] == 1
+        and orient["C"] == -1
+        and orient["D"] == "fail"
+        and plane["B"] == (E2, E3)
+        and plane["C"] == (NEG_E2, E3)
+        and plane["A"] == "fail",
+        str({name: orient_display(orient[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-O-lex-smallest-prev",
+        isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(m1["B"]) == frozenset({E1})
+        and o_prev["B"] == E3
+        and E3 in o1["B"]
+        and NEG_E3 in o1["B"]
+        and unique_o["B"] == "fail"
+        and orient["B"] == 1,
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset()
+        and all(frame_orient(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0),)
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and PROBES["A"] not in seed_map
+        and ticks[E1] == 2
+        and locks[E1] == {NEG_E3}
+        and Y_PROBES["A"] != PROBES["A"]
+        and Z_PROBES["A"] != PROBES["A"]
+        and Y_PROBES["A"] in seed_map
+        and Z_PROBES["A"] in seed_map,
+    )
+    checks.check(
+        "theorem2-reverse-orient-fail",
+        reverse == "fail"
+        and orient["A"] == "fail"
+        and orient["B"] == 1
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and split_reverse == "fail"
+        and cover_reverse == "fail",
+    )
+    checks.check(
+        "theorem3-face-orient-fail",
+        face == "fail"
+        and orient["C"] == -1
+        and orient["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and split_face == "fail"
+        and cover_face == "fail",
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split["C"] == "hold"
+        and cover["C"] == "hold"
+        and orient["C"] == -1
+        and unsigned_o["C"] == -1
+        and lex["C"] == -1
+        and largest["C"] == 1
+        and leftover_o["C"] == 1
+        and orient["C"] != leftover_o["C"]
+        and orient["C"] != largest["C"]
+        and integer_det_columns(E1, E2, E3) == 1
+        and orient["C"] != 1
+        and face == "fail"
+        and split_face == "fail",
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({NEG_E3}), frozenset({E1})) == "fail"
+        and axis_split(frozenset({NEG_E3}), frozenset({E1})) == "fail"
+        and o_next["A"] == E1
+        and o_prev["A"] == "fail"
+        and two_one["A"] == "fail"
+        and two_one["D"] == "fail"
+        and one_orient_reverse == "fail"
+        and one_split_reverse == "fail",
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-reverse-hold",
+        one_cover_reverse == "hold"
+        and one_split_reverse == "fail"
+        and one_orient_reverse == "fail"
+        and reverse == "fail"
+        and cover_reverse == "fail"
+        and one_m1["A"] != m1["A"]
+        and one_ticks[PROBES["A"]] == 3
+        and ticks[PROBES["A"]] == 2,
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset({E2})
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2}),
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m["A"] == frozenset({E1, E2})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_o["A"] == frozenset({E2, E3})
+        and lx_o["B"] == frozenset({E1})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-exist-opposite-and-pair-presence-differ",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "fail"
+        and o_exist_face == "fail"
+        and pair_present["A"] == "fail"
+        and pair_present["B"] == "hold"
+        and pair_present["C"] == "hold"
+        and pair_present["D"] == "fail"
+        and pair_bit(pair_present["C"], pair_present["D"]) == "fail"
+        and leftover_o["A"] == "fail"
+        and leftover_o["B"] == -1
+        and leftover_o["C"] == 1
+        and leftover_orient_reverse == "fail"
+        and leftover_orient_face == "fail"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "mutation-unsigned-leftover-differs-at-C",
+        unsigned_o["A"] == "fail"
+        and unsigned_o["B"] == -1
+        and unsigned_o["C"] == -1
+        and unsigned_o["D"] == "fail"
+        and leftover_o["C"] == 1
+        and leftover_o["C"] != orient["C"]
+        and unsigned_reverse == "fail"
+        and unsigned_face == "fail",
+    )
+    checks.check(
+        "mutation-lex-one-matches-signs-lex-largest-cyclic-differs",
+        lex["A"] == "fail"
+        and lex["B"] == 1
+        and lex["C"] == -1
+        and lex["D"] == "fail"
+        and lex["B"] == orient["B"]
+        and lex["C"] == orient["C"]
+        and largest["B"] == -1
+        and largest["C"] == 1
+        and largest["B"] != orient["B"]
+        and largest["C"] != orient["C"]
+        and unique_o["B"] == "fail"
+        and unique_o["C"] == "fail"
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter_o_b == UNDEFINED
+        and lex_reverse == "fail"
+        and lex_face == "fail"
+        and largest_reverse == "fail"
+        and largest_face == "fail"
+        and unique_reverse == "fail"
+        and unique_face == "fail",
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["B"], frozenset)
+        and sum_of_set(m1["B"]) == E1
+        and sum_of_set(o1["B"]) == E2
+        and axis_o["B"] == frozenset({E2, E3})
+        and o_next["B"] == E2
+        and o_prev["B"] == E3
+        and pair["B"] == E3,
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E3 in m1["A"]
+        and NEG_E3 not in o1["A"]
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        YZ in seed_map
+        and seed_map[YZ] == E2
+        and ticks[YZ] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and one_locks[E3] == {E3}
+        and YZ not in new_meet["A"],
+    )
+    y_m1, y_o1 = probe_sides(Y_PROBES, ticks, locks, seed_map)
+    y_split = {name: axis_split(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_orient = {name: frame_orient(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_leftover = {
+        name: leftover_pair_orient(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    y_reverse = reverse_report(y_orient["A"], y_orient["B"])
+    y_face = face_report(y_orient["C"], y_orient["D"])
+    z_m1, z_o1 = probe_sides(Z_PROBES, ticks, locks, seed_map)
+    z_orient = {name: frame_orient(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")}
+    z_leftover = {
+        name: leftover_pair_orient(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    z_reverse = reverse_report(z_orient["A"], z_orient["B"])
+    z_face = face_report(z_orient["C"], z_orient["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    perp_orient = {
+        name: frame_orient(perp_m1[name], perp_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    perp_reverse = reverse_report(perp_orient["A"], perp_orient["B"])
+    perp_face = face_report(perp_orient["C"], perp_orient["D"])
+    opp_m1, opp_o1 = probe_sides(PROBES, opp_ticks, opp_locks, opp_seeds)
+    nsopp_m1, nsopp_o1 = probe_sides(PROBES, nsopp_ticks, nsopp_locks, nsopp_seeds)
+    opp_pair_d = has_opposite_pair(opp_o1["D"])
+    opp_face_pair = pair_bit(has_opposite_pair(opp_o1["C"]), opp_pair_d)
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-y-probes-or-z-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SAME_LOCK_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SAME_LOCK_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites
+        and y_m1["A"] != m1["A"]
+        and y_split["A"] == "hold"
+        and split["A"] == "fail"
+        and y_orient["A"] == -1
+        and y_leftover["A"] == "fail"
+        and y_orient["A"] != y_leftover["A"]
+        and y_orient["C"] == 1
+        and y_face == "fail"
+        and y_reverse == "fail"
+        and y_orient["A"] == -1
+        and orient["A"] == "fail"
+        and y_split["A"] == "hold"
+        and z_reverse == "fail"
+        and z_face == "hold"
+        and face != z_face
+        and z_orient["A"] == "fail"
+        and z_orient["B"] == 1
+        and z_orient["C"] == -1
+        and z_orient["D"] == -1
+        and z_leftover["C"] == -1
+        and z_orient["B"] == 1
+        and z_leftover["B"] == -1
+        and z_orient["B"] != z_leftover["B"]
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and perp_reverse == "fail"
+        and perp_face == "hold"
+        and reverse == "fail"
+        and face == "fail",
+    )
+    checks.check(
+        "not-opposite-or-one-axis-or-y-symmetric-seed",
+        TWO_AXIS_SAME_LOCK_SEEDS != TWO_AXIS_OPPOSITE_SEEDS
+        and TWO_AXIS_SAME_LOCK_SEEDS != ONE_AXIS_SAME_LOCK_SEEDS
+        and TWO_AXIS_SAME_LOCK_SEEDS != NSOPP_SEEDS
+        and TWO_AXIS_SAME_LOCK_SEEDS != Y_SYMMETRIC_SEEDS
+        and opp_o1["D"] == frozenset({E1, NEG_E1})
+        and o1["D"] == frozenset({E1})
+        and opp_pair_d == "hold"
+        and pair_present["D"] == "fail"
+        and opp_face_pair == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) == "fail"
+        and one_m1["A"] != m1["A"]
+        and nsopp_m1["A"] != m1["A"]
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-Orient",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {−e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {−e_3}" in note
+        and "O(A, τ) = {+e_1}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {−e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1}" in note
+        and "split(A) = fail" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = fail" in note
+        and "i(A) = 3" in note
+        and "o_next(A) = +e_1" in note
+        and "o_prev(A) = fail" in note
+        and "det(A) = fail" in note
+        and "Orient(A) = fail" in note
+        and "i(B) = 1" in note
+        and "o_next(B) = +e_2" in note
+        and "o_prev(B) = +e_3" in note
+        and "det(B) = 1" in note
+        and "Orient(B) = +1" in note
+        and "i(C) = 1" in note
+        and "o_next(C) = −e_2" in note
+        and "o_prev(C) = +e_3" in note
+        and "det(C) = -1" in note
+        and "Orient(C) = −1" in note
+        and "i(D) = 3" in note
+        and "o_next(D) = +e_1" in note
+        and "o_prev(D) = fail" in note
+        and "det(D) = fail" in note
+        and "Orient(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (2, 0, 0)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-orient-reverse-face",
+        "Reverse oriented frame at τ: fail" in note
+        and "Face oriented frame at τ: fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split-or-lex-one",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2slx axis-cover" in normalized_note
+        and "not leftover of nm2sl12 1-in 2-out split" in normalized_note
+        and "not leftover of nm2oricyccz" in normalized_note
+        and "not leftover of nm2oricyclslx" in normalized_note
+        and "not leftover of nm2orionez" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "A is not a seed" in note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse oriented frame at τ: fail" in note
+        and "Face oriented frame at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_SAME_LOCK_XPROBE_CYCLIC_NEXT_PREV_LEX_SMALLEST_DET_ORIENTATION_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "cyclic_next_prev" in defined_fns
+        and "lex_largest_on_axis" in defined_fns
+        and "lex_smallest_on_axis" in defined_fns
+        and "cyclic_units" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "reverse_report" in defined_fns
+        and "face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "orient-fail-not-split-hold",
+        reverse == "fail"
+        and face == "fail"
+        and split_reverse == "fail"
+        and cover_reverse == "fail"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and pair_bit(pair_present["C"], pair_present["D"]) == "fail"
+        and opp_face_pair == "hold"
+        and orient["C"] == -1
+        and unsigned_o["C"] == -1
+        and lex["C"] == -1
+        and largest["C"] == 1
+        and unique_o["B"] == "fail"
+        and leftover_o["C"] == 1
+        and leftover_o["C"] != orient["C"]
+        and y_reverse == "fail"
+        and z_face == "hold"
+        and o_exist_reverse == "fail"
+        and o_exist_face == "fail",
+    )
+    _ = (
+        o0,
+        unique_letter_o_b,
+        one_cover_face,
+        one_split_face,
+        one_orient_face,
+        unsigned_reverse,
+        unsigned_face,
+        leftover_orient_reverse,
+        leftover_orient_face,
+        largest_reverse,
+        largest_face,
+        z_o1,
+        perp_o1,
+        nsopp_o1,
+        opp_m1,
+        y_leftover,
+        z_leftover,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Displayed member check. Cyclic smallest same-lock x: reverse fails, face fails. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_same_lock_xprobe_cyclic_next_prev_lex_smallest_det_orientation_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.