### PR TITLE
feat(nm2frm3pf): directed 3-step cyclic-frame transport along +e3 at t+1 on three-axis far-face opposite seed: reverse fails, face fails

### DIFF
--- a/docs/THREE_AXIS_FARFACE_OPPOSITE_DIRECTED_THREE_STEP_PLUS_E3_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/THREE_AXIS_FARFACE_OPPOSITE_DIRECTED_THREE_STEP_PLUS_E3_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,246 @@
+---
+claim_id: three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "Directed 3-step cyclic-frame transport along +e3 at t+1 on the three-axis far-face opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+---
+
+# Directed Three-Step Cyclic-Frame Transport Along +e3 At t+1 On The Three-Axis Far-Face Opposite Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact directed three-step bits along `+e_3` at `τ=t+1` on the
+three-axis far-face opposite seed in Euclidean `B_3(0)`, together with reverse
+and face from those bits.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`](../scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py)
+
+## Result up front
+
+On the three-axis far-face opposite seed, cyclic-frame transport along a named
+edge is the signed-permutation map of the ordered triple `F=(m,o_next,o_prev)`.
+This note displays the *directed* three-step along `+e_3` from each of the four
+probes. It is the opposite named direction from `−e_3`. Not leftover of −e3.
+The third pair is a new seed, not a formed child. First display: three hops
+along `+e_3` on the far-face seed.
+
+At the common cut `τ=t+1` of each seed (`t=0`, so `τ=1`), origin split fails,
+so the origin first hop fails and the origin three-step fails. The remaining
+reverse probe HOLDs its first hop and fails its second hop because the second
+dest has empty outgoing set. Its third dest `(0,1,3)` lies outside `B_3(0)`:
+fail not UNDEFINED. Face probe `(0,0,1)` fails its first hop (dest split
+fails). Face probe `(0,1,1)` fails its first hop the same way. Face third dests
+`(0,0,4)` and `(0,1,4)` lie outside `B_3(0)`. Therefore
+
+```text
+reverse: fail
+face: fail
+```
+
+The bits are Displayed, not adopted. Do not write into Admissibility. Do not
+attach L1. Uniqueness is not required.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact 3-step bits on Euclidean B_3(0) at one declared cut; the bits are displayed and not adopted."
+trace_class: frontier_discovery
+target_claim_id: three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+target_blocker_text: "display directed 3-step cyclic-frame transport along +e3 at t+1 on the three-axis far-face opposite seed and the reverse/face pair from those bits"
+source_of_blocker_text: frontier_question
+reachability_to_target: closed_finite_target
+artifact_role: theorem
+next_trace_action: "independent audit of the landed note and invocation-bound runner evidence"
+conditional_surface_status: "exact only for the declared three-axis far-face opposite seed, Euclidean B_3(0), and the named +e3 three-step at t+1"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility does not supply the formation site, probability, or rate. The
+perp-step incoming-lock process used below is a declared finite host process,
+not an axiom edit.
+
+## Exact objects
+
+Euclidean B_3(0)={n:n·n<=9} inside `Z^3`. No larger ball is used. Nearest
+neighbors are the six axial steps `{±e_1,±e_2,±e_3}` with
+`e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`.
+
+Seed at tick `0`, two disjoint opposite pairs plus far-face third pair:
+
+```text
+(0,0,0) locks +e_1
+(0,1,0) locks -e_1
+(0,0,1) locks +e_2
+(0,1,1) locks -e_2
+(0,0,-1) locks +e_3
+(0,1,-1) locks -e_3
+```
+
+The third pair is a new seed, not a formed child.
+
+From a recorded site `p` with unique lock `L(p)=±e_i`, a step `s` to
+`q=p+s` is allowed iff `s·e_i=0`. If `q` lies in `B_3(0)` and is unformed,
+`q` forms at `t(p)+1` and the incoming set `M(q)` is the set of earliest such
+steps. If that set is not a singleton, `q` has no unique lock and does not
+emit. Seed incoming sets are the assigned locks.
+
+Let `t(q)` be the formation tick. The cut is `τ=t+1`. For each seed probe,
+`t=0` so `τ=1`. A site is formed at `τ` iff it is recorded with tick `≤ τ`.
+Unformed at `τ` is fail, not UNDEFINED. A vertex outside `B_3(0)` is fail, not
+UNDEFINED.
+
+`M(q,τ)` is the earliest incoming set of `q` from records with tick `≤ τ`,
+defined only if `q` is formed at `τ`.
+
+`O(q,τ)={e in {±e_1,±e_2,±e_3} | q+e formed at τ and e in M(q+e,τ)}`.
+
+`Axis(S)={e_i | some ±e_i in S}`. Cover holds iff `Axis(M)∩Axis(O)` is empty
+and `Axis(M)∪Axis(O)={e_1,e_2,e_3}`. Split holds iff cover holds and
+`|Axis(M)|=1` with `m` unique in `M`. Two-in one-out is fail. If split fails,
+Orient fails, not UNDEFINED.
+
+When split holds, let `i` be the axis index of `m`. Set `e_next=e_{i+1}` with
+`3+1→1` and `e_prev=e_{i-1}` with `1-1→3`. Let
+`O_next=O∩{±e_next}` and `O_prev=O∩{±e_prev}`. If either is empty, Orient
+fails, not UNDEFINED. Order `+e < -e`. Then `o_next` is the lex-largest
+vector in `O_next` (hence `-e` if both signs), and `o_prev` likewise.
+`F(q)` is the `3×3` integer matrix with columns `(m,o_next,o_prev)`.
+`Orient(q)` is the sign of `det F(q)`. Split plus nonempty leftover axes
+makes `Orient∈{±1}` and makes `F` a signed permutation matrix.
+
+Directed-edge HOLD from `q` to `q+e_3` iff `q` and `q+e_3` lie in `B_3(0)`,
+both are formed at `τ`, split holds at both, Orient is `±1` at both, and the
+`3×3` integer matrix `P` sending columns of `F(q)` to columns of `F(q+e_3)`
+(the `P` with `P F(q)=F(q+e_3)`) is a signed permutation with
+`det P=Orient(q)Orient(q+e_3)`. Else that edge fails, not UNDEFINED.
+
+Directed 3-step along `+e_3` HOLDs at `q` iff `q`, `q+e_3`, `q+2e_3`, and
+`q+3e_3` lie in `B_3(0)` and the three named edges `(q,q+e_3)`,
+`(q+e_3,q+2e_3)`, and `(q+2e_3,q+3e_3)` HOLD.
+
+Reverse probes: origin and `(0,1,0)`. Face probes: `(0,0,1)` and `(0,1,1)`.
+Reverse HOLD iff 3-step along `+e_3` HOLDs at both reverse probes. Face HOLD
+iff both face probes HOLD.
+
+## Theorem 1
+
+At `τ=1` the six seeds are formed at tick `0`. The tick-1 records in
+`B_3(0)` are exactly twenty sites: the six seeds together with
+
+```text
+(0,-1,0)   M={-e_2}
+(0,2,0)    M={+e_2}
+(1,0,1)    M={+e_1}
+(-1,0,1)   M={-e_1}
+(0,0,2)    M={+e_3}
+(1,1,1)    M={+e_1}
+(-1,1,1)   M={-e_1}
+(0,1,2)    M={+e_3}
+(1,0,-1)   M={+e_1}
+(-1,0,-1)  M={-e_1}
+(0,-1,-1)  M={-e_2}
+(1,1,-1)   M={+e_1}
+(-1,1,-1)  M={-e_1}
+(0,2,-1)   M={+e_2}
+```
+
+Frames at the four probes:
+
+```text
+F((0,0,0)) fails
+  M={+e_1}, O={-e_2}; Axis(M)={e_1}, Axis(O)={e_2}; split fails
+F((0,1,0)) columns (-e_1,+e_2,-e_3); Orient((0,1,0))=+1
+F((0,0,1)) columns (+e_2,+e_3,-e_1); Orient((0,0,1))=-1
+F((0,1,1)) columns (-e_2,+e_3,-e_1); Orient((0,1,1))=+1
+```
+
+Origin split fails because the far-face seed at `(0,0,-1)` locks `+e_3`, so
+the step `−e_3` from origin is not in `M((0,0,-1))` and is not in origin
+`O`. The twelve named `+e_3` edges of the four three-hop chains and the four
+three-step bits:
+
+```text
+(0,0,0)->(0,0,1)
+  dest t=0; F dest columns (+e_2,+e_3,-e_1); Orient dest=-1
+  src split fail; edge fail
+(0,0,1)->(0,0,2)
+  dest t=1; formed, split fail (O empty); P fail; edge fail
+(0,0,2)->(0,0,3)
+  dest unformed at τ=1; (0,0,3) in B_3(0); P fail; edge fail
+  3-step at (0,0,0): fail
+
+(0,1,0)->(0,1,1)
+  dest t=0; F dest columns (-e_2,+e_3,-e_1); Orient dest=+1
+  P=[(0,0,1); (1,0,0); (0,1,0)]; det P=+1; edge hold
+(0,1,1)->(0,1,2)
+  dest t=1; formed, split fail (O empty); P fail; edge fail
+(0,1,2)->(0,1,3)
+  dest (0,1,3) has n·n=10 and is outside B_3(0); P fail; edge fail
+  3-step at (0,1,0): fail
+
+(0,0,1)->(0,0,2)
+  dest t=1; formed, split fail (O empty); P fail; edge fail
+(0,0,2)->(0,0,3)
+  dest unformed at τ=1; (0,0,3) in B_3(0); P fail; edge fail
+(0,0,3)->(0,0,4)
+  dest (0,0,4) has n·n=16 and is outside B_3(0); P fail; edge fail
+  3-step at (0,0,1): fail
+
+(0,1,1)->(0,1,2)
+  dest t=1; formed, split fail (O empty); P fail; edge fail
+(0,1,2)->(0,1,3)
+  dest (0,1,3) has n·n=10 and is outside B_3(0); P fail; edge fail
+(0,1,3)->(0,1,4)
+  dest (0,1,4) has n·n=17 and is outside B_3(0); P fail; edge fail
+  3-step at (0,1,1): fail
+```
+
+The vertices `(0,1,3)`, `(0,0,4)`, and `(0,1,4)` lie outside `B_3(0)` and
+those hops are fail not UNDEFINED. Vertex `(0,0,3)` lies in `B_3(0)` and is
+unformed at `τ=1`, so that edge fails, not UNDEFINED. On the HOLDING edge,
+`det P` equals the product of the two Orient signs. At the same cut, the named
+`−e_3` one-step fails at origin, HOLDs at `(0,1,0)`, fails at `(0,0,1)`, and
+HOLDs at `(0,1,1)`, while the `+e_3` one-step at `(0,1,1)` fails, so the
+displayed `+e_3` bits are not leftover of −e3.
+
+## Theorem 2
+
+Reverse probes are origin and `(0,1,0)`. Both three-step bits fail, neither is
+UNDEFINED, so reverse: fail.
+
+## Theorem 3
+
+Face probes are `(0,0,1)` and `(0,1,1)`. Both three-step bits fail, neither is
+UNDEFINED, so face: fail. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+
+## What this does not show
+
+The packet does not select a physical Record readout, a formation law, a
+holonomy identity, or a 4-cycle. It does not write the displayed bits into
+Admissibility. It does not attach L1. It does not enlarge Euclidean `B_3(0)`.
+It does not claim uniqueness of `F` among other frame conventions. Not leftover of −e3.
+It does not treat the far-face third pair as a formed child of the first pair.
+It does not adopt reverse or face.

--- a/logs/runner-cache/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,77 @@
+===== runner cache v1 =====
+runner: scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 4e0a6a1f0c0d288d08d79bc0e25b37bd1490e8cfdafba9ae7775b20e613a98b2
+input_fingerprint_sha256: c736830e49d614a1f3959d4d4c4321616966bf8ab4fdccc11d83da8d0ed9cb96
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.04
+status: ok
+----- stdout -----
+Directed 3-step cyclic-frame transport along +e3 at t+1
+AUDIT_INPUT_PATHS:
+  docs/THREE_AXIS_FARFACE_OPPOSITE_DIRECTED_THREE_STEP_PLUS_E3_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+displayed_not_adopted: true
+PASS: audit-input-paths-literal
+PASS: audit-inputs-exist
+PASS: source-lattice
+PASS: source-admissibility-unedited
+PASS: source-record-boundary
+PASS: euclidean-ball-cardinality
+PASS: seed-tick-zero
+PASS: seed-incoming-locks
+PASS: seed-six-tick-zero
+PASS: third-pair-are-seeds-not-children
+PASS: perp-step-blocks-parallel
+PASS: tick1-record-count  (20)
+PASS: signed-permutation-identity
+probe (0,0,0) t=0 tau=1 three_step=fail
+  F=fail Orient=fail
+probe (0,1,0) t=0 tau=1 three_step=fail
+  m=(-1,0,0) o_next=(0,1,0) o_prev=(0,0,-1) Orient=1 F=[(-1,0,0); (0,1,0); (0,0,-1)]
+probe (0,0,1) t=0 tau=1 three_step=fail
+  m=(0,1,0) o_next=(0,0,1) o_prev=(-1,0,0) Orient=-1 F=[(0,0,-1); (1,0,0); (0,1,0)]
+probe (0,1,1) t=0 tau=1 three_step=fail
+  m=(0,-1,0) o_next=(0,0,1) o_prev=(-1,0,0) Orient=1 F=[(0,0,-1); (-1,0,0); (0,1,0)]
+  edge (0,0,0)->(0,0,1) formed=(1,1) split=(0,1) in_ball=(1,1) P=fail edge=fail
+PASS: named-edge-(0,0,0)-(0,0,1)
+  edge (0,0,1)->(0,0,2) formed=(1,1) split=(1,0) in_ball=(1,1) P=fail edge=fail
+PASS: named-edge-(0,0,1)-(0,0,2)
+  edge (0,0,2)->(0,0,3) formed=(1,0) split=(0,0) in_ball=(1,1) P=fail edge=fail
+PASS: named-edge-(0,0,2)-(0,0,3)
+  edge (0,1,0)->(0,1,1) formed=(1,1) split=(1,1) in_ball=(1,1) P=[(0,0,1); (1,0,0); (0,1,0)] edge=hold
+PASS: named-edge-(0,1,0)-(0,1,1)
+  edge (0,1,1)->(0,1,2) formed=(1,1) split=(1,0) in_ball=(1,1) P=fail edge=fail
+PASS: named-edge-(0,1,1)-(0,1,2)
+  edge (0,1,2)->(0,1,3) formed=(1,0) split=(0,0) in_ball=(1,0) P=fail edge=fail
+PASS: named-edge-(0,1,2)-(0,1,3)
+  edge (0,0,1)->(0,0,2) formed=(1,1) split=(1,0) in_ball=(1,1) P=fail edge=fail
+  edge (0,0,2)->(0,0,3) formed=(1,0) split=(0,0) in_ball=(1,1) P=fail edge=fail
+  edge (0,0,3)->(0,0,4) formed=(0,0) split=(0,0) in_ball=(1,0) P=fail edge=fail
+PASS: named-edge-(0,0,3)-(0,0,4)
+  edge (0,1,1)->(0,1,2) formed=(1,1) split=(1,0) in_ball=(1,1) P=fail edge=fail
+  edge (0,1,2)->(0,1,3) formed=(1,0) split=(0,0) in_ball=(1,0) P=fail edge=fail
+  edge (0,1,3)->(0,1,4) formed=(0,0) split=(0,0) in_ball=(0,0) P=fail edge=fail
+PASS: named-edge-(0,1,3)-(0,1,4)
+reverse=fail bits=('fail', 'fail')
+face=fail bits=('fail', 'fail')
+PASS: theorem1-origin-split-fail
+PASS: theorem1-seed-frames
+PASS: theorem1-plus-e3-chain-sites
+PASS: theorem1-three-step-bits
+PASS: theorem2-reverse-fail
+PASS: theorem3-face-fail
+PASS: not-leftover-of-minus-e3
+PASS: mutation-lex-largest-uses-minus
+PASS: outside-ball-is-fail
+PASS: note-claim-scope
+PASS: note-computed-bits
+PASS: note-forbidden-phrases
+PASS: note-no-status-overclaim
+PASS: axiom-file-unedited-by-this-packet
+TOTAL: PASS=35 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python3
+"""Directed 3-step cyclic-frame transport along +e3 at t+1.
+
+Host: Euclidean B_3(0). Process: three-axis far-face opposite seed, perp-step
+incoming lock. Reverse and face bits are displayed, not adopted. Not leftover
+of −e3.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_AXIS_FARFACE_OPPOSITE_DIRECTED_THREE_STEP_PLUS_E3_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+RUNNER_PATH = Path(__file__).resolve()
+
+Vec = tuple[int, int, int]
+Mat = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+E1: Vec = (1, 0, 0)
+E2: Vec = (0, 1, 0)
+E3: Vec = (0, 0, 1)
+NEG_E1: Vec = (-1, 0, 0)
+NEG_E2: Vec = (0, -1, 0)
+NEG_E3: Vec = (0, 0, -1)
+STEP: Vec = E3
+NEIGHBOR_STEPS: tuple[Vec, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+SEED_LOCKS: dict[Vec, Vec] = {
+    (0, 0, 0): E1,
+    (0, 1, 0): NEG_E1,
+    (0, 0, 1): E2,
+    (0, 1, 1): NEG_E2,
+    (0, 0, -1): E3,
+    (0, 1, -1): NEG_E3,
+}
+REVERSE_PROBES: tuple[Vec, ...] = ((0, 0, 0), (0, 1, 0))
+FACE_PROBES: tuple[Vec, ...] = ((0, 0, 1), (0, 1, 1))
+ALL_PROBES: tuple[Vec, ...] = REVERSE_PROBES + FACE_PROBES
+CLAIM_SCOPE = (
+    "Directed 3-step cyclic-frame transport along +e3 at t+1 on the "
+    "three-axis far-face opposite seed, and reverse/face from that, are "
+    "reported. Displayed, not adopted."
+)
+
+
+def add(left: Vec, right: Vec) -> Vec:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Vec, right: Vec) -> Vec:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def scale(vec: Vec, factor: int) -> Vec:
+    return (factor * vec[0], factor * vec[1], factor * vec[2])
+
+
+def dot(left: Vec, right: Vec) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def neg(vec: Vec) -> Vec:
+    return (-vec[0], -vec[1], -vec[2])
+
+
+def in_ball(point: Vec) -> bool:
+    return dot(point, point) <= 9
+
+
+def axis_index(vec: Vec) -> int:
+    hits = [i for i, coord in enumerate(vec) if coord != 0]
+    if len(hits) != 1 or abs(vec[hits[0]]) != 1:
+        raise ValueError("lock is not a signed axis vector")
+    return hits[0]
+
+
+def unit_axis(index: int) -> Vec:
+    coords = [0, 0, 0]
+    coords[index] = 1
+    return (coords[0], coords[1], coords[2])
+
+
+def axis_set(vectors: frozenset[Vec]) -> frozenset[int]:
+    return frozenset(axis_index(vec) for vec in vectors)
+
+
+def unique_lock(incoming: frozenset[Vec]) -> Vec | None:
+    if len(incoming) != 1:
+        return None
+    return next(iter(incoming))
+
+
+def allowed_steps(lock: Vec) -> tuple[Vec, ...]:
+    axis = unit_axis(axis_index(lock))
+    return tuple(step for step in NEIGHBOR_STEPS if dot(step, axis) == 0)
+
+
+def columns_to_matrix(col0: Vec, col1: Vec, col2: Vec) -> Mat:
+    return (
+        (col0[0], col1[0], col2[0]),
+        (col0[1], col1[1], col2[1]),
+        (col0[2], col1[2], col2[2]),
+    )
+
+
+def mat_mul(left: Mat, right: Mat) -> Mat:
+    return tuple(
+        tuple(
+            sum(left[row][mid] * right[mid][col] for mid in range(3))
+            for col in range(3)
+        )
+        for row in range(3)
+    )  # type: ignore[return-value]
+
+
+def mat_transpose(matrix: Mat) -> Mat:
+    return tuple(tuple(matrix[col][row] for col in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def det3(matrix: Mat) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def is_signed_permutation(matrix: Mat) -> bool:
+    columns = [(matrix[0][col], matrix[1][col], matrix[2][col]) for col in range(3)]
+    rows_used: list[int] = []
+    for column in columns:
+        hits = [i for i, coord in enumerate(column) if coord != 0]
+        if len(hits) != 1 or abs(column[hits[0]]) != 1:
+            return False
+        rows_used.append(hits[0])
+    return len(set(rows_used)) == 3 and abs(det3(matrix)) == 1
+
+
+def lex_largest_signed_axis(options: frozenset[Vec]) -> Vec:
+    """Order +e < -e on a single axis; the negative letter is largest."""
+    if not options:
+        raise ValueError("empty leftover-axis set")
+    return max(options, key=lambda vec: next(coord for coord in vec if coord != 0) < 0)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                try:
+                    value = ast.literal_eval(node.value)
+                except (TypeError, ValueError):
+                    return None
+                if isinstance(value, tuple) and all(isinstance(item, str) for item in value):
+                    return value
+                return None
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+class History:
+    """Perp-step incoming-lock records on Euclidean B_3(0)."""
+
+    def __init__(self) -> None:
+        self.tick: dict[Vec, int] = {}
+        self.incoming: dict[Vec, frozenset[Vec]] = {}
+        for site, lock in SEED_LOCKS.items():
+            self.tick[site] = 0
+            self.incoming[site] = frozenset({lock})
+        self._grow_until(1)
+
+    def _grow_until(self, last_tick: int) -> None:
+        for parent_tick in range(last_tick):
+            candidates: dict[Vec, set[Vec]] = {}
+            for parent, formed_tick in self.tick.items():
+                if formed_tick != parent_tick:
+                    continue
+                lock = unique_lock(self.incoming[parent])
+                if lock is None:
+                    continue
+                for step in allowed_steps(lock):
+                    child = add(parent, step)
+                    if not in_ball(child) or child in self.tick:
+                        continue
+                    candidates.setdefault(child, set()).add(step)
+            for child, steps in candidates.items():
+                self.tick[child] = parent_tick + 1
+                self.incoming[child] = frozenset(steps)
+
+    def formed_at(self, site: Vec, tau: int) -> bool:
+        return site in self.tick and self.tick[site] <= tau
+
+    def M(self, site: Vec, tau: int) -> frozenset[Vec] | None:
+        if not self.formed_at(site, tau):
+            return None
+        return self.incoming[site]
+
+    def O(self, site: Vec, tau: int) -> frozenset[Vec] | None:
+        if not self.formed_at(site, tau):
+            return None
+        outgoing: set[Vec] = set()
+        for step in NEIGHBOR_STEPS:
+            neighbor = add(site, step)
+            incoming = self.M(neighbor, tau)
+            if incoming is not None and step in incoming:
+                outgoing.add(step)
+        return frozenset(outgoing)
+
+    def split_holds(self, site: Vec, tau: int) -> bool:
+        incoming = self.M(site, tau)
+        outgoing = self.O(site, tau)
+        if incoming is None or outgoing is None:
+            return False
+        axes_in = axis_set(incoming)
+        axes_out = axis_set(outgoing)
+        cover = axes_in.isdisjoint(axes_out) and axes_in | axes_out == frozenset({0, 1, 2})
+        return cover and len(axes_in) == 1 and len(incoming) == 1
+
+    def frame(self, site: Vec, tau: int) -> tuple[Vec, Vec, Vec, int, Mat] | None:
+        if not self.split_holds(site, tau):
+            return None
+        incoming = self.M(site, tau)
+        outgoing = self.O(site, tau)
+        assert incoming is not None and outgoing is not None
+        m = next(iter(incoming))
+        index = axis_index(m)
+        e_next = unit_axis((index + 1) % 3)
+        e_prev = unit_axis((index - 1) % 3)
+        o_next_set = frozenset({e_next, neg(e_next)}) & outgoing
+        o_prev_set = frozenset({e_prev, neg(e_prev)}) & outgoing
+        if not o_next_set or not o_prev_set:
+            return None
+        o_next = lex_largest_signed_axis(o_next_set)
+        o_prev = lex_largest_signed_axis(o_prev_set)
+        matrix = columns_to_matrix(m, o_next, o_prev)
+        orient = det3(matrix)
+        if orient not in (1, -1):
+            return None
+        return m, o_next, o_prev, orient, matrix
+
+
+def transport_matrix(src: Mat, dst: Mat) -> Mat:
+    """Integer P with P F(src) = F(dst)."""
+    return mat_mul(dst, mat_transpose(src))
+
+
+def edge_status(
+    history: History, src: Vec, step: Vec, tau: int
+) -> tuple[str, Mat | None]:
+    dst = add(src, step)
+    if not in_ball(src) or not in_ball(dst):
+        return "fail", None
+    if not history.formed_at(src, tau) or not history.formed_at(dst, tau):
+        return "fail", None
+    frame_src = history.frame(src, tau)
+    frame_dst = history.frame(dst, tau)
+    if frame_src is None or frame_dst is None:
+        return "fail", None
+    if frame_src[3] not in (1, -1) or frame_dst[3] not in (1, -1):
+        return "fail", None
+    matrix = transport_matrix(frame_src[4], frame_dst[4])
+    if not is_signed_permutation(matrix):
+        return "fail", None
+    if det3(matrix) != frame_src[3] * frame_dst[3]:
+        return "fail", None
+    return "hold", matrix
+
+
+def n_step_status(history: History, start: Vec, tau: int, hops: int, step: Vec) -> str:
+    sites = tuple(add(start, scale(step, k)) for k in range(hops + 1))
+    for site in sites:
+        if not in_ball(site):
+            return "fail"
+    for src in sites[:-1]:
+        status, _ = edge_status(history, src, step, tau)
+        if status != "hold":
+            return "fail"
+    return "hold"
+
+
+def three_step_status(history: History, start: Vec, tau: int, step: Vec = STEP) -> str:
+    return n_step_status(history, start, tau, 3, step)
+
+
+def two_step_status(history: History, start: Vec, tau: int, step: Vec = STEP) -> str:
+    return n_step_status(history, start, tau, 2, step)
+
+
+def one_step_status(history: History, start: Vec, tau: int, step: Vec = STEP) -> str:
+    return n_step_status(history, start, tau, 1, step)
+
+
+def pair_status(bits: tuple[str, str]) -> str:
+    if any(bit == "undefined" for bit in bits):
+        return "undefined"
+    if bits[0] == "hold" and bits[1] == "hold":
+        return "hold"
+    return "fail"
+
+
+def fmt_vec(vec: Vec) -> str:
+    return f"({vec[0]},{vec[1]},{vec[2]})"
+
+
+def fmt_mat(matrix: Mat) -> str:
+    return "[" + "; ".join("(" + ",".join(str(x) for x in row) + ")" for row in matrix) + "]"
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_src = RUNNER_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    history = History()
+
+    print("Directed 3-step cyclic-frame transport along +e3 at t+1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("displayed_not_adopted: true")
+
+    literal_paths = literal_audit_paths(runner_src)
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/THREE_AXIS_FARFACE_OPPOSITE_DIRECTED_THREE_STEP_PLUS_E3_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    checks.check(
+        "audit-inputs-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility-unedited",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in normalized_note
+        and "Do not write into Admissibility" in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        record_lock in normalized_axiom
+        and record_absence in normalized_axiom
+        and formation_boundary in normalized_axiom
+        and record_lock in normalized_note,
+    )
+
+    ball = [
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if x * x + y * y + z * z <= 9
+    ]
+    checks.check(
+        "euclidean-ball-cardinality",
+        len(ball) == 123 and in_ball((3, 0, 0)) and not in_ball((4, 0, 0)) and not in_ball((2, 2, 2)),
+    )
+    checks.check("seed-tick-zero", all(history.tick[site] == 0 for site in SEED_LOCKS))
+    checks.check(
+        "seed-incoming-locks",
+        all(history.incoming[site] == frozenset({lock}) for site, lock in SEED_LOCKS.items()),
+    )
+    checks.check("seed-six-tick-zero", len(SEED_LOCKS) == 6)
+    checks.check(
+        "third-pair-are-seeds-not-children",
+        history.tick[(0, 0, -1)] == 0
+        and history.tick[(0, 1, -1)] == 0
+        and history.incoming[(0, 0, -1)] == frozenset({E3})
+        and history.incoming[(0, 1, -1)] == frozenset({NEG_E3}),
+    )
+    checks.check(
+        "perp-step-blocks-parallel",
+        E3 not in allowed_steps(E3)
+        and E3 in allowed_steps(E1)
+        and E3 in allowed_steps(E2)
+        and STEP == E3
+        and STEP != NEG_E3,
+    )
+
+    tau = 1
+    formed_tick1 = sorted(site for site, tick in history.tick.items() if tick <= 1)
+    checks.check("tick1-record-count", len(formed_tick1) == 20, detail=str(len(formed_tick1)))
+
+    identity = columns_to_matrix(E1, E2, E3)
+    checks.check(
+        "signed-permutation-identity",
+        is_signed_permutation(identity)
+        and transport_matrix(identity, identity) == identity
+        and det3(identity) == 1,
+    )
+
+    expected_p: dict[tuple[Vec, Vec], Mat | None] = {
+        ((0, 0, 0), (0, 0, 1)): None,
+        ((0, 0, 1), (0, 0, 2)): None,
+        ((0, 0, 2), (0, 0, 3)): None,
+        ((0, 1, 0), (0, 1, 1)): ((0, 0, 1), (1, 0, 0), (0, 1, 0)),
+        ((0, 1, 1), (0, 1, 2)): None,
+        ((0, 1, 2), (0, 1, 3)): None,
+        ((0, 0, 3), (0, 0, 4)): None,
+        ((0, 1, 3), (0, 1, 4)): None,
+    }
+    three_step_bits: dict[Vec, str] = {}
+    named_edges: list[tuple[Vec, Vec]] = []
+    for probe in ALL_PROBES:
+        hop1 = add(probe, STEP)
+        hop2 = add(probe, scale(STEP, 2))
+        hop3 = add(probe, scale(STEP, 3))
+        named_edges.append((probe, hop1))
+        named_edges.append((hop1, hop2))
+        named_edges.append((hop2, hop3))
+        three_step_bits[probe] = three_step_status(history, probe, tau)
+        print(
+            f"probe {fmt_vec(probe)} t={history.tick.get(probe, -1)} "
+            f"tau={tau} three_step={three_step_bits[probe]}"
+        )
+        frame = history.frame(probe, tau)
+        if frame is None:
+            print("  F=fail Orient=fail")
+        else:
+            print(
+                f"  m={fmt_vec(frame[0])} o_next={fmt_vec(frame[1])} "
+                f"o_prev={fmt_vec(frame[2])} Orient={frame[3]} F={fmt_mat(frame[4])}"
+            )
+
+    seen_edges: set[tuple[Vec, Vec]] = set()
+    for src, dst in named_edges:
+        status, matrix = edge_status(history, src, sub(dst, src), tau)
+        formed_src = history.formed_at(src, tau)
+        formed_dst = history.formed_at(dst, tau)
+        split_src = history.split_holds(src, tau) if formed_src else False
+        split_dst = history.split_holds(dst, tau) if formed_dst else False
+        p_text = fmt_mat(matrix) if matrix is not None else "fail"
+        print(
+            f"  edge {fmt_vec(src)}->{fmt_vec(dst)} formed=({int(formed_src)},{int(formed_dst)}) "
+            f"split=({int(split_src)},{int(split_dst)}) in_ball=({int(in_ball(src))},{int(in_ball(dst))}) "
+            f"P={p_text} edge={status}"
+        )
+        if (src, dst) in seen_edges:
+            continue
+        seen_edges.add((src, dst))
+        expected = expected_p[(src, dst)]
+        if expected is None:
+            checks.check(
+                f"named-edge-{fmt_vec(src)}-{fmt_vec(dst)}",
+                status == "fail" and matrix is None,
+            )
+        else:
+            checks.check(
+                f"named-edge-{fmt_vec(src)}-{fmt_vec(dst)}",
+                status == "hold" and matrix == expected and det3(expected) == det3(matrix),
+            )
+
+    reverse_bits = tuple(three_step_bits[probe] for probe in REVERSE_PROBES)
+    face_bits = tuple(three_step_bits[probe] for probe in FACE_PROBES)
+    reverse = pair_status(reverse_bits)
+    face = pair_status(face_bits)
+    print(f"reverse={reverse} bits={reverse_bits}")
+    print(f"face={face} bits={face_bits}")
+
+    origin_frame = history.frame((0, 0, 0), tau)
+    yseed_frame = history.frame((0, 1, 0), tau)
+    zseed_frame = history.frame((0, 0, 1), tau)
+    yzseed_frame = history.frame((0, 1, 1), tau)
+    origin_out = history.O((0, 0, 0), tau)
+    origin_in = history.M((0, 0, 0), tau)
+    checks.check(
+        "theorem1-origin-split-fail",
+        origin_frame is None
+        and not history.split_holds((0, 0, 0), tau)
+        and origin_in == frozenset({E1})
+        and origin_out == frozenset({NEG_E2}),
+    )
+    checks.check(
+        "theorem1-seed-frames",
+        yseed_frame is not None
+        and zseed_frame is not None
+        and yzseed_frame is not None
+        and yseed_frame[0:4] == (NEG_E1, E2, NEG_E3, 1)
+        and zseed_frame[0:4] == (E2, E3, NEG_E1, -1)
+        and yzseed_frame[0:4] == (NEG_E2, E3, NEG_E1, 1),
+    )
+    checks.check(
+        "theorem1-plus-e3-chain-sites",
+        history.formed_at((0, 0, 1), tau)
+        and history.formed_at((0, 1, 1), tau)
+        and history.formed_at((0, 0, 2), tau)
+        and history.formed_at((0, 1, 2), tau)
+        and not history.formed_at((0, 0, 3), tau)
+        and not history.formed_at((0, 1, 3), tau)
+        and in_ball((0, 0, 2))
+        and in_ball((0, 1, 2))
+        and in_ball((0, 0, 3))
+        and not in_ball((0, 1, 3))
+        and not in_ball((0, 0, 4))
+        and not in_ball((0, 1, 4))
+        and history.tick[(0, 0, 1)] == 0
+        and history.tick[(0, 1, 1)] == 0
+        and history.tick[(0, 0, 2)] == 1
+        and history.tick[(0, 1, 2)] == 1
+        and history.split_holds((0, 0, 1), tau)
+        and history.split_holds((0, 1, 1), tau)
+        and not history.split_holds((0, 0, 2), tau)
+        and not history.split_holds((0, 1, 2), tau)
+        and history.O((0, 0, 2), tau) == frozenset()
+        and history.O((0, 1, 2), tau) == frozenset(),
+    )
+    checks.check(
+        "theorem1-three-step-bits",
+        three_step_bits[(0, 0, 0)] == "fail"
+        and three_step_bits[(0, 1, 0)] == "fail"
+        and three_step_bits[(0, 0, 1)] == "fail"
+        and three_step_bits[(0, 1, 1)] == "fail",
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse == "fail" and reverse != "undefined" and reverse_bits == ("fail", "fail"),
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face == "fail" and face != "undefined" and face_bits == ("fail", "fail"),
+    )
+
+    minus_three = tuple(three_step_status(history, probe, tau, NEG_E3) for probe in ALL_PROBES)
+    plus_three = tuple(three_step_bits[probe] for probe in ALL_PROBES)
+    minus_one = tuple(one_step_status(history, probe, tau, NEG_E3) for probe in ALL_PROBES)
+    plus_one = tuple(one_step_status(history, probe, tau, E3) for probe in ALL_PROBES)
+    minus_two = tuple(two_step_status(history, probe, tau, NEG_E3) for probe in ALL_PROBES)
+    plus_two = tuple(two_step_status(history, probe, tau, E3) for probe in ALL_PROBES)
+    hold_plus, mat_plus = edge_status(history, (0, 1, 0), E3, tau)
+    minus_edge_face, _ = edge_status(history, (0, 1, 1), NEG_E3, tau)
+    plus_edge_face, _ = edge_status(history, (0, 1, 1), E3, tau)
+    checks.check(
+        "not-leftover-of-minus-e3",
+        STEP == E3
+        and STEP != NEG_E3
+        and plus_three == ("fail", "fail", "fail", "fail")
+        and minus_three == ("fail", "fail", "fail", "fail")
+        and plus_one == ("fail", "hold", "fail", "fail")
+        and minus_one == ("fail", "hold", "fail", "hold")
+        and plus_two == ("fail", "fail", "fail", "fail")
+        and minus_two == ("fail", "fail", "fail", "hold")
+        and reverse == "fail"
+        and face == "fail"
+        and one_step_status(history, (0, 1, 1), tau, E3) == "fail"
+        and one_step_status(history, (0, 1, 1), tau, NEG_E3) == "hold"
+        and two_step_status(history, (0, 1, 1), tau, E3) == "fail"
+        and two_step_status(history, (0, 1, 1), tau, NEG_E3) == "hold"
+        and hold_plus == "hold"
+        and mat_plus == ((0, 0, 1), (1, 0, 0), (0, 1, 0))
+        and plus_edge_face == "fail"
+        and minus_edge_face == "hold",
+    )
+
+    both_signs = history.frame((0, 0, 1), tau)
+    assert both_signs is not None
+    mutated_prev = E1
+    mutated = columns_to_matrix(both_signs[0], both_signs[1], mutated_prev)
+    checks.check(
+        "mutation-lex-largest-uses-minus",
+        both_signs[2] == NEG_E1
+        and det3(mutated) == 1
+        and both_signs[3] == -1
+        and det3(mutated) != both_signs[3],
+    )
+    checks.check(
+        "outside-ball-is-fail",
+        not in_ball((0, 1, 3))
+        and in_ball((0, 0, 3))
+        and not in_ball((0, 0, 4))
+        and not in_ball((0, 1, 4))
+        and three_step_status(history, (0, 1, 0), tau) == "fail"
+        and three_step_status(history, (0, 1, 0), tau) != "undefined"
+        and three_step_status(history, (0, 1, 1), tau) == "fail"
+        and three_step_status(history, (0, 1, 1), tau) != "undefined"
+        and three_step_status(history, (0, 0, 1), tau) == "fail"
+        and three_step_status(history, (0, 0, 1), tau) != "undefined"
+        and edge_status(history, (0, 1, 2), E3, tau) == ("fail", None)
+        and edge_status(history, (0, 0, 3), E3, tau) == ("fail", None),
+    )
+
+    required_note = (
+        CLAIM_SCOPE,
+        "Displayed, not adopted",
+        "Do not attach L1",
+        "Do not write into Admissibility",
+        "hypothetical_axiom_status: no edit",
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "reverse: fail",
+        "face: fail",
+        "F((0,0,0)) fails",
+        "Orient((0,1,0))=+1",
+        "Orient((0,0,1))=-1",
+        "Orient((0,1,1))=+1",
+        "3-step at (0,0,0): fail",
+        "3-step at (0,1,0): fail",
+        "3-step at (0,0,1): fail",
+        "3-step at (0,1,1): fail",
+        "P=[(0,0,1); (1,0,0); (0,1,0)]",
+        "authors no audit verdict",
+        "Euclidean B_3(0)={n:n·n<=9}",
+        "Not leftover of −e3",
+        "third pair is a new seed, not a formed child",
+        "fail not UNDEFINED",
+    )
+    forbidden_note = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "Dijkstra",
+        "Gram",
+        "Cl(3,0)",
+        "S^+",
+        "S⁺",
+        "unique P_+",
+        "occupancy n",
+        "new axiom",
+    )
+    checks.check(
+        "note-claim-scope",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note or CLAIM_SCOPE in note,
+    )
+    missing = [phrase for phrase in required_note if phrase not in note]
+    checks.check(
+        "note-computed-bits",
+        not missing,
+        detail="; ".join(missing[:4]),
+    )
+    checks.check(
+        "note-forbidden-phrases",
+        not any(phrase in note for phrase in forbidden_note)
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note,
+    )
+    other = note
+    for line in (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "actual_current_surface_status: bounded-support",
+    ):
+        other = other.replace(line, "")
+    checks.check(
+        "note-no-status-overclaim",
+        "audit_required_before_effective_retained: true" in note
+        and "bare_retained_allowed: false" in note
+        and "retained" not in other.lower(),
+    )
+    checks.check(
+        "axiom-file-unedited-by-this-packet",
+        "Lattice / Physical Locality" in axiom and "Qubit / Site Possibility" in axiom,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Far-face three hops +e3. Reverse fails, face fails. Displayed, not adopted. FAIL=0. Not HOLDING_MEMBER.

## Runner

`scripts/three_axis_farface_opposite_directed_three_step_plus_e3_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.