### PR TITLE
feat(nm2frmpl): plane support of cyclic-frame transport on x=0 versus x=1 at t+1 on two-axis opposite seed: reverse fails, face fails

### DIFF
--- a/docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,899 @@
+---
+claim_id: two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Plane support of cyclic-frame transport on the x=0 versus x=1 formed sites in B_3 at t+1 on the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+---
+
+# X=0 Plane Support Of Cyclic-Frame Transport At t+1 Reverse And Face Versus The X=1 Plane On The Two-Axis Opposite Seed
+
+> **Key terms used in this doc** are indexed A-Z at `docs/KEY_TERMINOLOGY.md`;
+> each row points to the canonical source-of-truth doc.
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** plane support of cyclic-frame transport of `(m,o_next,o_prev)` of
+simultaneous earliest incoming set `M` and outgoing dual `O` at each formed
+site's `τ=t+1`, on the formed-at-τ sites of the `x=0` plane versus the `x=1`
+plane in `B_3(0)={n:n·n<=9}` of the two-axis opposite seed. Same process as
+nm2axz. Transport as nm2cycfrmz. `M`, `O`, split as nm2ax12z. Orient as
+nm2oricyclz (lex-largest cyclic); HOLDING cyclic #7451/#7452. Let `t(q)`
+be the formation tick of site `q`. Let `τ(q)=t(q)+1`. There is no global T.
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. Seeds are a singleton seed letter.
+`O(q,τ)` is the outgoing dual of `M`: the set of `e` in `{±e_1,±e_2,±e_3}`
+such that `q+e` is formed and `e` is in `M(q+e,τ)`. Unformed at `τ` is
+`UNDEFINED`. Empty `O` is empty, not `UNDEFINED`. Axis of a defined lock
+set `S` is `Axis(S)={e_i | some ±e_i in S}`. Cover HOLDs at `q` if and only
+if `Axis(M)` intersect `Axis(O)` is empty and `Axis(M)` union `Axis(O)`
+equals `{e_1,e_2,e_3}`. Split HOLDs at `q` if and only if cover HOLDs and
+`|Axis(M)|=1` (hence `|Axis(O)|=2`). When split HOLDs, `m` is unique in
+`M`. Let `i` in `{1,2,3}` be the axis index of `m`. `e_next = e_{i+1}`
+with `3+1→1`. `e_prev = e_{i-1}` with `1−1→3`. `O_next = O ∩ {±e_next}`.
+`O_prev = O ∩ {±e_prev}`. If either empty, Orient fails, not `UNDEFINED`.
+Order `+e < −e`. `o_next` is the lex-largest vector in `O_next` (hence
+`−e` if both signs). `o_prev` likewise. `Orient(q)` is the sign of the
+integer determinant of the 3×3 matrix with columns `m`, `o_next`,
+`o_prev`. If split fails, Orient fails, not `UNDEFINED`. When split
+HOLDs, `F(q)=(m,o_next,o_prev)` is an oriented lattice frame: a LIVE
+three-axis 1-in 2-out triple. Transport HOLDs at `q` if and only if split
+HOLDs at `q`, `Orient(q)` is `±1`, and some formed six-neighbor `r` has
+split HOLD, `Orient(r)` `±1`, and the 3×3 integer matrix sending the
+columns of `F(q)` to the columns of `F(r)` is a signed permutation with
+determinant `Orient(q)Orient(r)`. If split or Orient fails at `q`,
+transport fails, not `UNDEFINED`. Let Q0 = formed-at-τ sites q in B_3(0)
+with q_1=0. Let Q1 = formed-at-τ sites q in B_3(0) with q_1=1. A formed
+site is formed at its own `τ=t+1`. Empty Q0 or Q1 is fail, not UNDEFINED.
+Reverse HOLDs if and only if `Q0` is nonempty and transport HOLDs at every
+`q` in `Q0`. Face HOLDs if and only if `Q1` is nonempty and transport
+HOLDs at every `q` in `Q1`. Not a 6-NN forall. HOLDING transport #7490 on
+the four z-probes, HOLDING existential neighbor-read #7511, and universal
+6-NN neighbor-read fail/fail #7556 are leftover. Cover and split do not
+score handedness. This is not leftover of nm2cycfrmz cyclic-frame
+transport reverse HOLD whose sending inspects a signed permutation on
+four z-probes. This is not leftover of existential neighbor-read of
+transport. This is not leftover of universal 6-NN neighbor-read. This is
+not leftover of early-tick plane support whose `ticks<=1` restriction
+HOLDs on both planes. This is not leftover of equal transport bits
+including fail=fail. This is not leftover of nm2oricyclz cyclic Orient
+reverse HOLD whose bits are equal `±1` signs, not a signed-permutation
+sending. This is not leftover of scalar neighbor-read of Orient. This is
+not leftover of a unique nonnegative permutation sending. This is not
+leftover of nm2orichz leftover-axis reverse HOLD whose face fails because
+C and D swap `(m,pair)` columns. This is not leftover of nm2orionez
+lex-one reverse fail whose face HOLDs from `e1<e2<e3` order independent
+of `m`. This is not leftover of nm2chiralz lexicographic unsigned `o1,o2`
+orientation. This is not leftover of nm2oridetz unique signed outgoing
+letters. This is not leftover of nm2axz axis-cover. This is not leftover
+of nm2ax12z 1-in 2-out split. This is not leftover of leftover-of-`M`
+alone. This is not leftover of leftover-of-`O` alone. This is not
+leftover-empty fail of leftover axis. This is not leftover of nmunopp
+union. This is not leftover of nmt2opp `M` frozen at `t`. This is not
+leftover of nmot2opp two-tick composition. This is not leftover of
+nmoutopp untimed eventual-`O`. This is not leftover of mixed #7188
+fail/fail. This is not leftover of the 1-axis opposite two-site seed.
+This is not leftover of the same-lock two-site seed. The second pair is a
+new seed, not a formed child. Uniqueness is not required. Mixed remains a
+set. Displayed, not adopted. Do not write into Admissibility. Do not
+attach L1.
+**Audit-status authority:** independent audit lane only. This note authors no
+audit verdict and predicts none.
+**Primary runner:**
+[`scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`](../scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py)
+
+Framework input:
+
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies
+  cubic-lattice sites `Z^3` with nearest-neighbor adjacency, the one-site
+  algebra `M_2(C)`, and the Record sentences that records form and that a
+  present record locks exactly one admissible local possibility.
+
+Everything after that quoted input is a finite displayed process on `B_3(0)`
+and the formed sites of the `x=0` and `x=1` planes. Incoming lock letters are
+unit nearest-neighbor steps. `O` is the outgoing dual of those incoming sets
+at the per-site cut `τ=t+1`. Axis is the unsigned lattice direction of a
+signed lock. Cover is the complementary occupation of `{e_1,e_2,e_3}` by
+`Axis(M)` and `Axis(O)`. Split is cover together with `|Axis(M)|=1`. The
+cyclic next/prev lex-largest oriented frame is the integer sign of
+`det(m,o_next,o_prev)` with unique signed incoming letter `m` and the
+lex-largest signed outgoing letter on the cyclic next and prev axes of
+`Axis(M)` under `+e < −e`. When split HOLDs, `F=(m,o_next,o_prev)` is
+that LIVE three-axis frame. Transport is existential: some formed
+six-neighbor hosts a split-HOLDING frame whose columns are a signed
+permutation of the source columns with determinant the product of the
+two Orient signs. `Q0` and `Q1` are the formed-at-τ sites of those two
+planes. Reverse and face are scored on forall transport HOLD on `Q0` and
+on `Q1`. Occupancy of sites is not used. A six-neighbor star is not the
+letter. O is not M.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact report of plane support of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 on the formed-at-tau x=0 versus x=1 sites of the two-axis opposite seed, Q0, Q1, t and transport bit at each listed site, reverse fail and face fail from those plane foralls; uniqueness of a failing site is not claimed and the bits are not adopted."
+trace_class: frontier_discovery
+target_claim_id: two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face
+target_blocker_text: "display forall formed sites on the x=0 plane in B_3, transport HOLDs, versus the x=1 plane, not leftover of HOLDING z-probe transport #7490, not leftover of existential neighbor-read #7511, not leftover of universal 6-NN neighbor-read fail/fail #7556, not a 6-NN forall, not early-tick restriction, not scalar neighbor-read of Orient, not unique nonnegative sending, not leftover-axis, not lex-one e1<e2<e3, not unique |O_i|=1, not unsigned axis units, not cover, not split"
+source_of_blocker_text: handoff
+reachability_to_target: advances
+artifact_role: theorem
+next_trace_action: "Keep plane support of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 displayed; do not write plane support into Admissibility, do not reduce to 6-NN forall, do not reduce to nm2cycfrmz four-probe sending, do not reduce to existential neighbor-read, do not reduce to universal 6-NN neighbor-read, do not reduce to early-tick plane support, do not reduce to equal transport bit including fail, do not reduce to scalar neighbor-read of Orient, do not reduce to unique nonnegative permutation sending, do not reduce to unique signed |O_i|=1, do not reduce to lexicographic unsigned o1,o2, do not reduce to leftover-axis, do not reduce to lex-one signed e1<e2<e3, do not reduce to cyclic lex-smallest, do not reduce to cover, do not reduce to split, do not reduce to leftover-empty fail, do not reduce to leftover of M alone or leftover of O alone, do not replace plane support by unique outgoing letters, do not replace plane support by existential opposite of signed locks, do not replace plane support by six-neighbor lock union, and do not attach L1."
+conditional_surface_status: "exact on B_3(0) for plane support of cyclic-frame transport of (m,o_next,o_prev) of M and O at t+1 on the x=0 versus x=1 formed sites of the two-axis opposite seed and reverse/face from that plane support; displayed, not adopted"
+hypothetical_axiom_status: "no edit"
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Displayed process
+
+Write `e_1=(1,0,0)`, `e_2=(0,1,0)`, and `e_3=(0,0,1)`. The six nearest-neighbor
+steps are
+
+```text
+NN = {+e_1,-e_1,+e_2,-e_2,+e_3,-e_3}.
+```
+
+The finite host is the closed Euclidean ball of radius 3 centered at the
+origin,
+
+```text
+B_3(0) = { n in Z^3 : n·n <= 9 }.
+```
+
+No larger host is used. The scored sites are every formed site of the `x=0`
+plane and every formed site of the `x=1` plane. The four z-probes
+`A=(0,0,1)`, `B=(1,1,1)`, `C=(0,0,2)`, `D=(1,0,1)` sit inside those planes
+and are leftover of HOLDING transport #7490, not the object. These are not
+the y-probes `A=(0,1,0)`, `B=(1,1,1)`, `C=(0,2,0)`, `D=(1,1,0)`. These are
+not the x-probes `A=(1,0,0)`, `B=(1,1,1)`, `C=(2,0,0)`, `D=(1,1,0)`. Same
+process as nm2axz.
+
+Lock alphabet of the displayed process: `{±e_i}` with `i` in `{1,2,3}`.
+
+Seed: two disjoint opposite pairs recorded at formation tick 0. Origin
+locks `+e_1`. Site `(0,1,0)` locks `−e_1`. Site `(0,0,1)` locks `+e_2`.
+Site `(0,1,1)` locks `−e_2`. The second pair is a new seed, not a formed
+child of the first pair. This seed is not the 1-axis opposite two-site seed
+`{0,(0,1,0)}` with only `+e_1/−e_1`. This seed is not the perp two-site
+seed `+e_1/+e_2`. This seed is not the same-lock two-site seed
+`+e_1/+e_1`. This seed is not the z-symmetric three-site seed
+`{0,(0,0,1),(0,0,-1)}`. This seed is not the y-symmetric three-site seed
+that also records `(0,-1,0)` at tick 0.
+
+From a recorded site `p` with lock `L_in(p)=±e_i`, a six-neighbor step
+`s in NN` to `q=p+s` is allowed if and only if `s` is perpendicular to
+`e_i`, that is
+
+```text
+s · e_i = 0.
+```
+
+If `q` lies in `B_3(0)`, is still unformed, and the step is allowed, then `q`
+forms next and locks the incoming step `s`. If several allowed parents reach
+`q` at the same earliest formation, each such incoming step is kept. A later
+parent does not re-form `q`. Uniqueness is not required. Mixed remains a set.
+
+## Named plane support of cyclic-frame transport of `(m,o_next,o_prev)` at `τ=t+1`
+
+Let `t(q)` be the formation tick of site `q` when that tick is defined in
+`B_3(0)`. Let `τ(q)=t(q)+1`. There is no global T.
+
+`M(q,τ)` is the set of earliest incoming nearest-neighbor steps at `q`
+using only records with tick `<= τ`. If `q` is unformed at `τ`, then
+`M(q,τ)` is `UNDEFINED`. If `q` is a seed and `τ >= 0`, then `M(q,τ)` is
+the singleton seed letter.
+
+`O(q,τ)` is the outgoing dual of `M`:
+
+```text
+O(q,τ) = { e in {±e_1,±e_2,±e_3} | q+e formed and e in M(q+e,τ) }.
+```
+
+If `q` is unformed at `τ`, then `O(q,τ)` is `UNDEFINED`. Empty `O` is empty,
+not `UNDEFINED`. Duplicate steps collapse in the set. The construction does
+not require `O` to be a singleton. It does not sum either set. It does not
+replace `O` by `M`. It does not wait for a global later T. Occupancy of
+sites is not used. O is not M.
+
+Unsigned axis of a defined lock set:
+
+```text
+Axis(S) = { e_i | some ±e_i in S }.
+```
+
+Cover at a site at the same cut:
+
+```text
+cover(q) HOLDs iff Axis(M) intersect Axis(O) is empty
+and Axis(M) union Axis(O) equals {e_1,e_2,e_3}.
+```
+
+Split at a site at the same cut:
+
+```text
+split(q) HOLDs iff cover HOLDs and |Axis(M)|=1
+(hence |Axis(O)|=2).
+```
+
+2-in 1-out is fail of split, not UNDEFINED. If `q` is unformed at `τ`, then
+split is `UNDEFINED`.
+
+Oriented frame at the same cut:
+
+```text
+When split HOLDs, m is the unique signed letter in M.
+i in {1,2,3} is the axis index of m.
+e_next = e_{i+1} with 3+1→1. e_prev = e_{i-1} with 1−1→3.
+O_next = O ∩ {±e_next}. O_prev = O ∩ {±e_prev}.
+If either is empty, Orient fails, not UNDEFINED.
+Order +e < −e. o_next is lex-largest in O_next (hence −e if both signs).
+o_prev likewise.
+Orient(q) = sign of the integer determinant of columns (m, o_next, o_prev).
+Else fail, not UNDEFINED, if split fails.
+UNDEFINED if M or O is UNDEFINED.
+```
+
+Cyclic frame and transport at the same cut:
+
+```text
+When split HOLDs, F(q)=(m, o_next, o_prev).
+Transport HOLDs at q iff split HOLDs, Orient(q) is ±1,
+and some formed 6-NN r has split HOLD, Orient(r) ±1,
+and the 3×3 integer matrix P sending the columns of F(q)
+to the columns of F(r) (F(r)=F(q)P) is a signed permutation
+with det(P)=Orient(q)Orient(r).
+If split or Orient fails at q, transport fails, not UNDEFINED.
+UNDEFINED if M or O is UNDEFINED.
+Uniqueness of r is not required.
+
+Q0 = formed-at-τ sites q in B_3(0) with q_1=0.
+Q1 = formed-at-τ sites q in B_3(0) with q_1=1.
+A formed site is formed at its own τ=t(q)+1.
+Empty Q0 or Q1 is fail, not UNDEFINED.
+Reverse HOLDs iff Q0 is nonempty and transport HOLDs at every q in Q0.
+Face HOLDs iff Q1 is nonempty and transport HOLDs at every q in Q1.
+Not a 6-NN forall.
+Uniqueness of a failing q is not required.
+```
+
+HOLDING transport #7490 on the four z-probes HOLDs at `A,B,C,D` and is a
+different object: those four sites are a subset of `Q0 ∪ Q1`. Existential
+neighbor-read of HOLDING #7511 HOLDs if some formed six-neighbor has
+transport HOLD; that leftover HOLDs at each of the four z-probes. Universal
+6-NN neighbor-read fail/fail #7556 HOLDs at `q` iff transport HOLDs at `q`
+and every formed 6-NN in `N(q)` has transport HOLD; that leftover fails
+reverse and face on the four z-probes. Early-tick plane support restricts
+to `ticks<=1` and HOLDs on both planes; that leftover is not this letter.
+
+Reverse x=0 plane support of cyclic-frame transport holds if and only if
+`Q0` is nonempty and transport HOLDs at every site in `Q0`. Face x=1 plane
+support of cyclic-frame transport holds if and only if `Q1` is nonempty
+and transport HOLDs at every site in `Q1`. Empty Q0 or Q1 is fail, not
+UNDEFINED. Else if every listed transport HOLDs, reverse or face HOLDs.
+Else fail.
+
+Cover and split do not score handedness.
+
+## Theorem 1 — ticks, `Q0`, `Q1`, and transport bit at each listed site at `τ=t+1`
+
+On this process the `x=0` and `x=1` planes form inside `B_3(0)`. Compare to
+HOLDING transport #7490: the four z-probes all HOLD. Compare to existential
+neighbor-read #7511: some 6-NN HOLDs at each of those probes. Compare to
+universal 6-NN neighbor-read #7556: reverse fail and face fail from `N(q)`,
+not from a plane. This display reads the forall on formed-at-τ plane sites:
+
+```text
+|Q0|=27
+|Q1|=25
+hold-count(Q0) = 10
+fail-count(Q0) = 17
+hold-count(Q1) = 10
+fail-count(Q1) = 15
+t((0, -3, 0))=5
+transport((0, -3, 0)) = fail
+t((0, -2, -2))=4
+transport((0, -2, -2)) = fail
+t((0, -2, -1))=3
+transport((0, -2, -1)) = fail
+t((0, -2, 0))=4
+transport((0, -2, 0)) = fail
+t((0, -2, 1))=3
+transport((0, -2, 1)) = fail
+t((0, -2, 2))=4
+transport((0, -2, 2)) = fail
+t((0, -1, -2))=3
+transport((0, -1, -2)) = fail
+t((0, -1, -1))=2
+transport((0, -1, -1)) = fail
+t((0, -1, 0))=1
+transport((0, -1, 0)) = hold
+t((0, -1, 1))=2
+transport((0, -1, 1)) = fail
+t((0, -1, 2))=2
+transport((0, -1, 2)) = fail
+t((0, 0, -3))=5
+transport((0, 0, -3)) = fail
+t((0, 0, -2))=4
+transport((0, 0, -2)) = fail
+t((0, 0, -1))=1
+transport((0, 0, -1)) = hold
+t((0, 0, 0))=0
+transport((0, 0, 0)) = hold
+t((0, 0, 1))=0
+transport((0, 0, 1)) = hold
+t((0, 0, 2))=1
+transport((0, 0, 2)) = hold
+t((0, 1, -2))=4
+transport((0, 1, -2)) = fail
+t((0, 1, -1))=1
+transport((0, 1, -1)) = hold
+t((0, 1, 0))=0
+transport((0, 1, 0)) = hold
+t((0, 1, 1))=0
+transport((0, 1, 1)) = hold
+t((0, 1, 2))=1
+transport((0, 1, 2)) = hold
+t((0, 2, -2))=3
+transport((0, 2, -2)) = fail
+t((0, 2, -1))=2
+transport((0, 2, -1)) = fail
+t((0, 2, 0))=1
+transport((0, 2, 0)) = hold
+t((0, 2, 1))=2
+transport((0, 2, 1)) = fail
+t((0, 2, 2))=2
+transport((0, 2, 2)) = fail
+t((1, -2, -2))=5
+transport((1, -2, -2)) = fail
+t((1, -2, -1))=4
+transport((1, -2, -1)) = fail
+t((1, -2, 0))=3
+transport((1, -2, 0)) = hold
+t((1, -2, 1))=4
+transport((1, -2, 1)) = fail
+t((1, -2, 2))=4
+transport((1, -2, 2)) = fail
+t((1, -1, -2))=4
+transport((1, -1, -2)) = fail
+t((1, -1, -1))=3
+transport((1, -1, -1)) = fail
+t((1, -1, 0))=2
+transport((1, -1, 0)) = hold
+t((1, -1, 1))=2
+transport((1, -1, 1)) = hold
+t((1, -1, 2))=3
+transport((1, -1, 2)) = fail
+t((1, 0, -2))=3
+transport((1, 0, -2)) = hold
+t((1, 0, -1))=2
+transport((1, 0, -1)) = hold
+t((1, 0, 0))=2
+transport((1, 0, 0)) = fail
+t((1, 0, 1))=1
+transport((1, 0, 1)) = hold
+t((1, 0, 2))=2
+transport((1, 0, 2)) = fail
+t((1, 1, -2))=3
+transport((1, 1, -2)) = hold
+t((1, 1, -1))=2
+transport((1, 1, -1)) = hold
+t((1, 1, 0))=2
+transport((1, 1, 0)) = fail
+t((1, 1, 1))=1
+transport((1, 1, 1)) = hold
+t((1, 1, 2))=2
+transport((1, 1, 2)) = fail
+t((1, 2, -2))=4
+transport((1, 2, -2)) = fail
+t((1, 2, -1))=3
+transport((1, 2, -1)) = fail
+t((1, 2, 0))=2
+transport((1, 2, 0)) = fail
+t((1, 2, 1))=2
+transport((1, 2, 1)) = hold
+t((1, 2, 2))=3
+transport((1, 2, 2)) = fail
+fail-witness(Q0) = (0, -3, 0)
+fail-witness(Q1) = (1, -2, -2)
+```
+
+`A=(0,0,1)` and `C=(0,0,2)` lie in `Q0` with transport HOLD. `B=(1,1,1)`
+and `D=(1,0,1)` lie in `Q1` with transport HOLD. Those four HOLDING
+z-probes are leftover of #7490. First fail-witness in lex order on `Q0`
+is `(0,-3,0)` at tick 5. First fail-witness in lex order on `Q1` is
+`(1,-2,-2)` at tick 5. Uniqueness of a failing site is not required.
+Restricting to `ticks<=1` leaves ten `Q0` sites and two `Q1` sites, all
+with transport HOLD; that early-tick plane support is leftover, not this
+letter. The `x=3` slice of `B_3(0)` is empty of formed sites, so that
+empty plane is fail, not `UNDEFINED`. The `y=0` formed plane is a
+different slice and is not this letter. Mixed remains a set. O is not M.
+
+## Theorem 2 — reverse from x=0 plane support of cyclic-frame transport at `τ`
+
+Reverse x=0 plane support of cyclic-frame transport holds if and only if
+`Q0` is nonempty and transport HOLDs at every `q` in `Q0`. `Q0` has 27
+formed sites and 17 of them fail transport. Reverse fails. This is HOLD
+iff every formed-at-τ site on `x=0` transports, not leftover of HOLDING
+transport #7490 whose reverse HOLDs on `A` and `B`, not leftover of
+existential neighbor-read of HOLDING #7511 whose reverse HOLDs, not
+leftover of universal 6-NN neighbor-read fail/fail #7556 whose reverse
+fails from `N(B)` rather than from `(0,-3,0)`, not leftover of early-tick
+plane support whose reverse HOLDs, not leftover of equal transport bits
+including fail=fail, not leftover of nm2oricyclz cyclic Orient equal
+signs, not leftover of scalar neighbor-read, not leftover of a unique
+nonnegative permutation sending, not leftover of nm2chiralz lexicographic
+unsigned `o1,o2`, not leftover of nm2oridetz unique signed outgoing
+letters, not leftover of nm2orichz leftover-axis, not leftover of
+nm2orionez lex-one, not leftover of nm2axz axis-cover, not leftover of
+nm2ax12z 1-in 2-out split, not leftover-empty fail, and not
+exist-opposite.
+
+Reverse x=0 plane support of cyclic-frame transport at τ: fail
+
+Both sides are defined and `Q0` is nonempty, so this is not `UNDEFINED`.
+Cover reverse HOLDs because cover HOLDs at `A` and at `B`. Split reverse
+HOLDs because split HOLDs at `A` and at `B`. Cover and split do not score
+handedness. Transport reverse HOLDs because transport HOLDs at `A` and at
+`B`. Existential neighbor-read reverse HOLDs because existential
+neighbor-read HOLDs at `A` and at `B`. Universal 6-NN neighbor-read
+reverse fails because universal neighbor-read fails at `B`. This reverse
+fails because `(0,-3,0)` is a formed-at-τ site of the `x=0` plane whose
+transport fails. That failing site is not a 6-NN of `A`.
+
+Reverse fails.
+
+## Theorem 3 — face from x=1 plane support of cyclic-frame transport at `τ`
+
+Face x=1 plane support of cyclic-frame transport holds if and only if
+`Q1` is nonempty and transport HOLDs at every `q` in `Q1`. `Q1` has 25
+formed sites and 15 of them fail transport. Face fails.
+
+Face x=1 plane support of cyclic-frame transport at τ: fail
+
+Displayed, not adopted. The bits are not written into Admissibility.
+Do not write into Admissibility. Do not attach L1.
+
+Cover face HOLDs because cover HOLDs at `C` and at `D`. Split face HOLDs
+because split HOLDs at `C` and at `D`. Existential neighbor-read face
+HOLDs because existential neighbor-read HOLDs at `C` and at `D`. Transport
+face HOLDs because transport HOLDs at `C` and at `D`. Universal 6-NN
+neighbor-read face fails because universal neighbor-read fails at `C` and
+at `D`. This face fails because `(1,-2,-2)` is a formed-at-τ site of the
+`x=1` plane whose transport fails. Early-tick face HOLDs because the two
+`ticks<=1` sites of `Q1` are `D=(1,0,1)` and `B=(1,1,1)`, both with
+transport HOLD. Empty leftover does not make reverse `UNDEFINED`.
+Leftover-empty fail is not this reverse. On the 1-axis opposite two-site
+seed, both plane foralls fail. On the same-lock two-site seed, both plane
+foralls fail. On the LIVE three-axis three-site seed, both plane foralls
+fail. Those seeds are different members.
+
+Face fails.
+
+## What this note does not claim
+
+- It does not replace plane support of transport by HOLDING z-probe transport #7490.
+- It does not replace plane support of transport by existential neighbor-read of HOLDING #7511.
+- It does not replace plane support of transport by universal 6-NN neighbor-read fail/fail #7556.
+- It does not replace plane support by early-tick plane support on `ticks<=1`.
+- It does not replace plane support of transport by nm2cycfrmz signed-permutation sending on four z-probes.
+- It does not replace plane support by equal transport bits including fail=fail.
+- It does not replace plane support of transport by neighbor-read of the scalar Orient sign.
+- It does not replace plane support of transport by a unique nonnegative permutation sending.
+- It does not require a unique formed six-neighbor witness.
+- It does not reprint nm2oricyclz cyclic Orient reverse hold face hold as this plane support.
+- It does not select a unique outgoing or leftover lock.
+- It does not reduce lock vectors to named signs `{+,−}`.
+- It does not require outgoing sides to be singletons.
+- It does not sum either set.
+- It does not replace Orient by leftover-empty fail.
+- It does not replace Orient by leftover of `M` alone.
+- It does not replace Orient by leftover of `O` alone.
+- It does not replace Orient by existential opposite of signed locks.
+- It does not replace Orient by presence of an opposite pair in `O`.
+- It does not replace Orient by lexicographic unsigned `o1,o2` orientation.
+- It does not replace Orient by unique signed `|O_i|=1` letters.
+- It does not replace Orient by leftover-axis orientation.
+- It does not replace Orient by nm2orionez lex-one signed `e1<e2<e3`.
+- It does not replace Orient by cyclic lex-smallest (`+e` if both signs).
+- It does not replace Orient by unsigned axis units of `Axis(O)`.
+- It does not replace Orient by axis-cover without the frame sign.
+- It does not replace Orient by 1-in 2-out split without the frame sign.
+- It does not treat split fail as `UNDEFINED`.
+- It does not treat empty `O_i` as `UNDEFINED`.
+- It does not replace `O` by `M`.
+- It does not replace Orient by locks of six-neighbors.
+- It does not use a six-neighbor star as the letter.
+- It does not wait for a global later T.
+- It does not attach a formation member from already-recorded six-neighbor
+  locks.
+- It does not reprint nmsimopp exist-opposite of `M` and of `O` at `t+1`.
+- It does not reprint nmcover axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2axz axis-cover reverse hold face hold as this
+  oriented display.
+- It does not reprint nm2ax12z 1-in 2-out split reverse hold face hold as
+  this oriented display.
+- It does not reprint nm2chiralz lexicographic unsigned `o1,o2` reverse fail
+  face hold with `+1,+1` as this oriented display.
+- It does not reprint nm2oridetz unique signed reverse fail face fail as
+  this oriented display.
+- It does not reprint nm2orichz leftover-axis reverse hold face fail as
+  this oriented display.
+- It does not reprint nm2orionez lex-one reverse fail face hold as this
+  oriented display.
+- It does not reprint the 1-axis opposite two-site seed as this member.
+- It does not score the y-probes or the x-probes as this letter.
+- It does not reprint nmunopp untimed union.
+- It does not reprint nmt2opp `M` frozen at `t` as this oriented display.
+- It does not reprint nmot2opp two-tick composition of empty-then-HOLD `O`.
+- It does not reprint nmoutopp untimed eventual-`O`.
+- It does not reprint the two-tick lock-count clock composition.
+- It does not reprint mixed #7188 fail/fail as this member.
+- It does not use occupancy of sites as the letter.
+- It does not enlarge the host beyond `B_3(0)`.
+- It does not edit Lattice, Qubit, Admissibility, or Record.
+- It does not supply a physical rate or a continuum kernel.
+
+## Current premise boundary
+
+The Lattice, Qubit, Admissibility, and Record premises are quoted from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+Records form.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+The Admissibility reading note says the distribution concerns which possibility
+a forming record locks, conditional on formation at that site; it does not
+supply the formation site, probability, or rate.
+
+This display uses Lattice to name `B_3(0)` and the `x=0` and `x=1` planes. It
+uses Qubit only as the algebra of the local possibility domain. It uses Record
+only as a boundary: a present lock is content. It does not rewrite
+Admissibility. The two-axis opposite seed process, plane support of
+cyclic-frame transport of `(m,o_next,o_prev)` of `M` and `O` at `t+1`, and
+the reverse/face bits from that plane support are displayed theorem-domain
+data.
+
+## Exact target and obligation graph
+
+| Obligation | Status |
+|---|---|
+| current Lattice / Admissibility / Record premises | quoted; no edit |
+| perp-step incoming-lock process on `B_3(0)` | displayed; two-axis opposite seed `+e_1/−e_1` and `+e_2/−e_2` |
+| ticks of every formed-at-τ site in `Q0` and `Q1` | Theorem 1 |
+| transport bit of every formed-at-τ site in `Q0` and `Q1` | Theorem 1; 10 HOLD and 17 fail on `Q0`; 10 HOLD and 15 fail on `Q1` |
+| reverse from x=0 plane support of cyclic-frame transport at `τ` | Theorem 2; `fail` |
+| face from x=1 plane support of cyclic-frame transport at `τ` | Theorem 3; `fail` |
+| unique outgoing lock | not required |
+| occupancy of sites as the letter | not used |
+| named-sign `{+,−}` letter | not used; lost the axis |
+| singleton unique lock-vector letter | not used as the object; mixed remains a set |
+| `Z^3` sum of the lock set | not used; no aggregation |
+| six-neighbor star as the letter | not used |
+| leftover of HOLDING z-probe transport #7490 | not this plane forall |
+| leftover of existential neighbor-read of HOLDING #7511 | not this plane forall |
+| leftover of universal 6-NN neighbor-read fail/fail #7556 | not this plane forall |
+| leftover of early-tick plane support | not this plane forall |
+| leftover of nm2cycfrmz cyclic-frame transport sending | not this plane forall |
+| leftover of equal transport bits including fail=fail | not this plane forall |
+| leftover of scalar neighbor-read of Orient | not this plane forall |
+| leftover of unique nonnegative permutation sending | not this plane forall |
+| leftover of leftover-empty fail of leftover axis | not this oriented display |
+| leftover of exist-opposite HOLD | not this oriented display |
+| leftover of nmcover axis-cover HOLD | not this oriented display |
+| leftover of nm2axz axis-cover HOLD | not this oriented display |
+| leftover of nm2ax12z 1-in 2-out split HOLD | not this oriented display |
+| leftover of nm2chiralz lexicographic unsigned `o1,o2` | not this oriented display |
+| leftover of nm2oridetz unique signed `|O_i|=1` | not this oriented display |
+| leftover of nm2orichz leftover-axis | not this oriented display |
+| leftover of nm2orionez lex-one signed `e1<e2<e3` | not this oriented display |
+| leftover of cyclic lex-smallest | not this oriented display |
+| leftover of nm2oricyclz cyclic Orient equal signs | not this plane forall |
+| leftover of opposite-pair presence in `O` | not this oriented display |
+| y-probe or x-probe Orient on this seed | not this letter |
+| leftover of leftover-of-`M` alone | not this display |
+| leftover of leftover-of-`O` alone | not this display |
+| leftover of nmunopp untimed union | not this display |
+| leftover of nmt2opp `M` frozen at `t` | not this display |
+| leftover of nmot2opp two-tick composition | not this display |
+| leftover of nmoutopp untimed eventual-`O` | not this display |
+| two-tick lock-count clock composition | not this display |
+| leftover of mixed #7188 fail/fail | not this display |
+| leftover of the 1-axis opposite two-site seed | not this display |
+| leftover of the same-lock two-site seed | not this display; #7477 same-lock face transport fails |
+| leftover of the LIVE three-axis three-site seed | not this display; face transport fails |
+| split fail scored as `UNDEFINED` | refused; Orient fail |
+| empty `O_i` scored as `UNDEFINED` | refused; Orient fail |
+| empty `Q0` or empty `Q1` scored as `UNDEFINED` | refused; plane-support fail |
+| global later T | not used |
+| oriented frame as Admissibility content | not adopted |
+| formation site / probability / rate | open |
+| physical Record readout of the bits | open |
+
+## Value gate (V1–V5)
+
+| # | Answer |
+|---|---|
+| V1 | It answers the first-display question: forall formed sites on the x=0 plane in `B_3`, transport HOLDs, versus the x=1 plane, and reverse/face from that plane support. |
+| V2 | Current main has no landed x=0 versus x=1 plane support of cyclic-frame-transport reverse/face of timed `M` and `O` on the two-axis opposite seed. |
+| V3 | Plane-support reports at one cut and the two reverse/face bits are independently finite and exact. |
+| V4 | The theorem is more than a restatement of Record because it reads the transport HOLD bit at every formed-at-τ site of two named planes at the same `t+1` cut, reverse fails and face fails while four-probe transport reverse HOLDs and four-probe transport face HOLDs, existential neighbor-read reverse HOLDs and existential face HOLDs, universal 6-NN reverse fails from `N(q)` rather than from `(0,-3,0)`, and early-tick plane support HOLDs on both planes. |
+| V5 | It is not an adopted content rule: the bits remain displayed. |
+
+## No-go discipline gate
+
+The negative content is narrow: the display does not write those bits into
+Admissibility, does not reduce them to named signs, does not require a
+unique outgoing lock, does not replace Orient by leftover-empty fail, does
+not replace Orient by leftover of `M` alone or leftover of `O` alone, does
+not replace Orient by existential opposite of signed locks, does not
+replace Orient by presence of an opposite pair in `O`, does not replace
+Orient by nm2chiralz lexicographic unsigned `o1,o2`, does not replace
+Orient by nm2oridetz unique signed `|O_i|=1`, does not replace Orient by
+nm2orichz leftover-axis, does not replace Orient by nm2orionez lex-one,
+does not replace Orient by cyclic lex-smallest, does not replace Orient by
+nmcover axis-cover, does not replace Orient by nm2axz axis-cover, does not
+replace Orient by nm2ax12z 1-in 2-out split, does not identify this
+display with the 1-axis opposite two-site seed, and does not identify it
+with nmunopp union. No global impossibility is claimed.
+
+### N1 — materially distinct routes
+
+| Route | Attempt | Why it fails here | Marker |
+|---|---|---|---|
+| HOLDING z-probe transport #7490 | reuse transport HOLD at `A,B,C,D` | four-probe reverse HOLDs and four-probe face HOLDs; this reverse fails and this face fails from plane sites off those probes | ATTEMPTED |
+| existential neighbor-read of HOLDING #7511 | reuse some formed 6-NN with transport HOLD | existential HOLDs at `A,B,C,D` and reverse HOLDs and face HOLDs; this reverse fails and this face fails | ATTEMPTED |
+| universal 6-NN neighbor-read fail/fail #7556 | reuse every formed 6-NN in `N(q)` | universal reverse fails from `N(B)` containing `(1,1,2)`; this reverse fails from `(0,-3,0)`, which is not a 6-NN of `A`. Not a 6-NN forall | ATTEMPTED |
+| early-tick plane support | restrict `Q0` and `Q1` to `ticks<=1` | that restriction HOLDs reverse and face; this letter uses every formed-at-τ site | ATTEMPTED |
+| nm2cycfrmz cyclic-frame transport sending | reuse signed-permutation sending of `F(q)` to `F(r)` | sending inspects `P` at four z-probes; this plane forall requires every formed site of the plane to transport | ATTEMPTED |
+| equal transport bits including fail=fail | HOLD if some formed 6-NN has the same transport bit | at `(0,-1,1)` transport fails and a formed 6-NN also fails, so equal-bit HOLDs while plane support fails, not UNDEFINED | ATTEMPTED |
+| scalar neighbor-read of Orient | reuse equal Orient sign at some formed 6-NN | scalar HOLDs at `A` and fails at `B,C,D`; this reverse fails from a plane site, not from Orient sign | ATTEMPTED |
+| unique nonnegative permutation sending | require a unique sending with no minus signs | unique nonnegative sending fails at each of `A,B,C,D`; uniqueness is not required | ATTEMPTED |
+| nm2oricyclz cyclic Orient | reuse Orient reverse hold and face hold from equal `±1` signs | Orient reverse HOLDs and face HOLDs without a signed-permutation sending | ATTEMPTED |
+| nm2chiralz lexicographic unsigned `o1,o2` | reuse unsigned reverse fail and face hold | unsigned reverse fails as this reverse fails; unsigned face HOLDs while this face fails | ATTEMPTED |
+| nm2oridetz unique signed `|O_i|=1` | reuse unique signed reverse fail and face fail | unique signed reverse fails and face fails as these bits fail; an opposite pair in `O` makes `|O_i|≠1` | ATTEMPTED |
+| nm2orichz leftover-axis | reuse leftover-axis reverse hold and face fail | leftover-axis reverse HOLDs (`−1,−1`) while this reverse fails | ATTEMPTED |
+| nm2orionez lex-one | reuse lex-one reverse fail and face hold | lex-one reverse fails from `e1<e2<e3` order independent of `m` as this reverse fails; lex-one face HOLDs while this face fails | ATTEMPTED |
+| cyclic lex-smallest | reuse same cyclic axes with `+e` if both signs | lex-smallest reverse HOLDs with `+1,+1` and face HOLDs with `−1,−1` | ATTEMPTED |
+| nm2axz axis-cover | reuse cover reverse hold and cover face hold on these z-probes | cover HOLDs reverse and face without cyclic signed columns; this reverse fails and this face fails from plane sites | ATTEMPTED |
+| nm2ax12z 1-in 2-out split | reuse split reverse hold and split face hold | split HOLDs reverse and face without cyclic order of `Axis(M)`; Cover and split do not score handedness | ATTEMPTED |
+| leftover-empty fail | score reverse/face as leftover nonempty-equal | leftover reverse fails and leftover face fails as these bits fail, but leftover is unsigned unoccupied axes of `M` and `O`, not plane transport | ATTEMPTED |
+| leftover of `M` alone | score `{e_1,e_2,e_3}` minus `Axis(M)` | leftover of `M` is not plane transport | ATTEMPTED |
+| leftover of `O` alone | score `{e_1,e_2,e_3}` minus `Axis(O)` | leftover of `O` is not plane transport | ATTEMPTED |
+| exist-opposite across probes | reuse signed reverse hold and face hold of `M` and of `O` | exist-opposite reverse of signed `O` holds while this reverse fails | ATTEMPTED |
+| opposite-pair presence in `O` | score reverse/face as both sides containing some `e` and `−e` | pair-presence HOLDs at each of `A,B,C,D` without cyclic columns | ATTEMPTED |
+| nmunopp untimed union | score reverse/face from `M ∪ O` | union is signed letters; Orient is integer sign of unique signed incoming and cyclic lex-largest outgoing letters | ATTEMPTED |
+| unique outgoing letter | replace mixed `O` by a singleton or `UNDEFINED` | mixed `O` remains a set | ATTEMPTED |
+| unsigned incoming axis | replace signed `m` by the positive `Axis(M)` unit | flipping `m` on unique signed `O={+e_1,+e_3}` from `+e_2` to `−e_2` flips Orient | ATTEMPTED |
+| 2-in 1-out as `UNDEFINED` | treat `|Axis(M)|=2` cover as unformed | split fail is Orient fail, not UNDEFINED | ATTEMPTED |
+| empty `O_i` as `UNDEFINED` | treat empty signed outgoing on an axis as unformed | empty `O_i` is Orient fail, not UNDEFINED | ATTEMPTED |
+| empty plane as `UNDEFINED` | treat empty `Q0` or empty `Q1` as unformed | Empty Q0 or Q1 is fail, not UNDEFINED | ATTEMPTED |
+| 1-axis opposite two-site seed | reuse `t(A)=1`, `t(C)=4`, mixed `M(C)`, Orient fail at `C` | different seed; second pair is a new seed, not a formed child | ATTEMPTED |
+| y-probe Orient | score the four y-probes on this seed | this letter is the `x=0` versus `x=1` formed planes | ATTEMPTED |
+| x-probe Orient | score the four x-probes on this seed | this letter is the `x=0` versus `x=1` formed planes | ATTEMPTED |
+| two-tick lock-count clock | score a lock-count clock across two ticks | different member; this display scores plane forall of transport at `t+1` | ATTEMPTED |
+| mixed #7188 fail/fail | reuse z-symmetric mixed `M` reverse-fail face-fail | different process; this member reports plane-support reverse fail and face fail on the two-axis opposite seed | ATTEMPTED |
+| same-lock two-site seed | reuse `+e_1/+e_1` | different seed; this member is two disjoint opposite pairs | ATTEMPTED |
+| sum of a set | replace Orient by a `Z^3` sum | the construction does not sum | ATTEMPTED |
+| named-sign lettering | collapse `{±e_i}` to `{+,−}` | named-sign lettering lost the axis | ATTEMPTED |
+| global later T | wait until `max t` before reading | `τ(q)=t(q)+1` is per-site; no global T | ATTEMPTED |
+| attach a formation member from already-recorded six-neighbor locks | form the sites by a neighbor-lock letter instead of perp-step | refused; not attached | ATTEMPTED |
+| adopt bits into Admissibility | rewrite the local rule by the oriented frame | refused; displayed, not adopted | ATTEMPTED |
+
+### N2 — wall independence
+
+Missing physical adoption, missing identification of Orient with leftover of
+`M` alone, missing identification of Orient with leftover-empty fail, missing
+identification of Orient with existential opposite of signed locks, missing
+identification of Orient with presence of an opposite pair in `O`, missing
+identification of Orient with nm2chiralz lexicographic unsigned `o1,o2`,
+missing identification of Orient with nm2oridetz unique signed `|O_i|=1`,
+missing identification of Orient with nm2orichz leftover-axis, missing
+identification of Orient with nm2orionez lex-one, missing identification of
+Orient with cyclic lex-smallest, missing identification of Orient with
+nmcover axis-cover, missing identification of Orient with nm2axz axis-cover,
+missing identification of Orient with nm2ax12z 1-in 2-out split, missing
+identification of this seed with the 1-axis opposite two-site seed, and
+missing Record identification of plane support reverse are distinct open
+premises. This note claims no complete wall collection.
+
+### N3 — hidden-condition scan
+
+The host `B_3(0)`, two disjoint opposite seed pairs `+e_1/−e_1` and
+`+e_2/−e_2`, perpendicular step rule, incoming-step lock, own incoming set
+and own outgoing dual from records with tick `<= τ`, per-site `τ=t+1`,
+unsigned axis, cover as complementary occupation of `{e_1,e_2,e_3}`, split
+as cover and `|Axis(M)|=1`, unique signed `m` when split HOLDs, cyclic
+next/prev axes of `Axis(M)`, lex-largest signed outgoing letter under
+`+e < −e` (hence `−e` if both signs), integer determinant sign, empty
+`O_next` or empty `O_prev` as Orient fail not `UNDEFINED`, split fail as
+Orient fail not `UNDEFINED`, formed-at-τ sites of the `x=0` and `x=1`
+planes, empty plane as fail not `UNDEFINED`, second pair as a new seed not
+a formed child, and mixed remains a set are declared. No uniqueness of
+outgoing locks, no six-neighbor lock union as the scored object, no
+lock-count clock, no global later T, no formation attachment from
+already-recorded six-neighbor locks, and no Admissibility rewrite are
+silently assumed.
+
+### N4 — source residual matching
+
+The current axiom memo supplies cubic sites, `M_2(C)`,
+content-conditional-on-formation, and unreadable absence. The residual that
+formation site, probability, and rate remain unsupplied is unchanged. The
+plane-support `fail`/`hold` reports do not close that residual.
+
+### N5 — resolution and rhetoric audit
+
+| Resolution | Executed | Not claimed |
+|---|---|---|
+| per element | cyclic-frame transport at every formed-at-τ site on the x=0 and x=1 planes | no continuum alphabet |
+| per site | formed sites with `q_1=0` and `q_1=1` on `B_3(0)` | no other cubic slices as the letter |
+| per mode | no mode calculation | no spectral exhaustion |
+| per block | Q0/Q1 transport reports, reverse/face from those plane foralls | no adopted content law |
+| lattice wide | checked and not executed | no lattice-wide lettering rule |
+
+### N6 — live partial-closure paths
+
+Live routes include a later Record content map for plane support of
+cyclic-frame transport reverse/face, a formation-rate rule, and a
+physical selector among 1-in 2-out frames. None is taken here.
+
+### N7 — hostile steelman
+
+**Steelman:** Plane-support reverse fail and face fail are only leftover of
+universal 6-NN neighbor-read fail/fail #7556, or of HOLDING z-probe
+transport #7490, or of existential neighbor-read of HOLDING #7511, or of
+leftover-empty fail, or of nm2cycfrmz cyclic-frame transport sending, or
+of equal transport bits including fail=fail, or of nm2oricyclz cyclic
+Orient equal signs, or of neighbor-read of the scalar Orient sign, or of
+cover and split; leftover-axis already answers reverse HOLD; lex-one
+already answers face HOLD; unique signed `|O_i|=1` already answers mixed
+`O`; leftover of `M` alone already answers reverse; leftover of `O` alone
+already answers reverse; exist-opposite of signed `O` already answers
+reverse; mixed #7188 already reported fail/fail; the second pair is only
+the formed child `(0,0,1)` of the 1-axis seed; unique outgoing letters
+should be required; cyclic lex-smallest already gives the same HOLD bits
+with opposite signs; early-tick restriction already HOLDs on both planes;
+and unsigned incoming axis already gives the same signs because each `M`
+letter is the positive unit.
+
+**Answer:** Leftover empty is unsigned unoccupied directions of `M` and `O`
+together. Leftover-empty fail scores that empty leftover as reverse fail
+and face fail. Plane-support reverse fails because 17 of 27 formed-at-τ
+sites on `x=0` fail transport, with first fail-witness `(0,-3,0)`.
+Plane-support face fails because 15 of 25 formed-at-τ sites on `x=1` fail
+transport, with first fail-witness `(1,-2,-2)`. HOLDING transport #7490
+HOLDs at each of the four z-probes, so four-probe reverse HOLDs and
+four-probe face HOLDs; those four sites are a subset, not the plane.
+Existential neighbor-read of HOLDING #7511 HOLDs at each of the four
+z-probes, so existential reverse HOLDs and existential face HOLDs; that
+leftover reads some formed six-neighbor, not every formed site of a plane.
+Universal 6-NN neighbor-read fail/fail #7556 reverse fails from `N(B)`
+containing `(1,1,2)`; this reverse fails from `(0,-3,0)`, which is not a
+6-NN of `A`. Not a 6-NN forall. Early-tick plane support HOLDs reverse
+and face. Transport reverse HOLDs and transport face HOLDs from sending
+of `F` at `A,B` and at `C,D`. Scalar neighbor-read of Orient HOLDs only
+at `A` and fails at `B`, `C`, and `D`. HOLDING cyclic #7451/#7452 Orient
+reverse HOLDs from equal signs without a sending matrix. Unique
+nonnegative permutation sending fails at each probe. Cover and split HOLD
+reverse and face on this member and do not score cyclic signed columns.
+Leftover-axis reverse HOLDs with `−1,−1` and face fails with `+1,−1`
+because C and D swap `(m,pair)` columns. Lex-one reverse fails from
+`e1<e2<e3` order independent of `m`. Lexicographic unsigned `o1,o2`
+reverse fails with `−1,+1` and face HOLDs with `+1,+1`. Unique signed
+`|O_i|=1` reverse fails and face fails because each z-probe has an
+opposite pair in `O`. Cyclic lex-smallest reverse HOLDs with `+1,+1` and
+face HOLDs with `−1,−1`. Presence of an opposite pair in `O` HOLDs at each
+of the four z-probes without cyclic columns. Unique outgoing letters
+would assign `UNDEFINED` at mixed `O`; this Orient is a sign, not
+`UNDEFINED`. Mixed #7188 is a different z-symmetric process with mixed
+`M`. The second pair is a new seed, not a formed child: `(0,0,1)` is
+recorded at tick 0 with lock `+e_2`, whereas the 1-axis child forms at
+tick 1 with lock `+e_3`. Plane-support reverse is HOLD iff every
+formed-at-τ site on `x=0` transports, not leftover of existential
+neighbor-read and not leftover of leftover-axis and not leftover of
+nm2orionez lex-one.
+
+### N8 — cross-cycle echo
+
+nm2axz cover on this two-axis seed reported cover HOLD at each of the four
+z-probes, reverse hold, and face hold. nm2ax12z 1-in 2-out split on the
+same seed reported split HOLD at each of the four z-probes, reverse hold,
+and face hold. nm2chiralz lexicographic unsigned `o1,o2` on the same seed
+reported Orient `−1,+1,+1,+1`, reverse fail, and face hold. nm2oridetz
+unique signed outgoing letters on the same seed reported Orient fail at
+each probe, reverse fail, and face fail. nm2orichz leftover-axis on the
+same seed reported Orient `−1,−1,+1,−1`, reverse hold, and face fail
+because C and D swap `(m,pair)` columns. nm2orionez lex-one on the same
+seed reported Orient `−1,+1,−1,−1`, reverse fail, and face hold from
+`e1<e2<e3` order independent of `m`. Leftover axis reported empty leftover
+at each of four z-probes, leftover reverse fail, and leftover face fail.
+The four y-probes of this same seed reported cyclic Orient `+1` at `A`
+from `m=−e_1` and Orient fail at `D` from split fail, so y-reverse fails
+and y-face fails. nm2oricyclz cyclic next/prev lex-largest Orient on the
+same seed reported HOLDING cyclic #7451/#7452 with Orient `−1,−1,+1,+1`,
+reverse hold, and face hold from equal signs, without a sending matrix.
+nm2cycfrmz cyclic-frame transport on the same seed reported HOLDING
+transport #7490 at `A,B,C,D`, reverse hold, and face hold. Existential
+neighbor-read of that field reported HOLDING #7511 at each of those four
+probes. Universal 6-NN neighbor-read of that field reported fail/fail
+#7556. This note is not those displays: it reports plane support of
+cyclic-frame transport of `(m,o_next,o_prev)` of `M` and `O` at `τ=t+1`
+on the two-axis opposite seed, with `|Q0|=27`, `|Q1|=25`,
+`transport((0, -3, 0)) = fail`, `transport((1, -2, -2)) = fail`, reverse
+fail, and face fail, while four-probe transport HOLDs at `A,B,C,D`. Cover
+and split do not score handedness.
+
+**Gate disposition:** PASS for the plane-support of cyclic-frame-transport
+`t+1` reverse/face reports above. FAIL / DO NOT SHIP for “the predicate
+equals the named sign,” “the predicate equals the unique singleton lock
+vector,” “the predicate equals six-neighbor lock union,” “the predicate
+equals leftover-empty fail,” “the predicate equals leftover of `M`
+alone,” “the predicate equals leftover of `O` alone,” “the predicate
+equals exist-opposite HOLD,” “the predicate equals opposite-pair presence
+in `O`,” “the predicate equals nm2chiralz lexicographic unsigned `o1,o2`
+HOLD,” “the predicate equals nm2oridetz unique signed HOLD,” “the
+predicate equals nm2orichz leftover-axis HOLD,” “the predicate equals
+nm2orionez lex-one HOLD,” “the predicate equals cyclic lex-smallest HOLD,”
+“the predicate equals nm2oricyclz cyclic Orient HOLD,” “the predicate
+equals nm2cycfrmz cyclic-frame transport sending HOLD,” “the predicate
+equals existential neighbor-read HOLD,” “the predicate equals universal
+6-NN neighbor-read HOLD,” “the predicate equals early-tick plane support
+HOLD,” “the predicate equals equal transport bits including fail=fail
+HOLD,” “the predicate equals scalar neighbor-read of Orient HOLD,” “the
+predicate equals unique nonnegative permutation sending HOLD,” “the
+predicate equals nmcover axis-cover HOLD,” “the predicate equals nm2axz
+axis-cover HOLD,” “the predicate equals nm2ax12z 1-in 2-out split HOLD,”
+“the predicate equals the 1-axis opposite two-site seed,” “the predicate
+equals nmunopp union,” “bits are Admissibility,” “split fail is
+UNDEFINED,” “empty `O_i` is UNDEFINED,” or “empty `Q0` or empty `Q1` is
+UNDEFINED.”
+
+## Primary runner
+
+The paired runner builds Euclidean `B_3(0)`, runs the two-axis opposite
+perp-step incoming-lock process, reads each formed site's own earliest
+incoming set and own outgoing dual from the record prefix at that site's
+`t+1`, reports transport as nm2cycfrmz by a signed-permutation sending to
+some formed six-neighbor, lists every formed-at-τ site of the `x=0` plane
+and of the `x=1` plane with its formation tick and transport bit, and
+checks Theorems 1--3. It also checks that reverse fails and face fails
+from those plane foralls while four-probe transport reverse HOLDs and
+four-probe transport face HOLDs, that existential neighbor-read reverse
+HOLDs and existential face HOLDs, that universal 6-NN reverse fails and
+universal 6-NN face fails from `N(q)` rather than from the plane
+fail-witnesses, that early-tick plane support HOLDs on both planes, that
+empty `Q0` or empty `Q1` is fail not `UNDEFINED`, that unique nonnegative
+permutation sending fails at each probe, that HOLDING cyclic #7451/#7452
+Orient reverse HOLDs without being this plane support, that leftover-axis
+face fails because C and D swap `(m,pair)` columns and lex-one reverse
+fails from `e1<e2<e3` order independent of `m`, that transport fail at a
+plane site is plane-support fail not `UNDEFINED`, that equal transport
+bits including fail=fail HOLDs at `(0,-1,1)` while plane support fails,
+that empty `O_next` or empty `O_prev` is Orient fail not `UNDEFINED`, that
+the 1-axis opposite two-site seed is a different member, that #7477
+same-lock is a different member, that LIVE three-axis as a three-site seed
+is a different member, that leftover-empty fail is a different predicate,
+that leftover of `M` alone and leftover of `O` alone are different
+objects, that mixed sets remain sets, that the construction does not sum,
+that a formation member from already-recorded six-neighbor locks is not
+attached, that the second pair is a new seed not a formed child, that the
+y-probes and x-probes of this seed are not this letter, and that the
+display is not the two-tick lock-count clock composition. No runner cache
+is written.

