### PR TITLE
feat(nm2frm2lxf): L-path cyclic-frame transport -e3 then -e1 at t+1 on three-axis far-face opposite seed: reverse fails, face fails

### DIFF
--- a/docs/THREE_AXIS_FARFACE_OPPOSITE_LPATH_MINUS_E3_MINUS_E1_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+++ b/docs/THREE_AXIS_FARFACE_OPPOSITE_LPATH_MINUS_E3_MINUS_E1_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
@@ -1,0 +1,225 @@
+---
+claim_id: three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+claim_type: bounded_theorem
+claim_scope: "L-path cyclic-frame transport −e3 then −e1 at t+1 on the three-axis far-face opposite seed, and reverse/face from that, are reported. Displayed, not adopted."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+---
+
+# L-Path Cyclic-Frame Transport −e3 Then −e1 At t+1 On The Three-Axis Far-Face Opposite Seed
+
+**Date:** 2026-08-15
+**Type:** bounded_theorem
+**Scope:** exact L-path bits, one hop along `−e_3` then one hop along `−e_1`,
+at each site's own `τ=t+1` on the three-axis far-face opposite seed in
+Euclidean `B_3(0)`, together with reverse and face from those bits.
+**Audit-status authority:** independent audit lane only. This note authors no audit verdict and predicts none.
+**Primary runner:**
+[`scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`](../scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py)
+
+## Result up front
+
+On the three-axis far-face opposite seed, cyclic-frame transport along a named
+edge is the signed-permutation map of the ordered triple `F=(m,o_next,o_prev)`.
+This note displays the same named L-path as on the two-axis opposite seed: one
+`−e_3` hop then one `−e_1` hop from each of the four seed probes. It is not a
+2-step along one axis. It is not a 4-cycle. The third pair is a new seed, not a
+formed child.
+
+At each site's own cut `τ=t+1` origin split fails, so the origin first hop
+fails and the origin L-path fails. The reverse probe `(0,1,0)` HOLDs both hops.
+Both face L-path bits fail. Therefore
+
+```text
+reverse: fail
+face: fail
+```
+
+The bits are Displayed, not adopted. Do not write into Admissibility. Do not
+attach L1. Uniqueness is not required.
+
+## Machine status and trace
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite exact L-path bits on Euclidean B_3(0) at each site's own t+1; the bits are displayed and not adopted."
+trace_class: frontier_discovery
+target_claim_id: three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_bounded_theorem_note_2026-08-15
+target_blocker_text: "display L-path cyclic-frame transport -e3 then -e1 at t+1 on the three-axis far-face opposite seed and the reverse/face pair from those bits"
+source_of_blocker_text: frontier_question
+reachability_to_target: closed_finite_target
+artifact_role: theorem
+next_trace_action: "independent audit of the landed note and invocation-bound runner evidence"
+conditional_surface_status: "exact only for the declared three-axis far-face opposite seed, Euclidean B_3(0), and the named -e3 then -e1 L-path at t+1"
+hypothetical_axiom_status: no edit
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Premise boundary
+
+Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site.
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+
+For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions.
+
+When present, a record locks exactly one admissible local possibility.
+
+A readout value is determined by record content alone.
+
+A site with no record cannot be read.
+
+Admissibility does not supply the formation site, probability, or rate. The
+perp-step incoming-lock process used below is a declared finite host process,
+not an axiom edit.
+
+## Exact objects
+
+Euclidean B_3(0)={n:n·n<=9} inside `Z^3`. No larger ball is used. Nearest
+neighbors are the six axial steps `{±e_1,±e_2,±e_3}` with
+`e_1=(1,0,0)`, `e_2=(0,1,0)`, `e_3=(0,0,1)`.
+
+Seed at tick `0`, two disjoint opposite pairs plus far-face third pair:
+
+```text
+(0,0,0) locks +e_1
+(0,1,0) locks -e_1
+(0,0,1) locks +e_2
+(0,1,1) locks -e_2
+(0,0,-1) locks +e_3
+(0,1,-1) locks -e_3
+```
+
+The third pair is a new seed, not a formed child.
+
+From a recorded site `p` with unique lock `L(p)=±e_i`, a step `s` to
+`q=p+s` is allowed iff `s·e_i=0`. If `q` lies in `B_3(0)` and is unformed,
+`q` forms at `t(p)+1` and the incoming set `M(q)` is the set of earliest such
+steps. If that set is not a singleton, `q` has no unique lock and does not
+emit. Seed incoming sets are the assigned locks.
+
+Let `t(q)` be the formation tick. The cut is `τ=t+1` at each site: there is
+no global T. A site is formed at a cut `τ` iff it is recorded with tick
+`≤ τ`. Unformed at `τ` is fail, not UNDEFINED. A vertex outside `B_3(0)` is
+fail, not UNDEFINED.
+
+`M(q,τ)` is the earliest incoming set of `q` from records with tick `≤ τ`,
+defined only if `q` is formed at `τ`.
+
+`O(q,τ)={e in {±e_1,±e_2,±e_3} | q+e formed at τ and e in M(q+e,τ)}`.
+
+`Axis(S)={e_i | some ±e_i in S}`. Cover holds iff `Axis(M)∩Axis(O)` is empty
+and `Axis(M)∪Axis(O)={e_1,e_2,e_3}`. Split holds iff cover holds and
+`|Axis(M)|=1` with `m` unique in `M`. Two-in one-out is fail. If split fails,
+Orient fails, not UNDEFINED.
+
+When split holds, let `i` be the axis index of `m`. Set `e_next=e_{i+1}` with
+`3+1→1` and `e_prev=e_{i-1}` with `1-1→3`. Let
+`O_next=O∩{±e_next}` and `O_prev=O∩{±e_prev}`. If either is empty, Orient
+fails, not UNDEFINED. Order `+e < -e`. Then `o_next` is the lex-largest
+vector in `O_next` (hence `-e` if both signs), and `o_prev` likewise.
+`F(q)` is the `3×3` integer matrix with columns `(m,o_next,o_prev)`.
+`Orient(q)` is the sign of `det F(q)`. Split plus nonempty leftover axes
+makes `Orient∈{±1}` and makes `F` a signed permutation matrix.
+
+Directed-edge HOLD from `q` to `q+e` iff `q` and `q+e` lie in `B_3(0)`, both
+are formed, split holds at both at each site's own `τ=t+1`, Orient is `±1`
+at both, and the unique `3×3` integer matrix `P` sending columns of `F(q)` to
+columns of `F(q+e)` (the unique `P` with `P F(q)=F(q+e)`) is a signed
+permutation with `det P=Orient(q)Orient(q+e)`. Else that edge fails, not
+UNDEFINED.
+
+L-path HOLD at `q` iff `q`, `q−e_3`, and `q−e_3−e_1` lie in `B_3(0)` and both
+named edges `(q,q−e_3)` and `(q−e_3,q−e_3−e_1)` HOLD.
+
+Reverse probes: origin and `(0,1,0)`. Face probes: `(0,0,1)` and `(0,1,1)`.
+Reverse HOLD iff L-path HOLDs at both reverse probes. Face HOLD iff both face
+probes HOLD.
+
+## Theorem 1
+
+At `τ=t+1` the six seeds are formed at tick `0`. Frames at the four probes,
+the two far-face dest seeds, and the two reverse second-hop dests:
+
+```text
+F((0,0,0)) fails
+  M={+e_1}, O={-e_2}; Axis(M)={e_1}, Axis(O)={e_2}; split fails
+F((0,1,0)) columns (-e_1,+e_2,-e_3); Orient((0,1,0))=+1
+F((0,0,1)) columns (+e_2,+e_3,-e_1); Orient((0,0,1))=-1
+F((0,1,1)) columns (-e_2,+e_3,-e_1); Orient((0,1,1))=+1
+F((0,0,-1)) columns (+e_3,-e_1,-e_2); Orient((0,0,-1))=+1
+F((0,1,-1)) columns (-e_3,-e_1,+e_2); Orient((0,1,-1))=+1
+F((-1,0,-1)) columns (-e_1,-e_2,-e_3); Orient((-1,0,-1))=-1
+F((-1,1,-1)) columns (-e_1,+e_2,-e_3); Orient((-1,1,-1))=+1
+```
+
+Origin split fails because the far-face seed at `(0,0,-1)` locks `+e_3`, so
+the step `−e_3` from origin is not in `M((0,0,-1))` and is not in origin
+`O`. The eight named edges and the four L-path bits:
+
+```text
+(0,0,0)->(0,0,-1)->(-1,0,-1)
+  hop1 dest t=0; F dest columns (+e_3,-e_1,-e_2); Orient dest=+1
+  src split fail; P fail; edge fail
+  hop2 dest t=1; F dest columns (-e_1,-e_2,-e_3); Orient dest=-1
+  P=[0 0 -1; 1 0 0; 0 1 0]; det P=-1; edge hold
+  L-path at (0,0,0): fail
+
+(0,1,0)->(0,1,-1)->(-1,1,-1)
+  hop1 dest t=0; F dest columns (-e_3,-e_1,+e_2); Orient dest=+1
+  P=[0 -1 0; 0 0 -1; 1 0 0]; det P=+1; edge hold
+  hop2 dest t=1; F dest columns (-e_1,+e_2,-e_3); Orient dest=+1
+  P=[0 0 1; -1 0 0; 0 -1 0]; det P=+1; edge hold
+  L-path at (0,1,0): hold
+
+(0,0,1)->(0,0,0)->(-1,0,0)
+  hop1 dest t=0; F dest fails
+  dest split fail; P fail; edge fail
+  hop2 dest t=2; split fail at dest (Axis(M)={e_3}, two-in, Axis(O)={e_1}); P fail; edge fail
+  L-path at (0,0,1): fail
+
+(0,1,1)->(0,1,0)->(-1,1,0)
+  hop1 dest t=0; F dest as (0,1,0); Orient dest=+1
+  P=[0 1 0; 0 0 1; 1 0 0]; det P=+1; edge hold
+  hop2 dest t=2; split fail at dest (Axis(M)={e_3}, two-in, Axis(O) empty); P fail; edge fail
+  L-path at (0,1,1): fail
+```
+
+All twelve listed vertices lie in `B_3(0)`. On each HOLDING edge, `det P`
+equals the product of the two Orient signs. This is the same named `−e_3`
+then `−e_1` L-path as on the two-axis opposite seed, read on the six-site
+far-face host: origin `F` HOLDs on the four-site two-axis seed and fails here.
+This is not leftover of the 1-step along `−e_3`: that reverse bit fails with
+bits `(fail, hold)` and that face bit fails with bits `(fail, hold)`, while
+this reverse fails with bits `(fail, hold)` and this face fails with bits
+`(fail, fail)`. This is not leftover of the 2-step along `−e_3`: that reverse
+bit fails with bits `(fail, fail)` and that face bit fails with bits
+`(fail, hold)`, while this reverse fails with bits `(fail, hold)` and this
+face fails with bits `(fail, fail)`.
+
+## Theorem 2
+
+Reverse probes are origin and `(0,1,0)`. Origin L-path fails, `(0,1,0)` L-path
+holds, neither is UNDEFINED, so reverse: fail.
+
+## Theorem 3
+
+Face probes are `(0,0,1)` and `(0,1,1)`. Both L-path bits fail, neither is
+UNDEFINED, so face: fail. Displayed, not adopted. Do not write into
+Admissibility. Do not attach L1.
+
+## What this does not show
+
+The packet does not select a physical Record readout, a formation law, a
+holonomy identity, or a 4-cycle. It does not write the displayed bits into
+Admissibility. It does not attach L1. It does not enlarge Euclidean `B_3(0)`.
+It does not claim uniqueness of `F` among other frame conventions. It does
+not replace the L-path by the 1-step along `−e_3` or by the 2-step along
+`−e_3`. It does not treat the far-face third pair as a formed child of the
+first pair.

