### PR TITLE
feat(nm2frm3p3z): three-path cyclic-frame transport at t+1 on three-axis opposite near-face seed: reverse fails, face fails

### DIFF
--- a/docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,935 @@
+---
+claim_id: three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Equality of the three length-3 path-ordered products of cyclic-frame transport along the permutations of {e1,e2,e3} at t+1 on the three-axis opposite (near-face) seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+---
+
+# Three-Path Cyclic-Frame Transport At t+1 Reverse And Face On The Three-Axis Opposite Near-Face Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** equality of the three length-3 path-ordered products of cyclic-frame
+transport along the cyclic permutations of `{+e_1,+e_2,+e_3}` at each start's
+`τ=t+1` on the three-axis opposite (near-face) seed in `B_3(0)={n:n·n<=9}`,
+and reverse/face from that equality. `F` and Orient and `P` as nm2cycfrmhol.
+Reverse probes: origin and `(0,1,0)`. Face probes: `(0,0,1)` and `(0,1,1)`.
+For a start `s` let `w=s+e_1+e_2+e_3`. If `w·w>9`, the letter at `s` is fail,
+not `UNDEFINED`. The three paths of length 3 from `s` to `w` are the
+six-neighbor walks along the three cyclic permutations of
+`(+e_1,+e_2,+e_3)`. A path exists iff every vertex is in `B_3(0)` and formed
+at `τ` and every edge has a `P` as in nm2cycfrmhol. The path product is the
+3×3 product of those three `P`. Path-independence HOLDs at `s` iff all three
+paths exist and the three products are equal. Else fail not `UNDEFINED`.
+Reverse HOLDs iff path-independence HOLDs at both reverse probes. Face HOLDs
+iff both face probes HOLD. Face is displayed, not adopted. Cover and split
+do not score handedness. This is not leftover of nm2frm3pth two-axis
+three-path: those bits are the same readout on a different seed with four
+tick-0 sites, while this member has six tick-0 sites and a third near-face
+pair at `(2,0,0)`/`(2,1,0)`. Origin `F` HOLDs on both seeds, but the two
+surviving origin products are `[1 0 0; 0 -1 0; 0 0 1]` on the two-axis seed
+and `[1 0 0; 0 -1 0; 0 0 -1]` here, and `(1,0,0)` is a new 6-NN of origin at
+`t+1` here while it forms at tick 2 on the two-axis seed. This is not leftover
+of nm2frm3pfz far-face three-path: that third pair sits at `(0,0,−1)`/`(0,1,−1)`,
+origin `F` fails there, and transport reverse fails there, while origin `F`
+HOLDs here and transport reverse HOLDs here. This is not leftover of
+nm2cycfrmhol two-axis unit-square holonomy. This is not leftover of
+nm2cycfrmholfz far-face unit-square holonomy: holonomy reverse HOLDs and
+holonomy face fails, while three-path reverse fails and three-path face fails.
+This is not leftover of nm2cycfrmz cyclic-frame transport. This is not leftover
+of nm2cycfrmfz far-face cyclic-frame transport: transport reverse HOLDs and
+transport face HOLDs on these probes (#7513) while three-path reverse fails
+and three-path face fails. This is not leftover of nm2oricyclz cyclic Orient:
+Orient reverse HOLDs from `+1,+1` while three-path reverse fails. This is not
+leftover of scalar neighbor-read of Orient: scalar reverse HOLDs while
+three-path reverse fails. This is not leftover of scalar lex-largest Orient
+(#7475): lex-largest reverse fails from `+1,−1` at origin and `(0,1,0)` while
+transport HOLDs. This is not leftover of a unique nonnegative permutation
+sending. This is not leftover of nm2orichz leftover-axis. This is not leftover
+of nm2orionez lex-one. This is not leftover of nm2chiralz lexicographic
+unsigned `o1,o2` orientation. This is not leftover of nm2oridetz unique signed
+outgoing letters. This is not leftover of nm2axz axis-cover. This is not
+leftover of nm2ax12z 1-in 2-out split. This is not leftover of leftover-of-`M`
+alone. This is not leftover of leftover-of-`O` alone. This is not leftover-empty
+fail of leftover axis. This is not leftover of nmunopp union. This is not
+leftover of nmt2opp `M` frozen at `t`. This is not leftover of nmot2opp two-tick
+composition. This is not leftover of nmoutopp untimed eventual-`O`. This is not
+leftover of mixed #7188 fail/fail. This is not leftover of the 1-axis opposite
+two-site seed. This is not leftover of the same-lock two-site seed. The second
+pair is a new seed, not a formed child. The third pair is a new seed, not a
+formed child. Uniqueness is not required. Mixed remains a set. Displayed, not
+adopted. Do not write into Admissibility. Do not attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`](../scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the four named seed probes. Incoming lock letters are unit nearest-neighbor
+steps. `O` is the outgoing dual of those incoming sets at the per-vertex cut
+`τ=t+1`. Axis is the unsigned lattice direction of a signed lock. Cover is
+the complementary occupation of `{e_1,e_2,e_3}` by `Axis(M)` and `Axis(O)`.
+Split is cover together with `|Axis(M)|=1`. The cyclic next/prev
+lex-largest oriented frame is the integer sign of
+`det(m,o_next,o_prev)` with unique signed incoming letter `m` and the
+lex-largest signed outgoing letter on the cyclic next and prev axes of
+`Axis(M)` under `+e < −e`. When split HOLDs, `F=(m,o_next,o_prev)` is
+that LIVE three-axis frame. For a formed six-neighbor edge, `P` is the
+unique signed permutation sending columns of `F(q)` to columns of `F(r)`
+with determinant `Orient(q)Orient(r)`. Path-independence is equality of the
+three length-3 products along the cyclic permutations of `{+e_1,+e_2,+e_3}`.
+Reverse and face are scored on that equality at the reverse pair and at the
+face pair. Transport of nm2cycfrmz is a different readout: it is existential
+at a vertex, not three path products. Unit-square holonomy is a different
+readout: it is a four-edge product around a square, not three cube-diagonal
+paths. Neighbor-read of the scalar Orient sign is a different readout and is
+not used as the object. A unique nonnegative permutation sending is a
+different readout and is not used as the object. Named signs `{+,−}` of
+locks are a coarser readout and are not used as the object. Occupancy of
+sites is not used. A six-neighbor star is not the letter.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of equality of the three length-3 path-ordered products of cyclic-frame transport along the cyclic permutations of +e1,+e2,+e3 of M and O at t+1 on the three-axis opposite near-face seed, F and Orient at the four seed probes, P on the path edges, the three products at each probe, reverse fail and face fail from path-independence; uniqueness of a sending is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face
+target_blocker_text: "display three-path cyclic-frame transport reverse/face on the three-axis opposite near-face seed, not nm2frm3pth two-axis three-path, not nm2frm3pfz far-face three-path, not nm2cycfrmhol two-axis holonomy, not nm2cycfrmholfz far-face holonomy, not nm2cycfrmz transport, not nm2cycfrmfz far-face transport, not scalar neighbor-read of Orient, not scalar lex-largest Orient, not unique nonnegative sending, not leftover-axis, not lex-one e1<e2<e3, not unique |O_i|=1, not unsigned axis units, not cover, not split"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep three-path cyclic-frame transport of F at t+1 displayed; do not write path-independence into Admissibility, do not reduce to nm2frm3pth two-axis three-path, do not reduce to nm2frm3pfz far-face three-path, do not reduce to nm2cycfrmhol two-axis holonomy, do not reduce to nm2cycfrmholfz far-face holonomy, do not reduce to nm2cycfrmz transport, do not reduce to nm2cycfrmfz far-face transport, do not reduce to scalar neighbor-read of Orient, do not reduce to scalar lex-largest Orient, do not reduce to unique nonnegative permutation sending, do not reduce to unique signed |O_i|=1, do not reduce to lexicographic unsigned o1,o2, do not reduce to leftover-axis, do not reduce to lex-one signed e1<e2<e3, do not reduce to cyclic lex-smallest, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace path-independence by unique outgoing letters, do not replace path-independence by existential opposite of signed locks, do not replace path-independence by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for equality of the three length-3 path-ordered products of cyclic-frame transport of M and O at t+1 on the three-axis opposite near-face seed and reverse/face from that equality; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The reverse pair and the face pair are the only
+starts whose three-path cyclic-frame transport of `F=(m,o_next,o_prev)` of
+`M` and `O` is scored:
+
+```text
+A = (0,0,0),  B = (0,1,0).
+C = (0,0,1),  D = (0,1,1).
+```
+
+A start or endpoint outside `B_3(0)` is fail, not `UNDEFINED`. These are not
+the z-probes `A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(1,0,1)`. These are not
+the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`. These are not
+the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`. `A` and `B`
+are seeds of the first opposite pair. `C` and `D` are seeds of the second
+opposite pair. Same process as nm2axz. `F` and Orient as nm2cycfrmhol.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: three disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. Site `(2,0,0)` locks `+e_3`. Site `(2,1,0)`
+locks `−e_3`. The second pair is a new seed, not a formed child of the
+first pair. The third pair is a new seed, not a formed child, and sits on
+the near-face sites `x=2`. This seed is not the 1-axis opposite two-site
+seed `{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp
+two-site seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0. This seed is not the two-axis
+opposite seed of nm2frm3pth. This seed is not the three-axis far-face
+opposite seed of nm2frm3pfz.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named three-path cyclic-frame transport of `(m,o_next,o_prev)` at `τ=t+1`
+
+Let `t(q)` be the formation tick of a probe `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a probe at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a probe at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Oriented frame at the same cut:
+
+```text
+When split HOLDs, m is the unique signed letter in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1. e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}. O_prev = O ∩ {±e_prev}.
+If either is empty, Orient fails, not UNDEFINED.
+Order +e < −e. o_next is lex-largest in O_next (hence −e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+The outgoing pair is signed. Mixed opposite signs on one cyclic slot make
+`|O_next|=2` or `|O_prev|=2`; lex-largest still picks `−e`, so Orient is
+defined when split HOLDs. Unique outgoing letters of the whole set `O` are
+not required: mixed `O` remains a set, and unique-letter readout of mixed
+`O` is `UNDEFINED` while this Orient is a sign. Empty `O_next` or empty
+`O_prev` is Orient fail, not `UNDEFINED`. A vanishing determinant is fail.
+Sign of a nonzero integer determinant is `+1` or `−1`. Split HOLD
+required: 2-in 1-out is Orient fail, not UNDEFINED.
+
+Cyclic frame, edge sending, and three-path independence at the same cut:
+
+```text
+When split HOLDs, F(q)=(m, o_next, o_prev).
+For an edge q→r of a formed six-neighbor pair, P(q,r) is the
+unique 3×3 signed permutation with det = Orient(q)Orient(r)
+sending columns of F(q) to columns of F(r) (F(r)=F(q)P).
+If none, that edge fails.
+For a start s let w=s+e_1+e_2+e_3.
+If w·w>9, path-independence at s fails, not UNDEFINED.
+The three paths are the walks along
+(+e_1,+e_2,+e_3), (+e_2,+e_3,+e_1), (+e_3,+e_1,+e_2).
+A path exists iff every vertex is in B_3(0) and formed at τ
+and every edge has P.
+The path product is the 3×3 product of those three P.
+Path-independence HOLDs at s iff all three paths exist and
+the three products are equal. Else fail, not UNDEFINED.
+If a vertex lies outside B_3(0), the letter fails, not UNDEFINED.
+If a path misses, the letter fails, not UNDEFINED.
+Uniqueness of a sending neighbor is not required.
+```
+
+Neighbor-read of the scalar Orient sign HOLDs at `q` if and only if
+`Orient(q)` is `±1` and some formed six-neighbor has the same sign. That
+is a different object: scalar HOLDs at `A,B,C,D` on this member, so scalar
+reverse HOLDs and scalar face HOLDs, while three-path reverse fails and
+three-path face fails. Transport of nm2cycfrmz HOLDs at `q` if and only if
+some formed six-neighbor hosts a signed-permutation sending. That is a
+different object: transport HOLDs at `A,B,C,D` on this member (#7513), so
+transport reverse HOLDs and transport face HOLDs, while three-path reverse
+fails and three-path face fails. Scalar lex-largest Orient at origin is `+1`
+and at `(0,1,0)` is `−1`, so that reverse fails (#7475) while transport HOLDs.
+nm2cycfrmfz far-face cyclic-frame transport reverse HOLDs and face HOLDs on
+the z-probes of a different far-face seed: those bits are existential at
+those z-probes, not three cube-diagonal products. nm2cycfrmholfz far-face
+unit-square holonomy reverse HOLDs and face fails on `A-D-B-E` and
+`C-C1-C2-C3`; those squares are not these four seed probes. nm2frm3pth
+two-axis three-path is the same product test on four tick-0 sites; here
+`(2,0,0)` is a seed at tick 0 with lock `+e_3`, not a formed child at tick
+3, origin `F` HOLDs on both seeds, and the surviving origin products differ.
+nm2frm3pfz far-face three-path is the same product test on the −z third
+pair; origin `F` fails there. A unique nonnegative permutation sending is a
+different object.
+
+Reverse three-path cyclic-frame transport holds if and only if
+path-independence HOLDs at origin and at `(0,1,0)`. Face three-path
+cyclic-frame transport holds if and only if path-independence HOLDs at
+`(0,0,1)` and at `(0,1,1)`. Either probe `UNDEFINED` is `UNDEFINED`. Else
+HOLD or fail as the product test says.
+
+Cover and split do not score handedness. Identifying cover reverse with
+this reverse is refused: cover HOLDs reverse because origin `O` is
+`{−e_2,−e_3}` and `B` `O` is `{+e_2,−e_3}`, so cover occupies
+`{e_1,e_2,e_3}` at both reverse probes, while this reverse fails from
+missing paths, not from cover. Identifying split reverse with this reverse
+is refused: split HOLDs at origin and at `B`. Identifying leftover-empty
+fail with this reverse is refused: leftover-empty fail scores empty leftover
+as reverse fail, and leftover at origin is empty and leftover at `B` is
+empty, so leftover reverse fails by that empty-empty rule while the three
+products at origin are not all missing. Identifying nm2cycfrmz transport
+with this reverse is refused: transport reverse HOLDs from existential
+sendings at origin and at `B`, which is existential at a vertex, not three
+products. Identifying unit-square holonomy with this reverse is refused:
+holonomy reverse HOLDs on this same seed. Identifying nm2frm3pth two-axis
+three-path with this reverse is refused: origin `F` HOLDs on both seeds,
+but the two surviving origin products differ and `(1,0,0)` is a new 6-NN
+here. Identifying nm2frm3pfz far-face three-path with this reverse is
+refused: origin `F` fails there and transport reverse fails there.
+
+## Theorem 1 — ticks, `F`, Orient, `P`, the three products at each probe
+
+On this process the four seed probes form in `B_3(0)` at tick 0. Compare to
+leftover axis: leftover at origin is empty and leftover at `B` is empty.
+Compare to nm2axz cover and nm2ax12z split: both HOLD reverse because origin
+cover HOLDs. Compare to nm2oricyclz cyclic Orient: reverse HOLDs from
+`+1,+1`. Compare to nm2cycfrmz cyclic-frame transport: reverse HOLDs and
+face HOLDs from existential sendings. Compare to scalar neighbor-read of
+Orient: HOLD at `A,B,C,D`, so scalar reverse HOLDs and scalar face HOLDs.
+Compare to scalar lex-largest Orient: reverse fails from `+1` at origin and
+`−1` at `B` (#7475). Compare to nm2cycfrmholfz far-face holonomy: reverse
+HOLDs and face fails on the unit squares. This display reads the three
+path-ordered products of `(m,o_next,o_prev)` from each seed probe:
+
+```text
+t(A)=0
+t(B)=0
+t(C)=0
+t(D)=0
+M(A, τ) = {+e_1}
+M(B, τ) = {−e_1}
+M(C, τ) = {+e_2}
+M(D, τ) = {−e_2}
+O(A, τ) = {−e_2, −e_3}
+O(B, τ) = {+e_2, −e_3}
+O(C, τ) = {+e_1, −e_1, +e_3}
+O(D, τ) = {+e_1, −e_1, +e_3}
+split(A) = hold
+split(B) = hold
+split(C) = hold
+split(D) = hold
+m(A) = +e_1
+i(A) = 1
+o_next(A) = −e_2
+o_prev(A) = −e_3
+det(A) = 1
+Orient(A) = +1
+m(B) = −e_1
+i(B) = 1
+o_next(B) = +e_2
+o_prev(B) = −e_3
+det(B) = 1
+Orient(B) = +1
+m(C) = +e_2
+i(C) = 2
+o_next(C) = +e_3
+o_prev(C) = −e_1
+det(C) = -1
+Orient(C) = −1
+m(D) = −e_2
+i(D) = 2
+o_next(D) = +e_3
+o_prev(D) = −e_1
+det(D) = 1
+Orient(D) = +1
+F(A) = (+e_1, −e_2, −e_3)
+F(B) = (−e_1, +e_2, −e_3)
+F(C) = (+e_2, +e_3, −e_1)
+F(D) = (−e_2, +e_3, −e_1)
+product(A, e1e2e3) = fail
+product(A, e2e3e1) = [1 0 0; 0 -1 0; 0 0 -1]
+product(A, e3e1e2) = [1 0 0; 0 -1 0; 0 0 -1]
+product(B, e1e2e3) = fail
+product(B, e2e3e1) = fail
+product(B, e3e1e2) = fail
+product(C, e1e2e3) = fail
+product(C, e2e3e1) = fail
+product(C, e3e1e2) = fail
+product(D, e1e2e3) = fail
+product(D, e2e3e1) = fail
+product(D, e3e1e2) = fail
+path-independence(A) = fail
+path-independence(B) = fail
+path-independence(C) = fail
+path-independence(D) = fail
+```
+
+Origin is a seed at tick 0 with seed letter `+e_1`. The third near-face pair
+occupies `(2,0,0)` as a seed with lock `+e_3`, so origin outgoing at `τ=1`
+is `{−e_2,−e_3}`: cover HOLDs, split HOLDs, and `F=(+e_1,−e_2,−e_3)`. On the
+two-axis seed of nm2frm3pth, origin outgoing is the same `{−e_2,−e_3}` and
+origin `F` is the same triple, but `(1,0,0)` is not a new 6-NN at `t+1` and
+the two surviving origin products are `[1 0 0; 0 -1 0; 0 0 1]`. On the
+far-face seed of nm2frm3pfz, origin outgoing is only `{−e_2}`, so origin `F`
+fails. Mixed remains a set: `O(C,τ)` has three outgoing steps. Unique
+outgoing letters would assign `UNDEFINED` at mixed `O`. Unique signed
+`|O_i|=1` fails at `C` and at `D` because both have `{±e_1}`. Lex-largest
+picks `−e` on that mixed cyclic slot. At `B`, split HOLDs with unique signed
+`O` on both cyclic axes. Cover and split do not score handedness. O is not M.
+
+On the 1-axis opposite two-site seed, `C=(0,0,1)` is a formed child at
+tick 1 locking `+e_3`. Here both `(0,0,1)` and `(0,1,1)` are seeds of a
+second opposite pair on a second axis. Path-independence at the y-probes
+and at the x-probes of this same seed is not this letter.
+
+New records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors enter `O` and do not enter earliest `M`. Site `(0,1,0)` is a
+seed, so it is not a new 6-NN of `A`. Site `(1,0,0)` is a new 6-NN of `A`:
+it forms at tick 1 from the third-pair seed `(2,0,0)` locking `−e_1`, not
+from origin stepping `+e_1`. On the two-axis seed `(1,0,0)` forms at tick 2.
+
+```text
+new 6-NN of A at t(A)+1: (1, 0, 0), (0, -1, 0), (0, 0, -1)
+new 6-NN of B at t(B)+1: (1, 1, 0), (0, 2, 0), (0, 1, -1)
+new 6-NN of C at t(C)+1: (1, 0, 1), (-1, 0, 1), (0, 0, 2)
+new 6-NN of D at t(D)+1: (1, 1, 1), (-1, 1, 1), (0, 1, 2)
+```
+
+`M` is frozen from `t` to `t+1`. At `t`, `O` is empty at `A,B,C,D`. Path
+`e1e2e3` from origin misses: the first edge origin to `(1,0,0)` has `P`,
+but later edges fail. Paths `e2e3e1` and `e3e1e2` from origin exist, every
+edge has `P`, and both products equal `[1 0 0; 0 -1 0; 0 0 -1]`. Because
+path `e1e2e3` misses, path-independence at origin fails. From `B`, every
+cyclic path misses, so those three products fail. From `C` and from `D`
+every cyclic path misses a later vertex whose split fails, so those three
+products fail. A start whose endpoint lies outside `B_3(0)`, for example
+`(2,2,0)` with `w=(3,3,1)` or `(0,0,4)`, is fail, not `UNDEFINED`.
+
+## Theorem 2 — reverse from three-path cyclic-frame transport at `τ`
+
+Reverse three-path cyclic-frame transport holds if and only if
+path-independence HOLDs at origin and at `(0,1,0)`. Origin split HOLDs and
+two of the three origin products exist and agree, but path `e1e2e3` misses,
+so path-independence at origin fails. At `(0,1,0)` every cyclic path misses.
+Reverse fails. This is fail iff a path misses or the three products are
+unequal, not leftover of nm2cycfrmz cyclic-frame transport, not leftover of
+nm2cycfrmholfz far-face unit-square holonomy, not leftover of nm2frm3pth
+two-axis three-path, not leftover of nm2frm3pfz far-face three-path, not
+leftover of nm2oricyclz cyclic Orient equal signs, not leftover of scalar
+neighbor-read, not leftover of scalar lex-largest Orient, not leftover of a
+unique nonnegative permutation sending, not leftover of nm2chiralz
+lexicographic unsigned `o1,o2`, not leftover of nm2oridetz unique signed
+outgoing letters, not leftover of nm2orichz leftover-axis, not leftover of
+nm2orionez lex-one, not leftover of nm2axz axis-cover, not leftover of
+nm2ax12z 1-in 2-out split, not leftover-empty fail, and not exist-opposite.
+
+Reverse three-path cyclic-frame transport at τ: fail
+
+Both reverse probes are defined, so this is not `UNDEFINED`. Cover reverse
+HOLDs because cover HOLDs at origin and at `B`. Split reverse HOLDs because
+split HOLDs at origin and at `B`. Cover and split do not score handedness.
+nm2cycfrmz transport reverse HOLDs because transport HOLDs at origin and at
+`B`; that is existential at two vertices, not the three products. Scalar
+lex-largest Orient reverse fails because those signs are `+1` and `−1`
+(#7475), while transport HOLDs (#7513). nm2cycfrmholfz holonomy reverse
+HOLDs on this same seed; that four-edge identity is not this reverse. On the
+two-axis seed, origin `F` HOLDs and three-path reverse still fails from a
+missed `e1e2e3` path, but the two surviving origin products are
+`[1 0 0; 0 -1 0; 0 0 1]` there and `[1 0 0; 0 -1 0; 0 0 -1]` here: leftover
+of nm2frm3pth, not this near-face third pair. On the far-face seed, origin
+`F` fails and all three origin products fail: leftover of nm2frm3pfz, not
+this origin-`F`-HOLD. Leftover of `M` reverse HOLDs because leftover of `M`
+at `A` is `{e_2,e_3}` and at `B` is `{e_2,e_3}`: nonempty equal, while this
+reverse fails. Leftover of `O` at `A` is `{e_1}` and at `B` is `{e_1}`:
+nonempty equal, so leftover of `O` reverse HOLDs while this reverse fails.
+Exist-opposite reverse of signed `M` holds. Exist-opposite reverse of signed
+`O` holds. Those leftovers are not this display.
+
+Reverse fails.
+
+## Theorem 3 — face from three-path cyclic-frame transport at `τ`
+
+Face three-path cyclic-frame transport holds if and only if
+path-independence HOLDs at `(0,0,1)` and at `(0,1,1)`. Every cyclic path
+from each face probe misses a later vertex with split fail, so all six
+face products fail. Face fails. Displayed, not adopted.
+
+Face three-path cyclic-frame transport at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Cover face HOLDs because cover HOLDs at `C` and at `D`. Split face HOLDs
+because split HOLDs at `C` and at `D`. Those two vertices are the face
+probes, and split HOLD there does not make the three paths exist: later
+vertices on each walk are 2-in split fail. Cyclic lex-largest oriented face
+fails because the signs at `C` and `D` are `−1` and `+1`. nm2cycfrmz
+transport face HOLDs because transport HOLDs at `C` and at `D`; that
+existential pair is not this three-path letter. Scalar neighbor-read face
+HOLDs while this face fails. Leftover-axis face fails because those signs
+are `−1` and `+1`. Leftover of `M` face HOLDs because leftover of `M` at
+`C` and at `D` is `{e_1,e_3}` on both sides, while this face fails. Unique
+signed face fails because neither unique signed sign is `±1`. Cover and
+split do not score handedness. Presence of an opposite pair in `O` HOLDs at
+`C` and at `D`, so pair-presence face HOLDs while this face fails. On the
+1-axis opposite two-site seed, `t(C)` is not 0. The four y-probes of this
+same seed are not this letter. The four x-probes are not this letter. A
+start outside `B_3(0)` is path-independence fail, not `UNDEFINED`.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not replace three-path independence by nm2cycfrmz cyclic-frame transport.
+- It does not replace three-path independence by nm2cycfrmfz far-face cyclic-frame transport.
+- It does not reprint nm2frm3pth two-axis three-path as this member.
+- It does not reprint nm2frm3pfz far-face three-path as this member.
+- It does not reprint nm2cycfrmhol two-axis unit-square holonomy as this member.
+- It does not reprint nm2cycfrmholfz far-face unit-square holonomy as this member.
+- It does not replace three-path independence by neighbor-read of the scalar Orient sign.
+- It does not replace three-path independence by a unique nonnegative permutation sending.
+- It does not require a unique formed six-neighbor witness.
+- It does not reprint nm2oricyclz cyclic Orient reverse hold face hold as this letter.
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by lexicographic unsigned `o1,o2` orientation.
+- It does not replace Orient by unique signed `|O_i|=1` letters.
+- It does not replace Orient by leftover-axis orientation.
+- It does not replace Orient by nm2orionez lex-one signed `e1<e2<e3`.
+- It does not replace Orient by cyclic lex-smallest (`+e` if both signs).
+- It does not replace Orient by unsigned axis units of `Axis(O)`.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not treat split fail as `UNDEFINED`.
+- It does not treat empty `O_i` as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2axz axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2ax12z 1-in 2-out split reverse hold face hold as
+  this oriented display.
+- It does not reprint nm2chiralz lexicographic unsigned `o1,o2` reverse fail
+  face hold with `+1,+1` as this oriented display.
+- It does not reprint nm2oridetz unique signed reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orichz leftover-axis reverse hold face fail as
+  this oriented display.
+- It does not reprint nm2orionez lex-one reverse fail face hold as this
+  oriented display.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the four seed probes. It uses
+Qubit only as the algebra of the local possibility domain. It uses Record
+only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The three-axis opposite near-face seed process, three-path
+cyclic-frame transport of `(m,o_next,o_prev)` of `M` and `O` at `t+1`, and
+the reverse/face bits from that equality are displayed theorem-domain data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; three-axis opposite near-face seed `+e_1/−e_1`, `+e_2/−e_2`, and `+e_3/−e_3` at `(2,0,0)`/`(2,1,0)` |
+| ticks `t(A)`, `t(B)`, `t(C)`, `t(D)` | Theorem 1; `0`, `0`, `0`, `0` |
+| `M` at `τ=t+1` | Theorem 1; frozen equal to `M` at `t` |
+| `O` at `τ=t+1` | Theorem 1; origin `{−e_2,−e_3}`; `B` `{+e_2,−e_3}`; face mixed |
+| split at `τ` | Theorem 1; HOLD at origin and at `B,C,D` |
+| unique signed `m`, axis index `i`, cyclic `(o_next,o_prev)` | Theorem 1; origin and `B,C,D` defined |
+| integer `det(m,o_next,o_prev)` | Theorem 1; origin `+1`, `B` `+1`, `C` `-1`, `D` `+1` |
+| Orient at `τ` | Theorem 1; origin `+1`, `B` `+1`, `C` `−1`, `D` `+1` |
+| cyclic frame `F=(m,o_next,o_prev)` | Theorem 1; LIVE at origin and at `B,C,D` |
+| three path products at each probe | Theorem 1; origin fail and two equal matrices; `B` all fail; face all fail |
+| leftover of nm2cycfrmz cyclic-frame transport | Theorem 1; transport reverse hold and transport face hold; not this letter |
+| leftover of nm2cycfrmholfz far-face holonomy | Theorem 1; holonomy reverse hold and holonomy face fail; not this letter |
+| leftover of nm2frm3pth two-axis three-path | Theorem 1; origin `F` holds on four tick-0 sites; surviving origin products differ |
+| leftover of nm2frm3pfz far-face three-path | Theorem 1; origin `F` fails on the −z third pair; not this seed |
+| reverse from three-path cyclic-frame transport at `τ` | Theorem 2; `fail` |
+| face from three-path cyclic-frame transport at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2axz axis-cover HOLD | not this oriented display |
+| leftover of nm2ax12z 1-in 2-out split HOLD | not this oriented display |
+| leftover of nm2chiralz lexicographic unsigned `o1,o2` | not this oriented display |
+| leftover of nm2oridetz unique signed `|O_i|=1` | not this oriented display |
+| leftover of nm2orichz leftover-axis | not this oriented display |
+| leftover of nm2orionez lex-one signed `e1<e2<e3` | not this oriented display |
+| leftover of cyclic lex-smallest | not this oriented display |
+| leftover of nm2oricyclz cyclic Orient equal signs | not this letter |
+| leftover of nm2cycfrmz cyclic-frame transport | not this letter |
+| leftover of nm2cycfrmfz far-face cyclic-frame transport | not this letter |
+| leftover of nm2cycfrmhol two-axis unit-square holonomy | not this seed; four tick-0 sites |
+| leftover of nm2cycfrmholfz far-face unit-square holonomy | not this letter; four-edge square product |
+| leftover of nm2frm3pth two-axis three-path | not this seed; four tick-0 sites; surviving origin products differ |
+| leftover of nm2frm3pfz far-face three-path | not this seed; −z third pair; origin `F` fails there |
+| leftover of scalar lex-largest Orient | not this transport; reverse fails while transport HOLDs |
+| leftover of scalar neighbor-read of Orient | not this transport |
+| leftover of unique nonnegative permutation sending | not this transport |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or x-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display; #7477 same-lock face transport fails |
+| leftover of the LIVE three-axis three-site seed | not this display; face transport fails |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| empty `O_i` scored as `UNDEFINED` | refused; Orient fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: equality of the three length-3 path-ordered products of cyclic-frame transport of `(m,o_next,o_prev)` of `M` and `O` at `t+1` on the three-axis opposite near-face seed, and reverse/face from that equality. |
+| V2 | Current main has no landed three-path cyclic-frame-transport reverse/face of timed `M` and `O` on these four seed probes of the three-axis opposite near-face seed. |
+| V3 | Three path products at each of four probes and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the three length-3 signed-permutation products along cyclic permutations of `{+e_1,+e_2,+e_3}` at the same `t+1` cut, reverse fails and face fails while nm2cycfrmz transport reverse HOLDs and transport face HOLDs, scalar lex-largest Orient reverse fails while transport HOLDs, nm2cycfrmholfz far-face holonomy reverse HOLDs and face fails on the unit squares, nm2frm3pth two-axis three-path has the same origin `F` with different surviving products, nm2frm3pfz far-face three-path has origin `F` fail, scalar neighbor-read reverse HOLDs, and nm2oricyclz Orient equality does not supply the three products. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by nm2chiralz lexicographic unsigned `o1,o2`, does not replace
+Orient by nm2oridetz unique signed `|O_i|=1`, does not replace Orient by
+nm2orichz leftover-axis, does not replace Orient by nm2orionez lex-one,
+does not replace Orient by cyclic lex-smallest, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2axz axis-cover, does not
+replace Orient by nm2ax12z 1-in 2-out split, does not identify this
+display with the 1-axis opposite two-site seed, and does not identify it
+with nmunopp union. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| scalar neighbor-read of Orient | reuse equal Orient sign at some formed 6-NN | scalar HOLDs at `A,B,C,D`; scalar reverse HOLDs and scalar face HOLDs while this reverse fails and this face fails | ATTEMPTED |
+| scalar lex-largest Orient | reuse lex-one signed `e1<e2<e3` reverse fail | lex-largest reverse fails from `+1,−1` at origin and `B` (#7475) while transport HOLDs (#7513); those signs are not three products | ATTEMPTED |
+| unique nonnegative permutation sending | require a unique sending with no minus signs | unique nonnegative sending fails at origin and at `B`; uniqueness is not required | ATTEMPTED |
+| nm2cycfrmz cyclic-frame transport | reuse transport reverse hold and face hold from existential 6-NN sendings | transport reverse HOLDs and transport face HOLDs while this reverse fails and this face fails; transport is existential at a vertex, three-path is three products | ATTEMPTED |
+| nm2oricyclz cyclic Orient | reuse Orient reverse and face from equal `±1` signs | Orient reverse HOLDs from `+1,+1` and Orient face fails from `−1,+1`; HOLDING cyclic signs are the frame sign, not three products | ATTEMPTED |
+| nm2chiralz lexicographic unsigned `o1,o2` | reuse unsigned reverse and face | unsigned at `B` is `−1` while cyclic Orient at `B` is `+1`; those signs are not the three products | ATTEMPTED |
+| nm2oridetz unique signed `|O_i|=1` | reuse unique signed reverse and face | unique signed HOLDs at `B` and fails at `C,D`; an opposite pair in face `O` makes `|O_i|≠1` | ATTEMPTED |
+| nm2orichz leftover-axis | reuse leftover-axis reverse and face | leftover-axis fails at origin and at `B` from missing opposite pair in `O`; leftover-axis face fails because C and D disagree; those two signs are not three products | ATTEMPTED |
+| nm2orionez lex-one | reuse lex-one reverse and face | lex-one at `B` is `−1` from `e1<e2<e3` order independent of `m`; cyclic Orient at `B` is `+1` | ATTEMPTED |
+| cyclic lex-smallest | reuse same cyclic axes with `+e` if both signs | lex-smallest face is `+1,−1`; those signs are not these products | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse and cover face on these probes | cover HOLDs reverse and HOLDs face without cyclic signed columns | ATTEMPTED |
+| nm2ax12z 1-in 2-out split | reuse split reverse and split face | split HOLDs reverse and HOLDs face without the three products; Cover and split do not score handedness | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover at origin is empty and leftover at `B` is empty, so leftover reverse fails by the empty-empty rule; leftover face fails from empty leftover at both face probes | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` reverse HOLDs (`{e_2,e_3}` at origin and at `B`) while this reverse fails; leftover of `M` face HOLDs while this face fails | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` at origin is `{e_1}` and at `B` is `{e_1}`, nonempty equal, so leftover of `O` reverse HOLDs while this reverse fails | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `M` and of signed `O` both hold while this reverse fails | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence fails at origin and HOLDs at `C,D`; pair-presence face HOLDs while this face fails | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of unique signed incoming and cyclic lex-largest outgoing letters | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O(C,τ)` remains a set | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | at `B`, unsigned incoming Orient is `−1` while cyclic Orient is `+1` | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED; origin is 1-in 2-out split HOLD | ATTEMPTED |
+| empty `O_i` as `UNDEFINED` | treat empty signed outgoing on an axis as unformed | empty `O_i` is Orient fail, not UNDEFINED; origin cyclic plane is occupied | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(C)` as a formed child | different seed; second pair is a new seed, not a formed child; here `t(C)=0` | ATTEMPTED |
+| y-probe three-path | score the four y-probes on this seed | y-probe path-independence is not this letter | ATTEMPTED |
+| x-probe three-path | score the four x-probes on this seed | x-probe path-independence is not this letter | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores three path products of cyclic-frame transport at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports reverse fail and face fail from missed cube-diagonal paths on the three-axis opposite near-face seed | ATTEMPTED |
+| nm2cycfrmhol two-axis holonomy | reuse reverse hold and face fail of unit squares on four tick-0 sites | different seed; this member has six tick-0 sites | ATTEMPTED |
+| nm2cycfrmholfz far-face holonomy | reuse reverse hold and face fail of `A-D-B-E` and `C-C1-C2-C3` | holonomy reverse HOLDs while this reverse fails; holonomy is a four-edge square, not three cube-diagonal paths | ATTEMPTED |
+| nm2cycfrmfz far-face transport | reuse transport reverse hold and face hold on z-probes of a far-face seed | those z-probes are not origin and `(0,1,0)`; transport HOLDs on these four seed probes while this reverse fails and this face fails | ATTEMPTED |
+| nm2frm3pth two-axis three-path | reuse the same three products on four tick-0 sites | different seed; origin `F` HOLDs on both, surviving origin products differ, and `(1,0,0)` is a new 6-NN here | ATTEMPTED |
+| nm2frm3pfz far-face three-path | reuse the same three products on the −z third pair | different seed; origin `F` fails there and transport reverse fails there | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is three disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t(A,B,C,D)` before reading | `τ(q)=t(q)+1` is per-probe; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the probes by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of path-independence with
+leftover of `M` alone, missing identification of path-independence with
+leftover-empty fail, missing identification of path-independence with
+existential opposite of signed locks, missing identification of
+path-independence with presence of an opposite pair in `O`, missing
+identification of path-independence with nm2chiralz lexicographic unsigned
+`o1,o2`, missing identification of path-independence with nm2oridetz unique
+signed `|O_i|=1`, missing identification of path-independence with
+nm2orichz leftover-axis, missing identification of path-independence with
+nm2orionez lex-one, missing identification of path-independence with cyclic
+lex-smallest, missing identification of path-independence with nmcover
+axis-cover, missing identification of path-independence with nm2axz
+axis-cover, missing identification of path-independence with nm2ax12z 1-in
+2-out split, missing identification of this seed with the 1-axis opposite
+two-site seed, and missing Record identification of three-path reverse are
+distinct open premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, three disjoint opposite seed pairs `+e_1/−e_1`,
+`+e_2/−e_2`, and `+e_3/−e_3`, perpendicular step rule, incoming-step lock,
+own incoming set and own outgoing dual from records with tick `<= τ`,
+per-probe `τ=t+1`, unsigned axis, cover as complementary occupation of
+`{e_1,e_2,e_3}`, split as cover and `|Axis(M)|=1`, unique signed `m` when
+split HOLDs, cyclic next/prev axes of `Axis(M)`, lex-largest signed
+outgoing letter under `+e < −e` (hence `−e` if both signs), integer
+determinant sign, empty `O_next` or empty `O_prev` as Orient fail not
+`UNDEFINED`, split fail as Orient fail not `UNDEFINED`, four seed probes
+with origin `A`, second pair as a new seed not a formed child, third pair
+as a new seed not a formed child on the near-face sites `(2,0,0)` and
+`(2,1,0)`, three cyclic permutations of `{+e_1,+e_2,+e_3}`, miss as fail
+not `UNDEFINED`, endpoint outside `B_3(0)` as fail not `UNDEFINED`, and
+mixed remains a set are declared. No uniqueness of outgoing locks, no
+six-neighbor lock union as the scored object, no lock-count clock, no
+global later T, no formation attachment from already-recorded six-neighbor
+locks, and no Admissibility rewrite are silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+path-independence `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | cyclic frame `F=(m,o_next,o_prev)` and three length-3 path-ordered products | no continuum alphabet |
+| per site | reverse origin,`(0,1,0)` and face `(0,0,1)`,`(0,1,1)` on `B_3(0)` only | no other cubic sites |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | three path products, reverse/face from path-independence | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for three-path cyclic-frame
+transport reverse/face, a formation-rate rule, and a physical selector among
+1-in 2-out frames. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Three-path reverse fail and face fail are only leftover of
+nm2frm3pth two-axis three-path, or of nm2frm3pfz far-face three-path, or of
+nm2cycfrmholfz far-face unit-square holonomy, or of nm2cycfrmz cyclic-frame
+transport, or of nm2cycfrmfz far-face transport, or of nm2oricyclz cyclic
+Orient, or of neighbor-read of the scalar Orient sign, or of scalar
+lex-largest Orient, or of cover and split; leftover of `M` alone already
+answers reverse HOLD; leftover of `O` alone already answers reverse HOLD;
+exist-opposite of signed `O` already answers reverse; mixed #7188 already
+reported fail/fail; the second pair is only the formed child `(0,0,1)` of
+the 1-axis seed; the third pair is only the formed child `(2,0,0)` of the
+two-axis seed; unique outgoing letters should be required; and unsigned
+incoming axis already gives the same signs because each `M` letter is the
+positive unit.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Three-path reverse fails because path `e1e2e3` from origin
+misses, even though origin split HOLDs and the other two origin products
+agree, and because at `(0,1,0)` every cyclic path misses. Three-path face
+fails because every cyclic path from `C` and from `D` misses. Transport
+reverse HOLDs and transport face HOLDs: leftover of nm2cycfrmz cyclic-frame
+transport, not this letter. Scalar lex-largest Orient reverse fails while
+transport HOLDs: leftover of #7475, not this letter. nm2cycfrmholfz
+far-face holonomy reverse HOLDs and face fails with a four-edge product on
+the unit squares; holonomy reverse HOLDs while this reverse fails.
+nm2frm3pth two-axis three-path is the same product test on four tick-0
+sites; here the third pair is a new seed, not a formed child, origin `F`
+HOLDs on both seeds, and the surviving origin products differ. nm2frm3pfz
+far-face three-path is the same product test on the −z third pair; origin
+`F` fails there. Scalar neighbor-read of Orient HOLDs at `A,B,C,D`, so
+scalar reverse HOLDs and scalar face HOLDs. Unique nonnegative permutation
+sending fails at origin and at `B`. Cover reverse HOLDs and split reverse
+HOLDs; cover face HOLDs and split face HOLDs. Leftover of `M` reverse HOLDs
+while this reverse fails. Leftover of `O` reverse HOLDs while this reverse
+fails. Exist-opposite reverse of signed `M` and of signed `O` both HOLD
+while this reverse fails. Unique outgoing letters would assign `UNDEFINED`
+at mixed `O(C)`; this Orient at `C` is `−1`, not `UNDEFINED`. Mixed #7188
+is a different z-symmetric process with mixed `M`. The second pair is a new
+seed, not a formed child: `(0,0,1)` is recorded at tick 0 with lock `+e_2`,
+whereas the 1-axis child forms at tick 1 with lock `+e_3`. The third pair is
+a new seed, not a formed child: `(2,0,0)` is recorded at tick 0 with lock
+`+e_3`, whereas the two-axis child at `(2,0,0)` forms at tick 3. At `B`,
+unsigned incoming Orient is `−1` while cyclic Orient is `+1`.
+
+### N8 — cross-cycle echo
+
+nm2frm3pth two-axis three-path reported reverse fail and face fail on four
+tick-0 sites with origin `F` HOLD and surviving origin products
+`[1 0 0; 0 -1 0; 0 0 1]`. nm2frm3pfz far-face three-path reported reverse
+fail and face fail on the −z third pair with origin `F` fail. nm2cycfrmz
+transport on this near-face seed HOLDs at each of the four seed probes, so
+transport reverse HOLDs and transport face HOLDs (#7513). Scalar lex-largest
+Orient reverse fails from `+1,−1` at origin and `(0,1,0)` (#7475).
+nm2cycfrmholfz reported holonomy reverse HOLD and holonomy face fail on the
+unit squares. This note is not those displays: it reports equality of the
+three length-3 path-ordered products of cyclic-frame transport of
+`(m,o_next,o_prev)` of `M` and `O` at `τ=t+1` on the three-axis opposite
+near-face seed, with `t(A)=0`, `t(B)=0`, `t(C)=0`, and `t(D)=0`, reverse
+fail, and face fail, while origin `F` HOLDs, while the two surviving origin
+products are `[1 0 0; 0 -1 0; 0 0 -1]`, while `(1,0,0)` is a new 6-NN of
+origin at `t+1`, while nm2frm3pth two-axis three-path has different surviving
+origin products, while nm2frm3pfz far-face three-path has origin `F` fail,
+while holonomy reverse HOLDs on this same seed, and while transport reverse
+HOLDs and transport face HOLDs on these probes. Cover and split do not score
+handedness. The third pair is a new seed, not a formed child.
+
+**Gate disposition:** PASS for the three-path cyclic-frame-transport `t+1`
+reverse/face reports above. FAIL / DO NOT SHIP for “the predicate equals
+the named sign,” “the predicate equals the unique singleton lock vector,”
+“the predicate equals six-neighbor lock union,” “the predicate equals
+leftover-empty fail,” “the predicate equals leftover of `M` alone,” “the
+predicate equals leftover of `O` alone,” “the predicate equals
+exist-opposite HOLD,” “the predicate equals opposite-pair presence in
+`O`,” “the predicate equals nm2chiralz lexicographic unsigned `o1,o2`
+HOLD,” “the predicate equals nm2oridetz unique signed HOLD,” “the
+predicate equals nm2orichz leftover-axis HOLD,” “the predicate equals
+nm2orionez lex-one HOLD,” “the predicate equals cyclic lex-smallest HOLD,”
+“the predicate equals nm2oricyclz cyclic Orient HOLD,” “the predicate
+equals nm2cycfrmz cyclic-frame transport HOLD,” “the predicate equals
+nm2cycfrmfz far-face cyclic-frame transport HOLD,” “the predicate equals
+nm2cycfrmhol two-axis unit-square holonomy HOLD,” “the predicate equals
+nm2cycfrmholfz far-face unit-square holonomy HOLD,” “the predicate equals
+nm2frm3pth two-axis three-path HOLD,” “the predicate equals nm2frm3pfz
+far-face three-path HOLD,” “the predicate equals scalar lex-largest Orient
+HOLD,” “the predicate equals scalar neighbor-read of Orient HOLD,” “the
+predicate equals unique nonnegative
+permutation sending HOLD,” “the predicate equals nmcover axis-cover HOLD,”
+“the predicate equals nm2axz axis-cover HOLD,” “the predicate equals
+nm2ax12z 1-in 2-out split HOLD,” “the predicate equals the 1-axis opposite
+two-site seed,” “the predicate equals nmunopp union,” “bits are
+Admissibility,” “split fail is UNDEFINED,” or “empty `O_i` is UNDEFINED.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the three-axis opposite
+near-face perp-step incoming-lock process, reads each seed probe's own earliest
+incoming set and own outgoing dual from the record prefix at that vertex's
+`t+1`, reports split of the pair, reports the cyclic frame
+`F=(m,o_next,o_prev)` as nm2cycfrmz, reports Orient as nm2oricyclz
+lex-largest cyclic, reports `P` on each formed six-neighbor edge of the
+three cyclic paths from each probe, reports the three path products, lists
+new records in `B_3(0)` between `t` and `t+1` that meet a probe's
+six-neighbors, and checks Theorems 1--3. It also checks that reverse
+path-independence fails and face path-independence fails, that a start or
+endpoint outside `B_3(0)` is fail not `UNDEFINED`, that nm2cycfrmz transport
+reverse HOLDs and transport face HOLDs while three-path reverse fails and
+three-path face fails, that nm2cycfrmholfz holonomy reverse HOLDs while
+three-path reverse fails, that nm2frm3pth two-axis three-path is a different
+member with origin `F` HOLD and different surviving origin products, that
+nm2frm3pfz far-face three-path is a different member with origin `F` fail,
+that scalar neighbor-read HOLDs at origin, that scalar lex-largest Orient
+reverse fails while transport HOLDs, that unique nonnegative permutation
+sending fails at origin and at `B`, that leftover of `M` reverse HOLDs while
+this reverse fails, that leftover of `O` reverse HOLDs while this reverse
+fails, that split fail is path-independence fail not `UNDEFINED`, that empty
+`O_next` or empty `O_prev` is Orient fail not `UNDEFINED`, that the 1-axis
+opposite two-site seed is a different member, that #7477 same-lock is a
+different member, that LIVE three-axis as a three-site seed is a different
+member, that leftover-empty fail is a different predicate, that leftover of
+`M` alone and leftover of `O` alone are different objects, that mixed sets
+remain sets, that the construction does not sum, that a formation member
+from already-recorded six-neighbor locks is not attached, that the second
+pair is a new seed not a formed child, that the third pair is a new seed not
+a formed child, that the y-probes and x-probes of this seed are not this
+letter, and that the display is not the two-tick lock-count clock
+composition. No runner cache is written.

--- a/logs/runner-cache/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,91 @@
+===== runner cache v1 =====
+runner: scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 4e59f4f93e4c368498949daa692bf5706b5e9ec221f8fe705d2220f9e20ab897
+input_fingerprint_sha256: 778ebb233bf283ad102dedd9109aca93126bfff79049ee7dccddcef7d27aeb66
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+three-path cyclic-frame transport reverse/face at t+1 on three-axis opposite near-face seed
+AUDIT_INPUT_PATHS:
+  docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Equality of the three length-3 path-ordered products of cyclic-frame transport along the permutations of {e1,e2,e3} at t+1 on the three-axis opposite (near-face) seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-seed-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: orient-identity
+PASS: pair-orient-identity
+PASS: sending-identity
+A (0, 0, 0) t=0 M={+e_1} O={−e_2, −e_3} split=hold F=(+e_1, −e_2, −e_3) Orient=+1 pathind=fail
+  product(e1e2e3)=fail
+  product(e2e3e1)=[1 0 0; 0 -1 0; 0 0 -1]
+  product(e3e1e2)=[1 0 0; 0 -1 0; 0 0 -1]
+B (0, 1, 0) t=0 M={−e_1} O={+e_2, −e_3} split=hold F=(−e_1, +e_2, −e_3) Orient=+1 pathind=fail
+  product(e1e2e3)=fail
+  product(e2e3e1)=fail
+  product(e3e1e2)=fail
+C (0, 0, 1) t=0 M={+e_2} O={+e_1, −e_1, +e_3} split=hold F=(+e_2, +e_3, −e_1) Orient=−1 pathind=fail
+  product(e1e2e3)=fail
+  product(e2e3e1)=fail
+  product(e3e1e2)=fail
+D (0, 1, 1) t=0 M={−e_2} O={+e_1, −e_1, +e_3} split=hold F=(−e_2, +e_3, −e_1) Orient=+1 pathind=fail
+  product(e1e2e3)=fail
+  product(e2e3e1)=fail
+  product(e3e1e2)=fail
+pathind reverse=fail face=fail
+transport reverse=hold face=hold
+holonomy reverse=hold face=fail
+Orient reverse=hold face=fail
+per_element: three length-3 path-ordered products of cyclic-frame transport along cyclic permutations of +e1,+e2,+e3 at t+1
+per_site: scored only at reverse origin,(0,1,0) and face (0,0,1),(0,1,1) on Euclidean B_3(0); no other sites
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: three path products, reverse/face from path-independence
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-formation-ticks  ({'A': 0, 'B': 0, 'C': 0, 'D': 0})
+PASS: theorem1-M-O-split-F-Orient  ({'A': ('hold', '+1'), 'B': ('hold', '+1'), 'C': ('hold', '−1'), 'D': ('hold', '+1')})
+PASS: theorem1-three-products  ({'A': ('fail', '[1 0 0; 0 -1 0; 0 0 -1]', '[1 0 0; 0 -1 0; 0 0 -1]'), 'B': ('fail', 'fail', 'fail'), 'C': ('fail', 'fail', 'fail'), 'D': ('fail', 'fail', 'fail')})
+PASS: theorem2-reverse-pathind-fail
+PASS: theorem3-face-pathind-fail
+PASS: M-frozen-from-t
+PASS: new-records-meet-6nn  ({'A': ((1, 0, 0), (0, -1, 0), (0, 0, -1)), 'B': ((1, 1, 0), (0, 2, 0), (0, 1, -1)), 'C': ((1, 0, 1), (-1, 0, 1), (0, 0, 2)), 'D': ((1, 1, 1), (-1, 1, 1), (0, 1, 2))})
+PASS: third-pair-is-seed-not-formed-child
+PASS: not-leftover-of-holonomy-or-transport-or-two-axis
+PASS: mutations-differ
+PASS: not-x-or-y-probes-or-perp-or-zsym
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-M-O-F-products
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-cover-or-split-or-holonomy
+PASS: note-not-one-sided-or-leftover-empty
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+PASS: pathind-not-transport-or-holonomy-or-scalar
+TOTAL: PASS=46 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,2257 @@
+#!/usr/bin/env python3
+"""Three-path cyclic-frame transport at t+1 reverse/face.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is three disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2, (2,0,0) locks +e_3, (2,1,0) locks
+-e_3. The third pair is a new seed, not a formed child, and sits on the
+near-face x=2 sites. Perp-step incoming lock. F, Orient, P as
+nm2cycfrmhol. Path independence as nm2frm3pth: for start s, w=s+e_1+e_2+e_3.
+If w·w>9, the letter at s is fail not UNDEFINED. The three paths of length 3
+from s to w are the six-neighbor walks along the three cyclic permutations
+of (+e_1,+e_2,+e_3). A path exists iff every vertex is in B_3(0) and formed
+at tau and every edge has a P. The path product is the 3x3 product of those
+three P. Path-independence HOLDs at s iff all three paths exist and the
+three products are equal. Else fail not UNDEFINED. Reverse probes: origin
+and (0,1,0). Face probes: (0,0,1) and (0,1,1). Reverse HOLD iff
+path-independence HOLDs at both reverse probes. Face HOLD iff both face
+probes HOLD. Face is displayed, not adopted. Uniqueness is not required.
+Occupancy of sites is not used. No larger host. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+FrameVal = tuple[Point, Point, Point] | str
+Sending = tuple[Point, Point, Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+PAIR3: Point = (2, 0, 0)
+PAIR3B: Point = (2, 1, 0)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+    (PAIR3, E3),
+    (PAIR3B, NEG_E3),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+LIVE_THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+    (E3, E3),
+)
+PROBES = {
+    "A": (0, 0, 0),
+    "B": (0, 1, 0),
+    "C": (0, 0, 1),
+    "D": (0, 1, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Equality of the three length-3 path-ordered products of "
+    "cyclic-frame transport along the permutations of {e1,e2,e3} at t+1 "
+    "on the three-axis opposite (near-face) seed, and reverse/face from that, "
+    "are reported. Displayed, not adopted."
+)
+IDENTITY_COLUMNS: tuple[Point, Point, Point] = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+THREE_PATHS: tuple[tuple[Point, Point, Point], ...] = (
+    (E1, E2, E3),
+    (E2, E3, E1),
+    (E3, E1, E2),
+)
+PATH_NAMES: tuple[str, ...] = ("e1e2e3", "e2e3e1", "e3e1e2")
+DIAGONAL: Point = (1, 1, 1)
+REVERSE_SQUARE: tuple[Point, Point, Point, Point] = (
+    (0, 0, 1),
+    (1, 0, 1),
+    (1, 1, 1),
+    (0, 1, 1),
+)
+FACE_SQUARE: tuple[Point, Point, Point, Point] = (
+    (0, 0, 2),
+    (1, 0, 2),
+    (1, 1, 2),
+    (0, 1, 2),
+)
+SQUARE_NAMES = {
+    (0, 0, 1): "A",
+    (1, 0, 1): "D",
+    (1, 1, 1): "B",
+    (0, 1, 1): "E",
+    (0, 0, 2): "C",
+    (1, 0, 2): "C1",
+    (1, 1, 2): "C2",
+    (0, 1, 2): "C3",
+}
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def pair_display(value: tuple[Point, Point] | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple):
+        raise TypeError(f"signed pair is not a pair or fail: {value!r}")
+    return ", ".join(LOCK_NAME[vec] for vec in value)
+
+
+def frame_display(value: FrameVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"frame is not a triple or fail: {value!r}")
+    return "(" + ", ".join(LOCK_NAME[vec] for vec in value) + ")"
+
+
+def matrix_display(value: Sending) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"sending is not three columns or fail: {value!r}")
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return "[" + "; ".join(" ".join(str(entry) for entry in row) for row in rows) + "]"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = THREE_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3. Mutation: unsigned."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negative)
+    return picked[0], picked[1]
+
+
+def axis_index(lock: Point) -> int | str:
+    """Axis index i in {1,2,3} of a signed nearest-neighbor letter."""
+    axis = axis_of_letter(lock)
+    if axis == E1:
+        return 1
+    if axis == E2:
+        return 2
+    if axis == E3:
+        return 3
+    return "fail"
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    """e_next = e_{i+1} with 3+1->1. e_prev = e_{i-1} with 1-1->3."""
+    idx = axis_index(signed_m)
+    if idx == "fail" or not isinstance(idx, int):
+        return "fail"
+    e_next = AXES[idx % 3]
+    e_prev = AXES[idx - 2]
+    return e_next, e_prev
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-largest signed letter in O intersect {+/-axis}. Order +e < -e."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-smallest signed letter in O intersect {+/-axis}. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def cyclic_signed_outgoing(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = True
+) -> tuple[Point, Point] | str:
+    """o_next, o_prev on the two cyclic axes of Axis(M). Empty slot is fail."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    o_next = picker(outgoing, units[0])
+    o_prev = picker(outgoing, units[1])
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic unsigned o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane. Fail if an opposite pair occupies O_i."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_lex_smallest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: same cyclic axes, lex-smallest (+e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-largest cyclic slots."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o_next, o_prev = plane
+    det = integer_det_columns(signed_m, o_next, o_prev)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_triple(incoming: Incoming, outgoing: Outgoing) -> FrameVal:
+    """F=(m,o_next,o_prev) when split HOLDs. Else fail, not UNDEFINED unless unformed."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return signed_m, plane[0], plane[1]
+
+
+def transpose_columns(frame: tuple[Point, Point, Point]) -> tuple[Point, Point, Point]:
+    """Columns of the transpose. Inverse on signed permutation frames."""
+    return tuple(tuple(frame[column][row] for column in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def mul_columns(
+    left: tuple[Point, Point, Point], right: tuple[Point, Point, Point]
+) -> tuple[Point, Point, Point]:
+    """Integer matrix product of two column-triple matrices."""
+    return tuple(
+        tuple(
+            sum(left[k][i] * right[j][k] for k in range(3)) for i in range(3)
+        )
+        for j in range(3)
+    )  # type: ignore[return-value]
+
+
+def sending_matrix(source: FrameVal, target: FrameVal) -> Sending:
+    """Integer matrix P with F(r) = F(q) P, sending columns of F(q) to F(r)."""
+    if source == UNDEFINED or target == UNDEFINED:
+        return UNDEFINED
+    if source == "fail" or target == "fail":
+        return "fail"
+    if not isinstance(source, tuple) or not isinstance(target, tuple):
+        return "fail"
+    return mul_columns(transpose_columns(source), target)
+
+
+def is_signed_permutation(value: Sending) -> bool:
+    """Exactly one nonzero +/-1 in each row and each column."""
+    if not isinstance(value, tuple) or len(value) != 3:
+        return False
+    for column in value:
+        if any(entry not in (-1, 0, 1) for entry in column):
+            return False
+        if sum(abs(entry) for entry in column) != 1:
+            return False
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return all(sum(abs(entry) for entry in row) == 1 for row in rows)
+
+
+def sending_holds(
+    source: FrameVal, target: FrameVal, orient_q: OrientVal, orient_r: OrientVal
+) -> str:
+    """HOLD iff P is a signed permutation with det = Orient(q)Orient(r)."""
+    sending = sending_matrix(source, target)
+    if sending == UNDEFINED:
+        return UNDEFINED
+    if sending == "fail" or not isinstance(sending, tuple):
+        return "fail"
+    if orient_q not in (1, -1) or orient_r not in (1, -1):
+        return "fail"
+    det = integer_det_columns(sending[0], sending[1], sending[2])
+    if is_signed_permutation(sending) and det == orient_q * orient_r:
+        return "hold"
+    return "fail"
+
+
+def is_nonnegative_permutation(value: Sending) -> bool:
+    """Unsigned permutation: signed permutation with no minus signs. Mutation."""
+    if not is_signed_permutation(value):
+        return False
+    if not isinstance(value, tuple):
+        return False
+    return all(entry >= 0 for column in value for entry in column)
+
+
+def site_sides(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Incoming, Outgoing]:
+    if site not in ticks:
+        return UNDEFINED, UNDEFINED
+    tau = ticks[site] + 1
+    return (
+        incoming_set(site, tau, ticks, locks, seed_map),
+        outgoing_set(site, tau, ticks, locks, seed_map),
+    )
+
+
+def formed_six_neighbors(site: Point, ticks: dict[Point, int]) -> tuple[Point, ...]:
+    """Formed 6-NN of site in B_3(0). Not a six-neighbor star letter."""
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def frame_transport(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, and some formed 6-NN r transports."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_transport_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, Sending] | str:
+    """First formed 6-NN in NN order that transports. Uniqueness is not required."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return neighbor, sending
+    return "fail"
+
+
+def scalar_orient_neighbor(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: HOLD iff some formed 6-NN has the same scalar Orient sign."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    orient = frame_orient(incoming, outgoing)
+    if orient == UNDEFINED:
+        return UNDEFINED
+    if orient not in (1, -1):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        if frame_orient(n_in, n_out) == orient:
+            return "hold"
+    return "fail"
+
+
+def unique_positive_sending(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: unique nonnegative permutation sending. Not this letter."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    hits = 0
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_orient = frame_orient(n_in, n_out)
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if (
+            sending_holds(source, target, orient, n_orient) == "hold"
+            and is_nonnegative_permutation(sending)
+        ):
+            hits += 1
+    if hits == 1:
+        return "hold"
+    return "fail"
+
+
+def site_frame_state(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[str, OrientVal, FrameVal]:
+    """split, Orient, F at tau=t+1. Outside the host is fail, not UNDEFINED."""
+    if not in_ball(site):
+        return "fail", "fail", "fail"
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    return (
+        axis_split(incoming, outgoing),
+        frame_orient(incoming, outgoing),
+        frame_triple(incoming, outgoing),
+    )
+
+
+def edge_sending(
+    source: Point,
+    target: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Sending:
+    """P(q,r) on a formed six-neighbor pair, else fail. Outside is fail."""
+    if not in_ball(source) or not in_ball(target):
+        return "fail"
+    if source not in ticks or target not in ticks:
+        return UNDEFINED
+    if sub(target, source) not in NN:
+        return "fail"
+    _split_q, orient_q, frame_q = site_frame_state(source, ticks, locks, seed_map)
+    _split_r, orient_r, frame_r = site_frame_state(target, ticks, locks, seed_map)
+    sending = sending_matrix(frame_q, frame_r)
+    if sending_holds(frame_q, frame_r, orient_q, orient_r) == "hold":
+        return sending
+    if sending == UNDEFINED:
+        return UNDEFINED
+    return "fail"
+
+
+def product_columns(
+    matrices: tuple[Sending, ...],
+) -> Sending:
+    """Path-ordered product of sendings in column convention."""
+    if any(item == UNDEFINED for item in matrices):
+        return UNDEFINED
+    if any(not isinstance(item, tuple) for item in matrices):
+        return "fail"
+    product: tuple[Point, Point, Point] = IDENTITY_COLUMNS
+    for item in matrices:
+        if not isinstance(item, tuple):
+            return "fail"
+        product = mul_columns(product, item)
+    return product
+
+
+def square_holonomy(
+    vertices: tuple[Point, Point, Point, Point],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, every edge has P, product is I_3."""
+    if any(not in_ball(site) for site in vertices):
+        return "fail"
+    splits: list[str] = []
+    orients: list[OrientVal] = []
+    sendings: list[Sending] = []
+    for site in vertices:
+        split, orient, _frame = site_frame_state(site, ticks, locks, seed_map)
+        splits.append(split)
+        orients.append(orient)
+    if any(item == UNDEFINED for item in splits) or any(
+        item == UNDEFINED for item in orients
+    ):
+        return UNDEFINED
+    for index in range(4):
+        sendings.append(
+            edge_sending(
+                vertices[index],
+                vertices[(index + 1) % 4],
+                ticks,
+                locks,
+                seed_map,
+            )
+        )
+    if any(item == UNDEFINED for item in sendings):
+        return UNDEFINED
+    if any(split != "hold" for split in splits):
+        return "fail"
+    if any(orient not in (1, -1) for orient in orients):
+        return "fail"
+    if any(not isinstance(item, tuple) for item in sendings):
+        return "fail"
+    product = product_columns(
+        (sendings[0], sendings[1], sendings[2], sendings[3])
+    )
+    if product == IDENTITY_COLUMNS:
+        return "hold"
+    return "fail"
+
+
+def path_vertices(start: Point, steps: tuple[Point, Point, Point]) -> tuple[Point, ...]:
+    """Length-3 walk vertices from start along the three steps."""
+    site = start
+    vertices = [start]
+    for step in steps:
+        site = add(site, step)
+        vertices.append(site)
+    return tuple(vertices)
+
+
+def path_sendings(
+    start: Point,
+    steps: tuple[Point, Point, Point],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Sending, Sending, Sending]:
+    """Three edge sendings along a length-3 walk. Miss is fail, not UNDEFINED."""
+    vertices = path_vertices(start, steps)
+    sendings: list[Sending] = []
+    for index in range(3):
+        source = vertices[index]
+        target = vertices[index + 1]
+        if not in_ball(source) or not in_ball(target):
+            sendings.append("fail")
+            continue
+        if source not in ticks or target not in ticks:
+            sendings.append("fail")
+            continue
+        sending = edge_sending(source, target, ticks, locks, seed_map)
+        if sending == UNDEFINED:
+            sendings.append("fail")
+        else:
+            sendings.append(sending)
+    return sendings[0], sendings[1], sendings[2]
+
+
+def path_product(
+    start: Point,
+    steps: tuple[Point, Point, Point],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Sending:
+    """3x3 product of the three edge P along one permutation. Miss is fail."""
+    sendings = path_sendings(start, steps, ticks, locks, seed_map)
+    product = product_columns(sendings)
+    if product == UNDEFINED:
+        return "fail"
+    return product
+
+
+def path_independence(
+    start: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff all three cyclic paths exist and the three products are equal.
+
+    If w=s+e1+e2+e3 lies outside B_3(0), fail not UNDEFINED. If a path
+    misses, fail not UNDEFINED. Equality is of the three 3x3 products.
+    """
+    if not in_ball(start):
+        return "fail"
+    endpoint = add(start, DIAGONAL)
+    if not in_ball(endpoint):
+        return "fail"
+    products: list[Sending] = []
+    for steps in THREE_PATHS:
+        vertices = path_vertices(start, steps)
+        if any(not in_ball(site) for site in vertices):
+            return "fail"
+        if any(site not in ticks for site in vertices):
+            return "fail"
+        product = path_product(start, steps, ticks, locks, seed_map)
+        if not isinstance(product, tuple):
+            return "fail"
+        products.append(product)
+    if products[0] == products[1] == products[2]:
+        return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Orient reverse HOLDs iff Orient(A)=Orient(B) both +/-1. Contrast."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Orient face HOLDs iff Orient(C)=Orient(D) both +/-1. Contrast."""
+    return pair_orient(orient_c, orient_d)
+
+
+def transport_reverse_report(left: str, right: str) -> str:
+    """Reverse HOLDs iff transport at A and at B."""
+    return pair_bit(left, right)
+
+
+def transport_face_report(left: str, right: str) -> str:
+    """Face HOLDs iff transport at C and at D."""
+    return pair_bit(left, right)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    plane = cyclic_signed_outgoing(frozenset({unsigned_m}), outgoing, largest=True)
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print(
+        "three-path cyclic-frame transport reverse/face at t+1 "
+        "on three-axis opposite near-face seed"
+    )
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    z_probe_sites = ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-seed-probes-in-host",
+        probe_sites == ((0, 0, 0), (0, 1, 0), (0, 0, 1), (0, 1, 1))
+        and set(probe_sites) <= host
+        and ORIGIN in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and probe_sites != z_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E3, NEG_E1) == -1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E3, NEG_E1, NEG_E2) == 1
+        and integer_det_columns(E1, NEG_E2, NEG_E3) == 1
+        and integer_det_columns(E2, E3, E1) == 1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E3, E1, NEG_E2) == -1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2, E3, NEG_E3}), frozenset({E1, NEG_E1}))
+        == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and frame_orient(frozenset({E2}), frozenset({NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E2}), frozenset({E1, NEG_E1, E3})) == -1
+        and frame_orient(frozenset({E1}), frozenset({E2, E3, NEG_E3})) == -1
+        and frame_orient(frozenset({E3}), frozenset({E1, NEG_E1, NEG_E2})) == 1
+        and frame_orient(frozenset({NEG_E2}), frozenset({E1, E3})) == -1
+        and frame_orient(frozenset({E1, NEG_E1}), frozenset({E2, E3})) == "fail"
+        and cyclic_units(E2) == (E3, E1)
+        and cyclic_units(E1) == (E2, E3)
+        and cyclic_units(E3) == (E1, E2)
+        and cyclic_units(NEG_E2) == (E3, E1)
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1
+        and lex_largest_on_axis(frozenset({E1}), E1) == E1
+        and lex_smallest_on_axis(frozenset({E1, NEG_E1}), E1) == E1
+        and cyclic_signed_outgoing(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E3, NEG_E1)
+        and leftover_axis(frozenset({E2}), frozenset({E1, E3})) == frozenset()
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+    checks.check(
+        "pair-orient-identity",
+        pair_orient(UNDEFINED, 1) == UNDEFINED
+        and pair_orient(1, UNDEFINED) == UNDEFINED
+        and pair_orient(1, 1) == "hold"
+        and pair_orient(-1, -1) == "hold"
+        and pair_orient(-1, 1) == "fail"
+        and pair_orient(1, "fail") == "fail"
+        and pair_orient("fail", "fail") == "fail",
+    )
+    identity_frame = (E2, E3, NEG_E1)
+    identity_target = (E1, NEG_E2, NEG_E3)
+    identity_sending = sending_matrix(identity_frame, identity_target)
+    checks.check(
+        "sending-identity",
+        frame_triple(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E2, E3, NEG_E1)
+        and sending_matrix(UNDEFINED, identity_frame) == UNDEFINED
+        and sending_matrix(identity_frame, "fail") == "fail"
+        and sending_matrix(identity_frame, identity_frame) == (E1, E2, E3)
+        and is_signed_permutation((E1, E2, E3))
+        and not is_signed_permutation((E1, E1, E2))
+        and sending_holds(identity_frame, identity_frame, -1, -1) == "hold"
+        and sending_holds(identity_frame, identity_target, -1, 1) == "hold"
+        and integer_det_columns(*identity_sending) == -1
+        and is_signed_permutation(identity_sending)
+        and not is_nonnegative_permutation(identity_sending)
+        and mul_columns(identity_frame, identity_sending) == identity_target,
+    )
+
+    ticks, locks, seed_map = form()
+    two_ticks, two_locks, two_seeds = form(TWO_AXIS_SEEDS)
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    live_ticks, live_locks, live_seeds = form(LIVE_THREE_AXIS_SEEDS)
+    tau0: dict[str, int] = {}
+    m0: dict[str, Incoming] = {}
+    m1: dict[str, Incoming] = {}
+    o0: dict[str, Outgoing] = {}
+    o1: dict[str, Outgoing] = {}
+    cover: dict[str, str] = {}
+    split: dict[str, str] = {}
+    two_one: dict[str, str] = {}
+    signed_m: dict[str, Point | str] = {}
+    cyclic_plane: dict[str, tuple[Point, Point] | str] = {}
+    unique_plane: dict[str, tuple[Point, Point] | str] = {}
+    pair: dict[str, Point | str] = {}
+    det: dict[str, int | str] = {}
+    lex: dict[str, OrientVal] = {}
+    leftover_pair: dict[str, OrientVal] = {}
+    unique_signed: dict[str, OrientVal] = {}
+    pair_present: dict[str, str] = {}
+    cyclic_small: dict[str, OrientVal] = {}
+    axis_i: dict[str, int | str] = {}
+    orient: dict[str, OrientVal] = {}
+    lx: dict[str, AxisSet] = {}
+    lx_m: dict[str, AxisSet] = {}
+    lx_o: dict[str, AxisSet] = {}
+    new_meet: dict[str, tuple[Point, ...]] = {}
+    frames: dict[str, FrameVal] = {}
+    transport: dict[str, str] = {}
+    scalar: dict[str, str] = {}
+    unique_pos: dict[str, str] = {}
+    witness: dict[str, tuple[Point, Sending] | str] = {}
+    independence: dict[str, str] = {}
+    products: dict[str, tuple[Sending, Sending, Sending]] = {}
+    sendings_by_path: dict[str, dict[str, tuple[Sending, Sending, Sending]]] = {}
+    for name in ("A", "B", "C", "D"):
+        site = PROBES[name]
+        tau0[name] = ticks[site]
+        tau1 = ticks[site] + 1
+        m0[name] = incoming_set(site, tau0[name], ticks, locks, seed_map)
+        m1[name] = incoming_set(site, tau1, ticks, locks, seed_map)
+        o0[name] = outgoing_set(site, tau0[name], ticks, locks, seed_map)
+        o1[name] = outgoing_set(site, tau1, ticks, locks, seed_map)
+        cover[name] = axis_cover(m1[name], o1[name])
+        split[name] = axis_split(m1[name], o1[name])
+        two_one[name] = two_in_one_out(m1[name], o1[name])
+        signed_m[name] = unique_signed_m(m1[name])
+        unique_plane[name] = unique_signed_outgoing_plane(o1[name])
+        cyclic_plane[name] = cyclic_signed_outgoing(m1[name], o1[name], largest=True)
+        pair[name] = opposite_pair_unit(o1[name])
+        if isinstance(signed_m[name], tuple):
+            axis_i[name] = axis_index(signed_m[name])
+        else:
+            axis_i[name] = "fail"
+        if isinstance(signed_m[name], tuple) and isinstance(cyclic_plane[name], tuple):
+            det[name] = integer_det_columns(
+                signed_m[name], cyclic_plane[name][0], cyclic_plane[name][1]
+            )
+        else:
+            det[name] = "fail"
+        pair_present[name] = has_opposite_pair(o1[name])
+        lex[name] = lex_frame_orient(m1[name], o1[name])
+        leftover_pair[name] = leftover_pair_orient(m1[name], o1[name])
+        unique_signed[name] = unique_signed_orient(m1[name], o1[name])
+        cyclic_small[name] = cyclic_lex_smallest_orient(m1[name], o1[name])
+        orient[name] = frame_orient(m1[name], o1[name])
+        frames[name] = frame_triple(m1[name], o1[name])
+        transport[name] = frame_transport(site, ticks, locks, seed_map)
+        scalar[name] = scalar_orient_neighbor(site, ticks, locks, seed_map)
+        unique_pos[name] = unique_positive_sending(site, ticks, locks, seed_map)
+        witness[name] = first_transport_witness(site, ticks, locks, seed_map)
+        lx[name] = leftover_axis(m1[name], o1[name])
+        lx_m[name] = leftover_of_one(m1[name])
+        lx_o[name] = leftover_of_one(o1[name])
+        new_meet[name] = new_records_meeting_six_nn(site, ticks)
+        independence[name] = path_independence(site, ticks, locks, seed_map)
+        path_products: list[Sending] = []
+        sendings_by_path[name] = {}
+        for path_name, steps in zip(PATH_NAMES, THREE_PATHS):
+            sendings_by_path[name][path_name] = path_sendings(
+                site, steps, ticks, locks, seed_map
+            )
+            path_products.append(
+                path_product(site, steps, ticks, locks, seed_map)
+            )
+        products[name] = (path_products[0], path_products[1], path_products[2])
+        print(
+            f"{name} {site} t={ticks[site]} "
+            f"M={lockset_display(m1[name])} "
+            f"O={lockset_display(o1[name])} "
+            f"split={split[name]} "
+            f"F={frame_display(frames[name])} "
+            f"Orient={orient_display(orient[name])} "
+            f"pathind={independence[name]}"
+        )
+        for path_name, product in zip(PATH_NAMES, products[name]):
+            print(f"  product({path_name})={matrix_display(product)}")
+
+    reverse = pair_bit(independence["A"], independence["B"])
+    face = pair_bit(independence["C"], independence["D"])
+    transport_reverse = transport_reverse_report(transport["A"], transport["B"])
+    transport_face = transport_face_report(transport["C"], transport["D"])
+    holonomy_reverse = square_holonomy(REVERSE_SQUARE, ticks, locks, seed_map)
+    holonomy_face = square_holonomy(FACE_SQUARE, ticks, locks, seed_map)
+    two_independence = {
+        name: path_independence(PROBES[name], two_ticks, two_locks, two_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    two_reverse = pair_bit(two_independence["A"], two_independence["B"])
+    two_face = pair_bit(two_independence["C"], two_independence["D"])
+    two_frames_a = site_frame_state(PROBES["A"], two_ticks, two_locks, two_seeds)[2]
+    two_products_a = tuple(
+        path_product(PROBES["A"], steps, two_ticks, two_locks, two_seeds)
+        for steps in THREE_PATHS
+    )
+    two_products_b = tuple(
+        path_product(PROBES["B"], steps, two_ticks, two_locks, two_seeds)
+        for steps in THREE_PATHS
+    )
+    two_new_a = new_records_meeting_six_nn(PROBES["A"], two_ticks)
+    one_independence = {
+        name: path_independence(PROBES[name], one_ticks, one_locks, one_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    same_independence = {
+        name: path_independence(PROBES[name], same_ticks, same_locks, same_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    live_independence = {
+        name: path_independence(PROBES[name], live_ticks, live_locks, live_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    outside_start = (0, 0, 4)
+    outside_independence = path_independence(
+        outside_start, ticks, locks, seed_map
+    )
+    far_start = (2, 2, 0)
+    far_independence = path_independence(far_start, ticks, locks, seed_map)
+    orient_reverse = reverse_report(orient["A"], orient["B"])
+    orient_face = face_report(orient["C"], orient["D"])
+    scalar_reverse = pair_bit(scalar["A"], scalar["B"])
+    scalar_face = pair_bit(scalar["C"], scalar["D"])
+    unique_pos_reverse = pair_bit(unique_pos["A"], unique_pos["B"])
+    unique_pos_face = pair_bit(unique_pos["C"], unique_pos["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    leftover_reverse = leftover_match(lx["A"], lx["B"])
+    leftover_face = leftover_match(lx["C"], lx["D"])
+    reverse_m_alone = leftover_match(lx_m["A"], lx_m["B"])
+    face_m_alone = leftover_match(lx_m["C"], lx_m["D"])
+    reverse_o_alone = leftover_match(lx_o["A"], lx_o["B"])
+    face_o_alone = leftover_match(lx_o["C"], lx_o["D"])
+    m_exist_reverse = existential_opposite(m1["A"], m1["B"])
+    m_exist_face = existential_opposite(m1["C"], m1["D"])
+    o_exist_reverse = existential_opposite(o1["A"], o1["B"])
+    o_exist_face = existential_opposite(o1["C"], o1["D"])
+    unsigned_orient = {
+        name: unsigned_incoming_orient(m1[name], o1[name])
+        for name in ("A", "B", "C", "D")
+    }
+    print(f"pathind reverse={reverse} face={face}")
+    print(f"transport reverse={transport_reverse} face={transport_face}")
+    print(f"holonomy reverse={holonomy_reverse} face={holonomy_face}")
+    print(f"Orient reverse={orient_reverse} face={orient_face}")
+    print(
+        "per_element: three length-3 path-ordered products of cyclic-frame "
+        "transport along cyclic permutations of +e1,+e2,+e3 at t+1"
+    )
+    print(
+        "per_site: scored only at reverse origin,(0,1,0) and face "
+        "(0,0,1),(0,1,1) on Euclidean B_3(0); no other sites"
+    )
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: three path products, reverse/face from path-independence")
+    print(
+        "lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed"
+    )
+
+    origin_parallel_blocked = (
+        incoming_set(E1, ticks[E1] + 1, ticks, locks, seed_map) == frozenset({NEG_E1})
+        and E1 not in locks[E1]
+        and ticks[NEG_E1] != 1
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    third_pair_parallel_blocked = all(
+        ticks.get(add(PAIR3, step)) != 1 for step in (E3, NEG_E3)
+    ) and all(ticks.get(add(PAIR3B, step)) != 1 for step in (E3, NEG_E3))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and third_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 0
+        and ticks[PROBES["C"]] == 0
+        and ticks[PROBES["D"]] == 0
+        and ticks[PAIR3] == 0
+        and ticks[PAIR3B] == 0
+        and PAIR3 == (2, 0, 0)
+        and PAIR3B == (2, 1, 0)
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set((1, 1, 1), 0, ticks, locks, seed_map) == UNDEFINED
+        and outgoing_set((1, 1, 1), 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_orient(
+            incoming_set((1, 1, 1), 0, ticks, locks, seed_map),
+            outgoing_set((1, 1, 1), 0, ticks, locks, seed_map),
+        )
+        == UNDEFINED
+        and frame_transport((1, 1, 1), {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1})
+        == UNDEFINED
+        and path_independence((1, 1, 1), {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1})
+        == "fail",
+    )
+    checks.check(
+        "theorem1-formation-ticks",
+        ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 0
+        and ticks[PROBES["C"]] == 0
+        and ticks[PROBES["D"]] == 0,
+        str({name: ticks[PROBES[name]] for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-M-O-split-F-Orient",
+        m1["A"] == frozenset({E1})
+        and m1["B"] == frozenset({NEG_E1})
+        and m1["C"] == frozenset({E2})
+        and m1["D"] == frozenset({NEG_E2})
+        and o1["A"] == frozenset({NEG_E2, NEG_E3})
+        and o1["B"] == frozenset({E2, NEG_E3})
+        and o1["C"] == frozenset({E1, NEG_E1, E3})
+        and o1["D"] == frozenset({E1, NEG_E1, E3})
+        and split["A"] == "hold"
+        and split["B"] == "hold"
+        and split["C"] == "hold"
+        and split["D"] == "hold"
+        and frames["A"] == (E1, NEG_E2, NEG_E3)
+        and frames["B"] == (NEG_E1, E2, NEG_E3)
+        and frames["C"] == (E2, E3, NEG_E1)
+        and frames["D"] == (NEG_E2, E3, NEG_E1)
+        and orient["A"] == 1
+        and orient["B"] == 1
+        and orient["C"] == -1
+        and orient["D"] == 1
+        and signed_m["A"] == E1
+        and signed_m["B"] == NEG_E1
+        and signed_m["C"] == E2
+        and signed_m["D"] == NEG_E2
+        and axis_i["A"] == 1
+        and axis_i["B"] == 1
+        and axis_i["C"] == 2
+        and axis_i["D"] == 2
+        and cyclic_plane["A"] == (NEG_E2, NEG_E3)
+        and cyclic_plane["B"] == (E2, NEG_E3)
+        and cyclic_plane["C"] == (E3, NEG_E1)
+        and cyclic_plane["D"] == (E3, NEG_E1)
+        and det["A"] == 1
+        and det["B"] == 1
+        and det["C"] == -1
+        and det["D"] == 1,
+        str({name: (split[name], orient_display(orient[name])) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem1-three-products",
+        products["A"][0] == "fail"
+        and products["A"][1] == ((1, 0, 0), (0, -1, 0), (0, 0, -1))
+        and products["A"][2] == ((1, 0, 0), (0, -1, 0), (0, 0, -1))
+        and products["A"][1] == products["A"][2]
+        and products["A"][1] != IDENTITY_COLUMNS
+        and products["B"] == ("fail", "fail", "fail")
+        and products["C"] == ("fail", "fail", "fail")
+        and products["D"] == ("fail", "fail", "fail")
+        and sendings_by_path["A"]["e2e3e1"]
+        == (
+            ((-1, 0, 0), (0, -1, 0), (0, 0, 1)),
+            ((0, -1, 0), (0, 0, -1), (1, 0, 0)),
+            ((0, 0, -1), (-1, 0, 0), (0, 1, 0)),
+        )
+        and sendings_by_path["A"]["e3e1e2"]
+        == (
+            ((0, -1, 0), (0, 0, -1), (-1, 0, 0)),
+            ((0, 0, -1), (-1, 0, 0), (0, 1, 0)),
+            ((1, 0, 0), (0, -1, 0), (0, 0, 1)),
+        )
+        and all(independence[name] == "fail" for name in ("A", "B", "C", "D"))
+        and independence["A"] != UNDEFINED
+        and path_independence((2, 1, 1), ticks, locks, seed_map) == "fail"
+        and far_independence == "fail"
+        and outside_independence == "fail"
+        and outside_independence != UNDEFINED,
+        str({name: tuple(matrix_display(item) for item in products[name]) for name in ("A", "B", "C", "D")}),
+    )
+    checks.check(
+        "theorem2-reverse-pathind-fail",
+        reverse == "fail"
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and independence["A"] == "fail"
+        and independence["B"] == "fail"
+        and transport_reverse == "hold"
+        and transport["A"] == "hold"
+        and transport["B"] == "hold"
+        and transport_reverse != reverse
+        and holonomy_reverse == "hold"
+        and holonomy_reverse != reverse
+        and orient_reverse == "hold"
+        and orient_reverse != reverse
+        and split_reverse == "hold"
+        and cover_reverse == "hold"
+        and scalar_reverse == "hold"
+        and scalar_reverse != reverse
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and two_frames_a == (E1, NEG_E2, NEG_E3)
+        and frames["A"] == (E1, NEG_E2, NEG_E3)
+        and two_frames_a == frames["A"]
+        and two_products_a[1] == ((1, 0, 0), (0, -1, 0), (0, 0, 1))
+        and two_products_a[1] != products["A"][1]
+        and two_independence["A"] == "fail"
+        and two_reverse == "fail",
+    )
+    checks.check(
+        "theorem3-face-pathind-fail",
+        face == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and independence["C"] == "fail"
+        and independence["D"] == "fail"
+        and transport_face == "hold"
+        and transport_face != face
+        and holonomy_face == "fail"
+        and orient_face == "fail"
+        and split_face == "hold"
+        and cover_face == "hold"
+        and scalar_face == "hold"
+        and scalar_face != face
+        and unique_pos_face == "fail",
+    )
+    checks.check(
+        "M-frozen-from-t",
+        m1["A"] == m0["A"]
+        and m1["B"] == m0["B"]
+        and m1["C"] == m0["C"]
+        and m1["D"] == m0["D"]
+        and o0["A"] == frozenset()
+        and o0["B"] == frozenset()
+        and o0["C"] == frozenset()
+        and o0["D"] == frozenset(),
+    )
+    checks.check(
+        "new-records-meet-6nn",
+        new_meet["A"] == ((1, 0, 0), (0, -1, 0), (0, 0, -1))
+        and new_meet["B"] == ((1, 1, 0), (0, 2, 0), (0, 1, -1))
+        and new_meet["C"] == ((1, 0, 1), (-1, 0, 1), (0, 0, 2))
+        and new_meet["D"] == ((1, 1, 1), (-1, 1, 1), (0, 1, 2))
+        and (1, 0, 0) in new_meet["A"]
+        and (1, 0, 0) not in two_new_a
+        and two_ticks[(1, 0, 0)] == 2
+        and ticks[(1, 0, 0)] == 1,
+        str(new_meet),
+    )
+    checks.check(
+        "third-pair-is-seed-not-formed-child",
+        PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and E3 in seed_map
+        and seed_map[E3] == E2
+        and ticks[E3] == 0
+        and PAIR3 in seed_map
+        and seed_map[PAIR3] == E3
+        and ticks[PAIR3] == 0
+        and PAIR3B in seed_map
+        and seed_map[PAIR3B] == NEG_E3
+        and ticks[PAIR3B] == 0
+        and PAIR3 == (2, 0, 0)
+        and PAIR3B == (2, 1, 0)
+        and one_ticks[E3] == 1
+        and two_ticks[NEG_E3] == 1
+        and ticks[NEG_E3] == 1
+        and two_ticks[PAIR3] == 3
+        and two_ticks[PAIR3B] == 3
+        and sum(time == 0 for time in ticks.values()) == 6
+        and sum(time == 0 for time in two_ticks.values()) == 4,
+    )
+    checks.check(
+        "not-leftover-of-holonomy-or-transport-or-two-axis",
+        reverse == "fail"
+        and face == "fail"
+        and holonomy_reverse == "hold"
+        and holonomy_face == "fail"
+        and holonomy_reverse != reverse
+        and transport_reverse == "hold"
+        and transport_face == "hold"
+        and transport_reverse != reverse
+        and transport_face != face
+        and two_reverse == "fail"
+        and two_face == "fail"
+        and two_frames_a == frames["A"]
+        and two_products_a[1] != products["A"][1]
+        and two_products_b[2] != products["B"][2]
+        and two_products_b[2] != "fail"
+        and products["B"][2] == "fail"
+        and THREE_AXIS_SEEDS != TWO_AXIS_SEEDS
+        and THREE_AXIS_SEEDS != TWO_SITE_SEEDS
+        and THREE_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and THREE_AXIS_SEEDS != LIVE_THREE_AXIS_SEEDS
+        and one_independence["A"] == "fail"
+        and same_independence["A"] == "fail"
+        and live_independence["A"] == "fail",
+    )
+    checks.check(
+        "mutations-differ",
+        leftover_reverse == "fail"
+        and leftover_face == "fail"
+        and reverse_m_alone == "hold"
+        and reverse_m_alone != reverse
+        and face_m_alone == "hold"
+        and reverse_o_alone == "hold"
+        and reverse_o_alone != reverse
+        and face_o_alone == "hold"
+        and m_exist_reverse == "hold"
+        and m_exist_face == "hold"
+        and o_exist_reverse == "hold"
+        and o_exist_face == "hold"
+        and m_exist_reverse != reverse
+        and unique_pos["A"] == "fail"
+        and unique_pos["B"] == "fail"
+        and unique_pos_reverse == "fail"
+        and unique_signed["A"] == 1
+        and unique_signed["B"] == 1
+        and unique_signed["C"] == "fail"
+        and lex["A"] == 1
+        and lex["B"] == -1
+        and lex["B"] != orient["B"]
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and leftover_pair["C"] == -1
+        and leftover_pair["D"] == 1
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and cyclic_small["C"] == 1
+        and cyclic_small["D"] == -1
+        and unsigned_orient["B"] == -1
+        and unsigned_orient["B"] != orient["B"]
+        and pair_present["A"] == "fail"
+        and pair_present["C"] == "hold"
+        and unique_plane["A"] == (NEG_E2, NEG_E3)
+        and unique_plane["B"] == (E2, NEG_E3)
+        and unique_plane["C"] == "fail"
+        and two_one["A"] == "fail"
+        and o1["A"] != m1["A"],
+    )
+    y_independence = {
+        name: path_independence(Y_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    x_independence = {
+        name: path_independence(X_PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    checks.check(
+        "not-x-or-y-probes-or-perp-or-zsym",
+        probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites
+        and y_independence["A"] == "fail"
+        and x_independence["A"] == "fail"
+        and THREE_AXIS_SEEDS != PERP_SEEDS
+        and THREE_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and incoming_set(
+            PROBES["B"], perp_ticks[PROBES["B"]] + 1, perp_ticks, perp_locks, perp_seeds
+        )
+        != m1["B"]
+        and incoming_set(
+            PROBES["C"], zsym_ticks[PROBES["C"]] + 1, zsym_ticks, zsym_locks, zsym_seeds
+        )
+        != m1["C"]
+        and sum(time == 0 for time in ysym_ticks.values()) == 3,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-M-O-F-products",
+        "t(A)=0" in note
+        and "t(B)=0" in note
+        and "t(C)=0" in note
+        and "t(D)=0" in note
+        and "M(A, τ) = {+e_1}" in note
+        and "M(B, τ) = {−e_1}" in note
+        and "M(C, τ) = {+e_2}" in note
+        and "M(D, τ) = {−e_2}" in note
+        and "O(A, τ) = {−e_2, −e_3}" in note
+        and "O(B, τ) = {+e_2, −e_3}" in note
+        and "O(C, τ) = {+e_1, −e_1, +e_3}" in note
+        and "O(D, τ) = {+e_1, −e_1, +e_3}" in note
+        and "split(A) = hold" in note
+        and "split(B) = hold" in note
+        and "F(A) = (+e_1, −e_2, −e_3)" in note
+        and "F(B) = (−e_1, +e_2, −e_3)" in note
+        and "F(C) = (+e_2, +e_3, −e_1)" in note
+        and "F(D) = (−e_2, +e_3, −e_1)" in note
+        and "Orient(A) = +1" in note
+        and "Orient(B) = +1" in note
+        and "Orient(C) = −1" in note
+        and "Orient(D) = +1" in note
+        and "product(A, e1e2e3) = fail" in note
+        and "product(A, e2e3e1) = [1 0 0; 0 -1 0; 0 0 -1]" in note
+        and "product(A, e3e1e2) = [1 0 0; 0 -1 0; 0 0 -1]" in note
+        and "product(B, e1e2e3) = fail" in note
+        and "product(B, e2e3e1) = fail" in note
+        and "product(B, e3e1e2) = fail" in note
+        and "product(C, e1e2e3) = fail" in note
+        and "product(D, e1e2e3) = fail" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse three-path cyclic-frame transport at τ: fail" in note
+        and "Face three-path cyclic-frame transport at τ: fail" in note
+        and "path-independence(A) = fail" in note
+        and "path-independence(B) = fail" in note
+        and "path-independence(C) = fail" in note
+        and "path-independence(D) = fail" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-cover-or-split-or-holonomy",
+        "Cover and split do not score handedness" in note
+        and "not leftover of nm2axz axis-cover" in normalized_note
+        and "not leftover of nm2ax12z 1-in 2-out split" in normalized_note
+        and "not leftover of nm2chiralz lexicographic" in normalized_note
+        and "not leftover of nm2orichz leftover-axis" in normalized_note
+        and "not leftover of nm2orionez lex-one" in normalized_note
+        and "not leftover of nm2oridetz unique signed" in normalized_note
+        and "not leftover of nm2oricyclz cyclic Orient" in normalized_note
+        and "not leftover of nm2cycfrmz cyclic-frame transport" in normalized_note
+        and "not leftover of nm2cycfrmfz far-face cyclic-frame transport" in normalized_note
+        and "not leftover of nm2cycfrmhol two-axis unit-square holonomy" in normalized_note
+        and "not leftover of nm2cycfrmholfz far-face unit-square holonomy" in normalized_note
+        and "not leftover of nm2frm3pth two-axis three-path" in normalized_note
+        and "not leftover of nm2frm3pfz far-face three-path" in normalized_note
+        and "not leftover of scalar neighbor-read" in normalized_note
+        and "O is not M" in note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "third pair is a new seed, not a formed child" in normalized_note,
+    )
+    checks.check(
+        "note-not-one-sided-or-leftover-empty",
+        "not leftover of leftover-of-`M` alone" in normalized_note
+        and "not leftover of leftover-of-`O` alone" in normalized_note
+        and "not leftover-empty fail" in normalized_note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse three-path cyclic-frame transport at τ: fail" in note
+        and "Face three-path cyclic-frame transport at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/THREE_AXIS_OPPOSITE_THREE_PATH_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "cyclic_signed_outgoing" in defined_fns
+        and "lex_largest_on_axis" in defined_fns
+        and "cyclic_units" in defined_fns
+        and "unique_signed_outgoing_plane" in defined_fns
+        and "leftover_pair_orient" in defined_fns
+        and "lex_frame_orient" in defined_fns
+        and "cyclic_lex_smallest_orient" in defined_fns
+        and "integer_det_columns" in defined_fns
+        and "frame_triple" in defined_fns
+        and "sending_matrix" in defined_fns
+        and "is_signed_permutation" in defined_fns
+        and "frame_transport" in defined_fns
+        and "scalar_orient_neighbor" in defined_fns
+        and "unique_positive_sending" in defined_fns
+        and "edge_sending" in defined_fns
+        and "path_independence" in defined_fns
+        and "path_product" in defined_fns
+        and "product_columns" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    checks.check(
+        "pathind-not-transport-or-holonomy-or-scalar",
+        reverse == "fail"
+        and face == "fail"
+        and transport_reverse == "hold"
+        and transport_face == "hold"
+        and holonomy_reverse == "hold"
+        and holonomy_face == "fail"
+        and split_reverse == "hold"
+        and cover_reverse == "hold"
+        and leftover_reverse == "fail"
+        and scalar_reverse == "hold"
+        and unique_pos_reverse == "fail"
+        and orient_reverse == "hold"
+        and orient_face == "fail"
+        and reverse_report(lex["A"], lex["B"]) == "fail"
+        and reverse_report(lex["B"], lex["C"]) == "hold"
+        and face_report(leftover_pair["C"], leftover_pair["D"]) == "fail"
+        and products["A"][1] != IDENTITY_COLUMNS
+        and products["A"][0] == "fail"
+        and products["B"] == ("fail", "fail", "fail"),
+    )
+    _ = (
+        unsigned_orient,
+        unique_pos_face,
+        face_m_alone,
+        face_o_alone,
+        reverse_o_alone,
+        reverse_m_alone,
+        two_one,
+        pair,
+        ysym_ticks,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Near-face 3-path reverse fails, face fails as two-axis #7549. Displayed, not adopted. FAIL=0. Not HOLDING_MEMBER.

## Runner

`scripts/three_axis_opposite_three_path_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.