### PR TITLE
physics: construct the metric-weighted exterior kernel

### DIFF
--- a/.claude/science/physics-loops/toe-axiom-closure-block214-weighted-kernel-metric-symbol-20260827/NO_GO_LEDGER.md
+++ b/.claude/science/physics-loops/toe-axiom-closure-block214-weighted-kernel-metric-symbol-20260827/NO_GO_LEDGER.md
@@ -1,0 +1,39 @@
+# Block 214 no-go ledger — weighted exterior kernel
+
+## Rejected routes
+
+1. **Independent scalar weights on the three staggered axes.** Their squared
+   symbol is diagonal in the direction labels,
+   `sum_d w_d^2 sin^2(k_d)`, so it cannot reproduce any nonzero
+   `(g^-1)_de sin(k_d) sin(k_e)` term. A sheared metric needs matrix-valued
+   direction mixing, oblique hops, or an equivalent non-scalar carrier.
+
+2. **Treating the D3 parameter `V` as independent while demanding a single
+   metric quadratic form on every exterior degree.** The exact middle-degree
+   adjoint is multiplied by `det(g)/V^2`. The generalized Clifford residual
+   vanishes for positive `g,V` exactly at `V^2=det(g)`.
+
+3. **Calling the positive three-metric quadratic form a physical light cone.**
+   The construction is Euclidean and constant-cell. No physical time choice,
+   Lorentzian signature, OS/Wick bridge, dynamics, or continuum limit is in
+   the calculation.
+
+4. **Promoting an internal D3 consistency selector to an axiom-level geometry
+   derivation.** The theorem is conditional on the declared Block 209 D3
+   candidate and the canonical exterior differential. The framework axioms do
+   not yet select that candidate or its metric.
+
+## Surviving route
+
+Use `Gamma_d = epsilon_d + epsilon_d^dagger(D3)` on the metric-volume locus.
+It is nearest-neighbor, carries exact off-diagonal co-metric mixing, returns to
+two copies of the landed covariant rule in the flat limit, and overlaps the
+landed 2D shear-Hodge form at the rational `(c,V)=(3/5,4/5)` window.
+
+## Next obstruction
+
+For cell-dependent `g_s`, the centered hop joins different inner products.
+A local transport/connection must be constructed so the full operator is
+skew-adjoint across each link and reduces to the constant-cell theorem. Until
+that exists, variable geometry, curvature propagation, and physical cone
+claims remain open.

