### PR TITLE
feat(nm2frmrd3yt2): neighbor-read of cyclic-frame transport freeze t+1 vs t+2 on three-axis opposite y-probes: reverse HOLD, face fails, composition HOLD

### DIFF
--- a/docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,1076 @@
+---
+claim_id: three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Neighbor-read of cyclic-frame transport at t+1 versus t+2 on the four y-probes of the three-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+---
+
+# Neighbor-Read Of Cyclic-Frame Transport Freeze t+1 Versus t+2 Reverse And Face On Four Y-Probes Of The Three-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** neighbor-read of cyclic-frame transport of `(m,o_next,o_prev)`
+of simultaneous earliest incoming set `M` and outgoing dual `O` at each
+probe's `τ1=t+1` and `τ2=t+2`, reverse/face from that neighbor-read at
+each cut, and composition of neighbor-read, on the four y-probes of the
+three-axis opposite seed in `B_3(0)={n:n·n<=9}`. Same process and y-probes
+as nm2ax. `M`, `O`, split as nm2ax12. Orient as nm2oricyccz (lex-smallest
+cyclic). Transport as nm2cycfrmz at each cut. Neighbor-read as nm2frmrd3y
+at each cut. Let `t(q)` be the formation tick of probe `q`.
+Cuts are local: `τ1=t+1`, `τ2=t+2`. There is no global T. Do not score τ=t. `M(q,τ)` is the set of earliest incoming
+nearest-neighbor steps at `q` using only records with tick `<= τ`. Seeds
+are a singleton seed letter. `O(q,τ)` is the outgoing dual of `M`: the
+set of `e` in `{±e_1,±e_2,±e_3}` such that `q+e` is formed and `e` is in
+`M(q+e,τ)`. Unformed at `τ` is `UNDEFINED`. Empty `O` is empty, not
+`UNDEFINED`. Axis of a defined lock set `S` is
+`Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only if
+`Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)` equals
+`{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). When split HOLDs, `m` is unique in
+`M`. Let `i` in `{1,2,3}` be the axis index of `m`. `e_next = e_{i+1}`
+with `3+1→1`. `e_prev = e_{i-1}` with `1−1→3`. `O_next = O ∩ {±e_next}`.
+`O_prev = O ∩ {±e_prev}`. If either empty, Orient fails, not `UNDEFINED`.
+Order `+e < −e`. `o_next` is the lex-smallest vector in `O_next` (hence
+`+e` if both signs). `o_prev` likewise. `Orient(q,τ)` is the sign of the
+integer determinant of the 3×3 matrix with columns `m`, `o_next`,
+`o_prev`. If split fails, Orient fails, not `UNDEFINED`. When split
+HOLDs, `F(q,τ)=(m,o_next,o_prev)` is an oriented lattice frame: a LIVE
+three-axis 1-in 2-out triple. Transport as nm2cycfrmz at each cut.
+Transport HOLDs at `q` at a cut if and only if split HOLDs at `q`,
+`Orient(q)` is `±1`, and some formed six-neighbor `r` has split HOLD,
+`Orient(r)` `±1`, and the 3×3 integer matrix sending the columns of
+`F(q)` to the columns of `F(r)` is a signed permutation with determinant
+`Orient(q)Orient(r)`, with `M`, `O`, and `F` read at that site's
+`t+offset`. If split or Orient fails at `q`, transport fails, not
+`UNDEFINED`. Neighbor-read as nm2frmrd3y at each cut. Neighbor-read HOLDs
+at `q` at a cut if and only if transport HOLDs at `q` and some formed
+six-neighbor `r` has transport HOLD, with transport read at that site's
+`t+offset`. If transport fails at `q`, neighbor-read fails, not
+`UNDEFINED`. Reverse HOLDs if and only if neighbor-read HOLDs at `A` and
+at `B` at that cut. Face HOLDs if and only if neighbor-read HOLDs at `C`
+and at `D` at that cut. Composition HOLDs if and only if neighbor-read at
+`τ1` equals neighbor-read at `τ2` at `A,B,C,D`. Neighbor-read of the
+scalar Orient sign fails site-locally at `B` and at `D` on this member
+and HOLDs at `A` and at `C`, including #7477 same-lock as a different seed
+whose face transport fails, and including LIVE three-axis as the frame
+itself rather than a scalar. Cover and split do not score handedness.
+This is not leftover of nm2frmrd3y neighbor-read of cyclic-frame transport
+at `t+1` alone, whose reverse HOLDs and face fails. This is not leftover
+of nm2cycfrmyt2 cyclic-frame transport freeze. This is not leftover of
+nm2cycfrmz cyclic-frame transport at `t+1` alone. This is not leftover of
+nm2oricyccz cyclic Orient reverse HOLD from equal `+1,+1` signs, not a
+signed-permutation sending. This is not leftover of cyclic lex-largest. This is not leftover of
+nm2oricycy cyclic Orient. This is not leftover of nm2simt2 simultaneous
+`M` and `O` freeze. This is not leftover of equal transport bits including
+fail=fail. This is not leftover of scalar neighbor-read of Orient. This is not
+leftover of a unique nonnegative permutation sending. This is not leftover
+of nm2orichy leftover-axis reverse fail whose `A` has no opposite pair in
+`O`. This is not leftover of nm2orioney lex-one reverse HOLD from
+`e1<e2<e3` order independent of `m`. This is
+not leftover of nm2chiraly lexicographic unsigned `o1,o2` orientation.
+This is not leftover of unique signed `|O_i|=1` unique signed outgoing letters. This
+is not leftover of nm2ax axis-cover. This is not leftover of nm2ax12
+1-in 2-out split. This is not leftover of leftover-of-`M` alone. This is
+not leftover of leftover-of-`O` alone. This is not leftover-empty fail of
+leftover axis. This is not leftover of nmunopp union. This is not leftover
+of nmt2opp `M` frozen at `t`. This is not leftover of nmot2opp two-tick
+composition. This is not leftover of nmoutopp untimed eventual-`O`. This
+is not leftover of mixed #7188 fail/fail. This is not leftover of the
+1-axis opposite two-site seed. This is not leftover of the same-lock
+two-site seed. The second pair is a new seed, not a formed child. The
+third pair is a new seed, not a formed child.
+Uniqueness is not required. Mixed remains a set. Displayed, not adopted.
+Do not write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py`](../scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named y-probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-probe cuts
+`τ1=t+1` and `τ2=t+2`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. The cyclic next/prev
+lex-smallest oriented frame is the integer sign of
+`det(m,o_next,o_prev)` with unique signed incoming letter `m` and the
+lex-smallest signed outgoing letter on the cyclic next and prev axes of
+`Axis(M)` under `+e < −e`. When split HOLDs, `F=(m,o_next,o_prev)` is
+that LIVE three-axis frame. Transport is existential: some formed
+six-neighbor hosts a split-HOLDING frame whose columns are a signed
+permutation of the source columns with determinant the product of the
+two Orient signs. Neighbor-read of that transport HOLDs at a probe if
+and only if transport HOLDs there and some formed six-neighbor has
+transport HOLD. Reverse and face are scored on neighbor-read HOLD at the
+paired probes at each cut. Composition is equality of those four
+neighbor-read reports across the two cuts. Neighbor-read of the scalar Orient sign is a different
+readout and is not used as the object. Equal transport bits including
+fail=fail is a different readout and is not used as the object. A unique nonnegative permutation
+sending is a different readout and is not used as the object. Named
+signs `{+,−}` of locks are a coarser readout and are not used as the
+object. A singleton unique outgoing lock letter is a different readout
+and is not used as the object. Unsigned axis units of `Axis(O)` are a
+different readout and are not used. Unique signed letters requiring
+`|O_i|=1` are a different readout and are not used. Opposite-pair
+leftover-axis orientation is a different readout and is not used.
+Lex-one signed outgoing letters in axis order `e1<e2<e3` independent of
+`m` are a different readout and are not used. Cyclic lex-largest (`−e`
+if both signs) is a different readout and is not used. Existential
+opposite of signed locks is a different readout and is not used.
+Axis-cover without the frame sign is a different readout and is not
+used. 1-in 2-out split without the frame sign is a different readout and
+is not used. Equal `±1` Orient signs without a sending matrix are a
+different readout and are not used. Leftover-empty fail of unsigned
+leftover axis sets is a different readout and is not used. A `Z^3` sum
+of those locks is a different readout and is not used. Occupancy of
+sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of neighbor-read of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 versus t+2 on the four y-probes of the three-axis opposite seed, transport and neighbor-read at A,B,C hold and D fail at each cut, reverse hold and face fail at each cut, composition hold; uniqueness of the matching neighbor is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face
+target_blocker_text: "display neighbor-read of cyclic-frame transport freeze t+1 versus t+2 reverse/face composition on the four y-probes of the three-axis opposite seed, not leftover of nm2frmrd3y t+1 alone, not leftover of nm2cycfrmyt2 transport freeze, not leftover of equal transport bits including fail, not scalar neighbor-read of Orient, not leftover of nm2simt2"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep neighbor-read of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 versus t+2 displayed; do not write neighbor-read into Admissibility, do not reduce to nm2frmrd3y t+1 alone, do not reduce to nm2cycfrmyt2 transport freeze, do not reduce to nm2cycfrmz t+1 alone, do not reduce to nm2simt2 M-and-O freeze, do not reduce to equal transport bits including fail, do not reduce to scalar neighbor-read of Orient, do not reduce to unique nonnegative permutation sending, do not reduce to unique signed |O_i|=1, do not reduce to lexicographic unsigned o1,o2, do not reduce to leftover-axis, do not reduce to lex-one signed e1<e2<e3, do not reduce to cyclic lex-largest, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace neighbor-read by unique outgoing letters, do not replace neighbor-read by existential opposite of signed locks, do not replace neighbor-read by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for neighbor-read of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 versus t+2 on the four y-probes of the three-axis opposite seed, reverse/face at each cut, and composition; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The four y-probes are the only sites whose
+neighbor-read of cyclic-frame transport of `F=(m,o_next,o_prev)` of `M`
+and `O` is scored:
+
+```text
+A = (0,1,0),  B = (1,1,1),  C = (0,2,0),  D = (1,1,0).
+```
+
+These are not the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`,
+`D=(1,0,1)`. These are not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`,
+`D=(1,1,0)`. `A` is a seed of the first opposite pair. `C` of the
+x-probes is the third-pair seed `(2,0,0)`. y-probes as nm2ax.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: three disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. Site `(2,0,0)` locks `+e_3`. Site `(2,1,0)`
+locks `−e_3`. The second pair is a new seed, not a formed child of the
+first pair. The third pair is a new seed, not a formed child: on the
+two-axis opposite seed those sites form at tick 3 locking `+e_1`. This
+seed is not the two-axis opposite seed. This seed
+is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named neighbor-read of cyclic-frame transport of `(m,o_next,o_prev)` at `τ1` and `τ2`
+
+Let `t(q)` be the formation tick of y-probe `q` when that tick is defined in
+`B_3(0)`. Let `τ1(q)=t(q)+1` and `τ2(q)=t(q)+2`. There is no global T.
+Do not score `τ=t`.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Oriented frame at the same cut:
+
+```text
+When split HOLDs, m is the unique signed letter in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1. e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}. O_prev = O ∩ {±e_prev}.
+If either is empty, Orient fails, not UNDEFINED.
+Order +e < −e. o_next is lex-smallest in O_next (hence +e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+The outgoing pair is signed. Mixed opposite signs on one cyclic slot make
+`|O_next|=2` or `|O_prev|=2`; lex-smallest still picks `+e`, so Orient is
+defined when split HOLDs. Unique outgoing letters of the whole set `O` are
+not required: mixed `O` remains a set, and unique-letter readout of mixed
+`O` is `UNDEFINED` while this Orient is a sign. Empty `O_next` or empty
+`O_prev` is Orient fail, not `UNDEFINED`. A vanishing determinant is fail.
+Sign of a nonzero integer determinant is `+1` or `−1`. Split HOLD
+required: 2-in 1-out is Orient fail, not UNDEFINED.
+
+Cyclic frame and transport at the same cut:
+
+```text
+When split HOLDs, F(q)=(m, o_next, o_prev).
+Transport HOLDs at q iff split HOLDs, Orient(q) is ±1,
+and some formed 6-NN r has split HOLD, Orient(r) ±1,
+and the 3×3 integer matrix P sending the columns of F(q)
+to the columns of F(r) (F(r)=F(q)P) is a signed permutation
+with det(P)=Orient(q)Orient(r).
+If split or Orient fails at q, transport fails, not UNDEFINED.
+UNDEFINED if M or O is UNDEFINED.
+Uniqueness of r is not required.
+```
+
+Neighbor-read of the scalar Orient sign HOLDs at `q` if and only if
+`Orient(q)` is `±1` and some formed six-neighbor has the same sign. That
+is a different object: it fails at `B` and at `D` on this member while transport HOLDs at `B`,
+because a signed permutation may send a frame to a neighbor of opposite
+Orient with `det(P)=Orient(q)Orient(r)`. A unique nonnegative permutation
+sending is a different object: it HOLDs at `C` and fails at `A`, `B`, and
+`D`. Uniqueness is not required. Equal transport bits including fail=fail
+is a different object: it HOLDs at `D` because some formed six-neighbor also
+fails transport, while neighbor-read fails at `D`.
+
+Neighbor-read of that transport HOLDs at `q` at a cut if and only if
+transport HOLDs at `q` and some formed six-neighbor `r` has transport HOLD.
+If transport fails at `q`, neighbor-read fails, not `UNDEFINED`. Uniqueness
+of `r` is not required.
+
+Reverse neighbor-read of cyclic-frame transport at a cut holds if and only
+if neighbor-read HOLDs at `A` and at `B` at that cut. Face neighbor-read of
+cyclic-frame transport at a cut holds if and only if neighbor-read HOLDs at
+`C` and at `D` at that cut. Either side `UNDEFINED` is `UNDEFINED`. Else if
+both sides HOLD, reverse or face HOLDs. Else fail.
+
+Composition holds if and only if neighbor-read at `τ1` equals neighbor-read
+at `τ2` at each of `A,B,C,D`. Either side `UNDEFINED` is `UNDEFINED`. Else if
+the four neighbor-read bits agree across the two cuts, composition HOLDs.
+Else fail.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover HOLDs reverse and fails face without reading
+cyclic signed columns; Orient reverse HOLDs without a sending while this reverse HOLDs from a sending.
+Identifying split reverse with this reverse is refused: split HOLDs reverse
+and fails face without the cyclic order of `Axis(M)`. Identifying leftover-empty
+fail with this reverse is refused: leftover-empty fail scores empty leftover
+as reverse fail and face fail, while this reverse HOLDs; leftover of the
+union at `A` is empty while `Orient(A)=+1`. Identifying lexicographic
+unsigned `o1,o2` with this reverse is refused: unsigned reverse fails with
+`−1,+1` while this reverse HOLDs. Identifying nm2orioney lex-one signed
+`e1<e2<e3` with this reverse is refused: lex-one reverse HOLDs from axis
+order independent of `m`; those signs are not this sending. Identifying
+unique signed `|O_i|=1` with this reverse is refused: unique signed reverse
+HOLDs coincidentally at `A` and at `B` and fails at `C`. Identifying leftover-axis orientation with this
+reverse is refused: leftover-axis reverse fails because `A` has no opposite
+pair in `O`, while this reverse HOLDs. Identifying cyclic lex-largest with this reverse is refused: lex-largest
+reverse HOLDs with `+1,+1` on this member because mixed slots at `A` and at
+`B` are singletons. Identifying a named sign of
+those locks with reverse or face is refused: named-sign lettering lost the
+axis.
+
+## Theorem 1 — ticks, `M`, `O`, Orient, `F`, transport, and neighbor-read at `τ1` and `τ2`
+
+On this process the four y-probes form. Compare to leftover axis: leftover of the union is empty at each of
+`A`, `B`, `C`, and `D`, leftover reverse fail and leftover face fail.
+Compare to nm2ax cover and nm2ax12 split: both HOLD reverse and fail face
+on this member. Compare to nm2oricyccz cyclic Orient: reverse HOLDs from
+equal `+1,+1` signs and face fails from Orient fail at `D`, without a
+sending matrix. Compare to
+scalar neighbor-read of Orient: HOLD at `A` and at `C`, fail at `B` and at
+`D`. Compare to nm2chiraly lexicographic unsigned `o1,o2` orientation:
+reverse fails and face fails on this member with signs `−1,+1,−1`, fail.
+Compare to unique signed `|O_i|=1` unique signed outgoing letters: reverse
+HOLDs coincidentally at `A` and at `B` and fails at mixed `O` of `C`; unique
+signed face fails. Compare to nm2orichy leftover-axis reverse fail because
+`A` has no opposite pair in `O`. Compare to nm2orioney lex-one reverse HOLD
+from `e1<e2<e3` order independent of `m`. This display reads the
+cyclic-frame transport of `(m,o_next,o_prev)` of those same timed sets
+at both cuts. Compare to nm2frmrd3y: that letter is the `t+1` cut alone.
+Compare to nm2cycfrmyt2: that letter is transport freeze, not neighbor-read.
+
+```text
+t(A)=0
+t(B)=1
+t(C)=1
+t(D)=1
+M(A, τ1) = {−e_1}
+M(B, τ1) = {+e_1}
+M(C, τ1) = {+e_2}
+M(D, τ1) = {−e_1}
+O(A, τ1) = {+e_2, −e_3}
+O(B, τ1) = {+e_2, +e_3}
+O(C, τ1) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ1) = {−e_1, +e_2, −e_3}
+split(A, τ1) = hold
+split(B, τ1) = hold
+split(C, τ1) = hold
+split(D, τ1) = fail
+m(A, τ1) = −e_1
+i(A, τ1) = 1
+o_next(A, τ1) = +e_2
+o_prev(A, τ1) = −e_3
+det(A, τ1) = 1
+Orient(A, τ1) = +1
+m(B, τ1) = +e_1
+i(B, τ1) = 1
+o_next(B, τ1) = +e_2
+o_prev(B, τ1) = +e_3
+det(B, τ1) = 1
+Orient(B, τ1) = +1
+m(C, τ1) = +e_2
+i(C, τ1) = 2
+o_next(C, τ1) = +e_3
+o_prev(C, τ1) = +e_1
+det(C, τ1) = 1
+Orient(C, τ1) = +1
+Orient(D, τ1) = fail
+F(A, τ1) = (−e_1, +e_2, −e_3)
+F(B, τ1) = (+e_1, +e_2, +e_3)
+F(C, τ1) = (+e_2, +e_3, +e_1)
+F(D, τ1) = fail
+transport(A, τ1) = hold
+transport(B, τ1) = hold
+transport(C, τ1) = hold
+transport(D, τ1) = fail
+neighbor-read(A, τ1) = hold
+neighbor-read(B, τ1) = hold
+neighbor-read(C, τ1) = hold
+neighbor-read(D, τ1) = fail
+scalar neighbor-read(A, τ1) = hold
+scalar neighbor-read(B, τ1) = fail
+scalar neighbor-read(C, τ1) = hold
+scalar neighbor-read(D, τ1) = fail
+witness(A, τ1) = (0, 2, 0)
+witness(B, τ1) = (0, 1, 1)
+witness(C, τ1) = (0, 1, 0)
+witness(D, τ1) = fail
+read-witness(A, τ1) = (0, 2, 0)
+read-witness(B, τ1) = (0, 1, 1)
+read-witness(C, τ1) = (0, 1, 0)
+read-witness(D, τ1) = fail
+M(A, τ2) = {−e_1}
+M(B, τ2) = {+e_1}
+M(C, τ2) = {+e_2}
+M(D, τ2) = {−e_1}
+O(A, τ2) = {+e_2, −e_3}
+O(B, τ2) = {+e_2, +e_3}
+O(C, τ2) = {+e_1, −e_1, +e_3, −e_3}
+O(D, τ2) = {−e_1, +e_2, −e_3}
+Orient(A, τ2) = +1
+Orient(B, τ2) = +1
+Orient(C, τ2) = +1
+Orient(D, τ2) = fail
+F(A, τ2) = (−e_1, +e_2, −e_3)
+F(B, τ2) = (+e_1, +e_2, +e_3)
+F(C, τ2) = (+e_2, +e_3, +e_1)
+F(D, τ2) = fail
+transport(A, τ2) = hold
+transport(B, τ2) = hold
+transport(C, τ2) = hold
+transport(D, τ2) = fail
+neighbor-read(A, τ2) = hold
+neighbor-read(B, τ2) = hold
+neighbor-read(C, τ2) = hold
+neighbor-read(D, τ2) = fail
+scalar neighbor-read(A, τ2) = hold
+scalar neighbor-read(B, τ2) = fail
+scalar neighbor-read(C, τ2) = hold
+scalar neighbor-read(D, τ2) = fail
+witness(A, τ2) = (0, 2, 0)
+witness(B, τ2) = (0, 1, 1)
+witness(C, τ2) = (0, 1, 0)
+witness(D, τ2) = fail
+read-witness(A, τ2) = (0, 2, 0)
+read-witness(B, τ2) = (0, 1, 1)
+read-witness(C, τ2) = (0, 1, 0)
+read-witness(D, τ2) = fail
+```
+
+`A` is a seed at tick 0 with seed letter `−e_1`. Mixed remains a set:
+`O(A,τ)` has two outgoing steps, `O(B,τ)` has two, `O(C,τ)` has four,
+and `O(D,τ)` has three. Unique outgoing letters would assign `UNDEFINED` at
+mixed `O`. Unique signed `|O_i|=1` HOLDs at `A` and at `B` and fails at
+`C` and at `D`: `O(C)` has both `±e_1` and both `±e_3`, and split fails at
+`D`. Lex-smallest picks `+e` on each mixed cyclic slot, so
+`(o_next,o_prev)` is defined at `A`, `B`, and `C` even though unique signed
+fails at `C`. `M` is a singleton at each probe, so the unique signed `m`
+exists. Split HOLDs at `A`, `B`, and `C` and fails at `D`. Cover HOLDs at
+`A`, `B`, and `C` and fails at `D` because `−e_1` sits in both `M` and `O`.
+Cover and split HOLD reverse and fail face and do not score that cyclic
+lex-smallest Orient is `+1,+1,+1`, fail. At `A`, `i=1` so `e_next=e_2` and
+`e_prev=e_3`; `O_next={+e_2}` and `O_prev={−e_3}`. At `B`, `i=1` so
+`e_next=e_2` and `e_prev=e_3`; `O_prev={+e_3}` yields `o_prev=+e_3`. At
+`C`, `i=2` so `e_next=e_3` and `e_prev=e_1`; mixed slots yield
+`o_next=+e_3` and `o_prev=+e_1`. Leftover-axis at `A` and at `B` fails
+because those `O` have no opposite pair. Lexicographic unsigned at `A` uses
+`(e_2,e_3)` and reports `−1`, while cyclic `(+e_2,−e_3)` reports `+1`.
+Unsigned incoming axis at `A` replaces `m=−e_1` by `+e_1` and reports
+`−1`. Cyclic lex-largest at `A` and at `B` agrees with lex-smallest because
+those cyclic slots are singletons. On the two-axis opposite seed, `O(B)`
+also has `−e_3`. O is not M.
+
+On the 1-axis opposite two-site seed, `A=(0,1,0)` is still a seed at tick
+0 locking `−e_1`, `t(B)=2`, `t(D)=3`, cover HOLDs at `D` from 2-in 1-out,
+and transport face fails at `D`. That is leftover of the first pair. Here
+both `(0,0,1)` and `(0,1,1)` are seeds of a second opposite pair on a
+second axis, and `(2,0,0)` and `(2,1,0)` are seeds of a third opposite pair
+on a third axis, `t(B)=1`, and `t(D)=1`. On the z-probes of this same seed,
+transport HOLDs at each of `A,B,C,D`, reverse HOLDs, and face HOLDs, while
+this y-probe reverse HOLDs and this y-face fails. Z-probe Orient reverse
+HOLDs from equal `+1,+1` as this Orient reverse HOLDs from `+1,+1`.
+X-probe reverse fails and x-face fails. X-probe neighbor-read reverse
+HOLDs.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,1)` is a
+seed, so it is not a new 6-NN of `A`. Site `(1,1,0)` is probe `D`, a
+formed child at tick 1, and is a new 6-NN of `A` at `t+1`. The `t+2`
+neighbor `(−1,1,0)` of `A` forms with earliest incoming `−e_3`, so `−e_1`
+does not enter `O(A,τ2)`:
+
+```text
+new 6-NN of A at t(A)+1: (1, 1, 0), (0, 2, 0), (0, 1, -1)
+new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2)
+new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)
+new 6-NN of D at t(D)+1: (1, 2, 0), (1, 1, -1)
+new 6-NN of A at t(A)+2: (-1, 1, 0)
+new 6-NN of B at t(B)+2: (2, 1, 1)
+new 6-NN of C at t(C)+2: none
+new 6-NN of D at t(D)+2: none
+```
+
+`M` is frozen from `t` to `t+1` and from `t+1` to `t+2`. At `t`, `O` is
+empty at `A`, `B`, and `C`, while `O(D,t)={−e_1}` is nonempty. Split fails
+at `t` at each probe, Orient is fail, not UNDEFINED, and the cyclic frame
+fails, not UNDEFINED. Transport at `t` therefore fails, not UNDEFINED. Do
+not score `τ=t`.
+
+`A`, `B`, and `C` each have a formed six-neighbor with split HOLD and a
+signed permutation sending. `D` has split fail, so transport fails, not
+UNDEFINED. Uniqueness of that neighbor is not required. First witness in
+six-neighbor order: `A` sends to `C=(0,2,0)` with
+`det(P)=1=Orient(A)Orient(C)`; `B` sends to `(0,1,1)` with `det(P)=-1`;
+`C` sends to `A=(0,1,0)` with `det(P)=1`; `D` has no witness. Scalar
+neighbor-read HOLDs at `A` and at `C` and fails at `B` and at `D`, so
+scalar reverse fails and scalar face fails while transport reverse HOLDs
+and transport face fails. Unique nonnegative permutation sending HOLDs at
+`C` and fails at `A`, `B`, and `D`; uniqueness is not required. The
+3-split is a field: opposite Orient at a neighbor is allowed when
+`det(P)` equals the product of the two signs. `B` transports to a neighbor
+of opposite Orient.
+
+## Theorem 2 — reverse and face from neighbor-read of cyclic-frame transport at `τ1` and `τ2`
+
+Reverse neighbor-read of cyclic-frame transport holds if and only if
+neighbor-read HOLDs at `A` and at `B`. At `τ1`, `neighbor-read(A,τ1)=hold`
+and `neighbor-read(B,τ1)=hold`. Reverse HOLDs. At `τ2`,
+`neighbor-read(A,τ2)=hold` and `neighbor-read(B,τ2)=hold`. Reverse HOLDs.
+This is HOLD iff both neighbor-reads HOLD, not leftover of
+nm2oricyccz cyclic Orient equal signs, not leftover of scalar
+neighbor-read, not leftover of a unique nonnegative permutation sending,
+not leftover of nm2chiraly lexicographic unsigned `o1,o2`, not leftover of
+unique signed `|O_i|=1` unique signed outgoing letters, not leftover of
+nm2orichy leftover-axis, not leftover of nm2orioney lex-one, not leftover
+of nm2ax axis-cover, not leftover of nm2ax12 1-in 2-out split, not
+leftover-empty fail, and not exist-opposite.
+
+Reverse neighbor-read of cyclic-frame transport at τ1: hold
+Reverse neighbor-read of cyclic-frame transport at τ2: hold
+
+Both sides are defined, so this is not `UNDEFINED`. Cover reverse HOLDs
+because cover HOLDs at `A` and at `B`. Split reverse HOLDs because split
+HOLDs at `A` and at `B`. Cover and split do not score handedness: Orient at `A` is `+1` and at `B`
+is `+1`. Cyclic Orient reverse HOLDs from those equal signs without a sending
+while this reverse HOLDs from signed-permutation sendings.
+Leftover-axis reverse fails because leftover-axis at `A` is fail from no
+opposite pair in `O`. Lexicographic unsigned reverse fails because
+unsigned `Orient(A)=−1` and `Orient(B)=+1`. Unique signed reverse HOLDs coincidentally because unique signed at `A`
+and at `B` is `+1`; unique signed still fails at `C`. Lex-one signed
+reverse fails from `e1<e2<e3` order independent of `m`. Cyclic lex-largest
+reverse HOLDs with `+1,+1` on this member because mixed slots at `A` and at
+`B` are singletons. Leftover-empty reverse
+fails because leftover of the union is empty at `A` and at `B`. Leftover
+of `M` reverse HOLDs because leftover of `M` at `A` and at `B` is
+`{e_2, e_3}`: nonempty and equal; leftover of `M` is unsigned leftover of
+`Axis(M)`, not a sending. Leftover of `O` reverse HOLDs because leftover
+of `O` at `A` and at `B` is `{e_1}`: nonempty and equal. Exist-opposite
+reverse of signed `M` holds. Exist-opposite reverse of signed `O` holds.
+Presence of an opposite pair in `O` fails at `A` and HOLDs at `B`, so
+pair-presence reverse fails. Those leftovers are not this display.
+
+Reverse HOLDs at both cuts.
+
+Face neighbor-read of cyclic-frame transport holds if and only if
+neighbor-read HOLDs at `C` and at `D`. At `τ1`, `neighbor-read(C,τ1)=hold`
+and `neighbor-read(D,τ1)=fail`. Face fails. At `τ2`,
+`neighbor-read(C,τ2)=hold` and `neighbor-read(D,τ2)=fail`. Face fails.
+
+Face neighbor-read of cyclic-frame transport at τ1: fail
+Face neighbor-read of cyclic-frame transport at τ2: fail
+
+Cover face fails because cover HOLDs at `C` and fails at `D`. Split face
+fails because split HOLDs at `C` and fails at `D`. Cyclic lex-smallest
+oriented face fails because Orient at `D` is fail, not UNDEFINED. Cover
+and split do not score handedness. Presence of an opposite pair in `O` HOLDs at `C` and fails at `D`, so
+pair-presence face fails as this face fails. Exist-opposite face of signed `O` HOLDs while this face fails. Unique
+nonnegative sending fails at each probe, so unique nonnegative face fails. On the 1-axis opposite
+two-site seed, cover face HOLDs while split face fails at `D` from 2-in
+1-out, and transport face fails at `D`. This three-axis member has cover
+face fail because `−e_1` sits in both `M` and `O` at `D`, which the 1-axis cover face does not.
+The four z-probes of this same seed give transport HOLD at each probe,
+reverse hold, and face hold, while this y-face fails. The four x-probes
+give oriented reverse fail and oriented face fail. Those probe-direction
+readouts are not this y-probe display. Leftover-empty face fails because leftover of the union is empty at `C`
+and at `D`. Leftover of `M` at `C` is `{e_1, e_3}` and leftover of `M` at
+`D` is `{e_2, e_3}`: nonempty and unequal. Leftover of `O` at `C` is `{e_2}`
+and leftover of `O` at `D` is empty: unequal. Exist-opposite face of
+signed `M` fails. Cyclic lex-smallest oriented face fails.
+
+Empty leftover does not make reverse `UNDEFINED`. Leftover-empty fail is
+not this reverse. Cover fails at `D` and split fails at `D`. Orient at `D` is fail, not UNDEFINED, from split fail, even though `M(D)`
+is the singleton `−e_1`.
+
+Face fails at both cuts.
+
+## Theorem 3 — composition of neighbor-read of cyclic-frame transport at `τ1` versus `τ2`
+
+Composition HOLDs if and only if neighbor-read at `τ1` equals neighbor-read
+at `τ2` at `A,B,C,D`. `neighbor-read(A,τ1)=neighbor-read(A,τ2)=hold`,
+`neighbor-read(B,τ1)=neighbor-read(B,τ2)=hold`,
+`neighbor-read(C,τ1)=neighbor-read(C,τ2)=hold`,
+`neighbor-read(D,τ1)=neighbor-read(D,τ2)=fail`. Composition HOLDs.
+
+Composition of neighbor-read of cyclic-frame transport: hold
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+The reverse-and-face neighbor-read of cyclic-frame transport of nm2frmrd3y
+(reverse HOLD, face fail at `t+1`) freezes at `t+2`: the four neighbor-read
+bits are unchanged. That freeze is the present letter. It is not leftover
+of nm2frmrd3y, which scores only one cut. It is not leftover of
+nm2cycfrmyt2, which scores transport freeze rather than neighbor-read
+freeze. It is not leftover of nm2simt2 simultaneous `M` and `O` freeze,
+which scores equality of `M` and of `O` rather than equality of
+neighbor-read. On this member `M`, `O`, and transport also freeze, so
+those leftovers HOLD; the scored object remains the four neighbor-read
+bits. Bit-stability of reverse HOLD and face fail is a leftover predicate:
+those bits can agree while a probe neighbor-read flips, which composition
+of neighbor-read would fail. Composition of neighbor-read at `τ=t` versus
+`τ=t+1` fails because neighbor-read is fail at formation and hold or fail
+at `t+1` with a different pattern. Do not score `τ=t`.
+
+## What this note does not claim
+
+- It does not replace transport by neighbor-read of the scalar Orient sign.
+- It does not replace transport by a unique nonnegative permutation sending.
+- It does not require a unique formed six-neighbor witness.
+- It does not reprint nm2oricyccz cyclic Orient reverse fail face fail as this transport.
+- It does not reprint nm2frmrd3y neighbor-read of cyclic-frame transport at `t+1` alone.
+- It does not reprint nm2cycfrmyt2 cyclic-frame transport freeze.
+- It does not reprint nm2cycfrmz cyclic-frame transport at `t+1` alone.
+- It does not replace neighbor-read composition by simultaneous `M` and `O` freeze.
+- It does not replace neighbor-read by equal transport bits including fail=fail.
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by lexicographic unsigned `o1,o2` orientation.
+- It does not replace Orient by unique signed `|O_i|=1` letters.
+- It does not replace Orient by leftover-axis orientation.
+- It does not replace Orient by nm2orioney lex-one signed `e1<e2<e3`.
+- It does not replace Orient by cyclic lex-largest (`−e` if both signs).
+- It does not replace Orient by unsigned axis units of `Axis(O)`.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not treat split fail as `UNDEFINED`.
+- It does not treat empty `O_i` as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2ax axis-cover reverse hold face fail as this
+  oriented display.
+- It does not reprint nm2ax12 1-in 2-out split reverse hold face fail as
+  this oriented display.
+- It does not reprint nm2chiraly lexicographic unsigned `o1,o2` reverse fail
+  face fail as this oriented display.
+- It does not reprint unique signed `|O_i|=1` reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orichy leftover-axis reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orioney lex-one reverse hold face fail as this
+  oriented display.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the z-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four y-probes. It uses Qubit
+only as the algebra of the local possibility domain. It uses Record only as a
+boundary: a present lock is content. It does not rewrite Admissibility. The
+three-axis opposite seed process, neighbor-read of cyclic-frame transport of
+`(m,o_next,o_prev)` of `M` and `O` at `t+1` versus `t+2`, reverse/face at
+each cut, and composition of neighbor-read are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; three-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `1`, `1`, `1` |
+| `M` at `τ1` and at `τ2` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ1` and at `τ2` | Theorem 1; HOLDING outgoing dual, freeze |
+| split at both cuts | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| unique signed `m`, axis index `i`, cyclic `(o_next,o_prev)` | Theorem 1; singleton `M`; pair defined at `A,B,C`; fail at `D` |
+| integer `det(m,o_next,o_prev)` at both cuts | Theorem 1; `1`, `1`, `1`, fail at each cut |
+| Orient at `τ1` | Theorem 1; `+1`, `+1`, `+1`, fail |
+| Orient at `τ2` | Theorem 1; `+1`, `+1`, `+1`, fail |
+| cyclic frame `F=(m,o_next,o_prev)` at both cuts | Theorem 1; LIVE three-axis at `A,B,C`; fail at `D` |
+| transport at `τ1` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| transport at `τ2` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| neighbor-read at `τ1` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| neighbor-read at `τ2` | Theorem 1; HOLD at `A,B,C`; fail at `D` |
+| scalar neighbor-read of Orient | Theorem 1; HOLD at `A,C`, fail at `B,D`; not this letter |
+| reverse from neighbor-read at `τ1` and at `τ2` | Theorem 2; `hold` at each cut |
+| face from neighbor-read at `τ1` and at `τ2` | Theorem 2; `fail` at each cut |
+| composition of neighbor-read | Theorem 3; `hold` |
+| leftover of nm2frmrd3y `t+1` alone | not this freeze letter |
+| leftover of nm2cycfrmyt2 transport freeze | not this neighbor-read composition |
+| leftover of nm2simt2 simultaneous `M` and `O` freeze | not this neighbor-read composition |
+| leftover of equal transport bits including fail=fail | not this neighbor-read |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2ax axis-cover HOLD | not this oriented display |
+| leftover of nm2ax12 1-in 2-out split HOLD | not this oriented display |
+| leftover of nm2chiraly lexicographic unsigned `o1,o2` | not this oriented display |
+| leftover of unique signed `|O_i|=1` | not this oriented display |
+| leftover of nm2orichy leftover-axis | not this oriented display |
+| leftover of nm2orioney lex-one signed `e1<e2<e3` | not this oriented display |
+| leftover of cyclic lex-largest | not this oriented display |
+| leftover of nm2oricyccz cyclic Orient opposite signs | not this neighbor-read |
+| leftover of scalar neighbor-read of Orient | not this neighbor-read |
+| leftover of unique nonnegative permutation sending | not this neighbor-read |
+| leftover of nm2cycfrmz cyclic-frame transport at `t+1` | not this neighbor-read |
+| score at `τ=t` | refused |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| z-probe or x-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display; #7477 same-lock face transport fails |
+| leftover of the LIVE three-axis three-site seed | not this display; face transport fails |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| empty `O_i` scored as `UNDEFINED` | refused; Orient fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: do the reverse-and-face neighbor-read bits of nm2frmrd3y freeze from `t+1` to `t+2` on the four y-probes of the three-axis opposite seed. |
+| V2 | Current main has no landed neighbor-read of cyclic-frame-transport reverse/face composition of timed `M` and `O` at `t+1` versus `t+2` on these four y-probes of the three-axis opposite seed. |
+| V3 | Neighbor-read reports at two cuts, the reverse/face bits at each cut, and composition are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads neighbor-read of a signed-permutation sending of the cyclic frame to a formed six-neighbor at each of `t+1` and `t+2`, reverse HOLDs and face fails at both cuts while scalar neighbor-read reverse fails and scalar face fails, unique nonnegative sending fails at each probe, equal transport bits HOLD at `D` while neighbor-read fails at `D`, nm2oricyccz Orient equality does not supply the sending, nm2frmrd3y scores only one cut (#7536 face fail at `t+1`), and nm2cycfrmyt2 scores transport freeze. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by nm2chiraly lexicographic unsigned `o1,o2`, does not replace
+Orient by unique signed `|O_i|=1`, does not replace Orient by
+nm2orichy leftover-axis, does not replace Orient by nm2orioney lex-one,
+does not replace Orient by cyclic lex-largest, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2ax axis-cover, does not
+replace Orient by nm2ax12 1-in 2-out split, does not identify this
+display with the 1-axis opposite two-site seed, does not identify it
+with nmunopp union, does not replace this freeze by nm2frmrd3y `t+1`
+alone, does not replace this freeze by nm2cycfrmyt2 transport freeze, and does not replace neighbor-read composition by simultaneous `M` and `O` freeze. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| scalar neighbor-read of Orient | reuse equal Orient sign at some formed 6-NN | scalar HOLDs at `A` and at `C` and fails at `B` and at `D`; scalar reverse fails while this reverse HOLDs | ATTEMPTED |
+| unique nonnegative permutation sending | require a unique sending with no minus signs | unique nonnegative sending HOLDs at `C` and fails at `A`, `B`, and `D`; uniqueness is not required | ATTEMPTED |
+| nm2frmrd3y `t+1` alone | reuse reverse hold and face fail at one cut | that letter has no `t+2` cut and no neighbor-read composition | ATTEMPTED |
+| nm2cycfrmyt2 transport freeze | reuse transport equality across cuts | transport freeze HOLDs here as leftover; composition of this letter is equality of neighbor-read bits | ATTEMPTED |
+| nm2simt2 simultaneous `M` and `O` freeze | score equality of lock sets | simultaneous freeze HOLDs here as leftover; composition of this letter is equality of neighbor-read bits | ATTEMPTED |
+| equal transport bits including fail=fail | score some formed 6-NN with the same transport bit | equal-bit HOLDs at `D` while neighbor-read fails at `D` | ATTEMPTED |
+| reverse/face bit-stability | score reverse and face bits equal across cuts | those bits can agree while a probe neighbor-read flips; composition of neighbor-read would then fail | ATTEMPTED |
+| nm2oricyccz cyclic Orient | reuse Orient reverse hold and face fail from equal `±1` signs | Orient reverse HOLDs without a signed-permutation sending; this reverse HOLDs from a sending | ATTEMPTED |
+| nm2chiraly lexicographic unsigned `o1,o2` | reuse unsigned reverse fail and face fail | unsigned reverse fails as this reverse HOLDs; unsigned at `A` is `−1` while cyclic is `+1` | ATTEMPTED |
+| unique signed `|O_i|=1` | reuse unique signed reverse fail and face fail | unique signed HOLDs at `A` and fails at mixed `B,C,D`; this reverse HOLDs | ATTEMPTED |
+| nm2orichy leftover-axis | reuse leftover-axis reverse fail and face fail | leftover-axis reverse fails because `A` has no opposite pair in `O`, while this reverse HOLDs | ATTEMPTED |
+| nm2orioney lex-one | reuse lex-one reverse hold and face fail | lex-one reverse HOLDs from `e1<e2<e3` order independent of `m`; those signs are not this sending | ATTEMPTED |
+| cyclic lex-largest | reuse same cyclic axes with `−e` if both signs | lex-largest reverse HOLDs with `+1,+1` on this member because mixed slots at `A` and at `B` are singletons | ATTEMPTED |
+| nm2ax axis-cover | reuse cover reverse hold and cover face fail on these y-probes | cover HOLDs reverse and fails face without cyclic signed columns | ATTEMPTED |
+| nm2ax12 1-in 2-out split | reuse split reverse hold and split face fail | split HOLDs reverse and fails face without cyclic order of `Axis(M)`; Cover and split do not score handedness | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails while this reverse HOLDs; leftover at `A` is empty while `Orient(A)=+1` | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` at `A` and at `B` is `{e_2,e_3}`, nonempty equal; leftover of `M` reverse HOLDs without a sending | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at `A` and at `B` is `{e_1}`, nonempty equal; leftover of `O` reverse HOLDs without a sending | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `O` holds as this reverse HOLDs; exist-opposite face of signed `O` HOLDs while this face fails | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence reverse fails at `A` while this reverse HOLDs; pair-presence face HOLDs while this face fails | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of unique signed incoming and cyclic lex-smallest outgoing letters | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(A,τ)` remains a set; unique-letter Orient is `UNDEFINED` while this Orient is `+1` | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | unsigned at `A` reports `−1` while cyclic reports `+1` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; `D` misses `e_2` and is not 2-in 1-out | ATTEMPTED |
+| empty `O_i` as `UNDEFINED` | treat empty signed outgoing on an axis as unformed | empty `O_i` is Orient fail, not UNDEFINED | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(B)=2`, `t(D)=3`, cover face HOLD at `D` | different seed; second pair is a new seed, not a formed child; here `t(B)=1` and `t(D)=1` and cover face fails | ATTEMPTED |
+| z-probe Orient | score the four z-probes on this seed | z-probe reverse HOLDs and z-face HOLDs; this letter is the four y-probes | ATTEMPTED |
+| x-probe Orient | score the four x-probes on this seed | x-probe reverse fails at `A`; this letter is the four y-probes | ATTEMPTED |
+| score at `τ=t` | compose transport at formation versus `t+1` | leftover of nmot2opp; transport is fail at `t` and hold or fail at `t+1`; Do not score `τ=t` | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores cyclic-frame transport of own incoming and outgoing at `t+1` versus `t+2` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports reverse hold and face fail on the three-axis opposite seed | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum; mixed `O(A)` sums to `(0,1,−1)` while cyclic is `(+e_2,−e_3)` | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ1(q)=t(q)+1` and `τ2(q)=t(q)+2` are per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with nm2chiraly lexicographic unsigned `o1,o2`,
+missing identification of Orient with unique signed |O_i|=1 unique signed `|O_i|=1`,
+missing identification of Orient with nm2orichy leftover-axis, missing
+identification of Orient with nm2orioney lex-one, missing identification of
+Orient with cyclic lex-smallest, missing identification of Orient with
+nmcover axis-cover, missing identification of Orient with nm2ax axis-cover,
+missing identification of Orient with nm2ax12 1-in 2-out split, missing
+identification of this seed with the 1-axis opposite two-site seed, and
+missing Record identification of Orient reverse are distinct open premises.
+This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-probe `τ1=t+1`
+and `τ2=t+2`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, unique signed `m` when split HOLDs, cyclic
+next/prev axes of `Axis(M)`, lex-smallest signed outgoing letter under
+`+e < −e` (hence `+e` if both signs), integer determinant sign, empty
+`O_next` or empty `O_prev` as Orient fail not `UNDEFINED`, split fail as
+Orient fail not `UNDEFINED`, four y-probes with seed `A`, second pair as a
+new seed not a formed child, mixed remains a set, and composition as
+equality of neighbor-read at the two cuts are declared. No uniqueness of
+outgoing locks, no six-neighbor lock union as the scored object, no
+lock-count clock, no global later T, no formation attachment from
+already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+Orient `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | neighbor-read of the cyclic-frame transport HOLD bit at a formed 6-NN at a probe's `t+1` and `t+2` | no continuum alphabet |
+| per site | `A,B,C,D` y-probes on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | four neighbor-read reports at `t+1` and `t+2`, reverse/face at each cut, composition | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for neighbor-read of
+cyclic-frame transport reverse/face, a formation-rate rule, a later cut
+`t+3`, and a physical selector among 1-in 2-out frames. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Transport reverse hold and face fail are only leftover of
+nm2oricyccz cyclic Orient opposite signs, or of neighbor-read of the scalar
+Orient sign, or of cover and split; leftover-axis already answers reverse
+fail; lex-one already answers reverse HOLD; unique signed `|O_i|=1`
+already answers mixed `O`; leftover of `M` alone already answers reverse;
+leftover of `O` alone already answers reverse; exist-opposite of signed
+`O` already answers reverse; mixed #7188 already reported fail/fail; the
+second pair is only the formed child of the 1-axis seed; unique outgoing
+letters should be required; cyclic lex-smallest already gives HOLD reverse
+with `+1,+1`; unsigned incoming axis already gives the same signs; because
+`M` and `O` freeze, composition is simultaneous freeze; because reverse
+HOLD and face fail at both cuts, composition is only bit-stability; because
+transport freezes, composition is nm2cycfrmyt2; because neighbor-read
+HOLDs at `t+1`, composition is nm2frmrd3y; and equal transport bits already
+answer `D`.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Transport reverse HOLDs because transport HOLDs at `A` and
+at `B`. Transport face fails because transport fails at `D`. Scalar
+neighbor-read of Orient HOLDs at `A` and at `C` and fails at `B` and at
+`D`, so scalar reverse fails while this reverse HOLDs. Cyclic Orient
+reverse HOLDs from `+1,+1` without a sending matrix; this reverse HOLDs
+from a signed permutation of LIVE three-axis frames. Unique nonnegative
+permutation sending fails at each of `A`, `B`, `C`, and `D`.
+Orient reverse HOLDs because `Orient(A)=+1` and `Orient(B)=+1`. Orient
+face fails because Orient at `D` is fail. Cover and split HOLD reverse
+and fail face on this member and do not score cyclic signed columns.
+Leftover-axis reverse fails because `A` and `B` have no opposite pair in
+`O`; this reverse HOLDs. Lex-one reverse fails from `e1<e2<e3` order
+independent of `m`. Lexicographic unsigned
+`o1,o2` reverse fails with `−1,+1`. Unique signed `|O_i|=1` reverse HOLDs
+coincidentally at `A` and at `B` and fails at `C`; this reverse HOLDs.
+Cyclic lex-largest reverse HOLDs with `+1,+1` on this member because mixed
+slots at `A` and at `B` are singletons. Presence of an
+opposite pair in `O` fails at `A` and at `B`, so pair-presence
+reverse fails. Leftover of `M` alone at `A` and at `B` is `{e_2,e_3}`:
+nonempty equal without a sending. Leftover of `O` alone at `A` and at `B`
+is `{e_1}`. Unique outgoing letters would assign `UNDEFINED` at mixed
+`O(A)`; this Orient is `+1`, not `UNDEFINED`. On unique signed
+`O={+e_1,+e_3}` leftover is empty while Orient is `+1`, so leftover-empty
+fail is not this predicate. Mixed #7188 is a different z-symmetric process
+with mixed `M`. The second pair is a new seed, not a formed child:
+`(0,0,1)` is recorded at tick 0 with lock `+e_2`, whereas the 1-axis child
+forms at tick 1 with lock `+e_3`. The third pair is a new seed, not a
+formed child. nm2frmrd3y scores only `τ=t+1` (#7536 face fail).
+nm2cycfrmyt2 scores transport freeze. nm2simt2 scores equality of `M` and
+of `O`. Reverse/face bit-stability can HOLD while a probe neighbor-read
+flips. Equal transport bits HOLD at `D` while neighbor-read fails at `D`.
+Reverse neighbor-read of cyclic-frame transport is HOLD iff neighbor-read
+HOLDs at `A` and at `B` at that cut, not leftover of leftover-axis and not
+leftover of nm2orioney lex-one. Composition of neighbor-read of
+cyclic-frame transport: hold.
+
+### N8 — cross-cycle echo
+
+nm2ax cover on this three-axis seed reported cover HOLD at `A,B,C` and fail
+at `D`, reverse hold, and face fail. nm2ax12 1-in 2-out split on the same
+seed reported split HOLD at `A,B,C` and fail at `D`, reverse hold, and
+face fail. nm2chiraly lexicographic unsigned `o1,o2` on the same seed
+reported Orient `−1,+1,−1`, fail, reverse fail, and face fail. Unique
+signed `|O_i|=1` outgoing letters on the same seed reported unique signed
+HOLD at `A` and at `B` and fail at mixed `C`, reverse hold, and face fail.
+nm2orichy leftover-axis on the same seed reported leftover-axis fail at
+`A` and at `B` from no opposite pair in `O`, reverse fail, and face fail. nm2orioney
+lex-one on the same seed reported reverse fail from `e1<e2<e3` order
+independent of `m`. Leftover axis reported empty leftover at each of
+`A,B,C,D`, leftover reverse fail, and leftover face fail. The four
+z-probes of this same seed reported transport HOLD at each of `A,B,C,D`,
+reverse hold, and face hold. nm2oricyccz cyclic next/prev lex-smallest
+Orient on the same seed reported Orient `+1,+1,+1`, fail, reverse hold
+from equal signs, and face fail, without a sending matrix. nm2frmrd3y
+neighbor-read of cyclic-frame transport on the same seed reported
+neighbor-read HOLD at `A,B,C` and fail at `D`, reverse hold, and face fail
+at `t+1` alone (#7536). nm2cycfrmyt2 cyclic-frame transport freeze on the same
+seed reported transport HOLD at `A,B,C` and fail at `D` at both cuts,
+reverse hold, face fail, and transport composition hold. nm2simt2 scores
+equality of lock sets from `t+1` to `t+2`. This note is not those
+displays: it reports neighbor-read of cyclic-frame transport of
+`(m,o_next,o_prev)` of `M` and `O` at `τ1=t+1` versus `τ2=t+2` on the
+three-axis opposite seed, with `t(A)=0`, `t(B)=1`, `t(C)=1`, and `t(D)=1`,
+`neighbor-read=hold` at `A,B,C` and `neighbor-read=fail` at `D` at both
+cuts, reverse hold at both cuts, face fail at both cuts, and composition
+hold, while scalar neighbor-read fails at `B` and at `D`. Cover and split
+do not score handedness.
+
+**Gate disposition:** PASS for the neighbor-read of cyclic-frame-transport
+`t+1` versus `t+2` reverse/face reports and displayed composition above. FAIL / DO NOT SHIP
+for “the predicate equals the named sign,” “the predicate equals the
+unique singleton lock vector,” “the predicate equals six-neighbor lock
+union,” “the predicate equals leftover-empty fail,” “the predicate equals
+leftover of `M` alone,” “the predicate equals leftover of `O` alone,” “the
+predicate equals exist-opposite HOLD,” “the predicate equals opposite-pair
+presence in `O`,” “the predicate equals nm2chiraly lexicographic unsigned
+`o1,o2` HOLD,” “the predicate equals unique signed `|O_i|=1` HOLD,” “the
+predicate equals nm2orichy leftover-axis HOLD,” “the predicate equals
+nm2orioney lex-one HOLD,” “the predicate equals cyclic lex-largest HOLD,”
+“the predicate equals nm2oricyccz cyclic Orient HOLD,” “the predicate
+equals scalar neighbor-read of Orient HOLD,” “the predicate equals unique
+nonnegative permutation sending HOLD,” “the predicate equals nmcover
+axis-cover HOLD,” “the predicate equals nm2ax axis-cover HOLD,” “the
+predicate equals nm2ax12 1-in 2-out split HOLD,” “the predicate equals
+nm2frmrd3y `t+1` alone,” “the predicate equals nm2cycfrmyt2 transport freeze,” “the predicate equals nm2simt2 simultaneous `M` and `O` freeze,” “the predicate equals equal transport bits including fail=fail,” “the predicate equals the 1-axis opposite two-site seed,” “the
+predicate equals nmunopp union,” “bits are Admissibility,” “split fail is
+UNDEFINED,” “empty `O_i` is UNDEFINED,” or “composition of neighbor-read of cyclic-frame
+transport fails.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the three-axis opposite
+perp-step incoming-lock process, reads each probe's own earliest incoming
+set and own outgoing dual from the record prefix at that probe's `t+1`
+and `t+2`, reports the cyclic frame `F=(m,o_next,o_prev)`, reports Orient
+as nm2oricyccz lex-smallest cyclic, reports transport by a
+signed-permutation sending to some formed six-neighbor at each cut,
+reports neighbor-read of that transport at each cut, lists
+new records in `B_3(0)` between `t` and `t+1` and between `t+1` and `t+2`
+that meet a probe's six-neighbors, and checks Theorems 1--3. It also
+checks that neighbor-read HOLDs at `A,B,C` and fails at `D` at both cuts while
+scalar neighbor-read HOLDs at `A` and at `C` and fails at `B` and at `D`,
+that reverse HOLDs and face fails from neighbor-read at both cuts while
+scalar reverse fails, that composition HOLDs, that unique nonnegative
+permutation sending fails at each probe, that
+equal transport bits HOLD at `D` while neighbor-read fails at `D`, that
+nm2oricyccz Orient reverse HOLDs from equal signs without being this
+sending, that leftover-axis reverse fails because `A` and `B` have no opposite pair
+in `O` and lex-one reverse fails from `e1<e2<e3` order independent of `m`,
+that the third pair is a new seed not a formed child, that #7536 is the
+`t+1` face fail of nm2frmrd3y,
+that split fail is transport fail not `UNDEFINED`, that empty `O_next` or
+empty `O_prev` is Orient fail not `UNDEFINED`, that the 1-axis opposite
+two-site seed is a different member with `t(D)=3` and cover face HOLD,
+that #7477 same-lock is a different member with face transport fail, that
+LIVE three-axis as a three-site seed is a different member with face
+transport fail, that leftover-empty fail is a different predicate, that
+leftover of `M` alone and leftover of `O` alone are different objects,
+that mixed sets remain sets, that the construction does not sum, that a
+formation member from already-recorded six-neighbor locks is not
+attached, that the second pair is a new seed not a formed child, that the
+z-probes and x-probes of this seed are not this letter, that `τ=t` is not
+scored, and that the display is not the two-tick lock-count clock
+composition. No runner cache is written.

--- a/logs/runner-cache/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.txt
@@ -1,0 +1,94 @@
+===== runner cache v1 =====
+runner: scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+runner_sha256: 36f47c12c2b045faef8c0b367937cb9d7f3b0642f5a62e97aab7e34e8427bf65
+input_fingerprint_sha256: f06e5ee83de45e88782eedf96bb1b6a0bdb0cabc0518cf84f2d51779300fdfb5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.14
+status: ok
+----- stdout -----
+neighbor-read of cyclic-frame transport freeze t+1 versus t+2 reverse/face composition on three-axis opposite y-probes
+AUDIT_INPUT_PATHS:
+  docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Neighbor-read of cyclic-frame transport at t+1 versus t+2 on the four y-probes of the three-axis opposite seed, reverse/face at each cut, and composition, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-y-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+PASS: sending-identity
+PASS: composition-identity
+A t=0 M(tau1)={−e_1} O(tau1)={+e_2, −e_3} Orient(tau1)=+1 transport(tau1)=hold neighbor-read(tau1)=hold M(tau2)={−e_1} O(tau2)={+e_2, −e_3} Orient(tau2)=+1 transport(tau2)=hold neighbor-read(tau2)=hold witness(tau1)=(0, 2, 0)
+B t=1 M(tau1)={+e_1} O(tau1)={+e_2, +e_3} Orient(tau1)=+1 transport(tau1)=hold neighbor-read(tau1)=hold M(tau2)={+e_1} O(tau2)={+e_2, +e_3} Orient(tau2)=+1 transport(tau2)=hold neighbor-read(tau2)=hold witness(tau1)=(0, 1, 1)
+C t=1 M(tau1)={+e_2} O(tau1)={+e_1, −e_1, +e_3, −e_3} Orient(tau1)=+1 transport(tau1)=hold neighbor-read(tau1)=hold M(tau2)={+e_2} O(tau2)={+e_1, −e_1, +e_3, −e_3} Orient(tau2)=+1 transport(tau2)=hold neighbor-read(tau2)=hold witness(tau1)=(0, 1, 0)
+D t=1 M(tau1)={−e_1} O(tau1)={−e_1, +e_2, −e_3} Orient(tau1)=fail transport(tau1)=fail neighbor-read(tau1)=fail M(tau2)={−e_1} O(tau2)={−e_1, +e_2, −e_3} Orient(tau2)=fail transport(tau2)=fail neighbor-read(tau2)=fail witness(tau1)=fail
+neighbor-read reverse tau1=hold tau2=hold
+neighbor-read face tau1=fail tau2=fail
+neighbor-read composition=hold
+per_element: neighbor-read of the cyclic-frame transport HOLD bit at a formed 6-NN at a probe's t+1 and t+2
+per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: four neighbor-read reports at t+1 and t+2, reverse/face at each cut, composition
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 1, 'C': 1, 'D': 1})
+PASS: theorem1-M-O-Orient-transport-neighbor-read-at-tau1  ({'A': ('hold', 'hold'), 'B': ('hold', 'hold'), 'C': ('hold', 'hold'), 'D': ('fail', 'fail')})
+PASS: theorem1-M-O-Orient-transport-neighbor-read-at-tau2  ({'A': ('hold', 'hold'), 'B': ('hold', 'hold'), 'C': ('hold', 'hold'), 'D': ('fail', 'fail')})
+PASS: do-not-score-tau-t
+PASS: theorem1-mixed-O-cyclic-not-unique
+PASS: theorem1-new-records-meet-6nn  ({'A': (((1, 1, 0), (0, 2, 0), (0, 1, -1)), ((-1, 1, 0),)), 'B': (((1, 2, 1), (1, 1, 2)), ((2, 1, 1),)), 'C': (((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)), ()), 'D': (((1, 2, 0), (1, 1, -1)), ())})
+PASS: theorem1-new-tplus2-neighbor-does-not-enter-O
+PASS: theorem1-A-is-seed
+PASS: theorem2-reverse-tau1-and-tau2-hold
+PASS: theorem2-face-tau1-and-tau2-fail
+PASS: theorem3-composition-hold  (hold)
+PASS: cover-and-split-do-not-score-handedness
+PASS: split-fail-is-orient-fail-not-undefined
+PASS: empty-Oi-is-orient-fail-not-undefined
+PASS: not-leftover-of-1-axis-cover-face-hold
+PASS: not-leftover-empty-fail
+PASS: mutation-leftover-of-M-or-O-alone-differs
+PASS: mutation-exist-opposite-differs
+PASS: mutation-unsigned-incoming-axis-disagrees-at-A
+PASS: mutation-unique-letter-undefined-at-mixed-O
+PASS: mutation-sum-cancels-mixed
+PASS: O-is-not-M
+PASS: second-and-third-pair-are-seeds-not-formed-children
+PASS: not-x-probes-or-z-probes-or-z-symmetric-or-perp
+PASS: not-same-lock-or-one-axis-or-live-three-axis-seed
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-Orient-transport-neighbor-read-at-both-cuts
+PASS: note-reports-new-neighbors
+PASS: note-reports-neighbor-read-reverse-face-composition
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split-or-tplus1-alone
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: neighbor-read-not-scalar-or-transport-or-tplus1-alone
+TOTAL: PASS=62 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py
+++ b/scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py
@@ -1,0 +1,2829 @@
+#!/usr/bin/env python3
+"""Neighbor-read of cyclic-frame transport freeze t+1 versus t+2.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is three disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2, (2,0,0) locks +e_3, (2,1,0) locks
+-e_3. y-probes as nm2ax. Perp-step incoming lock. M, O, split as nm2ax12.
+Orient as nm2oricyccz (lex-smallest cyclic). Transport as nm2cycfrmz at
+each cut. Neighbor-read as nm2frmrd3y at each cut. Unformed => UNDEFINED.
+When split HOLDs, F(q)=(m,o_next,o_prev) is an oriented lattice frame.
+Neighbor-read HOLDs at q at a cut iff transport HOLDs at q and some formed
+6-NN r has transport HOLD, with M,O,F,transport read at that site's
+t+offset. If transport fails at q, neighbor-read fails, not UNDEFINED.
+t(q)=formation tick. tau1=t+1, tau2=t+2. No global T. Do not score tau=t.
+Reverse/face from neighbor-read at each cut. Reverse HOLDs iff
+neighbor-read at A and at B. Face on C,D. Composition HOLD iff
+neighbor-read bits at tau1 equal neighbor-read bits at tau2 at A,B,C,D.
+Neighbor-read of the scalar Orient sign is a different object. Uniqueness
+is not required. Occupancy of sites is not used. No larger host.
+Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+FrameVal = tuple[Point, Point, Point] | str
+Sending = tuple[Point, Point, Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+PAIR3: Point = (2, 0, 0)
+PAIR3B: Point = (2, 1, 0)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+    (PAIR3, E3),
+    (PAIR3B, NEG_E3),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+LIVE_THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+    (E3, E3),
+)
+PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+Z_PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "S⁺",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Neighbor-read of cyclic-frame transport at t+1 versus t+2 on the four "
+    "y-probes of the three-axis opposite seed, reverse/face at each cut, and "
+    "composition, are reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def pair_display(value: tuple[Point, Point] | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple):
+        raise TypeError(f"signed pair is not a pair or fail: {value!r}")
+    return ", ".join(LOCK_NAME[vec] for vec in value)
+
+
+def frame_display(value: FrameVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"frame is not a triple or fail: {value!r}")
+    return "(" + ", ".join(LOCK_NAME[vec] for vec in value) + ")"
+
+
+def matrix_display(value: Sending) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"sending is not three columns or fail: {value!r}")
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return "[" + "; ".join(" ".join(str(entry) for entry in row) for row in rows) + "]"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = THREE_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3. Mutation: unsigned."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negative)
+    return picked[0], picked[1]
+
+
+def axis_index(lock: Point) -> int | str:
+    """Axis index i in {1,2,3} of a signed nearest-neighbor letter."""
+    axis = axis_of_letter(lock)
+    if axis == E1:
+        return 1
+    if axis == E2:
+        return 2
+    if axis == E3:
+        return 3
+    return "fail"
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    """e_next = e_{i+1} with 3+1->1. e_prev = e_{i-1} with 1-1->3."""
+    idx = axis_index(signed_m)
+    if idx == "fail" or not isinstance(idx, int):
+        return "fail"
+    e_next = AXES[idx % 3]
+    e_prev = AXES[idx - 2]
+    return e_next, e_prev
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-largest signed letter in O intersect {+/-axis}. Order +e < -e."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-smallest signed letter in O intersect {+/-axis}. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def cyclic_signed_outgoing(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = False
+) -> tuple[Point, Point] | str:
+    """o_next, o_prev on the two cyclic axes of Axis(M). Empty slot is fail."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    o_next = picker(outgoing, units[0])
+    o_prev = picker(outgoing, units[1])
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic unsigned o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane. Fail if an opposite pair occupies O_i."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_lex_largest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: same cyclic axes, lex-largest (-e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_lex_smallest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Letter: same cyclic axes, lex-smallest (+e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-smallest cyclic slots."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o_next, o_prev = plane
+    det = integer_det_columns(signed_m, o_next, o_prev)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_triple(incoming: Incoming, outgoing: Outgoing) -> FrameVal:
+    """F=(m,o_next,o_prev) when split HOLDs. Else fail, not UNDEFINED unless unformed."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return signed_m, plane[0], plane[1]
+
+
+def transpose_columns(frame: tuple[Point, Point, Point]) -> tuple[Point, Point, Point]:
+    """Columns of the transpose. Inverse on signed permutation frames."""
+    return tuple(tuple(frame[column][row] for column in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def mul_columns(
+    left: tuple[Point, Point, Point], right: tuple[Point, Point, Point]
+) -> tuple[Point, Point, Point]:
+    """Integer matrix product of two column-triple matrices."""
+    return tuple(
+        tuple(
+            sum(left[k][i] * right[j][k] for k in range(3)) for i in range(3)
+        )
+        for j in range(3)
+    )  # type: ignore[return-value]
+
+
+def sending_matrix(source: FrameVal, target: FrameVal) -> Sending:
+    """Integer matrix P with F(r) = F(q) P, sending columns of F(q) to F(r)."""
+    if source == UNDEFINED or target == UNDEFINED:
+        return UNDEFINED
+    if source == "fail" or target == "fail":
+        return "fail"
+    if not isinstance(source, tuple) or not isinstance(target, tuple):
+        return "fail"
+    return mul_columns(transpose_columns(source), target)
+
+
+def is_signed_permutation(value: Sending) -> bool:
+    """Exactly one nonzero +/-1 in each row and each column."""
+    if not isinstance(value, tuple) or len(value) != 3:
+        return False
+    for column in value:
+        if any(entry not in (-1, 0, 1) for entry in column):
+            return False
+        if sum(abs(entry) for entry in column) != 1:
+            return False
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return all(sum(abs(entry) for entry in row) == 1 for row in rows)
+
+
+def sending_holds(
+    source: FrameVal, target: FrameVal, orient_q: OrientVal, orient_r: OrientVal
+) -> str:
+    """HOLD iff P is a signed permutation with det = Orient(q)Orient(r)."""
+    sending = sending_matrix(source, target)
+    if sending == UNDEFINED:
+        return UNDEFINED
+    if sending == "fail" or not isinstance(sending, tuple):
+        return "fail"
+    if orient_q not in (1, -1) or orient_r not in (1, -1):
+        return "fail"
+    det = integer_det_columns(sending[0], sending[1], sending[2])
+    if is_signed_permutation(sending) and det == orient_q * orient_r:
+        return "hold"
+    return "fail"
+
+
+def is_nonnegative_permutation(value: Sending) -> bool:
+    """Unsigned permutation: signed permutation with no minus signs. Mutation."""
+    if not is_signed_permutation(value):
+        return False
+    if not isinstance(value, tuple):
+        return False
+    return all(entry >= 0 for column in value for entry in column)
+
+
+def site_sides(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> tuple[Incoming, Outgoing]:
+    if site not in ticks:
+        return UNDEFINED, UNDEFINED
+    tau = ticks[site] + offset
+    return (
+        incoming_set(site, tau, ticks, locks, seed_map),
+        outgoing_set(site, tau, ticks, locks, seed_map),
+    )
+
+
+def formed_six_neighbors(site: Point, ticks: dict[Point, int]) -> tuple[Point, ...]:
+    """Formed 6-NN of site in B_3(0). Not a six-neighbor star letter."""
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def frame_transport(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, and some formed 6-NN r transports."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map, offset)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map, offset)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_transport_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> tuple[Point, Sending] | str:
+    """First formed 6-NN in NN order that transports. Uniqueness is not required."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map, offset)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map, offset)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return neighbor, sending
+    return "fail"
+
+
+def scalar_orient_neighbor(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> str:
+    """Mutation: HOLD iff some formed 6-NN has the same scalar Orient sign."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map, offset)
+    orient = frame_orient(incoming, outgoing)
+    if orient == UNDEFINED:
+        return UNDEFINED
+    if orient not in (1, -1):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map, offset)
+        if frame_orient(n_in, n_out) == orient:
+            return "hold"
+    return "fail"
+
+
+def unique_positive_sending(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> str:
+    """Mutation: unique nonnegative permutation sending. Not this letter."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map, offset)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    hits = 0
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map, offset)
+        n_orient = frame_orient(n_in, n_out)
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if (
+            sending_holds(source, target, orient, n_orient) == "hold"
+            and is_nonnegative_permutation(sending)
+        ):
+            hits += 1
+    if hits == 1:
+        return "hold"
+    return "fail"
+
+
+def transport_neighbor_read(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> str:
+    """HOLD iff transport HOLDs at q and some formed 6-NN r has transport HOLD."""
+    own = frame_transport(site, ticks, locks, seed_map, offset)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own != "hold":
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        if frame_transport(neighbor, ticks, locks, seed_map, offset) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_read_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> Point | str:
+    """First formed 6-NN in NN order with transport HOLD. Uniqueness is not required."""
+    own = frame_transport(site, ticks, locks, seed_map, offset)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own != "hold":
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        if frame_transport(neighbor, ticks, locks, seed_map, offset) == "hold":
+            return neighbor
+    return "fail"
+
+
+def equal_transport_bit(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+    offset: int = 1,
+) -> str:
+    """Leftover: some formed 6-NN has the same transport bit, including fail=fail."""
+    own = frame_transport(site, ticks, locks, seed_map, offset)
+    if own == UNDEFINED:
+        return UNDEFINED
+    for neighbor in formed_six_neighbors(site, ticks):
+        if frame_transport(neighbor, ticks, locks, seed_map, offset) == own:
+            return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Orient reverse HOLDs iff Orient(A)=Orient(B) both +/-1. Contrast."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Orient face HOLDs iff Orient(C)=Orient(D) both +/-1. Contrast."""
+    return pair_orient(orient_c, orient_d)
+
+
+def transport_reverse_report(left: str, right: str) -> str:
+    """Leftover: reverse HOLDs iff transport at A and at B."""
+    return pair_bit(left, right)
+
+
+def transport_face_report(left: str, right: str) -> str:
+    """Leftover: face HOLDs iff transport at C and at D."""
+    return pair_bit(left, right)
+
+
+def neighbor_read_reverse_report(left: str, right: str) -> str:
+    """Reverse HOLDs iff neighbor-read at A and at B."""
+    return pair_bit(left, right)
+
+
+def neighbor_read_face_report(left: str, right: str) -> str:
+    """Face HOLDs iff neighbor-read at C and at D."""
+    return pair_bit(left, right)
+
+
+def composition_report(
+    left_a: str,
+    right_a: str,
+    left_b: str,
+    right_b: str,
+    left_c: str,
+    right_c: str,
+    left_d: str,
+    right_d: str,
+) -> str:
+    """HOLD iff neighbor-read at tau1 equals neighbor-read at tau2 at A, B, C, and D."""
+    sides = (left_a, right_a, left_b, right_b, left_c, right_c, left_d, right_d)
+    if any(side == UNDEFINED for side in sides):
+        return UNDEFINED
+    if (
+        left_a == right_a
+        and left_b == right_b
+        and left_c == right_c
+        and left_d == right_d
+    ):
+        return "hold"
+    return "fail"
+
+
+def leftover_bit_composition(rev1: str, rev2: str, face1: str, face2: str) -> str:
+    """Leftover: score composition on reverse/face bits, not neighbor-read equality."""
+    if any(bit == UNDEFINED for bit in (rev1, rev2, face1, face2)):
+        return UNDEFINED
+    if rev1 != rev2 or face1 != face2:
+        return "fail"
+    return "hold"
+
+
+def leftover_mo_composition(
+    m1_a: Incoming,
+    m2_a: Incoming,
+    o1_a: Outgoing,
+    o2_a: Outgoing,
+    m1_b: Incoming,
+    m2_b: Incoming,
+    o1_b: Outgoing,
+    o2_b: Outgoing,
+    m1_c: Incoming,
+    m2_c: Incoming,
+    o1_c: Outgoing,
+    o2_c: Outgoing,
+    m1_d: Incoming,
+    m2_d: Incoming,
+    o1_d: Outgoing,
+    o2_d: Outgoing,
+) -> str:
+    """Leftover of simultaneous M-and-O freeze: M and O freeze, not neighbor-read equality."""
+    sides = (
+        m1_a,
+        m2_a,
+        o1_a,
+        o2_a,
+        m1_b,
+        m2_b,
+        o1_b,
+        o2_b,
+        m1_c,
+        m2_c,
+        o1_c,
+        o2_c,
+        m1_d,
+        m2_d,
+        o1_d,
+        o2_d,
+    )
+    if any(side == UNDEFINED for side in sides):
+        return UNDEFINED
+    if (
+        m1_a == m2_a
+        and o1_a == o2_a
+        and m1_b == m2_b
+        and o1_b == o2_b
+        and m1_c == m2_c
+        and o1_c == o2_c
+        and m1_d == m2_d
+        and o1_d == o2_d
+    ):
+        return "hold"
+    return "fail"
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+    offset: int = 1,
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+offset and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + offset:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    plane = cyclic_signed_outgoing(frozenset({unsigned_m}), outgoing, largest=True)
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    return probe_sides_at(probes, site_ticks, site_locks, site_seeds, 1)
+
+
+def probe_sides_at(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+    offset: int,
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + offset
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("neighbor-read of cyclic-frame transport freeze t+1 versus t+2 reverse/face composition on three-axis opposite y-probes")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = tuple(Z_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-y-probes-in-host",
+        probe_sites == ((0, 1, 0), (1, 1, 1), (0, 2, 0), (1, 1, 0))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E3, NEG_E1) == -1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E3, NEG_E1, NEG_E2) == 1
+        and integer_det_columns(E1, NEG_E2, NEG_E3) == 1
+        and integer_det_columns(E2, E3, E1) == 1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E3, E1, NEG_E2) == -1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({E2}), frozenset({NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == 1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == 1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == -1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and frame_orient(frozenset({E1, NEG_E1}), frozenset({E2, E3})) == "fail"
+        and cyclic_units(E2) == (E3, E1)
+        and cyclic_units(E1) == (E2, E3)
+        and cyclic_units(E3) == (E1, E2)
+        and cyclic_units(NEG_E2) == (E3, E1)
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1
+        and lex_largest_on_axis(frozenset({E1}), E1) == E1
+        and lex_smallest_on_axis(frozenset({E1, NEG_E1}), E1) == E1
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E3, E1)
+        and cyclic_signed_outgoing(frozenset({E1}), frozenset({E2, E3, NEG_E3}))
+        == (E2, E3)
+        and cyclic_signed_outgoing(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2}))
+        == (E1, NEG_E2)
+        and cyclic_signed_outgoing(frozenset({E1}), frozenset({NEG_E2, E3, NEG_E3}))
+        == (NEG_E2, E3)
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1})) == "fail"
+        and unique_signed_outgoing_plane(frozenset({E1, NEG_E1, E3})) == "fail"
+        and unique_signed_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == "fail"
+        and lex_frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and leftover_pair_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and cyclic_lex_largest_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == -1
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+    identity_frame = (E2, E3, E1)
+    identity_target = (E1, E2, E3)
+    identity_sending = sending_matrix(identity_frame, identity_target)
+    checks.check(
+        "sending-identity",
+        frame_triple(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E2, E3, E1)
+        and sending_matrix(UNDEFINED, identity_frame) == UNDEFINED
+        and sending_matrix(identity_frame, "fail") == "fail"
+        and sending_matrix(identity_frame, identity_frame)
+        == (E1, E2, E3)
+        and is_signed_permutation((E1, E2, E3))
+        and not is_signed_permutation((E1, E1, E2))
+        and sending_holds(identity_frame, identity_frame, 1, 1) == "hold"
+        and sending_holds(identity_frame, identity_target, 1, 1) == "hold"
+        and integer_det_columns(*identity_sending) == 1
+        and is_signed_permutation(identity_sending)
+        and is_nonnegative_permutation(identity_sending)
+        and mul_columns(identity_frame, identity_sending) == identity_target,
+    )
+    checks.check(
+        "composition-identity",
+        composition_report("hold", "hold", "hold", "hold", "hold", "hold", "hold", "hold")
+        == "hold"
+        and composition_report("hold", "fail", "hold", "hold", "hold", "hold", "hold", "hold")
+        == "fail"
+        and composition_report("fail", "fail", "fail", "fail", "fail", "fail", "fail", "fail")
+        == "hold"
+        and composition_report(UNDEFINED, "hold", "hold", "hold", "hold", "hold", "hold", "hold")
+        == UNDEFINED
+        and leftover_bit_composition("hold", "hold", "hold", "hold") == "hold"
+        and leftover_bit_composition("hold", "hold", "hold", "fail") == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    two_ticks, two_locks, two_seeds = form(TWO_AXIS_SEEDS)
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    live_ticks, live_locks, live_seeds = form(LIVE_THREE_AXIS_SEEDS)
+    tau0: dict[str, int] = {}
+    tau1: dict[str, int] = {}
+    tau2: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    m2: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    o2: dict[str, Outgoing] = {}
+    axis_m1: dict[str, AxisSet] = {}
+    axis_o1: dict[str, AxisSet] = {}
+    cover1: dict[str, str] = {}
+    cover2: dict[str, str] = {}
+    split0: dict[str, str] = {}
+    split1: dict[str, str] = {}
+    split2: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m1: dict[str, Point | str] = {}
+    signed_m2: dict[str, Point | str] = {}
+    plane1: dict[str, tuple[Point, Point] | str] = {}
+    pair1: dict[str, Point | str] = {}
+    leftover1: dict[str, Point | str] = {}
+    det1: dict[str, int | str] = {}
+    det2: dict[str, int | str] = {}
+    lex1: dict[str, OrientVal] = {}
+    leftover_pair1: dict[str, OrientVal] = {}
+    leftover_pair2: dict[str, OrientVal] = {}
+    unique_signed1: dict[str, OrientVal] = {}
+    unique_signed2: dict[str, OrientVal] = {}
+    pair_present1: dict[str, str] = {}
+    unique_plane1: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_plane1: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_plane2: dict[str, tuple[Point, Point] | str] = {}
+    cyclic_small1: dict[str, OrientVal] = {}
+    axis_i1: dict[str, int | str] = {}
+    orient0: dict[str, OrientVal] = {}
+    orient1: dict[str, OrientVal] = {}
+    orient2: dict[str, OrientVal] = {}
+    lx1: dict[str, AxisSet] = {}
+    lx_m1: dict[str, AxisSet] = {}
+    lx_o1: dict[str, AxisSet] = {}
+    new_meet1: dict[str, tuple[Point, ...]] = {}
+    new_meet2: dict[str, tuple[Point, ...]] = {}
+    frames0: dict[str, FrameVal] = {}
+    frames1: dict[str, FrameVal] = {}
+    frames2: dict[str, FrameVal] = {}
+    transport0: dict[str, str] = {}
+    transport1: dict[str, str] = {}
+    transport2: dict[str, str] = {}
+    reads0: dict[str, str] = {}
+    reads1: dict[str, str] = {}
+    reads2: dict[str, str] = {}
+    equal_bit0: dict[str, str] = {}
+    equal_bit1: dict[str, str] = {}
+    equal_bit2: dict[str, str] = {}
+    read_witness1: dict[str, Point | str] = {}
+    read_witness2: dict[str, Point | str] = {}
+    scalar1: dict[str, str] = {}
+    scalar2: dict[str, str] = {}
+    unique_pos1: dict[str, str] = {}
+    unique_pos2: dict[str, str] = {}
+    witness1: dict[str, tuple[Point, Sending] | str] = {}
+    witness2: dict[str, tuple[Point, Sending] | str] = {}
+    formed_nn: dict[str, tuple[Point, ...]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1[name] = ticks[site] + 1
+        tau2[name] = ticks[site] + 2
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1[name], ticks, locks, seed_map)
+        m2[name] = incoming_set(site, tau2[name], ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1[name], ticks, locks, seed_map)
+        o2[name] = outgoing_set(site, tau2[name], ticks, locks, seed_map)
+        axis_m1[name] = axis_set(m1[name])
+        axis_o1[name] = axis_set(o1[name])
+        cover1[name] = axis_cover(m1[name], o1[name])
+        cover2[name] = axis_cover(m2[name], o2[name])
+        split0[name] = axis_split(m0[name], o0[name])
+        split1[name] = axis_split(m1[name], o1[name])
+        split2[name] = axis_split(m2[name], o2[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m1[name] = unique_signed_m(m1[name])
+        signed_m2[name] = unique_signed_m(m2[name])
+        plane1[name] = outgoing_plane(axis_o1[name])
+        unique_plane1[name] = unique_signed_outgoing_plane(o1[name])
+        cyclic_plane1[name] = cyclic_signed_outgoing(m1[name], o1[name], largest=False)
+        cyclic_plane2[name] = cyclic_signed_outgoing(m2[name], o2[name], largest=False)
+        pair1[name] = opposite_pair_unit(o1[name])
+        if isinstance(signed_m1[name], tuple):
+            axis_i1[name] = axis_index(signed_m1[name])
+        else:
+            axis_i1[name] = "fail"
+        if isinstance(signed_m1[name], tuple) and isinstance(pair1[name], tuple):
+            leftover1[name] = leftover_unit(signed_m1[name], pair1[name])
+        else:
+            leftover1[name] = "fail"
+        if isinstance(signed_m1[name], tuple) and isinstance(cyclic_plane1[name], tuple):
+            det1[name] = integer_det_columns(
+                signed_m1[name], cyclic_plane1[name][0], cyclic_plane1[name][1]
+            )
+        else:
+            det1[name] = "fail"
+        if isinstance(signed_m2[name], tuple) and isinstance(cyclic_plane2[name], tuple):
+            det2[name] = integer_det_columns(
+                signed_m2[name], cyclic_plane2[name][0], cyclic_plane2[name][1]
+            )
+        else:
+            det2[name] = "fail"
+        pair_present1[name] = has_opposite_pair(o1[name])
+        lex1[name] = lex_frame_orient(m1[name], o1[name])
+        leftover_pair1[name] = leftover_pair_orient(m1[name], o1[name])
+        leftover_pair2[name] = leftover_pair_orient(m2[name], o2[name])
+        unique_signed1[name] = unique_signed_orient(m1[name], o1[name])
+        unique_signed2[name] = unique_signed_orient(m2[name], o2[name])
+        cyclic_small1[name] = cyclic_lex_smallest_orient(m1[name], o1[name])
+        orient0[name] = frame_orient(m0[name], o0[name])
+        orient1[name] = frame_orient(m1[name], o1[name])
+        orient2[name] = frame_orient(m2[name], o2[name])
+        frames0[name] = frame_triple(m0[name], o0[name])
+        frames1[name] = frame_triple(m1[name], o1[name])
+        frames2[name] = frame_triple(m2[name], o2[name])
+        transport0[name] = frame_transport(site, ticks, locks, seed_map, 0)
+        transport1[name] = frame_transport(site, ticks, locks, seed_map, 1)
+        transport2[name] = frame_transport(site, ticks, locks, seed_map, 2)
+        reads0[name] = transport_neighbor_read(site, ticks, locks, seed_map, 0)
+        reads1[name] = transport_neighbor_read(site, ticks, locks, seed_map, 1)
+        reads2[name] = transport_neighbor_read(site, ticks, locks, seed_map, 2)
+        equal_bit0[name] = equal_transport_bit(site, ticks, locks, seed_map, 0)
+        equal_bit1[name] = equal_transport_bit(site, ticks, locks, seed_map, 1)
+        equal_bit2[name] = equal_transport_bit(site, ticks, locks, seed_map, 2)
+        read_witness1[name] = first_read_witness(site, ticks, locks, seed_map, 1)
+        read_witness2[name] = first_read_witness(site, ticks, locks, seed_map, 2)
+        scalar1[name] = scalar_orient_neighbor(site, ticks, locks, seed_map, 1)
+        scalar2[name] = scalar_orient_neighbor(site, ticks, locks, seed_map, 2)
+        unique_pos1[name] = unique_positive_sending(site, ticks, locks, seed_map, 1)
+        unique_pos2[name] = unique_positive_sending(site, ticks, locks, seed_map, 2)
+        witness1[name] = first_transport_witness(site, ticks, locks, seed_map, 1)
+        witness2[name] = first_transport_witness(site, ticks, locks, seed_map, 2)
+        formed_nn[name] = formed_six_neighbors(site, ticks)
+        lx1[name] = leftover_axis(m1[name], o1[name])
+        lx_m1[name] = leftover_of_one(m1[name])
+        lx_o1[name] = leftover_of_one(o1[name])
+        new_meet1[name] = new_records_meeting_six_nn(site, ticks, 1)
+        new_meet2[name] = new_records_meeting_six_nn(site, ticks, 2)
+        witness_text1 = "fail"
+        if isinstance(witness1[name], tuple):
+            witness_text1 = f"{witness1[name][0]}"
+        print(
+            f"{name} t={ticks[site]} "
+            f"M(tau1)={lockset_display(m1[name])} "
+            f"O(tau1)={lockset_display(o1[name])} "
+            f"Orient(tau1)={orient_display(orient1[name])} "
+            f"transport(tau1)={transport1[name]} "
+            f"neighbor-read(tau1)={reads1[name]} "
+            f"M(tau2)={lockset_display(m2[name])} "
+            f"O(tau2)={lockset_display(o2[name])} "
+            f"Orient(tau2)={orient_display(orient2[name])} "
+            f"transport(tau2)={transport2[name]} "
+            f"neighbor-read(tau2)={reads2[name]} "
+            f"witness(tau1)={witness_text1}"
+        )
+
+    reverse1 = neighbor_read_reverse_report(reads1["A"], reads1["B"])
+    reverse2 = neighbor_read_reverse_report(reads2["A"], reads2["B"])
+    reverse0 = neighbor_read_reverse_report(reads0["A"], reads0["B"])
+    face1 = neighbor_read_face_report(reads1["C"], reads1["D"])
+    face2 = neighbor_read_face_report(reads2["C"], reads2["D"])
+    face0 = neighbor_read_face_report(reads0["C"], reads0["D"])
+    composition = composition_report(
+        reads1["A"], reads2["A"],
+        reads1["B"], reads2["B"],
+        reads1["C"], reads2["C"],
+        reads1["D"], reads2["D"],
+    )
+    leftover_transport_composition = composition_report(
+        transport1["A"], transport2["A"],
+        transport1["B"], transport2["B"],
+        transport1["C"], transport2["C"],
+        transport1["D"], transport2["D"],
+    )
+    leftover_t_tplus1_composition = composition_report(
+        reads0["A"], reads1["A"],
+        reads0["B"], reads1["B"],
+        reads0["C"], reads1["C"],
+        reads0["D"], reads1["D"],
+    )
+    leftover_bits = leftover_bit_composition(reverse1, reverse2, face1, face2)
+    leftover_mo = leftover_mo_composition(
+        m1["A"], m2["A"], o1["A"], o2["A"],
+        m1["B"], m2["B"], o1["B"], o2["B"],
+        m1["C"], m2["C"], o1["C"], o2["C"],
+        m1["D"], m2["D"], o1["D"], o2["D"],
+    )
+    orient_reverse1 = reverse_report(orient1["A"], orient1["B"])
+    orient_face1 = face_report(orient1["C"], orient1["D"])
+    orient_composition = composition_report(
+        orient_display(orient1["A"]), orient_display(orient2["A"]),
+        orient_display(orient1["B"]), orient_display(orient2["B"]),
+        orient_display(orient1["C"]), orient_display(orient2["C"]),
+        orient_display(orient1["D"]), orient_display(orient2["D"]),
+    )
+    scalar_reverse1 = pair_bit(scalar1["A"], scalar1["B"])
+    scalar_face1 = pair_bit(scalar1["C"], scalar1["D"])
+    unique_pos_reverse1 = pair_bit(unique_pos1["A"], unique_pos1["B"])
+    unique_pos_face1 = pair_bit(unique_pos1["C"], unique_pos1["D"])
+    cover_reverse1 = pair_bit(cover1["A"], cover1["B"])
+    cover_face1 = pair_bit(cover1["C"], cover1["D"])
+    split_reverse1 = pair_bit(split1["A"], split1["B"])
+    split_face1 = pair_bit(split1["C"], split1["D"])
+    leftover_reverse = leftover_match(lx1["A"], lx1["B"])
+    leftover_face = leftover_match(lx1["C"], lx1["D"])
+    reverse_m_alone = leftover_match(lx_m1["A"], lx_m1["B"])
+    face_m_alone = leftover_match(lx_m1["C"], lx_m1["D"])
+    reverse_o_alone = leftover_match(lx_o1["A"], lx_o1["B"])
+    face_o_alone = leftover_match(lx_o1["C"], lx_o1["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unsigned_orient1 = {
+        name: unsigned_incoming_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    unique_o_orient_a = frame_orient(unique_letter(m1["A"]), unique_letter(o1["A"]))
+    two_m1, two_o1 = probe_sides(PROBES, two_ticks, two_locks, two_seeds)
+    two_orient = {
+        name: frame_orient(two_m1[name], two_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    two_transport1 = {
+        name: frame_transport(PROBES[name], two_ticks, two_locks, two_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    two_reverse = transport_reverse_report(two_transport1["A"], two_transport1["B"])
+    two_face = transport_face_report(two_transport1["C"], two_transport1["D"])
+    two_orient_reverse = reverse_report(two_orient["A"], two_orient["B"])
+    two_orient_face = face_report(two_orient["C"], two_orient["D"])
+    two_reads1 = {
+        name: transport_neighbor_read(PROBES[name], two_ticks, two_locks, two_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    two_read_reverse = neighbor_read_reverse_report(two_reads1["A"], two_reads1["B"])
+    two_read_face = neighbor_read_face_report(two_reads1["C"], two_reads1["D"])
+    one_m1, one_o1 = probe_sides(PROBES, one_ticks, one_locks, one_seeds)
+    one_cover = {name: axis_cover(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_split = {name: axis_split(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")}
+    one_orient = {
+        name: frame_orient(one_m1[name], one_o1[name]) for name in ("A", "B", "C", "D")
+    }
+    one_cover_face = pair_bit(one_cover["C"], one_cover["D"])
+    one_split_face = pair_bit(one_split["C"], one_split["D"])
+    one_orient_face = face_report(one_orient["C"], one_orient["D"])
+    one_transport1 = {
+        name: frame_transport(PROBES[name], one_ticks, one_locks, one_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    one_transport_face1 = transport_face_report(
+        one_transport1["C"], one_transport1["D"]
+    )
+    live_transport1 = {
+        name: frame_transport(PROBES[name], live_ticks, live_locks, live_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    live_transport_face1 = transport_face_report(
+        live_transport1["C"], live_transport1["D"]
+    )
+    same_transport1 = {
+        name: frame_transport(PROBES[name], same_ticks, same_locks, same_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    same_transport_face1 = transport_face_report(
+        same_transport1["C"], same_transport1["D"]
+    )
+    one_reads1 = {
+        name: transport_neighbor_read(PROBES[name], one_ticks, one_locks, one_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    one_read_face1 = neighbor_read_face_report(one_reads1["C"], one_reads1["D"])
+    live_reads1 = {
+        name: transport_neighbor_read(PROBES[name], live_ticks, live_locks, live_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    live_read_face1 = neighbor_read_face_report(live_reads1["C"], live_reads1["D"])
+    same_reads1 = {
+        name: transport_neighbor_read(PROBES[name], same_ticks, same_locks, same_seeds, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    same_read_face1 = neighbor_read_face_report(same_reads1["C"], same_reads1["D"])
+    fail_site: Point = PROBES["D"]
+    fail_read1 = transport_neighbor_read(fail_site, ticks, locks, seed_map, 1)
+    fail_equal1 = equal_transport_bit(fail_site, ticks, locks, seed_map, 1)
+    fail_read2 = transport_neighbor_read(fail_site, ticks, locks, seed_map, 2)
+    fail_equal2 = equal_transport_bit(fail_site, ticks, locks, seed_map, 2)
+    print(f"neighbor-read reverse tau1={reverse1} tau2={reverse2}")
+    print(f"neighbor-read face tau1={face1} tau2={face2}")
+    print(f"neighbor-read composition={composition}")
+    print(
+        "per_element: neighbor-read of the cyclic-frame transport HOLD bit at a "
+        "formed 6-NN at a probe's t+1 and t+2"
+    )
+    print("per_site: scored only at y-probes A,B,C,D on Euclidean B_3(0); no other sites")
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: four neighbor-read reports at t+1 and t+2, reverse/face at each cut, composition")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = (
+        not perpendicular(E1, E1)
+        and E1 not in locks.get(add(ORIGIN, E1), set())
+        and NEG_E1 not in locks.get(add(ORIGIN, NEG_E1), set())
+    )
+    second_pair_parallel_blocked = (
+        not perpendicular(E2, E2)
+        and E2 not in locks.get(add(E3, E2), set())
+        and NEG_E2 not in locks.get(add(E3, NEG_E2), set())
+        and E2 not in locks.get(add(PAIR2, E2), set())
+        and NEG_E2 not in locks.get(add(PAIR2, NEG_E2), set())
+    )
+    third_pair_parallel_blocked = (
+        not perpendicular(E3, E3)
+        and E3 not in locks.get(add(PAIR3, E3), set())
+        and NEG_E3 not in locks.get(add(PAIR3, NEG_E3), set())
+        and E3 not in locks.get(add(PAIR3B, E3), set())
+        and NEG_E3 not in locks.get(add(PAIR3B, NEG_E3), set())
+    )
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and third_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and ticks[PAIR3] == 0
+        and ticks[PAIR3B] == 0
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_transport(PROBES["B"], {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1}, 1)
+        == UNDEFINED
+        and transport_neighbor_read(
+            PROBES["B"], {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1}, 1
+        )
+        == UNDEFINED
+        and frame_triple(
+            incoming_set(PROBES["B"], 0, ticks, locks, seed_map),
+            outgoing_set(PROBES["B"], 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-Orient-transport-neighbor-read-at-tau1",
+        m1["A"] == frozenset({NEG_E1})
+        and m1["B"] == frozenset({E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E1})
+        and o1["A"] == frozenset({E2, NEG_E3})
+        and o1["B"] == frozenset({E2, E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3, NEG_E3})
+        and o1["D"] == frozenset({NEG_E1, E2, NEG_E3})
+        and split1["A"] == "hold"
+        and split1["B"] == "hold"
+        and split1["C"] == "hold"
+        and split1["D"] == "fail"
+        and cover1["A"] == "hold"
+        and cover1["B"] == "hold"
+        and cover1["C"] == "hold"
+        and cover1["D"] == "fail"
+        and signed_m1["A"] == NEG_E1
+        and signed_m1["B"] == E1
+        and signed_m1["C"] == E2
+        and signed_m1["D"] == NEG_E1
+        and axis_i1["A"] == 1
+        and axis_i1["B"] == 1
+        and axis_i1["C"] == 2
+        and axis_i1["D"] == 1
+        and cyclic_plane1["A"] == (E2, NEG_E3)
+        and cyclic_plane1["B"] == (E2, E3)
+        and cyclic_plane1["C"] == (E3, E1)
+        and unique_plane1["A"] == (E2, NEG_E3)
+        and unique_plane1["B"] == (E2, E3)
+        and unique_plane1["C"] == "fail"
+        and unique_plane1["D"] == "fail"
+        and det1["A"] == 1
+        and det1["B"] == 1
+        and det1["C"] == 1
+        and orient1["A"] == 1
+        and orient1["B"] == 1
+        and orient1["C"] == 1
+        and orient1["D"] == "fail"
+        and frames1["A"] == (NEG_E1, E2, NEG_E3)
+        and frames1["B"] == (E1, E2, E3)
+        and frames1["C"] == (E2, E3, E1)
+        and frames1["D"] == "fail"
+        and transport1["A"] == "hold"
+        and transport1["B"] == "hold"
+        and transport1["C"] == "hold"
+        and transport1["D"] == "fail"
+        and isinstance(witness1["A"], tuple)
+        and isinstance(witness1["B"], tuple)
+        and isinstance(witness1["C"], tuple)
+        and witness1["D"] == "fail"
+        and witness1["A"] == ((0, 2, 0), ((0, 1, 0), (0, 0, -1), (-1, 0, 0)))
+        and witness1["B"] == ((0, 1, 1), ((0, -1, 0), (0, 0, 1), (1, 0, 0)))
+        and witness1["C"] == ((0, 1, 0), ((0, 0, -1), (1, 0, 0), (0, -1, 0)))
+        and scalar1["A"] == "hold"
+        and scalar1["B"] == "fail"
+        and scalar1["C"] == "hold"
+        and scalar1["D"] == "fail"
+        and unique_pos1["A"] == "fail"
+        and unique_pos1["B"] == "fail"
+        and unique_pos1["C"] == "fail"
+        and unique_pos1["D"] == "fail"
+        and reads1["A"] == "hold"
+        and reads1["B"] == "hold"
+        and reads1["C"] == "hold"
+        and reads1["D"] == "fail"
+        and read_witness1["A"] == (0, 2, 0)
+        and read_witness1["B"] == (0, 1, 1)
+        and read_witness1["C"] == (0, 1, 0)
+        and read_witness1["D"] == "fail"
+        and equal_bit1["A"] == "hold"
+        and equal_bit1["B"] == "hold"
+        and equal_bit1["C"] == "hold"
+        and equal_bit1["D"] == "hold"
+        and equal_bit1["D"] != reads1["D"],
+        str({name: (transport1[name], reads1[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-Orient-transport-neighbor-read-at-tau2",
+        m2["A"] == m1["A"]
+        and m2["B"] == m1["B"]
+        and m2["C"] == m1["C"]
+        and m2["D"] == m1["D"]
+        and o2["A"] == o1["A"]
+        and o2["B"] == o1["B"]
+        and o2["C"] == o1["C"]
+        and o2["D"] == o1["D"]
+        and split2["A"] == "hold"
+        and split2["B"] == "hold"
+        and split2["C"] == "hold"
+        and split2["D"] == "fail"
+        and signed_m2["A"] == signed_m1["A"]
+        and cyclic_plane2["A"] == cyclic_plane1["A"]
+        and cyclic_plane2["B"] == cyclic_plane1["B"]
+        and cyclic_plane2["C"] == cyclic_plane1["C"]
+        and cyclic_plane2["D"] == cyclic_plane1["D"]
+        and det2["A"] == det1["A"]
+        and det2["B"] == det1["B"]
+        and det2["C"] == det1["C"]
+        and det2["D"] == det1["D"]
+        and orient2["A"] == 1
+        and orient2["B"] == 1
+        and orient2["C"] == 1
+        and orient2["D"] == "fail"
+        and frames2["A"] == frames1["A"]
+        and frames2["B"] == frames1["B"]
+        and frames2["C"] == frames1["C"]
+        and frames2["D"] == frames1["D"]
+        and transport2["A"] == "hold"
+        and transport2["B"] == "hold"
+        and transport2["C"] == "hold"
+        and transport2["D"] == "fail"
+        and transport2["A"] == transport1["A"]
+        and transport2["B"] == transport1["B"]
+        and transport2["C"] == transport1["C"]
+        and transport2["D"] == transport1["D"]
+        and witness2["A"] == witness1["A"]
+        and witness2["B"] == witness1["B"]
+        and witness2["C"] == witness1["C"]
+        and witness2["D"] == witness1["D"]
+        and scalar2["A"] == scalar1["A"]
+        and unique_pos2["A"] == "fail"
+        and unique_pos2["B"] == "fail"
+        and unique_pos2["C"] == "fail"
+        and unique_pos2["D"] == "fail"
+        and reads2["A"] == "hold"
+        and reads2["B"] == "hold"
+        and reads2["C"] == "hold"
+        and reads2["D"] == "fail"
+        and reads2["A"] == reads1["A"]
+        and reads2["B"] == reads1["B"]
+        and reads2["C"] == reads1["C"]
+        and reads2["D"] == reads1["D"]
+        and read_witness2["A"] == read_witness1["A"]
+        and read_witness2["B"] == read_witness1["B"]
+        and read_witness2["C"] == read_witness1["C"]
+        and read_witness2["D"] == read_witness1["D"]
+        and equal_bit2["D"] == "hold"
+        and equal_bit2["D"] != reads2["D"],
+        str({name: (transport2[name], reads2[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "do-not-score-tau-t",
+        o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset({NEG_E1})
+        and all(orient0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(split0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(frames0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(transport0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and all(reads0[name] == "fail" for name in ("A", "B", "C", "D"))
+        and reverse0 == "fail"
+        and face0 == "fail"
+        and leftover_t_tplus1_composition == "fail"
+        and reverse1 == "hold"
+        and face1 == "fail",
+    )
+    checks.check(
+        "theorem1-mixed-O-cyclic-not-unique",
+        isinstance(o1["A"], frozenset)
+        and len(o1["A"]) == 2
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and unique_plane1["A"] == (E2, NEG_E3)
+        and unique_signed1["A"] == 1
+        and cyclic_plane1["A"] == (E2, NEG_E3)
+        and unique_o_orient_a == UNDEFINED
+        and orient1["A"] == 1
+        and unique_letter(o2["A"]) == UNDEFINED,
+    )
+    checks.check(
+        "theorem1-new-records-meet-6nn",
+        new_meet1["A"] == ((1, 1, 0), (0, 2, 0), (0, 1, -1))
+        and new_meet1["B"] == ((1, 2, 1), (1, 1, 2))
+        and new_meet1["C"] == ((1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1))
+        and new_meet1["D"] == ((1, 2, 0), (1, 1, -1))
+        and new_meet2["A"] == ((-1, 1, 0),)
+        and new_meet2["B"] == ((2, 1, 1),)
+        and new_meet2["C"] == ()
+        and new_meet2["D"] == (),
+        str({name: (new_meet1[name], new_meet2[name]) for name in ("A", "B", "C", "D")}),
+    )
+    child_of_a_tplus2 = (-1, 1, 0)
+    checks.check(
+        "theorem1-new-tplus2-neighbor-does-not-enter-O",
+        child_of_a_tplus2 in new_meet2["A"]
+        and ticks[child_of_a_tplus2] == ticks[PROBES["A"]] + 2
+        and incoming_set(child_of_a_tplus2, tau2["A"], ticks, locks, seed_map)
+        == frozenset({NEG_E3})
+        and E1 not in o2["A"]
+        and NEG_E1 not in o2["A"]
+        and o2["A"] == o1["A"]
+        and transport2["A"] == transport1["A"]
+        and reads2["A"] == reads1["A"],
+    )
+    checks.check(
+        "theorem1-A-is-seed",
+        PROBES["A"] == E2
+        and ticks[E2] == 0
+        and locks[E2] == {NEG_E1}
+        and m1["A"] == frozenset({NEG_E1})
+        and ticks[PAIR2] == 0
+        and locks[PAIR2] == {NEG_E2},
+    )
+    checks.check(
+        "theorem2-reverse-tau1-and-tau2-hold",
+        reverse1 == "hold"
+        and reverse2 == "hold"
+        and reads1["A"] == "hold"
+        and reads1["B"] == "hold"
+        and reads2["A"] == "hold"
+        and reads2["B"] == "hold"
+        and transport1["A"] == "hold"
+        and transport1["B"] == "hold"
+        and transport2["A"] == "hold"
+        and transport2["B"] == "hold"
+        and reverse1 != UNDEFINED
+        and reverse2 != "fail"
+        and orient_reverse1 == "hold"
+        and scalar_reverse1 == "fail"
+        and unique_pos_reverse1 == "fail"
+        and split_reverse1 == "hold"
+        and cover_reverse1 == "hold"
+        and scalar_reverse1 != reverse1,
+    )
+    checks.check(
+        "theorem2-face-tau1-and-tau2-fail",
+        face1 == "fail"
+        and face2 == "fail"
+        and reads1["C"] == "hold"
+        and reads1["D"] == "fail"
+        and reads2["C"] == "hold"
+        and reads2["D"] == "fail"
+        and transport1["C"] == "hold"
+        and transport1["D"] == "fail"
+        and transport2["C"] == "hold"
+        and transport2["D"] == "fail"
+        and face1 != UNDEFINED
+        and face1 == "fail"
+        and orient_face1 == "fail"
+        and scalar_face1 == "fail"
+        and unique_pos_face1 == "fail"
+        and split_face1 == "fail"
+        and cover_face1 == "fail",
+    )
+    checks.check(
+        "theorem3-composition-hold",
+        composition == "hold"
+        and leftover_mo == "hold"
+        and leftover_bits == "hold"
+        and leftover_transport_composition == "hold"
+        and leftover_t_tplus1_composition == "fail"
+        and leftover_t_tplus1_composition != composition
+        and reads1["A"] == reads2["A"]
+        and reads1["B"] == reads2["B"]
+        and reads1["C"] == reads2["C"]
+        and reads1["D"] == reads2["D"]
+        and transport1["A"] == transport2["A"]
+        and transport1["B"] == transport2["B"]
+        and transport1["C"] == transport2["C"]
+        and transport1["D"] == transport2["D"]
+        and orient_composition == "hold"
+        and orient_composition != leftover_t_tplus1_composition,
+        composition,
+    )
+    checks.check(
+        "cover-and-split-do-not-score-handedness",
+        split_reverse1 == "hold"
+        and cover_reverse1 == "hold"
+        and reverse1 == "hold"
+        and split_face1 == "fail"
+        and cover_face1 == "fail"
+        and face1 == "fail"
+        and leftover_pair1["A"] == "fail"
+        and leftover_pair1["B"] == "fail"
+        and leftover_pair1["C"] == -1
+        and leftover_pair1["D"] == "fail"
+        and reverse_report(leftover_pair1["A"], leftover_pair1["B"]) == "fail"
+        and reverse_report(leftover_pair1["A"], leftover_pair1["B"]) != reverse1
+        and reverse_report(lex1["A"], lex1["B"]) == "fail"
+        and reverse_report(lex1["A"], lex1["B"]) != reverse1
+        and reverse2 == "hold"
+        and face2 == "fail"
+        and leftover_pair2["C"] == leftover_pair1["C"]
+        and leftover_pair2["D"] == leftover_pair1["D"]
+        and orient1["A"] == 1
+        and orient1["B"] == 1
+        and orient1["C"] == 1
+        and orient1["D"] == "fail",
+    )
+    checks.check(
+        "split-fail-is-orient-fail-not-undefined",
+        frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and axis_split(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1})) == "fail"
+        and two_in_one_out(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "hold"
+        and two_one["C"] == "fail"
+        and two_one["D"] == "fail"
+        and one_orient["D"] == "fail"
+        and one_split["D"] == "fail"
+        and one_cover["D"] == "hold"
+        and one_orient_face == "fail"
+        and one_split_face == "fail"
+        and one_cover_face == "hold"
+        and one_transport1["D"] == "fail"
+        and one_transport_face1 == "fail"
+        and one_reads1["D"] == "fail"
+        and one_read_face1 == "fail"
+        and frame_triple(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail",
+    )
+    checks.check(
+        "empty-Oi-is-orient-fail-not-undefined",
+        cyclic_signed_outgoing(frozenset({E2}), frozenset()) == "fail"
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1})) == "fail"
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset()) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1,
+    )
+    checks.check(
+        "not-leftover-of-1-axis-cover-face-hold",
+        one_ticks[PROBES["B"]] == 2
+        and one_ticks[PROBES["D"]] == 3
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and one_cover_face == "hold"
+        and cover_face1 == "fail"
+        and one_transport_face1 == "fail"
+        and one_read_face1 == "fail"
+        and face1 == "fail"
+        and reverse1 == "hold"
+        and one_o1["A"] != o1["A"],
+    )
+    checks.check(
+        "not-leftover-empty-fail",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and leftover_reverse != reverse1
+        and leftover_face == face1
+        and lx1["A"] == frozenset()
+        and lx1["B"] == frozenset()
+        and lx1["C"] == frozenset()
+        and lx1["D"] == frozenset()
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "mutation-leftover-of-M-or-O-alone-differs",
+        lx_m1["A"] == frozenset({E2, E3})
+        and lx_m1["B"] == frozenset({E2, E3})
+        and lx_o1["A"] == frozenset({E1})
+        and lx_o1["B"] == frozenset({E1})
+        and reverse_m_alone == "hold"
+        and face_m_alone == "fail"
+        and reverse_o_alone == "hold"
+        and face_o_alone == "fail"
+        and reverse1 == "hold"
+        and face1 == "fail"
+        and lx_m1["A"] != lx1["A"]
+        and lx_m1["C"] == frozenset({E1, E3})
+        and lx_o1["C"] == frozenset({E2}),
+    )
+    checks.check(
+        "mutation-exist-opposite-differs",
+        m_exist_reverse == "hold"
+        and m_exist_face == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and reverse1 == "hold"
+        and face1 == "fail"
+        and o_exist_face != face1
+        and pair_present1["A"] == "fail"
+        and pair_present1["B"] == "fail"
+        and pair_present1["C"] == "hold"
+        and pair_present1["D"] == "fail"
+        and pair_bit(pair_present1["A"], pair_present1["B"]) == "fail"
+        and pair_bit(pair_present1["C"], pair_present1["D"]) == "fail"
+        and leftover_pair1["A"] == "fail"
+        and leftover_pair1["B"] == "fail"
+        and leftover_pair1["C"] == -1
+        and leftover_pair1["D"] == "fail"
+        and reverse_report(leftover_pair1["A"], leftover_pair1["B"]) != reverse1,
+    )
+    checks.check(
+        "mutation-unsigned-incoming-axis-disagrees-at-A",
+        unsigned_orient1["A"] == -1
+        and unsigned_orient1["B"] == 1
+        and unsigned_orient1["C"] == 1
+        and unsigned_orient1["D"] == "fail"
+        and unsigned_orient1["A"] != orient1["A"]
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and unsigned_incoming_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({E1}), o1["A"]) == -1
+        and unsigned_incoming_orient(frozenset({NEG_E1}), o1["A"]) == -1
+        and orient1["A"] == 1,
+    )
+    checks.check(
+        "mutation-unique-letter-undefined-at-mixed-O",
+        unique_letter(m1["A"]) == frozenset({NEG_E1})
+        and unique_letter(o1["A"]) == UNDEFINED
+        and unique_letter(o1["B"]) == UNDEFINED
+        and unique_letter(o1["C"]) == UNDEFINED
+        and unique_letter(o1["D"]) == UNDEFINED
+        and unique_o_orient_a == UNDEFINED
+        and unique_signed1["A"] == 1
+        and unique_signed1["B"] == 1
+        and unique_signed1["C"] == "fail"
+        and unique_signed1["D"] == "fail"
+        and unique_signed2["A"] == 1
+        and orient1["A"] == 1
+        and orient1["D"] == "fail"
+        and unique_letter(o2["A"]) == UNDEFINED,
+    )
+    checks.check(
+        "mutation-sum-cancels-mixed",
+        isinstance(o1["A"], frozenset)
+        and sum_of_set(m1["A"]) == NEG_E1
+        and sum_of_set(o1["A"]) == (0, 1, -1)
+        and sum_of_set(o1["C"]) == ZERO
+        and axis_o1["A"] == frozenset({E2, E3})
+        and pair1["A"] == "fail"
+        and leftover1["A"] == "fail"
+        and cyclic_plane1["A"] == (E2, NEG_E3)
+        and plane1["A"] == (E2, E3),
+    )
+    checks.check(
+        "O-is-not-M",
+        isinstance(m1["A"], frozenset)
+        and isinstance(o1["A"], frozenset)
+        and NEG_E1 in m1["A"]
+        and NEG_E1 not in o1["A"]
+        and E2 in o1["A"]
+        and o1["A"] != m1["A"]
+        and o2["A"] != m2["A"],
+    )
+    checks.check(
+        "second-and-third-pair-are-seeds-not-formed-children",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and PAIR3 in seed_map
+        and seed_map[PAIR3] == E3
+        and ticks[PAIR3] == 0
+        and PAIR3B in seed_map
+        and seed_map[PAIR3B] == NEG_E3
+        and ticks[PAIR3B] == 0
+        and two_ticks[PAIR3] == 3
+        and two_locks[PAIR3] == {E1}
+        and two_ticks[PAIR3B] == 3
+        and two_locks[PAIR3B] == {E1}
+        and one_ticks[E3] == 1
+        and PAIR2 not in new_meet1["A"],
+    )
+    z_m1, z_o1 = probe_sides_at(Z_PROBES, ticks, locks, seed_map, 1)
+    z_split1 = {name: axis_split(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")}
+    z_orient1 = {name: frame_orient(z_m1[name], z_o1[name]) for name in ("A", "B", "C", "D")}
+    z_reverse1 = reverse_report(z_orient1["A"], z_orient1["B"])
+    z_face1 = face_report(z_orient1["C"], z_orient1["D"])
+    z_transport1 = {
+        name: frame_transport(Z_PROBES[name], ticks, locks, seed_map, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    z_transport2 = {
+        name: frame_transport(Z_PROBES[name], ticks, locks, seed_map, 2)
+        for name in ("A", "B", "C", "D")
+    }
+    z_transport_reverse1 = transport_reverse_report(z_transport1["A"], z_transport1["B"])
+    z_transport_face1 = transport_face_report(z_transport1["C"], z_transport1["D"])
+    z_reads1 = {
+        name: transport_neighbor_read(Z_PROBES[name], ticks, locks, seed_map, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    z_read_reverse1 = neighbor_read_reverse_report(z_reads1["A"], z_reads1["B"])
+    z_read_face1 = neighbor_read_face_report(z_reads1["C"], z_reads1["D"])
+    x_m1, x_o1 = probe_sides_at(X_PROBES, ticks, locks, seed_map, 1)
+    x_orient1 = {name: frame_orient(x_m1[name], x_o1[name]) for name in ("A", "B", "C", "D")}
+    x_reverse1 = reverse_report(x_orient1["A"], x_orient1["B"])
+    x_face1 = face_report(x_orient1["C"], x_orient1["D"])
+    x_transport1 = {
+        name: frame_transport(X_PROBES[name], ticks, locks, seed_map, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    x_transport_reverse1 = transport_reverse_report(x_transport1["A"], x_transport1["B"])
+    x_transport_face1 = transport_face_report(x_transport1["C"], x_transport1["D"])
+    x_reads1 = {
+        name: transport_neighbor_read(X_PROBES[name], ticks, locks, seed_map, 1)
+        for name in ("A", "B", "C", "D")
+    }
+    x_read_reverse1 = neighbor_read_reverse_report(x_reads1["A"], x_reads1["B"])
+    x_read_face1 = neighbor_read_face_report(x_reads1["C"], x_reads1["D"])
+    perp_m1, perp_o1 = probe_sides(PROBES, perp_ticks, perp_locks, perp_seeds)
+    same_m_a = incoming_set(
+        PROBES["A"], same_ticks[PROBES["A"]] + 1, same_ticks, same_locks, same_seeds
+    )
+    zsym_m1, _zsym_o1 = probe_sides(PROBES, zsym_ticks, zsym_locks, zsym_seeds)
+    checks.check(
+        "not-x-probes-or-z-probes-or-z-symmetric-or-perp",
+        THREE_AXIS_SEEDS != PERP_SEEDS
+        and THREE_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and THREE_AXIS_SEEDS != TWO_AXIS_SEEDS
+        and probe_sites != x_probe_sites
+        and probe_sites != z_probe_sites
+        and z_m1["A"] != m1["A"]
+        and z_split1["A"] == "hold"
+        and z_orient1["A"] == 1
+        and z_orient1["B"] == 1
+        and z_reverse1 == "hold"
+        and z_face1 == "hold"
+        and all(z_split1[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(z_transport1[name] == "hold" for name in ("A", "B", "C", "D"))
+        and z_transport_reverse1 == "hold"
+        and z_transport_face1 == "hold"
+        and z_transport2["D"] == "hold"
+        and all(z_reads1[name] == "hold" for name in ("A", "B", "C", "D"))
+        and z_read_reverse1 == "hold"
+        and z_read_face1 == "hold"
+        and x_reverse1 == "fail"
+        and x_face1 == "fail"
+        and x_read_reverse1 == "hold"
+        and x_read_face1 == "fail"
+        and X_PROBES["C"] == PAIR3
+        and PAIR3 in seed_map
+        and x_orient1["C"] == -1
+        and zsym_m1["A"] != m1["A"]
+        and perp_m1["A"] != m1["A"]
+        and reverse1 == "hold"
+        and face1 == "fail"
+        and z_transport_face1 != face1
+        and z_read_face1 != face1
+        and z_face1 != face1,
+    )
+    checks.check(
+        "not-same-lock-or-one-axis-or-live-three-axis-seed",
+        THREE_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and THREE_AXIS_SEEDS != TWO_SITE_SEEDS
+        and THREE_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and THREE_AXIS_SEEDS != LIVE_THREE_AXIS_SEEDS
+        and THREE_AXIS_SEEDS != TWO_AXIS_SEEDS
+        and same_m_a != m1["A"]
+        and same_transport_face1 == "fail"
+        and one_transport_face1 == "fail"
+        and same_read_face1 == "fail"
+        and one_read_face1 == "fail"
+        and live_transport1["B"] == "fail"
+        and live_transport1["C"] == "fail"
+        and live_transport_face1 == "fail"
+        and live_reads1["B"] == "fail"
+        and live_reads1["C"] == "fail"
+        and live_read_face1 == "fail"
+        and face1 == "fail"
+        and live_reads1["B"] != reads1["B"]
+        and two_orient_reverse == "hold"
+        and two_orient_face == "fail"
+        and two_o1["B"] == frozenset({E2, E3, NEG_E3})
+        and o1["B"] == frozenset({E2, E3})
+        and unique_signed_orient(two_m1["B"], two_o1["B"]) == "fail"
+        and unique_signed1["B"] == 1
+        and two_ticks[PROBES["D"]] == 2
+        and ticks[PROBES["D"]] == 1
+        and two_read_reverse == "hold"
+        and two_read_face == "fail"
+        and sum(time == 0 for time in ticks.values()) == 6
+        and sum(time == 0 for time in two_ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3
+        and sum(time == 0 for time in live_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-Orient-transport-neighbor-read-at-both-cuts",
+        "t(A)=0" in note
+        and "t(B)=1" in note
+        and "t(C)=1" in note
+        and "t(D)=1" in note
+        and "M(A, τ1) = {−e_1}" in note
+        and "M(B, τ1) = {+e_1}" in note
+        and "M(C, τ1) = {+e_2}" in note
+        and "M(D, τ1) = {−e_1}" in note
+        and "O(A, τ1) = {+e_2, −e_3}" in note
+        and "O(B, τ1) = {+e_2, +e_3}" in note
+        and "O(C, τ1) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ1) = {−e_1, +e_2, −e_3}" in note
+        and "Orient(A, τ1) = +1" in note
+        and "Orient(B, τ1) = +1" in note
+        and "Orient(C, τ1) = +1" in note
+        and "Orient(D, τ1) = fail" in note
+        and "transport(A, τ1) = hold" in note
+        and "transport(B, τ1) = hold" in note
+        and "transport(C, τ1) = hold" in note
+        and "transport(D, τ1) = fail" in note
+        and "neighbor-read(A, τ1) = hold" in note
+        and "neighbor-read(B, τ1) = hold" in note
+        and "neighbor-read(C, τ1) = hold" in note
+        and "neighbor-read(D, τ1) = fail" in note
+        and "M(A, τ2) = {−e_1}" in note
+        and "M(B, τ2) = {+e_1}" in note
+        and "M(C, τ2) = {+e_2}" in note
+        and "M(D, τ2) = {−e_1}" in note
+        and "O(A, τ2) = {+e_2, −e_3}" in note
+        and "O(B, τ2) = {+e_2, +e_3}" in note
+        and "O(C, τ2) = {+e_1, −e_1, +e_3, −e_3}" in note
+        and "O(D, τ2) = {−e_1, +e_2, −e_3}" in note
+        and "Orient(A, τ2) = +1" in note
+        and "Orient(B, τ2) = +1" in note
+        and "Orient(C, τ2) = +1" in note
+        and "Orient(D, τ2) = fail" in note
+        and "transport(A, τ2) = hold" in note
+        and "transport(B, τ2) = hold" in note
+        and "transport(C, τ2) = hold" in note
+        and "transport(D, τ2) = fail" in note
+        and "neighbor-read(A, τ2) = hold" in note
+        and "neighbor-read(B, τ2) = hold" in note
+        and "neighbor-read(C, τ2) = hold" in note
+        and "neighbor-read(D, τ2) = fail" in note
+        and "F(A, τ1) = (−e_1, +e_2, −e_3)" in note
+        and "F(B, τ1) = (+e_1, +e_2, +e_3)" in note
+        and "F(C, τ1) = (+e_2, +e_3, +e_1)" in note
+        and "F(D, τ1) = fail" in note
+        and "scalar neighbor-read(A, τ1) = hold" in note
+        and "scalar neighbor-read(B, τ1) = fail" in note
+        and "scalar neighbor-read(C, τ1) = hold" in note
+        and "scalar neighbor-read(D, τ1) = fail" in note
+        and "o_next(A, τ1) = +e_2" in note
+        and "o_prev(A, τ1) = −e_3" in note
+        and "Orient(D, τ1) = fail" in note,
+    )
+    checks.check(
+        "note-reports-new-neighbors",
+        "new 6-NN of A at t(A)+1: (1, 1, 0), (0, 2, 0), (0, 1, -1)" in note
+        and "new 6-NN of B at t(B)+1: (1, 2, 1), (1, 1, 2)" in note
+        and "new 6-NN of C at t(C)+1: (1, 2, 0), (-1, 2, 0), (0, 2, 1), (0, 2, -1)"
+        in note
+        and "new 6-NN of D at t(D)+1: (1, 2, 0), (1, 1, -1)" in note
+        and "new 6-NN of A at t(A)+2: (-1, 1, 0)" in note
+        and "new 6-NN of B at t(B)+2: (2, 1, 1)" in note
+        and "new 6-NN of C at t(C)+2: none" in note
+        and "new 6-NN of D at t(D)+2: none" in note,
+    )
+    checks.check(
+        "note-reports-neighbor-read-reverse-face-composition",
+        "Reverse neighbor-read of cyclic-frame transport at τ1: hold" in note
+        and "Reverse neighbor-read of cyclic-frame transport at τ2: hold" in note
+        and "Face neighbor-read of cyclic-frame transport at τ1: fail" in note
+        and "Face neighbor-read of cyclic-frame transport at τ2: fail" in note
+        and "Composition of neighbor-read of cyclic-frame transport: hold" in note
+        and "read-witness(A, τ1) = (0, 2, 0)" in note
+        and "read-witness(B, τ1) = (0, 1, 1)" in note
+        and "read-witness(C, τ1) = (0, 1, 0)" in note
+        and "read-witness(D, τ1) = fail" in note
+        and "read-witness(A, τ2) = (0, 2, 0)" in note
+        and "read-witness(D, τ2) = fail" in note
+        and "witness(A, τ1) = (0, 2, 0)" in note
+        and "witness(B, τ1) = (0, 1, 1)" in note
+        and "witness(C, τ1) = (0, 1, 0)" in note
+        and "witness(D, τ1) = fail" in note
+        and "witness(A, τ2) = (0, 2, 0)" in note
+        and "witness(D, τ2) = fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split-or-tplus1-alone",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2frmrd3y" in normalized_note
+        and "not leftover of nm2cycfrmyt2" in normalized_note
+        and "not leftover of nm2cycfrmz" in normalized_note
+        and "not leftover of nm2oricycy" in normalized_note
+        and "not leftover of nm2simt2" in normalized_note
+        and "not leftover of scalar neighbor-read" in normalized_note
+        and "not leftover of equal transport bits" in normalized_note
+        and "not leftover of nm2chiraly lexicographic" in normalized_note
+        and "not leftover of nm2orichy leftover-axis" in normalized_note
+        and "not leftover of nm2orioney lex-one" in normalized_note
+        and "not leftover of unique signed" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "third pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse neighbor-read of cyclic-frame transport at τ1: hold" in note
+        and "Face neighbor-read of cyclic-frame transport at τ1: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "Do not score τ=t" in note
+        and "τ1=t+1" in note.replace(" ", "")
+        and "τ2=t+2" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/THREE_AXIS_OPPOSITE_YPROBE_NEIGHBOR_READ_CYCLIC_FRAME_TRANSPORT_TPLUS1_TPLUS2_COMPOSITION_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "cyclic_signed_outgoing" in defined_fns
+        and "lex_largest_on_axis" in defined_fns
+        and "cyclic_units" in defined_fns
+        and "unique_signed_outgoing_plane" in defined_fns
+        and "leftover_pair_orient" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "cyclic_lex_smallest_orient" in defined_fns
+        and "cyclic_lex_largest_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "frame_triple" in defined_fns
+        and "sending_matrix" in defined_fns
+        and "is_signed_permutation" in defined_fns
+        and "frame_transport" in defined_fns
+        and "transport_neighbor_read" in defined_fns
+        and "first_read_witness" in defined_fns
+        and "equal_transport_bit" in defined_fns
+        and "scalar_orient_neighbor" in defined_fns
+        and "unique_positive_sending" in defined_fns
+        and "transport_reverse_report" in defined_fns
+        and "transport_face_report" in defined_fns
+        and "neighbor_read_reverse_report" in defined_fns
+        and "neighbor_read_face_report" in defined_fns
+        and "composition_report" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "neighbor-read-not-scalar-or-transport-or-tplus1-alone",
+        reverse1 == "hold"
+        and face1 == "fail"
+        and reverse2 == "hold"
+        and face2 == "fail"
+        and composition == "hold"
+        and leftover_transport_composition == "hold"
+        and split_reverse1 == "hold"
+        and cover_reverse1 == "hold"
+        and leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and leftover_reverse != reverse1
+        and one_orient_face == "fail"
+        and one_transport_face1 == "fail"
+        and one_read_face1 == "fail"
+        and scalar_reverse1 == "fail"
+        and scalar_face1 == "fail"
+        and unique_pos_reverse1 == "fail"
+        and unique_pos_face1 == "fail"
+        and unique_pos1["C"] == "fail"
+        and scalar_reverse1 != reverse1
+        and fail_read1 == "fail"
+        and fail_equal1 == "hold"
+        and fail_read2 == "fail"
+        and fail_equal2 == "hold"
+        and fail_equal1 != fail_read1
+        and orient_reverse1 == "hold"
+        and orient_face1 == "fail"
+        and leftover_t_tplus1_composition == "fail"
+        and leftover_t_tplus1_composition != composition
+        and lex1["A"] == -1
+        and lex1["B"] == 1
+        and lex1["C"] == -1
+        and lex1["D"] == "fail"
+        and reverse_report(lex1["A"], lex1["B"]) == "fail"
+        and face_report(lex1["C"], lex1["D"]) == "fail"
+        and reverse_report(lex1["A"], lex1["B"]) != reverse1
+        and lex1["A"] != orient1["A"]
+        and leftover_pair1["A"] == "fail"
+        and leftover_pair1["B"] == "fail"
+        and leftover_pair1["C"] == -1
+        and leftover_pair1["D"] == "fail"
+        and reverse_report(leftover_pair1["A"], leftover_pair1["B"]) == "fail"
+        and reverse_report(leftover_pair1["A"], leftover_pair1["B"]) != reverse1
+        and cyclic_small1["A"] == 1
+        and cyclic_small1["B"] == 1
+        and cyclic_small1["C"] == 1
+        and cyclic_small1["D"] == "fail"
+        and reverse_report(cyclic_small1["A"], cyclic_small1["B"]) == "hold"
+        and face_report(cyclic_small1["C"], cyclic_small1["D"]) == "fail"
+        and unique_signed1["A"] == 1
+        and unique_signed1["B"] == 1
+        and unique_signed1["C"] == "fail"
+        and unique_signed1["D"] == "fail"
+        and reverse_report(unique_signed1["A"], unique_signed1["B"]) == "hold"
+        and face_report(unique_signed1["C"], unique_signed1["D"]) == "fail"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and o_exist_face != face1
+        and leftover_mo == "hold"
+        and leftover_bits == "hold"
+        and formed_nn["A"][:1] == ((1, 1, 0),),
+    )
+    _ = (
+        o0,
+        unique_o_orient_a,
+        one_cover_face,
+        one_split_face,
+        unsigned_orient1,
+        leftover_bits,
+        leftover_transport_composition,
+        perp_o1,
+        axis_m1,
+        cover2,
+        unique_pos2,
+        equal_bit0,
+        equal_bit1,
+        equal_bit2,
+        tau1,
+        tau2,
+        z_read_face1,
+        x_read_face1,
+        two_reverse,
+        two_face,
+        two_read_reverse,
+        two_read_face,
+        x_transport_reverse1,
+        x_transport_face1,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

First display of neighbor-read of cyclic-frame transport at t+1 versus t+2 on the four y-probes of the three-axis opposite (near-face) seed. Reverse HOLD, face fails, composition HOLD. Displayed, not adopted. FAIL=0. Not HOLDING_MEMBER (face fails).

## Runner

`scripts/three_axis_opposite_yprobe_neighbor_read_cyclic_frame_transport_tplus1_tplus2_composition_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.