### PR TITLE
feat(nm2cycfrmhol): cyclic-frame holonomy around the unit square at t+1 on two-axis opposite z: reverse HOLD, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,966 @@
+---
+claim_id: two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Cyclic-frame holonomy around the unit square at t+1 on the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py
+---
+
+# Cyclic-Frame Holonomy Around The Unit Square At t+1 Reverse And Face On The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** cyclic-frame holonomy around the unit square of simultaneous
+earliest incoming set `M` and outgoing dual `O` at each vertex's `τ=t+1`,
+and reverse/face from that holonomy, on the two-axis opposite seed in
+`B_3(0)={n:n·n<=9}`. `F` and Orient as nm2cycfrmz. Reverse square
+`A=(0,0,1)`, `D=(1,0,1)`, `B=(1,1,1)`, `E=(0,1,1)`. Face square
+`C=(0,0,2)`, `C1=(1,0,2)`, `C2=(1,1,2)`, `C3=(0,1,2)` that lie in
+`B_3(0)`. Drop any vertex outside `B_3(0)` as fail, not `UNDEFINED`. Let
+`t(q)` be the formation tick of vertex `q`. Let `τ(q)=t(q)+1`. `M(q,τ)`
+is the set of earliest incoming nearest-neighbor steps at `q` using only
+records with tick `<= τ`. Seeds are a singleton seed letter. `O(q,τ)` is
+the outgoing dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}` such that
+`q+e` is formed and `e` is in `M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`.
+Empty `O` is empty, not `UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals
+`{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). When split HOLDs, `m` is unique in
+`M`. Let `i` in `{1,2,3}` be the axis index of `m`. `e_next = e_{i+1}`
+with `3+1→1`. `e_prev = e_{i-1}` with `1−1→3`. `O_next = O ∩ {±e_next}`.
+`O_prev = O ∩ {±e_prev}`. If either empty, Orient fails, not `UNDEFINED`.
+Order `+e < −e`. `o_next` is the lex-largest vector in `O_next` (hence
+`−e` if both signs). `o_prev` likewise. `Orient(q)` is the sign of the
+integer determinant of the 3×3 matrix with columns `m`, `o_next`,
+`o_prev`. If split fails, Orient fails, not `UNDEFINED`. When split
+HOLDs, `F(q)=(m,o_next,o_prev)` is an oriented lattice frame. For an edge
+`q→r` of a formed six-neighbor pair, `P(q,r)` is the unique 3×3 signed
+permutation with `det = Orient(q)Orient(r)` sending columns of `F(q)` to
+columns of `F(r)`; if none, that edge fails. Holonomy of a square is the
+matrix product `P12 P23 P34 P41`. Holonomy HOLDs if and only if every
+vertex split HOLDs, every Orient is `±1`, every edge has `P`, and the
+product is the 3×3 identity. Reverse HOLDs if and only if holonomy of
+`A-D-B-E` HOLDs. Face HOLDs if and only if holonomy of `C-C1-C2-C3` HOLDs.
+Face is displayed, not adopted. Cover and split do not score handedness.
+This is not leftover of nm2cycfrmz cyclic-frame transport reverse HOLD
+face HOLD: transport is existential at a vertex, holonomy is the product
+around a square. Transport face HOLDs on this member while holonomy face
+fails because `C1` and `C2` are 2-in split fail. This is not leftover of
+nm2oricyclz cyclic Orient reverse HOLD whose bits are equal `±1` signs,
+not a four-edge product. This is not leftover of scalar neighbor-read of
+Orient. This is not leftover of a unique nonnegative permutation sending.
+This is not leftover of nm2orichz leftover-axis reverse HOLD whose face
+fails because C and D swap `(m,pair)` columns: those signs are not the
+holonomy product, and holonomy face fails from split fail at `C1,C2`. This
+is not leftover of nm2orionez lex-one reverse fail whose face HOLDs from
+`e1<e2<e3` order independent of `m`. This is not leftover of nm2chiralz
+lexicographic unsigned `o1,o2` orientation. This is not leftover of
+nm2oridetz unique signed outgoing letters. This is not leftover of nm2axz
+axis-cover. This is not leftover of nm2ax12z 1-in 2-out split. This is not
+leftover of leftover-of-`M` alone. This is not leftover of leftover-of-`O`
+alone. This is not leftover-empty fail of leftover axis. This is not
+leftover of nmunopp union. This is not leftover of nmt2opp `M` frozen at
+`t`. This is not leftover of nmot2opp two-tick composition. This is not
+leftover of nmoutopp untimed eventual-`O`. This is not leftover of mixed
+#7188 fail/fail. This is not leftover of the 1-axis opposite two-site
+seed. This is not leftover of the same-lock two-site seed. The second pair
+is a new seed, not a formed child. Uniqueness is not required. Mixed
+remains a set. Displayed, not adopted. Do not write into Admissibility. Do
+not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the two named unit squares. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-vertex cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. The cyclic next/prev
+lex-largest oriented frame is the integer sign of
+`det(m,o_next,o_prev)` with unique signed incoming letter `m` and the
+lex-largest signed outgoing letter on the cyclic next and prev axes of
+`Axis(M)` under `+e < −e`. When split HOLDs, `F=(m,o_next,o_prev)` is
+that LIVE three-axis frame. For a formed six-neighbor edge, `P` is the
+unique signed permutation sending columns of `F(q)` to columns of `F(r)`
+with determinant `Orient(q)Orient(r)`. Holonomy is the product of the four
+edge matrices around the square. Reverse and face are scored on holonomy
+HOLD of the reverse square and of the face square. Transport of nm2cycfrmz
+is a different readout: it is existential at a vertex, not the product
+around a square. Neighbor-read of the scalar Orient sign is a different
+readout and is not used as the object. A unique nonnegative permutation
+sending is a different readout and is not used as the object. Named
+signs `{+,−}` of locks are a coarser readout and are not used as the
+object. A singleton unique outgoing lock letter is a different readout
+and is not used as the object. Unsigned axis units of `Axis(O)` are a
+different readout and are not used. Unique signed letters requiring
+`|O_i|=1` are a different readout and are not used. Opposite-pair
+leftover-axis orientation is a different readout and is not used.
+Lex-one signed outgoing letters in axis order `e1<e2<e3` independent of
+`m` are a different readout and are not used. Cyclic lex-smallest (`+e`
+if both signs) is a different readout and is not used. Existential
+opposite of signed locks is a different readout and is not used.
+Axis-cover without the frame sign is a different readout and is not
+used. 1-in 2-out split without the frame sign is a different readout and
+is not used. Equal `±1` Orient signs without a sending matrix are a
+different readout and are not used. Leftover-empty fail of unsigned
+leftover axis sets is a different readout and is not used. A `Z^3` sum
+of those locks is a different readout and is not used. Occupancy of
+sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of cyclic-frame holonomy around the unit square of M and O at t+1 on the two-axis opposite seed, F and Orient at the eight square vertices, P on each edge, holonomy matrices, reverse hold and face fail from holonomy of the two squares; uniqueness of a sending is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face
+target_blocker_text: "display cyclic-frame holonomy reverse/face on the unit square of the two-axis opposite seed, not nm2cycfrmz transport, not scalar neighbor-read of Orient, not unique nonnegative sending, not leftover-axis, not lex-one e1<e2<e3, not unique |O_i|=1, not unsigned axis units, not cover, not split"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep cyclic-frame holonomy of F around the unit square at t+1 displayed; do not write holonomy into Admissibility, do not reduce to nm2cycfrmz transport, do not reduce to scalar neighbor-read of Orient, do not reduce to unique nonnegative permutation sending, do not reduce to unique signed |O_i|=1, do not reduce to lexicographic unsigned o1,o2, do not reduce to leftover-axis, do not reduce to lex-one signed e1<e2<e3, do not reduce to cyclic lex-smallest, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace holonomy by unique outgoing letters, do not replace holonomy by existential opposite of signed locks, do not replace holonomy by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for cyclic-frame holonomy around the unit square of M and O at t+1 on the two-axis opposite seed and reverse/face from that holonomy; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The reverse unit square and the parallel face
+square are the only cycles whose cyclic-frame holonomy of
+`F=(m,o_next,o_prev)` of `M` and `O` is scored:
+
+```text
+A = (0,0,1),  D = (1,0,1),  B = (1,1,1),  E = (0,1,1).
+C = (0,0,2),  C1 = (1,0,2),  C2 = (1,1,2),  C3 = (0,1,2).
+```
+
+A vertex outside `B_3(0)` is fail, not `UNDEFINED`. These are not the
+y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`. These are not
+the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`. `A` and
+`E` are seeds of the second opposite pair. Same process as nm2axz. `F`
+and Orient as nm2cycfrmz.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named cyclic-frame holonomy of `(m,o_next,o_prev)` at `τ=t+1`
+
+Let `t(q)` be the formation tick of a square vertex `q` when that tick is
+defined in `B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Oriented frame at the same cut:
+
+```text
+When split HOLDs, m is the unique signed letter in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1. e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}. O_prev = O ∩ {±e_prev}.
+If either is empty, Orient fails, not UNDEFINED.
+Order +e < −e. o_next is lex-largest in O_next (hence −e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+The outgoing pair is signed. Mixed opposite signs on one cyclic slot make
+`|O_next|=2` or `|O_prev|=2`; lex-largest still picks `−e`, so Orient is
+defined when split HOLDs. Unique outgoing letters of the whole set `O` are
+not required: mixed `O` remains a set, and unique-letter readout of mixed
+`O` is `UNDEFINED` while this Orient is a sign. Empty `O_next` or empty
+`O_prev` is Orient fail, not `UNDEFINED`. A vanishing determinant is fail.
+Sign of a nonzero integer determinant is `+1` or `−1`. Split HOLD
+required: 2-in 1-out is Orient fail, not UNDEFINED.
+
+Cyclic frame, edge sending, and holonomy at the same cut:
+
+```text
+When split HOLDs, F(q)=(m, o_next, o_prev).
+For an edge q→r of a formed six-neighbor pair, P(q,r) is the
+unique 3×3 signed permutation with det = Orient(q)Orient(r)
+sending columns of F(q) to columns of F(r) (F(r)=F(q)P).
+If none, that edge fails.
+Holonomy of a square is P12 P23 P34 P41.
+Holonomy HOLDs iff every vertex split HOLDs, every Orient is ±1,
+every edge has P, and the product is the 3×3 identity.
+If a vertex lies outside B_3(0), holonomy fails, not UNDEFINED.
+If split or Orient fails at a vertex, holonomy fails, not UNDEFINED.
+UNDEFINED if a vertex in the host is unformed at τ.
+Uniqueness of a sending neighbor is not required.
+```
+
+Neighbor-read of the scalar Orient sign HOLDs at `q` if and only if
+`Orient(q)` is `±1` and some formed six-neighbor has the same sign. That
+is a different object. Transport of nm2cycfrmz HOLDs at `q` if and only if
+some formed six-neighbor hosts a signed-permutation sending. That is a
+different object: transport HOLDs at `A,B,C,D` on this member, so transport
+reverse HOLDs and transport face HOLDs, while holonomy reverse HOLDs and
+holonomy face fails because `C1` and `C2` are split fail. A unique
+nonnegative permutation sending is a different object and fails at each
+of `A,B,C,D`.
+
+Reverse cyclic-frame holonomy holds if and only if holonomy of `A-D-B-E`
+HOLDs. Face cyclic-frame holonomy holds if and only if holonomy of
+`C-C1-C2-C3` HOLDs. Either square `UNDEFINED` is `UNDEFINED`. Else HOLD or
+fail as the product test says.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover HOLDs reverse and face without reading
+cyclic signed columns; leftover-axis face fails as this face fails, but
+cover face HOLDs while this face fails. Identifying split reverse with
+this reverse is refused: split HOLDs reverse and face without the four-edge
+product; split face HOLDs on `C,D` while holonomy face fails at `C1,C2`.
+Identifying leftover-empty fail with this reverse is refused: leftover-empty
+fail scores empty leftover as reverse fail and face fail, while this reverse
+HOLDs; leftover face fail is not this face fail, whose reason is split fail
+at `C1,C2`. Identifying nm2cycfrmz transport with this reverse is refused:
+transport reverse HOLDs and transport face HOLDs, while this reverse HOLDs
+and this face fails. Identifying lexicographic unsigned `o1,o2` with this
+reverse is refused: unsigned reverse fails and unsigned face HOLDs, while
+this reverse HOLDs and this face fails. Identifying nm2orionez lex-one
+signed `e1<e2<e3` with this reverse is refused: lex-one reverse fails from
+axis order independent of `m`, while this reverse HOLDs; lex-one face HOLDs
+while this face fails. Identifying unique signed `|O_i|=1` with this reverse
+is refused: unique signed reverse fails while this reverse HOLDs. Identifying
+leftover-axis orientation with this reverse is refused: leftover-axis reverse
+HOLDs and face fails because C and D swap `(m,pair)` columns; those two
+signs are not the holonomy product of four edge sendings, and holonomy face
+fails from split fail at `C1,C2`. Identifying cyclic lex-smallest with this
+reverse is refused: lex-smallest picks `+e` if both signs. Identifying a
+named sign of those locks with reverse or face is refused: named-sign
+lettering lost the axis.
+
+## Theorem 1 — ticks, `F`, Orient, `P` on each edge, holonomy matrices
+
+On this process the eight square vertices form in `B_3(0)`. Compare to
+leftover axis: that leftover reports empty leftover at `A,B,C,D` and leftover
+reverse fail and leftover face fail. Compare to nm2axz cover and nm2ax12z
+split: both HOLD reverse and face on `A,B,C,D`. Compare to nm2oricyclz cyclic
+Orient: reverse HOLDs and face HOLDs from equal `±1` signs without a
+four-edge product. Compare to nm2cycfrmz cyclic-frame transport: reverse
+HOLDs and face HOLDs from existential sendings at `A,B,C,D`. Compare to
+scalar neighbor-read of Orient: HOLD at `A` and fail at `B`, `C`, and `D`.
+Compare to nm2chiralz lexicographic unsigned `o1,o2` orientation: reverse
+fails and face HOLDs. Compare to nm2oridetz unique signed outgoing letters:
+reverse fails and face fails because `|O_i|≠1`. Compare to nm2orichz
+leftover-axis reverse HOLD whose face fails because C and D swap `(m,pair)`
+columns. Compare to nm2orionez lex-one reverse fail whose face HOLDs from
+`e1<e2<e3` order independent of `m`. This display reads the cyclic-frame
+holonomy of `(m,o_next,o_prev)` around the two unit squares of those same
+timed sets:
+
+```text
+t(A)=0
+t(D)=1
+t(B)=1
+t(E)=0
+t(C)=1
+t(C1)=2
+t(C2)=2
+t(C3)=1
+M(A, τ) = {+e_2}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_3}
+M(D, τ) = {+e_1}
+M(E, τ) = {−e_2}
+M(C1, τ) = {+e_1, +e_3}
+M(C2, τ) = {+e_1, +e_3}
+M(C3, τ) = {+e_3}
+O(A, τ) = {+e_1, −e_1, +e_3}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {+e_1, −e_1, −e_2}
+O(D, τ) = {−e_2, +e_3, −e_3}
+O(E, τ) = {+e_1, −e_1, +e_3}
+O(C1, τ) = {+e_1, −e_2}
+O(C2, τ) = {+e_1, +e_2}
+O(C3, τ) = {+e_1, −e_1, +e_2}
+split(A) = hold
+split(B) = hold
+split(C) = hold
+split(D) = hold
+split(E) = hold
+split(C1) = fail
+split(C2) = fail
+split(C3) = hold
+m(A) = +e_2
+i(A) = 2
+o_next(A) = +e_3
+o_prev(A) = −e_1
+det(A) = -1
+Orient(A) = −1
+m(B) = +e_1
+i(B) = 1
+o_next(B) = +e_2
+o_prev(B) = −e_3
+det(B) = -1
+Orient(B) = −1
+m(C) = +e_3
+i(C) = 3
+o_next(C) = −e_1
+o_prev(C) = −e_2
+det(C) = 1
+Orient(C) = +1
+m(D) = +e_1
+i(D) = 1
+o_next(D) = −e_2
+o_prev(D) = −e_3
+det(D) = 1
+Orient(D) = +1
+Orient(E) = +1
+Orient(C1) = fail
+Orient(C2) = fail
+Orient(C3) = −1
+F(A) = (+e_2, +e_3, −e_1)
+F(B) = (+e_1, +e_2, −e_3)
+F(C) = (+e_3, −e_1, −e_2)
+F(D) = (+e_1, −e_2, −e_3)
+F(E) = (−e_2, +e_3, −e_1)
+F(C1) = fail
+F(C2) = fail
+F(C3) = (+e_3, −e_1, +e_2)
+P(A→D) = [0 -1 0; 0 0 -1; -1 0 0]
+P(D→B) = [1 0 0; 0 -1 0; 0 0 1]
+P(B→E) = [0 0 -1; -1 0 0; 0 -1 0]
+P(E→A) = [-1 0 0; 0 1 0; 0 0 1]
+holonomy(A-D-B-E) = [1 0 0; 0 1 0; 0 0 1]
+P(C→C1) = fail
+P(C1→C2) = fail
+P(C2→C3) = fail
+P(C3→C) = [1 0 0; 0 1 0; 0 0 -1]
+holonomy(C-C1-C2-C3) = fail
+```
+
+`A` is a seed at tick 0 with seed letter `+e_2`. Mixed remains a set:
+`O(A,τ)` has three outgoing steps and `O(D,τ)` has three outgoing steps.
+Unique outgoing letters would assign `UNDEFINED` at mixed `O`. Unique
+signed `|O_i|=1` fails at each probe: `O(A)` has both `±e_1`, `O(B)` has
+both `±e_3`, `O(C)` has both `±e_1`, and `O(D)` has both `±e_3`.
+Lex-largest picks `−e` on each mixed cyclic slot, so `(o_next,o_prev)` is
+defined. `M` is a singleton at each probe, so the unique signed `m`
+exists. At each probe split HOLDs. Cover and split HOLD at each probe and
+do not score that cyclic lex-largest Orient is `−1,−1,+1,+1`. At `A`,
+`i=2` so `e_next=e_3` and `e_prev=e_1`; mixed `O_prev={±e_1}` yields
+`o_prev=−e_1`. At `B`, `i=1` so `e_next=e_2` and `e_prev=e_3`; mixed
+`O_prev={±e_3}` yields `o_prev=−e_3`. Leftover-axis at `A` is pair `+e_1`
+leftover `+e_3` and that Orient is `−1`; leftover-axis at `C` and `D` swap
+`(m,pair)` columns and disagree. Lex-one at `B` uses axis order
+`(+e_2,+e_3)` independent of `m` and reports `+1`, while cyclic
+`(o_next,o_prev)=(+e_2,−e_3)` reports `−1`. Cyclic lex-smallest at `A`
+picks `o_prev=+e_1` and reports `+1`. O is not M.
+
+On the 1-axis opposite two-site seed, `A=(0,0,1)` is a formed child at
+tick 1 locking `+e_3`, and `C` is 2-in 1-out, so split fails at `C` and
+Orient at `C` is fail, not UNDEFINED. That is leftover of the first pair.
+Here both `(0,0,1)` and `(0,1,1)` are seeds of a second opposite pair on a
+second axis. On the y-probes of this same seed, split HOLDs at `A` with
+`m=−e_1` so `i=1`, `o_next=+e_2`, `o_prev=−e_3`, and cyclic Orient at that
+y-probe is `+1`. Y-probe `B` is `−1`, so y-probe reverse fails while this
+z-probe reverse HOLDs. Y-probe `D` has split fail, so y-face fails.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`:
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)
+new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)
+```
+
+`M` is frozen from `t` to `t+1`. At `t`, `O` is empty at each probe, split
+fails, Orient is fail, not UNDEFINED, and the cyclic frame fails, not
+UNDEFINED. Transport at `t` therefore fails, not UNDEFINED.
+
+Each probe has a formed six-neighbor with split HOLD and a signed
+permutation sending. Uniqueness of that neighbor is not required. First
+witness in six-neighbor order: `A` sends to `D=(1,0,1)` with
+`det(P)=-1=Orient(A)Orient(D)`; `B` sends to `(0,1,1)` with
+`det(P)=-1`; `C` sends to `(0,1,2)` with `det(P)=-1`; `D` sends to
+`A=(0,0,1)` with `det(P)=-1`. Scalar neighbor-read HOLDs only at `A`:
+`B`, `C`, and `D` have no formed six-neighbor of equal Orient sign, so
+scalar reverse fails and scalar face fails while transport reverse HOLDs
+and transport face HOLDs. Those existential transport bits are leftover of
+nm2cycfrmz cyclic-frame transport, not this holonomy. Reverse-square
+holonomy HOLDs because the product of the four edge sendings is the
+identity. Face-square holonomy fails because `C1` and `C2` are split fail.
+The 3-split is a field: opposite Orient at a neighbor is allowed when
+`det(P)` equals the product of the two signs.
+
+## Theorem 2 — reverse from cyclic-frame holonomy at `τ`
+
+Reverse cyclic-frame holonomy holds if and only if holonomy of `A-D-B-E`
+HOLDs. Every reverse-square vertex split HOLDs, every Orient is `±1`, every
+edge has `P`, and `P(A→D) P(D→B) P(B→E) P(E→A)` is the 3×3 identity.
+Reverse HOLDs. This is HOLD iff that product is the identity, not leftover of
+nm2cycfrmz cyclic-frame transport, not leftover of nm2oricyclz cyclic Orient
+equal signs, not leftover of scalar neighbor-read, not leftover of a unique
+nonnegative permutation sending, not leftover of nm2chiralz lexicographic
+unsigned `o1,o2`, not leftover of nm2oridetz unique signed outgoing letters,
+not leftover of nm2orichz leftover-axis, not leftover of nm2orionez lex-one,
+not leftover of nm2axz axis-cover, not leftover of nm2ax12z 1-in 2-out
+split, not leftover-empty fail, and not exist-opposite.
+
+Reverse cyclic-frame holonomy at τ: hold
+
+Both squares are defined, so this is not `UNDEFINED`. Cover reverse HOLDs
+because cover HOLDs at `A` and at `B`. Split reverse HOLDs because split
+HOLDs at `A` and at `B`. Cover and split do not score handedness.
+nm2cycfrmz transport reverse HOLDs because transport HOLDs at `A` and at
+`B`; that is existential at two vertices, not the four-edge product.
+Leftover-axis reverse HOLDs with `−1,−1` bits, but leftover-axis is two
+signs, not `P12 P23 P34 P41`. Lexicographic unsigned reverse fails because
+unsigned `Orient(A)=−1` and `Orient(B)=+1`. Unique signed reverse fails
+because both unique signed signs fail. Lex-one signed reverse fails because
+lex-one `Orient(B)=+1` from `e1<e2<e3` order independent of `m`. Cyclic
+lex-smallest reverse HOLDs with opposite signs `+1,+1`. Leftover-empty
+reverse fails because leftover of the union is empty at `A` and at `B`.
+Leftover of `M` reverse fails because leftover of `M` at `A` is `{e_1, e_3}`
+and at `B` is `{e_2, e_3}`: nonempty and unequal. Leftover of `O` reverse
+fails because leftover of `O` at `A` is `{e_2}` and at `B` is `{e_1}`:
+nonempty and unequal. Exist-opposite reverse of signed `M` fails.
+Exist-opposite reverse of signed `O` holds. Presence of an opposite pair in
+`O` at `A` and at `B` HOLDs. Those leftovers are not this display.
+
+Reverse HOLDs.
+
+## Theorem 3 — face from cyclic-frame holonomy at `τ`
+
+Face cyclic-frame holonomy holds if and only if holonomy of `C-C1-C2-C3`
+HOLDs. Split fails at `C1` and at `C2` from mixed incoming `{+e_1,+e_3}`,
+so `P(C→C1)`, `P(C1→C2)`, and `P(C2→C3)` fail. Face fails. Displayed, not
+adopted.
+
+Face cyclic-frame holonomy at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Cover face HOLDs because cover HOLDs at `C` and at `D`. Split face HOLDs
+because split HOLDs at `C` and at `D`. Those two vertices are not the face
+square: holonomy face reads `C,C1,C2,C3`, and split fails at `C1` and
+`C2`. Cyclic lex-largest oriented face HOLDs because both signs at `C` and
+`D` are `+1`; that pair is not the four-edge product. nm2cycfrmz transport
+face HOLDs because transport HOLDs at `C` and at `D`; that existential pair
+is not this holonomy. Leftover-axis face fails because those signs are `+1`
+and `−1`: C and D swap `(m,pair)` columns. That face fail is two leftover
+signs, not split fail at `C1,C2`. Lex-one signed oriented face HOLDs because
+both lex-one signs are `−1`. Lexicographic unsigned face HOLDs because both
+unsigned signs are `+1`. Unique signed face fails because neither unique
+signed sign is `±1`. Cover and split do not score handedness. Presence of
+an opposite pair in `O` HOLDs at `C` and at `D`, so pair-presence face HOLDs
+while this face fails. On the 1-axis opposite two-site seed, reverse
+holonomy of `A-D-B-E` HOLDs with `t(A)=1`, and face holonomy fails because
+split fails at `C` and at `C3`; here `t(A)=0` and face holonomy fails at
+`C1,C2`. The four y-probes of this same seed give cyclic Orient `+1` at `A`
+and Orient fail at `D` from split fail, so oriented y-face fails. The four
+x-probes give oriented reverse fail and oriented face fail. Those
+probe-direction readouts are not this unit-square holonomy. Leftover-empty
+face fails because leftover of the union is empty at `C` and at `D`.
+Leftover of `M` at `C` is `{e_1, e_2}` and leftover of `M` at `D` is
+`{e_2, e_3}`: nonempty and unequal. Leftover of `O` at `C` is `{e_3}` and
+leftover of `O` at `D` is `{e_1}`: nonempty and unequal. Exist-opposite
+face of signed `M` fails. Exist-opposite face of signed `O` fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover HOLDs at `D` and split HOLDs at `D`. Orient at `D`
+is `+1` from cyclic `(−e_2,−e_3)` even though `|O ∩ {±e_3}|=2`. A vertex
+outside `B_3(0)`, for example the parallel square at height 4, is holonomy
+fail, not `UNDEFINED`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not replace holonomy by nm2cycfrmz cyclic-frame transport.
+- It does not replace holonomy by neighbor-read of the scalar Orient sign.
+- It does not replace holonomy by a unique nonnegative permutation sending.
+- It does not require a unique formed six-neighbor witness.
+- It does not reprint nm2oricyclz cyclic Orient reverse hold face hold as this holonomy.
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by lexicographic unsigned `o1,o2` orientation.
+- It does not replace Orient by unique signed `|O_i|=1` letters.
+- It does not replace Orient by leftover-axis orientation.
+- It does not replace Orient by nm2orionez lex-one signed `e1<e2<e3`.
+- It does not replace Orient by cyclic lex-smallest (`+e` if both signs).
+- It does not replace Orient by unsigned axis units of `Axis(O)`.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not treat split fail as `UNDEFINED`.
+- It does not treat empty `O_i` as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2axz axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2ax12z 1-in 2-out split reverse hold face hold as
+  this oriented display.
+- It does not reprint nm2chiralz lexicographic unsigned `o1,o2` reverse fail
+  face hold with `+1,+1` as this oriented display.
+- It does not reprint nm2oridetz unique signed reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orichz leftover-axis reverse hold face fail as
+  this oriented display.
+- It does not reprint nm2orionez lex-one reverse fail face hold as this
+  oriented display.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the two unit squares. It uses
+Qubit only as the algebra of the local possibility domain. It uses Record
+only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The two-axis opposite seed process, cyclic-frame holonomy of
+`(m,o_next,o_prev)` of `M` and `O` at `t+1` around the unit square, and the
+reverse/face bits from that holonomy are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(D)`, `t(B)`, `t(E)`, `t(C)`, `t(C1)`, `t(C2)`, `t(C3)` | Theorem 1; `0`, `1`, `1`, `0`, `1`, `2`, `2`, `1` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual |
+| split at `τ` | Theorem 1; HOLD at `A,D,B,E,C,C3`; fail at `C1,C2` |
+| unique signed `m`, axis index `i`, cyclic `(o_next,o_prev)` | Theorem 1; singleton `M` on reverse square; lex-largest pair defined |
+| integer `det(m,o_next,o_prev)` | Theorem 1; reverse square `-1`, `1`, `-1`, `1` |
+| Orient at `τ` | Theorem 1; reverse `−1,+1,−1,+1`; face `+1`, fail, fail, `−1` |
+| cyclic frame `F=(m,o_next,o_prev)` | Theorem 1; LIVE three-axis on reverse square; fail at `C1,C2` |
+| `P` on each reverse edge | Theorem 1; four signed permutations, dets `-1,-1,-1,-1` |
+| holonomy matrix of `A-D-B-E` | Theorem 1; identity |
+| holonomy matrix of `C-C1-C2-C3` | Theorem 1; fail |
+| leftover of nm2cycfrmz cyclic-frame transport | Theorem 1; transport reverse hold and transport face hold; not this letter |
+| reverse from cyclic-frame holonomy at `τ` | Theorem 2; `hold` |
+| face from cyclic-frame holonomy at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2axz axis-cover HOLD | not this oriented display |
+| leftover of nm2ax12z 1-in 2-out split HOLD | not this oriented display |
+| leftover of nm2chiralz lexicographic unsigned `o1,o2` | not this oriented display |
+| leftover of nm2oridetz unique signed `|O_i|=1` | not this oriented display |
+| leftover of nm2orichz leftover-axis | not this oriented display |
+| leftover of nm2orionez lex-one signed `e1<e2<e3` | not this oriented display |
+| leftover of cyclic lex-smallest | not this oriented display |
+| leftover of nm2oricyclz cyclic Orient equal signs | not this holonomy |
+| leftover of nm2cycfrmz cyclic-frame transport | not this holonomy |
+| leftover of scalar neighbor-read of Orient | not this transport |
+| leftover of unique nonnegative permutation sending | not this transport |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or x-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display; #7477 same-lock face transport fails |
+| leftover of the LIVE three-axis three-site seed | not this display; face transport fails |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| empty `O_i` scored as `UNDEFINED` | refused; Orient fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: cyclic-frame holonomy around the unit square of `(m,o_next,o_prev)` of `M` and `O` at `t+1` on the two-axis opposite seed, and reverse/face from that holonomy. |
+| V2 | Current main has no landed cyclic-frame-holonomy reverse/face of timed `M` and `O` on these two unit squares of the two-axis opposite seed. |
+| V3 | Edge sendings, two holonomy matrices, and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the four-edge signed-permutation product around a unit square at the same `t+1` cut, reverse HOLDs and face fails while nm2cycfrmz transport reverse HOLDs and transport face HOLDs, scalar neighbor-read reverse fails, unique nonnegative sending fails at each of `A,B,C,D`, and nm2oricyclz Orient equality does not supply the product. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by nm2chiralz lexicographic unsigned `o1,o2`, does not replace
+Orient by nm2oridetz unique signed `|O_i|=1`, does not replace Orient by
+nm2orichz leftover-axis, does not replace Orient by nm2orionez lex-one,
+does not replace Orient by cyclic lex-smallest, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2axz axis-cover, does not
+replace Orient by nm2ax12z 1-in 2-out split, does not identify this
+display with the 1-axis opposite two-site seed, and does not identify it
+with nmunopp union. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| scalar neighbor-read of Orient | reuse equal Orient sign at some formed 6-NN | scalar HOLDs at `A` and fails at `B,C,D`; scalar reverse fails and scalar face fails while this reverse HOLDs | ATTEMPTED |
+| unique nonnegative permutation sending | require a unique sending with no minus signs | unique nonnegative sending fails at each of `A,B,C,D`; uniqueness is not required | ATTEMPTED |
+| nm2cycfrmz cyclic-frame transport | reuse transport reverse hold and face hold from existential 6-NN sendings | transport reverse HOLDs and transport face HOLDs while this reverse HOLDs and this face fails; transport is existential at a vertex, holonomy is the four-edge product | ATTEMPTED |
+| nm2oricyclz cyclic Orient | reuse Orient reverse hold and face hold from equal `±1` signs | Orient reverse HOLDs and face HOLDs without a four-edge product; HOLDING cyclic #7451/#7452 is the frame sign, not holonomy | ATTEMPTED |
+| nm2chiralz lexicographic unsigned `o1,o2` | reuse unsigned reverse fail and face hold | unsigned reverse fails while this reverse HOLDs; unsigned face HOLDs while this face fails | ATTEMPTED |
+| nm2oridetz unique signed `|O_i|=1` | reuse unique signed reverse fail and face fail | unique signed reverse fails while this reverse HOLDs; an opposite pair in `O` makes `|O_i|≠1` but lex-largest still picks `−e` | ATTEMPTED |
+| nm2orichz leftover-axis | reuse leftover-axis reverse hold and face fail | leftover-axis reverse HOLDs (`−1,−1`) as this reverse HOLDs, but leftover-axis face fails because C and D swap `(m,pair)` columns; holonomy face fails from split fail at `C1,C2`; those two signs are not `P12 P23 P34 P41` | ATTEMPTED |
+| nm2orionez lex-one | reuse lex-one reverse fail and face hold | lex-one reverse fails from `e1<e2<e3` order independent of `m`; this reverse HOLDs from the identity product; lex-one face HOLDs while this face fails | ATTEMPTED |
+| cyclic lex-smallest | reuse same cyclic axes with `+e` if both signs | lex-smallest reverse HOLDs with `+1,+1` and face HOLDs with `−1,−1`; this reverse HOLDs from identity holonomy and this face fails | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse hold and cover face hold on these z-probes | cover HOLDs reverse and face without cyclic signed columns; cover face HOLDs while this face fails | ATTEMPTED |
+| nm2ax12z 1-in 2-out split | reuse split reverse hold and split face hold | split HOLDs reverse and face on `A,B,C,D` without the four-edge product; Cover and split do not score handedness; split face HOLDs while this face fails | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails while this reverse HOLDs; leftover face fail is empty leftover, not split fail at `C1,C2` | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_3}` and at `B` is `{e_2,e_3}`, nonempty unequal; leftover of `M` reverse fails while this reverse HOLDs | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is `{e_2}` and at `B` is `{e_1}`, nonempty unequal | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `O` holds as this reverse HOLDs; exist-opposite face of signed `O` fails as this face fails, from a different object | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence HOLDs at each of `A,B,C,D` without cyclic columns; pair-presence face HOLDs while this face fails | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of unique signed incoming and cyclic lex-largest outgoing letters | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; unique-letter Orient is `UNDEFINED` while this Orient is `−1` | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | on this member both agree; flipping `m` on unique signed `O={+e_1,+e_3}` from `+e_2` to `−e_2` flips Orient from `+1` to `−1` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; none of these four probes is 2-in 1-out | ATTEMPTED |
+| empty `O_i` as `UNDEFINED` | treat empty signed outgoing on an axis as unformed | empty `O_i` is Orient fail, not UNDEFINED | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(A)=1`, `t(C)=4`, mixed `M(C)`, Orient fail at `C` | different seed; second pair is a new seed, not a formed child; here `t(A)=0` and split HOLDs at `C` | ATTEMPTED |
+| y-probe Orient | score the four y-probes on this seed | y-probe reverse fails (`+1,−1`) and y-face fails; this letter is the four z-probes | ATTEMPTED |
+| x-probe Orient | score the four x-probes on this seed | x-probe reverse fails at `A`; this letter is the four z-probes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores cyclic next/prev lex-largest outgoing determinant orientation of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports reverse hold and face hold on the two-axis opposite seed | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum; mixed `O(A)` sums to `+e_3` while cyclic is `(+e_3,−e_1)` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with nm2chiralz lexicographic unsigned `o1,o2`,
+missing identification of Orient with nm2oridetz unique signed `|O_i|=1`,
+missing identification of Orient with nm2orichz leftover-axis, missing
+identification of Orient with nm2orionez lex-one, missing identification of
+Orient with cyclic lex-smallest, missing identification of Orient with
+nmcover axis-cover, missing identification of Orient with nm2axz axis-cover,
+missing identification of Orient with nm2ax12z 1-in 2-out split, missing
+identification of this seed with the 1-axis opposite two-site seed, and
+missing Record identification of Orient reverse are distinct open premises.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, unique signed `m` when split HOLDs, cyclic
+next/prev axes of `Axis(M)`, lex-largest signed outgoing letter under
+`+e < −e` (hence `−e` if both signs), integer determinant sign, empty
+`O_next` or empty `O_prev` as Orient fail not `UNDEFINED`, split fail as
+Orient fail not `UNDEFINED`, four z-probes with seed `A`, second pair as a
+new seed not a formed child, and mixed remains a set are declared. No
+uniqueness of outgoing locks, no six-neighbor lock union as the scored
+object, no lock-count clock, no global later T, no formation attachment
+from already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+Orient `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | cyclic frame `F=(m,o_next,o_prev)` and signed-permutation sending to a formed 6-NN | no continuum alphabet |
+| per site | `A,B,C,D` z-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | edge sendings, two holonomy matrices, reverse/face from holonomy | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for cyclic-frame holonomy
+reverse/face, a formation-rate rule, and a physical selector among 1-in
+2-out frames. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Holonomy reverse hold and face fail are only leftover of
+nm2cycfrmz cyclic-frame transport, or of nm2oricyclz cyclic Orient equal
+signs, or of neighbor-read of the scalar Orient sign, or of cover and
+split; leftover-axis already answers reverse HOLD and face fail; lex-one
+already answers face HOLD; unique signed `|O_i|=1` already answers mixed
+`O`; leftover of `M` alone already answers reverse; leftover of `O` alone
+already answers reverse; exist-opposite of signed `O` already answers
+reverse; mixed #7188 already reported fail/fail; the second pair is only
+the formed child `(0,0,1)` of the 1-axis seed; unique outgoing letters
+should be required; cyclic lex-smallest already gives the same HOLD bits
+with opposite signs; and unsigned incoming axis already gives the same
+signs because each `M` letter is the positive unit.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Holonomy reverse HOLDs because the product of the four
+edge sendings around `A-D-B-E` is the identity. Holonomy face fails
+because split fails at `C1` and at `C2`. Transport reverse HOLDs and
+transport face HOLDs: leftover of nm2cycfrmz cyclic-frame transport, not
+this holonomy. Scalar neighbor-read of Orient HOLDs only at `A` and fails
+at `B`, `C`, and `D`, so scalar reverse fails and scalar face fails.
+HOLDING cyclic #7451/#7452 Orient reverse HOLDs from equal signs without a
+four-edge product; this reverse HOLDs from `P12 P23 P34 P41 = I_3`. Unique
+nonnegative permutation sending fails at each of `A,B,C,D`. Orient reverse
+HOLDs because `Orient(A)=−1` and `Orient(B)=−1`. Orient face HOLDs because
+both signs at `C` and `D` are `+1`; those two signs are not the face
+square. Cover and split HOLD reverse and face on `A,B,C,D` and do not
+score the four-edge product. Leftover-axis reverse HOLDs with `−1,−1` and
+face fails with `+1,−1` because C and D swap `(m,pair)` columns; this
+reverse HOLDs from identity holonomy and this face fails from split fail
+at `C1,C2`. Lex-one reverse fails from `e1<e2<e3` order independent of
+`m`; this reverse HOLDs. Lexicographic unsigned `o1,o2` reverse fails with
+`−1,+1` and face HOLDs with `+1,+1`. Unique signed `|O_i|=1` reverse fails
+and face fails because each of `A,B,C,D` has an opposite pair in `O`; this
+reverse HOLDs. Cyclic lex-smallest reverse HOLDs with `+1,+1` and face
+HOLDs with `−1,−1`; those signs are not these holonomy bits. Presence of an opposite pair in
+`O` HOLDs at each of the four z-probes without cyclic columns. Leftover of
+`M` alone at `A` is `{e_1,e_3}` and at `B` is `{e_2,e_3}`: nonempty unequal.
+Leftover of `O` alone at `A` is `{e_2}` and at `B` is `{e_1}`. Unique
+outgoing letters would assign `UNDEFINED` at mixed `O(A)`; this Orient is
+`−1`, not `UNDEFINED`. On unique signed `O={+e_1,+e_3}` leftover is empty
+while Orient is `+1`, so leftover-empty fail is not this predicate. Mixed
+#7188 is a different z-symmetric process with mixed `M`. The second pair
+is a new seed, not a formed child: `(0,0,1)` is recorded at tick 0 with
+lock `+e_2`, whereas the 1-axis child forms at tick 1 with lock `+e_3`.
+Reverse oriented frame is HOLD iff equal `±1` signs at `A` and at `B`, not
+leftover of leftover-axis and not leftover of nm2orionez lex-one.
+
+### N8 — cross-cycle echo
+
+nm2axz cover on this two-axis seed reported cover HOLD at each of the four
+z-probes, reverse hold, and face hold. nm2ax12z 1-in 2-out split on the
+same seed reported split HOLD at each of the four z-probes, reverse hold,
+and face hold. nm2chiralz lexicographic unsigned `o1,o2` on the same seed
+reported Orient `−1,+1,+1,+1`, reverse fail, and face hold. nm2oridetz
+unique signed outgoing letters on the same seed reported Orient fail at
+each probe, reverse fail, and face fail. nm2orichz leftover-axis on the
+same seed reported Orient `−1,−1,+1,−1`, reverse hold, and face fail
+because C and D swap `(m,pair)` columns. nm2orionez lex-one on the same
+seed reported Orient `−1,+1,−1,−1`, reverse fail, and face hold from
+`e1<e2<e3` order independent of `m`. Leftover axis reported empty leftover
+at each of four z-probes, leftover reverse fail, and leftover face fail.
+The four y-probes of this same seed reported cyclic Orient `+1` at `A`
+from `m=−e_1` and Orient fail at `D` from split fail, so y-reverse fails
+and y-face fails. nm2oricyclz cyclic next/prev lex-largest Orient on the
+same seed reported HOLDING cyclic #7451/#7452 with Orient `−1,−1,+1,+1`,
+reverse hold, and face hold from equal signs, without a sending matrix.
+This note is not those displays: it reports cyclic-frame holonomy of
+`(m,o_next,o_prev)` of `M` and `O` at `τ=t+1` around the unit square on
+the two-axis opposite seed, with `t(A)=0`, `t(D)=1`, `t(B)=1`, `t(E)=0`,
+`t(C)=1`, `t(C1)=2`, `t(C2)=2`, and `t(C3)=1`, reverse holonomy hold, and
+face holonomy fail, while nm2cycfrmz transport reverse HOLDs and transport
+face HOLDs, and while scalar neighbor-read fails at `B,C,D`. Cover and
+split do not score handedness.
+
+**Gate disposition:** PASS for the cyclic-frame-holonomy `t+1`
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals
+the named sign,” “the predicate equals the unique singleton lock vector,”
+“the predicate equals six-neighbor lock union,” “the predicate equals
+leftover-empty fail,” “the predicate equals leftover of `M` alone,” “the
+predicate equals leftover of `O` alone,” “the predicate equals
+exist-opposite HOLD,” “the predicate equals opposite-pair presence in
+`O`,” “the predicate equals nm2chiralz lexicographic unsigned `o1,o2`
+HOLD,” “the predicate equals nm2oridetz unique signed HOLD,” “the
+predicate equals nm2orichz leftover-axis HOLD,” “the predicate equals
+nm2orionez lex-one HOLD,” “the predicate equals cyclic lex-smallest HOLD,”
+“the predicate equals nm2oricyclz cyclic Orient HOLD,” “the predicate
+equals nm2cycfrmz cyclic-frame transport HOLD,” “the predicate equals
+scalar neighbor-read of Orient HOLD,” “the predicate equals unique
+nonnegative permutation sending HOLD,” “the predicate equals nmcover
+axis-cover HOLD,” “the predicate equals nm2axz axis-cover HOLD,” “the
+predicate equals nm2ax12z 1-in 2-out split HOLD,” “the predicate equals
+the 1-axis opposite two-site seed,” “the predicate equals nmunopp union,”
+“bits are Admissibility,” “split fail is UNDEFINED,” or “empty `O_i` is
+UNDEFINED.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each square vertex's own earliest
+incoming set and own outgoing dual from the record prefix at that vertex's
+`t+1`, reports split of the pair, reports the cyclic frame
+`F=(m,o_next,o_prev)` as nm2cycfrmz, reports Orient as nm2oricyclz
+lex-largest cyclic, reports `P` on each formed six-neighbor edge of the
+reverse square `A-D-B-E` and of the face square `C-C1-C2-C3`, reports the
+holonomy products, lists new records in `B_3(0)` between `t` and `t+1`
+that meet a probe's six-neighbors, and checks Theorems 1--3. It also
+checks that reverse holonomy HOLDs and face holonomy fails, that a vertex
+outside `B_3(0)` is fail not `UNDEFINED`, that nm2cycfrmz transport reverse
+HOLDs and transport face HOLDs while holonomy face fails, that scalar
+neighbor-read fails at `B,C,D`, that unique nonnegative permutation sending
+fails at each of `A,B,C,D`, that HOLDING cyclic #7451/#7452 Orient reverse
+HOLDs without being this product, that leftover-axis face fails because C
+and D swap `(m,pair)` columns and lex-one reverse fails from `e1<e2<e3`
+order independent of `m`, that split fail is holonomy fail not
+`UNDEFINED`, that empty `O_next` or empty `O_prev` is Orient fail not
+`UNDEFINED`, that the 1-axis opposite two-site seed is a different member
+with `t(A)=1`, that #7477 same-lock is a different member with `t(A)=1`,
+that LIVE three-axis as a three-site seed is a different member with
+reverse holonomy fail, that leftover-empty fail is a different predicate,
+that leftover of `M` alone and leftover of `O` alone are different objects,
+that mixed sets remain sets, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not attached,
+that the second pair is a new seed not a formed child, that the y-probes
+and x-probes of this seed are not this letter, and that the display is not
+the two-tick lock-count clock composition. No runner cache is written.

--- a/logs/runner-cache/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,115 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py
+runner_sha256: d36035744297172f4727d8202717ecf9c7bff870ebb6e58cb27656e0e755d371
+input_fingerprint_sha256: 38421e976d1b7a4e838f5ae943d6a503c4459efef14e42aee464a76638eeaddc
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+cyclic-frame holonomy around the unit square reverse/face at t+1 on two-axis opposite seed
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Cyclic-frame holonomy around the unit square at t+1 on the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+PASS: sending-identity
+A t=0 M={+e_2} O={+e_1, −e_1, +e_3} split=hold F=(+e_2, +e_3, −e_1) Orient=−1 transport=hold scalar=hold witness=(1, 0, 1) P=[0 -1 0; 0 0 -1; -1 0 0]
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} split=hold F=(+e_1, +e_2, −e_3) Orient=−1 transport=hold scalar=fail witness=(0, 1, 1) P=[0 0 -1; -1 0 0; 0 -1 0]
+C t=1 M={+e_3} O={+e_1, −e_1, −e_2} split=hold F=(+e_3, −e_1, −e_2) Orient=+1 transport=hold scalar=fail witness=(0, 1, 2) P=[1 0 0; 0 1 0; 0 0 -1]
+D t=1 M={+e_1} O={−e_2, +e_3, −e_3} split=hold F=(+e_1, −e_2, −e_3) Orient=+1 transport=hold scalar=fail witness=(0, 0, 1) P=[0 0 -1; -1 0 0; 0 -1 0]
+A (0, 0, 1) t=0 M={+e_2} O={+e_1, −e_1, +e_3} split=hold F=(+e_2, +e_3, −e_1) Orient=−1
+D (1, 0, 1) t=1 M={+e_1} O={−e_2, +e_3, −e_3} split=hold F=(+e_1, −e_2, −e_3) Orient=+1
+B (1, 1, 1) t=1 M={+e_1} O={+e_2, +e_3, −e_3} split=hold F=(+e_1, +e_2, −e_3) Orient=−1
+E (0, 1, 1) t=0 M={−e_2} O={+e_1, −e_1, +e_3} split=hold F=(−e_2, +e_3, −e_1) Orient=+1
+C (0, 0, 2) t=1 M={+e_3} O={+e_1, −e_1, −e_2} split=hold F=(+e_3, −e_1, −e_2) Orient=+1
+C1 (1, 0, 2) t=2 M={+e_1, +e_3} O={+e_1, −e_2} split=fail F=fail Orient=fail
+C2 (1, 1, 2) t=2 M={+e_1, +e_3} O={+e_1, +e_2} split=fail F=fail Orient=fail
+C3 (0, 1, 2) t=1 M={+e_3} O={+e_1, −e_1, +e_2} split=hold F=(+e_3, −e_1, +e_2) Orient=−1
+P(A->D)=[0 -1 0; 0 0 -1; -1 0 0]
+P(D->B)=[1 0 0; 0 -1 0; 0 0 1]
+P(B->E)=[0 0 -1; -1 0 0; 0 -1 0]
+P(E->A)=[-1 0 0; 0 1 0; 0 0 1]
+P(C->C1)=fail
+P(C1->C2)=fail
+P(C2->C3)=fail
+P(C3->C)=[1 0 0; 0 1 0; 0 0 -1]
+holonomy reverse product=[1 0 0; 0 1 0; 0 0 1]
+holonomy face product=fail
+holonomy reverse=hold face=fail
+transport reverse=hold face=hold
+Orient reverse=hold face=hold
+scalar reverse=fail face=fail
+split reverse=hold face=hold
+cover reverse=hold face=hold
+per_element: cyclic frame F=(m,o_next,o_prev) and four-edge signed-permutation holonomy around a unit square at t+1
+per_site: scored only at reverse square A-D-B-E and face square C-C1-C2-C3 on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: edge sendings, two holonomy matrices, reverse/face from holonomy
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-O-split  ({'A': ('{+e_2}', 'hold'), 'B': ('{+e_1}', 'hold'), 'C': ('{+e_3}', 'hold'), 'D': ('{+e_1}', 'hold')})
+PASS: theorem1-Orient  ({'A': '−1', 'B': '−1', 'C': '+1', 'D': '+1'})
+PASS: theorem1-transport  ({'A': ('hold', 'hold'), 'B': ('hold', 'fail'), 'C': ('hold', 'fail'), 'D': ('hold', 'fail')})
+PASS: theorem1-mixed-O-cyclic-not-unique
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((1, 0, 1), (-1, 0, 1), (0, 0, 2)), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((1, 0, 2), (-1, 0, 2), (0, -1, 2)), 'D': ((1, -1, 1), (1, 0, 2), (1, 0, 0))})
+PASS: theorem1-A-is-seed
+PASS: theorem1-square-ticks-F-Orient
+PASS: theorem1-edge-P-and-holonomy-matrices  (rev=[1 0 0; 0 1 0; 0 0 1] faceP=('fail', 'fail', 'fail', '[1 0 0; 0 1 0; 0 0 -1]'))
+PASS: theorem2-reverse-holonomy-hold
+PASS: theorem3-face-holonomy-fail
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: empty-Oi-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unsigned-incoming-axis-agrees-here
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-pair-is-seed-not-formed-child
+PASS: not-x-probes-or-y-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-or-one-axis-or-live-three-axis-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-Orient
+PASS: note-reports-new-neighbors
+PASS: note-reports-holonomy-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: holonomy-not-transport-or-scalar-or-orient-equality
+TOTAL: PASS=62 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,2521 @@
+#!/usr/bin/env python3
+"""Cyclic-frame holonomy around the unit square at t+1 reverse/face.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Perp-step incoming lock. F and Orient
+as nm2cycfrmz. Reverse square A=(0,0,1), D=(1,0,1), B=(1,1,1), E=(0,1,1).
+Face square C=(0,0,2) and mates (1,0,2),(1,1,2),(0,1,2). Vertex outside
+B_3(0) is fail, not UNDEFINED. For an edge q->r of a formed six-neighbor
+pair, P(q,r) is the unique 3x3 signed permutation with
+det = Orient(q)Orient(r) sending columns of F(q) to columns of F(r); if
+none, that edge fails. Holonomy is P12 P23 P34 P41. HOLD iff every vertex
+split HOLDs, every Orient is +/-1, every edge has P, and the product is
+the 3x3 identity. Reverse HOLD iff holonomy of A-D-B-E HOLDs. Face HOLD
+iff holonomy of C-C1-C2-C3 HOLDs. Face is displayed, not adopted.
+Uniqueness is not required. Occupancy of sites is not used. No larger host.
+Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+FrameVal = tuple[Point, Point, Point] | str
+Sending = tuple[Point, Point, Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+LIVE_THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+    (E3, E3),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Cyclic-frame holonomy around the unit square at t+1 on the "
+    "two-axis opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+IDENTITY_COLUMNS: tuple[Point, Point, Point] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+REVERSE_SQUARE: tuple[Point, Point, Point, Point] = (
+    (0, 0, 1),
+    (1, 0, 1),
+    (1, 1, 1),
+    (0, 1, 1),
+)
+FACE_SQUARE: tuple[Point, Point, Point, Point] = (
+    (0, 0, 2),
+    (1, 0, 2),
+    (1, 1, 2),
+    (0, 1, 2),
+)
+SQUARE_NAMES = {
+    (0, 0, 1): "A",
+    (1, 0, 1): "D",
+    (1, 1, 1): "B",
+    (0, 1, 1): "E",
+    (0, 0, 2): "C",
+    (1, 0, 2): "C1",
+    (1, 1, 2): "C2",
+    (0, 1, 2): "C3",
+}
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def pair_display(value: tuple[Point, Point] | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple):
+        raise TypeError(f"signed pair is not a pair or fail: {value!r}")
+    return ", ".join(LOCK_NAME[vec] for vec in value)
+
+
+def frame_display(value: FrameVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"frame is not a triple or fail: {value!r}")
+    return "(" + ", ".join(LOCK_NAME[vec] for vec in value) + ")"
+
+
+def matrix_display(value: Sending) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"sending is not three columns or fail: {value!r}")
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return "[" + "; ".join(" ".join(str(entry) for entry in row) for row in rows) + "]"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3. Mutation: unsigned."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negative)
+    return picked[0], picked[1]
+
+
+def axis_index(lock: Point) -> int | str:
+    """Axis index i in {1,2,3} of a signed nearest-neighbor letter."""
+    axis = axis_of_letter(lock)
+    if axis == E1:
+        return 1
+    if axis == E2:
+        return 2
+    if axis == E3:
+        return 3
+    return "fail"
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    """e_next = e_{i+1} with 3+1->1. e_prev = e_{i-1} with 1-1->3."""
+    idx = axis_index(signed_m)
+    if idx == "fail" or not isinstance(idx, int):
+        return "fail"
+    e_next = AXES[idx % 3]
+    e_prev = AXES[idx - 2]
+    return e_next, e_prev
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-largest signed letter in O intersect {+/-axis}. Order +e < -e."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-smallest signed letter in O intersect {+/-axis}. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def cyclic_signed_outgoing(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = True
+) -> tuple[Point, Point] | str:
+    """o_next, o_prev on the two cyclic axes of Axis(M). Empty slot is fail."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    o_next = picker(outgoing, units[0])
+    o_prev = picker(outgoing, units[1])
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic unsigned o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane. Fail if an opposite pair occupies O_i."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_lex_smallest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: same cyclic axes, lex-smallest (+e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-largest cyclic slots."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o_next, o_prev = plane
+    det = integer_det_columns(signed_m, o_next, o_prev)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_triple(incoming: Incoming, outgoing: Outgoing) -> FrameVal:
+    """F=(m,o_next,o_prev) when split HOLDs. Else fail, not UNDEFINED unless unformed."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return signed_m, plane[0], plane[1]
+
+
+def transpose_columns(frame: tuple[Point, Point, Point]) -> tuple[Point, Point, Point]:
+    """Columns of the transpose. Inverse on signed permutation frames."""
+    return tuple(tuple(frame[column][row] for column in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def mul_columns(
+    left: tuple[Point, Point, Point], right: tuple[Point, Point, Point]
+) -> tuple[Point, Point, Point]:
+    """Integer matrix product of two column-triple matrices."""
+    return tuple(
+        tuple(
+            sum(left[k][i] * right[j][k] for k in range(3)) for i in range(3)
+        )
+        for j in range(3)
+    )  # type: ignore[return-value]
+
+
+def sending_matrix(source: FrameVal, target: FrameVal) -> Sending:
+    """Integer matrix P with F(r) = F(q) P, sending columns of F(q) to F(r)."""
+    if source == UNDEFINED or target == UNDEFINED:
+        return UNDEFINED
+    if source == "fail" or target == "fail":
+        return "fail"
+    if not isinstance(source, tuple) or not isinstance(target, tuple):
+        return "fail"
+    return mul_columns(transpose_columns(source), target)
+
+
+def is_signed_permutation(value: Sending) -> bool:
+    """Exactly one nonzero +/-1 in each row and each column."""
+    if not isinstance(value, tuple) or len(value) != 3:
+        return False
+    for column in value:
+        if any(entry not in (-1, 0, 1) for entry in column):
+            return False
+        if sum(abs(entry) for entry in column) != 1:
+            return False
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return all(sum(abs(entry) for entry in row) == 1 for row in rows)
+
+
+def sending_holds(
+    source: FrameVal, target: FrameVal, orient_q: OrientVal, orient_r: OrientVal
+) -> str:
+    """HOLD iff P is a signed permutation with det = Orient(q)Orient(r)."""
+    sending = sending_matrix(source, target)
+    if sending == UNDEFINED:
+        return UNDEFINED
+    if sending == "fail" or not isinstance(sending, tuple):
+        return "fail"
+    if orient_q not in (1, -1) or orient_r not in (1, -1):
+        return "fail"
+    det = integer_det_columns(sending[0], sending[1], sending[2])
+    if is_signed_permutation(sending) and det == orient_q * orient_r:
+        return "hold"
+    return "fail"
+
+
+def is_nonnegative_permutation(value: Sending) -> bool:
+    """Unsigned permutation: signed permutation with no minus signs. Mutation."""
+    if not is_signed_permutation(value):
+        return False
+    if not isinstance(value, tuple):
+        return False
+    return all(entry >= 0 for column in value for entry in column)
+
+
+def site_sides(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Incoming, Outgoing]:
+    if site not in ticks:
+        return UNDEFINED, UNDEFINED
+    tau = ticks[site] + 1
+    return (
+        incoming_set(site, tau, ticks, locks, seed_map),
+        outgoing_set(site, tau, ticks, locks, seed_map),
+    )
+
+
+def formed_six_neighbors(site: Point, ticks: dict[Point, int]) -> tuple[Point, ...]:
+    """Formed 6-NN of site in B_3(0). Not a six-neighbor star letter."""
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def frame_transport(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, and some formed 6-NN r transports."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_transport_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, Sending] | str:
+    """First formed 6-NN in NN order that transports. Uniqueness is not required."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return neighbor, sending
+    return "fail"
+
+
+def scalar_orient_neighbor(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: HOLD iff some formed 6-NN has the same scalar Orient sign."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    orient = frame_orient(incoming, outgoing)
+    if orient == UNDEFINED:
+        return UNDEFINED
+    if orient not in (1, -1):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        if frame_orient(n_in, n_out) == orient:
+            return "hold"
+    return "fail"
+
+
+def unique_positive_sending(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: unique nonnegative permutation sending. Not this letter."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    hits = 0
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_orient = frame_orient(n_in, n_out)
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if (
+            sending_holds(source, target, orient, n_orient) == "hold"
+            and is_nonnegative_permutation(sending)
+        ):
+            hits += 1
+    if hits == 1:
+        return "hold"
+    return "fail"
+
+
+def site_frame_state(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[str, OrientVal, FrameVal]:
+    """split, Orient, F at tau=t+1. Outside the host is fail, not UNDEFINED."""
+    if not in_ball(site):
+        return "fail", "fail", "fail"
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    return (
+        axis_split(incoming, outgoing),
+        frame_orient(incoming, outgoing),
+        frame_triple(incoming, outgoing),
+    )
+
+
+def edge_sending(
+    source: Point,
+    target: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Sending:
+    """P(q,r) on a formed six-neighbor pair, else fail. Outside is fail."""
+    if not in_ball(source) or not in_ball(target):
+        return "fail"
+    if source not in ticks or target not in ticks:
+        return UNDEFINED
+    if sub(target, source) not in NN:
+        return "fail"
+    _split_q, orient_q, frame_q = site_frame_state(source, ticks, locks, seed_map)
+    _split_r, orient_r, frame_r = site_frame_state(target, ticks, locks, seed_map)
+    sending = sending_matrix(frame_q, frame_r)
+    if sending_holds(frame_q, frame_r, orient_q, orient_r) == "hold":
+        return sending
+    if sending == UNDEFINED:
+        return UNDEFINED
+    return "fail"
+
+
+def product_columns(
+    matrices: tuple[Sending, Sending, Sending, Sending],
+) -> Sending:
+    """Four-matrix product P12 P23 P34 P41 in column convention."""
+    if any(item == UNDEFINED for item in matrices):
+        return UNDEFINED
+    if any(not isinstance(item, tuple) for item in matrices):
+        return "fail"
+    product: tuple[Point, Point, Point] = IDENTITY_COLUMNS
+    for item in matrices:
+        if not isinstance(item, tuple):
+            return "fail"
+        product = mul_columns(product, item)
+    return product
+
+
+def square_holonomy(
+    vertices: tuple[Point, Point, Point, Point],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, every edge has P, product is I_3."""
+    if any(not in_ball(site) for site in vertices):
+        return "fail"
+    splits: list[str] = []
+    orients: list[OrientVal] = []
+    sendings: list[Sending] = []
+    for site in vertices:
+        split, orient, _frame = site_frame_state(site, ticks, locks, seed_map)
+        splits.append(split)
+        orients.append(orient)
+    if any(item == UNDEFINED for item in splits) or any(
+        item == UNDEFINED for item in orients
+    ):
+        return UNDEFINED
+    for index in range(4):
+        sendings.append(
+            edge_sending(
+                vertices[index],
+                vertices[(index + 1) % 4],
+                ticks,
+                locks,
+                seed_map,
+            )
+        )
+    if any(item == UNDEFINED for item in sendings):
+        return UNDEFINED
+    if any(split != "hold" for split in splits):
+        return "fail"
+    if any(orient not in (1, -1) for orient in orients):
+        return "fail"
+    if any(not isinstance(item, tuple) for item in sendings):
+        return "fail"
+    product = product_columns(
+        (sendings[0], sendings[1], sendings[2], sendings[3])
+    )
+    if product == IDENTITY_COLUMNS:
+        return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Orient reverse HOLDs iff Orient(A)=Orient(B) both +/-1. Contrast."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Orient face HOLDs iff Orient(C)=Orient(D) both +/-1. Contrast."""
+    return pair_orient(orient_c, orient_d)
+
+
+def transport_reverse_report(left: str, right: str) -> str:
+    """Reverse HOLDs iff transport at A and at B."""
+    return pair_bit(left, right)
+
+
+def transport_face_report(left: str, right: str) -> str:
+    """Face HOLDs iff transport at C and at D."""
+    return pair_bit(left, right)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    plane = cyclic_signed_outgoing(frozenset({unsigned_m}), outgoing, largest=True)
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("cyclic-frame holonomy around the unit square reverse/face at t+1 on two-axis opposite seed")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E3, NEG_E1) == -1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E3, NEG_E1, NEG_E2) == 1
+        and integer_det_columns(E1, NEG_E2, NEG_E3) == 1
+        and integer_det_columns(E2, E3, E1) == 1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E3, E1, NEG_E2) == -1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({E2}), frozenset({NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and frame_orient(frozenset({E1, NEG_E1}), frozenset({E2, E3})) == "fail"
+        and cyclic_units(E2) == (E3, E1)
+        and cyclic_units(E1) == (E2, E3)
+        and cyclic_units(E3) == (E1, E2)
+        and cyclic_units(NEG_E2) == (E3, E1)
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1
+        and lex_largest_on_axis(frozenset({E1}), E1) == E1
+        and lex_smallest_on_axis(frozenset({E1, NEG_E1}), E1) == E1
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E3, NEG_E1)
+        and cyclic_signed_outgoing(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == (E2, NEG_E3)
+        and cyclic_signed_outgoing(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2}))
+        == (NEG_E1, NEG_E2)
+        and cyclic_signed_outgoing(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3}))
+        == (NEG_E2, NEG_E3)
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1})) == "fail"
+        and unique_signed_outgoing_plane(frozenset({E1, NEG_E1, E3})) == "fail"
+        and unique_signed_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == "fail"
+        and lex_frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and leftover_pair_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and cyclic_lex_smallest_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == 1
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+    identity_frame = (E2, E3, NEG_E1)
+    identity_target = (E1, NEG_E2, NEG_E3)
+    identity_sending = sending_matrix(identity_frame, identity_target)
+    checks.check(
+        "sending-identity",
+        frame_triple(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E2, E3, NEG_E1)
+        and sending_matrix(UNDEFINED, identity_frame) == UNDEFINED
+        and sending_matrix(identity_frame, "fail") == "fail"
+        and sending_matrix(identity_frame, identity_frame)
+        == (E1, E2, E3)
+        and is_signed_permutation((E1, E2, E3))
+        and not is_signed_permutation((E1, E1, E2))
+        and sending_holds(identity_frame, identity_frame, -1, -1) == "hold"
+        and sending_holds(identity_frame, identity_target, -1, 1) == "hold"
+        and integer_det_columns(*identity_sending) == -1
+        and is_signed_permutation(identity_sending)
+        and not is_nonnegative_permutation(identity_sending)
+        and mul_columns(identity_frame, identity_sending) == identity_target,
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    live_ticks, live_locks, live_seeds = form(LIVE_THREE_AXIS_SEEDS)
+    tau0: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m: dict[str, Point | str] = {}
+    plane: dict[str, tuple[Point, Point] | str] = {}
+    pair: dict[str, Point | str] = {}
+    leftover: dict[str, Point | str] = {}
+    det: dict[str, int | str] = {}
+    lex: dict[str, OrientVal] = {}
+    leftover_pair: dict[str, OrientVal] = {}
+    unique_signed: dict[str, OrientVal] = {}
+    pair_present: dict[str, str] = {}
+    unique_plane: dict[str, tuple[Point, Point] | str] = {}
+    lex_plane: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_plane: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_small: dict[str, OrientVal] = {}
+    axis_i: dict[str, int | str] = {}
+    orient: dict[str, OrientVal] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    frames: dict[str, FrameVal] = {}
+    transport: dict[str, str] = {}
+    scalar: dict[str, str] = {}
+    unique_pos: dict[str, str] = {}
+    witness: dict[str, tuple[Point, Sending] | str] = {}
+    formed_nn: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1 = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1, ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1, ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m[name] = unique_signed_m(m1[name])
+        plane[name] = outgoing_plane(axis_o[name])
+        unique_plane[name] = unique_signed_outgoing_plane(o1[name])
+        lex_plane[name] = lex_signed_outgoing_plane(o1[name])
+        cyclic_plane[name] = cyclic_signed_outgoing(m1[name], o1[name], largest=True)
+        pair[name] = opposite_pair_unit(o1[name])
+        if isinstance(signed_m[name], tuple):
+            axis_i[name] = axis_index(signed_m[name])
+        else:
+            axis_i[name] = "fail"
+        if isinstance(signed_m[name], tuple) and isinstance(pair[name], tuple):
+            leftover[name] = leftover_unit(signed_m[name], pair[name])
+        else:
+            leftover[name] = "fail"
+        if isinstance(signed_m[name], tuple) and isinstance(cyclic_plane[name], tuple):
+            det[name] = integer_det_columns(
+                signed_m[name], cyclic_plane[name][0], cyclic_plane[name][1]
+            )
+        else:
+            det[name] = "fail"
+        pair_present[name] = has_opposite_pair(o1[name])
+        lex[name] = lex_frame_orient(m1[name], o1[name])
+        leftover_pair[name] = leftover_pair_orient(m1[name], o1[name])
+        unique_signed[name] = unique_signed_orient(m1[name], o1[name])
+        cyclic_small[name] = cyclic_lex_smallest_orient(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        frames[name] = frame_triple(m1[name], o1[name])
+        transport[name] = frame_transport(site, ticks, locks, seed_map)
+        scalar[name] = scalar_orient_neighbor(site, ticks, locks, seed_map)
+        unique_pos[name] = unique_positive_sending(site, ticks, locks, seed_map)
+        witness[name] = first_transport_witness(site, ticks, locks, seed_map)
+        formed_nn[name] = formed_six_neighbors(site, ticks)
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        witness_text = "fail"
+        if isinstance(witness[name], tuple):
+            witness_text = (
+                f"{witness[name][0]} P={matrix_display(witness[name][1])}"
+            )
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"split={split[name]} "
+            f"F={frame_display(frames[name])} "
+            f"Orient={orient_display(orient[name])} "
+            f"transport={transport[name]} "
+            f"scalar={scalar[name]} "
+            f"witness={witness_text}"
+        )
+
+    transport_reverse = transport_reverse_report(transport["A"], transport["B"])
+    transport_face = transport_face_report(transport["C"], transport["D"])
+    reverse = square_holonomy(REVERSE_SQUARE, ticks, locks, seed_map)
+    face = square_holonomy(FACE_SQUARE, ticks, locks, seed_map)
+    reverse_sendings = tuple(
+        edge_sending(
+            REVERSE_SQUARE[index],
+            REVERSE_SQUARE[(index + 1) % 4],
+            ticks,
+            locks,
+            seed_map,
+        )
+        for index in range(4)
+    )
+    face_sendings = tuple(
+        edge_sending(
+            FACE_SQUARE[index],
+            FACE_SQUARE[(index + 1) % 4],
+            ticks,
+            locks,
+            seed_map,
+        )
+        for index in range(4)
+    )
+    reverse_product = product_columns(reverse_sendings)
+    face_product = product_columns(face_sendings)
+    square_sites = REVERSE_SQUARE + FACE_SQUARE
+    square_split: dict[Point, str] = {}
+    square_orient: dict[Point, OrientVal] = {}
+    square_frame: dict[Point, FrameVal] = {}
+    square_tick: dict[Point, int | str] = {}
+    square_m: dict[Point, Incoming] = {}
+    square_o: dict[Point, Outgoing] = {}
+    for site in square_sites:
+        square_tick[site] = ticks[site] if site in ticks else UNDEFINED
+        incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+        square_m[site] = incoming
+        square_o[site] = outgoing
+        square_split[site], square_orient[site], square_frame[site] = site_frame_state(
+            site, ticks, locks, seed_map
+        )
+        print(
+            f"{SQUARE_NAMES[site]} {site} t={square_tick[site]} "
+            f"M={lockset_display(incoming)} "
+            f"O={lockset_display(outgoing)} "
+            f"split={square_split[site]} "
+            f"F={frame_display(square_frame[site])} "
+            f"Orient={orient_display(square_orient[site])}"
+        )
+    for index, sending in enumerate(reverse_sendings):
+        q = REVERSE_SQUARE[index]
+        r = REVERSE_SQUARE[(index + 1) % 4]
+        print(
+            f"P({SQUARE_NAMES[q]}->{SQUARE_NAMES[r]})={matrix_display(sending)}"
+        )
+    for index, sending in enumerate(face_sendings):
+        q = FACE_SQUARE[index]
+        r = FACE_SQUARE[(index + 1) % 4]
+        print(
+            f"P({SQUARE_NAMES[q]}->{SQUARE_NAMES[r]})={matrix_display(sending)}"
+        )
+    print(f"holonomy reverse product={matrix_display(reverse_product)}")
+    print(f"holonomy face product={matrix_display(face_product)}")
+    outside_square = ((0, 0, 4), (1, 0, 4), (1, 1, 4), (0, 1, 4))
+    outside_holonomy = square_holonomy(outside_square, ticks, locks, seed_map)
+    one_reverse = square_holonomy(REVERSE_SQUARE, one_ticks, one_locks, one_seeds)
+    one_face = square_holonomy(FACE_SQUARE, one_ticks, one_locks, one_seeds)
+    same_reverse = square_holonomy(REVERSE_SQUARE, same_ticks, same_locks, same_seeds)
+    same_face = square_holonomy(FACE_SQUARE, same_ticks, same_locks, same_seeds)
+    live_reverse = square_holonomy(REVERSE_SQUARE, live_ticks, live_locks, live_seeds)
+    live_face = square_holonomy(FACE_SQUARE, live_ticks, live_locks, live_seeds)
+    orient_reverse = reverse_report(orient["A"], orient["B"])
+    orient_face = face_report(orient["C"], orient["D"])
+    scalar_reverse = pair_bit(scalar["A"], scalar["B"])
+    scalar_face = pair_bit(scalar["C"], scalar["D"])
+    unique_pos_reverse = pair_bit(unique_pos["A"], unique_pos["B"])
+    unique_pos_face = pair_bit(unique_pos["C"], unique_pos["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unsigned_orient = {
+        name: unsigned_incoming_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    unique_o_orient_a = frame_orient(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = face_report(one_orient["C"], one_orient["D"])
+    one_transport = {
+        name: frame_transport(PROBES[name], one_ticks, one_locks, one_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    one_transport_face = transport_face_report(
+        one_transport["C"], one_transport["D"]
+    )
+    live_transport = {
+        name: frame_transport(PROBES[name], live_ticks, live_locks, live_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    live_transport_face = transport_face_report(
+        live_transport["C"], live_transport["D"]
+    )
+    same_transport = {
+        name: frame_transport(PROBES[name], same_ticks, same_locks, same_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    same_transport_face = transport_face_report(
+        same_transport["C"], same_transport["D"]
+    )
+    print(f"holonomy reverse={reverse} face={face}")
+    print(f"transport reverse={transport_reverse} face={transport_face}")
+    print(f"Orient reverse={orient_reverse} face={orient_face}")
+    print(f"scalar reverse={scalar_reverse} face={scalar_face}")
+    print(f"split reverse={split_reverse} face={split_face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: cyclic frame F=(m,o_next,o_prev) and four-edge signed-permutation "
+        "holonomy around a unit square at t+1"
+    )
+    print(
+        "per_site: scored only at reverse square A-D-B-E and face square C-C1-C2-C3 "
+        "on Euclidean B_3(0); no other sites"
+    )
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: edge sendings, two holonomy matrices, reverse/face from holonomy")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["D"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_transport(PROBES["B"], {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1})
+        == UNDEFINED
+        and frame_triple(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-split",
+        m1["A"] == frozenset({E2})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E3})
+        and m1["D"] == frozenset({E1})
+        and o1["A"] == frozenset({E1, NEG_E1, E3})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, NEG_E2})
+        and o1["D"] == frozenset({NEG_E2, E3, NEG_E3})
+        and all(split[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(cover[name] == "hold" for name in ("A", "B", "C", "D")),
+        str({name: (lockset_display(m1[name]), split[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Orient",
+        signed_m["A"] == E2
+        and signed_m["B"] == E1
+        and signed_m["C"] == E3
+        and signed_m["D"] == E1
+        and axis_i["A"] == 2
+        and axis_i["B"] == 1
+        and axis_i["C"] == 3
+        and axis_i["D"] == 1
+        and cyclic_plane["A"] == (E3, NEG_E1)
+        and cyclic_plane["B"] == (E2, NEG_E3)
+        and cyclic_plane["C"] == (NEG_E1, NEG_E2)
+        and cyclic_plane["D"] == (NEG_E2, NEG_E3)
+        and unique_plane["A"] == "fail"
+        and unique_plane["B"] == "fail"
+        and unique_plane["C"] == "fail"
+        and unique_plane["D"] == "fail"
+        and det["A"] == -1
+        and det["B"] == -1
+        and det["C"] == 1
+        and det["D"] == 1
+        and orient["A"] == -1
+        and orient["B"] == -1
+        and orient["C"] == 1
+        and orient["D"] == 1
+        and plane["A"] == (E1, E3)
+        and pair["A"] == E1
+        and frames["A"] == (E2, E3, NEG_E1)
+        and frames["B"] == (E1, E2, NEG_E3)
+        and frames["C"] == (E3, NEG_E1, NEG_E2)
+        and frames["D"] == (E1, NEG_E2, NEG_E3),
+        str({name: orient_display(orient[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-transport",
+        all(transport[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(isinstance(witness[name], tuple) for name in ("A", "B", "C", "D"))
+        and witness["A"] == ((1, 0, 1), ((0, 0, -1), (-1, 0, 0), (0, -1, 0)))
+        and witness["B"] == ((0, 1, 1), ((0, -1, 0), (0, 0, -1), (-1, 0, 0)))
+        and witness["C"] == ((0, 1, 2), ((1, 0, 0), (0, 1, 0), (0, 0, -1)))
+        and witness["D"] == ((0, 0, 1), ((0, -1, 0), (0, 0, -1), (-1, 0, 0)))
+        and integer_det_columns(*witness["A"][1]) == -1
+        and integer_det_columns(*witness["B"][1]) == -1
+        and integer_det_columns(*witness["C"][1]) == -1
+        and integer_det_columns(*witness["D"][1]) == -1
+        and integer_det_columns(*witness["A"][1]) == orient["A"] * orient["D"]
+        and integer_det_columns(*witness["B"][1]) == orient["B"] * 1
+        and sending_holds(frames["A"], frames["D"], orient["A"], orient["D"])
+        == "hold"
+        and scalar["A"] == "hold"
+        and scalar["B"] == "fail"
+        and scalar["C"] == "fail"
+        and scalar["D"] == "fail"
+        and all(unique_pos[name] == "fail" for name in ("A", "B", "C", "D")),
+        str({name: (transport[name], scalar[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-O-cyclic-not-unique",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 3
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["A"]) == frozenset({E2})
+        and unique_plane["A"] == "fail"
+        and unique_signed["A"] == "fail"
+        and cyclic_plane["A"] == (E3, NEG_E1)
+        and unique_o_orient_a == UNDEFINED
+        and orient["A"] == -1
+        and orient["A"] != UNDEFINED,
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and all(o0[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and all(frame_orient(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D"))
+        and all(frame_triple(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((1, 0, 2), (-1, 0, 2), (0, -1, 2))
+        and new_meet["D"] == ((1, -1, 1), (1, 0, 2), (1, 0, 0)),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E3
+        and ticks[E3] == 0
+        and locks[E3] == {E2}
+        and m1["A"] == frozenset({E2})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem1-square-ticks-F-Orient",
+        square_tick[(0, 0, 1)] == 0
+        and square_tick[(1, 0, 1)] == 1
+        and square_tick[(1, 1, 1)] == 1
+        and square_tick[(0, 1, 1)] == 0
+        and square_tick[(0, 0, 2)] == 1
+        and square_tick[(1, 0, 2)] == 2
+        and square_tick[(1, 1, 2)] == 2
+        and square_tick[(0, 1, 2)] == 1
+        and square_frame[(0, 0, 1)] == (E2, E3, NEG_E1)
+        and square_frame[(1, 0, 1)] == (E1, NEG_E2, NEG_E3)
+        and square_frame[(1, 1, 1)] == (E1, E2, NEG_E3)
+        and square_frame[(0, 1, 1)] == (NEG_E2, E3, NEG_E1)
+        and square_frame[(0, 0, 2)] == (E3, NEG_E1, NEG_E2)
+        and square_frame[(1, 0, 2)] == "fail"
+        and square_frame[(1, 1, 2)] == "fail"
+        and square_frame[(0, 1, 2)] == (E3, NEG_E1, E2)
+        and square_orient[(0, 0, 1)] == -1
+        and square_orient[(1, 0, 1)] == 1
+        and square_orient[(1, 1, 1)] == -1
+        and square_orient[(0, 1, 1)] == 1
+        and square_orient[(0, 0, 2)] == 1
+        and square_orient[(1, 0, 2)] == "fail"
+        and square_orient[(1, 1, 2)] == "fail"
+        and square_orient[(0, 1, 2)] == -1
+        and all(square_split[site] == "hold" for site in REVERSE_SQUARE)
+        and square_split[(0, 0, 2)] == "hold"
+        and square_split[(1, 0, 2)] == "fail"
+        and square_split[(1, 1, 2)] == "fail"
+        and square_split[(0, 1, 2)] == "hold"
+        and square_m[(1, 0, 2)] == frozenset({E1, E3})
+        and square_m[(1, 1, 2)] == frozenset({E1, E3})
+        and square_o[(0, 1, 1)] == frozenset({E1, NEG_E1, E3}),
+    )
+    checks.check(
+        "theorem1-edge-P-and-holonomy-matrices",
+        reverse_sendings
+        == (
+            ((0, 0, -1), (-1, 0, 0), (0, -1, 0)),
+            ((1, 0, 0), (0, -1, 0), (0, 0, 1)),
+            ((0, -1, 0), (0, 0, -1), (-1, 0, 0)),
+            ((-1, 0, 0), (0, 1, 0), (0, 0, 1)),
+        )
+        and all(isinstance(item, tuple) for item in reverse_sendings)
+        and all(is_signed_permutation(item) for item in reverse_sendings)
+        and integer_det_columns(*reverse_sendings[0]) == -1
+        and integer_det_columns(*reverse_sendings[1]) == -1
+        and integer_det_columns(*reverse_sendings[2]) == -1
+        and integer_det_columns(*reverse_sendings[3]) == -1
+        and reverse_product == IDENTITY_COLUMNS
+        and face_sendings[0] == "fail"
+        and face_sendings[1] == "fail"
+        and face_sendings[2] == "fail"
+        and face_sendings[3] == ((1, 0, 0), (0, 1, 0), (0, 0, -1))
+        and integer_det_columns(*face_sendings[3]) == -1
+        and face_product == "fail"
+        and sending_holds(
+            square_frame[(0, 0, 1)],
+            square_frame[(1, 0, 1)],
+            square_orient[(0, 0, 1)],
+            square_orient[(1, 0, 1)],
+        )
+        == "hold"
+        and sending_holds(
+            square_frame[(0, 1, 2)],
+            square_frame[(0, 0, 2)],
+            square_orient[(0, 1, 2)],
+            square_orient[(0, 0, 2)],
+        )
+        == "hold",
+        f"rev={matrix_display(reverse_product)} faceP={tuple(matrix_display(item) for item in face_sendings)}",
+    )
+    checks.check(
+        "theorem2-reverse-holonomy-hold",
+        reverse == "hold"
+        and reverse != UNDEFINED
+        and reverse != "fail"
+        and reverse_product == IDENTITY_COLUMNS
+        and transport_reverse == "hold"
+        and orient_reverse == "hold"
+        and scalar_reverse == "fail"
+        and unique_pos_reverse == "fail"
+        and split_reverse == "hold"
+        and cover_reverse == "hold"
+        and scalar_reverse != reverse
+        and reverse_report(square_orient[(0, 0, 1)], square_orient[(1, 1, 1)])
+        == "hold"
+        and reverse_report(square_orient[(0, 0, 1)], square_orient[(1, 0, 1)])
+        == "fail",
+    )
+    checks.check(
+        "theorem3-face-holonomy-fail",
+        face == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and face_product == "fail"
+        and transport_face == "hold"
+        and transport_face != face
+        and orient_face == "hold"
+        and orient_face != face
+        and scalar_face == "fail"
+        and unique_pos_face == "fail"
+        and split_face == "hold"
+        and cover_face == "hold"
+        and square_split[(1, 0, 2)] == "fail"
+        and square_split[(1, 1, 2)] == "fail"
+        and outside_holonomy == "fail"
+        and outside_holonomy != UNDEFINED,
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split_reverse == "hold"
+        and cover_reverse == "hold"
+        and reverse == "hold"
+        and split_face == "hold"
+        and cover_face == "hold"
+        and face == "fail"
+        and leftover_pair["C"] == 1
+        and leftover_pair["D"] == -1
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and reverse_report(lex["A"], lex["B"]) != reverse
+        and orient["C"] == 1
+        and orient["D"] == 1
+        and transport_face == "hold"
+        and transport_face != face,
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and one_orient["C"] == "fail"
+        and one_split["C"] == "fail"
+        and one_cover["C"] == "hold"
+        and one_orient_face == "fail"
+        and one_split_face == "fail"
+        and one_cover_face == "hold"
+        and one_transport["C"] == "fail"
+        and one_transport_face == "fail"
+        and frame_triple(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail",
+    )
+    checks.check(
+        "empty-Oi-is-orient-fail-not-undefined",
+        cyclic_signed_outgoing(frozenset({E2}), frozenset()) == "fail"
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1})) == "fail"
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset()) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1,
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["A"]] == 1
+        and one_ticks[PROBES["C"]] == 4
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["C"]] == 1
+        and one_orient["C"] == "fail"
+        and one_orient_face == "fail"
+        and face == "fail"
+        and reverse == "hold"
+        and one_reverse == "hold"
+        and one_face == "fail"
+        and one_ticks[PROBES["A"]] == 1
+        and ticks[PROBES["A"]] == 0
+        and square_split[(1, 0, 2)] == "fail"
+        and site_frame_state((0, 0, 2), one_ticks, one_locks, one_seeds)[0]
+        == "fail"
+        and one_m1["A"] != m1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and leftover_reverse != reverse
+        and reverse == "hold"
+        and face == "fail"
+        and all(lx[name] == frozenset() for name in ("A", "B", "C", "D"))
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m["A"] == frozenset({E1, E3})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_o["A"] == frozenset({E2})
+        and lx_o["B"] == frozenset({E1})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse == "hold"
+        and face == "fail"
+        and reverse_m_alone != reverse
+        and lx_m["A"] != lx["A"],
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and reverse == "hold"
+        and face == "fail"
+        and o_exist_reverse == "hold"
+        and pair_present["A"] == "hold"
+        and pair_present["B"] == "hold"
+        and pair_present["C"] == "hold"
+        and pair_present["D"] == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) == "hold"
+        and leftover_pair["A"] == -1
+        and leftover_pair["B"] == -1
+        and leftover_pair["C"] == 1
+        and leftover_pair["D"] == -1
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and reverse_product == IDENTITY_COLUMNS
+        and leftover_pair["C"] != reverse_product,
+    )
+    checks.check(
+        "mutation-unsigned-incoming-axis-agrees-here",
+        unsigned_orient["A"] == -1
+        and unsigned_orient["B"] == -1
+        and unsigned_orient["C"] == 1
+        and unsigned_orient["D"] == 1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and unsigned_incoming_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({NEG_E2}), o1["A"]) == 1
+        and unsigned_incoming_orient(frozenset({NEG_E2}), o1["A"]) == -1
+        and orient["A"] == -1,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({E2})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED
+        and unique_signed["A"] == "fail"
+        and unique_signed["C"] == "fail"
+        and unique_signed["D"] == "fail"
+        and orient["A"] == -1
+        and orient["D"] == 1
+        and orient["A"] != UNDEFINED,
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == E2
+        and sum_of_set(o1["A"]) == E3
+        and axis_o["A"] == frozenset({E1, E3})
+        and pair["A"] == E1
+        and leftover["A"] == E3
+        and cyclic_plane["A"] == (E3, NEG_E1)
+        and plane["A"] == (E1, E3),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and E2 in m1["A"]
+        and E2 not in o1["A"]
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "second-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    y_m1, y_o1 = probe_sides(Y_PROBES, ticks, locks, seed_map)
+    y_split = {name: axis_split(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_orient = {name: frame_orient(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_reverse = reverse_report(y_orient["A"], y_orient["B"])
+    y_face = face_report(y_orient["C"], y_orient["D"])
+    y_transport = {
+        name: frame_transport(Y_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    y_transport_reverse = transport_reverse_report(y_transport["A"], y_transport["B"])
+    y_transport_face = transport_face_report(y_transport["C"], y_transport["D"])
+    x_m1, x_o1 = probe_sides(X_PROBES, ticks, locks, seed_map)
+    x_orient = {name: frame_orient(x_m1[name], x_o1[name]) for name in ("A", "B", "C", "D")}
+    x_reverse = reverse_report(x_orient["A"], x_orient["B"])
+    x_face = face_report(x_orient["C"], x_orient["D"])
+    x_transport = {
+        name: frame_transport(X_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    x_transport_reverse = transport_reverse_report(x_transport["A"], x_transport["B"])
+    x_transport_face = transport_face_report(x_transport["C"], x_transport["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    same_m_a = incoming_set(
+        PROBES["A"], same_ticks[PROBES["A"]] + 1, same_ticks, same_locks, same_seeds
+    )
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-x-probes-or-y-probes-or-z-symmetric-or-perp",
+        TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and y_m1["A"] != m1["A"]
+        and y_split["A"] == "hold"
+        and y_orient["A"] == 1
+        and y_orient["B"] == -1
+        and y_reverse == "fail"
+        and lex_frame_orient(y_m1["A"], y_o1["A"]) == -1
+        and leftover_pair_orient(y_m1["A"], y_o1["A"]) == "fail"
+        and unique_signed_orient(y_m1["A"], y_o1["A"]) == 1
+        and y_split["D"] == "fail"
+        and y_orient["D"] == "fail"
+        and y_face == "fail"
+        and y_transport["D"] == "fail"
+        and y_transport_face == "fail"
+        and y_transport_reverse == "hold"
+        and x_reverse == "fail"
+        and x_face == "fail"
+        and x_transport_reverse == "fail"
+        and x_transport_face == "fail"
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse == "hold"
+        and face == "fail"
+        and y_reverse == "fail"
+        and y_reverse != reverse
+        and y_face == "fail",
+    )
+    checks.check(
+        "not-same-lock-or-one-axis-or-live-three-axis-seed",
+        TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and TWO_AXIS_SEEDS != LIVE_THREE_AXIS_SEEDS
+        and same_m_a != m1["A"]
+        and same_transport_face == "fail"
+        and one_transport_face == "fail"
+        and live_transport["B"] == "fail"
+        and live_transport["C"] == "fail"
+        and live_transport_face == "fail"
+        and reverse == "hold"
+        and face == "fail"
+        and same_face == "fail"
+        and live_face == "fail"
+        and same_reverse == "hold"
+        and live_reverse == "fail"
+        and live_reverse != reverse
+        and same_ticks[PROBES["A"]] == 1
+        and ticks[PROBES["A"]] == 0
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3
+        and sum(time == 0 for time in live_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-Orient",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ) = {+e_2}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_3}" in note
+        and "M(D, τ) = {+e_1}" in note
+        and "O(A, τ) = {+e_1, −e_1, +e_3}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, −e_2}" in note
+        and "O(D, τ) = {−e_2, +e_3, −e_3}" in note
+        and "split(A) = hold" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = hold" in note
+        and "m(A) = +e_2" in note
+        and "i(A) = 2" in note
+        and "o_next(A) = +e_3" in note
+        and "o_prev(A) = −e_1" in note
+        and "det(A) = -1" in note
+        and "Orient(A) = −1" in note
+        and "m(B) = +e_1" in note
+        and "i(B) = 1" in note
+        and "o_next(B) = +e_2" in note
+        and "o_prev(B) = −e_3" in note
+        and "det(B) = -1" in note
+        and "Orient(B) = −1" in note
+        and "m(C) = +e_3" in note
+        and "i(C) = 3" in note
+        and "o_next(C) = −e_1" in note
+        and "o_prev(C) = −e_2" in note
+        and "det(C) = 1" in note
+        and "Orient(C) = +1" in note
+        and "m(D) = +e_1" in note
+        and "i(D) = 1" in note
+        and "o_next(D) = −e_2" in note
+        and "o_prev(D) = −e_3" in note
+        and "det(D) = 1" in note
+        and "Orient(D) = +1" in note
+        and "F(A) = (+e_2, +e_3, −e_1)" in note
+        and "F(B) = (+e_1, +e_2, −e_3)" in note
+        and "F(C) = (+e_3, −e_1, −e_2)" in note
+        and "F(D) = (+e_1, −e_2, −e_3)" in note
+        and "F(E) = (−e_2, +e_3, −e_1)" in note
+        and "F(C1) = fail" in note
+        and "F(C2) = fail" in note
+        and "F(C3) = (+e_3, −e_1, +e_2)" in note
+        and "Orient(E) = +1" in note
+        and "Orient(C1) = fail" in note
+        and "Orient(C2) = fail" in note
+        and "Orient(C3) = −1" in note
+        and "t(E)=0" in note
+        and "t(C1)=2" in note
+        and "t(C2)=2" in note
+        and "t(C3)=1" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (1, 0, 2), (-1, 0, 2), (0, -1, 2)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, -1, 1), (1, 0, 2), (1, 0, 0)" in note,
+    )
+    checks.check(
+        "note-reports-holonomy-reverse-face",
+        "Reverse cyclic-frame holonomy at τ: hold" in note
+        and "Face cyclic-frame holonomy at τ: fail" in note
+        and "P(A→D) = [0 -1 0; 0 0 -1; -1 0 0]" in note
+        and "P(D→B) = [1 0 0; 0 -1 0; 0 0 1]" in note
+        and "P(B→E) = [0 0 -1; -1 0 0; 0 -1 0]" in note
+        and "P(E→A) = [-1 0 0; 0 1 0; 0 0 1]" in note
+        and "holonomy(A-D-B-E) = [1 0 0; 0 1 0; 0 0 1]" in note
+        and "P(C→C1) = fail" in note
+        and "P(C1→C2) = fail" in note
+        and "P(C2→C3) = fail" in note
+        and "P(C3→C) = [1 0 0; 0 1 0; 0 0 -1]" in note
+        and "holonomy(C-C1-C2-C3) = fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2axz axis-cover" in normalized_note
+        and "not leftover of nm2ax12z 1-in 2-out split" in normalized_note
+        and "not leftover of nm2chiralz lexicographic" in normalized_note
+        and "not leftover of nm2orichz leftover-axis" in normalized_note
+        and "not leftover of nm2orionez lex-one" in normalized_note
+        and "not leftover of nm2oridetz unique signed" in normalized_note
+        and "not leftover of nm2oricyclz cyclic Orient" in normalized_note
+        and "not leftover of nm2cycfrmz cyclic-frame transport" in normalized_note
+        and "not leftover of scalar neighbor-read" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse cyclic-frame holonomy at τ: hold" in note
+        and "Face cyclic-frame holonomy at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_UNIT_SQUARE_CYCLIC_FRAME_HOLONOMY_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "cyclic_signed_outgoing" in defined_fns
+        and "lex_largest_on_axis" in defined_fns
+        and "cyclic_units" in defined_fns
+        and "unique_signed_outgoing_plane" in defined_fns
+        and "leftover_pair_orient" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "cyclic_lex_smallest_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "frame_triple" in defined_fns
+        and "sending_matrix" in defined_fns
+        and "is_signed_permutation" in defined_fns
+        and "frame_transport" in defined_fns
+        and "scalar_orient_neighbor" in defined_fns
+        and "unique_positive_sending" in defined_fns
+        and "edge_sending" in defined_fns
+        and "square_holonomy" in defined_fns
+        and "product_columns" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "holonomy-not-transport-or-scalar-or-orient-equality",
+        reverse == "hold"
+        and face == "fail"
+        and transport_reverse == "hold"
+        and transport_face == "hold"
+        and transport_face != face
+        and split_reverse == "hold"
+        and cover_reverse == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and leftover_reverse != reverse
+        and one_orient_face == "fail"
+        and one_transport_face == "fail"
+        and scalar_reverse == "fail"
+        and scalar_face == "fail"
+        and unique_pos_reverse == "fail"
+        and unique_pos_face == "fail"
+        and scalar_reverse != reverse
+        and orient_reverse == "hold"
+        and orient_face == "hold"
+        and orient_face != face
+        and lex["A"] == -1
+        and lex["B"] == 1
+        and lex["C"] == 1
+        and lex["D"] == 1
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and face_report(lex["C"], lex["D"]) == "hold"
+        and reverse_report(lex["A"], lex["B"]) != reverse
+        and face_report(lex["C"], lex["D"]) != face
+        and lex["B"] != orient["B"]
+        and leftover_pair["A"] == -1
+        and leftover_pair["B"] == -1
+        and leftover_pair["C"] == 1
+        and leftover_pair["D"] == -1
+        and reverse_report(leftover_pair["A"], leftover_pair["B"]) == "hold"
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and cyclic_small["A"] == 1
+        and cyclic_small["B"] == 1
+        and cyclic_small["C"] == -1
+        and cyclic_small["D"] == -1
+        and reverse_report(cyclic_small["A"], cyclic_small["B"]) == "hold"
+        and face_report(cyclic_small["C"], cyclic_small["D"]) == "hold"
+        and face_report(cyclic_small["C"], cyclic_small["D"]) != face
+        and cyclic_small["A"] != orient["A"]
+        and unique_signed["A"] == "fail"
+        and unique_signed["B"] == "fail"
+        and unique_signed["C"] == "fail"
+        and unique_signed["D"] == "fail"
+        and reverse_report(unique_signed["A"], unique_signed["B"]) == "fail"
+        and reverse_report(unique_signed["A"], unique_signed["B"]) != reverse
+        and o_exist_reverse == "hold"
+        and o_exist_face == "fail"
+        and formed_nn["A"][:1] == ((1, 0, 1),)
+        and reverse_product == IDENTITY_COLUMNS,
+    )
+    _ = (
+        o0,
+        unique_o_orient_a,
+        one_cover_face,
+        one_split_face,
+        unsigned_orient,
+        perp_o1,
+        axis_m,
+        axis_o,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

New object: product of signed-permutation transports around A-D-B-E is the identity. Reverse HOLDs. Face square fails. Frame transport HOLDING #7490; scalar neighbor-read fails. PASS=62 FAIL=0. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_unit_square_cyclic_frame_holonomy_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.