--- a/docs/ADMISSIBILITY_DIRAC_KAHLER_WEIGHTED_EXTERIOR_KERNEL_METRIC_SYMBOL_BOUNDED_THEOREM_NOTE_2026-08-27.md
+++ b/docs/ADMISSIBILITY_DIRAC_KAHLER_WEIGHTED_EXTERIOR_KERNEL_METRIC_SYMBOL_BOUNDED_THEOREM_NOTE_2026-08-27.md
@@ -1,0 +1,364 @@
+---
+claim_id: admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_bounded_theorem_note_2026-08-27
+final_path: docs/ADMISSIBILITY_DIRAC_KAHLER_WEIGHTED_EXTERIOR_KERNEL_METRIC_SYMBOL_BOUNDED_THEOREM_NOTE_2026-08-27.md
+claim_type: bounded_theorem
+claim_scope: "Exact finite exterior-algebra construction of a constant-coefficient nearest-neighbor kernel from the declared D3(g,V) carrier; necessary and sufficient metric-volume normalization V^2=det(g) for full generalized-Clifford closure at positive g; exact flat-rule intertwiner, a landed two-dimensional shear window, and one genuinely three-direction rational witness. No framework selection of D3 or g, variable metric, physical time, Lorentzian signature, dynamics, gravity law, or continuum limit is supplied."
+runner: scripts/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.py
+status: proposed_retained
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+trace_class: upstream_support
+target_claim_id: null
+target_blocker_text: "the constant positive three-metric symbol is not yet a variable spacetime operator, and the framework axioms do not yet select D3, g, or a Lorentzian continuation"
+source_of_blocker_text: physics_loop
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Construct the variable-cell transport/connection required for D3(g_s,V_s)-adjointness across neighboring cells, then test the OS/Wick interface without assuming a physical time direction."
+conditional_surface_status: "stacked on an unmerged ancestor chain; proposed science remains review- and audit-required"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "exact rational-function identities, an exact normalization selector, an explicit flat intertwiner, and exact finite rational witnesses"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+parent_ref: origin/physics-loop/toe-axiom-closure-block212-joint-pin-order-extended-alphabet-20260827
+parent_commit: 4e9931a970ded94f769553da9e6d77770d612f64
+scientific_parent: block_209_three_direction_rule_geometry
+current_main: 66e478505e055faf4a5b9e6f4883211e44304718
+registered: 0
+adopted: 0
+axiom_movement: none
+---
+
+# The metric-weighted exterior kernel and its exact finite symbol
+
+**Date:** 2026-08-27
+
+**Type:** `bounded_theorem`
+
+**Status:** `proposed_retained` — a review proposal, not an audit verdict.
+
+## Result in plain language
+
+Block 209 produced a finite three-dimensional geometry candidate
+
+```text
+D3(g,V) = diag(V, V g^-1, E g E/V, 1/V).
+```
+
+This block makes it carry a propagation kernel instead of merely being a cell
+weight. The construction is canonical once `D3` and the exterior differential
+are supplied: take exterior multiplication and add its adjoint in the `D3`
+inner product. The resulting direction matrices square to the inverse-metric
+quadratic form, including all off-diagonal direction mixing.
+
+The calculation also removes one freedom. Full closure on all exterior degrees
+occurs exactly when
+
+```text
+V^2 = det(g).
+```
+
+Thus `V` cannot remain an independent positive scale if it is to be the volume
+used by this metric Kähler-Dirac kernel. It must equal the positive metric
+volume `sqrt(det(g))`. This is a selection theorem **inside the declared D3
+candidate family**. It is not a derivation that Nature or the four framework
+axioms select `D3`.
+
+## 1. Supplied finite objects
+
+Use direction order `(t,x,y)` only as a coordinate label and set
+
+```text
+g = [[1,    c_tx, c_ty],
+     [c_tx, 1,    c_xy],
+     [c_ty, c_xy, 1   ]].
+```
+
+The exterior basis is the eight corners
+
+```text
+1, dy, dx, dx^dy, dt, dt^dy, dt^dx, dt^dx^dy,
+```
+
+with corner index `4t+2x+y`. Let `epsilon_d` be left exterior multiplication
+by the one-form in direction `d`. These exact integer matrices obey
+
+```text
+epsilon_d^2 = 0,
+epsilon_d epsilon_e + epsilon_e epsilon_d = 0.
+```
+
+The supplied inner-product candidate is Block 209's
+
+```text
+D3(g,V) = diag(W0,W1,W2,W3),
+W0 = V,
+W1 = V g^-1,
+W2 = E g E/V,       E = diag(1,-1,1),
+W3 = 1/V.
+```
+
+No import of a continuum Dirac operator is made. All matrices are built
+directly on this eight-element finite exterior carrier.
+
+## 2. The weighted link matrices
+
+Define the adjoint of `epsilon_d` with respect to `D3` by
+
+```text
+epsilon_d^dagger = D3^-1 epsilon_d^T D3,
+Gamma_d = epsilon_d + epsilon_d^dagger.
+```
+
+Each `Gamma_d` is exactly self-adjoint in the supplied inner product:
+
+```text
+Gamma_d^T D3 = D3 Gamma_d.
+```
+
+On a periodic coordinate lattice, let the centered difference be
+
+```text
+nabla_d = (T_d - T_d^-1)/2
+```
+
+and define the constant-cell kernel
+
+```text
+K_D3 = sum_d Gamma_d nabla_d.
+```
+
+Equivalently, the forward hop in direction `d` carries `Gamma_d/2` and the
+backward hop carries `-Gamma_d/2`. Because the link matrices are
+`D3`-self-adjoint and the centered differences are antisymmetric, `K_D3` is
+skew-adjoint in the product `D3` inner product.
+
+At momentum `k`, put `q_d = sin(k_d)`. The Fourier symbol is
+
+```text
+K_D3(k) = i Gamma(q),
+Gamma(q) = sum_d q_d Gamma_d.
+```
+
+## 3. Where the volume condition comes from
+
+Let `iota_d^(g)` be contraction with the co-metric:
+
+```text
+iota_d^(g) = sum_e (g^-1)_de epsilon_e^T.
+```
+
+The runner evaluates the `D3` adjoint separately on every adjacent degree.
+It finds
+
+```text
+degree 1 -> 0:  epsilon_d^dagger = iota_d^(g),
+degree 2 -> 1:  epsilon_d^dagger = [det(g)/V^2] iota_d^(g),
+degree 3 -> 2:  epsilon_d^dagger = iota_d^(g).
+```
+
+The only mismatch is the middle lowering map. It is not a numerical accident
+or a fitted coefficient: it is the exact rational function
+`rho = det(g)/V^2`.
+
+Consequently all six generalized-Clifford residuals
+
+```text
+Gamma_d Gamma_e + Gamma_e Gamma_d - 2(g^-1)_de I8
+```
+
+are divisible by `V^2-det(g)`. Setting `V^2=det(g)` kills them identically.
+
+Necessity on the positive-metric domain is also exact. For each direction,
+
+```text
+tr[Gamma_d^2 - (g^-1)_dd I8]
+    = 4 [det(g)/V^2 - 1] (g^-1)_dd.
+```
+
+If `g` is positive definite, `(g^-1)_dd>0`. Full closure therefore forces
+`det(g)/V^2=1`. Together with sufficiency, this proves:
+
+> For positive `g` and positive `V`, the full eight-component D3-adjoint
+> exterior kernel obeys the generalized Clifford algebra if and only if
+> `V^2=det(g)`.
+
+## 4. The metric symbol
+
+On that locus,
+
+```text
+Gamma(q)^2 = q^T g^-1 q I8,
+-K_D3(k)^2 = sin(k)^T g^-1 sin(k) I8.
+```
+
+This is the requested off-diagonal weighted symbol. For example, its mixed
+`t-x` term is
+
+```text
+2 (g^-1)_tx sin(k_t) sin(k_x).
+```
+
+The squared finite symbol therefore carries the exact co-metric quadratic
+form rather than only three independently rescaled coordinate squares.
+
+For positive `g`, the quadratic form is nonnegative. This is a Euclidean
+co-metric statement. The coordinate called `t` has not been identified as
+physical time, no Lorentzian signature has been derived, and no physical
+light cone is claimed.
+
+## 5. Exact flat bridge to the landed covariant rule
+
+At `g=I3`, `V=1`, the carrier is `D3=I8`. The three exterior generators are
+ordinary real symmetric `Cl(3,0)` generators. The runner supplies an explicit
+integer matrix `S` with
+
+```text
+S^T S = 8 I8,
+det(S) = 4096,
+Gamma_d S = S diag(G_d,G_d),
+```
+
+where the `G_d` are exactly Block 209's real `4 x 4` generators. Thus the
+flat exterior carrier is two exact copies of the landed pre-staggered rule,
+not merely another representation with matching eigenvalues.
+
+Transporting Block 209's word staggering through this same `S` gives an exact
+orthogonal `Omega_8(s)`. On all eight anchor parities and all three links,
+
+```text
+Omega_8(s)^T [Gamma_d/2] Omega_8(s+e_d)
+    = eta_d(s) I8/2.
+```
+
+So the construction returns to the landed scalar eta link in the flat limit.
+The exact `(4,4)` and `(4,4,4)` momentum histograms are respectively
+
+```text
+{0:4, 1:8, 2:4},
+{0:8, 1:24, 2:24, 3:8},
+```
+
+which are precisely the finite `sum_d sin^2(k_d)` values and multiplicities.
+
+## 6. Exact landed two-dimensional window
+
+Set
+
+```text
+c_tx = 3/5,
+c_ty = c_xy = 0,
+V = 4/5.
+```
+
+Then `det(g)=16/25=V^2`. On the `tx` exterior subspace, `D3` restricts exactly
+to the landed two-dimensional shear-Hodge form
+
+```text
+diag(V, V [[1,c],[c,1]]^-1, 1/V).
+```
+
+For `q_y=0`, the weighted symbol obeys
+
+```text
+Gamma(q)^2
+  = [q_t^2 - 2c q_t q_x + q_x^2]/(1-c^2) I8.
+```
+
+This is an exact overlap with the landed 2D geometry at a rational
+metric-volume point. It is not an interpolation or a continuum approximation.
+
+## 7. A genuinely three-direction rational witness
+
+To prove that the construction is not only a decoupled-plane result, choose
+
+```text
+c_tx = c_ty = c_xy = 11/50,
+V = 117/125.
+```
+
+Then
+
+```text
+det(g) = 13689/15625 = (117/125)^2,
+
+g^-1 = (1/1404) [[1525,-275,-275],
+                  [-275,1525,-275],
+                  [-275,-275,1525]].
+```
+
+All eight leading principal minors of `D3` are positive. Every off-diagonal
+co-metric entry is nonzero, and all six generalized-Clifford identities hold
+exactly. Across all `64` momenta of the `4^3` grid, the quadratic values and
+multiplicities are
+
+```text
+0             : 8
+1525/1404     : 24
+625/351       : 12
+25/12         : 2
+100/39        : 12
+5125/1404     : 6
+```
+
+The split away from the flat `{0,1,2,3}` histogram is the exact finite effect
+of direction mixing.
+
+## 8. Why scalar eta reweighting is insufficient
+
+If one keeps scalar staggered links and merely gives the three axes scalar
+magnitudes `w_d`, their square has the form
+
+```text
+sum_d w_d^2 sin^2(k_d).
+```
+
+Its mixed derivatives with respect to two different `sin(k_d)` variables are
+zero. A sheared co-metric instead has mixed derivative `2(g^-1)_de`, nonzero
+at the rational witness above. Therefore axis-by-axis scalar weights cannot
+carry the off-diagonal metric.
+
+At least one structural change is necessary: matrix-valued link mixing as
+constructed here, oblique hops, or another carrier with the same mixed
+anticommutators. The present construction chooses the first and remains
+nearest-neighbor along the coordinate axes.
+
+## 9. What advanced, and what remains open
+
+This block closes the constant-cell design question posed after the flat
+dispersion scout:
+
+- an explicit weighted kernel now exists;
+- its square is the exact inverse-metric quadratic form;
+- its flat limit is exactly tied to the landed covariant rule;
+- its 2D restriction meets the landed shear-Hodge form;
+- and compatibility selects `V=sqrt(det(g))` inside the D3 family.
+
+It does **not** yet supply:
+
+- a derivation selecting `D3` or `g` from the four framework axioms;
+- a rule for varying `g` and `V` from cell to cell;
+- the transport/connection terms needed for adjointness when neighboring
+  cells have different carriers;
+- a physical temporal direction, Lorentzian continuation, causal cone, or
+  dispersion relation solved for energy;
+- record-production dynamics, a gravity field equation, backreaction, or a
+  continuum limit.
+
+The next load-bearing science block is the variable-cell transport problem.
+It must determine whether neighboring `D3(g_s,V_s)` carriers admit a local
+link transport that preserves the weighted adjoint and reduces to this
+constant-cell kernel. Only after that construction is explicit is an OS/Wick
+or physical cone analysis licensed.
+
+## Reproduction
+
+```bash
+python3 scripts/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.py
+```
+
+Expected result:
+
+```text
+TOTAL: PASS=18 FAIL=0
+```

