### PR TITLE
feat(nm2cycfrmfx): cyclic-frame transport of (m,o_next,o_prev) at t+1 on three-axis far-face opposite x-probes: reverse fails, face fails

### DIFF
--- a/docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,900 @@
+---
+claim_id: three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Cyclic-frame transport of (m,o_next,o_prev) at t+1 on the four x-probes of the three-axis far-face opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+---
+
+# Cyclic-Frame Transport Of (m, o_next, o_prev) At t+1 Reverse And Face On Four X-Probes Of The Three-Axis Far-Face Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** cyclic-frame transport of `(m,o_next,o_prev)` of simultaneous
+earliest incoming set `M` and outgoing dual `O` at each probe's `τ=t+1`,
+and reverse/face from that transport, on the four x-probes of the three-axis far-face
+opposite seed in `B_3(0)={n:n·n<=9}`. Same process and x-probes as nm2axx.
+`M`, `O`, split as nm2ax12x. Orient as nm2oricyclz (lex-largest cyclic).
+Transport as nm2cycfrmz. Let `t(q)` be the formation tick of probe `q`.
+Let `τ(q)=t(q)+1`. `M(q,τ)` is the set of earliest incoming
+nearest-neighbor steps at `q` using only records with tick `<= τ`. Seeds
+are a singleton seed letter. `O(q,τ)` is the outgoing dual of `M`: the
+set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in
+`M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not
+`UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals
+`{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). When split HOLDs, `m` is unique in
+`M`. Let `i` in `{1,2,3}` be the axis index of `m`. `e_next = e_{i+1}`
+with `3+1→1`. `e_prev = e_{i-1}` with `1−1→3`. `O_next = O ∩ {±e_next}`.
+`O_prev = O ∩ {±e_prev}`. If either empty, Orient fails, not `UNDEFINED`.
+Order `+e < −e`. `o_next` is the lex-largest vector in `O_next` (hence
+`−e` if both signs). `o_prev` likewise. `Orient(q)` is the sign of the
+integer determinant of the 3×3 matrix with columns `m`, `o_next`,
+`o_prev`. If split fails, Orient fails, not `UNDEFINED`. When split
+HOLDs, `F(q)=(m,o_next,o_prev)` is an oriented lattice frame: a LIVE
+three-axis 1-in 2-out triple. Transport HOLDs at `q` if and only if split
+HOLDs at `q`, `Orient(q)` is `±1`, and some formed six-neighbor `r` has
+split HOLD, `Orient(r)` `±1`, and the 3×3 integer matrix sending the
+columns of `F(q)` to the columns of `F(r)` is a signed permutation with
+determinant `Orient(q)Orient(r)`. If split or Orient fails at `q`,
+transport fails, not `UNDEFINED`. Reverse HOLDs if and only if transport
+HOLDs at `A` and at `B`. Face HOLDs if and only if transport HOLDs at `C`
+and at `D`. Cover fails at `A` and at `D` because leftover axis `{e_2}`
+is missing, so split fails, Orient fails, and transport fails at `A` and
+at `D`. Transport HOLDs at `B` and at `C`. Reverse fails. Face fails.
+Neighbor-read of the scalar Orient sign fails at each of the four
+x-probes, including at `B` and `C` where transport HOLDs. Cover and split
+do not score handedness. This is not leftover of nm2cycfrmz cyclic-frame
+transport reverse HOLD and face HOLD on the four z-probes of this same
+seed. This is not leftover of y-probe transport reverse HOLD whose face
+fails. This is not leftover of nm2oricyclz cyclic Orient equal `±1` signs.
+This is not leftover of scalar neighbor-read of Orient. This is not
+leftover of a unique nonnegative permutation sending. This is not leftover
+of nm2orichz leftover-axis. This is not leftover of nm2orionez lex-one.
+This is not leftover of nm2chiralz lexicographic unsigned `o1,o2`
+orientation. This is not leftover of nm2oridetz unique signed outgoing
+letters. This is not leftover of nm2axx axis-cover. This is not leftover
+of nm2ax12x 1-in 2-out split. This is not leftover of leftover-of-`M`
+alone. This is not leftover of leftover-of-`O` alone. This is not
+leftover-empty fail of leftover axis. This is not leftover of nmunopp
+union. This is not leftover of nmt2opp `M` frozen at `t`. This is not
+leftover of nmot2opp two-tick composition. This is not leftover of
+nmoutopp untimed eventual-`O`. This is not leftover of mixed #7188
+fail/fail. This is not leftover of the 1-axis opposite two-site seed.
+This is not leftover of the same-lock two-site seed. This is not leftover
+of the two-axis opposite seed of nm2cycfrmx. The second pair is a
+new seed, not a formed child. The third pair is a new seed, not a formed
+child. `A` is not a seed. Uniqueness is not
+required. Mixed remains a set. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`](../scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named x-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. The cyclic next/prev
+lex-largest oriented frame is the integer sign of
+`det(m,o_next,o_prev)` with unique signed incoming letter `m` and the
+lex-largest signed outgoing letter on the cyclic next and prev axes of
+`Axis(M)` under `+e < −e`. When split HOLDs, `F=(m,o_next,o_prev)` is
+that LIVE three-axis frame. Transport is existential: some formed
+six-neighbor hosts a split-HOLDING frame whose columns are a signed
+permutation of the source columns with determinant the product of the
+two Orient signs. Reverse and face are scored on transport HOLD at the
+paired probes. Neighbor-read of the scalar Orient sign is a different
+readout and is not used as the object. A unique nonnegative permutation
+sending is a different readout and is not used as the object. Named
+signs `{+,−}` of locks are a coarser readout and are not used as the
+object. A singleton unique outgoing lock letter is a different readout
+and is not used as the object. Unsigned axis units of `Axis(O)` are a
+different readout and are not used. Unique signed letters requiring
+`|O_i|=1` are a different readout and are not used. Opposite-pair
+leftover-axis orientation is a different readout and are not used.
+Lex-one signed outgoing letters in axis order `e1<e2<e3` independent of
+`m` are a different readout and are not used. Cyclic lex-smallest (`+e`
+if both signs) is a different readout and is not used. Existential
+opposite of signed locks is a different readout and is not used.
+Axis-cover without the frame sign is a different readout and is not
+used. 1-in 2-out split without the frame sign is a different readout and
+is not used. Equal `±1` Orient signs without a sending matrix are a
+different readout and are not used. Leftover-empty fail of unsigned
+leftover axis sets is a different readout and is not used. A `Z^3` sum
+of those locks is a different readout and is not used. Occupancy of
+sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 on the four x-probes of the three-axis far-face opposite seed, transport fail at A and D, transport hold at B and C, reverse fail and face fail from transport at paired probes; uniqueness of the sending neighbor is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face
+target_blocker_text: "display cyclic-frame transport of (m,o_next,o_prev) reverse/face on the four x-probes of the three-axis far-face opposite seed, not scalar neighbor-read of Orient, not unique nonnegative sending, not leftover-axis, not lex-one e1<e2<e3, not unique |O_i|=1, not unsigned axis units, not cover, not split"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 displayed; do not write transport into Admissibility, do not reduce to scalar neighbor-read of Orient, do not reduce to unique nonnegative permutation sending, do not reduce to unique signed |O_i|=1, do not reduce to lexicographic unsigned o1,o2, do not reduce to leftover-axis, do not reduce to lex-one signed e1<e2<e3, do not reduce to cyclic lex-smallest, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace transport by unique outgoing letters, do not replace transport by existential opposite of signed locks, do not replace transport by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 on the four x-probes of the three-axis far-face opposite seed and reverse/face from that transport; reverse fail and face fail; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four x-probes are the only sites whose
+cyclic-frame transport of `F=(m,o_next,o_prev)` of `M` and `O` is scored:
+
+```text
+A = (1,0,0),  B = (1,1,1),  C = (2,0,0),  D = (1,1,0).
+```
+
+These are not the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`,
+`D=(1,1,0)`. These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. `A` is not a seed. Same process and x-probes as nm2axx.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: three disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. Site `(0,0,−1)` locks `+e_3`. Site `(0,1,−1)`
+locks `−e_3`. The second pair is a new seed, not a formed
+child of the first pair. The third pair is a new seed, not a formed child,
+and sits on the `−z` face. This seed is not the two-axis opposite seed of
+nm2cycfrmx. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named cyclic-frame transport of `(m,o_next,o_prev)` at `τ=t+1`
+
+Let `t(q)` be the formation tick of x-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Oriented frame at the same cut:
+
+```text
+When split HOLDs, m is the unique signed letter in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1. e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}. O_prev = O ∩ {±e_prev}.
+If either is empty, Orient fails, not UNDEFINED.
+Order +e < −e. o_next is lex-largest in O_next (hence −e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+The outgoing pair is signed. Mixed opposite signs on one cyclic slot make
+`|O_next|=2` or `|O_prev|=2`; lex-largest still picks `−e`, so Orient is
+defined when split HOLDs. Unique outgoing letters of the whole set `O` are
+not required: mixed `O` remains a set, and unique-letter readout of mixed
+`O` is `UNDEFINED` while this Orient is a sign. Empty `O_next` or empty
+`O_prev` is Orient fail, not `UNDEFINED`. A vanishing determinant is fail.
+Sign of a nonzero integer determinant is `+1` or `−1`. Split HOLD
+required: 2-in 1-out is Orient fail, not UNDEFINED.
+
+Cyclic frame and transport at the same cut:
+
+```text
+When split HOLDs, F(q)=(m, o_next, o_prev).
+Transport HOLDs at q iff split HOLDs, Orient(q) is ±1,
+and some formed 6-NN r has split HOLD, Orient(r) ±1,
+and the 3×3 integer matrix P sending the columns of F(q)
+to the columns of F(r) (F(r)=F(q)P) is a signed permutation
+with det(P)=Orient(q)Orient(r).
+If split or Orient fails at q, transport fails, not UNDEFINED.
+UNDEFINED if M or O is UNDEFINED.
+Uniqueness of r is not required.
+```
+
+Neighbor-read of the scalar Orient sign HOLDs at `q` if and only if
+`Orient(q)` is `±1` and some formed six-neighbor has the same sign. That
+is a different object: it fails at each of the four x-probes, including
+at `B` and at `C` where transport HOLDs, because a signed permutation may
+send a frame to a neighbor of opposite Orient with
+`det(P)=Orient(q)Orient(r)`. A unique nonnegative permutation sending is
+a different object and fails at each of the four x-probes.
+
+Reverse cyclic-frame transport holds if and only if transport HOLDs at
+`A` and at `B`. Face cyclic-frame transport holds if and only if
+transport HOLDs at `C` and at `D`. Either side `UNDEFINED` is
+`UNDEFINED`. Else if both sides HOLD, reverse or face HOLDs. Else fail.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover fails reverse and face on these x-probes
+because leftover `{e_2}` is missing at `A` and at `D`, without reading
+cyclic signed columns; transport HOLDs at `B` and at `C` while cover
+there also HOLDs, but cover does not score the signed-permutation sending.
+Identifying split reverse with this reverse is refused: `|Axis(M)|=1` at
+each of the four x-probes, so split equals cover on this member, without
+the cyclic order of `Axis(M)`. Identifying leftover-empty fail with this
+reverse is refused: leftover-empty fail scores empty leftover at `B` as
+reverse fail, while transport HOLDs at `B`; reverse fails here because
+transport fails at `A`. Identifying lexicographic unsigned `o1,o2` with
+this reverse is refused: lex-one at `B` is `+1` while cyclic Orient at
+`B` is `−1`. Identifying unique signed `|O_i|=1` with this reverse is
+refused: unique signed fails at `B` and at `C` because those outgoing
+sets have an opposite pair, while transport HOLDs there. Identifying
+leftover-axis orientation with this reverse is refused: leftover-axis at
+`B` and at `C` is `−1,−1` without a sending matrix. Identifying cyclic
+lex-smallest with this reverse is refused: lex-smallest at `B` is `+1`
+while cyclic lex-largest at `B` is `−1`. Identifying a named sign of
+those locks with reverse or face is refused: named-sign lettering lost
+the axis. Identifying nm2cycfrmz z-probe transport reverse HOLD and face
+HOLD with this reverse is refused: those are the four z-probes of this
+same seed, not these x-probes.
+
+## Theorem 1 — ticks, `M`, `O`, split, Orient, `F`, and transport at `τ=t+1`
+
+On this process the four x-probes form. Compare to leftover axis: leftover
+of the union is `{e_2}` at `A` and at `D` and empty at `B` and at `C`, so
+leftover reverse fails from empty leftover at `B`. Compare to nm2axx cover
+and nm2ax12x split: both fail reverse and fail face on this member because
+cover fails at `A` and at `D`. Compare to nm2cycfrmz cyclic-frame transport
+on the four z-probes of this same seed: reverse HOLDs and face HOLDs.
+Compare to y-probe transport on this same seed: reverse HOLDs and face
+fails. Compare to scalar neighbor-read of Orient: fail at each of the
+four x-probes, including at `B` and at `C` where transport HOLDs. Compare
+to unique nonnegative permutation sending: fail at each probe, including
+at `B` and at `C`. Compare to nm2oridetz unique signed outgoing letters:
+fail at `B` and at `C` because `|O_i|≠1`, while transport HOLDs there.
+This display reads the cyclic-frame transport of `(m,o_next,o_prev)` of
+those same timed sets:
+
+```text
+t(A)=2
+t(B)=1
+t(C)=3
+t(D)=2
+M(A, τ) = {+e_3, −e_3}
+M(B, τ) = {+e_1}
+M(C, τ) = {+e_1}
+M(D, τ) = {+e_3, −e_3}
+O(A, τ) = {+e_1}
+O(B, τ) = {+e_2, +e_3, −e_3}
+O(C, τ) = {−e_2, +e_3, −e_3}
+O(D, τ) = {+e_1, −e_1}
+split(A) = fail
+split(B) = hold
+split(C) = hold
+split(D) = fail
+m(A) = fail
+i(A) = fail
+o_next(A) fail
+o_prev(A) fail
+det(A) = fail
+Orient(A) = fail
+m(B) = +e_1
+i(B) = 1
+o_next(B) = +e_2
+o_prev(B) = −e_3
+det(B) = -1
+Orient(B) = −1
+m(C) = +e_1
+i(C) = 1
+o_next(C) = −e_2
+o_prev(C) = −e_3
+det(C) = 1
+Orient(C) = +1
+m(D) = fail
+i(D) = fail
+o_next(D) fail
+o_prev(D) fail
+det(D) = fail
+Orient(D) = fail
+F(A) = fail
+F(B) = (+e_1, +e_2, −e_3)
+F(C) = (+e_1, −e_2, −e_3)
+F(D) = fail
+transport(A) = fail
+transport(B) = hold
+transport(C) = hold
+transport(D) = fail
+scalar neighbor-read(A) = fail
+scalar neighbor-read(B) = fail
+scalar neighbor-read(C) = fail
+scalar neighbor-read(D) = fail
+witness(A) = fail
+witness(B) = (0, 1, 1)
+witness(C) = (2, 1, 0)
+witness(D) = fail
+```
+
+`A` is not a seed. `A` is the site `(1,0,0)` forming at tick 2 with mixed
+incoming `{+e_3, −e_3}`. Mixed remains a set: `M(A,τ)` and `M(D,τ)` each
+have two incoming steps on one axis, `O(B,τ)` has three outgoing steps,
+`O(C,τ)` has three outgoing steps, and `O(D,τ)` has two outgoing steps on
+one axis. Unique incoming letters would assign `UNDEFINED` at mixed `M(A)`
+and mixed `M(D)`. Unique outgoing letters would assign `UNDEFINED` at
+mixed `O`. Unique signed `|O_i|=1` fails at `B` and at `C` because those
+outgoing sets have an opposite pair, while transport HOLDs there.
+Lex-largest picks `−e` on each mixed cyclic slot at `B` and at `C`, so
+`(o_next,o_prev)` is defined there. `M` is mixed at `A` and at `D`, so
+unique signed `m` fails there, split fails, Orient fails, and transport
+fails. Cover fails at `A` and at `D` because `Axis(M)∪Axis(O)={e_1,e_3}`
+misses `e_2`. Cover and split HOLD at `B` and at `C` and do not score that
+cyclic lex-largest Orient is `−1` at `B` and `+1` at `C`. At `B`, `i=1` so
+`e_next=e_2` and `e_prev=e_3`; mixed `O_prev={±e_3}` yields `o_prev=−e_3`.
+At `C`, `i=1` so `e_next=e_2` and `e_prev=e_3`; mixed `O_prev={±e_3}`
+yields `o_prev=−e_3`. Lex-one at `B` uses axis order `(+e_2,+e_3)`
+independent of `m` and reports `+1`, while cyclic
+`(o_next,o_prev)=(+e_2,−e_3)` reports `−1`. Cyclic lex-smallest at `B`
+picks `o_prev=+e_3` and reports `+1`. On the two-axis opposite seed of
+nm2cycfrmx, `M(A,τ)={−e_3}` is a singleton and `M(D,τ)={−e_3}` is a
+singleton; here the third pair mixes those incoming sets. O is not M.
+
+On the 1-axis opposite two-site seed, `A=(1,0,0)` forms at tick 3 with
+mixed `M={+e_2,+e_3,−e_3}` and cover HOLDs, so 1-axis cover reverse HOLDs
+while this transport reverse fails. That is leftover of the first pair.
+Here `(0,0,1)` and `(0,1,1)` are seeds of a second opposite pair, and
+`(0,0,−1)` and `(0,1,−1)` are seeds of a third opposite pair. On the
+y-probes of this same seed, transport reverse HOLDs and transport face
+fails. On the z-probes of this same seed, transport reverse HOLDs and
+transport face HOLDs. Those probe-direction readouts are not this x-probe
+display. `C=(2,0,0)` is a formed child at tick 3, not the far-face
+third-pair seed.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`:
+
+```text
+new 6-NN of A at t(A)+1: (2, 0, 0)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)
+new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)
+new 6-NN of D at t(D)+1: (2, 1, 0)
+```
+
+`M` is frozen from `t` to `t+1`. At `t`, `O` is empty at `A`, `B`, and
+`C`, while `O(D,t)={−e_1}`. Split fails, Orient is fail, not UNDEFINED,
+and the cyclic frame fails, not UNDEFINED. Transport at `t` therefore
+fails, not UNDEFINED.
+
+Uniqueness of a transporting neighbor is not required. First witness in
+six-neighbor order: transport fails at `A` and at `D`; `B` sends to seed
+`(0,1,1)` with a signed permutation of determinant `−1`; `C` sends to
+`(2,1,0)` with a signed permutation of determinant `−1`. Scalar
+neighbor-read fails at each of the four x-probes, including at `B` and at
+`C` where transport HOLDs, because a signed permutation may send a frame
+to a neighbor of opposite Orient. Unique nonnegative sending fails at
+each probe.
+
+## Theorem 2 — reverse from cyclic-frame transport at `τ`
+
+Reverse cyclic-frame transport holds if and only if transport HOLDs at
+`A` and at `B`. `transport(A)=fail` and `transport(B)=hold`. Reverse
+fails. This is HOLD iff both transports HOLD, not leftover of nm2oricyclz
+cyclic Orient equal signs, not leftover of scalar neighbor-read, not
+leftover of a unique nonnegative permutation sending, not leftover of
+nm2chiralz lexicographic unsigned `o1,o2`, not leftover of nm2oridetz
+unique signed outgoing letters, not leftover of nm2orichz leftover-axis,
+not leftover of nm2orionez lex-one, not leftover of nm2axx axis-cover,
+not leftover of nm2ax12x 1-in 2-out split, not leftover of nm2cycfrmx
+two-axis x-probe transport, not leftover-empty fail, and not
+exist-opposite.
+
+Reverse cyclic-frame transport at τ: fail
+
+Both sides are defined, so this is not `UNDEFINED`. Cover reverse fails
+because cover fails at `A` and HOLDs at `B`. Split reverse fails because
+split fails at `A` and HOLDs at `B`. Cover and split do not score
+handedness. Leftover-empty reverse fails because leftover of the union is
+`{e_2}` at `A` and empty at `B`; leftover-empty fail scores that empty
+leftover at `B` as reverse fail, while transport HOLDs at `B`. Reverse
+fails here because transport fails at `A`. Leftover of `M` reverse fails
+because leftover of `M` at `A` is `{e_1, e_2}` and at `B` is `{e_2, e_3}`:
+nonempty and unequal. Leftover of `O` reverse fails because leftover of
+`O` at `A` is `{e_2, e_3}` and at `B` is `{e_1}`: nonempty and unequal.
+Exist-opposite reverse of signed `M` fails. Exist-opposite reverse of
+signed `O` fails. Presence of an opposite pair in `O` fails at `A` and
+HOLDs at `B`. Unique signed reverse fails. Lex-one reverse fails because
+lex-one at `A` fails and at `B` is `+1`. Cyclic lex-smallest reverse
+fails because lex-smallest at `A` fails and at `B` is `+1`. Scalar reverse
+fails. On the z-probes of this same seed, transport reverse HOLDs. On the
+y-probes, transport reverse HOLDs. On the two-axis opposite seed,
+x-probe transport reverse also fails, but `M(A)` there is `{−e_3}`, not
+mixed `{+e_3, −e_3}`. Those leftovers are not this display.
+
+Reverse fails.
+
+## Theorem 3 — face from cyclic-frame transport at `τ`
+
+Face cyclic-frame transport holds if and only if transport HOLDs at `C`
+and at `D`. `transport(C)=hold` and `transport(D)=fail`. Face fails.
+
+Face cyclic-frame transport at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+This is not `hold` and not `UNDEFINED`. Cover face fails because cover
+HOLDs at `C` and fails at `D`. Split face fails because split HOLDs at `C`
+and fails at `D`. Cover and split do not score handedness. Leftover-empty
+face fails because leftover of the union is empty at `C` and `{e_2}` at
+`D`; leftover-empty fail scores that empty leftover at `C` as face fail,
+while transport HOLDs at `C`. Face fails here because transport fails at
+`D`. Presence of an opposite pair in `O` HOLDs at `C` and at `D`, so
+pair-presence face HOLDs while this face fails. Unique signed face fails
+because unique signed at `C` fails from mixed `±e_3`. Lex-one face fails
+because lex-one at `D` fails. Cyclic lex-smallest face fails because
+lex-smallest at `D` fails. Scalar face fails. On the 1-axis opposite
+two-site seed, cover face HOLDs while split face fails and transport face
+fails. This three-axis far-face member is not leftover of that 1-axis
+cover face HOLD: here cover fails at `D`. On the z-probes of this same
+seed, transport face HOLDs. On the y-probes, transport face fails. On the
+two-axis opposite seed, x-probe transport face also fails, but `M(D)`
+there is `{−e_3}`, not mixed `{+e_3, −e_3}`. Leftover of `M` at `C` is
+`{e_2, e_3}` and leftover of `M` at `D` is `{e_1, e_2}`: nonempty and
+unequal. Leftover of `O` at `C` is `{e_1}` and leftover of `O` at `D` is
+`{e_2, e_3}`: nonempty and unequal. Exist-opposite face of signed `M`
+fails. Exist-opposite face of signed `O` fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover fails at `D` and split fails at `D`. Orient at
+`D` is fail from mixed `M={±e_3}` and leftover `{e_2}`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not replace transport by neighbor-read of the scalar Orient sign.
+- It does not replace transport by a unique nonnegative permutation sending.
+- It does not require a unique formed six-neighbor witness.
+- It does not reprint nm2oricyclz cyclic Orient reverse hold face hold as this transport.
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by lexicographic unsigned `o1,o2` orientation.
+- It does not replace Orient by unique signed `|O_i|=1` letters.
+- It does not replace Orient by leftover-axis orientation.
+- It does not replace Orient by nm2orionez lex-one signed `e1<e2<e3`.
+- It does not replace Orient by cyclic lex-smallest (`+e` if both signs).
+- It does not replace Orient by unsigned axis units of `Axis(O)`.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not treat split fail as `UNDEFINED`.
+- It does not treat empty `O_i` as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2axx axis-cover reverse fail face fail as this
+  oriented display.
+- It does not reprint nm2ax12x 1-in 2-out split reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2chiralz lexicographic unsigned `o1,o2` reverse fail
+  face hold with `+1,+1` as this oriented display.
+- It does not reprint nm2oridetz unique signed reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orichz leftover-axis reverse hold face fail as
+  this oriented display.
+- It does not reprint nm2orionez lex-one reverse fail face hold as this
+  oriented display.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four x-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+three-axis far-face opposite seed process, cyclic-frame transport of
+`(m,o_next,o_prev)` of `M` and `O` at `t+1`, and the reverse/face bits
+from that transport are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; three-axis far-face opposite seed `+e_1/−e_1`, `+e_2/−e_2`, and `+e_3/−e_3` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `2`, `1`, `3`, `2` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t`; mixed `{±e_3}` at `A,D` |
+| `O` at `τ=t+1` | Theorem 1; HOLDING outgoing dual at `B,C`; singleton at `A`; mixed pair at `D` |
+| split at `τ` | Theorem 1; fail at `A,D`; HOLD at `B,C` |
+| unique signed `m`, axis index `i`, cyclic `(o_next,o_prev)` | Theorem 1; mixed `M` fail at `A,D`; cyclic pair defined at `B,C` |
+| integer `det(m,o_next,o_prev)` | Theorem 1; fail, `-1`, `1`, fail |
+| Orient at `τ` | Theorem 1; fail, `−1`, `+1`, fail |
+| cyclic frame `F=(m,o_next,o_prev)` | Theorem 1; fail at `A,D`; LIVE three-axis at `B,C` |
+| transport at `τ` | Theorem 1; fail at `A,D`; HOLD at `B,C` |
+| scalar neighbor-read of Orient | Theorem 1; fail at each of `A,B,C,D`; not this letter |
+| reverse from cyclic-frame transport at `τ` | Theorem 2; `fail` |
+| face from cyclic-frame transport at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2axx axis-cover fail | not this oriented display |
+| leftover of nm2ax12x 1-in 2-out split fail | not this oriented display |
+| leftover of nm2chiralz lexicographic unsigned `o1,o2` | not this oriented display |
+| leftover of nm2oridetz unique signed `|O_i|=1` | not this oriented display |
+| leftover of nm2orichz leftover-axis | not this oriented display |
+| leftover of nm2orionez lex-one signed `e1<e2<e3` | not this oriented display |
+| leftover of cyclic lex-smallest | not this oriented display |
+| leftover of nm2oricyclz cyclic Orient equal signs | not this transport |
+| leftover of nm2cycfrmx two-axis x-probe transport | not this display; `M(A)` there is `{−e_3}` |
+| leftover of nm2cycfrmfz z-probe transport HOLD | not this letter |
+| leftover of scalar neighbor-read of Orient | not this transport |
+| leftover of unique nonnegative permutation sending | not this transport |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or z-probe transport on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display; #7477 same-lock face transport fails |
+| leftover of the LIVE three-axis three-site seed | not this display; face transport fails |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| empty `O_i` scored as `UNDEFINED` | refused; Orient fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: cyclic-frame transport of `(m,o_next,o_prev)` of `M` and `O` at `t+1` on the four x-probes of the three-axis far-face opposite seed, and reverse/face from that transport. |
+| V2 | Current main has no landed cyclic-frame-transport reverse/face of timed `M` and `O` on these four x-probes of the three-axis far-face opposite seed. |
+| V3 | Transport reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads a signed-permutation sending of the cyclic frame to a formed six-neighbor at the same `t+1` cut, reverse fails and face fails while transport HOLDs at `B` and at `C`, scalar neighbor-read fails at each probe including at `B` and at `C`, unique nonnegative sending fails at each probe, `M(A)` is mixed `{±e_3}` unlike the two-axis singleton `{−e_3}`, nm2cycfrmfz z-probe reverse HOLD and face HOLD are a different letter, and nm2oricyclz Orient equality does not supply the sending. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by nm2chiralz lexicographic unsigned `o1,o2`, does not replace
+Orient by nm2oridetz unique signed `|O_i|=1`, does not replace Orient by
+nm2orichz leftover-axis, does not replace Orient by nm2orionez lex-one,
+does not replace Orient by cyclic lex-smallest, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2axx axis-cover, does not
+replace Orient by nm2ax12x 1-in 2-out split, does not identify this
+display with the 1-axis opposite two-site seed, and does not identify it
+with nmunopp union. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| scalar neighbor-read of Orient | reuse equal Orient sign at some formed 6-NN | scalar fails at each of `A,B,C,D`; transport HOLDs at `B` and at `C` while scalar fails there | ATTEMPTED |
+| unique nonnegative permutation sending | require a unique sending with no minus signs | unique nonnegative sending fails at each of `A,B,C,D` while transport HOLDs at `B` and at `C`; uniqueness is not required | ATTEMPTED |
+| nm2cycfrmz z-probe transport | reuse z-probe reverse hold and face hold on this seed | z-probe reverse HOLDs and face HOLDs; this letter is the four x-probes, reverse fail and face fail | ATTEMPTED |
+| nm2cycfrmfz far-face z-probe transport | reuse far-face z-probe reverse hold and face hold | that letter is the four z-probes of this same seed; `A` there is a seed at tick 0 | ATTEMPTED |
+| nm2cycfrmx two-axis x-probe transport | reuse two-axis x-probe reverse fail and face fail | two-axis `M(A)={−e_3}` is a singleton; here `M(A)={+e_3, −e_3}` from the third pair | ATTEMPTED |
+| nm2oricyclz cyclic Orient | reuse Orient reverse hold and face hold from equal `±1` signs | Orient reverse HOLDs and face HOLDs on the z-probes without a signed-permutation sending; this x-probe reverse fails | ATTEMPTED |
+| nm2chiralz lexicographic unsigned `o1,o2` | reuse unsigned reverse fail and face hold | lex-one at `B` is `+1` while cyclic Orient at `B` is `−1`; unsigned columns are not cyclic `o_next,o_prev` | ATTEMPTED |
+| nm2oridetz unique signed `|O_i|=1` | reuse unique signed reverse fail and face fail | unique signed fails at `B` and at `C` while transport HOLDs there; an opposite pair in `O` makes `|O_i|≠1` but lex-largest still picks `−e` | ATTEMPTED |
+| nm2orichz leftover-axis | reuse leftover-axis reverse hold and face fail | leftover-axis at `B` and at `C` is `−1,−1` without a sending matrix; leftover-axis at `A` and at `D` fails | ATTEMPTED |
+| nm2orionez lex-one | reuse lex-one reverse fail and face hold | lex-one at `B` is `+1` from `e1<e2<e3` order independent of `m`; cyclic Orient at `B` is `−1` | ATTEMPTED |
+| cyclic lex-smallest | reuse same cyclic axes with `+e` if both signs | lex-smallest at `B` is `+1` while cyclic lex-largest at `B` is `−1` | ATTEMPTED |
+| nm2axx axis-cover | reuse cover reverse fail and cover face fail on these x-probes | cover fails reverse and face without cyclic signed columns; transport HOLDs at `B` and at `C` | ATTEMPTED |
+| nm2ax12x 1-in 2-out split | reuse split reverse fail and split face fail | `|Axis(M)|=1` at `B` and at `C` so split equals cover there; Cover and split do not score handedness | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails from empty leftover at `B` while transport HOLDs at `B`; reverse fails here because transport fails at `A` | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` is `{e_1,e_2}` and at `B` is `{e_2,e_3}`, nonempty unequal | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` is `{e_2,e_3}` and at `B` is `{e_1}`, nonempty unequal | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `M` and of signed `O` both fail on these x-probes; that readout never reads the sending | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence fails at `A` and HOLDs at `B,C,D`; pair-presence face HOLDs while this face fails | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of unique signed incoming and cyclic lex-largest outgoing letters | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(B,τ)` remains a set; unique-letter Orient at `B` is `UNDEFINED` while this Orient is `−1` | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | on this member both agree at `B` and at `C`; flipping `m` on unique signed `O={+e_1,+e_3}` from `+e_2` to `−e_2` flips Orient from `+1` to `−1` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; none of these four probes is 2-in 1-out | ATTEMPTED |
+| empty `O_i` as `UNDEFINED` | treat empty signed outgoing on an axis as unformed | empty `O_i` is Orient fail, not UNDEFINED | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(A)=3`, `t(C)=4`, mixed `M(A)`, cover HOLD | different seed; second pair is a new seed, not a formed child; here `t(A)=2` and cover fails at `A` | ATTEMPTED |
+| y-probe transport | score the four y-probes on this seed | y-probe transport reverse HOLDs and y-face fails; this letter is the four x-probes | ATTEMPTED |
+| z-probe transport | score the four z-probes on this seed | z-probe reverse HOLDs and z-face HOLDs; this letter is the four x-probes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores cyclic next/prev lex-largest outgoing determinant orientation of own incoming and outgoing at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports reverse fail and face fail from transport fail at `A` and at `D` on the three-axis far-face opposite seed | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is three disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum; mixed `O(B)` sums to `+e_2` while cyclic is `(+e_2,−e_3)` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with nm2chiralz lexicographic unsigned `o1,o2`,
+missing identification of Orient with nm2oridetz unique signed `|O_i|=1`,
+missing identification of Orient with nm2orichz leftover-axis, missing
+identification of Orient with nm2orionez lex-one, missing identification of
+Orient with cyclic lex-smallest, missing identification of Orient with
+nmcover axis-cover, missing identification of Orient with nm2axx axis-cover,
+missing identification of Orient with nm2ax12x 1-in 2-out split, missing
+identification of this seed with the 1-axis opposite two-site seed, and
+missing Record identification of Orient reverse are distinct open premises.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, three disjoint opposite seed pairs `+e_1/−e_1`,
+`+e_2/−e_2`, and `+e_3/−e_3` at far-face `(0,0,−1)/(0,1,−1)`,
+perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ=t+1`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, unique signed `m` when split HOLDs, cyclic
+next/prev axes of `Axis(M)`, lex-largest signed outgoing letter under
+`+e < −e` (hence `−e` if both signs), integer determinant sign, empty
+`O_next` or empty `O_prev` as Orient fail not `UNDEFINED`, split fail as
+Orient fail not `UNDEFINED`, four x-probes with `A` not a seed, second pair as a
+new seed not a formed child, third pair as a new seed not a formed child,
+and mixed remains a set are declared. No
+uniqueness of outgoing locks, no six-neighbor lock union as the scored
+object, no lock-count clock, no global later T, no formation attachment
+from already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+Orient `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | cyclic frame `F=(m,o_next,o_prev)` and signed-permutation sending to a formed 6-NN | no continuum alphabet |
+| per site | `A,B,C,D` x-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four transport reports, reverse/face from transport at paired probes | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for cyclic-frame transport
+reverse/face, a formation-rate rule, and a physical selector among 1-in
+2-out frames. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Transport reverse fail and face fail are only leftover of
+nm2axx cover fail, or of nm2cycfrmx two-axis x-probe transport fail, or of
+neighbor-read of the scalar Orient sign, or of leftover-empty fail; unique
+signed `|O_i|=1` already answers mixed `O`; leftover of `M` alone already
+answers reverse; leftover of `O` alone already answers reverse;
+exist-opposite of signed `O` already answers reverse; mixed #7188 already
+reported fail/fail; the third pair is only the formed child of the
+two-axis seed; unique outgoing letters should be required; and unsigned
+incoming axis already gives the same signs because each `M` letter is the
+positive unit.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores empty leftover at `B` as reverse fail
+while transport HOLDs at `B`. Reverse fails here because transport fails
+at `A`. Cover reverse also fails because cover fails at `A`, without
+reading cyclic signed columns or a signed-permutation sending. Transport
+HOLDs at `B` and at `C` while scalar neighbor-read fails there. Unique
+nonnegative sending fails at each probe. Unique signed `|O_i|=1` fails at
+`B` and at `C` while transport HOLDs there. Pair-presence face HOLDs while
+this face fails. On the two-axis opposite seed, `M(A)={−e_3}` is a
+singleton; here mixed `M(A)={+e_3, −e_3}` from the third pair at tick 0.
+On unique signed `O={+e_1,+e_3}` leftover is empty while Orient is `+1`,
+so leftover-empty fail is not this predicate. Mixed #7188 is a different
+z-symmetric process with mixed `M`. The second pair is a new seed, not a
+formed child. The third pair is a new seed, not a formed child: `(0,0,−1)`
+is recorded at tick 0 with lock `+e_3`, whereas the two-axis child forms
+at tick 1 with lock `−e_3`. Z-probe transport reverse HOLDs and face HOLDs
+on this same seed; this letter is the four x-probes.
+
+### N8 — cross-cycle echo
+
+nm2axx cover on the two-axis opposite seed reported cover fail at `A` and
+at `D`, reverse fail, and face fail on these x-probes, with `M(A)={−e_3}`.
+nm2cycfrmx cyclic-frame transport on that two-axis seed reported the same
+transport fail at `A` and at `D` with singleton `M(A)={−e_3}`. nm2cycfrmfz
+cyclic-frame transport on this three-axis far-face seed reported reverse
+hold and face hold on the four z-probes. The four y-probes of this same
+seed reported transport reverse hold and transport face fail. This note
+is not those displays: it reports cyclic-frame transport of
+`(m,o_next,o_prev)` of `M` and `O` at `τ=t+1` on the four x-probes of the
+three-axis far-face opposite seed, with `t(A)=2`, `t(B)=1`, `t(C)=3`, and
+`t(D)=2`, mixed `M(A)={+e_3, −e_3}`, `transport(A)=fail`,
+`transport(B)=hold`, `transport(C)=hold`, `transport(D)=fail`, reverse
+fail, and face fail, while scalar neighbor-read fails at each probe.
+Cover and split do not score handedness.
+
+**Gate disposition:** PASS for the cyclic-frame-transport `t+1`
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals
+the named sign,” “the predicate equals the unique singleton lock vector,”
+“the predicate equals six-neighbor lock union,” “the predicate equals
+leftover-empty fail,” “the predicate equals leftover of `M` alone,” “the
+predicate equals leftover of `O` alone,” “the predicate equals
+exist-opposite HOLD,” “the predicate equals opposite-pair presence in
+`O`,” “the predicate equals nm2chiralz lexicographic unsigned `o1,o2`
+HOLD,” “the predicate equals nm2oridetz unique signed HOLD,” “the
+predicate equals nm2orichz leftover-axis HOLD,” “the predicate equals
+nm2orionez lex-one HOLD,” “the predicate equals cyclic lex-smallest HOLD,”
+“the predicate equals nm2oricyclz cyclic Orient HOLD,” “the predicate
+equals scalar neighbor-read of Orient HOLD,” “the predicate equals unique
+nonnegative permutation sending HOLD,” “the predicate equals nmcover
+axis-cover HOLD,” “the predicate equals nm2axx axis-cover HOLD,” “the
+predicate equals nm2ax12x 1-in 2-out split HOLD,” “the predicate equals
+the 1-axis opposite two-site seed,” “the predicate equals nmunopp union,”
+“bits are Admissibility,” “split fail is UNDEFINED,” or “empty `O_i` is
+UNDEFINED.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the three-axis far-face
+opposite perp-step incoming-lock process, reads each probe's own earliest
+incoming set and own outgoing dual from the record prefix at that probe's
+`t+1`, reports split of the pair, reports the cyclic frame
+`F=(m,o_next,o_prev)`, reports Orient as nm2oricyclz lex-largest cyclic,
+reports transport by a signed-permutation sending to some formed
+six-neighbor, lists new records in `B_3(0)` between `t` and `t+1` that
+meet a probe's six-neighbors, and checks Theorems 1--3. It also checks
+that transport fails at `A` and at `D` and HOLDs at `B` and at `C`, that
+reverse fails and face fails from transport while leftover-empty reverse
+fails from empty leftover at `B` where transport HOLDs, that scalar
+neighbor-read fails at each probe including at `B` and at `C`, that unique
+nonnegative permutation sending fails at each probe, that z-probe
+transport reverse HOLDs and face HOLDs on this same seed, that y-probe
+transport reverse HOLDs while this reverse fails, that two-axis
+nm2cycfrmx reverse fails from singleton `M(A)={−e_3}` while this `M(A)`
+is mixed `{+e_3, −e_3}`, that split fail is transport fail not
+`UNDEFINED`, that empty `O_next` or empty `O_prev` is Orient fail not
+`UNDEFINED`, that the 1-axis opposite two-site seed is a different member
+with cover HOLD at `A`, that leftover-empty fail is a different
+predicate, that leftover of `M` alone and leftover of `O` alone are
+different objects, that mixed sets remain sets, that unique-letter Orient
+is `UNDEFINED` at mixed `M(A)` and mixed `O(B)`, that the construction
+does not sum, that a formation member from already-recorded six-neighbor
+locks is not attached, that the second pair is a new seed not a formed
+child, that the third pair is a new seed not a formed child on the `−z`
+face, that the y-probes and z-probes of this seed are not this letter,
+and that the display is not the two-tick lock-count clock composition. No
+runner cache is written.