--- a/logs/runner-cache/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,125 @@
+===== runner cache v1 =====
+runner: scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+runner_sha256: c0dbd1568dd9275d6807785f469f16366827f8c083c45c37e1520d54bed0de29
+input_fingerprint_sha256: 0463c122f683608b8ecc3a891f492eb87fbd6a60738339b91d81f61d7478fb0b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+x=0 plane support of cyclic-frame transport reverse/face at t+1
+AUDIT_INPUT_PATHS:
+  docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+claim_scope: Plane support of cyclic-frame transport on the x=0 versus x=1 formed sites in B_3 at t+1 on the two-axis opposite seed, and reverse/face from that, are reported. Displayed, not adopted.
+PASS: audit-input-paths-literal  (('docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md', 'docs/MINIMAL_AXIOMS_2026-06-29.md'))
+PASS: audit-input-paths-exist
+PASS: audit-timeout-declared
+PASS: host-is-b3-closed-ball
+PASS: four-z-probes-in-host
+PASS: host-is-euclidean-not-taxicab
+PASS: id-add-dot-perp
+PASS: det-identity
+PASS: sending-identity
+PASS: empty-plane-is-fail-not-undefined
+PASS: orient-identity
+|Q0|=27 hold=10 fail=17
+|Q1|=25 hold=10 fail=15
+Q0 (0, -3, 0) t=5 transport=fail
+Q0 (0, -2, -2) t=4 transport=fail
+Q0 (0, -2, -1) t=3 transport=fail
+Q0 (0, -2, 0) t=4 transport=fail
+Q0 (0, -2, 1) t=3 transport=fail
+Q0 (0, -2, 2) t=4 transport=fail
+Q0 (0, -1, -2) t=3 transport=fail
+Q0 (0, -1, -1) t=2 transport=fail
+Q0 (0, -1, 0) t=1 transport=hold
+Q0 (0, -1, 1) t=2 transport=fail
+Q0 (0, -1, 2) t=2 transport=fail
+Q0 (0, 0, -3) t=5 transport=fail
+Q0 (0, 0, -2) t=4 transport=fail
+Q0 (0, 0, -1) t=1 transport=hold
+Q0 (0, 0, 0) t=0 transport=hold
+Q0 (0, 0, 1) t=0 transport=hold
+Q0 (0, 0, 2) t=1 transport=hold
+Q0 (0, 1, -2) t=4 transport=fail
+Q0 (0, 1, -1) t=1 transport=hold
+Q0 (0, 1, 0) t=0 transport=hold
+Q0 (0, 1, 1) t=0 transport=hold
+Q0 (0, 1, 2) t=1 transport=hold
+Q0 (0, 2, -2) t=3 transport=fail
+Q0 (0, 2, -1) t=2 transport=fail
+Q0 (0, 2, 0) t=1 transport=hold
+Q0 (0, 2, 1) t=2 transport=fail
+Q0 (0, 2, 2) t=2 transport=fail
+Q1 (1, -2, -2) t=5 transport=fail
+Q1 (1, -2, -1) t=4 transport=fail
+Q1 (1, -2, 0) t=3 transport=hold
+Q1 (1, -2, 1) t=4 transport=fail
+Q1 (1, -2, 2) t=4 transport=fail
+Q1 (1, -1, -2) t=4 transport=fail
+Q1 (1, -1, -1) t=3 transport=fail
+Q1 (1, -1, 0) t=2 transport=hold
+Q1 (1, -1, 1) t=2 transport=hold
+Q1 (1, -1, 2) t=3 transport=fail
+Q1 (1, 0, -2) t=3 transport=hold
+Q1 (1, 0, -1) t=2 transport=hold
+Q1 (1, 0, 0) t=2 transport=fail
+Q1 (1, 0, 1) t=1 transport=hold
+Q1 (1, 0, 2) t=2 transport=fail
+Q1 (1, 1, -2) t=3 transport=hold
+Q1 (1, 1, -1) t=2 transport=hold
+Q1 (1, 1, 0) t=2 transport=fail
+Q1 (1, 1, 1) t=1 transport=hold
+Q1 (1, 1, 2) t=2 transport=fail
+Q1 (1, 2, -2) t=4 transport=fail
+Q1 (1, 2, -1) t=3 transport=fail
+Q1 (1, 2, 0) t=2 transport=fail
+Q1 (1, 2, 1) t=2 transport=hold
+Q1 (1, 2, 2) t=3 transport=fail
+plane-support reverse=fail face=fail
+fail-witness Q0=(0, -3, 0) Q1=(1, -2, -2)
+z-probe transport reverse=hold face=hold
+universal 6-NN reverse=fail face=fail
+existential 6-NN reverse=hold face=hold
+early-tick plane reverse=hold face=hold
+per_element: cyclic-frame transport at every formed-at-tau site on the x=0 and x=1 planes
+per_site: scored on formed sites with q_1=0 and q_1=1 in Euclidean B_3(0)
+per_mode: no spectral or mode calculation is executed on this finite host
+per_block: Q0/Q1 transport reports, reverse/face from those plane foralls
+lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed
+PASS: perp-step-incoming-lock
+PASS: undefined-if-unformed
+PASS: theorem1-Q0-Q1-sites  (|Q0|=27 |Q1|=25)
+PASS: theorem1-ticks-and-transport-bits
+PASS: theorem2-reverse-x0-plane-support-fail
+PASS: theorem3-face-x1-plane-support-fail
+PASS: not-6nn-forall-and-not-zprobe-transport
+PASS: cover-and-split-do-not-score-plane-support
+PASS: not-leftover-of-1-axis-or-same-lock-or-live
+PASS: formation-stays-in-host
+PASS: no-larger-ball
+PASS: note-claim-scope
+PASS: note-reports-Q0-Q1-transport
+PASS: note-reports-reverse-face
+PASS: note-displayed-not-adopted
+PASS: note-not-6nn-or-zprobe-leftovers
+PASS: note-not-two-tick-lock-count-clock
+PASS: note-not-mixed-7188-fail-fail
+PASS: note-no-global-T
+PASS: note-forbids-enlargement-and-cache
+PASS: note-forbidden-tokens-absent
+PASS: axiom-record-sentences-current
+PASS: note-quotes-current-premises
+PASS: note-machine-status-no-axiom-edit
+PASS: note-n-gates-present
+PASS: note-no-author-retained-verdict
+PASS: source-audit-paths-are-static-literals
+PASS: identity-gates-present
+PASS: source-formation-is-perp-step-queue
+TOTAL: PASS=40 FAIL=0
+
+----- stderr -----
+