--- a/logs/runner-cache/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.txt
+++ b/logs/runner-cache/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.py
+runner_sha256: d04d76b37b7e7c647fea9af046b5e3207fe50b1d9235fc0aeeb17b828433bd02
+input_fingerprint_sha256: 613dec6079a96a1fcb612e1508bbebc00f5466410561402943f62e65b92252f2
+timeout_sec: 600
+exit_code: 0
+elapsed_sec: 4.75
+status: ok
+----- stdout -----
+[PASS] A1 exterior creation operators are nilpotent and anticommute
+[PASS] A2 D3 has blocks (V, V g^-1, E g E/V, 1/V) in the declared basis
+[PASS] B1 D3-adjoint equals metric contraction except for det(g)/V^2 on degree 2->1
+[PASS] B2 every weighted Gamma_d is exactly self-adjoint in the D3 inner product
+[PASS] C1 all six generalized-Clifford residuals vanish on V^2=det(g)
+[PASS] C2 the exact closure defect trace is 4(det(g)/V^2-1)(g^-1)_dd
+[PASS] C3 positive-metric full-carrier closure selects V^2=det(g), not an arbitrary V
+[PASS] C4 Gamma(q)^2 = q^T g^-1 q on the selected metric-volume locus
+[PASS] D1 at g=I,V=1 the carrier is I8 and the exact intertwiner is orthogonal up to 8
+[PASS] D2 the flat exterior generators intertwine with two copies of Block 209's generators
+[PASS] D3 the transported flat staggering scalarizes every corner link to eta_d I8/2
+[PASS] E1 flat exact momentum histograms reproduce sum sin^2(k_d)
+[PASS] E2 c=3/5,V=4/5 is an exact metric-volume point and D3 restricts to the landed 2D Hodge form
+[PASS] E3 the landed 2D window squares to (q_t^2-2c q_t q_x+q_x^2)/(1-c^2)
+[PASS] F1 the all-shear rational witness has det(g)=V^2 and positive D3
+[PASS] F2 the rational witness has exact off-diagonal co-metric mixing and closes the generalized Clifford algebra
+[PASS] F3 all 64 exact 4^3 momenta give the six predicted mixed-metric values
+[PASS] G1 scalar axis-weighted eta links have zero mixed coefficient, while the sheared metric requires one
+MEASURED
+  stack parent: 4e9931a970ded94f769553da9e6d77770d612f64
+  scientific parent: Block 209 three-direction rule geometry
+  main at campaign start: 66e478505e055faf4a5b9e6f4883211e44304718
+  det(g): -c_tx**2 + 2*c_tx*c_ty*c_xy - c_ty**2 - c_xy**2 + 1
+  selected normalization: V^2 = det(g)
+  weighted symbol: Gamma(q)^2 = q^T g^-1 q I8
+  rational 3D witness: c=11/50, V=117/125, histogram={0: 8, 1525/1404: 24, 625/351: 12, 100/39: 12, 25/12: 2, 5125/1404: 6}
+  scope: finite exact conditional D3/exterior construction; no physical time, Lorentzian cone, dynamics, gravity, or continuum limit
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.py
+++ b/scripts/admissibility_dirac_kahler_weighted_exterior_kernel_metric_symbol_2026_08_27.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Block 214: a metric-weighted exterior kernel and its exact symbol.
+
+This runner asks the next constructive question after the finite D3 geometry:
+does the canonical exterior differential, paired with its adjoint under
+
+    D3(g,V) = diag(V, V g^-1, E g E / V, 1/V),
+
+produce a nearest-neighbour kernel whose square is the co-metric quadratic
+form?  It does exactly on the metric-volume locus V^2 = det(g).  Off that
+locus the middle-degree adjoint carries the exact mismatch det(g)/V^2.
+
+All identities are exact over rational functions or exact rational witnesses.
+The result is a conditional finite Kähler-Dirac construction.  It does not
+select D3 from the framework axioms, identify physical time, perform a Wick
+rotation, supply dynamics or gravity, or take a continuum limit.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from collections import Counter
+
+import sympy as sp
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_WEIGHTED_EXTERIOR_KERNEL_METRIC_SYMBOL_BOUNDED_THEOREM_NOTE_2026-08-27.md",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_THREE_DIRECTION_RULE_GEOMETRY_BOUNDED_THEOREM_NOTE_2026-08-26.md",
+    "scripts/admissibility_dirac_kahler_three_direction_rule_geometry_2026_08_26.py",
+    "docs/ADMISSIBILITY_DIRAC_KAHLER_COVARIANT_RULE_IDENTIFICATION_BOUNDED_THEOREM_NOTE_2026-08-26.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    ".claude/science/physics-loops/CAMPAIGN_20260824_GRAVITY_MAINLINE.md",
+)
+
+STACK_PARENT = "4e9931a970ded94f769553da9e6d77770d612f64"
+SCIENTIFIC_PARENT = "Block 209 three-direction rule geometry"
+CURRENT_MAIN_AT_START = "66e478505e055faf4a5b9e6f4883211e44304718"
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: object) -> None:
+    global PASS, FAIL
+    ok = bool(condition)
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}", flush=True)
+    PASS += int(ok)
+    FAIL += int(not ok)
+
+
+def kron(left: sp.MatrixBase, right: sp.MatrixBase) -> sp.Matrix:
+    return sp.Matrix(sp.kronecker_product(left, right))
+
+
+# Exterior basis: dt^t dx^x dy^y at corner index 4t+2x+y.
+CORNERS = tuple(itertools.product((0, 1), repeat=3))
+INDEX = {corner: 4 * corner[0] + 2 * corner[1] + corner[2]
+         for corner in CORNERS}
+DEGREE = tuple(sum(corner) for corner in CORNERS)
+ONE = (INDEX[(1, 0, 0)], INDEX[(0, 1, 0)], INDEX[(0, 0, 1)])
+TWO = (INDEX[(0, 1, 1)], INDEX[(1, 0, 1)], INDEX[(1, 1, 0)])
+WEDGE_SIGNATURE = sp.diag(1, -1, 1)
+
+
+def wedge(direction: int) -> sp.Matrix:
+    """Left exterior multiplication by dt, dx, or dy."""
+    operator = sp.zeros(8)
+    for corner in CORNERS:
+        if corner[direction]:
+            continue
+        target = list(corner)
+        target[direction] = 1
+        sign = sp.Integer(-1) ** sum(corner[:direction])
+        operator[INDEX[tuple(target)], INDEX[corner]] = sign
+    return operator
+
+
+WEDGES = tuple(wedge(direction) for direction in range(3))
+CONTRACTIONS = tuple(operator.T for operator in WEDGES)
+
+
+def metric(shear_tx: sp.Expr, shear_ty: sp.Expr,
+           shear_xy: sp.Expr) -> sp.Matrix:
+    return sp.Matrix([
+        [1, shear_tx, shear_ty],
+        [shear_tx, 1, shear_xy],
+        [shear_ty, shear_xy, 1],
+    ])
+
+
+def d3_carrier(g: sp.MatrixBase, volume: sp.Expr) -> sp.Matrix:
+    inverse = sp.simplify(g.inv())
+    carrier = sp.zeros(8)
+    carrier[0, 0] = volume
+    carrier[7, 7] = 1 / volume
+    for row in range(3):
+        for column in range(3):
+            carrier[ONE[row], ONE[column]] = volume * inverse[row, column]
+            carrier[TWO[row], TWO[column]] = (
+                WEDGE_SIGNATURE * g * WEDGE_SIGNATURE / volume
+            )[row, column]
+    return sp.Matrix(carrier)
+
+
+def weighted_generators(g: sp.MatrixBase, volume: sp.Expr) -> tuple:
+    """Gamma_d = epsilon_d + epsilon_d^dagger in the D3 inner product."""
+    carrier = d3_carrier(g, volume)
+    carrier_inverse = sp.simplify(carrier.inv())
+    adjoints = tuple(sp.simplify(
+        carrier_inverse * operator.T * carrier) for operator in WEDGES)
+    generators = tuple(sp.simplify(WEDGES[d] + adjoints[d])
+                       for d in range(3))
+    return carrier, adjoints, generators
+
+
+def matrix_is_zero(matrix: sp.MatrixBase) -> bool:
+    return all(sp.cancel(entry) == 0 for entry in matrix)
+
+
+def vanishes_mod_volume(matrix: sp.MatrixBase, volume: sp.Symbol,
+                        determinant: sp.Expr) -> bool:
+    """Test a rational matrix on the algebraic locus volume^2=determinant."""
+    modulus = sp.Poly(volume**2 - determinant, volume)
+    for entry in matrix:
+        numerator = sp.together(entry).as_numer_denom()[0]
+        if numerator == 0:
+            continue
+        remainder = sp.rem(sp.Poly(numerator, volume), modulus)
+        if sp.expand(remainder.as_expr()) != 0:
+            return False
+    return True
+
+
+def degree_block(matrix: sp.MatrixBase, target_degree: int,
+                 source_degree: int) -> sp.Matrix:
+    rows = [i for i, degree in enumerate(DEGREE) if degree == target_degree]
+    columns = [i for i, degree in enumerate(DEGREE) if degree == source_degree]
+    return matrix.extract(rows, columns)
+
+
+def symbol(generators: tuple, q: tuple) -> sp.Matrix:
+    return sum((q[d] * generators[d] for d in range(3)), sp.zeros(8))
+
+
+def momentum_histogram(extents: tuple, inverse: sp.MatrixBase) -> Counter:
+    values = Counter()
+    for mode in itertools.product(*(range(extent) for extent in extents)):
+        q = sp.Matrix([
+            sp.sin(2 * sp.pi * n / extent)
+            for n, extent in zip(mode, extents)
+        ])
+        if len(extents) == 2:
+            q = sp.Matrix([q[0], q[1], 0])
+        value = sp.cancel((q.T * inverse * q)[0])
+        values[value] += 1
+    return values
+
+
+def omega4(site: tuple, generators: tuple) -> sp.Matrix:
+    result = sp.eye(4)
+    for direction, coordinate in enumerate(site):
+        if coordinate % 2:
+            result = result * generators[direction]
+    return sp.Matrix(result)
+
+
+def main() -> int:
+    shear_tx, shear_ty, shear_xy = sp.symbols("c_tx c_ty c_xy")
+    volume = sp.Symbol("V", positive=True)
+    g = metric(shear_tx, shear_ty, shear_xy)
+    determinant = sp.factor(g.det())
+    inverse = sp.simplify(g.inv())
+    carrier, adjoints, generators = weighted_generators(g, volume)
+
+    # A. Exterior algebra and the declared D3 carrier.
+    nilpotent = all(matrix_is_zero(operator * operator)
+                    for operator in WEDGES)
+    exterior_anticommutation = all(matrix_is_zero(
+        WEDGES[left] * WEDGES[right]
+        + WEDGES[right] * WEDGES[left])
+        for left in range(3) for right in range(left + 1, 3))
+    check("A1 exterior creation operators are nilpotent and anticommute",
+          nilpotent and exterior_anticommutation)
+    expected_two = WEDGE_SIGNATURE * g * WEDGE_SIGNATURE / volume
+    check("A2 D3 has blocks (V, V g^-1, E g E/V, 1/V) in the declared basis",
+          carrier[0, 0] == volume
+          and carrier[7, 7] == 1 / volume
+          and carrier.extract(ONE, ONE) == volume * inverse
+          and carrier.extract(TWO, TWO) == expected_two
+          and carrier == carrier.T)
+
+    # B. Locate exactly where the volume enters the exterior adjoint.
+    rho = sp.cancel(determinant / volume**2)
+    adjoint_pattern = True
+    for direction in range(3):
+        canonical = sum(
+            (inverse[direction, other] * CONTRACTIONS[other]
+             for other in range(3)), sp.zeros(8))
+        adjoint_pattern = adjoint_pattern and matrix_is_zero(
+            degree_block(adjoints[direction] - canonical, 0, 1))
+        adjoint_pattern = adjoint_pattern and matrix_is_zero(
+            degree_block(adjoints[direction] - rho * canonical, 1, 2))
+        adjoint_pattern = adjoint_pattern and matrix_is_zero(
+            degree_block(adjoints[direction] - canonical, 2, 3))
+    check("B1 D3-adjoint equals metric contraction except for det(g)/V^2 on degree 2->1",
+          adjoint_pattern)
+    check("B2 every weighted Gamma_d is exactly self-adjoint in the D3 inner product",
+          all(matrix_is_zero(generator.T * carrier - carrier * generator)
+              for generator in generators))
+
+    # C. Generalized Clifford closure and the volume selector.
+    clifford_residuals = []
+    for left in range(3):
+        for right in range(left, 3):
+            anticommutator = (
+                generators[left] * generators[right]
+                + generators[right] * generators[left]
+            )
+            clifford_residuals.append(sp.simplify(
+                anticommutator - 2 * inverse[left, right] * sp.eye(8)))
+    check("C1 all six generalized-Clifford residuals vanish on V^2=det(g)",
+          all(vanishes_mod_volume(residual, volume, determinant)
+              for residual in clifford_residuals))
+    diagonal_trace_formula = all(sp.cancel(
+        sp.trace(generators[direction] * generators[direction]
+                 - inverse[direction, direction] * sp.eye(8))
+        - 4 * (rho - 1) * inverse[direction, direction]) == 0
+        for direction in range(3))
+    check("C2 the exact closure defect trace is 4(det(g)/V^2-1)(g^-1)_dd",
+          diagonal_trace_formula)
+    # For a positive-definite g, every diagonal of g^-1 is positive.  Thus C2
+    # makes V^2=det(g) necessary, while C1 makes it sufficient.
+    check("C3 positive-metric full-carrier closure selects V^2=det(g), not an arbitrary V",
+          diagonal_trace_formula
+          and sp.factor(determinant - volume**2) != 0)
+
+    q_t, q_x, q_y = sp.symbols("q_t q_x q_y")
+    q = (q_t, q_x, q_y)
+    weighted_symbol = symbol(generators, q)
+    quadratic = sp.cancel((sp.Matrix(q).T * inverse * sp.Matrix(q))[0])
+    symbol_residual = sp.simplify(weighted_symbol * weighted_symbol
+                                  - quadratic * sp.eye(8))
+    check("C4 Gamma(q)^2 = q^T g^-1 q on the selected metric-volume locus",
+          vanishes_mod_volume(symbol_residual, volume, determinant))
+
+    # D. The flat carrier is exactly two copies of Block 209's Cl(3,0) rule.
+    sigma_x = sp.Matrix([[0, 1], [1, 0]])
+    sigma_z = sp.diag(1, -1)
+    identity_2 = sp.eye(2)
+    rule_generators = (
+        kron(sigma_x, identity_2),
+        kron(sigma_z, sigma_x),
+        kron(sigma_z, sigma_z),
+    )
+    doubled_rule = tuple(sp.diag(generator, generator)
+                         for generator in rule_generators)
+    flat_carrier, _, flat_generators = weighted_generators(sp.eye(3), sp.Integer(1))
+    intertwiner = sp.Matrix([
+        [-1,  1, -1,  1,  1, -1, -1,  1],
+        [-1, -1,  1,  1,  1,  1,  1,  1],
+        [ 1, -1, -1,  1, -1,  1, -1,  1],
+        [-1, -1, -1, -1,  1,  1, -1, -1],
+        [-1,  1, -1,  1, -1,  1,  1, -1],
+        [ 1,  1, -1, -1,  1,  1,  1,  1],
+        [-1,  1,  1, -1, -1,  1, -1,  1],
+        [-1, -1, -1, -1, -1, -1,  1,  1],
+    ])
+    check("D1 at g=I,V=1 the carrier is I8 and the exact intertwiner is orthogonal up to 8",
+          flat_carrier == sp.eye(8)
+          and intertwiner.T * intertwiner == 8 * sp.eye(8)
+          and intertwiner.det() == 4096)
+    check("D2 the flat exterior generators intertwine with two copies of Block 209's generators",
+          all(flat_generators[d] * intertwiner
+              == intertwiner * doubled_rule[d] for d in range(3)))
+    scalarization = True
+    for site in CORNERS:
+        omega_left = (intertwiner
+                      * sp.diag(omega4(site, rule_generators),
+                                omega4(site, rule_generators))
+                      * intertwiner.T / 8)
+        for direction in range(3):
+            neighbour = list(site)
+            neighbour[direction] += 1
+            neighbour = tuple(neighbour)
+            omega_right = (intertwiner
+                           * sp.diag(omega4(neighbour, rule_generators),
+                                     omega4(neighbour, rule_generators))
+                           * intertwiner.T / 8)
+            eta = sp.Integer(-1) ** sum(site[:direction])
+            link = sp.simplify(
+                omega_left.T * (flat_generators[direction] / 2) * omega_right)
+            scalarization = scalarization and link == eta * sp.eye(8) / 2
+    check("D3 the transported flat staggering scalarizes every corner link to eta_d I8/2",
+          scalarization)
+
+    # E. Exact finite-momentum checks, including the landed two-dimensional window.
+    flat_2d = momentum_histogram((4, 4), sp.eye(3))
+    flat_3d = momentum_histogram((4, 4, 4), sp.eye(3))
+    check("E1 flat exact momentum histograms reproduce sum sin^2(k_d)",
+          flat_2d == Counter({0: 4, 1: 8, 2: 4})
+          and flat_3d == Counter({0: 8, 1: 24, 2: 24, 3: 8}))
+
+    shear_2d = sp.Rational(3, 5)
+    volume_2d = sp.Rational(4, 5)
+    g_2d_window = metric(shear_2d, 0, 0)
+    carrier_2d, _, generators_2d = weighted_generators(g_2d_window, volume_2d)
+    plane_indices = (INDEX[(0, 0, 0)], INDEX[(0, 1, 0)],
+                     INDEX[(1, 0, 0)], INDEX[(1, 1, 0)])
+    g2 = sp.Matrix([[1, shear_2d], [shear_2d, 1]])
+    landed_2d = sp.diag(volume_2d, volume_2d * g2.inv(), 1 / volume_2d)
+    q2 = (q_t, q_x, sp.Integer(0))
+    quadratic_2d = sp.cancel(
+        (sp.Matrix(q2).T * g_2d_window.inv() * sp.Matrix(q2))[0])
+    check("E2 c=3/5,V=4/5 is an exact metric-volume point and D3 restricts to the landed 2D Hodge form",
+          sp.factor(g_2d_window.det() - volume_2d**2) == 0
+          and carrier_2d.extract(plane_indices, plane_indices) == landed_2d)
+    plane_symbol = symbol(generators_2d, q2)
+    check("E3 the landed 2D window squares to (q_t^2-2c q_t q_x+q_x^2)/(1-c^2)",
+          matrix_is_zero(plane_symbol * plane_symbol
+                         - quadratic_2d * sp.eye(8))
+          and sp.cancel(quadratic_2d
+                        - (q_t**2 - 2 * shear_2d * q_t * q_x + q_x**2)
+                        / (1 - shear_2d**2)) == 0)
+
+    # F. A genuinely three-direction rational witness with exact volume.
+    witness_shear = sp.Rational(11, 50)
+    witness_volume = sp.Rational(117, 125)
+    witness_metric = metric(witness_shear, witness_shear, witness_shear)
+    witness_inverse = witness_metric.inv()
+    witness_carrier, _, witness_generators = weighted_generators(
+        witness_metric, witness_volume)
+    witness_minors = tuple(sp.factor(
+        witness_carrier[:size, :size].det()) for size in range(1, 9))
+    check("F1 the all-shear rational witness has det(g)=V^2 and positive D3",
+          sp.factor(witness_metric.det() - witness_volume**2) == 0
+          and all(minor > 0 for minor in witness_minors))
+    expected_inverse = sp.Matrix([
+        [sp.Rational(1525, 1404), sp.Rational(-275, 1404), sp.Rational(-275, 1404)],
+        [sp.Rational(-275, 1404), sp.Rational(1525, 1404), sp.Rational(-275, 1404)],
+        [sp.Rational(-275, 1404), sp.Rational(-275, 1404), sp.Rational(1525, 1404)],
+    ])
+    witness_clifford = all(matrix_is_zero(
+        witness_generators[left] * witness_generators[right]
+        + witness_generators[right] * witness_generators[left]
+        - 2 * witness_inverse[left, right] * sp.eye(8))
+        for left in range(3) for right in range(left, 3))
+    check("F2 the rational witness has exact off-diagonal co-metric mixing and closes the generalized Clifford algebra",
+          witness_inverse == expected_inverse
+          and all(witness_inverse[i, j] != 0
+                  for i in range(3) for j in range(3) if i != j)
+          and witness_clifford)
+    witness_histogram = momentum_histogram((4, 4, 4), witness_inverse)
+    expected_histogram = Counter({
+        sp.Integer(0): 8,
+        sp.Rational(1525, 1404): 24,
+        sp.Rational(625, 351): 12,
+        sp.Rational(25, 12): 2,
+        sp.Rational(100, 39): 12,
+        sp.Rational(5125, 1404): 6,
+    })
+    check("F3 all 64 exact 4^3 momenta give the six predicted mixed-metric values",
+          witness_histogram == expected_histogram)
+
+    # G. Design boundary: scalar eta weights alone cannot carry shear.
+    diagonal_weights = sp.symbols("w_t w_x w_y")
+    scalar_eta_quadratic = sum(
+        diagonal_weights[d]**2 * q[d]**2 for d in range(3))
+    mixed_metric_quadratic = sp.cancel(
+        (sp.Matrix(q).T * witness_inverse * sp.Matrix(q))[0])
+    mixed_scalar = sp.diff(scalar_eta_quadratic, q_t, q_x)
+    mixed_metric = sp.diff(mixed_metric_quadratic, q_t, q_x)
+    check("G1 scalar axis-weighted eta links have zero mixed coefficient, while the sheared metric requires one",
+          mixed_scalar == 0
+          and mixed_metric == 2 * witness_inverse[0, 1]
+          and mixed_metric != 0)
+
+    print("MEASURED", flush=True)
+    print(f"  stack parent: {STACK_PARENT}", flush=True)
+    print(f"  scientific parent: {SCIENTIFIC_PARENT}", flush=True)
+    print(f"  main at campaign start: {CURRENT_MAIN_AT_START}", flush=True)
+    print(f"  det(g): {determinant}", flush=True)
+    print("  selected normalization: V^2 = det(g)", flush=True)
+    print("  weighted symbol: Gamma(q)^2 = q^T g^-1 q I8", flush=True)
+    print(f"  rational 3D witness: c=11/50, V=117/125, histogram={dict(witness_histogram)}",
+          flush=True)
+    print("  scope: finite exact conditional D3/exterior construction; no physical time, Lorentzian cone, dynamics, gravity, or continuum limit", flush=True)
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}", flush=True)
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as error:
+        print(f"[FAIL] INTERNAL-EXCEPTION: {type(error).__name__}: {error}",
+              flush=True)
+        print("TOTAL: PASS=0 FAIL=1", flush=True)
+        raise