--- a/logs/runner-cache/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,94 @@
+===== runner cache v1 =====
+runner: scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+runner_sha256: ce7472872e25479c44dd76a4fda203e5f069dbe05825e236763aca23d2bb8f49
+input_fingerprint_sha256: c2f9a78572941f8f23d0fc545bb41aeb49b1f3568d7c76f5ea6720effa4008bf
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.08
+status: ok
+----- stdout -----
+cyclic-frame transport of (m,o_next,o_prev) reverse/face at t+1 on three-axis far-face opposite x-probes
+AUDIT_INPUT_PATHS:
+  docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Cyclic-frame transport of (m,o_next,o_prev) at t+1 on the four x-probes of the three-axis far-face opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-x-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+PASS: sending-identity
+A t=2 M={+e_3, −e_3} O={+e_1} split=fail F=fail Orient=fail transport=fail scalar=fail witness=fail
+B t=1 M={+e_1} O={+e_2, +e_3, −e_3} split=hold F=(+e_1, +e_2, −e_3) Orient=−1 transport=hold scalar=fail witness=(0, 1, 1) P=[0 0 -1; -1 0 0; 0 -1 0]
+C t=3 M={+e_1} O={−e_2, +e_3, −e_3} split=hold F=(+e_1, −e_2, −e_3) Orient=+1 transport=hold scalar=fail witness=(2, 1, 0) P=[1 0 0; 0 -1 0; 0 0 1]
+D t=2 M={+e_3, −e_3} O={+e_1, −e_1} split=fail F=fail Orient=fail transport=fail scalar=fail witness=fail
+transport reverse=fail face=fail
+Orient reverse=fail face=fail
+scalar reverse=fail face=fail
+split reverse=fail face=fail
+cover reverse=fail face=fail
+per_element: cyclic frame F=(m,o_next,o_prev) and signed-permutation sending to a formed 6-NN at a probe's t+1
+per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four transport reports, reverse/face from transport at paired probes
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 2, 'B': 1, 'C': 3, 'D': 2})
+PASS: theorem1-M-O-split  ({'A': ('{+e_3, −e_3}', 'fail'), 'B': ('{+e_1}', 'hold'), 'C': ('{+e_1}', 'hold'), 'D': ('{+e_3, −e_3}', 'fail')})
+PASS: theorem1-Orient  ({'A': 'fail', 'B': '−1', 'C': '+1', 'D': 'fail'})
+PASS: theorem1-transport  ({'A': ('fail', 'fail'), 'B': ('hold', 'fail'), 'C': ('hold', 'fail'), 'D': ('fail', 'fail')})
+PASS: theorem1-mixed-O-cyclic-not-unique
+PASS: theorem1-M-frozen-from-t
+PASS: theorem1-new-records-meet-6nn  ({'A': ((2, 0, 0),), 'B': ((1, 2, 1), (1, 1, 2), (1, 1, 0)), 'C': ((2, -1, 0), (2, 0, 1), (2, 0, -1)), 'D': ((2, 1, 0),)})
+PASS: theorem1-A-is-not-seed
+PASS: theorem2-reverse-transport-fail
+PASS: theorem3-face-transport-fail
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: empty-Oi-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unsigned-incoming-axis-agrees-here
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-and-third-pair-are-seeds-not-formed-children
+PASS: not-z-probes-or-y-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-or-one-axis-or-live-three-axis-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-split-Orient
+PASS: note-reports-new-neighbors
+PASS: note-reports-transport-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: transport-not-scalar-or-orient-equality-or-lex-one
+TOTAL: PASS=60 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,2330 @@
+#!/usr/bin/env python3
+"""Cyclic-frame transport of (m,o_next,o_prev) at t+1 reverse/face.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is three disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2, (0,0,-1) locks +e_3, (0,1,-1) locks
+-e_3. The third pair is a new seed, not a formed child, and sits on the -z
+face. Same process and x-probes as nm2axx. Perp-step incoming lock. M, O,
+split as nm2ax12x. Orient as nm2oricyclz (lex-largest cyclic). Transport as
+nm2cycfrmz. Unformed => UNDEFINED. When split HOLDs, F(q)=(m,o_next,o_prev)
+is an oriented lattice frame. Transport HOLDs at q iff split HOLDs at q,
+Orient(q) is +/-1, and some formed 6-NN r has split HOLD, Orient(r) +/-1,
+and the 3x3 integer matrix sending the columns of F(q) to the columns of
+F(r) is a signed permutation with determinant Orient(q)*Orient(r). If split
+or Orient fails at q, transport fails, not UNDEFINED. Reverse HOLDs iff
+transport at A and at B. Face on C,D. Neighbor-read of the scalar Orient
+sign is a different object. Uniqueness is not required. Occupancy of sites
+is not used. No larger host. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+FrameVal = tuple[Point, Point, Point] | str
+Sending = tuple[Point, Point, Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+PAIR3: Point = (0, 0, -1)
+PAIR3B: Point = (0, 1, -1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+    (PAIR3, E3),
+    (PAIR3B, NEG_E3),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+LIVE_THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+    (E3, E3),
+)
+PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Cyclic-frame transport of (m,o_next,o_prev) at t+1 on the four x-probes of the three-axis "
+    "far-face opposite seed, and reverse/face from that, are reported. "
+    "Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def pair_display(value: tuple[Point, Point] | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple):
+        raise TypeError(f"signed pair is not a pair or fail: {value!r}")
+    return ", ".join(LOCK_NAME[vec] for vec in value)
+
+
+def frame_display(value: FrameVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"frame is not a triple or fail: {value!r}")
+    return "(" + ", ".join(LOCK_NAME[vec] for vec in value) + ")"
+
+
+def matrix_display(value: Sending) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"sending is not three columns or fail: {value!r}")
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return "[" + "; ".join(" ".join(str(entry) for entry in row) for row in rows) + "]"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = THREE_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3. Mutation: unsigned."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negative)
+    return picked[0], picked[1]
+
+
+def axis_index(lock: Point) -> int | str:
+    """Axis index i in {1,2,3} of a signed nearest-neighbor letter."""
+    axis = axis_of_letter(lock)
+    if axis == E1:
+        return 1
+    if axis == E2:
+        return 2
+    if axis == E3:
+        return 3
+    return "fail"
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    """e_next = e_{i+1} with 3+1->1. e_prev = e_{i-1} with 1-1->3."""
+    idx = axis_index(signed_m)
+    if idx == "fail" or not isinstance(idx, int):
+        return "fail"
+    e_next = AXES[idx % 3]
+    e_prev = AXES[idx - 2]
+    return e_next, e_prev
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-largest signed letter in O intersect {+/-axis}. Order +e < -e."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-smallest signed letter in O intersect {+/-axis}. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def cyclic_signed_outgoing(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = True
+) -> tuple[Point, Point] | str:
+    """o_next, o_prev on the two cyclic axes of Axis(M). Empty slot is fail."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    o_next = picker(outgoing, units[0])
+    o_prev = picker(outgoing, units[1])
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic unsigned o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane. Fail if an opposite pair occupies O_i."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_lex_smallest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: same cyclic axes, lex-smallest (+e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-largest cyclic slots."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o_next, o_prev = plane
+    det = integer_det_columns(signed_m, o_next, o_prev)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_triple(incoming: Incoming, outgoing: Outgoing) -> FrameVal:
+    """F=(m,o_next,o_prev) when split HOLDs. Else fail, not UNDEFINED unless unformed."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return signed_m, plane[0], plane[1]
+
+
+def transpose_columns(frame: tuple[Point, Point, Point]) -> tuple[Point, Point, Point]:
+    """Columns of the transpose. Inverse on signed permutation frames."""
+    return tuple(tuple(frame[column][row] for column in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def mul_columns(
+    left: tuple[Point, Point, Point], right: tuple[Point, Point, Point]
+) -> tuple[Point, Point, Point]:
+    """Integer matrix product of two column-triple matrices."""
+    return tuple(
+        tuple(
+            sum(left[k][i] * right[j][k] for k in range(3)) for i in range(3)
+        )
+        for j in range(3)
+    )  # type: ignore[return-value]
+
+
+def sending_matrix(source: FrameVal, target: FrameVal) -> Sending:
+    """Integer matrix P with F(r) = F(q) P, sending columns of F(q) to F(r)."""
+    if source == UNDEFINED or target == UNDEFINED:
+        return UNDEFINED
+    if source == "fail" or target == "fail":
+        return "fail"
+    if not isinstance(source, tuple) or not isinstance(target, tuple):
+        return "fail"
+    return mul_columns(transpose_columns(source), target)
+
+
+def is_signed_permutation(value: Sending) -> bool:
+    """Exactly one nonzero +/-1 in each row and each column."""
+    if not isinstance(value, tuple) or len(value) != 3:
+        return False
+    for column in value:
+        if any(entry not in (-1, 0, 1) for entry in column):
+            return False
+        if sum(abs(entry) for entry in column) != 1:
+            return False
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return all(sum(abs(entry) for entry in row) == 1 for row in rows)
+
+
+def sending_holds(
+    source: FrameVal, target: FrameVal, orient_q: OrientVal, orient_r: OrientVal
+) -> str:
+    """HOLD iff P is a signed permutation with det = Orient(q)Orient(r)."""
+    sending = sending_matrix(source, target)
+    if sending == UNDEFINED:
+        return UNDEFINED
+    if sending == "fail" or not isinstance(sending, tuple):
+        return "fail"
+    if orient_q not in (1, -1) or orient_r not in (1, -1):
+        return "fail"
+    det = integer_det_columns(sending[0], sending[1], sending[2])
+    if is_signed_permutation(sending) and det == orient_q * orient_r:
+        return "hold"
+    return "fail"
+
+
+def is_nonnegative_permutation(value: Sending) -> bool:
+    """Unsigned permutation: signed permutation with no minus signs. Mutation."""
+    if not is_signed_permutation(value):
+        return False
+    if not isinstance(value, tuple):
+        return False
+    return all(entry >= 0 for column in value for entry in column)
+
+
+def site_sides(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Incoming, Outgoing]:
+    if site not in ticks:
+        return UNDEFINED, UNDEFINED
+    tau = ticks[site] + 1
+    return (
+        incoming_set(site, tau, ticks, locks, seed_map),
+        outgoing_set(site, tau, ticks, locks, seed_map),
+    )
+
+
+def formed_six_neighbors(site: Point, ticks: dict[Point, int]) -> tuple[Point, ...]:
+    """Formed 6-NN of site in B_3(0). Not a six-neighbor star letter."""
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def frame_transport(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, and some formed 6-NN r transports."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_transport_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, Sending] | str:
+    """First formed 6-NN in NN order that transports. Uniqueness is not required."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return neighbor, sending
+    return "fail"
+
+
+def scalar_orient_neighbor(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: HOLD iff some formed 6-NN has the same scalar Orient sign."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    orient = frame_orient(incoming, outgoing)
+    if orient == UNDEFINED:
+        return UNDEFINED
+    if orient not in (1, -1):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        if frame_orient(n_in, n_out) == orient:
+            return "hold"
+    return "fail"
+
+
+def unique_positive_sending(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: unique nonnegative permutation sending. Not this letter."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    hits = 0
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_orient = frame_orient(n_in, n_out)
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if (
+            sending_holds(source, target, orient, n_orient) == "hold"
+            and is_nonnegative_permutation(sending)
+        ):
+            hits += 1
+    if hits == 1:
+        return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Orient reverse HOLDs iff Orient(A)=Orient(B) both +/-1. Contrast."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Orient face HOLDs iff Orient(C)=Orient(D) both +/-1. Contrast."""
+    return pair_orient(orient_c, orient_d)
+
+
+def transport_reverse_report(left: str, right: str) -> str:
+    """Reverse HOLDs iff transport at A and at B."""
+    return pair_bit(left, right)
+
+
+def transport_face_report(left: str, right: str) -> str:
+    """Face HOLDs iff transport at C and at D."""
+    return pair_bit(left, right)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    plane = cyclic_signed_outgoing(frozenset({unsigned_m}), outgoing, largest=True)
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("cyclic-frame transport of (m,o_next,o_prev) reverse/face at t+1 on three-axis far-face opposite x-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-x-probes-in-host",
+        probe_sites == ((1, 0, 0), (1, 1, 1), (2, 0, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != z_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and add(PAIR3, E3) == ORIGIN
+        and add(PAIR3, E2) == PAIR3B
+        and perpendicular(E1, E2)
+        and perpendicular(E3, E1)
+        and not perpendicular(E3, E3)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and in_ball(PAIR3)
+        and in_ball(PAIR3B)
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E3, NEG_E1) == -1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E3, NEG_E1, NEG_E2) == 1
+        and integer_det_columns(E1, NEG_E2, NEG_E3) == 1
+        and integer_det_columns(E2, E3, E1) == 1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E3, E1, NEG_E2) == -1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({E2}), frozenset({NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and frame_orient(frozenset({E1, NEG_E1}), frozenset({E2, E3})) == "fail"
+        and cyclic_units(E2) == (E3, E1)
+        and cyclic_units(E1) == (E2, E3)
+        and cyclic_units(E3) == (E1, E2)
+        and cyclic_units(NEG_E2) == (E3, E1)
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1
+        and lex_largest_on_axis(frozenset({E1}), E1) == E1
+        and lex_smallest_on_axis(frozenset({E1, NEG_E1}), E1) == E1
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E3, NEG_E1)
+        and cyclic_signed_outgoing(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == (E2, NEG_E3)
+        and cyclic_signed_outgoing(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2}))
+        == (NEG_E1, NEG_E2)
+        and cyclic_signed_outgoing(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3}))
+        == (NEG_E2, NEG_E3)
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1})) == "fail"
+        and unique_signed_outgoing_plane(frozenset({E1, NEG_E1, E3})) == "fail"
+        and unique_signed_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == "fail"
+        and lex_frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and leftover_pair_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and cyclic_lex_smallest_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == 1
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+    identity_frame = (E2, E3, NEG_E1)
+    identity_target = (E1, NEG_E2, NEG_E3)
+    identity_sending = sending_matrix(identity_frame, identity_target)
+    checks.check(
+        "sending-identity",
+        frame_triple(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E2, E3, NEG_E1)
+        and sending_matrix(UNDEFINED, identity_frame) == UNDEFINED
+        and sending_matrix(identity_frame, "fail") == "fail"
+        and sending_matrix(identity_frame, identity_frame)
+        == (E1, E2, E3)
+        and is_signed_permutation((E1, E2, E3))
+        and not is_signed_permutation((E1, E1, E2))
+        and sending_holds(identity_frame, identity_frame, -1, -1) == "hold"
+        and sending_holds(identity_frame, identity_target, -1, 1) == "hold"
+        and integer_det_columns(*identity_sending) == -1
+        and is_signed_permutation(identity_sending)
+        and not is_nonnegative_permutation(identity_sending)
+        and mul_columns(identity_frame, identity_sending) == identity_target,
+    )
+
+    ticks, locks, seed_map = form()
+    two_ticks, two_locks, two_seeds = form(TWO_AXIS_SEEDS)
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    live_ticks, live_locks, live_seeds = form(LIVE_THREE_AXIS_SEEDS)
+    tau0: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    axis_m: dict[str, AxisSet] = {}
+    axis_o: dict[str, AxisSet] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m: dict[str, Point | str] = {}
+    plane: dict[str, tuple[Point, Point] | str] = {}
+    pair: dict[str, Point | str] = {}
+    leftover: dict[str, Point | str] = {}
+    det: dict[str, int | str] = {}
+    lex: dict[str, OrientVal] = {}
+    leftover_pair: dict[str, OrientVal] = {}
+    unique_signed: dict[str, OrientVal] = {}
+    pair_present: dict[str, str] = {}
+    unique_plane: dict[str, tuple[Point, Point] | str] = {}
+    lex_plane: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_plane: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_small: dict[str, OrientVal] = {}
+    axis_i: dict[str, int | str] = {}
+    orient: dict[str, OrientVal] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    frames: dict[str, FrameVal] = {}
+    transport: dict[str, str] = {}
+    scalar: dict[str, str] = {}
+    unique_pos: dict[str, str] = {}
+    witness: dict[str, tuple[Point, Sending] | str] = {}
+    formed_nn: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1 = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1, ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1, ticks, locks, seed_map)
+        axis_m[name] = axis_set(m1[name])
+        axis_o[name] = axis_set(o1[name])
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m[name] = unique_signed_m(m1[name])
+        plane[name] = outgoing_plane(axis_o[name])
+        unique_plane[name] = unique_signed_outgoing_plane(o1[name])
+        lex_plane[name] = lex_signed_outgoing_plane(o1[name])
+        cyclic_plane[name] = cyclic_signed_outgoing(m1[name], o1[name], largest=True)
+        pair[name] = opposite_pair_unit(o1[name])
+        if isinstance(signed_m[name], tuple):
+            axis_i[name] = axis_index(signed_m[name])
+        else:
+            axis_i[name] = "fail"
+        if isinstance(signed_m[name], tuple) and isinstance(pair[name], tuple):
+            leftover[name] = leftover_unit(signed_m[name], pair[name])
+        else:
+            leftover[name] = "fail"
+        if isinstance(signed_m[name], tuple) and isinstance(cyclic_plane[name], tuple):
+            det[name] = integer_det_columns(
+                signed_m[name], cyclic_plane[name][0], cyclic_plane[name][1]
+            )
+        else:
+            det[name] = "fail"
+        pair_present[name] = has_opposite_pair(o1[name])
+        lex[name] = lex_frame_orient(m1[name], o1[name])
+        leftover_pair[name] = leftover_pair_orient(m1[name], o1[name])
+        unique_signed[name] = unique_signed_orient(m1[name], o1[name])
+        cyclic_small[name] = cyclic_lex_smallest_orient(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        frames[name] = frame_triple(m1[name], o1[name])
+        transport[name] = frame_transport(site, ticks, locks, seed_map)
+        scalar[name] = scalar_orient_neighbor(site, ticks, locks, seed_map)
+        unique_pos[name] = unique_positive_sending(site, ticks, locks, seed_map)
+        witness[name] = first_transport_witness(site, ticks, locks, seed_map)
+        formed_nn[name] = formed_six_neighbors(site, ticks)
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        witness_text = "fail"
+        if isinstance(witness[name], tuple):
+            witness_text = (
+                f"{witness[name][0]} P={matrix_display(witness[name][1])}"
+            )
+        print(
+            f"{name} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"split={split[name]} "
+            f"F={frame_display(frames[name])} "
+            f"Orient={orient_display(orient[name])} "
+            f"transport={transport[name]} "
+            f"scalar={scalar[name]} "
+            f"witness={witness_text}"
+        )
+
+    reverse = transport_reverse_report(transport["A"], transport["B"])
+    face = transport_face_report(transport["C"], transport["D"])
+    orient_reverse = reverse_report(orient["A"], orient["B"])
+    orient_face = face_report(orient["C"], orient["D"])
+    scalar_reverse = pair_bit(scalar["A"], scalar["B"])
+    scalar_face = pair_bit(scalar["C"], scalar["D"])
+    unique_pos_reverse = pair_bit(unique_pos["A"], unique_pos["B"])
+    unique_pos_face = pair_bit(unique_pos["C"], unique_pos["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unsigned_orient = {
+        name: unsigned_incoming_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    unique_o_orient_a = frame_orient(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    unique_o_orient_b = frame_orient(unique_letter(m1["B"]), unique_letter(o1["B"]))
+    two_m1, two_o1 = probe_sides(PROBES, two_ticks, two_locks, two_seeds)
+    two_transport = {
+        name: frame_transport(PROBES[name], two_ticks, two_locks, two_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    two_transport_reverse = transport_reverse_report(two_transport["A"], two_transport["B"])
+    two_transport_face = transport_face_report(two_transport["C"], two_transport["D"])
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = face_report(one_orient["C"], one_orient["D"])
+    one_transport = {
+        name: frame_transport(PROBES[name], one_ticks, one_locks, one_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    one_transport_face = transport_face_report(
+        one_transport["C"], one_transport["D"]
+    )
+    live_transport = {
+        name: frame_transport(PROBES[name], live_ticks, live_locks, live_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    live_transport_face = transport_face_report(
+        live_transport["C"], live_transport["D"]
+    )
+    same_transport = {
+        name: frame_transport(PROBES[name], same_ticks, same_locks, same_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    same_transport_face = transport_face_report(
+        same_transport["C"], same_transport["D"]
+    )
+    print(f"transport reverse={reverse} face={face}")
+    print(f"Orient reverse={orient_reverse} face={orient_face}")
+    print(f"scalar reverse={scalar_reverse} face={scalar_face}")
+    print(f"split reverse={split_reverse} face={split_face}")
+    print(f"cover reverse={cover_reverse} face={cover_face}")
+    print(
+        "per_element: cyclic frame F=(m,o_next,o_prev) and signed-permutation "
+        "sending to a formed 6-NN at a probe's t+1"
+    )
+    print("per_site: scored only at x-probes A,B,C,D on Euclidean B_3(0); no other sites")
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: four transport reports, reverse/face from transport at paired probes")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    z_transport = {
+        name: frame_transport(Z_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    z_transport_reverse = transport_reverse_report(z_transport["A"], z_transport["B"])
+    z_transport_face = transport_face_report(z_transport["C"], z_transport["D"])
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    third_pair_parallel_blocked = all(
+        ticks.get(add(PAIR3, step)) != 1 for step in (E3, NEG_E3)
+    ) and all(ticks.get(add(PAIR3B, step)) != 1 for step in (E3, NEG_E3))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and third_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 0
+        and ticks[ORIGIN] == 0
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2
+        and ticks[PAIR3] == 0
+        and ticks[PAIR3B] == 0
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["C"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["C"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["D"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["D"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_transport(PROBES["B"], {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1})
+        == UNDEFINED
+        and frame_triple(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 2
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 3
+        and ticks[PROBES["D"]] == 2,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-split",
+        m1["A"] == frozenset({E3, NEG_E3})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E1})
+        and m1["D"] == frozenset({E3, NEG_E3})
+        and o1["A"] == frozenset({E1})
+        and o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["C"] == frozenset({NEG_E2, E3, NEG_E3})
+        and o1["D"] == frozenset({E1, NEG_E1})
+        and split["A"] == "fail"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "fail"
+        and cover["A"] == "fail"
+        and cover["B"] == "hold"
+        and cover["C"] == "hold"
+        and cover["D"] == "fail",
+        str({name: (lockset_display(m1[name]), split[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-Orient",
+        signed_m["A"] == "fail"
+        and signed_m["B"] == E1
+        and signed_m["C"] == E1
+        and signed_m["D"] == "fail"
+        and axis_i["A"] == "fail"
+        and axis_i["B"] == 1
+        and axis_i["C"] == 1
+        and axis_i["D"] == "fail"
+        and cyclic_plane["A"] == "fail"
+        and cyclic_plane["B"] == (E2, NEG_E3)
+        and cyclic_plane["C"] == (NEG_E2, NEG_E3)
+        and cyclic_plane["D"] == "fail"
+        and unique_plane["A"] == "fail"
+        and unique_plane["B"] == "fail"
+        and unique_plane["C"] == "fail"
+        and unique_plane["D"] == "fail"
+        and det["A"] == "fail"
+        and det["B"] == -1
+        and det["C"] == 1
+        and det["D"] == "fail"
+        and orient["A"] == "fail"
+        and orient["B"] == -1
+        and orient["C"] == 1
+        and orient["D"] == "fail"
+        and plane["A"] == "fail"
+        and pair["A"] == "fail"
+        and frames["A"] == "fail"
+        and frames["B"] == (E1, E2, NEG_E3)
+        and frames["C"] == (E1, NEG_E2, NEG_E3)
+        and frames["D"] == "fail",
+        str({name: orient_display(orient[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-transport",
+        transport["A"] == "fail"
+        and transport["B"] == "hold"
+        and transport["C"] == "hold"
+        and transport["D"] == "fail"
+        and witness["A"] == "fail"
+        and isinstance(witness["B"], tuple)
+        and isinstance(witness["C"], tuple)
+        and witness["D"] == "fail"
+        and witness["B"] == ((0, 1, 1), ((0, -1, 0), (0, 0, -1), (-1, 0, 0)))
+        and witness["C"] == ((2, 1, 0), ((1, 0, 0), (0, -1, 0), (0, 0, 1)))
+        and integer_det_columns(*witness["B"][1]) == -1
+        and integer_det_columns(*witness["C"][1]) == -1
+        and integer_det_columns(*witness["B"][1]) == orient["B"] * 1
+        and integer_det_columns(*witness["C"][1]) == orient["C"] * -1
+        and sending_holds(frames["B"], frames["C"], orient["B"], orient["C"])
+        == "hold"
+        and scalar["A"] == "fail"
+        and scalar["B"] == "fail"
+        and scalar["C"] == "fail"
+        and scalar["D"] == "fail"
+        and all(unique_pos[name] == "fail" for name in ("A", "B", "C", "D"))
+        and scalar["B"] != transport["B"]
+        and unique_pos["C"] != transport["C"],
+        str({name: (transport[name], scalar[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-mixed-O-cyclic-not-unique",
+        isinstance(o1["B"], frozenset)
+        and len(o1["B"]) == 3
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(m1["B"]) == frozenset({E1})
+        and unique_plane["B"] == "fail"
+        and unique_signed["B"] == "fail"
+        and cyclic_plane["B"] == (E2, NEG_E3)
+        and unique_o_orient_b == UNDEFINED
+        and orient["B"] == -1
+        and orient["B"] != UNDEFINED
+        and unique_letter(o1["A"]) == frozenset({E1})
+        and unique_letter(m1["A"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED
+        and cyclic_plane["A"] == "fail"
+        and orient["A"] == "fail",
+    )
+    checks.check(
+        "theorem1-M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and all(frame_orient(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D"))
+        and all(frame_triple(m0[name], o0[name]) == "fail" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet["A"] == ((2, 0, 0),)
+        and new_meet["B"] == ((1, 2, 1), (1, 1, 2), (1, 1, 0))
+        and new_meet["C"] == ((2, -1, 0), (2, 0, 1), (2, 0, -1))
+        and new_meet["D"] == ((2, 1, 0),),
+        str(new_meet),
+    )
+    checks.check(
+        "theorem1-A-is-not-seed",
+        PROBES["A"] == E1
+        and ticks[E1] == 2
+        and locks[E1] == {E3, NEG_E3}
+        and m1["A"] == frozenset({E3, NEG_E3})
+        and E1 not in seed_map
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem2-reverse-transport-fail",
+        reverse == "fail"
+        and transport["A"] == "fail"
+        and transport["B"] == "hold"
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and orient_reverse == "fail"
+        and scalar_reverse == "fail"
+        and unique_pos_reverse == "fail"
+        and split_reverse == "fail"
+        and cover_reverse == "fail"
+        and z_transport_reverse == "hold"
+        and z_transport_reverse != reverse,
+    )
+    checks.check(
+        "theorem3-face-transport-fail",
+        face == "fail"
+        and transport["C"] == "hold"
+        and transport["D"] == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and orient_face == "fail"
+        and scalar_face == "fail"
+        and unique_pos_face == "fail"
+        and split_face == "fail"
+        and cover_face == "fail"
+        and z_transport_face == "hold"
+        and z_transport_face != face
+        and scalar["C"] != transport["C"],
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split_reverse == "fail"
+        and cover_reverse == "fail"
+        and reverse == "fail"
+        and split_face == "fail"
+        and cover_face == "fail"
+        and face == "fail"
+        and leftover_pair["B"] == -1
+        and leftover_pair["C"] == -1
+        and leftover_pair["A"] == "fail"
+        and leftover_pair["D"] == "fail"
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and lex["B"] == 1
+        and orient["B"] == -1
+        and lex["B"] != orient["B"]
+        and cover["B"] == "hold"
+        and split["B"] == "hold"
+        and orient["C"] == 1
+        and cover["C"] == "hold"
+        and split["C"] == "hold"
+        and cover["A"] == "fail"
+        and cover["D"] == "fail",
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_one["A"] == "fail"
+        and two_one["D"] == "fail"
+        and split["A"] == "fail"
+        and orient["A"] == "fail"
+        and transport["A"] == "fail"
+        and one_orient["C"] == 1
+        and one_split["C"] == "hold"
+        and one_cover["C"] == "hold"
+        and one_cover["A"] == "hold"
+        and one_split["A"] == "fail"
+        and one_orient["A"] == "fail"
+        and one_orient_face == "fail"
+        and one_split_face == "fail"
+        and one_cover_face == "hold"
+        and one_transport["C"] == "hold"
+        and one_transport["D"] == "fail"
+        and one_transport_face == "fail"
+        and frame_triple(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail",
+    )
+    checks.check(
+        "empty-Oi-is-orient-fail-not-undefined",
+        cyclic_signed_outgoing(frozenset({E2}), frozenset()) == "fail"
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1})) == "fail"
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset()) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1,
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["A"]] == 3
+        and one_ticks[PROBES["C"]] == 4
+        and ticks[PROBES["A"]] == 2
+        and ticks[PROBES["C"]] == 3
+        and one_cover["A"] == "hold"
+        and cover["A"] == "fail"
+        and one_cover_face == "hold"
+        and face == "fail"
+        and one_cover_face != face
+        and one_m1["A"] != m1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and lx["A"] == frozenset({E2})
+        and lx["B"] == frozenset()
+        and lx["C"] == frozenset()
+        and lx["D"] == frozenset({E2})
+        and leftover_match(frozenset(), frozenset()) == "fail"
+        and leftover_match(frozenset({E2}), frozenset()) == "fail"
+        and cover["B"] == "hold"
+        and transport["B"] == "hold"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m["A"] == frozenset({E1, E2})
+        and lx_m["B"] == frozenset({E2, E3})
+        and lx_o["A"] == frozenset({E2, E3})
+        and lx_o["B"] == frozenset({E1})
+        and reverse_m_alone == "fail"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "fail"
+        and face_o_alone == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and lx_m["A"] != lx["A"]
+        and lx["B"] == frozenset()
+        and lx_m["B"] != lx["B"],
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "fail"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "fail"
+        and o_exist_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and pair_present["A"] == "fail"
+        and pair_present["B"] == "hold"
+        and pair_present["C"] == "hold"
+        and pair_present["D"] == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) == "hold"
+        and pair_bit(pair_present["C"], pair_present["D"]) != face
+        and leftover_pair["A"] == "fail"
+        and leftover_pair["B"] == -1
+        and leftover_pair["C"] == -1
+        and leftover_pair["D"] == "fail"
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail",
+    )
+    checks.check(
+        "mutation-unsigned-incoming-axis-agrees-here",
+        unsigned_orient["A"] == "fail"
+        and unsigned_orient["B"] == -1
+        and unsigned_orient["C"] == 1
+        and unsigned_orient["D"] == "fail"
+        and unsigned_orient["B"] == orient["B"]
+        and unsigned_orient["C"] == orient["C"]
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and unsigned_incoming_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({NEG_E2}), o1["B"]) == "fail"
+        and unsigned_incoming_orient(frozenset({NEG_E2}), o1["B"]) == "fail"
+        and orient["B"] == -1,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["B"]) == frozenset({E1})
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_o_orient_b == UNDEFINED
+        and unique_signed["B"] == "fail"
+        and unique_signed["C"] == "fail"
+        and unique_signed["D"] == "fail"
+        and unique_signed["A"] == "fail"
+        and orient["B"] == -1
+        and orient["C"] == 1
+        and orient["B"] != UNDEFINED
+        and unique_letter(o1["A"]) == frozenset({E1})
+        and unique_letter(m1["A"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED,
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["B"], frozenset)
+        and sum_of_set(m1["A"]) == ZERO
+        and sum_of_set(o1["A"]) == E1
+        and sum_of_set(o1["B"]) == E2
+        and sum_of_set(o1["D"]) == ZERO
+        and axis_o["A"] == frozenset({E1})
+        and pair["A"] == "fail"
+        and leftover["A"] == "fail"
+        and cyclic_plane["A"] == "fail"
+        and plane["A"] == "fail"
+        and cyclic_plane["B"] == (E2, NEG_E3),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and E3 in m1["A"]
+        and NEG_E3 in m1["A"]
+        and E3 not in o1["A"]
+        and NEG_E3 not in o1["A"]
+        and E1 in o1["A"]
+        and E1 not in m1["A"]
+        and o1["A"] != m1["A"],
+    )
+    checks.check(
+        "second-and-third-pair-are-seeds-not-formed-children",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and PAIR3 in seed_map
+        and seed_map[PAIR3] == E3
+        and ticks[PAIR3] == 0
+        and PAIR3B in seed_map
+        and seed_map[PAIR3B] == NEG_E3
+        and ticks[PAIR3B] == 0
+        and two_ticks[PAIR3] == 1
+        and two_locks[PAIR3] == {NEG_E3}
+        and two_m1["A"] == frozenset({NEG_E3})
+        and m1["A"] != two_m1["A"]
+        and two_transport_reverse == "fail"
+        and two_transport_face == "fail"
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet["A"],
+    )
+    y_m1, y_o1 = probe_sides(Y_PROBES, ticks, locks, seed_map)
+    y_split = {name: axis_split(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_orient = {name: frame_orient(y_m1[name], y_o1[name]) for name in ("A", "B", "C", "D")}
+    y_reverse = reverse_report(y_orient["A"], y_orient["B"])
+    y_face = face_report(y_orient["C"], y_orient["D"])
+    y_transport = {
+        name: frame_transport(Y_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    y_transport_reverse = transport_reverse_report(y_transport["A"], y_transport["B"])
+    y_transport_face = transport_face_report(y_transport["C"], y_transport["D"])
+    z_m1, z_o1 = probe_sides(Z_PROBES, ticks, locks, seed_map)
+    z_orient = {name: frame_orient(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")}
+    z_reverse = reverse_report(z_orient["A"], z_orient["B"])
+    z_face = face_report(z_orient["C"], z_orient["D"])
+    z_transport = {
+        name: frame_transport(Z_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    z_transport_reverse = transport_reverse_report(z_transport["A"], z_transport["B"])
+    z_transport_face = transport_face_report(z_transport["C"], z_transport["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    same_m_a = incoming_set(
+        PROBES["A"], same_ticks[PROBES["A"]] + 1, same_ticks, same_locks, same_seeds
+    )
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-z-probes-or-y-probes-or-z-symmetric-or-perp",
+        THREE_AXIS_SEEDS != PERP_SEEDS
+        and THREE_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and THREE_AXIS_SEEDS != TWO_AXIS_SEEDS
+        and probe_sites != z_probe_sites
+        and probe_sites != y_probe_sites
+        and y_m1["A"] != m1["A"]
+        and y_split["A"] == "hold"
+        and y_orient["A"] == 1
+        and y_orient["B"] == -1
+        and y_reverse == "fail"
+        and lex_frame_orient(y_m1["A"], y_o1["A"]) == -1
+        and leftover_pair_orient(y_m1["A"], y_o1["A"]) == "fail"
+        and unique_signed_orient(y_m1["A"], y_o1["A"]) == 1
+        and y_split["D"] == "fail"
+        and y_orient["D"] == "fail"
+        and y_face == "fail"
+        and y_transport["D"] == "fail"
+        and y_transport_face == "fail"
+        and y_transport_reverse == "hold"
+        and z_reverse == "hold"
+        and z_face == "hold"
+        and z_transport_reverse == "hold"
+        and z_transport_face == "hold"
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse == "fail"
+        and face == "fail"
+        and y_transport_reverse != reverse
+        and z_transport_face != face
+        and y_transport_face == face,
+    )
+    checks.check(
+        "not-same-lock-or-one-axis-or-live-three-axis-seed",
+        THREE_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and THREE_AXIS_SEEDS != TWO_SITE_SEEDS
+        and THREE_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and THREE_AXIS_SEEDS != LIVE_THREE_AXIS_SEEDS
+        and THREE_AXIS_SEEDS != TWO_AXIS_SEEDS
+        and same_m_a != m1["A"]
+        and same_transport_face == "fail"
+        and one_transport_face == "fail"
+        and live_transport["B"] == "fail"
+        and live_transport["C"] == "fail"
+        and live_transport["D"] == "hold"
+        and live_transport_face == "fail"
+        and transport["D"] == "fail"
+        and live_transport["D"] != transport["D"]
+        and face == "fail"
+        and sum(time == 0 for time in ticks.values()) == 6
+        and sum(time == 0 for time in two_ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3
+        and sum(time == 0 for time in live_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-split-Orient",
+        "t(A)=2" in note
+        and "t(B)=1" in note
+        and "t(C)=3" in note
+        and "t(D)=2" in note
+        and "M(A, τ) = {+e_3, −e_3}" in note
+        and "M(B, τ) = {+e_1}" in note
+        and "M(C, τ) = {+e_1}" in note
+        and "M(D, τ) = {+e_3, −e_3}" in note
+        and "O(A, τ) = {+e_1}" in note
+        and "O(B, τ) = {+e_2, +e_3, −e_3}" in note
+        and "O(C, τ) = {−e_2, +e_3, −e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1}" in note
+        and "split(A) = fail" in note
+        and "split(B) = hold" in note
+        and "split(C) = hold" in note
+        and "split(D) = fail" in note
+        and "m(A) = fail" in note
+        and "i(A) = fail" in note
+        and "o_next(A) fail" in note
+        and "o_prev(A) fail" in note
+        and "det(A) = fail" in note
+        and "Orient(A) = fail" in note
+        and "m(B) = +e_1" in note
+        and "i(B) = 1" in note
+        and "o_next(B) = +e_2" in note
+        and "o_prev(B) = −e_3" in note
+        and "det(B) = -1" in note
+        and "Orient(B) = −1" in note
+        and "m(C) = +e_1" in note
+        and "i(C) = 1" in note
+        and "o_next(C) = −e_2" in note
+        and "o_prev(C) = −e_3" in note
+        and "det(C) = 1" in note
+        and "Orient(C) = +1" in note
+        and "m(D) = fail" in note
+        and "i(D) = fail" in note
+        and "o_next(D) fail" in note
+        and "o_prev(D) fail" in note
+        and "det(D) = fail" in note
+        and "Orient(D) = fail" in note
+        and "F(A) = fail" in note
+        and "F(B) = (+e_1, +e_2, −e_3)" in note
+        and "F(C) = (+e_1, −e_2, −e_3)" in note
+        and "F(D) = fail" in note
+        and "transport(A) = fail" in note
+        and "transport(B) = hold" in note
+        and "transport(C) = hold" in note
+        and "transport(D) = fail" in note
+        and "scalar neighbor-read(A) = fail" in note
+        and "scalar neighbor-read(B) = fail" in note
+        and "scalar neighbor-read(C) = fail" in note
+        and "scalar neighbor-read(D) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (2, 0, 0)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2), (1, 1, 0)" in note
+        and "new 6-NN of C at t(C)+1: (2, -1, 0), (2, 0, 1), (2, 0, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (2, 1, 0)" in note,
+    )
+    checks.check(
+        "note-reports-transport-reverse-face",
+        "Reverse cyclic-frame transport at τ: fail" in note
+        and "Face cyclic-frame transport at τ: fail" in note
+        and "witness(A) = fail" in note
+        and "witness(B) = (0, 1, 1)" in note
+        and "witness(C) = (2, 1, 0)" in note
+        and "witness(D) = fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2axx axis-cover" in normalized_note
+        and "not leftover of nm2ax12x 1-in 2-out split" in normalized_note
+        and "not leftover of nm2chiralz lexicographic" in normalized_note
+        and "not leftover of nm2orichz leftover-axis" in normalized_note
+        and "not leftover of nm2orionez lex-one" in normalized_note
+        and "not leftover of nm2oridetz unique signed" in normalized_note
+        and "not leftover of nm2oricyclz cyclic Orient" in normalized_note
+        and "not leftover of scalar neighbor-read" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "third pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse cyclic-frame transport at τ: fail" in note
+        and "Face cyclic-frame transport at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/THREE_AXIS_FARFACE_OPPOSITE_XPROBE_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "cyclic_signed_outgoing" in defined_fns
+        and "lex_largest_on_axis" in defined_fns
+        and "cyclic_units" in defined_fns
+        and "unique_signed_outgoing_plane" in defined_fns
+        and "leftover_pair_orient" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "cyclic_lex_smallest_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "frame_triple" in defined_fns
+        and "sending_matrix" in defined_fns
+        and "is_signed_permutation" in defined_fns
+        and "frame_transport" in defined_fns
+        and "scalar_orient_neighbor" in defined_fns
+        and "unique_positive_sending" in defined_fns
+        and "transport_reverse_report" in defined_fns
+        and "transport_face_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[ORIGIN] == 0
+        and ticks[PROBES["A"]] == 2
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "transport-not-scalar-or-orient-equality-or-lex-one",
+        reverse == "fail"
+        and face == "fail"
+        and split_reverse == "fail"
+        and cover_reverse == "fail"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and one_orient_face == "fail"
+        and one_transport_face == "fail"
+        and scalar_reverse == "fail"
+        and scalar_face == "fail"
+        and unique_pos_reverse == "fail"
+        and unique_pos_face == "fail"
+        and transport["B"] == "hold"
+        and scalar["B"] == "fail"
+        and unique_pos["B"] == "fail"
+        and transport["C"] == "hold"
+        and scalar["C"] == "fail"
+        and unique_pos["C"] == "fail"
+        and scalar["B"] != transport["B"]
+        and unique_pos["C"] != transport["C"]
+        and orient_reverse == "fail"
+        and orient_face == "fail"
+        and lex["A"] == "fail"
+        and lex["B"] == 1
+        and lex["C"] == 1
+        and lex["D"] == "fail"
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and face_report(lex["C"], lex["D"]) == "fail"
+        and lex["B"] != orient["B"]
+        and leftover_pair["A"] == "fail"
+        and leftover_pair["B"] == -1
+        and leftover_pair["C"] == -1
+        and leftover_pair["D"] == "fail"
+        and reverse_report(leftover_pair["A"], leftover_pair["B"]) == "fail"
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and cyclic_small["A"] == "fail"
+        and cyclic_small["B"] == 1
+        and cyclic_small["C"] == -1
+        and cyclic_small["D"] == "fail"
+        and reverse_report(cyclic_small["A"], cyclic_small["B"]) == "fail"
+        and face_report(cyclic_small["C"], cyclic_small["D"]) == "fail"
+        and cyclic_small["B"] != orient["B"]
+        and unique_signed["A"] == "fail"
+        and unique_signed["B"] == "fail"
+        and unique_signed["C"] == "fail"
+        and unique_signed["D"] == "fail"
+        and reverse_report(unique_signed["A"], unique_signed["B"]) == "fail"
+        and face_report(unique_signed["C"], unique_signed["D"]) == "fail"
+        and o_exist_reverse == "fail"
+        and o_exist_face == "fail"
+        and formed_nn["A"][:1] == ((2, 0, 0),)
+        and z_transport_reverse != reverse
+        and z_transport_face != face
+        and two_m1["A"] == frozenset({NEG_E3})
+        and m1["A"] == frozenset({E3, NEG_E3})
+        and two_ticks[PAIR3] == 1
+        and ticks[PAIR3] == 0,
+    )
+    _ = (
+        o0,
+        unique_o_orient_a,
+        one_cover_face,
+        one_split_face,
+        unsigned_orient,
+        perp_o1,
+        axis_m,
+        axis_o,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Far-face x-probes of triad transport. Reverse fails, face fails. Z HOLDS #7492. PASS=60 FAIL=0. Displayed, not adopted. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/three_axis_farface_opposite_xprobe_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.