--- a/scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,1994 @@
+#!/usr/bin/env python3
+"""x=0 plane support of cyclic-frame transport at t+1 reverse/face.
+
+Finite host: Euclidean ball of radius 3 centered at the origin. Seed at tick
+0 is two disjoint opposite pairs: origin locks +e_1, (0,1,0) locks -e_1,
+(0,0,1) locks +e_2, (0,1,1) locks -e_2. Same process as nm2axz. Perp-step
+incoming lock. M, O, split as nm2ax12z. Orient as nm2oricyclz (lex-largest
+cyclic). Transport as nm2cycfrmz (existential 6-NN sending). Unformed =>
+UNDEFINED. Let Q0 be the formed-at-tau sites q in B_3(0) with q_1=0. Let
+Q1 be the formed-at-tau sites q in B_3(0) with q_1=1. tau=t(q)+1 is
+per-site; a formed site is formed at that cut. Empty Q0 or Q1 is fail, not
+UNDEFINED. Reverse HOLDs iff Q0 is nonempty and transport HOLDs at every
+q in Q0. Face HOLDs iff Q1 is nonempty and transport HOLDs at every q in
+Q1. Not a 6-NN forall. HOLDING transport #7490 on four z-probes, HOLDING
+existential neighbor-read #7511, and universal 6-NN neighbor-read fail/fail
+#7556 are leftover. Uniqueness is not required. Occupancy of sites is not
+used. No larger host. Displayed, not adopted. Do not attach L1.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+AUDIT_INPUT_PATHS = (
+    "docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+
+Point = tuple[int, int, int]
+Incoming = frozenset[Point] | str
+Outgoing = frozenset[Point] | str
+AxisSet = frozenset[Point] | str
+OrientVal = int | str
+FrameVal = tuple[Point, Point, Point] | str
+Sending = tuple[Point, Point, Point] | str
+ORIGIN: Point = (0, 0, 0)
+ZERO: Point = (0, 0, 0)
+E1: Point = (1, 0, 0)
+E2: Point = (0, 1, 0)
+E3: Point = (0, 0, 1)
+NEG_E1: Point = (-1, 0, 0)
+NEG_E2: Point = (0, -1, 0)
+NEG_E3: Point = (0, 0, -1)
+PAIR2: Point = (0, 1, 1)
+NN: tuple[Point, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+AXES: tuple[Point, ...] = (E1, E2, E3)
+BALL_SQ = 9
+TWO_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (E3, E2),
+    (PAIR2, NEG_E2),
+)
+TWO_SITE_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+)
+PERP_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+)
+SAME_LOCK_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E1),
+)
+Z_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E3, NEG_E1),
+    (NEG_E3, NEG_E1),
+)
+Y_SYMMETRIC_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, NEG_E1),
+    (NEG_E2, NEG_E1),
+)
+LIVE_THREE_AXIS_SEEDS: tuple[tuple[Point, Point], ...] = (
+    (ORIGIN, E1),
+    (E2, E2),
+    (E3, E3),
+)
+PROBES = {
+    "A": (0, 0, 1),
+    "B": (1, 1, 1),
+    "C": (0, 0, 2),
+    "D": (1, 0, 1),
+}
+Y_PROBES = {
+    "A": (0, 1, 0),
+    "B": (1, 1, 1),
+    "C": (0, 2, 0),
+    "D": (1, 1, 0),
+}
+X_PROBES = {
+    "A": (1, 0, 0),
+    "B": (1, 1, 1),
+    "C": (2, 0, 0),
+    "D": (1, 1, 0),
+}
+LOCK_NAME = {
+    E1: "+e_1",
+    NEG_E1: "−e_1",
+    E2: "+e_2",
+    NEG_E2: "−e_2",
+    E3: "+e_3",
+    NEG_E3: "−e_3",
+}
+AXIS_NAME = {
+    E1: "e_1",
+    E2: "e_2",
+    E3: "e_3",
+}
+FORBIDDEN_NOTE_TOKENS = (
+    "G_N",
+    "1/r",
+    "1/r^2",
+    "Lattice-named",
+    "not a TOE",
+    "Dijkstra",
+    "Gram",
+    "P_+",
+    "S^+",
+    "Cl(3,0)",
+    "Runner cache",
+    "ndot",
+)
+CLAIM_SCOPE = (
+    "Plane support of cyclic-frame transport on the x=0 versus x=1 formed "
+    "sites in B_3 at t+1 on the two-axis opposite seed, and reverse/face from "
+    "that, are reported. Displayed, not adopted."
+)
+UNDEFINED = "UNDEFINED"
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Point, right: Point) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def in_ball(site: Point) -> bool:
+    return dot(site, site) <= BALL_SQ
+
+
+def ball_sites() -> frozenset[Point]:
+    return frozenset(
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if in_ball((x, y, z))
+    )
+
+
+def perpendicular(lock: Point, step: Point) -> bool:
+    return dot(lock, step) == 0
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def axis_of_letter(lock: Point) -> Point:
+    return (abs(lock[0]), abs(lock[1]), abs(lock[2]))
+
+
+def set_display(locks: frozenset[Point]) -> str:
+    if not locks:
+        return "{}"
+    names = ", ".join(LOCK_NAME[lock] for lock in NN if lock in locks)
+    return "{" + names + "}"
+
+
+def axis_display(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    if not value:
+        return "{}"
+    names = ", ".join(AXIS_NAME[axis] for axis in AXES if axis in value)
+    return "{" + names + "}"
+
+
+def lockset_display(value: Incoming) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    return set_display(value)
+
+
+def axis_card(value: AxisSet) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"axis set is not an axis set: {value!r}")
+    return str(len(value))
+
+
+def orient_display(value: OrientVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if value == 1:
+        return "+1"
+    if value == -1:
+        return "−1"
+    raise TypeError(f"orient is not a signed unit or fail: {value!r}")
+
+
+def pair_display(value: tuple[Point, Point] | str) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple):
+        raise TypeError(f"signed pair is not a pair or fail: {value!r}")
+    return ", ".join(LOCK_NAME[vec] for vec in value)
+
+
+def frame_display(value: FrameVal) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"frame is not a triple or fail: {value!r}")
+    return "(" + ", ".join(LOCK_NAME[vec] for vec in value) + ")"
+
+
+def matrix_display(value: Sending) -> str:
+    if value == UNDEFINED:
+        return UNDEFINED
+    if value == "fail":
+        return "fail"
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise TypeError(f"sending is not three columns or fail: {value!r}")
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return "[" + "; ".join(" ".join(str(entry) for entry in row) for row in rows) + "]"
+
+
+def assignment_string_tuple(tree: ast.AST, name: str) -> tuple[str, ...] | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    value = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    return None
+                if isinstance(value, tuple) and all(
+                    isinstance(item, str) for item in value
+                ):
+                    return value
+                return None
+    return None
+
+
+def form(
+    seeds: tuple[tuple[Point, Point], ...] = TWO_AXIS_SEEDS,
+    *,
+    require_perp: bool = True,
+) -> tuple[dict[Point, int], dict[Point, set[Point]], dict[Point, Point]]:
+    """Earliest formation ticks and incoming locks on B_3(0)."""
+    ticks: dict[Point, int] = {site: 0 for site, _lock in seeds}
+    locks: dict[Point, set[Point]] = {site: {lock} for site, lock in seeds}
+    seed_map: dict[Point, Point] = {site: lock for site, lock in seeds}
+    queue: deque[tuple[Point, int]] = deque((site, 0) for site, _lock in seeds)
+    while queue:
+        parent, parent_tick = queue.popleft()
+        for lock in tuple(locks[parent]):
+            for step in NN:
+                if require_perp and not perpendicular(lock, step):
+                    continue
+                child = add(parent, step)
+                if not in_ball(child):
+                    continue
+                next_tick = parent_tick + 1
+                if child not in ticks:
+                    ticks[child] = next_tick
+                    locks[child] = {step}
+                    queue.append((child, next_tick))
+                elif ticks[child] == next_tick:
+                    locks[child].add(step)
+    return ticks, locks, seed_map
+
+
+def incoming_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Incoming:
+    """Earliest incoming NN steps at site using only records with tick <= tau."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    if site in seed_map:
+        return frozenset({seed_map[site]})
+    arrivals: dict[int, set[Point]] = {}
+    for step in NN:
+        parent = sub(site, step)
+        if parent not in ticks or ticks[parent] > tau:
+            continue
+        if any(perpendicular(lock, step) for lock in locks[parent]):
+            arrivals.setdefault(ticks[parent] + 1, set()).add(step)
+    if not arrivals:
+        return frozenset()
+    earliest = min(arrivals)
+    return frozenset(arrivals[earliest])
+
+
+def outgoing_set(
+    site: Point,
+    tau: int,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Outgoing:
+    """Outgoing dual of M. Unformed at tau => UNDEFINED. Empty O is empty."""
+    if site not in ticks or ticks[site] > tau:
+        return UNDEFINED
+    outgoing: set[Point] = set()
+    for step in NN:
+        neighbor = add(site, step)
+        if not in_ball(neighbor):
+            continue
+        incoming = incoming_set(neighbor, tau, ticks, locks, seed_map)
+        if incoming == UNDEFINED:
+            continue
+        if not isinstance(incoming, frozenset):
+            raise TypeError(f"incoming is not a lock set: {incoming!r}")
+        if step in incoming:
+            outgoing.add(step)
+    return frozenset(outgoing)
+
+
+def axis_set(value: Incoming) -> AxisSet:
+    """Unsigned lattice axes occupied by signed locks. UNDEFINED if unformed."""
+    if value == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(value, frozenset):
+        raise TypeError(f"lock set is not a lock set: {value!r}")
+    occupied: set[Point] = set()
+    for lock in value:
+        axis = axis_of_letter(lock)
+        if axis not in AXES:
+            raise ValueError(f"lock is not a six-neighbor step: {lock!r}")
+        occupied.add(axis)
+    return frozenset(occupied)
+
+
+def leftover_axis(incoming: Incoming, outgoing: Outgoing) -> AxisSet:
+    """Leftover-empty contrast: {e_1,e_2,e_3} minus (Axis(M) union Axis(O))."""
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    return frozenset(AXES) - (axes_m | axes_o)
+
+
+def leftover_of_one(value: Incoming) -> AxisSet:
+    """One-sided leftover contrast. Not this letter."""
+    occupied = axis_set(value)
+    if occupied == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(occupied, frozenset):
+        raise TypeError("one-sided leftover needs an axis set")
+    return frozenset(AXES) - occupied
+
+
+def leftover_match(left: AxisSet, right: AxisSet) -> str:
+    """Leftover-empty fail contrast. Empty leftover => fail, not UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("leftover sides must be axis sets or UNDEFINED")
+    if not left or not right:
+        return "fail"
+    if left == right:
+        return "hold"
+    return "fail"
+
+
+def axis_cover(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff axes disjoint and union is {e_1,e_2,e_3}. UNDEFINED if unformed."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or not isinstance(outgoing, frozenset):
+        return UNDEFINED
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if axes_m == UNDEFINED or axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets or UNDEFINED")
+    if axes_m & axes_o:
+        return "fail"
+    if axes_m | axes_o != frozenset(AXES):
+        return "fail"
+    return "hold"
+
+
+def axis_split(incoming: Incoming, outgoing: Outgoing) -> str:
+    """HOLD iff cover HOLD and |Axis(M)|=1 (hence |Axis(O)|=2)."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) != 1:
+        return "fail"
+    if len(axes_o) != 2:
+        return "fail"
+    return "hold"
+
+
+def two_in_one_out(incoming: Incoming, outgoing: Outgoing) -> str:
+    """Cover HOLD with |Axis(M)|=2. Not UNDEFINED."""
+    cover = axis_cover(incoming, outgoing)
+    if cover == UNDEFINED:
+        return UNDEFINED
+    if cover != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    axes_o = axis_set(outgoing)
+    if not isinstance(axes_m, frozenset) or not isinstance(axes_o, frozenset):
+        raise TypeError("axis sides must be axis sets")
+    if len(axes_m) == 2 and len(axes_o) == 1:
+        return "hold"
+    return "fail"
+
+
+def integer_det_columns(col1: Point, col2: Point, col3: Point) -> int:
+    """Integer determinant of the 3x3 matrix with those columns."""
+    a11, a21, a31 = col1
+    a12, a22, a32 = col2
+    a13, a23, a33 = col3
+    return (
+        a11 * (a22 * a33 - a23 * a32)
+        - a12 * (a21 * a33 - a23 * a31)
+        + a13 * (a21 * a32 - a22 * a31)
+    )
+
+
+def outgoing_plane(axes_o: AxisSet) -> tuple[Point, Point] | str:
+    """Two Axis(O) unit vectors in axis order e1<e2<e3. Mutation: unsigned."""
+    if axes_o == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes_o, frozenset):
+        raise TypeError("outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes_o)
+    if len(ordered) != 2:
+        return "fail"
+    return ordered[0], ordered[1]
+
+
+def unique_signed_m(incoming: Incoming) -> Point | str:
+    """Unique signed incoming letter. Else fail, not UNDEFINED."""
+    if incoming == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(incoming, frozenset) or len(incoming) != 1:
+        return "fail"
+    letter = next(iter(incoming))
+    if letter not in LOCK_NAME:
+        return "fail"
+    return letter
+
+
+def unique_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Unique signed outgoing letter per Axis(O). Fail if |O_i| != 1."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("unique signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if len(occupied) != 1:
+            return "fail"
+        picked.append(next(iter(occupied)))
+    return picked[0], picked[1]
+
+
+def lex_signed_outgoing_plane(outgoing: Outgoing) -> tuple[Point, Point] | str:
+    """Lex-smallest signed letter per Axis(O) under +e_i < -e_i. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    axes = axis_set(outgoing)
+    if axes == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(axes, frozenset):
+        raise TypeError("lex signed outgoing plane needs an axis set")
+    ordered = tuple(axis for axis in AXES if axis in axes)
+    if len(ordered) != 2:
+        return "fail"
+    picked: list[Point] = []
+    for axis in ordered:
+        negative = (-axis[0], -axis[1], -axis[2])
+        occupied = outgoing & {axis, negative}
+        if not occupied:
+            return "fail"
+        if axis in occupied:
+            picked.append(axis)
+        else:
+            picked.append(negative)
+    return picked[0], picked[1]
+
+
+def axis_index(lock: Point) -> int | str:
+    """Axis index i in {1,2,3} of a signed nearest-neighbor letter."""
+    axis = axis_of_letter(lock)
+    if axis == E1:
+        return 1
+    if axis == E2:
+        return 2
+    if axis == E3:
+        return 3
+    return "fail"
+
+
+def cyclic_units(signed_m: Point) -> tuple[Point, Point] | str:
+    """e_next = e_{i+1} with 3+1->1. e_prev = e_{i-1} with 1-1->3."""
+    idx = axis_index(signed_m)
+    if idx == "fail" or not isinstance(idx, int):
+        return "fail"
+    e_next = AXES[idx % 3]
+    e_prev = AXES[idx - 2]
+    return e_next, e_prev
+
+
+def lex_largest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-largest signed letter in O intersect {+/-axis}. Order +e < -e."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if negative in occupied:
+        return negative
+    return axis
+
+
+def lex_smallest_on_axis(outgoing: Outgoing, axis: Point) -> Point | str:
+    """Lex-smallest signed letter in O intersect {+/-axis}. Mutation."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    negative = (-axis[0], -axis[1], -axis[2])
+    occupied = outgoing & {axis, negative}
+    if not occupied:
+        return "fail"
+    if axis in occupied:
+        return axis
+    return negative
+
+
+def cyclic_signed_outgoing(
+    incoming: Incoming, outgoing: Outgoing, *, largest: bool = True
+) -> tuple[Point, Point] | str:
+    """o_next, o_prev on the two cyclic axes of Axis(M). Empty slot is fail."""
+    if incoming == UNDEFINED or outgoing == UNDEFINED:
+        return UNDEFINED
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    units = cyclic_units(signed_m)
+    if units == "fail" or not isinstance(units, tuple):
+        return "fail"
+    picker = lex_largest_on_axis if largest else lex_smallest_on_axis
+    o_next = picker(outgoing, units[0])
+    o_prev = picker(outgoing, units[1])
+    if o_next == UNDEFINED or o_prev == UNDEFINED:
+        return UNDEFINED
+    if o_next == "fail" or o_prev == "fail":
+        return "fail"
+    if not isinstance(o_next, tuple) or not isinstance(o_prev, tuple):
+        return "fail"
+    return o_next, o_prev
+
+
+def opposite_pair_unit(outgoing: Outgoing) -> Point | str:
+    """Positive unit of the smallest-index axis with both e and -e in O."""
+    if outgoing == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(outgoing, frozenset):
+        raise TypeError(f"outgoing is not a lock set: {outgoing!r}")
+    for axis in AXES:
+        negative = (-axis[0], -axis[1], -axis[2])
+        if axis in outgoing and negative in outgoing:
+            return axis
+    return "fail"
+
+
+def leftover_unit(signed_m: Point, pair_unit: Point) -> Point | str:
+    """Unique Axis not in {axis(m), axis(e)}, oriented as the unit +l."""
+    occupied = {axis_of_letter(signed_m), axis_of_letter(pair_unit)}
+    leftover = tuple(axis for axis in AXES if axis not in occupied)
+    if len(leftover) != 1:
+        return "fail"
+    return leftover[0]
+
+
+def has_opposite_pair(outgoing: Outgoing) -> str:
+    """HOLD iff O contains some e and -e. Fail if none. UNDEFINED if unformed."""
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    return "hold"
+
+
+def lex_frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Lexicographic unsigned o1,o2 orientation. Mutation: not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = outgoing_plane(axis_set(outgoing))
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o1, o2 = plane
+    det = integer_det_columns(signed_m, o1, o2)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def leftover_pair_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: sign of det(m, e, +l). Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    pair = opposite_pair_unit(outgoing)
+    if pair == UNDEFINED:
+        return UNDEFINED
+    if pair == "fail":
+        return "fail"
+    if not isinstance(pair, tuple):
+        return "fail"
+    leftover = leftover_unit(signed_m, pair)
+    if leftover == "fail" or not isinstance(leftover, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, pair, leftover)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def unique_signed_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: unique |O_i|=1 signed plane. Fail if an opposite pair occupies O_i."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = unique_signed_outgoing_plane(outgoing)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def cyclic_lex_smallest_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: same cyclic axes, lex-smallest (+e if both signs)."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=False)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(signed_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Sign of det(m, o_next, o_prev) with lex-largest cyclic slots."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail":
+        return "fail"
+    if not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail":
+        return "fail"
+    if not isinstance(plane, tuple):
+        return "fail"
+    o_next, o_prev = plane
+    det = integer_det_columns(signed_m, o_next, o_prev)
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+def frame_triple(incoming: Incoming, outgoing: Outgoing) -> FrameVal:
+    """F=(m,o_next,o_prev) when split HOLDs. Else fail, not UNDEFINED unless unformed."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    signed_m = unique_signed_m(incoming)
+    if signed_m == UNDEFINED:
+        return UNDEFINED
+    if signed_m == "fail" or not isinstance(signed_m, tuple):
+        return "fail"
+    plane = cyclic_signed_outgoing(incoming, outgoing, largest=True)
+    if plane == UNDEFINED:
+        return UNDEFINED
+    if plane == "fail" or not isinstance(plane, tuple):
+        return "fail"
+    return signed_m, plane[0], plane[1]
+
+
+def transpose_columns(frame: tuple[Point, Point, Point]) -> tuple[Point, Point, Point]:
+    """Columns of the transpose. Inverse on signed permutation frames."""
+    return tuple(tuple(frame[column][row] for column in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def mul_columns(
+    left: tuple[Point, Point, Point], right: tuple[Point, Point, Point]
+) -> tuple[Point, Point, Point]:
+    """Integer matrix product of two column-triple matrices."""
+    return tuple(
+        tuple(
+            sum(left[k][i] * right[j][k] for k in range(3)) for i in range(3)
+        )
+        for j in range(3)
+    )  # type: ignore[return-value]
+
+
+def sending_matrix(source: FrameVal, target: FrameVal) -> Sending:
+    """Integer matrix P with F(r) = F(q) P, sending columns of F(q) to F(r)."""
+    if source == UNDEFINED or target == UNDEFINED:
+        return UNDEFINED
+    if source == "fail" or target == "fail":
+        return "fail"
+    if not isinstance(source, tuple) or not isinstance(target, tuple):
+        return "fail"
+    return mul_columns(transpose_columns(source), target)
+
+
+def is_signed_permutation(value: Sending) -> bool:
+    """Exactly one nonzero +/-1 in each row and each column."""
+    if not isinstance(value, tuple) or len(value) != 3:
+        return False
+    for column in value:
+        if any(entry not in (-1, 0, 1) for entry in column):
+            return False
+        if sum(abs(entry) for entry in column) != 1:
+            return False
+    rows = tuple(tuple(value[j][i] for j in range(3)) for i in range(3))
+    return all(sum(abs(entry) for entry in row) == 1 for row in rows)
+
+
+def sending_holds(
+    source: FrameVal, target: FrameVal, orient_q: OrientVal, orient_r: OrientVal
+) -> str:
+    """HOLD iff P is a signed permutation with det = Orient(q)Orient(r)."""
+    sending = sending_matrix(source, target)
+    if sending == UNDEFINED:
+        return UNDEFINED
+    if sending == "fail" or not isinstance(sending, tuple):
+        return "fail"
+    if orient_q not in (1, -1) or orient_r not in (1, -1):
+        return "fail"
+    det = integer_det_columns(sending[0], sending[1], sending[2])
+    if is_signed_permutation(sending) and det == orient_q * orient_r:
+        return "hold"
+    return "fail"
+
+
+def is_nonnegative_permutation(value: Sending) -> bool:
+    """Unsigned permutation: signed permutation with no minus signs. Mutation."""
+    if not is_signed_permutation(value):
+        return False
+    if not isinstance(value, tuple):
+        return False
+    return all(entry >= 0 for column in value for entry in column)
+
+
+def site_sides(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Incoming, Outgoing]:
+    if site not in ticks:
+        return UNDEFINED, UNDEFINED
+    tau = ticks[site] + 1
+    return (
+        incoming_set(site, tau, ticks, locks, seed_map),
+        outgoing_set(site, tau, ticks, locks, seed_map),
+    )
+
+
+def formed_six_neighbors(site: Point, ticks: dict[Point, int]) -> tuple[Point, ...]:
+    """Formed 6-NN of site in B_3(0). Not a six-neighbor star letter."""
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def formed_neighbors_at_tau(site: Point, ticks: dict[Point, int]) -> tuple[Point, ...]:
+    """N(q): formed 6-NN of q that lie in B_3(0) at tau=t(q)+1."""
+    if site not in ticks:
+        return ()
+    tau = ticks[site] + 1
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] <= tau:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def frame_transport(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff split HOLD, Orient +/-1, and some formed 6-NN r transports."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_transport_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[Point, Sending] | str:
+    """First formed 6-NN in NN order that transports. Uniqueness is not required."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_split = axis_split(n_in, n_out)
+        n_orient = frame_orient(n_in, n_out)
+        if n_split != "hold" or n_orient not in (1, -1):
+            continue
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if sending_holds(source, target, orient, n_orient) == "hold":
+            return neighbor, sending
+    return "fail"
+
+
+def scalar_orient_neighbor(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: HOLD iff some formed 6-NN has the same scalar Orient sign."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    orient = frame_orient(incoming, outgoing)
+    if orient == UNDEFINED:
+        return UNDEFINED
+    if orient not in (1, -1):
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        if frame_orient(n_in, n_out) == orient:
+            return "hold"
+    return "fail"
+
+
+def unique_positive_sending(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Mutation: unique nonnegative permutation sending. Not this letter."""
+    incoming, outgoing = site_sides(site, ticks, locks, seed_map)
+    split = axis_split(incoming, outgoing)
+    orient = frame_orient(incoming, outgoing)
+    if split == UNDEFINED or orient == UNDEFINED:
+        return UNDEFINED
+    if split != "hold" or orient not in (1, -1):
+        return "fail"
+    source = frame_triple(incoming, outgoing)
+    if not isinstance(source, tuple):
+        return "fail"
+    hits = 0
+    for neighbor in formed_six_neighbors(site, ticks):
+        n_in, n_out = site_sides(neighbor, ticks, locks, seed_map)
+        n_orient = frame_orient(n_in, n_out)
+        target = frame_triple(n_in, n_out)
+        sending = sending_matrix(source, target)
+        if (
+            sending_holds(source, target, orient, n_orient) == "hold"
+            and is_nonnegative_permutation(sending)
+        ):
+            hits += 1
+    if hits == 1:
+        return "hold"
+    return "fail"
+
+
+def transport_neighbor_read(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover existential #7511: some formed 6-NN r has transport HOLD."""
+    own = frame_transport(site, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own != "hold":
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        if frame_transport(neighbor, ticks, locks, seed_map) == "hold":
+            return "hold"
+    return "fail"
+
+
+def first_read_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Point | str:
+    """First formed 6-NN in NN order with transport HOLD. Uniqueness is not required."""
+    own = frame_transport(site, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    if own != "hold":
+        return "fail"
+    for neighbor in formed_six_neighbors(site, ticks):
+        if frame_transport(neighbor, ticks, locks, seed_map) == "hold":
+            return neighbor
+    return "fail"
+
+
+def universal_neighbor_read(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff transport HOLDs, N(q) nonempty, and every r in N(q) transports."""
+    own = frame_transport(site, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    neighbors = formed_neighbors_at_tau(site, ticks)
+    if own != "hold" or not neighbors:
+        return "fail"
+    for neighbor in neighbors:
+        if frame_transport(neighbor, ticks, locks, seed_map) != "hold":
+            return "fail"
+    return "hold"
+
+
+def first_universal_fail_witness(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Point | str:
+    """First r in N(q) whose transport fails. Uniqueness is not required."""
+    own = frame_transport(site, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    neighbors = formed_neighbors_at_tau(site, ticks)
+    if own != "hold" or not neighbors:
+        return "fail"
+    for neighbor in neighbors:
+        if frame_transport(neighbor, ticks, locks, seed_map) != "hold":
+            return neighbor
+    return "fail"
+
+
+def neighbor_set_display(neighbors: tuple[Point, ...]) -> str:
+    if not neighbors:
+        return "()"
+    return "(" + ", ".join(str(item) for item in neighbors) + ")"
+
+
+def equal_transport_bit(
+    site: Point,
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """Leftover: some formed 6-NN has the same transport bit, including fail=fail."""
+    own = frame_transport(site, ticks, locks, seed_map)
+    if own == UNDEFINED:
+        return UNDEFINED
+    for neighbor in formed_six_neighbors(site, ticks):
+        if frame_transport(neighbor, ticks, locks, seed_map) == own:
+            return "hold"
+    return "fail"
+
+
+def pair_bit(left: str, right: str) -> str:
+    """HOLD iff both sides HOLD. UNDEFINED if either side is UNDEFINED."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left == "hold" and right == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_orient(left: OrientVal, right: OrientVal) -> str:
+    """HOLD iff both signs are equal and each is +/-1."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if left in (1, -1) and left == right:
+        return "hold"
+    return "fail"
+
+
+def reverse_report(orient_a: OrientVal, orient_b: OrientVal) -> str:
+    """Orient reverse HOLDs iff Orient(A)=Orient(B) both +/-1. Contrast."""
+    return pair_orient(orient_a, orient_b)
+
+
+def face_report(orient_c: OrientVal, orient_d: OrientVal) -> str:
+    """Orient face HOLDs iff Orient(C)=Orient(D) both +/-1. Contrast."""
+    return pair_orient(orient_c, orient_d)
+
+
+def transport_reverse_report(left: str, right: str) -> str:
+    """Reverse HOLDs iff transport at A and at B."""
+    return pair_bit(left, right)
+
+
+def transport_face_report(left: str, right: str) -> str:
+    """Face HOLDs iff transport at C and at D. Leftover contrast."""
+    return pair_bit(left, right)
+
+
+def neighbor_read_reverse_report(left: str, right: str) -> str:
+    """Reverse HOLDs iff universal neighbor-read at A and at B."""
+    return pair_bit(left, right)
+
+
+def neighbor_read_face_report(left: str, right: str) -> str:
+    """Face HOLDs iff universal neighbor-read at C and at D."""
+    return pair_bit(left, right)
+
+
+def existential_opposite(left: Incoming, right: Incoming) -> str:
+    """Signed exist-opposite leftover contrast. Not this reverse."""
+    if left == UNDEFINED or right == UNDEFINED:
+        return UNDEFINED
+    if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+        raise TypeError("sides must be lock sets or UNDEFINED")
+    if not left or not right:
+        return UNDEFINED
+    for a in left:
+        for b in right:
+            if add(a, b) == ZERO:
+                return "hold"
+    return "fail"
+
+
+def unique_letter(value: Incoming) -> Incoming:
+    if value == UNDEFINED or not isinstance(value, frozenset) or len(value) != 1:
+        return UNDEFINED
+    return value
+
+
+def new_records_meeting_six_nn(
+    site: Point,
+    ticks: dict[Point, int],
+) -> tuple[Point, ...]:
+    """Records in B_3(0) that form at t(site)+1 and are 6-NN of site."""
+    formation = ticks[site]
+    found: list[Point] = []
+    for step in NN:
+        neighbor = add(site, step)
+        if neighbor in ticks and ticks[neighbor] == formation + 1:
+            found.append(neighbor)
+    return tuple(found)
+
+
+def sum_of_set(locks: frozenset[Point]) -> Point:
+    total = ZERO
+    for lock in locks:
+        total = add(total, lock)
+    return total
+
+
+def unsigned_incoming_orient(incoming: Incoming, outgoing: Outgoing) -> OrientVal:
+    """Mutation: replace signed m by the unsigned Axis(M) unit. Not this letter."""
+    split = axis_split(incoming, outgoing)
+    if split == UNDEFINED:
+        return UNDEFINED
+    if split != "hold":
+        return "fail"
+    axes_m = axis_set(incoming)
+    if not isinstance(axes_m, frozenset) or len(axes_m) != 1:
+        return "fail"
+    unsigned_m = next(iter(axes_m))
+    plane = cyclic_signed_outgoing(frozenset({unsigned_m}), outgoing, largest=True)
+    if not isinstance(plane, tuple):
+        return "fail"
+    det = integer_det_columns(unsigned_m, plane[0], plane[1])
+    if det > 0:
+        return 1
+    if det < 0:
+        return -1
+    return "fail"
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+def probe_sides(
+    probes: dict[str, Point],
+    site_ticks: dict[Point, int],
+    site_locks: dict[Point, set[Point]],
+    site_seeds: dict[Point, Point],
+) -> tuple[dict[str, Incoming], dict[str, Outgoing]]:
+    incoming: dict[str, Incoming] = {}
+    outgoing: dict[str, Outgoing] = {}
+    for name in ("A", "B", "C", "D"):
+        site = probes[name]
+        if site not in site_ticks:
+            incoming[name] = UNDEFINED
+            outgoing[name] = UNDEFINED
+            continue
+        tau = site_ticks[site] + 1
+        incoming[name] = incoming_set(site, tau, site_ticks, site_locks, site_seeds)
+        outgoing[name] = outgoing_set(site, tau, site_ticks, site_locks, site_seeds)
+    return incoming, outgoing
+
+
+def formed_plane(ticks: dict[Point, int], axis_index: int, value: int) -> tuple[Point, ...]:
+    """Formed-at-tau sites in B_3(0) with the named coordinate. Lex order."""
+    return tuple(sorted(site for site in ticks if site[axis_index] == value))
+
+
+def transport_bits(
+    sites: tuple[Point, ...],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> tuple[str, ...]:
+    return tuple(frame_transport(site, ticks, locks, seed_map) for site in sites)
+
+
+def plane_support(
+    sites: tuple[Point, ...],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> str:
+    """HOLD iff sites nonempty and transport HOLDs at every listed site."""
+    if not sites:
+        return "fail"
+    bits = transport_bits(sites, ticks, locks, seed_map)
+    if any(bit == UNDEFINED for bit in bits):
+        return UNDEFINED
+    if all(bit == "hold" for bit in bits):
+        return "hold"
+    return "fail"
+
+
+def first_plane_fail_witness(
+    sites: tuple[Point, ...],
+    ticks: dict[Point, int],
+    locks: dict[Point, set[Point]],
+    seed_map: dict[Point, Point],
+) -> Point | str:
+    """First listed site whose transport is not HOLD. Uniqueness is not required."""
+    if not sites:
+        return "fail"
+    for site in sites:
+        bit = frame_transport(site, ticks, locks, seed_map)
+        if bit == UNDEFINED:
+            return UNDEFINED
+        if bit != "hold":
+            return site
+    return "fail"
+
+
+def site_row(site: Point, ticks: dict[Point, int], bit: str) -> str:
+    return f"{site} t={ticks[site]} transport={bit}"
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(Path(__file__).name))
+    literal_paths = assignment_string_tuple(tree, "AUDIT_INPUT_PATHS")
+
+    print("x=0 plane support of cyclic-frame transport reverse/face at t+1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print(f"claim_scope: {CLAIM_SCOPE}")
+
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL),
+        str(literal_paths),
+    )
+    checks.check(
+        "audit-input-paths-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS),
+    )
+    checks.check("audit-timeout-declared", AUDIT_TIMEOUT_SEC == 120)
+
+    host = ball_sites()
+    probe_sites = tuple(PROBES[name] for name in ("A", "B", "C", "D"))
+    y_probe_sites = tuple(Y_PROBES[name] for name in ("A", "B", "C", "D"))
+    x_probe_sites = tuple(X_PROBES[name] for name in ("A", "B", "C", "D"))
+    checks.check("host-is-b3-closed-ball", ORIGIN in host and len(host) == 123)
+    checks.check(
+        "four-z-probes-in-host",
+        probe_sites == ((0, 0, 1), (1, 1, 1), (0, 0, 2), (1, 0, 1))
+        and set(probe_sites) <= host
+        and ORIGIN not in probe_sites
+        and probe_sites != x_probe_sites
+        and probe_sites != y_probe_sites,
+    )
+    checks.check(
+        "host-is-euclidean-not-taxicab",
+        (2, 2, 0) in host and dot((2, 2, 0), (2, 2, 0)) == 8 and 2 + 2 + 0 > 3,
+    )
+    checks.check(
+        "id-add-dot-perp",
+        add(ORIGIN, E1) == E1
+        and add(NEG_E1, E1) == ZERO
+        and add(NEG_E2, E2) == ZERO
+        and add(E3, E2) == PAIR2
+        and perpendicular(E1, E2)
+        and not perpendicular(E1, E1)
+        and in_ball(PROBES["C"])
+        and not in_ball((4, 0, 0)),
+    )
+    checks.check(
+        "det-identity",
+        integer_det_columns(E2, E3, NEG_E1) == -1
+        and integer_det_columns(E1, E2, NEG_E3) == -1
+        and integer_det_columns(E3, NEG_E1, NEG_E2) == 1
+        and integer_det_columns(E1, NEG_E2, NEG_E3) == 1
+        and integer_det_columns(E1, E2, E3) == 1
+        and integer_det_columns(E1, E1, E2) == 0,
+    )
+    identity_frame = (E2, E3, NEG_E1)
+    identity_target = (E1, NEG_E2, NEG_E3)
+    identity_sending = sending_matrix(identity_frame, identity_target)
+    checks.check(
+        "sending-identity",
+        frame_triple(frozenset({E2}), frozenset({E1, NEG_E1, E3}))
+        == (E2, E3, NEG_E1)
+        and sending_matrix(UNDEFINED, identity_frame) == UNDEFINED
+        and sending_matrix(identity_frame, "fail") == "fail"
+        and sending_matrix(identity_frame, identity_frame) == (E1, E2, E3)
+        and is_signed_permutation((E1, E2, E3))
+        and not is_signed_permutation((E1, E1, E2))
+        and sending_holds(identity_frame, identity_frame, -1, -1) == "hold"
+        and sending_holds(identity_frame, identity_target, -1, 1) == "hold"
+        and integer_det_columns(*identity_sending) == -1
+        and is_signed_permutation(identity_sending)
+        and not is_nonnegative_permutation(identity_sending)
+        and mul_columns(identity_frame, identity_sending) == identity_target,
+    )
+    checks.check(
+        "empty-plane-is-fail-not-undefined",
+        plane_support((), {}, {}, {}) == "fail"
+        and plane_support((), {}, {}, {}) != UNDEFINED
+        and first_plane_fail_witness((), {}, {}, {}) == "fail",
+    )
+    checks.check(
+        "orient-identity",
+        frame_orient(UNDEFINED, frozenset({E2, E3})) == UNDEFINED
+        and frame_orient(frozenset({E2}), UNDEFINED) == UNDEFINED
+        and frame_orient(frozenset(), frozenset({E1, E3})) == "fail"
+        and frame_orient(frozenset({E2}), frozenset({E1, E3})) == 1
+        and cyclic_units(E2) == (E3, E1)
+        and cyclic_units(E1) == (E2, E3)
+        and cyclic_units(E3) == (E1, E2)
+        and lex_largest_on_axis(frozenset({E1, NEG_E1}), E1) == NEG_E1
+        and leftover_match(frozenset(), frozenset()) == "fail",
+    )
+
+    ticks, locks, seed_map = form()
+    one_ticks, one_locks, one_seeds = form(TWO_SITE_SEEDS)
+    perp_ticks, perp_locks, perp_seeds = form(PERP_SEEDS)
+    same_ticks, same_locks, same_seeds = form(SAME_LOCK_SEEDS)
+    zsym_ticks, zsym_locks, zsym_seeds = form(Z_SYMMETRIC_SEEDS)
+    ysym_ticks, _ysym_locks, _ysym_seeds = form(Y_SYMMETRIC_SEEDS)
+    live_ticks, live_locks, live_seeds = form(LIVE_THREE_AXIS_SEEDS)
+
+    q0 = formed_plane(ticks, 0, 0)
+    q1 = formed_plane(ticks, 0, 1)
+    q0_ticks = tuple(ticks[site] for site in q0)
+    q1_ticks = tuple(ticks[site] for site in q1)
+    q0_bits = transport_bits(q0, ticks, locks, seed_map)
+    q1_bits = transport_bits(q1, ticks, locks, seed_map)
+    reverse = plane_support(q0, ticks, locks, seed_map)
+    face = plane_support(q1, ticks, locks, seed_map)
+    fail0 = first_plane_fail_witness(q0, ticks, locks, seed_map)
+    fail1 = first_plane_fail_witness(q1, ticks, locks, seed_map)
+    early0 = tuple(site for site in q0 if ticks[site] <= 1)
+    early1 = tuple(site for site in q1 if ticks[site] <= 1)
+    early_reverse = plane_support(early0, ticks, locks, seed_map)
+    early_face = plane_support(early1, ticks, locks, seed_map)
+    y0 = formed_plane(ticks, 1, 0)
+    y0_support = plane_support(y0, ticks, locks, seed_map)
+    xm1 = formed_plane(ticks, 0, -1)
+    xm1_support = plane_support(xm1, ticks, locks, seed_map)
+    x3 = formed_plane(ticks, 0, 3)
+    x3_support = plane_support(x3, ticks, locks, seed_map)
+
+    m1, o1 = probe_sides(PROBES, ticks, locks, seed_map)
+    split = {name: axis_split(m1[name], o1[name]) for name in ("A", "B", "C", "D")}
+    orient = {name: frame_orient(m1[name], o1[name]) for name in ("A", "B", "C", "D")}
+    transport = {
+        name: frame_transport(PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    univ = {
+        name: universal_neighbor_read(PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    exist = {
+        name: transport_neighbor_read(PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    scalar = {
+        name: scalar_orient_neighbor(PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    unique_pos = {
+        name: unique_positive_sending(PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    equal_bit = {
+        name: equal_transport_bit(PROBES[name], ticks, locks, seed_map)
+        for name in ("A", "B", "C", "D")
+    }
+    cover = {name: axis_cover(m1[name], o1[name]) for name in ("A", "B", "C", "D")}
+    transport_reverse = transport_reverse_report(transport["A"], transport["B"])
+    transport_face = transport_face_report(transport["C"], transport["D"])
+    univ_reverse = neighbor_read_reverse_report(univ["A"], univ["B"])
+    univ_face = neighbor_read_face_report(univ["C"], univ["D"])
+    exist_reverse = neighbor_read_reverse_report(exist["A"], exist["B"])
+    exist_face = neighbor_read_face_report(exist["C"], exist["D"])
+    orient_reverse = reverse_report(orient["A"], orient["B"])
+    orient_face = face_report(orient["C"], orient["D"])
+    scalar_reverse = pair_bit(scalar["A"], scalar["B"])
+    scalar_face = pair_bit(scalar["C"], scalar["D"])
+    unique_pos_reverse = pair_bit(unique_pos["A"], unique_pos["B"])
+    unique_pos_face = pair_bit(unique_pos["C"], unique_pos["D"])
+    cover_reverse = pair_bit(cover["A"], cover["B"])
+    cover_face = pair_bit(cover["C"], cover["D"])
+    split_reverse = pair_bit(split["A"], split["B"])
+    split_face = pair_bit(split["C"], split["D"])
+    fail_site: Point = (0, -1, 1)
+    fail_transport = frame_transport(fail_site, ticks, locks, seed_map)
+    fail_equal = equal_transport_bit(fail_site, ticks, locks, seed_map)
+    fail_univ = universal_neighbor_read(fail_site, ticks, locks, seed_map)
+    isolated_ticks = {ORIGIN: 0}
+    isolated_locks = {ORIGIN: {E1}}
+    isolated_seeds = {ORIGIN: E1}
+    isolated_transport = frame_transport(
+        ORIGIN, isolated_ticks, isolated_locks, isolated_seeds
+    )
+    one_transport = {
+        name: frame_transport(PROBES[name], one_ticks, one_locks, one_seeds)
+        for name in ("A", "B", "C", "D")
+    }
+    one_q0 = formed_plane(one_ticks, 0, 0)
+    one_q1 = formed_plane(one_ticks, 0, 1)
+    one_reverse = plane_support(one_q0, one_ticks, one_locks, one_seeds)
+    one_face = plane_support(one_q1, one_ticks, one_locks, one_seeds)
+    same_q0 = formed_plane(same_ticks, 0, 0)
+    same_q1 = formed_plane(same_ticks, 0, 1)
+    same_reverse = plane_support(same_q0, same_ticks, same_locks, same_seeds)
+    same_face = plane_support(same_q1, same_ticks, same_locks, same_seeds)
+    live_q0 = formed_plane(live_ticks, 0, 0)
+    live_q1 = formed_plane(live_ticks, 0, 1)
+    live_reverse = plane_support(live_q0, live_ticks, live_locks, live_seeds)
+    live_face = plane_support(live_q1, live_ticks, live_locks, live_seeds)
+    expected_q0 = (
+        (0, -3, 0),
+        (0, -2, -2),
+        (0, -2, -1),
+        (0, -2, 0),
+        (0, -2, 1),
+        (0, -2, 2),
+        (0, -1, -2),
+        (0, -1, -1),
+        (0, -1, 0),
+        (0, -1, 1),
+        (0, -1, 2),
+        (0, 0, -3),
+        (0, 0, -2),
+        (0, 0, -1),
+        (0, 0, 0),
+        (0, 0, 1),
+        (0, 0, 2),
+        (0, 1, -2),
+        (0, 1, -1),
+        (0, 1, 0),
+        (0, 1, 1),
+        (0, 1, 2),
+        (0, 2, -2),
+        (0, 2, -1),
+        (0, 2, 0),
+        (0, 2, 1),
+        (0, 2, 2),
+    )
+    expected_q1 = (
+        (1, -2, -2),
+        (1, -2, -1),
+        (1, -2, 0),
+        (1, -2, 1),
+        (1, -2, 2),
+        (1, -1, -2),
+        (1, -1, -1),
+        (1, -1, 0),
+        (1, -1, 1),
+        (1, -1, 2),
+        (1, 0, -2),
+        (1, 0, -1),
+        (1, 0, 0),
+        (1, 0, 1),
+        (1, 0, 2),
+        (1, 1, -2),
+        (1, 1, -1),
+        (1, 1, 0),
+        (1, 1, 1),
+        (1, 1, 2),
+        (1, 2, -2),
+        (1, 2, -1),
+        (1, 2, 0),
+        (1, 2, 1),
+        (1, 2, 2),
+    )
+    expected_t0 = (
+        5, 4, 3, 4, 3, 4, 3, 2, 1, 2, 2, 5, 4, 1, 0, 0, 1, 4, 1, 0, 0, 1, 3, 2, 1, 2, 2
+    )
+    expected_t1 = (
+        5, 4, 3, 4, 4, 4, 3, 2, 2, 3, 3, 2, 2, 1, 2, 3, 2, 2, 1, 2, 4, 3, 2, 2, 3
+    )
+    expected_b0 = (
+        "fail", "fail", "fail", "fail", "fail", "fail", "fail", "fail", "hold",
+        "fail", "fail", "fail", "fail", "hold", "hold", "hold", "hold", "fail",
+        "hold", "hold", "hold", "hold", "fail", "fail", "hold", "fail", "fail",
+    )
+    expected_b1 = (
+        "fail", "fail", "hold", "fail", "fail", "fail", "fail", "hold", "hold",
+        "fail", "hold", "hold", "fail", "hold", "fail", "hold", "hold", "fail",
+        "hold", "fail", "fail", "fail", "fail", "hold", "fail",
+    )
+
+    print(f"|Q0|={len(q0)} hold={q0_bits.count('hold')} fail={q0_bits.count('fail')}")
+    print(f"|Q1|={len(q1)} hold={q1_bits.count('hold')} fail={q1_bits.count('fail')}")
+    for site, bit in zip(q0, q0_bits):
+        print(f"Q0 {site_row(site, ticks, bit)}")
+    for site, bit in zip(q1, q1_bits):
+        print(f"Q1 {site_row(site, ticks, bit)}")
+    print(f"plane-support reverse={reverse} face={face}")
+    print(f"fail-witness Q0={fail0} Q1={fail1}")
+    print(f"z-probe transport reverse={transport_reverse} face={transport_face}")
+    print(f"universal 6-NN reverse={univ_reverse} face={univ_face}")
+    print(f"existential 6-NN reverse={exist_reverse} face={exist_face}")
+    print(f"early-tick plane reverse={early_reverse} face={early_face}")
+    print("per_element: cyclic-frame transport at every formed-at-tau site on the x=0 and x=1 planes")
+    print("per_site: scored on formed sites with q_1=0 and q_1=1 in Euclidean B_3(0)")
+    print("per_mode: no spectral or mode calculation is executed on this finite host")
+    print("per_block: Q0/Q1 transport reports, reverse/face from those plane foralls")
+    print("lattice_wide: checked and not executed — no lattice-wide lettering rule is claimed")
+
+    origin_parallel_blocked = all(
+        ticks.get(add(ORIGIN, step)) != 1 for step in (E1, NEG_E1)
+    )
+    second_pair_parallel_blocked = all(
+        ticks.get(add(E3, step)) != 1 for step in (E2, NEG_E2)
+    ) and all(ticks.get(add(PAIR2, step)) != 1 for step in (E2, NEG_E2))
+    checks.check(
+        "perp-step-incoming-lock",
+        origin_parallel_blocked
+        and second_pair_parallel_blocked
+        and ticks[NEG_E2] == 1
+        and ticks[NEG_E3] == 1
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and "s·e_i=0" in note.replace(" ", ""),
+    )
+    checks.check(
+        "undefined-if-unformed",
+        incoming_set(PROBES["B"], 0, ticks, locks, seed_map) == UNDEFINED
+        and frame_transport(PROBES["B"], {ORIGIN: 0}, {ORIGIN: {E1}}, {ORIGIN: E1})
+        == UNDEFINED
+        and isolated_transport == "fail"
+        and isolated_transport != UNDEFINED,
+    )
+    checks.check(
+        "theorem1-Q0-Q1-sites",
+        q0 == expected_q0
+        and q1 == expected_q1
+        and len(q0) == 27
+        and len(q1) == 25
+        and q0
+        and q1
+        and all(site[0] == 0 for site in q0)
+        and all(site[0] == 1 for site in q1)
+        and set(q0) <= set(ticks) <= host
+        and set(q1) <= set(ticks)
+        and PROBES["A"] in q0
+        and PROBES["C"] in q0
+        and PROBES["B"] in q1
+        and PROBES["D"] in q1
+        and ORIGIN in q0
+        and PAIR2 in q0,
+        f"|Q0|={len(q0)} |Q1|={len(q1)}",
+    )
+    checks.check(
+        "theorem1-ticks-and-transport-bits",
+        q0_ticks == expected_t0
+        and q1_ticks == expected_t1
+        and q0_bits == expected_b0
+        and q1_bits == expected_b1
+        and q0_bits.count("hold") == 10
+        and q0_bits.count("fail") == 17
+        and q1_bits.count("hold") == 10
+        and q1_bits.count("fail") == 15
+        and UNDEFINED not in q0_bits
+        and UNDEFINED not in q1_bits
+        and transport["A"] == "hold"
+        and transport["B"] == "hold"
+        and transport["C"] == "hold"
+        and transport["D"] == "hold"
+        and ticks[PROBES["A"]] == 0
+        and ticks[PROBES["B"]] == 1
+        and ticks[PROBES["C"]] == 1
+        and ticks[PROBES["D"]] == 1
+        and fail_transport == "fail",
+    )
+    checks.check(
+        "theorem2-reverse-x0-plane-support-fail",
+        reverse == "fail"
+        and reverse != UNDEFINED
+        and reverse != "hold"
+        and q0
+        and fail0 == (0, -3, 0)
+        and fail0 in q0
+        and q0_bits[0] == "fail"
+        and transport_reverse == "hold"
+        and transport_reverse != reverse
+        and exist_reverse == "hold"
+        and exist_reverse != reverse
+        and univ_reverse == "fail"
+        and univ["A"] == "hold"
+        and univ["B"] == "fail"
+        and early_reverse == "hold"
+        and early_reverse != reverse
+        and y0_support == "fail"
+        and xm1_support == "fail"
+        and x3_support == "fail"
+        and x3 == ()
+        and x3_support != UNDEFINED,
+    )
+    checks.check(
+        "theorem3-face-x1-plane-support-fail",
+        face == "fail"
+        and face != UNDEFINED
+        and face != "hold"
+        and q1
+        and fail1 == (1, -2, -2)
+        and fail1 in q1
+        and q1_bits[0] == "fail"
+        and transport_face == "hold"
+        and transport_face != face
+        and exist_face == "hold"
+        and exist_face != face
+        and univ_face == "fail"
+        and univ["C"] == "fail"
+        and univ["D"] == "fail"
+        and early_face == "hold"
+        and early_face != face
+        and early1 == ((1, 0, 1), (1, 1, 1)),
+    )
+    checks.check(
+        "not-6nn-forall-and-not-zprobe-transport",
+        univ_reverse == "fail"
+        and univ_face == "fail"
+        and reverse == "fail"
+        and face == "fail"
+        and transport_reverse == "hold"
+        and transport_face == "hold"
+        and all(exist[name] == "hold" for name in ("A", "B", "C", "D"))
+        and all(transport[name] == "hold" for name in ("A", "B", "C", "D"))
+        and q0_bits.count("fail") == 17
+        and q1_bits.count("fail") == 15
+        and formed_six_neighbors(PROBES["A"], ticks)
+        != q0
+        and fail0 not in formed_six_neighbors(PROBES["A"], ticks),
+    )
+    checks.check(
+        "cover-and-split-do-not-score-plane-support",
+        split_reverse == "hold"
+        and cover_reverse == "hold"
+        and split_face == "hold"
+        and cover_face == "hold"
+        and orient_reverse == "hold"
+        and orient_face == "hold"
+        and reverse == "fail"
+        and face == "fail"
+        and scalar_reverse == "fail"
+        and scalar_face == "fail"
+        and unique_pos_reverse == "fail"
+        and unique_pos_face == "fail"
+        and fail_equal == "hold"
+        and fail_univ == "fail"
+        and fail_equal != fail_univ
+        and all(equal_bit[name] == "hold" for name in ("A", "B", "C", "D")),
+    )
+    checks.check(
+        "not-leftover-of-1-axis-or-same-lock-or-live",
+        TWO_AXIS_SEEDS != TWO_SITE_SEEDS
+        and TWO_AXIS_SEEDS != SAME_LOCK_SEEDS
+        and TWO_AXIS_SEEDS != LIVE_THREE_AXIS_SEEDS
+        and TWO_AXIS_SEEDS != PERP_SEEDS
+        and TWO_AXIS_SEEDS != Z_SYMMETRIC_SEEDS
+        and TWO_AXIS_SEEDS != Y_SYMMETRIC_SEEDS
+        and one_transport["C"] == "fail"
+        and one_reverse == "fail"
+        and one_face == "fail"
+        and same_reverse == "fail"
+        and same_face == "fail"
+        and live_reverse == "fail"
+        and live_face == "fail"
+        and sum(time == 0 for time in ticks.values()) == 4
+        and sum(time == 0 for time in one_ticks.values()) == 2
+        and sum(time == 0 for time in ysym_ticks.values()) == 3
+        and PAIR2 in seed_map
+        and seed_map[PAIR2] == NEG_E2
+        and ticks[PAIR2] == 0
+        and one_ticks[E3] == 1
+        and ticks[E3] == 0,
+    )
+    checks.check("formation-stays-in-host", set(ticks) <= host)
+    checks.check(
+        "no-larger-ball",
+        BALL_SQ == 9 and all(dot(site, site) <= 9 for site in ticks),
+    )
+    checks.check("note-claim-scope", CLAIM_SCOPE in note)
+    checks.check(
+        "note-reports-Q0-Q1-transport",
+        "Q0 = formed-at-τ sites q in B_3(0) with q_1=0" in note
+        and "Q1 = formed-at-τ sites q in B_3(0) with q_1=1" in note
+        and "|Q0|=27" in note
+        and "|Q1|=25" in note
+        and "transport((0, -3, 0)) = fail" in note
+        and "transport((0, 0, 0)) = hold" in note
+        and "transport((0, 0, 1)) = hold" in note
+        and "transport((1, -2, -2)) = fail" in note
+        and "transport((1, 0, 1)) = hold" in note
+        and "transport((1, 1, 1)) = hold" in note
+        and "t((0, 0, 0))=0" in note
+        and "t((0, 0, 1))=0" in note
+        and "t((1, 1, 1))=1" in note
+        and "t((0, -3, 0))=5" in note
+        and "fail-witness(Q0) = (0, -3, 0)" in note
+        and "fail-witness(Q1) = (1, -2, -2)" in note
+        and "hold-count(Q0) = 10" in note
+        and "fail-count(Q0) = 17" in note
+        and "hold-count(Q1) = 10" in note
+        and "fail-count(Q1) = 15" in note,
+    )
+    checks.check(
+        "note-reports-reverse-face",
+        "Reverse x=0 plane support of cyclic-frame transport at τ: fail" in note
+        and "Face x=1 plane support of cyclic-frame transport at τ: fail" in note
+        and "Empty Q0 or Q1 is fail, not UNDEFINED" in note,
+    )
+    checks.check(
+        "note-displayed-not-adopted",
+        "displayed, not adopted" in normalized_note.lower()
+        and "Do not write into Admissibility." in note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-6nn-or-zprobe-leftovers",
+        "not leftover of nm2cycfrmz cyclic-frame transport" in normalized_note
+        and "not leftover of existential neighbor-read" in normalized_note
+        and "not leftover of universal 6-NN neighbor-read" in normalized_note
+        and "Not a 6-NN forall" in note
+        and "not leftover of early-tick plane support" in normalized_note
+        and "not leftover of nm2axz axis-cover" in normalized_note
+        and "not leftover of nm2ax12z 1-in 2-out split" in normalized_note
+        and "second pair is a new seed, not a formed child" in normalized_note
+        and "O is not M" in note,
+    )
+    checks.check(
+        "note-not-two-tick-lock-count-clock",
+        "not the two-tick lock-count clock composition" in normalized_note
+        and "Do not attach L1." in note,
+    )
+    checks.check(
+        "note-not-mixed-7188-fail-fail",
+        "not leftover of mixed #7188 fail/fail" in normalized_note
+        and "Reverse x=0 plane support of cyclic-frame transport at τ: fail" in note
+        and "Face x=1 plane support of cyclic-frame transport at τ: fail" in note,
+    )
+    checks.check(
+        "note-no-global-T",
+        "no global T" in normalized_note
+        and "τ(q)=t(q)+1" in note.replace(" ", ""),
+    )
+    checks.check(
+        "note-forbids-enlargement-and-cache",
+        "No larger host is used." in normalized_note
+        and "B_3(0)" in note
+        and "{n:n·n<=9}" in note.replace(" ", "")
+        and "No runner cache is written." in normalized_note,
+    )
+    checks.check(
+        "note-forbidden-tokens-absent",
+        all(token not in note for token in FORBIDDEN_NOTE_TOKENS),
+    )
+    checks.check(
+        "axiom-record-sentences-current",
+        "Records form." in axiom
+        and "When present, a record locks exactly one admissible local possibility."
+        in axiom
+        and "Physical sites are the points of the cubic lattice `Z^3`" in axiom
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom
+        and "does not supply the formation site, probability, or rate"
+        in normalized_axiom,
+    )
+    checks.check(
+        "note-quotes-current-premises",
+        "Physical sites are the points of the cubic lattice `Z^3`" in note
+        and "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in note
+        and "When present, a record locks exactly one admissible local possibility."
+        in note
+        and "does not supply the formation site, probability, or rate"
+        in normalized_note,
+    )
+    checks.check(
+        "note-machine-status-no-axiom-edit",
+        'hypothetical_axiom_status: "no edit"' in note
+        and "claim_type: bounded_theorem" in note
+        and "authors no audit verdict" in normalized_note
+        and "FAIL / DO NOT SHIP" in note,
+    )
+    checks.check(
+        "note-n-gates-present",
+        all(f"### N{index}" in note for index in range(1, 9)),
+    )
+    allowed_retained = (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+    )
+    other_retained = note
+    for line in allowed_retained:
+        other_retained = other_retained.replace(line, "")
+    checks.check(
+        "note-no-author-retained-verdict",
+        all(line in note for line in allowed_retained)
+        and "retained" not in other_retained
+        and "promoted" not in note.lower(),
+    )
+    checks.check(
+        "source-audit-paths-are-static-literals",
+        "AUDIT_INPUT_PATHS = (\n"
+        '    "docs/TWO_AXIS_OPPOSITE_X0_PLANE_SUPPORT_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",\n'
+        '    "docs/MINIMAL_AXIOMS_2026-06-29.md",\n'
+        ")" in source,
+    )
+    defined_fns = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    checks.check(
+        "identity-gates-present",
+        "incoming_set" in defined_fns
+        and "outgoing_set" in defined_fns
+        and "axis_split" in defined_fns
+        and "frame_orient" in defined_fns
+        and "frame_triple" in defined_fns
+        and "sending_matrix" in defined_fns
+        and "is_signed_permutation" in defined_fns
+        and "frame_transport" in defined_fns
+        and "formed_plane" in defined_fns
+        and "plane_support" in defined_fns
+        and "first_plane_fail_witness" in defined_fns
+        and "universal_neighbor_read" in defined_fns
+        and "transport_neighbor_read" in defined_fns
+        and "form" in defined_fns
+        and not any("occup" in name for name in defined_fns),
+    )
+    checks.check(
+        "source-formation-is-perp-step-queue",
+        "from collections import deque" in source
+        and "while queue:" in source
+        and "require_perp" in source
+        and ticks[PROBES["A"]] == 0
+        and set(ticks) <= host,
+    )
+    _ = (
+        perp_ticks,
+        perp_locks,
+        perp_seeds,
+        zsym_ticks,
+        zsym_locks,
+        zsym_seeds,
+        y0,
+        xm1,
+        one_q0,
+        one_q1,
+        same_q0,
+        same_q1,
+        live_q0,
+        live_q1,
+        unique_pos,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary

Forall plane-support of cyclic-frame transport fails on x=0 versus x=1 while four-probe transport HOLDs. Reverse fails, face fails. Displayed, not adopted. Not leftover of #7490. Campaign toe-lphys-20260812. Source-only. No axiom edit.

## Runner

`scripts/two_axis_opposite_x0_plane_support_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.