### PR DESCRIPTION
First new science block after the repaired #7753 stack. This PR is intentionally left open for the review-loop landing process.

MAIN RESULT. Starting from the declared Block 209 carrier D3(g,V)=diag(V,Vg^-1,EgE/V,1/V), define Gamma_d=epsilon_d+epsilon_d^dagger using the D3 inner product and K=sum_d Gamma_d nabla_d. Exact exterior algebra gives

- Gamma(q)^2 = q^T g^-1 q I8,
- -K(k)^2 = sin(k)^T g^-1 sin(k) I8,

including the off-diagonal direction-mixing terms.

NEW SELECTOR. The degree-2-to-1 adjoint carries the exact factor det(g)/V^2. For positive g and V, full generalized-Clifford closure is therefore necessary and sufficient at V^2=det(g). Inside the supplied D3 candidate family, propagation fixes V to the metric volume rather than leaving it independent.

BRIDGES CHECKED EXACTLY.

- At g=I,V=1 an explicit integer intertwiner shows the 8-component exterior carrier is two copies of Block 209s 4x4 Cl(3,0) rule; all 24 parity/direction links scalarize to eta_d I8/2.
- The rational 2D point c=3/5,V=4/5 restricts exactly to the landed shear-Hodge form and carries its inverse-metric quadratic.
- A genuinely mixed 3D point c_tx=c_ty=c_xy=11/50, V=117/125 has positive D3, nonzero off-diagonal co-metric entries, exact Clifford closure, and six exact values across all 64 momenta of the 4^3 grid.
- Pure scalar axis reweighting cannot reproduce shear because it has no mixed momentum coefficient; matrix-valued link mixing is load-bearing.

VERIFICATION. Runner PASS 18/18 with source/input-bound cache. A separate exact reconstruction returned PASS and independently confirmed the volume selector, symbol, flat intertwiner/scalarization, both rational witnesses, and positivity.

SCOPE. Constant positive Euclidean cell only. This does not select D3 or g from the axioms, identify physical time, provide a Lorentzian/causal cone, handle variable cells, supply dynamics/gravity, or take a continuum limit. The next science target is local transport between neighboring D3(g_s,V_s) carriers.