--- a/logs/runner-cache/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
+++ b/logs/runner-cache/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.txt
@@ -1,0 +1,83 @@
+===== runner cache v1 =====
+runner: scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+runner_sha256: 36ea408df52281dc0de539c6377381a0b4b830aee6421aacc9a6bf4b360a1108
+input_fingerprint_sha256: 6844242b6f38ce423efcf16d402415b7046856003a66cda2b094e8f7c6e293df
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.09
+status: ok
+----- stdout -----
+L-path cyclic-frame transport -e3 then -e1 at t+1
+AUDIT_INPUT_PATHS:
+  docs/THREE_AXIS_FARFACE_OPPOSITE_LPATH_MINUS_E3_MINUS_E1_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+AUDIT_TIMEOUT_SEC: 120
+cache_write: false
+displayed_not_adopted: true
+PASS: audit-input-paths-literal
+PASS: audit-inputs-exist
+PASS: source-lattice
+PASS: source-admissibility-unedited
+PASS: source-record-boundary
+PASS: euclidean-ball-cardinality
+PASS: seed-tick-zero
+PASS: seed-incoming-locks
+PASS: seed-six-tick-zero
+PASS: third-pair-are-seeds-not-children
+PASS: perp-step-blocks-parallel
+PASS: tick1-record-count  (20)
+PASS: signed-permutation-identity
+probe (0,0,0) t=0 tau=1 lpath=fail path=(0,0,0)->(0,0,-1)->(-1,0,-1)
+  (0,0,0) t=0 F=fail Orient=fail
+  (0,0,-1) t=0 m=(0,0,1) o_next=(-1,0,0) o_prev=(0,-1,0) Orient=1 F=[0 -1 0; 0 0 -1; 1 0 0]
+  (-1,0,-1) t=1 m=(-1,0,0) o_next=(0,-1,0) o_prev=(0,0,-1) Orient=-1 F=[-1 0 0; 0 -1 0; 0 0 -1]
+  hop1 (0,0,0)->(0,0,-1) P=fail edge=fail
+  hop2 (0,0,-1)->(-1,0,-1) P=[0 0 -1; 1 0 0; 0 1 0] edge=hold
+PASS: named-first-edge-(0,0,0)-(0,0,-1)
+PASS: named-second-edge-(0,0,-1)-(-1,0,-1)
+probe (0,1,0) t=0 tau=1 lpath=hold path=(0,1,0)->(0,1,-1)->(-1,1,-1)
+  (0,1,0) t=0 m=(-1,0,0) o_next=(0,1,0) o_prev=(0,0,-1) Orient=1 F=[-1 0 0; 0 1 0; 0 0 -1]
+  (0,1,-1) t=0 m=(0,0,-1) o_next=(-1,0,0) o_prev=(0,1,0) Orient=1 F=[0 -1 0; 0 0 1; -1 0 0]
+  (-1,1,-1) t=1 m=(-1,0,0) o_next=(0,1,0) o_prev=(0,0,-1) Orient=1 F=[-1 0 0; 0 1 0; 0 0 -1]
+  hop1 (0,1,0)->(0,1,-1) P=[0 -1 0; 0 0 -1; 1 0 0] edge=hold
+  hop2 (0,1,-1)->(-1,1,-1) P=[0 0 1; -1 0 0; 0 -1 0] edge=hold
+PASS: named-first-edge-(0,1,0)-(0,1,-1)
+PASS: named-second-edge-(0,1,-1)-(-1,1,-1)
+probe (0,0,1) t=0 tau=1 lpath=fail path=(0,0,1)->(0,0,0)->(-1,0,0)
+  (0,0,1) t=0 m=(0,1,0) o_next=(0,0,1) o_prev=(-1,0,0) Orient=-1 F=[0 0 -1; 1 0 0; 0 1 0]
+  (0,0,0) t=0 F=fail Orient=fail
+  (-1,0,0) t=2 F=fail Orient=fail
+  hop1 (0,0,1)->(0,0,0) P=fail edge=fail
+  hop2 (0,0,0)->(-1,0,0) P=fail edge=fail
+PASS: named-first-edge-(0,0,1)-(0,0,0)
+PASS: named-second-edge-(0,0,0)-(-1,0,0)
+probe (0,1,1) t=0 tau=1 lpath=fail path=(0,1,1)->(0,1,0)->(-1,1,0)
+  (0,1,1) t=0 m=(0,-1,0) o_next=(0,0,1) o_prev=(-1,0,0) Orient=1 F=[0 0 -1; -1 0 0; 0 1 0]
+  (0,1,0) t=0 m=(-1,0,0) o_next=(0,1,0) o_prev=(0,0,-1) Orient=1 F=[-1 0 0; 0 1 0; 0 0 -1]
+  (-1,1,0) t=2 F=fail Orient=fail
+  hop1 (0,1,1)->(0,1,0) P=[0 1 0; 0 0 1; 1 0 0] edge=hold
+  hop2 (0,1,0)->(-1,1,0) P=fail edge=fail
+PASS: named-first-edge-(0,1,1)-(0,1,0)
+PASS: named-second-edge-(0,1,0)-(-1,1,0)
+reverse=fail bits=('fail', 'hold')
+face=fail bits=('fail', 'fail')
+PASS: theorem1-origin-split-fail
+PASS: theorem1-seed-frames
+PASS: theorem1-path-frames
+PASS: theorem1-lpath-bits
+PASS: theorem2-reverse-fail
+PASS: theorem3-face-fail
+PASS: not-leftover-of-one-step-minus-e3
+PASS: not-leftover-of-two-step-minus-e3
+PASS: mutation-lex-largest-uses-minus
+PASS: outside-ball-is-fail
+PASS: face-second-hop-split-fail
+PASS: note-claim-scope
+PASS: note-computed-bits
+PASS: note-forbidden-phrases
+PASS: note-no-status-overclaim
+PASS: axiom-file-unedited-by-this-packet
+TOTAL: PASS=37 FAIL=0
+
+----- stderr -----
+

--- a/scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
+++ b/scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py
@@ -1,0 +1,742 @@
+#!/usr/bin/env python3
+"""L-path cyclic-frame transport -e3 then -e1 at t+1.
+
+Host: Euclidean B_3(0). Process: three-axis far-face opposite seed, perp-step
+incoming lock. Reverse and face bits are displayed, not adopted.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+AUDIT_TIMEOUT_SEC = 120
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_INPUT_PATHS = (
+    "docs/THREE_AXIS_FARFACE_OPPOSITE_LPATH_MINUS_E3_MINUS_E1_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+NOTE_PATH = ROOT / AUDIT_INPUT_PATHS[0]
+AXIOM_PATH = ROOT / AUDIT_INPUT_PATHS[1]
+RUNNER_PATH = Path(__file__).resolve()
+
+Vec = tuple[int, int, int]
+Mat = tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]
+
+E1: Vec = (1, 0, 0)
+E2: Vec = (0, 1, 0)
+E3: Vec = (0, 0, 1)
+NEG_E1: Vec = (-1, 0, 0)
+NEG_E2: Vec = (0, -1, 0)
+NEG_E3: Vec = (0, 0, -1)
+FIRST_STEP: Vec = NEG_E3
+SECOND_STEP: Vec = NEG_E1
+NEIGHBOR_STEPS: tuple[Vec, ...] = (
+    E1,
+    NEG_E1,
+    E2,
+    NEG_E2,
+    E3,
+    NEG_E3,
+)
+SEED_LOCKS: dict[Vec, Vec] = {
+    (0, 0, 0): E1,
+    (0, 1, 0): NEG_E1,
+    (0, 0, 1): E2,
+    (0, 1, 1): NEG_E2,
+    (0, 0, -1): E3,
+    (0, 1, -1): NEG_E3,
+}
+REVERSE_PROBES: tuple[Vec, ...] = ((0, 0, 0), (0, 1, 0))
+FACE_PROBES: tuple[Vec, ...] = ((0, 0, 1), (0, 1, 1))
+ALL_PROBES: tuple[Vec, ...] = REVERSE_PROBES + FACE_PROBES
+CLAIM_SCOPE = (
+    "L-path cyclic-frame transport −e3 then −e1 at t+1 on the "
+    "three-axis far-face opposite seed, and reverse/face from that, are "
+    "reported. Displayed, not adopted."
+)
+
+
+def add(left: Vec, right: Vec) -> Vec:
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def sub(left: Vec, right: Vec) -> Vec:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def dot(left: Vec, right: Vec) -> int:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def neg(vec: Vec) -> Vec:
+    return (-vec[0], -vec[1], -vec[2])
+
+
+def in_ball(point: Vec) -> bool:
+    return dot(point, point) <= 9
+
+
+def axis_index(vec: Vec) -> int:
+    hits = [i for i, coord in enumerate(vec) if coord != 0]
+    if len(hits) != 1 or abs(vec[hits[0]]) != 1:
+        raise ValueError("lock is not a signed axis vector")
+    return hits[0]
+
+
+def unit_axis(index: int) -> Vec:
+    coords = [0, 0, 0]
+    coords[index] = 1
+    return (coords[0], coords[1], coords[2])
+
+
+def axis_set(vectors: frozenset[Vec]) -> frozenset[int]:
+    return frozenset(axis_index(vec) for vec in vectors)
+
+
+def unique_lock(incoming: frozenset[Vec]) -> Vec | None:
+    if len(incoming) != 1:
+        return None
+    return next(iter(incoming))
+
+
+def allowed_steps(lock: Vec) -> tuple[Vec, ...]:
+    axis = unit_axis(axis_index(lock))
+    return tuple(step for step in NEIGHBOR_STEPS if dot(step, axis) == 0)
+
+
+def columns_to_matrix(col0: Vec, col1: Vec, col2: Vec) -> Mat:
+    return (
+        (col0[0], col1[0], col2[0]),
+        (col0[1], col1[1], col2[1]),
+        (col0[2], col1[2], col2[2]),
+    )
+
+
+def mat_mul(left: Mat, right: Mat) -> Mat:
+    return tuple(
+        tuple(
+            sum(left[row][mid] * right[mid][col] for mid in range(3))
+            for col in range(3)
+        )
+        for row in range(3)
+    )  # type: ignore[return-value]
+
+
+def mat_transpose(matrix: Mat) -> Mat:
+    return tuple(tuple(matrix[col][row] for col in range(3)) for row in range(3))  # type: ignore[return-value]
+
+
+def det3(matrix: Mat) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def is_signed_permutation(matrix: Mat) -> bool:
+    columns = [(matrix[0][col], matrix[1][col], matrix[2][col]) for col in range(3)]
+    rows_used: list[int] = []
+    for column in columns:
+        hits = [i for i, coord in enumerate(column) if coord != 0]
+        if len(hits) != 1 or abs(column[hits[0]]) != 1:
+            return False
+        rows_used.append(hits[0])
+    return len(set(rows_used)) == 3 and abs(det3(matrix)) == 1
+
+
+def lex_largest_signed_axis(options: frozenset[Vec]) -> Vec:
+    """Order +e < -e on a single axis; the negative letter is largest."""
+    if not options:
+        raise ValueError("empty leftover-axis set")
+    return max(options, key=lambda vec: next(coord for coord in vec if coord != 0) < 0)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def literal_audit_paths(source: str) -> tuple[str, ...] | None:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "AUDIT_INPUT_PATHS":
+                try:
+                    value = ast.literal_eval(node.value)
+                except (TypeError, ValueError):
+                    return None
+                if isinstance(value, tuple) and all(isinstance(item, str) for item in value):
+                    return value
+                return None
+    return None
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, condition: bool, detail: str = "") -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{'PASS' if ok else 'FAIL'}: {label}{suffix}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+class History:
+    """Perp-step incoming-lock records on Euclidean B_3(0)."""
+
+    def __init__(self) -> None:
+        self.tick: dict[Vec, int] = {}
+        self.incoming: dict[Vec, frozenset[Vec]] = {}
+        for site, lock in SEED_LOCKS.items():
+            self.tick[site] = 0
+            self.incoming[site] = frozenset({lock})
+        self._grow_until(5)
+
+    def _grow_until(self, last_tick: int) -> None:
+        for parent_tick in range(last_tick):
+            candidates: dict[Vec, set[Vec]] = {}
+            for parent, formed_tick in self.tick.items():
+                if formed_tick != parent_tick:
+                    continue
+                lock = unique_lock(self.incoming[parent])
+                if lock is None:
+                    continue
+                for step in allowed_steps(lock):
+                    child = add(parent, step)
+                    if not in_ball(child) or child in self.tick:
+                        continue
+                    candidates.setdefault(child, set()).add(step)
+            for child, steps in candidates.items():
+                self.tick[child] = parent_tick + 1
+                self.incoming[child] = frozenset(steps)
+
+    def formed_at(self, site: Vec, tau: int) -> bool:
+        return site in self.tick and self.tick[site] <= tau
+
+    def M(self, site: Vec, tau: int) -> frozenset[Vec] | None:
+        if not self.formed_at(site, tau):
+            return None
+        return self.incoming[site]
+
+    def O(self, site: Vec, tau: int) -> frozenset[Vec] | None:
+        if not self.formed_at(site, tau):
+            return None
+        outgoing: set[Vec] = set()
+        for step in NEIGHBOR_STEPS:
+            neighbor = add(site, step)
+            incoming = self.M(neighbor, tau)
+            if incoming is not None and step in incoming:
+                outgoing.add(step)
+        return frozenset(outgoing)
+
+    def split_holds(self, site: Vec, tau: int) -> bool:
+        incoming = self.M(site, tau)
+        outgoing = self.O(site, tau)
+        if incoming is None or outgoing is None:
+            return False
+        axes_in = axis_set(incoming)
+        axes_out = axis_set(outgoing)
+        cover = axes_in.isdisjoint(axes_out) and axes_in | axes_out == frozenset({0, 1, 2})
+        return cover and len(axes_in) == 1 and len(incoming) == 1
+
+    def frame(self, site: Vec, tau: int) -> tuple[Vec, Vec, Vec, int, Mat] | None:
+        if not self.split_holds(site, tau):
+            return None
+        incoming = self.M(site, tau)
+        outgoing = self.O(site, tau)
+        assert incoming is not None and outgoing is not None
+        m = next(iter(incoming))
+        index = axis_index(m)
+        e_next = unit_axis((index + 1) % 3)
+        e_prev = unit_axis((index - 1) % 3)
+        o_next_set = frozenset({e_next, neg(e_next)}) & outgoing
+        o_prev_set = frozenset({e_prev, neg(e_prev)}) & outgoing
+        if not o_next_set or not o_prev_set:
+            return None
+        o_next = lex_largest_signed_axis(o_next_set)
+        o_prev = lex_largest_signed_axis(o_prev_set)
+        matrix = columns_to_matrix(m, o_next, o_prev)
+        orient = det3(matrix)
+        if orient not in (1, -1):
+            return None
+        return m, o_next, o_prev, orient, matrix
+
+
+def transport_matrix(src: Mat, dst: Mat) -> Mat:
+    """Unique integer P with P F(src) = F(dst)."""
+    return mat_mul(dst, mat_transpose(src))
+
+
+def site_tau(history: History, site: Vec) -> int | None:
+    if site not in history.tick:
+        return None
+    return history.tick[site] + 1
+
+
+def edge_status(history: History, src: Vec, step: Vec) -> tuple[str, Mat | None]:
+    dst = add(src, step)
+    if not in_ball(src) or not in_ball(dst):
+        return "fail", None
+    tau_src = site_tau(history, src)
+    tau_dst = site_tau(history, dst)
+    if tau_src is None or tau_dst is None:
+        return "fail", None
+    if not history.formed_at(src, tau_src) or not history.formed_at(dst, tau_dst):
+        return "fail", None
+    frame_src = history.frame(src, tau_src)
+    frame_dst = history.frame(dst, tau_dst)
+    if frame_src is None or frame_dst is None:
+        return "fail", None
+    if frame_src[3] not in (1, -1) or frame_dst[3] not in (1, -1):
+        return "fail", None
+    matrix = transport_matrix(frame_src[4], frame_dst[4])
+    if not is_signed_permutation(matrix):
+        return "fail", None
+    if det3(matrix) != frame_src[3] * frame_dst[3]:
+        return "fail", None
+    return "hold", matrix
+
+
+def lpath_sites(start: Vec) -> tuple[Vec, Vec, Vec]:
+    mid = add(start, FIRST_STEP)
+    end = add(mid, SECOND_STEP)
+    return start, mid, end
+
+
+def lpath_status(history: History, start: Vec) -> str:
+    start, mid, end = lpath_sites(start)
+    for site in (start, mid, end):
+        if not in_ball(site):
+            return "fail"
+    first, _ = edge_status(history, start, FIRST_STEP)
+    second, _ = edge_status(history, mid, SECOND_STEP)
+    if first == "hold" and second == "hold":
+        return "hold"
+    return "fail"
+
+
+def one_step_minus_e3_status(history: History, start: Vec) -> str:
+    end = add(start, FIRST_STEP)
+    for site in (start, end):
+        if not in_ball(site):
+            return "fail"
+    status, _ = edge_status(history, start, FIRST_STEP)
+    if status == "hold":
+        return "hold"
+    return "fail"
+
+
+def two_step_minus_e3_status(history: History, start: Vec) -> str:
+    mid = add(start, FIRST_STEP)
+    end = add(mid, FIRST_STEP)
+    for site in (start, mid, end):
+        if not in_ball(site):
+            return "fail"
+    first, _ = edge_status(history, start, FIRST_STEP)
+    second, _ = edge_status(history, mid, FIRST_STEP)
+    if first == "hold" and second == "hold":
+        return "hold"
+    return "fail"
+
+
+def pair_status(bits: tuple[str, str]) -> str:
+    if any(bit == "undefined" for bit in bits):
+        return "undefined"
+    if bits[0] == "hold" and bits[1] == "hold":
+        return "hold"
+    return "fail"
+
+
+def fmt_vec(vec: Vec) -> str:
+    return f"({vec[0]},{vec[1]},{vec[2]})"
+
+
+def fmt_mat(matrix: Mat) -> str:
+    return "[" + "; ".join(" ".join(str(x) for x in row) for row in matrix) + "]"
+
+
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    runner_src = RUNNER_PATH.read_text(encoding="utf-8")
+    normalized_note = normalize(note)
+    normalized_axiom = normalize(axiom)
+    history = History()
+
+    print("L-path cyclic-frame transport -e3 then -e1 at t+1")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("displayed_not_adopted: true")
+
+    literal_paths = literal_audit_paths(runner_src)
+    checks.check(
+        "audit-input-paths-literal",
+        literal_paths == AUDIT_INPUT_PATHS
+        and AUDIT_INPUT_PATHS
+        == (
+            "docs/THREE_AXIS_FARFACE_OPPOSITE_LPATH_MINUS_E3_MINUS_E1_CYCLIC_FRAME_TRANSPORT_TPLUS1_REVERSE_FACE_BOUNDED_THEOREM_NOTE_2026-08-15.md",
+            "docs/MINIMAL_AXIOMS_2026-06-29.md",
+        ),
+    )
+    checks.check(
+        "audit-inputs-exist",
+        all((ROOT / path).is_file() for path in AUDIT_INPUT_PATHS)
+        and AUDIT_TIMEOUT_SEC == 120,
+    )
+
+    lattice_sentence = (
+        "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor"
+    )
+    admissibility_sentence = (
+        "For each site, the probability distribution over the possibilities is "
+        "determined by, and varies with, the nearest-neighbor conditions."
+    )
+    record_lock = "When present, a record locks exactly one admissible local possibility."
+    record_absence = "A site with no record cannot be read."
+    formation_boundary = "does not supply the formation site, probability, or rate"
+    checks.check(
+        "source-lattice",
+        lattice_sentence in normalized_axiom and lattice_sentence in note,
+    )
+    checks.check(
+        "source-admissibility-unedited",
+        admissibility_sentence in normalized_axiom
+        and admissibility_sentence in normalized_note
+        and "Do not write into Admissibility" in note,
+    )
+    checks.check(
+        "source-record-boundary",
+        record_lock in normalized_axiom
+        and record_absence in normalized_axiom
+        and formation_boundary in normalized_axiom
+        and record_lock in normalized_note,
+    )
+
+    ball = [
+        (x, y, z)
+        for x in range(-3, 4)
+        for y in range(-3, 4)
+        for z in range(-3, 4)
+        if x * x + y * y + z * z <= 9
+    ]
+    checks.check(
+        "euclidean-ball-cardinality",
+        len(ball) == 123 and in_ball((3, 0, 0)) and not in_ball((4, 0, 0)) and not in_ball((2, 2, 2)),
+    )
+    checks.check("seed-tick-zero", all(history.tick[site] == 0 for site in SEED_LOCKS))
+    checks.check(
+        "seed-incoming-locks",
+        all(history.incoming[site] == frozenset({lock}) for site, lock in SEED_LOCKS.items()),
+    )
+    checks.check("seed-six-tick-zero", len(SEED_LOCKS) == 6 and len(history.tick) >= 6)
+    checks.check(
+        "third-pair-are-seeds-not-children",
+        history.tick[(0, 0, -1)] == 0
+        and history.tick[(0, 1, -1)] == 0
+        and history.incoming[(0, 0, -1)] == frozenset({E3})
+        and history.incoming[(0, 1, -1)] == frozenset({NEG_E3}),
+    )
+    checks.check(
+        "perp-step-blocks-parallel",
+        E1 not in allowed_steps(E1) and E1 in allowed_steps(E2) and E1 in allowed_steps(E3),
+    )
+
+    formed_tick1 = sorted(site for site, tick in history.tick.items() if tick <= 1)
+    checks.check("tick1-record-count", len(formed_tick1) == 20, detail=str(len(formed_tick1)))
+
+    identity = columns_to_matrix(E1, E2, E3)
+    checks.check(
+        "signed-permutation-identity",
+        is_signed_permutation(identity)
+        and transport_matrix(identity, identity) == identity
+        and det3(identity) == 1,
+    )
+
+    lpath_bits: dict[Vec, str] = {}
+    expected_first: dict[tuple[Vec, Vec], tuple[str, Mat | None]] = {
+        ((0, 0, 0), (0, 0, -1)): ("fail", None),
+        ((0, 1, 0), (0, 1, -1)): (
+            "hold",
+            ((0, -1, 0), (0, 0, -1), (1, 0, 0)),
+        ),
+        ((0, 0, 1), (0, 0, 0)): ("fail", None),
+        ((0, 1, 1), (0, 1, 0)): (
+            "hold",
+            ((0, 1, 0), (0, 0, 1), (1, 0, 0)),
+        ),
+    }
+    expected_second: dict[tuple[Vec, Vec], tuple[str, Mat | None]] = {
+        ((0, 0, -1), (-1, 0, -1)): (
+            "hold",
+            ((0, 0, -1), (1, 0, 0), (0, 1, 0)),
+        ),
+        ((0, 1, -1), (-1, 1, -1)): (
+            "hold",
+            ((0, 0, 1), (-1, 0, 0), (0, -1, 0)),
+        ),
+        ((0, 0, 0), (-1, 0, 0)): ("fail", None),
+        ((0, 1, 0), (-1, 1, 0)): ("fail", None),
+    }
+    for probe in ALL_PROBES:
+        start, mid, end = lpath_sites(probe)
+        lpath_bits[probe] = lpath_status(history, probe)
+        tau = site_tau(history, probe)
+        print(
+            f"probe {fmt_vec(probe)} t={history.tick.get(probe, -1)} "
+            f"tau={tau} lpath={lpath_bits[probe]} path={fmt_vec(start)}->{fmt_vec(mid)}->{fmt_vec(end)}"
+        )
+        for site in (start, mid, end):
+            site_cut = site_tau(history, site)
+            frame = history.frame(site, site_cut) if site_cut is not None else None
+            if frame is None:
+                print(f"  {fmt_vec(site)} t={history.tick.get(site, -1)} F=fail Orient=fail")
+            else:
+                print(
+                    f"  {fmt_vec(site)} t={history.tick.get(site, -1)} "
+                    f"m={fmt_vec(frame[0])} o_next={fmt_vec(frame[1])} "
+                    f"o_prev={fmt_vec(frame[2])} Orient={frame[3]} F={fmt_mat(frame[4])}"
+                )
+        first_status, first_p = edge_status(history, start, FIRST_STEP)
+        second_status, second_p = edge_status(history, mid, SECOND_STEP)
+        print(
+            f"  hop1 {fmt_vec(start)}->{fmt_vec(mid)} P="
+            f"{fmt_mat(first_p) if first_p is not None else 'fail'} edge={first_status}"
+        )
+        print(
+            f"  hop2 {fmt_vec(mid)}->{fmt_vec(end)} P="
+            f"{fmt_mat(second_p) if second_p is not None else 'fail'} edge={second_status}"
+        )
+        expected_first_status, expected_first_p = expected_first[(start, mid)]
+        checks.check(
+            f"named-first-edge-{fmt_vec(start)}-{fmt_vec(mid)}",
+            first_status == expected_first_status and first_p == expected_first_p,
+        )
+        expected_second_status, expected_second_p = expected_second[(mid, end)]
+        checks.check(
+            f"named-second-edge-{fmt_vec(mid)}-{fmt_vec(end)}",
+            second_status == expected_second_status and second_p == expected_second_p,
+        )
+
+    reverse_bits = tuple(lpath_bits[probe] for probe in REVERSE_PROBES)
+    face_bits = tuple(lpath_bits[probe] for probe in FACE_PROBES)
+    reverse = pair_status(reverse_bits)
+    face = pair_status(face_bits)
+    print(f"reverse={reverse} bits={reverse_bits}")
+    print(f"face={face} bits={face_bits}")
+
+    origin_frame = history.frame((0, 0, 0), 1)
+    yseed_frame = history.frame((0, 1, 0), 1)
+    zseed_frame = history.frame((0, 0, 1), 1)
+    yzseed_frame = history.frame((0, 1, 1), 1)
+    mid_a = history.frame((0, 0, -1), 1)
+    mid_b = history.frame((0, 1, -1), 1)
+    end_a = history.frame((-1, 0, -1), 2)
+    end_b = history.frame((-1, 1, -1), 2)
+    origin_out = history.O((0, 0, 0), 1)
+    origin_in = history.M((0, 0, 0), 1)
+    checks.check(
+        "theorem1-origin-split-fail",
+        origin_frame is None
+        and not history.split_holds((0, 0, 0), 1)
+        and origin_in == frozenset({E1})
+        and origin_out == frozenset({NEG_E2}),
+    )
+    checks.check(
+        "theorem1-seed-frames",
+        yseed_frame is not None
+        and zseed_frame is not None
+        and yzseed_frame is not None
+        and yseed_frame[0:4] == (NEG_E1, E2, NEG_E3, 1)
+        and zseed_frame[0:4] == (E2, E3, NEG_E1, -1)
+        and yzseed_frame[0:4] == (NEG_E2, E3, NEG_E1, 1),
+    )
+    checks.check(
+        "theorem1-path-frames",
+        mid_a is not None
+        and mid_b is not None
+        and end_a is not None
+        and end_b is not None
+        and mid_a[0:4] == (E3, NEG_E1, NEG_E2, 1)
+        and mid_b[0:4] == (NEG_E3, NEG_E1, E2, 1)
+        and end_a[0:4] == (NEG_E1, NEG_E2, NEG_E3, -1)
+        and end_b[0:4] == (NEG_E1, E2, NEG_E3, 1)
+        and history.tick[(0, 0, -1)] == 0
+        and history.tick[(0, 1, -1)] == 0
+        and history.tick[(-1, 0, -1)] == 1
+        and history.tick[(-1, 1, -1)] == 1
+        and history.tick[(-1, 0, 0)] == 2
+        and history.tick[(-1, 1, 0)] == 2,
+    )
+    checks.check(
+        "theorem1-lpath-bits",
+        lpath_bits[(0, 0, 0)] == "fail"
+        and lpath_bits[(0, 1, 0)] == "hold"
+        and lpath_bits[(0, 0, 1)] == "fail"
+        and lpath_bits[(0, 1, 1)] == "fail",
+    )
+    checks.check(
+        "theorem2-reverse-fail",
+        reverse == "fail" and reverse != "undefined" and reverse_bits == ("fail", "hold"),
+    )
+    checks.check(
+        "theorem3-face-fail",
+        face == "fail" and face != "undefined" and face_bits == ("fail", "fail"),
+    )
+
+    one_reverse_bits = (
+        one_step_minus_e3_status(history, REVERSE_PROBES[0]),
+        one_step_minus_e3_status(history, REVERSE_PROBES[1]),
+    )
+    one_face_bits = (
+        one_step_minus_e3_status(history, FACE_PROBES[0]),
+        one_step_minus_e3_status(history, FACE_PROBES[1]),
+    )
+    two_reverse_bits = (
+        two_step_minus_e3_status(history, REVERSE_PROBES[0]),
+        two_step_minus_e3_status(history, REVERSE_PROBES[1]),
+    )
+    two_face_bits = (
+        two_step_minus_e3_status(history, FACE_PROBES[0]),
+        two_step_minus_e3_status(history, FACE_PROBES[1]),
+    )
+    checks.check(
+        "not-leftover-of-one-step-minus-e3",
+        one_reverse_bits == ("fail", "hold")
+        and one_face_bits == ("fail", "hold")
+        and reverse_bits == ("fail", "hold")
+        and face_bits == ("fail", "fail"),
+    )
+    checks.check(
+        "not-leftover-of-two-step-minus-e3",
+        two_reverse_bits == ("fail", "fail")
+        and two_face_bits == ("fail", "hold")
+        and reverse_bits == ("fail", "hold")
+        and face_bits == ("fail", "fail"),
+    )
+
+    both_signs = history.frame((0, 0, 1), 1)
+    assert both_signs is not None
+    mutated_prev = E1
+    mutated = columns_to_matrix(both_signs[0], both_signs[1], mutated_prev)
+    checks.check(
+        "mutation-lex-largest-uses-minus",
+        both_signs[2] == NEG_E1
+        and det3(mutated) == 1
+        and both_signs[3] == -1
+        and det3(mutated) != both_signs[3],
+    )
+    checks.check(
+        "outside-ball-is-fail",
+        not in_ball((0, 0, -4))
+        and lpath_status(history, (0, 0, -3)) == "fail"
+        and lpath_status(history, (0, 0, -3)) != "undefined",
+    )
+    face_end_a = (-1, 0, 0)
+    face_end_b = (-1, 1, 0)
+    checks.check(
+        "face-second-hop-split-fail",
+        history.split_holds(face_end_a, 3) is False
+        and history.split_holds(face_end_b, 3) is False
+        and history.frame(face_end_a, 3) is None
+        and history.frame(face_end_b, 3) is None,
+    )
+
+    required_note = (
+        CLAIM_SCOPE,
+        "Displayed, not adopted",
+        "Do not attach L1",
+        "Do not write into Admissibility",
+        "hypothetical_axiom_status: no edit",
+        "actual_current_surface_status: bounded-support",
+        "target_claim_type: bounded_theorem",
+        "reverse: fail",
+        "face: fail",
+        "F((0,0,0)) fails",
+        "Orient((0,1,0))=+1",
+        "Orient((0,0,1))=-1",
+        "Orient((0,1,1))=+1",
+        "Orient((0,0,-1))=+1",
+        "Orient((0,1,-1))=+1",
+        "authors no audit verdict",
+        "Euclidean B_3(0)={n:n·n<=9}",
+        "L-path at (0,0,0): fail",
+        "L-path at (0,1,0): hold",
+        "L-path at (0,0,1): fail",
+        "L-path at (0,1,1): fail",
+        "P=[0 0 -1; 1 0 0; 0 1 0]",
+        "P=[0 -1 0; 0 0 -1; 1 0 0]",
+        "P=[0 0 1; -1 0 0; 0 -1 0]",
+        "P=[0 1 0; 0 0 1; 1 0 0]",
+        "no global T",
+        "third pair is a new seed, not a formed child",
+        "not leftover of the 1-step along",
+        "not leftover of the 2-step along",
+    )
+    forbidden_note = (
+        "G_N",
+        "1/r",
+        "1/r^2",
+        "Lattice-named",
+        "not a TOE",
+        "Dijkstra",
+        "Cl(3,0)",
+        "S^+",
+        "S⁺",
+        "unique P_+",
+        "occupancy n",
+        "new axiom",
+        "Gram",
+    )
+    checks.check(
+        "note-claim-scope",
+        f'claim_scope: "{CLAIM_SCOPE}"' in note or CLAIM_SCOPE in note,
+    )
+    missing = [phrase for phrase in required_note if phrase not in note]
+    checks.check(
+        "note-computed-bits",
+        not missing,
+        detail=("missing:" + ",".join(missing) if missing else ""),
+    )
+    checks.check(
+        "note-forbidden-phrases",
+        not any(phrase in note for phrase in forbidden_note)
+        and "promoted" not in note.lower()
+        and "toe-lphys" not in note,
+    )
+    other = note
+    for line in (
+        "audit_required_before_effective_retained: true",
+        "bare_retained_allowed: false",
+        "actual_current_surface_status: bounded-support",
+    ):
+        other = other.replace(line, "")
+    checks.check(
+        "note-no-status-overclaim",
+        "audit_required_before_effective_retained: true" in note
+        and "bare_retained_allowed: false" in note
+        and "retained" not in other.lower(),
+    )
+    checks.check(
+        "axiom-file-unedited-by-this-packet",
+        "Lattice / Physical Locality" in axiom and "Qubit / Site Possibility" in axiom,
+    )
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Far-face kills the reverse-HOLD L-path, same placement kill as far-face 1-step #7626. Reverse fails, face fails. Displayed, not adopted. FAIL=0. Not HOLDING_MEMBER.

## Runner

`scripts/three_axis_farface_opposite_lpath_minus_e3_minus_e1_cyclic_frame_transport_tplus1_reverse_face_2026_08_15.py`

Campaign `toe-lphys-20260812`. Source-only. No axiom edit.