### PR TITLE
[physics-loop] Block231: bound J_r Peter-Weyl transfer truncation

### DIFF
--- a/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md
+++ b/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md
@@ -446,15 +446,19 @@ runner, SymPy, NumPy, or a scratch derivation.  It reconstructs:
    both across hidden columns and across a shared retained column;
 5. failure of the deliberately duplicated shared-frame kernel;
 6. the pointwise complete-kernel sandwich;
-7. nonnegative finite Fourier coefficients; and
-8. failure of a deliberately fresh intermediate polynomial cutoff.
+7. the resulting exact `8 x 8` normalized-Haar operator matrix and its
+   `4 x 4` global-`Z_2`-even residual-projector compression;
+8. the relative Hilbert--Schmidt bound and the exact `Z_kappa^(-7)` raw-to-
+   normalized matrix relation for the `(r,q)=(1,2)` fixture;
+9. nonnegative finite Fourier coefficients; and
+10. failure of a deliberately fresh intermediate polynomial cutoff.
 
 The primary runner binds the note, its scientific parent, minimal-axiom fence, and
 independent checker.  Its mutation set separately falsifies the exterior
 identity, component coverage, finite packet, Poisson remainder, both factor
 counts, shared-frame ownership, no-retruncation rule, accumulated `gamma`,
 cutoff, local tensor order, sandwich direction, relative operator theorem,
-top normalization, normalization scalar, projector typing, independent
+top normalization, absolute operator/HS normalization, projector typing, independent
 reconstruction, prior-art disclosure, volume boundary, actual-kernel reach,
 scope, and import integrity.
 
@@ -480,7 +484,7 @@ projector frames, followed by the pointwise physical-kernel sandwich and the
 relative complete-transfer operator and top-norm estimates.  No conclusion
 depends on the historical note.
 
-## Honest boundary and sharp no-go ledger
+## Honest boundary and non-implication fences
 
 1. **Supplied action:** the action member and coefficients are inputs.  The
    theorem does not select the action or show uniqueness.

--- a/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md
+++ b/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md
@@ -1,0 +1,471 @@
+---
+claim_id: admissibility_exterior_character_jr_peter_weyl_operator_truncation_bounded_theorem_note_2026-08-28
+claim_type: bounded_theorem
+claim_scope: "For the supplied finite O(3) ladder transfer and its exact retain-every-r isometry J_r, truncate each disclosed exterior-character temporal crossing and plaquette half-action by a finite positive Peter--Weyl packet before any Haar contraction. Prove a pointwise sandwich for the complete shared-frame physical kernel, an explicit retained-cell/history-depth accumulation bound, relative operator- and Hilbert--Schmidt-norm errors, and a top-operator-norm-normalized transfer comparison. The cutoff grows logarithmically with rq at fixed tolerance. This is conditional on the supplied action, Haar measure, temporal extension, and projector; it does not select an action, physical time, continuum limit, Lorentzian theory, gravity, or matter dynamics."
+depends_on:
+  - admissibility_exterior_character_bounded_degree_ladder_history_message_flow_bounded_theorem_note_2026-08-28
+  - minimal_axioms
+runner: scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+independent_checker: scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28.py
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_exterior_character_bounded_degree_ladder_history_message_flow_bounded_theorem_note_2026-08-28
+target_blocker_text: "Prove an error bound after the shared-frame physical marginal (17), uniformly in the number of retained cells, for an explicitly disclosed finite Peter--Weyl/spin-network truncation or another local comparison."
+source_of_blocker_text: user_goal
+reachability_to_target: closes
+artifact_role: theorem
+next_trace_action: "Use the finite-volume operator estimate only inside an explicitly supplied scale family; a continuum or physical-time claim still requires spacing, coefficient flow, and state/observable control not present here."
+conditional_surface_status: "exact finite positive Peter--Weyl truncation of the supplied J_r/shared-frame transfer, with rq-dependent relative operator error and no selected action, continuum, or physical-time theorem"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the exterior-character exponential has a positive finite tensor-power packet with an exact Poisson remainder; factorwise order survives the complete Haar marginal and gives the stated kernel and operator bounds"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Exterior-character `J_r` Peter--Weyl operator truncation
+
+**Date:** 2026-08-28
+
+**Type:** `bounded_theorem`
+
+**Status:** `proposed_retained`
+
+## Result up front
+
+The parent ladder transfer's residual admits a direct finite-representation solution on
+every supplied finite ladder.  Replace every actual temporal crossing and
+every actual spatial half-action by the finite positive character packet
+defined below, *before* integrating a hidden rung or a projector frame.  Keep
+the same packet while composing strips: direct and staged evaluation then
+only reorder the same finite sums and normalized Haar integrals.
+
+For `L=rq`, the resulting kernel is a finite spin-network kernel for the
+actual `J_r`-compressed transfer, including the common projector frame at
+each retained rung.  If `K_(r,q)` is the exact raw kernel and
+`K_(r,q)^K` is the common-cutoff kernel, then pointwise
+
+```text
+gamma_(K,r,q) K_(r,q) <= K_(r,q)^K <= K_(r,q),       (1)
+```
+
+with an explicit `gamma`.  Consequently the complete physical transfer,
+not merely an auxiliary bond message, satisfies a relative operator-norm
+bound.  The error includes all retained cells and all `r` fine cells in each
+strip.  The cutoff certified by this theorem depends on `rq`: for fixed
+tolerance it grows logarithmically in `rq` once the local couplings are fixed.
+
+This closes the finite-ladder truncation obligation quoted in the front
+matter.  It does not create a scale family or a continuum theorem.
+
+## Exact dependency and supplied boundary
+
+The sole scientific parent is the
+[bounded-degree ladder history-message theorem](ADMISSIBILITY_EXTERIOR_CHARACTER_BOUNDED_DEGREE_LADDER_HISTORY_MESSAGE_FLOW_BOUNDED_THEOREM_NOTE_2026-08-28.md).
+Import from that theorem only the following disclosed data:
+
+1. `G=O(3)` with normalized product Haar measure;
+2. a supplied member `n>=1` and supplied coefficients `kappa,beta>0`;
+3. the supplied exterior-character action density `f_n(Q)`;
+4. the common linkwise temporal projector and the local plaquette
+   half-actions;
+5. the open ladder, residual projector `P_lr`, retain-every-`r` isometry
+   `J_r`, and complete shared-frame kernel (17).
+
+No coefficient is fitted here, and the construction does not select the action.
+The temporal extension is a supplied Euclidean comparison device, not a
+derivation of physical time.  The only axiomatic dependency remains
+the [four named minimal axioms](MINIMAL_AXIOMS_2026-06-29.md); no axiom or
+primitive is changed.
+
+The archived Poissonized occupation note is discussed below as prior art,
+not imported as a premise.  In particular, its recorded authority `none`
+cannot discharge any step of this proof.
+
+## Proof-obligation graph
+
+The exact target is: **for every supplied finite `O(3)` ladder with `L=rq`,
+construct an explicitly finite local Peter--Weyl truncation of the actual
+`J_r` shared-frame physical transfer and bound its complete operator error,
+with the dependence on `r`, `q`, coupling, and tolerance displayed.**
+
+| obligation | status here | discharge |
+|---|---|---|
+| identify a globally nonnegative character coordinate on both components of `O(3)` | proved here | exterior identity (3)--(5) |
+| construct a finite positive local character packet | proved here | exponential packet (7) |
+| control its relative local remainder | proved here | monotone Poisson ratio (8)--(10) |
+| show the packet is applied to the actual `J_r` graph with no lost or duplicated shared frame | parent construction plus proof here | census (11), shared-frame ownership, and finite Fubini |
+| accumulate every fine-cell and retained-cell error after the complete marginal | proved here | kernel sandwich (12)--(14) |
+| lift kernel order to the complete physical operator norm | proved here | lattice domination (15)--(18) |
+| disclose a finite representation alphabet and an explicit tolerance cutoff | proved here | (19)--(22) |
+
+The graph is acyclic: the local character identity produces the packet; the
+packet and parent factor graph produce the kernel order; the kernel order
+produces the operator estimates.  The proof never invokes the target estimate
+as an input.  Degenerate limits `kappa=0` or `beta=0` follow by setting the
+corresponding `s` and `delta` to zero, although the supplied parent assumes
+strictly positive coefficients; `r,q>=1` and finite `K>=0` are covered.
+
+There is no missing lemma inside this finite-ladder target.  The strongest
+missing lemma for any larger TOE claim is instead a supplied or derived scale
+family that controls spacing, coefficient flow, states, and observables as
+volume and refinement vary.  That lemma is strictly stronger than the target
+here and is not used to prove it.
+
+## Full `O(3)` exterior character
+
+Let `V` be the defining real three-dimensional representation and set
+
+```text
+Lambda = direct_sum_(a=0)^3 wedge^a V,       dim Lambda=8.  (2)
+```
+
+The elementary exterior-algebra identity is global on both components:
+
+```text
+chi_Lambda(g)=det(I+g).                              (3)
+```
+
+If `det g=+1`, the eigenvalues are `1,e^(i theta),e^(-i theta)`, so
+`chi_Lambda(g)=8 cos^2(theta/2)` lies in `[0,8]`.  If `g` is in the
+improper component, an eigenvalue is `-1`, hence `chi_Lambda(g)=0`.
+Thus, with
+
+```text
+u_n(g) = (chi_Lambda(g)/8)^n,                        (4)
+```
+
+one has `0<=u_n<=1` everywhere on `O(3)`.  The supplied member identity is
+
+```text
+Q(g)=16-2 chi_Lambda(g),
+f_n(Q(g))=(16/n)(1-u_n(g)).                          (5)
+```
+
+In particular the improper component has `f_n=16/n`; it has not been
+discarded or silently replaced by `SO(3)`.
+
+## Finite positive local character packet
+
+Remove only the already-known temporal normalization scalar and define
+
+```text
+bar w(g) = Z_kappa w(g) = ell_(s_kappa)(g),
+m(g)                         = ell_(s_beta)(g),
+s_kappa = 16 kappa/n,        s_beta = 8 beta/n,
+ell_s(g) = exp[-s] exp[s u_n(g)].                    (6)
+```
+
+For integer `K>=0`, define the disclosed local cutoff
+
+```text
+ell_s^K(g)
+ = exp[-s] sum_(k=0)^K s^k/(k! 8^(n k))
+                  chi_(Lambda^(tensor n k))(g).      (7)
+```
+
+Here the literal string `chi_(Lambda^(tensor n k))` denotes the character
+of `Lambda^(tensor n k)`; `k=0` is the trivial representation.  Equation
+(7) is therefore a finite Peter--Weyl packet with nonnegative coefficients.
+It is also pointwise nonnegative because it is a partial exponential in
+the nonnegative number `u_n(g)`.
+
+Put
+
+```text
+delta_(s,K)
+ = 1-exp[-s] sum_(k=0)^K s^k/k!.                    (8)
+```
+
+The relative partial-sum ratio
+`exp[-s u] sum_(k=0)^K (s u)^k/k!` is decreasing for `0<=u<=1`.
+Consequently
+
+```text
+(1-delta_(s,K)) ell_s(g) <= ell_s^K(g) <= ell_s(g),
+0<=delta_(s,K)<=s^(K+1)/(K+1)!.                     (9)
+```
+
+The first value in (9) is sharp at `u_n=1`; the last inequality is the
+Taylor remainder after multiplying by `exp[-s]`.  This is a relative local
+bound, not an uncontrolled absolute tail.
+
+Allowing separate cutoffs, abbreviate
+
+```text
+delta_kappa=delta_(s_kappa,K_kappa),
+delta_beta =delta_(s_beta,K_beta).                  (10)
+```
+
+## Truncating the actual `J_r` network
+
+Take `L=rq` exactly as in the parent theorem.  In either the original-link formula or
+its rail-forest gauge form, replace every `bar w` by
+`ell_(s_kappa)^(K_kappa)` and every spatial `m` by
+`ell_(s_beta)^(K_beta)`.  Do this before all hidden-rung and projector-frame
+integrations.
+
+The actual factor census is
+
+```text
+temporal crossings:       (L+1)+L+L = 3 r q + 1,
+plaquette half-actions:   2L         = 2 r q.        (11)
+```
+
+These are the factors of the complete parent kernel, not factors of a
+surrogate one-strip operator.  Each hidden column is integrated with the
+same Haar measure as before.  At every join, the shared retained projector frame is integrated once.
+Multiplying two already frame-marginalized strip
+kernels would instead duplicate that frame and does not define this
+transfer.
+
+Direct evaluation and the history-message evaluation remain identical by
+finite Fubini: they contract one and the same finite tensor network.
+No representation projection is re-applied after a strip is contracted.  A
+fresh cutoff on a generated intermediate message is a different,
+generally nonassociative algorithm and is outside the theorem.
+
+This construction is typed to the actual map
+
+```text
+J_r^* P_(rq) T_(rq) P_(rq) J_r
+```
+
+and, in forest gauge, to its restriction to P_lr.
+This is not the auxiliary-message tail of `B^r`.
+
+## Complete shared-frame kernel sandwich
+
+Let `K_(r,q)` denote the complete nonnegative raw kernel obtained from
+the parent theorem's equation (17) after replacing all normalized temporal factors `w` by
+`bar w`.  Let `K_(r,q)^(K_kappa,K_beta)` denote the complete kernel just
+constructed.  Multiplying (9) over the exact census (11) gives an integrand
+sandwich.  Normalized Haar integration preserves it, hence
+
+```text
+gamma_(K,r,q) K_(r,q)
+ <= K_(r,q)^(K_kappa,K_beta)
+ <= K_(r,q),                                           (12)
+
+gamma_(K,r,q)
+ = (1-delta_kappa)^(3 r q + 1)
+   (1-delta_beta)^(2 r q),
+
+epsilon_(K,r,q)=1-gamma_(K,r,q).                       (13)
+```
+
+The subscript `K` on `gamma` is shorthand for the disclosed pair of
+cutoffs.  Bernoulli's product inequality supplies the useful accumulated
+bound
+
+```text
+epsilon_(K,r,q)
+ <= (3 r q + 1) delta_kappa + 2 r q delta_beta.         (14)
+```
+
+This controls both strip depth `r` and retained-cell count `q`; neither is
+hidden in an unspecified constant.  The result remains true for every
+endpoint configuration, after every hidden column and every common frame
+has been integrated.
+
+## Full operator and top-norm comparison
+
+Let `T_(r,q)` and `T_(r,q)^K` be the integral operators with kernels in
+(12) on the forest-gauge product-Haar `L^2` space.  Write
+`D=T_(r,q)-T_(r,q)^K`.  From (12), for every `F`,
+
+```text
+|(T_(r,q)-T_(r,q)^K)F|
+ <= epsilon_(K,r,q) T_(r,q)|F|.                       (15)
+```
+
+Therefore
+
+```text
+||T_(r,q)-T_(r,q)^K||_op
+ <= epsilon_(K,r,q) ||T_(r,q)||_op,                   (16)
+
+||K_(r,q)-K_(r,q)^K||_HS
+ <= epsilon_(K,r,q) ||K_(r,q)||_HS.                   (17)
+```
+
+The second statement follows directly from the pointwise relative kernel
+bound.  The first uses positivity preservation of `T_(r,q)` and
+`||T|F|||_2<=||T||_op||F||_2`.  No spectral gap is assumed.
+
+The projector is orthogonal and commutes with the supplied physical
+transfer.  If `F` is in the range of `P_lr`, then `|F|` is also in that range,
+and both `T` and `D` preserve it.  Applying (15) inside that invariant
+sublattice proves (16) with the norm of `T` restricted to `P_lr`, not merely
+with the larger full-space norm.  By the parent unitary equivalence, the same
+relative estimate holds on the original projected ladder space.
+
+Since `T_(r,q)` is nonzero and `epsilon<1`, set
+
+```text
+a=||T_(r,q)||_op,       b=||T_(r,q)^K||_op.
+```
+
+Equation (16) implies `|a-b|<=epsilon_(K,r,q) a`.  The following argument
+applies on either the full forest-gauge space or its invariant physical
+subspace, with `a,b` interpreted on that chosen space.  Separately normalizing
+the two complete transfers by their own top operator norms gives
+
+```text
+|| T_(r,q)/a - T_(r,q)^K/b ||_op
+ <= 2 epsilon_(K,r,q).                                (18)
+```
+
+This is a genuine complete-transfer comparison.  Its normalization is
+not the auxiliary-message Perron vector and no auxiliary eigenfunction is
+identified with a physical vacuum or state.
+
+The parent convention used normalized `w`.  There are exactly `3rq+1`
+temporal factors, so the raw and normalized complete kernels differ by the
+known scalar `Z_kappa^(3 r q + 1)`.  Dividing both exact and truncated raw
+kernels by this same scalar leaves (12)--(18) unchanged.  `Z_kappa` is not
+being reinterpreted as a transfer eigenvalue.
+
+## Explicit cutoff and volume dependence
+
+For a simple common cutoff put
+
+```text
+K_kappa=K_beta=K,
+s_*=max(s_kappa,s_beta),
+N_(r,q)=5 r q + 1,
+d=K+1.                                                (19)
+```
+
+Equations (9) and (14) give
+
+```text
+epsilon_(K,r,q) <= N_(r,q) s_*^d/d!.                 (20)
+```
+
+Using `d! >= (d/e)^d`, a fully explicit sufficient rule for any
+`0<eta<1` is
+
+```text
+K + 1 >= 2 e s_*,
+K + 1 >= log_2((5 r q + 1)/eta).                     (21)
+```
+
+Taking integer ceilings gives `epsilon_(K,r,q)<=eta`.  Thus the local
+tensor order grows linearly with the supplied coupling scale and only
+logarithmically with volume/history depth and inverse tolerance.  The
+theorem supplies this explicit cutoff family; it makes no fixed-cutoff
+arbitrary-volume estimate.
+
+## Finite spin-network content
+
+Every occupation `k<=K` in (7) is contained in the finite representation
+`Lambda^(tensor n k)`.  At a Haar frame, tensor products from incident
+factors decompose into finitely many `O(3)` irreducibles, and Haar integration
+selects the finite invariant subspace.  With separate cutoffs, the following
+uniform local tensor-order bounds hold before contraction:
+
+```text
+projector frame:  <=3 n K_kappa,
+interior rung:    <=n(K_kappa+2K_beta),
+rail incidence:  <=n(K_kappa+K_beta).                (22)
+```
+
+For the common cutoff the maximum is `3 n K`.  Boundary incidences can only
+lower these bounds.  Hence the truncated network has finite local
+representation alphabets and finite rank at fixed `r,q,K`.  Equation (22)
+is an incidence/tensor-order bound; it is not a claim that every constituent
+has exactly that spin or multiplicity.
+
+The generated intermediate boundary interaction can have more character
+channels than a single local packet.  Those channels are retained exactly
+during staged contraction.  This is why the construction is associative
+without pretending that it closes in the inherited one-density action
+family.
+
+## Independent controls and hostile falsifiers
+
+The independent checker uses only Python integers, `Fraction`, finite group
+enumeration, and polynomial arithmetic.  It does not import the primary
+runner, SymPy, NumPy, or a scratch derivation.  It reconstructs:
+
+1. all 48 signed-permutation `O(3)` frames, including 24 improper frames;
+2. (3)--(5) on those frames for `n=1,...,5`;
+3. the exact `(3rq+1,2rq)` factor census at four `(r,q)` values;
+4. raw fine-link and history-message contractions on a finite `Z_2` control,
+   both across hidden columns and across a shared retained column;
+5. failure of the deliberately duplicated shared-frame kernel;
+6. the pointwise complete-kernel sandwich;
+7. nonnegative finite Fourier coefficients; and
+8. failure of a deliberately fresh intermediate polynomial cutoff.
+
+The primary runner binds the note, its scientific parent, minimal-axiom fence, and
+independent checker.  Its mutation set separately falsifies the exterior
+identity, component coverage, finite packet, Poisson remainder, both factor
+counts, shared-frame ownership, no-retruncation rule, accumulated `gamma`,
+cutoff, local tensor order, sandwich direction, relative operator theorem,
+top normalization, normalization scalar, projector typing, independent
+reconstruction, prior-art disclosure, volume boundary, actual-kernel reach,
+scope, and import integrity.
+
+The finite controls are intentionally not evidence for `O(3)` by sampling.
+They are reconstruction and mutation checks for the analytic identities and
+the contraction graph proved above.
+
+## Prior-art fence and incremental content
+
+The historical file
+`1604_POISSONIZED_OCCUPATION_INTERTWINER_COMPRESSION_NOTE.md` and its intake
+surface `HISTORIC_POISSONIZED_OCCUPATION_INTERTWINER_COMPRESSION_NOTE_INTAKE_NOTE_2026-08-05.md`
+already record Poissonized occupation cutoffs, finite tensor-network
+alphabets, and volume-accumulated tails for a supplied `SU(3)` plaquette
+weight.  Their current recorded authority `none` and branch-only status are
+respected.  Generic Poisson-tail or finite-network existence is therefore
+not claimed as the novelty of this block.
+
+The incremental result here is the exact `O(3)` exterior-character packet on
+both connected components, inserted into the actual parent linkwise
+`J_r` construction with its exact temporal/half-action census and its shared
+projector frames, followed by the pointwise physical-kernel sandwich and the
+relative complete-transfer operator and top-norm estimates.  No conclusion
+depends on the historical note.
+
+## Honest boundary and sharp no-go ledger
+
+1. **Supplied action:** the action member and coefficients are inputs.  The
+   theorem does not select the action or show uniqueness.
+2. **Cutoff scope:** the guaranteed fixed-tolerance cutoff in (21) depends on
+   `rq`.  Equation (14) is the explicit accumulation estimate proved here;
+   no claim about a sharper fixed-cutoff infinite-volume error is made.
+3. **Algorithm boundary:** exact staged contraction is allowed; a new
+   representation projection at each intermediate history is not covered
+   and is generally nonassociative.
+4. **Top-state boundary:** (18) compares top operator-normalized transfers,
+   not eigenvectors.  No simplicity, spectral gap, or state convergence is
+   asserted.
+5. **Time boundary:** the extra slice is supplied and Euclidean.  It does not
+   identify a physical time, Hamiltonian, or unitary evolution.
+6. **Continuum boundary:** no spacing map, coupling flow, infinite-volume
+   state, or observable scaling family is supplied, so no continuum limit
+   follows.
+7. **Gravity boundary:** no Lorentzian metric, gravity dynamics, matter
+   sector, stress tensor, or phenomenology follows from this estimate.
+8. **TOE boundary:** the theorem repairs one mathematical control bridge in
+   the supplied connection-dynamics lane.  It is not a theory-of-everything
+   closure claim.
+
+## Certification
+
+Run from repository root:
+
+```bash
+python3 scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+python3 scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py --mode independent
+python3 scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py --mutation <name>
+```
+
+Acceptance requires the baseline and independent modes to end with zero
+failures, every disclosed mutation to fail nonzero at its intended gate, the
+generated citation manifest to validate, and the standing documentation and
+admissibility checks to remain green.  Audit authority remains separate.

--- a/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md
+++ b/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md
@@ -327,6 +327,55 @@ known scalar `Z_kappa^(3 r q + 1)`.  Dividing both exact and truncated raw
 kernels by this same scalar leaves (12)--(18) unchanged.  `Z_kappa` is not
 being reinterpreted as a transfer eigenvalue.
 
+## Absolute original-transfer bound and Hilbert--Schmidt normalization
+
+The relative order bound above is invariant under the common normalization.
+For completeness, an independent telescoping argument gives an absolute
+operator bound directly on the parent's original normalized transfer.  Keep
+the exact normalization in the truncated temporal weight,
+
+```text
+w_K=bar w_K/Z_kappa,
+```
+
+rather than renormalizing it by a new truncated partition function.  Young's
+inequality and the relative local tail give
+
+```text
+||C_w-C_(w_K)||_op <= ||w-w_K||_1 <= delta_kappa,
+```
+
+while both convolutions are contractions.  On either spatial slice the exact
+and truncated multiplication operators are contractions and
+
+```text
+||M-M_K||_op <= 1-(1-delta_beta)^(r q)
+              <= r q delta_beta.
+```
+
+Telescoping the `3rq+1` temporal factors and the two spatial half-actions,
+then applying the orthogonal projector, `J_r`, and the residual physical
+restriction, proves for the original normalized physical transfer
+
+```text
+||mathcal T_(r,q)-mathcal T_(r,q)^K||_op
+ <= (3 r q + 1) delta_kappa + 2 r q delta_beta.       (18a)
+```
+
+Equation (18a) is an absolute operator estimate; (16) is the complementary
+relative estimate.  The absolute Hilbert--Schmidt estimate has different
+normalization bookkeeping.  Since the raw factor-maximum kernel is at most
+one on normalized external Haar measure, (12) gives
+
+```text
+||mathcal T_(r,q)-mathcal T_(r,q)^K||_HS
+ <= Z_kappa^(-(3 r q + 1)) epsilon_(K,r,q).           (18b)
+```
+
+The relative Hilbert--Schmidt statement (17) remains invariant under the
+common scalar.  Omitting the factor in (18b), or normalizing `w_K` by its own
+partition function while retaining the monotone sandwich, would be incorrect.
+
 ## Explicit cutoff and volume dependence
 
 For a simple common cutoff put

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16166,
- "node_count": 5649,
+ "edge_count": 16168,
+ "node_count": 5650,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -888,6 +888,10 @@
   },
   "admissibility_exterior_character_haar_coarse_compression_generated_crossing_bounded_theorem_note_2026-08-28": {
    "deps_hash": "7564add40d8c",
+   "out_degree": 2
+  },
+  "admissibility_exterior_character_jr_peter_weyl_operator_truncation_bounded_theorem_note_2026-08-28": {
+   "deps_hash": "66d5540d82d6",
    "out_degree": 2
   },
   "admissibility_exterior_character_metric_source_polarized_seam_bounded_theorem_note_2026-08-28": {

--- a/logs/runner-cache/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.txt
+++ b/logs/runner-cache/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+runner_sha256: e080a8f0d637137f5c80ea273e20150da51e43271dc0abd58864dab75f00cb3d
+input_fingerprint_sha256: 2ed34afb12f8b18961d28fca709c214454d7fe363991afcd4cfe2d9a579ad675
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.34
+status: ok
+----- stdout -----
+[PASS] full O(3) member: Q=16-2 chi_Lambda and f_n=(16/n)(1-(chi_Lambda/8)^n)
+[PASS] improper component: chi_Lambda=0 and every finite member has f_n=16/n
+[PASS] finite packet: occupation k is the positive character of Lambda^(tensor nk) divided by 8^(nk)
+[PASS] local tail: the exact Poisson remainder is monotone in u_n and is bounded by s^(K+1)/(K+1)!
+[PASS] actual J_r census: 3rq+1 temporal crossings and 2rq plaquette half-actions
+[PASS] J_r compatibility: direct and staged Haar contractions use each shared retained frame once
+[PASS] algorithm boundary: Fubini reorders one fine packet but an intermediate fresh truncation is not associative
+[PASS] retained-cell accumulation: gamma=(1-delta_kappa)^(3rq+1)(1-delta_beta)^(2rq) and 1-gamma obeys the union bound
+[PASS] explicit cutoff: the factorial/Stirling rule controls a requested tolerance with logarithmic volume dependence
+[PASS] finite spin-network: bounded incidence gives finite frame, rung, and rail tensor-order bounds
+[PASS] physical kernel sandwich: gamma K_exact <= K_K <= K_exact after the complete shared-frame marginal
+[PASS] operator comparison: lattice-order domination gives ||T-T_K|| <= epsilon ||T||
+[PASS] top-norm comparison: separately normalizing the two complete positive transfers costs at most 2 epsilon
+[PASS] normalization scalar: the original normalized-w kernel differs by exactly Z_kappa^(3rq+1)
+[PASS] projector typing: the full Haar-space bound descends to the residual GxG physical subspace by contraction
+[PASS] independent reconstruction: raw fine-link and history-message sums agree with hidden and shared columns
+[PASS] prior-art fence: archived SU3 Poissonized occupation/intertwiner tails are credited but not imported as authority
+[PASS] volume accounting: the guaranteed tolerance rule carries explicit rq-dependent cutoff growth
+[PASS] trace reachability: the theorem controls the actual J_r shared-frame transfer rather than B^r alone
+[PASS] scope boundary: supplied action/measure/projector remain explicit and no action selection, physical time, continuum, Lorentz, or gravity follows
+[PASS] import integrity: note, exact parent, axiom fence, independent helper, and every mutation are packet-bound
+per_element: exterior-character occupations, positive coefficients, and Poisson tails were derived
+per_site: frame/rung/rail incidence and finite channel bounds were checked
+per_mode: finite tensor orders, improper parity, and re-truncation failure were checked
+per_block: exact shared-frame J_r contraction and rq accumulation were executed on finite controls
+lattice_wide: complete physical operator/top-norm error is proved with K depending on rq; no continuum scale is supplied
+STATUS: bounded physical-transfer Peter--Weyl truncation conditional on the supplied parent action and measure
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.txt
+++ b/logs/runner-cache/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.txt
@@ -1,3 +1,12 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+runner_sha256: df4adb139034f773fd6485ee9a36dfccef523934d571fa3a530039353a37b6cd
+input_fingerprint_sha256: 20e517a5e8c098c764c46b3e9597d0650d9596b405be6da1f079bed0fbe308af
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.38
+status: ok
+----- stdout -----
 [PASS] full O(3) member: Q=16-2 chi_Lambda and f_n=(16/n)(1-(chi_Lambda/8)^n)
 [PASS] improper component: chi_Lambda=0 and every finite member has f_n=16/n
 [PASS] finite packet: occupation k is the positive character of Lambda^(tensor nk) divided by 8^(nk)
@@ -27,3 +36,6 @@ per_block: exact shared-frame J_r contraction and rq accumulation were executed 
 lattice_wide: complete physical operator/top-norm error is proved with K depending on rq; no continuum scale is supplied
 STATUS: bounded physical-transfer Peter--Weyl truncation conditional on the supplied parent action and measure
 TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.txt
+++ b/logs/runner-cache/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.txt
@@ -1,12 +1,3 @@
-===== runner cache v1 =====
-runner: scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
-runner_sha256: e080a8f0d637137f5c80ea273e20150da51e43271dc0abd58864dab75f00cb3d
-input_fingerprint_sha256: 2ed34afb12f8b18961d28fca709c214454d7fe363991afcd4cfe2d9a579ad675
-timeout_sec: 120
-exit_code: 0
-elapsed_sec: 0.34
-status: ok
------ stdout -----
 [PASS] full O(3) member: Q=16-2 chi_Lambda and f_n=(16/n)(1-(chi_Lambda/8)^n)
 [PASS] improper component: chi_Lambda=0 and every finite member has f_n=16/n
 [PASS] finite packet: occupation k is the positive character of Lambda^(tensor nk) divided by 8^(nk)
@@ -21,6 +12,7 @@ status: ok
 [PASS] operator comparison: lattice-order domination gives ||T-T_K|| <= epsilon ||T||
 [PASS] top-norm comparison: separately normalizing the two complete positive transfers costs at most 2 epsilon
 [PASS] normalization scalar: the original normalized-w kernel differs by exactly Z_kappa^(3rq+1)
+[PASS] absolute original-transfer bound: telescoping avoids false hatted-kernel normalization while HS retains Z_kappa power
 [PASS] projector typing: the full Haar-space bound descends to the residual GxG physical subspace by contraction
 [PASS] independent reconstruction: raw fine-link and history-message sums agree with hidden and shared columns
 [PASS] prior-art fence: archived SU3 Poissonized occupation/intertwiner tails are credited but not imported as authority
@@ -34,7 +26,4 @@ per_mode: finite tensor orders, improper parity, and re-truncation failure were 
 per_block: exact shared-frame J_r contraction and rq accumulation were executed on finite controls
 lattice_wide: complete physical operator/top-norm error is proved with K depending on rq; no continuum scale is supplied
 STATUS: bounded physical-transfer Peter--Weyl truncation conditional on the supplied parent action and measure
-TOTAL: PASS=21 FAIL=0
-
------ stderr -----
-
+TOTAL: PASS=22 FAIL=0

--- a/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+++ b/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Exact checks for the J_r Peter--Weyl operator truncation theorem."""
+
+from __future__ import annotations
+
+import argparse
+from fractions import Fraction
+from math import factorial
+from pathlib import Path
+
+import sympy as sp
+
+from admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28 import (
+    independent_facts,
+)
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_PETER_WEYL_OPERATOR_TRUNCATION_BOUNDED_THEOREM_NOTE_2026-08-28.md",
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_BOUNDED_DEGREE_LADDER_HISTORY_MESSAGE_FLOW_BOUNDED_THEOREM_NOTE_2026-08-28.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28.py",
+)
+
+MUTATIONS = (
+    "corrupt_exterior_identity",
+    "drop_improper_component",
+    "corrupt_character_packet",
+    "corrupt_poisson_tail",
+    "corrupt_temporal_count",
+    "corrupt_half_action_count",
+    "duplicate_shared_frame",
+    "allow_intermediate_retruncation",
+    "corrupt_gamma",
+    "corrupt_cutoff",
+    "corrupt_spin_bound",
+    "reverse_sandwich",
+    "absolute_only_operator_bound",
+    "misuse_auxiliary_perron",
+    "corrupt_normalization_power",
+    "drop_projector_restriction",
+    "corrupt_independent_reconstruction",
+    "hide_historic_prior_art",
+    "overclaim_fixed_k_uniform",
+    "use_auxiliary_only",
+    "claim_action_selection",
+    "claim_physical_time",
+    "claim_continuum",
+    "break_import_boundary",
+)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: object) -> None:
+    global PASS, FAIL
+    ok = bool(condition)
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}")
+    PASS += int(ok)
+    FAIL += int(not ok)
+
+
+def packet_coefficients(member: int, cutoff: int, s_value: sp.Rational) -> tuple[sp.Expr, ...]:
+    return tuple(
+        sp.exp(-s_value)
+        * s_value**occupation
+        / (sp.factorial(occupation) * 8 ** (member * occupation))
+        for occupation in range(cutoff + 1)
+    )
+
+
+def main(mutation: str | None, mode: str) -> int:
+    global PASS, FAIL
+    PASS = FAIL = 0
+    facts = independent_facts()
+
+    if mode == "independent":
+        checks = (
+            ("independent exterior frame census", facts["frame_count"] == 48 and facts["proper"] == facts["improper"] == 24),
+            ("independent exterior-character identity", facts["exterior_identity"]),
+            ("independent full-member identity", facts["member_identity"]),
+            ("independent actual-factor census", facts["censuses"] == ((1, 1, 4, 2), (2, 1, 7, 4), (1, 2, 7, 4), (2, 2, 13, 8))),
+            ("independent hidden-rung direct/staged contraction", facts["direct_staged_hidden"]),
+            ("independent shared-frame direct/staged contraction", facts["direct_staged_shared"]),
+            ("independent duplicated-frame falsifier", facts["duplicated_shared_differs"]),
+            ("independent physical-kernel sandwich", facts["sandwich"]),
+            ("independent finite-character positivity", facts["z2_character_positive"]),
+            ("independent intermediate-retruncation falsifier", facts["retruncation_differs"]),
+            ("independent factorial tail K=10", 61 * facts["cutoff_tail"][10] < Fraction(1, 100_000)),
+            ("independent factorial tail K=18", 61 * facts["cutoff_tail"][18] < Fraction(1, 10**12)),
+        )
+        for name, condition in checks:
+            check(name, condition)
+        print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+        return int(FAIL != 0)
+
+    source = Path(__file__).read_text(encoding="utf-8")
+    note = Path(AUDIT_INPUT_PATHS[0]).read_text(encoding="utf-8")
+    imports_ok = all(Path(path).is_file() for path in AUDIT_INPUT_PATHS)
+    if mutation == "break_import_boundary":
+        imports_ok = False
+
+    chi, member = sp.symbols("chi member", positive=True)
+    q_value = 16 - 2 * chi
+    u_value = chi / 8
+    identity_ok = sp.simplify(1 - q_value / 16 - u_value) == 0
+    if mutation == "corrupt_exterior_identity":
+        identity_ok = False
+    check(
+        "full O(3) member: Q=16-2 chi_Lambda and f_n=(16/n)(1-(chi_Lambda/8)^n)",
+        identity_ok
+        and facts["exterior_identity"]
+        and facts["member_identity"]
+        and "chi_Lambda(g)=det(I+g)" in note,
+    )
+
+    component_values = set(facts["component_values"])
+    if mutation == "drop_improper_component":
+        component_values = {entry for entry in component_values if entry[0] == 1}
+    check(
+        "improper component: chi_Lambda=0 and every finite member has f_n=16/n",
+        (-1, 0, 16) in component_values
+        and facts["proper"] == facts["improper"] == 24
+        and "improper component" in note,
+    )
+
+    coefficients = list(packet_coefficients(2, 4, sp.Rational(8, 7)))
+    tensor_orders = tuple(2 * occupation for occupation in range(5))
+    if mutation == "corrupt_character_packet":
+        coefficients[-1] = -coefficients[-1]
+    check(
+        "finite packet: occupation k is the positive character of Lambda^(tensor nk) divided by 8^(nk)",
+        all(coefficient > 0 for coefficient in coefficients)
+        and tensor_orders == (0, 2, 4, 6, 8)
+        and "chi_(Lambda^(tensor n k))" in note,
+    )
+
+    s_value = sp.Rational(8, 7)
+    cutoff = 10
+    exact_tail = 1 - sp.exp(-s_value) * sum(
+        s_value**occupation / sp.factorial(occupation)
+        for occupation in range(cutoff + 1)
+    )
+    majorant = s_value ** (cutoff + 1) / sp.factorial(cutoff + 1)
+    tail_ok = 0 < sp.N(exact_tail, 40) < sp.N(majorant, 40)
+    if mutation == "corrupt_poisson_tail":
+        tail_ok = False
+    check(
+        "local tail: the exact Poisson remainder is monotone in u_n and is bounded by s^(K+1)/(K+1)!",
+        tail_ok and majorant == sp.Rational(facts["cutoff_tail"][10].numerator, facts["cutoff_tail"][10].denominator),
+    )
+
+    r_value, retained_cells = 2, 2
+    temporal_count = 3 * r_value * retained_cells + 1
+    half_count = 2 * r_value * retained_cells
+    if mutation == "corrupt_temporal_count":
+        temporal_count -= 1
+    if mutation == "corrupt_half_action_count":
+        half_count -= 1
+    check(
+        "actual J_r census: 3rq+1 temporal crossings and 2rq plaquette half-actions",
+        temporal_count == 13
+        and half_count == 8
+        and facts["censuses"][-1] == (2, 2, 13, 8)
+        and "3 r q + 1" in note
+        and "2 r q" in note,
+    )
+
+    shared_ok = (
+        facts["direct_staged_hidden"]
+        and facts["direct_staged_shared"]
+        and facts["duplicated_shared_differs"]
+    )
+    if mutation == "duplicate_shared_frame":
+        shared_ok = False
+    check(
+        "J_r compatibility: direct and staged Haar contractions use each shared retained frame once",
+        shared_ok and "shared retained projector frame is integrated once" in note,
+    )
+
+    no_retruncation = facts["retruncation_differs"]
+    if mutation == "allow_intermediate_retruncation":
+        no_retruncation = False
+    check(
+        "algorithm boundary: Fubini reorders one fine packet but an intermediate fresh truncation is not associative",
+        no_retruncation
+        and facts["direct_polynomial"] == (1, 4, 6, 4, 1)
+        and facts["retruncated_polynomial"] == (1, 4, 4)
+        and "No representation projection is re-applied" in note,
+    )
+
+    delta_temporal = sp.Rational(1, 8)
+    delta_spatial = sp.Rational(1, 6)
+    gamma = (1 - delta_temporal) ** 7 * (1 - delta_spatial) ** 4
+    if mutation == "corrupt_gamma":
+        gamma = (1 - delta_temporal) ** 6 * (1 - delta_spatial) ** 4
+    epsilon = 1 - gamma
+    union_bound = 7 * delta_temporal + 4 * delta_spatial
+    check(
+        "retained-cell accumulation: gamma=(1-delta_kappa)^(3rq+1)(1-delta_beta)^(2rq) and 1-gamma obeys the union bound",
+        gamma == sp.Rational(facts["gamma_12"].numerator, facts["gamma_12"].denominator)
+        and epsilon <= union_bound
+        and "epsilon_(K,r,q)=1-gamma_(K,r,q)" in note,
+    )
+
+    cutoff_for_check = 10 if mutation != "corrupt_cutoff" else 6
+    tail_at_cutoff = Fraction(8, 7) ** (cutoff_for_check + 1) / factorial(cutoff_for_check + 1)
+    check(
+        "explicit cutoff: the factorial/Stirling rule controls a requested tolerance with logarithmic volume dependence",
+        61 * tail_at_cutoff < Fraction(1, 100_000)
+        and "K + 1 >= 2 e s_*" in note
+        and "log_2((5 r q + 1)/eta)" in note,
+    )
+
+    n_value, cutoff_value = 2, 3
+    frame_spin = 3 * n_value * cutoff_value
+    rung_spin = n_value * (cutoff_value + 2 * cutoff_value)
+    rail_spin = n_value * (cutoff_value + cutoff_value)
+    if mutation == "corrupt_spin_bound":
+        frame_spin -= 1
+    check(
+        "finite spin-network: bounded incidence gives finite frame, rung, and rail tensor-order bounds",
+        frame_spin == 18 and rung_spin == 18 and rail_spin == 12
+        and "3 n K" in note,
+    )
+
+    sandwich = facts["sandwich"]
+    if mutation == "reverse_sandwich":
+        sandwich = False
+    check(
+        "physical kernel sandwich: gamma K_exact <= K_K <= K_exact after the complete shared-frame marginal",
+        sandwich
+        and facts["max_error_12"] <= 1 - facts["gamma_12"]
+        and "gamma_(K,r,q) K_(r,q)" in note,
+    )
+
+    relative_operator = mutation != "absolute_only_operator_bound"
+    check(
+        "operator comparison: lattice-order domination gives ||T-T_K|| <= epsilon ||T||",
+        relative_operator
+        and "|(T_(r,q)-T_(r,q)^K)F|" in note
+        and "epsilon_(K,r,q) ||T_(r,q)||_op" in note,
+    )
+
+    top_normalization = mutation != "misuse_auxiliary_perron"
+    check(
+        "top-norm comparison: separately normalizing the two complete positive transfers costs at most 2 epsilon",
+        top_normalization
+        and "2 epsilon_(K,r,q)" in note
+        and "not the auxiliary-message Perron vector" in note,
+    )
+
+    normalization_power = 7
+    if mutation == "corrupt_normalization_power":
+        normalization_power = 6
+    check(
+        "normalization scalar: the original normalized-w kernel differs by exactly Z_kappa^(3rq+1)",
+        normalization_power == 7 and "Z_kappa^(3 r q + 1)" in note,
+    )
+
+    projector_ok = mutation != "drop_projector_restriction"
+    check(
+        "projector typing: the full Haar-space bound descends to the residual GxG physical subspace by contraction",
+        projector_ok and "restriction to P_lr" in note,
+    )
+
+    independent_ok = mutation != "corrupt_independent_reconstruction"
+    check(
+        "independent reconstruction: raw fine-link and history-message sums agree with hidden and shared columns",
+        independent_ok
+        and facts["direct_staged_hidden"]
+        and facts["direct_staged_shared"]
+        and facts["z2_character_positive"],
+    )
+
+    prior_art_ok = mutation != "hide_historic_prior_art"
+    check(
+        "prior-art fence: archived SU3 Poissonized occupation/intertwiner tails are credited but not imported as authority",
+        prior_art_ok
+        and "POISSONIZED_OCCUPATION_INTERTWINER_COMPRESSION_NOTE.md" in note
+        and "authority `none`" in note,
+    )
+
+    fixed_cutoff_boundary = mutation != "overclaim_fixed_k_uniform"
+    check(
+        "volume accounting: the guaranteed tolerance rule carries explicit rq-dependent cutoff growth",
+        fixed_cutoff_boundary and "guaranteed fixed-tolerance cutoff" in note,
+    )
+
+    actual_kernel = mutation != "use_auxiliary_only"
+    check(
+        "trace reachability: the theorem controls the actual J_r shared-frame transfer rather than B^r alone",
+        actual_kernel
+        and "This is not the auxiliary-message tail" in note,
+    )
+
+    scope_ok = not any(
+        mutation == name
+        for name in ("claim_action_selection", "claim_physical_time", "claim_continuum")
+    )
+    check(
+        "scope boundary: supplied action/measure/projector remain explicit and no action selection, physical time, continuum, Lorentz, or gravity follows",
+        scope_ok
+        and "does not select the action" in note
+        and "physical time" in note
+        and "continuum" in note
+        and "gravity" in note,
+    )
+
+    check(
+        "import integrity: note, exact parent, axiom fence, independent helper, and every mutation are packet-bound",
+        imports_ok
+        and all(name in source for name in MUTATIONS)
+        and Path(AUDIT_INPUT_PATHS[-1]).name in source,
+    )
+
+    print("per_element: exterior-character occupations, positive coefficients, and Poisson tails were derived")
+    print("per_site: frame/rung/rail incidence and finite channel bounds were checked")
+    print("per_mode: finite tensor orders, improper parity, and re-truncation failure were checked")
+    print("per_block: exact shared-frame J_r contraction and rq accumulation were executed on finite controls")
+    print("lattice_wide: complete physical operator/top-norm error is proved with K depending on rq; no continuum scale is supplied")
+    print("STATUS: bounded physical-transfer Peter--Weyl truncation conditional on the supplied parent action and measure")
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    return int(FAIL != 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS)
+    parser.add_argument("--mode", choices=("primary", "independent"), default="primary")
+    arguments = parser.parse_args()
+    raise SystemExit(main(arguments.mutation, arguments.mode))

--- a/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+++ b/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
@@ -8,6 +8,7 @@ from fractions import Fraction
 from math import factorial
 from pathlib import Path
 
+import numpy as np
 import sympy as sp
 
 from admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28 import (
@@ -72,6 +73,30 @@ def packet_coefficients(member: int, cutoff: int, s_value: sp.Rational) -> tuple
     )
 
 
+def sympy_matrix(values: tuple[tuple[Fraction, ...], ...]) -> sp.Matrix:
+    return sp.Matrix(
+        [
+            [sp.Rational(value.numerator, value.denominator) for value in row]
+            for row in values
+        ]
+    )
+
+
+def operator_norm(matrix: sp.Matrix) -> float:
+    """Numerical SVD diagnostic on an exact rational finite matrix."""
+
+    assert matrix == matrix.T
+    values = np.array(
+        [[float(sp.N(matrix[row, column], 40)) for column in range(matrix.cols)] for row in range(matrix.rows)],
+        dtype=float,
+    )
+    return float(np.linalg.svd(values, compute_uv=False)[0])
+
+
+def hilbert_schmidt_norm(matrix: sp.Matrix) -> sp.Expr:
+    return sp.sqrt(sum(value * value for value in matrix))
+
+
 def main(mutation: str | None, mode: str) -> int:
     global PASS, FAIL
     PASS = FAIL = 0
@@ -87,6 +112,19 @@ def main(mutation: str | None, mode: str) -> int:
             ("independent shared-frame direct/staged contraction", facts["direct_staged_shared"]),
             ("independent duplicated-frame falsifier", facts["duplicated_shared_differs"]),
             ("independent physical-kernel sandwich", facts["sandwich"]),
+            ("independent 8x8 Haar-matrix sandwich", facts["pointwise_matrix_sandwich"]),
+            ("independent residual-projector range", facts["residual_exact"] and facts["residual_truncated"]),
+            (
+                "independent relative Hilbert--Schmidt bound",
+                facts["hs_difference_squared"]
+                <= (1 - facts["gamma_12"]) ** 2 * facts["hs_exact_squared"],
+            ),
+            (
+                "independent Z_kappa normalization power",
+                facts["normalization_exact"]
+                and facts["normalization_truncated"]
+                and facts["normalization_difference"],
+            ),
             ("independent finite-character positivity", facts["z2_character_positive"]),
             ("independent intermediate-retruncation falsifier", facts["retruncation_differs"]),
             ("independent factorial tail K=10", 61 * facts["cutoff_tail"][10] < Fraction(1, 100_000)),
@@ -169,13 +207,10 @@ def main(mutation: str | None, mode: str) -> int:
         and "2 r q" in note,
     )
 
-    shared_ok = (
-        facts["direct_staged_hidden"]
-        and facts["direct_staged_shared"]
-        and facts["duplicated_shared_differs"]
-    )
+    shared_q2 = facts["direct_staged_shared"]
     if mutation == "duplicate_shared_frame":
-        shared_ok = False
+        shared_q2 = not facts["duplicated_shared_differs"]
+    shared_ok = facts["direct_staged_hidden"] and shared_q2
     check(
         "J_r compatibility: direct and staged Haar contractions use each shared retained frame once",
         shared_ok and "shared retained projector frame is integrated once" in note,
@@ -227,9 +262,21 @@ def main(mutation: str | None, mode: str) -> int:
         and "3 n K" in note,
     )
 
-    sandwich = facts["sandwich"]
+    exact_matrix = sympy_matrix(facts["exact_matrix"])
+    truncated_matrix = sympy_matrix(facts["truncated_matrix"])
+    difference_matrix = exact_matrix - truncated_matrix
+    physical_exact = sympy_matrix(facts["physical_exact_matrix"])
+    physical_truncated = sympy_matrix(facts["physical_truncated_matrix"])
+    physical_difference = physical_exact - physical_truncated
     if mutation == "reverse_sandwich":
-        sandwich = False
+        sandwich = all(
+            truncated_matrix[row, column] <= gamma * exact_matrix[row, column]
+            and exact_matrix[row, column] <= truncated_matrix[row, column]
+            for row in range(8)
+            for column in range(8)
+        )
+    else:
+        sandwich = facts["pointwise_matrix_sandwich"]
     check(
         "physical kernel sandwich: gamma K_exact <= K_K <= K_exact after the complete shared-frame marginal",
         sandwich
@@ -237,15 +284,25 @@ def main(mutation: str | None, mode: str) -> int:
         and "gamma_(K,r,q) K_(r,q)" in note,
     )
 
-    relative_operator = mutation != "absolute_only_operator_bound"
+    exact_op = operator_norm(physical_exact)
+    truncated_op = operator_norm(physical_truncated)
+    difference_op = operator_norm(physical_difference)
+    relative_coefficient = epsilon / 2 if mutation == "absolute_only_operator_bound" else epsilon
+    relative_operator = difference_op <= sp.N(relative_coefficient, 60) * exact_op
     check(
         "operator comparison: lattice-order domination gives ||T-T_K|| <= epsilon ||T||",
         relative_operator
+        and abs(operator_norm(difference_matrix) - difference_op) < 1e-13
         and "|(T_(r,q)-T_(r,q)^K)F|" in note
         and "epsilon_(K,r,q) ||T_(r,q)||_op" in note,
     )
 
-    top_normalization = mutation != "misuse_auxiliary_perron"
+    top_denominator = exact_op if mutation == "misuse_auxiliary_perron" else truncated_op
+    normalized_difference = physical_exact / exact_op - physical_truncated / top_denominator
+    top_normalization = (
+        top_denominator == truncated_op
+        and operator_norm(normalized_difference) <= sp.N(2 * epsilon, 60)
+    )
     check(
         "top-norm comparison: separately normalizing the two complete positive transfers costs at most 2 epsilon",
         top_normalization
@@ -253,24 +310,49 @@ def main(mutation: str | None, mode: str) -> int:
         and "not the auxiliary-message Perron vector" in note,
     )
 
-    normalization_power = 7
-    if mutation == "corrupt_normalization_power":
-        normalization_power = 6
+    normalization_power = 6 if mutation == "corrupt_normalization_power" else 7
+    normalization_scalar = facts["temporal_normalization"]
+    normalized_exact = sympy_matrix(facts["normalized_exact_matrix"])
+    normalized_truncated = sympy_matrix(facts["normalized_truncated_matrix"])
+    normalized_actual_difference = normalized_exact - normalized_truncated
+    normalization_factor = sp.Rational(
+        normalization_scalar.numerator, normalization_scalar.denominator
+    ) ** (-normalization_power)
+    normalization_power_ok = (
+        normalized_exact == normalization_factor * exact_matrix
+        and normalized_truncated == normalization_factor * truncated_matrix
+        and normalized_actual_difference == normalization_factor * difference_matrix
+    )
     check(
         "normalization scalar: the original normalized-w kernel differs by exactly Z_kappa^(3rq+1)",
-        normalization_power == 7 and "Z_kappa^(3 r q + 1)" in note,
+        normalization_power_ok and "Z_kappa^(3 r q + 1)" in note,
     )
 
-    absolute_operator = mutation != "misstate_absolute_operator_bound"
+    absolute_rhs = 7 * delta_temporal + 4 * delta_spatial
+    if mutation == "misstate_absolute_operator_bound":
+        absolute_rhs /= 8
+    absolute_operator = operator_norm(normalized_actual_difference) <= sp.N(absolute_rhs, 60)
+    normalized_hs = hilbert_schmidt_norm(normalized_actual_difference)
+    hs_rhs = normalization_factor * epsilon
     check(
         "absolute original-transfer bound: telescoping avoids false hatted-kernel normalization while HS retains Z_kappa power",
         absolute_operator
+        and normalized_hs <= hs_rhs
         and "(3 r q + 1) delta_kappa + 2 r q delta_beta" in note
         and "Z_kappa^(-(3 r q + 1)) epsilon_(K,r,q)" in note
         and "rather than renormalizing it by a new truncated partition function" in note,
     )
 
-    projector_ok = mutation != "drop_projector_restriction"
+    if mutation == "drop_projector_restriction":
+        wrong_restriction = exact_matrix[:4, :4]
+        projector_ok = operator_norm(wrong_restriction) == exact_op
+    else:
+        projector_ok = (
+            facts["residual_exact"]
+            and facts["residual_truncated"]
+            and abs(operator_norm(exact_matrix) - exact_op) < 1e-13
+            and abs(operator_norm(truncated_matrix) - truncated_op) < 1e-13
+        )
     check(
         "projector typing: the full Haar-space bound descends to the residual GxG physical subspace by contraction",
         projector_ok and "restriction to P_lr" in note,

--- a/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
+++ b/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_2026_08_28.py
@@ -39,6 +39,7 @@ MUTATIONS = (
     "absolute_only_operator_bound",
     "misuse_auxiliary_perron",
     "corrupt_normalization_power",
+    "misstate_absolute_operator_bound",
     "drop_projector_restriction",
     "corrupt_independent_reconstruction",
     "hide_historic_prior_art",
@@ -258,6 +259,15 @@ def main(mutation: str | None, mode: str) -> int:
     check(
         "normalization scalar: the original normalized-w kernel differs by exactly Z_kappa^(3rq+1)",
         normalization_power == 7 and "Z_kappa^(3 r q + 1)" in note,
+    )
+
+    absolute_operator = mutation != "misstate_absolute_operator_bound"
+    check(
+        "absolute original-transfer bound: telescoping avoids false hatted-kernel normalization while HS retains Z_kappa power",
+        absolute_operator
+        and "(3 r q + 1) delta_kappa + 2 r q delta_beta" in note
+        and "Z_kappa^(-(3 r q + 1)) epsilon_(K,r,q)" in note
+        and "rather than renormalizing it by a new truncated partition function" in note,
     )
 
     projector_ok = mutation != "drop_projector_restriction"

--- a/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28.py
+++ b/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Independent exact controls for the physical-transfer truncation theorem.
+
+This helper uses only Python integers, Fraction, finite enumeration, and
+elementary polynomial arithmetic.  It does not import the primary runner,
+SymPy, NumPy, or a campaign scratch calculation.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from functools import lru_cache
+from itertools import permutations, product
+from math import factorial
+
+
+AUDIT_TIMEOUT_SEC = 120
+G = (1, -1)
+PAIRS = tuple(product(G, repeat=2))
+STATES = tuple(product(G, repeat=4))
+
+
+def determinant3(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return (
+        matrix[0][0] * (matrix[1][1] * matrix[2][2] - matrix[1][2] * matrix[2][1])
+        - matrix[0][1] * (matrix[1][0] * matrix[2][2] - matrix[1][2] * matrix[2][0])
+        + matrix[0][2] * (matrix[1][0] * matrix[2][1] - matrix[1][1] * matrix[2][0])
+    )
+
+
+def trace3(matrix: tuple[tuple[int, ...], ...]) -> int:
+    return sum(matrix[i][i] for i in range(3))
+
+
+def multiply3(
+    left: tuple[tuple[int, ...], ...], right: tuple[tuple[int, ...], ...]
+) -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        tuple(sum(left[i][k] * right[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )
+
+
+def signed_permutation_frames() -> tuple[tuple[tuple[int, ...], ...], ...]:
+    frames = []
+    for permutation in permutations(range(3)):
+        for signs in product(G, repeat=3):
+            matrix = [[0 for _ in range(3)] for _ in range(3)]
+            for row, column in enumerate(permutation):
+                matrix[row][column] = signs[row]
+            frames.append(tuple(tuple(row) for row in matrix))
+    return tuple(frames)
+
+
+def exterior_facts() -> dict[str, object]:
+    identity = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    frames = signed_permutation_frames()
+    values = set()
+    exterior_identity = True
+    member_identity = True
+    proper = improper = 0
+    for frame in frames:
+        square = multiply3(frame, frame)
+        wedge2_trace = (trace3(frame) ** 2 - trace3(square)) // 2
+        chi_exterior = 1 + trace3(frame) + wedge2_trace + determinant3(frame)
+        plus_identity = tuple(
+            tuple(frame[i][j] + identity[i][j] for j in range(3))
+            for i in range(3)
+        )
+        chi_determinant = determinant3(plus_identity)
+        exterior_identity &= chi_exterior == chi_determinant
+        determinant = determinant3(frame)
+        proper += int(determinant == 1)
+        improper += int(determinant == -1)
+        q_value = 16 - 2 * chi_exterior
+        u_base = Fraction(chi_exterior, 8)
+        member_identity &= 0 <= u_base <= 1
+        for member in range(1, 6):
+            f_value = Fraction(16, member) * (1 - u_base**member)
+            if determinant == -1:
+                member_identity &= chi_exterior == 0 and f_value == Fraction(16, member)
+            else:
+                member_identity &= q_value == 16 * (1 - u_base)
+        values.add((determinant, chi_exterior, q_value))
+    return {
+        "frame_count": len(frames),
+        "proper": proper,
+        "improper": improper,
+        "exterior_identity": exterior_identity,
+        "member_identity": member_identity,
+        "component_values": tuple(sorted(values)),
+    }
+
+
+def weight(value: int, minus: Fraction, plus: Fraction = Fraction(1)) -> Fraction:
+    return plus if value == 1 else minus
+
+
+def factor_census(r: int, q: int) -> tuple[int, int]:
+    cells = r * q
+    return 3 * cells + 1, 2 * cells
+
+
+def fine_physical_kernel(
+    r: int,
+    q: int,
+    temporal_minus: Fraction,
+    spatial_minus: Fraction,
+    temporal_plus: Fraction = Fraction(1),
+    spatial_plus: Fraction = Fraction(1),
+) -> dict[tuple[int, ...], Fraction]:
+    """Raw fine-link enumeration with retained rungs at multiples of r."""
+
+    length = r * q
+    retained = tuple(range(0, length + 1, r))
+    hidden = tuple(index for index in range(length + 1) if index not in retained)
+    endpoints = tuple(product(G, repeat=2 * (q + 1)))
+    internal_count = 2 * (length + 1) + 2 * len(hidden)
+    normalization = Fraction(1, 2**internal_count)
+    output: dict[tuple[int, ...], Fraction] = {}
+
+    for endpoint in endpoints:
+        retained_prime = endpoint[: q + 1]
+        retained_value = endpoint[q + 1 :]
+        total = Fraction(0)
+        for internal in product(G, repeat=internal_count):
+            cursor = 0
+            bottom = internal[cursor : cursor + length + 1]
+            cursor += length + 1
+            top = internal[cursor : cursor + length + 1]
+            cursor += length + 1
+            rung_prime: list[int | None] = [None] * (length + 1)
+            rung_value: list[int | None] = [None] * (length + 1)
+            for retained_index, column in enumerate(retained):
+                rung_prime[column] = retained_prime[retained_index]
+                rung_value[column] = retained_value[retained_index]
+            for column in hidden:
+                rung_prime[column] = internal[cursor]
+                rung_value[column] = internal[cursor + 1]
+                cursor += 2
+
+            integrand = Fraction(1)
+            for column in range(length + 1):
+                integrand *= weight(
+                    int(rung_prime[column]) * top[column]
+                    * int(rung_value[column]) * bottom[column],
+                    temporal_minus,
+                    temporal_plus,
+                )
+            for column in range(length):
+                integrand *= weight(
+                    bottom[column + 1] * bottom[column],
+                    temporal_minus,
+                    temporal_plus,
+                )
+                integrand *= weight(
+                    top[column + 1] * top[column],
+                    temporal_minus,
+                    temporal_plus,
+                )
+                integrand *= weight(
+                    int(rung_prime[column + 1]) * int(rung_prime[column]),
+                    spatial_minus,
+                    spatial_plus,
+                )
+                integrand *= weight(
+                    int(rung_value[column + 1]) * int(rung_value[column]),
+                    spatial_minus,
+                    spatial_plus,
+                )
+            total += integrand
+        output[endpoint] = normalization * total
+    return output
+
+
+def history_data(
+    temporal_minus: Fraction,
+    spatial_minus: Fraction,
+    temporal_plus: Fraction = Fraction(1),
+    spatial_plus: Fraction = Fraction(1),
+) -> tuple[dict[tuple[int, ...], Fraction], dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction]]:
+    onsite = {
+        state: weight(state[2] * state[1] * state[3] * state[0], temporal_minus, temporal_plus)
+        for state in STATES
+    }
+    bond = {}
+    for left in STATES:
+        for right in STATES:
+            bond[left, right] = (
+                weight(right[0] * left[0], temporal_minus, temporal_plus)
+                * weight(right[1] * left[1], temporal_minus, temporal_plus)
+                * weight(right[2] * left[2], spatial_minus, spatial_plus)
+                * weight(right[3] * left[3], spatial_minus, spatial_plus)
+            )
+    return onsite, bond
+
+
+def compose_bonds(
+    left: dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction],
+    right: dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction],
+    onsite: dict[tuple[int, ...], Fraction],
+) -> dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction]:
+    return {
+        (start, stop): sum(
+            (left[start, middle] * onsite[middle] * right[middle, stop] / 16 for middle in STATES),
+            Fraction(0),
+        )
+        for start in STATES
+        for stop in STATES
+    }
+
+
+def bond_power(
+    bond: dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction],
+    onsite: dict[tuple[int, ...], Fraction],
+    exponent: int,
+) -> dict[tuple[tuple[int, ...], tuple[int, ...]], Fraction]:
+    result = bond
+    for _ in range(1, exponent):
+        result = compose_bonds(result, bond, onsite)
+    return result
+
+
+def history_physical_kernel(
+    r: int,
+    q: int,
+    temporal_minus: Fraction,
+    spatial_minus: Fraction,
+    temporal_plus: Fraction = Fraction(1),
+    spatial_plus: Fraction = Fraction(1),
+) -> dict[tuple[int, ...], Fraction]:
+    onsite, bond = history_data(
+        temporal_minus, spatial_minus, temporal_plus, spatial_plus
+    )
+    powered = bond_power(bond, onsite, r)
+    output = {}
+    for endpoint in product(G, repeat=2 * (q + 1)):
+        retained_pairs = tuple(
+            (endpoint[index], endpoint[q + 1 + index]) for index in range(q + 1)
+        )
+        matching = tuple(
+            tuple(state for state in STATES if state[2:] == pair)
+            for pair in retained_pairs
+        )
+        total = Fraction(0)
+        for retained_states in product(*matching):
+            term = Fraction(1)
+            for state in retained_states:
+                term *= onsite[state] / 4
+            for index in range(q):
+                term *= powered[retained_states[index], retained_states[index + 1]]
+            total += term
+        output[endpoint] = total
+    return output
+
+
+def duplicated_middle_kernel(
+    r: int,
+    endpoints: tuple[int, ...],
+    temporal_minus: Fraction,
+    spatial_minus: Fraction,
+) -> Fraction:
+    """Incorrect q=2 product of independently frame-marginalized strips."""
+
+    onsite, bond = history_data(temporal_minus, spatial_minus)
+    powered = bond_power(bond, onsite, r)
+    pairs = tuple((endpoints[index], endpoints[3 + index]) for index in range(3))
+
+    def strip(left_pair: tuple[int, int], right_pair: tuple[int, int]) -> Fraction:
+        return sum(
+            (
+                onsite[left] * onsite[right] * powered[left, right] / 16
+                for left in STATES
+                for right in STATES
+                if left[2:] == left_pair and right[2:] == right_pair
+            ),
+            Fraction(0),
+        )
+
+    return strip(pairs[0], pairs[1]) * strip(pairs[1], pairs[2])
+
+
+def poly_multiply(
+    left: tuple[Fraction, ...], right: tuple[Fraction, ...]
+) -> tuple[Fraction, ...]:
+    output = [Fraction(0)] * (len(left) + len(right) - 1)
+    for i, a in enumerate(left):
+        for j, b in enumerate(right):
+            output[i + j] += a * b
+    return tuple(output)
+
+
+def poly_power(base: tuple[Fraction, ...], exponent: int) -> tuple[Fraction, ...]:
+    output = (Fraction(1),)
+    for _ in range(exponent):
+        output = poly_multiply(output, base)
+    return output
+
+
+def truncation_algorithm_defect() -> tuple[tuple[Fraction, ...], tuple[Fraction, ...]]:
+    local = (Fraction(1), Fraction(1))
+    direct = poly_power(local, 4)
+    two_step = poly_power(local, 2)[:2]
+    retruncated_staged = poly_power(two_step, 2)
+    return direct, retruncated_staged
+
+
+def z2_fourier_positive(plus: Fraction, minus: Fraction) -> bool:
+    return (plus + minus) / 2 >= 0 and (plus - minus) / 2 >= 0
+
+
+@lru_cache(maxsize=1)
+def independent_facts() -> dict[str, object]:
+    exterior = exterior_facts()
+    temporal_minus = Fraction(1, 2)
+    spatial_minus = Fraction(2, 3)
+    temporal_delta = Fraction(1, 8)
+    spatial_delta = Fraction(1, 6)
+    temporal_plus = 1 - temporal_delta
+    spatial_plus = 1 - spatial_delta
+
+    direct_21 = fine_physical_kernel(2, 1, temporal_minus, spatial_minus)
+    staged_21 = history_physical_kernel(2, 1, temporal_minus, spatial_minus)
+    direct_12 = fine_physical_kernel(1, 2, temporal_minus, spatial_minus)
+    staged_12 = history_physical_kernel(1, 2, temporal_minus, spatial_minus)
+    truncated_12 = fine_physical_kernel(
+        1, 2, temporal_minus, spatial_minus, temporal_plus, spatial_plus
+    )
+    gamma_12 = (1 - temporal_delta) ** 7 * (1 - spatial_delta) ** 4
+    sandwich = all(
+        gamma_12 * direct_12[key] <= truncated_12[key] <= direct_12[key]
+        for key in direct_12
+    )
+    shared_difference = any(
+        duplicated_middle_kernel(1, endpoint, temporal_minus, spatial_minus)
+        != staged_12[endpoint]
+        for endpoint in staged_12
+    )
+
+    cutoff_tail = {
+        cutoff: Fraction(8, 7) ** (cutoff + 1) / factorial(cutoff + 1)
+        for cutoff in (6, 10, 14, 18)
+    }
+    direct_poly, retruncated_poly = truncation_algorithm_defect()
+
+    return {
+        **exterior,
+        "censuses": tuple((r, q, *factor_census(r, q)) for r, q in ((1, 1), (2, 1), (1, 2), (2, 2))),
+        "direct_staged_hidden": direct_21 == staged_21,
+        "direct_staged_shared": direct_12 == staged_12,
+        "duplicated_shared_differs": shared_difference,
+        "sandwich": sandwich,
+        "gamma_12": gamma_12,
+        "max_error_12": max(direct_12[key] - truncated_12[key] for key in direct_12),
+        "cutoff_tail": cutoff_tail,
+        "direct_polynomial": direct_poly,
+        "retruncated_polynomial": retruncated_poly,
+        "retruncation_differs": direct_poly != retruncated_poly,
+        "z2_character_positive": all(
+            (
+                z2_fourier_positive(plus, minus)
+                for plus, minus in (
+                    (Fraction(1), temporal_minus),
+                    (temporal_plus, temporal_minus),
+                    (Fraction(1), spatial_minus),
+                    (spatial_plus, spatial_minus),
+                )
+            )
+        ),
+    }
+
+
+if __name__ == "__main__":
+    facts = independent_facts()
+    checks = (
+        facts["frame_count"] == 48 and facts["proper"] == facts["improper"] == 24,
+        facts["exterior_identity"],
+        facts["member_identity"],
+        facts["censuses"] == ((1, 1, 4, 2), (2, 1, 7, 4), (1, 2, 7, 4), (2, 2, 13, 8)),
+        facts["direct_staged_hidden"],
+        facts["direct_staged_shared"],
+        facts["duplicated_shared_differs"],
+        facts["sandwich"],
+        facts["z2_character_positive"],
+        facts["retruncation_differs"],
+        61 * facts["cutoff_tail"][10] < Fraction(1, 100_000),
+        61 * facts["cutoff_tail"][18] < Fraction(1, 10**12),
+    )
+    for index, condition in enumerate(checks, start=1):
+        print(f"[{'PASS' if condition else 'FAIL'}] independent check {index}")
+    passed = sum(bool(value) for value in checks)
+    failed = len(checks) - passed
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    raise SystemExit(int(failed != 0))

--- a/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28.py
+++ b/scripts/admissibility_exterior_character_jr_peter_weyl_operator_truncation_independent_2026_08_28.py
@@ -309,6 +309,77 @@ def z2_fourier_positive(plus: Fraction, minus: Fraction) -> bool:
     return (plus + minus) / 2 >= 0 and (plus - minus) / 2 >= 0
 
 
+def operator_matrix(
+    kernel: dict[tuple[int, ...], Fraction], q: int
+) -> tuple[tuple[Fraction, ...], ...]:
+    """Matrix in the orthonormal delta basis for normalized input Haar."""
+
+    states = tuple(product(G, repeat=q + 1))
+    haar = Fraction(1, 2 ** (q + 1))
+    return tuple(
+        tuple(haar * kernel[output + value] for value in states)
+        for output in states
+    )
+
+
+def residual_matrix(
+    matrix: tuple[tuple[Fraction, ...], ...]
+) -> tuple[tuple[Fraction, ...], ...]:
+    """Compression to the global-Z2-even residual physical subspace."""
+
+    dimension = len(matrix)
+    representatives = tuple(range(dimension // 2))
+    return tuple(
+        tuple(
+            (
+                matrix[left][right]
+                + matrix[left][dimension - 1 - right]
+                + matrix[dimension - 1 - left][right]
+                + matrix[dimension - 1 - left][dimension - 1 - right]
+            )
+            / 2
+            for right in representatives
+        )
+        for left in representatives
+    )
+
+
+def matrix_subtract(
+    left: tuple[tuple[Fraction, ...], ...],
+    right: tuple[tuple[Fraction, ...], ...],
+) -> tuple[tuple[Fraction, ...], ...]:
+    return tuple(
+        tuple(a - b for a, b in zip(left_row, right_row))
+        for left_row, right_row in zip(left, right)
+    )
+
+
+def matrix_scale(
+    scalar: Fraction, matrix: tuple[tuple[Fraction, ...], ...]
+) -> tuple[tuple[Fraction, ...], ...]:
+    return tuple(tuple(scalar * value for value in row) for row in matrix)
+
+
+def hilbert_schmidt_squared(
+    matrix: tuple[tuple[Fraction, ...], ...]
+) -> Fraction:
+    return sum((value * value for row in matrix for value in row), Fraction(0))
+
+
+def residual_range_preserved(
+    matrix: tuple[tuple[Fraction, ...], ...]
+) -> bool:
+    """Exact test that P A P=A for P f(x)=(f(x)+f(-x))/2."""
+
+    dimension = len(matrix)
+    return all(
+        matrix[left][right] == matrix[dimension - 1 - left][right]
+        and matrix[left][right] == matrix[left][dimension - 1 - right]
+        for left in range(dimension)
+        for right in range(dimension)
+    )
+
+
 @lru_cache(maxsize=1)
 def independent_facts() -> dict[str, object]:
     exterior = exterior_facts()
@@ -343,6 +414,46 @@ def independent_facts() -> dict[str, object]:
     }
     direct_poly, retruncated_poly = truncation_algorithm_defect()
 
+    exact_matrix = operator_matrix(direct_12, 2)
+    truncated_matrix = operator_matrix(truncated_12, 2)
+    difference_matrix = matrix_subtract(exact_matrix, truncated_matrix)
+    physical_exact_matrix = residual_matrix(exact_matrix)
+    physical_truncated_matrix = residual_matrix(truncated_matrix)
+    physical_difference_matrix = matrix_subtract(
+        physical_exact_matrix, physical_truncated_matrix
+    )
+    pointwise_matrix_sandwich = all(
+        gamma_12 * exact_matrix[row][column]
+        <= truncated_matrix[row][column]
+        <= exact_matrix[row][column]
+        for row in range(8)
+        for column in range(8)
+    )
+
+    temporal_normalization = Fraction(3, 4)
+    normalized_exact_kernel = fine_physical_kernel(
+        1,
+        2,
+        Fraction(2, 3),
+        spatial_minus,
+        Fraction(4, 3),
+        Fraction(1),
+    )
+    normalized_truncated_kernel = fine_physical_kernel(
+        1,
+        2,
+        Fraction(2, 3),
+        spatial_minus,
+        Fraction(7, 6),
+        spatial_plus,
+    )
+    normalized_exact_matrix = operator_matrix(normalized_exact_kernel, 2)
+    normalized_truncated_matrix = operator_matrix(normalized_truncated_kernel, 2)
+    normalized_difference_matrix = matrix_subtract(
+        normalized_exact_matrix, normalized_truncated_matrix
+    )
+    inverse_normalization_power = temporal_normalization ** -7
+
     return {
         **exterior,
         "censuses": tuple((r, q, *factor_census(r, q)) for r, q in ((1, 1), (2, 1), (1, 2), (2, 2))),
@@ -350,8 +461,31 @@ def independent_facts() -> dict[str, object]:
         "direct_staged_shared": direct_12 == staged_12,
         "duplicated_shared_differs": shared_difference,
         "sandwich": sandwich,
+        "pointwise_matrix_sandwich": pointwise_matrix_sandwich,
         "gamma_12": gamma_12,
         "max_error_12": max(direct_12[key] - truncated_12[key] for key in direct_12),
+        "exact_matrix": exact_matrix,
+        "truncated_matrix": truncated_matrix,
+        "difference_matrix": difference_matrix,
+        "physical_exact_matrix": physical_exact_matrix,
+        "physical_truncated_matrix": physical_truncated_matrix,
+        "physical_difference_matrix": physical_difference_matrix,
+        "residual_exact": residual_range_preserved(exact_matrix),
+        "residual_truncated": residual_range_preserved(truncated_matrix),
+        "hs_exact_squared": hilbert_schmidt_squared(exact_matrix),
+        "hs_difference_squared": hilbert_schmidt_squared(difference_matrix),
+        "physical_hs_exact_squared": hilbert_schmidt_squared(physical_exact_matrix),
+        "physical_hs_difference_squared": hilbert_schmidt_squared(physical_difference_matrix),
+        "temporal_normalization": temporal_normalization,
+        "normalized_exact_matrix": normalized_exact_matrix,
+        "normalized_truncated_matrix": normalized_truncated_matrix,
+        "normalized_difference_matrix": normalized_difference_matrix,
+        "normalization_exact": normalized_exact_matrix
+        == matrix_scale(inverse_normalization_power, exact_matrix),
+        "normalization_truncated": normalized_truncated_matrix
+        == matrix_scale(inverse_normalization_power, truncated_matrix),
+        "normalization_difference": normalized_difference_matrix
+        == matrix_scale(inverse_normalization_power, difference_matrix),
         "cutoff_tail": cutoff_tail,
         "direct_polynomial": direct_poly,
         "retruncated_polynomial": retruncated_poly,
@@ -381,6 +515,13 @@ if __name__ == "__main__":
         facts["direct_staged_shared"],
         facts["duplicated_shared_differs"],
         facts["sandwich"],
+        facts["pointwise_matrix_sandwich"],
+        facts["residual_exact"] and facts["residual_truncated"],
+        facts["hs_difference_squared"]
+        <= (1 - facts["gamma_12"]) ** 2 * facts["hs_exact_squared"],
+        facts["normalization_exact"]
+        and facts["normalization_truncated"]
+        and facts["normalization_difference"],
         facts["z2_character_positive"],
         facts["retruncation_differs"],
         61 * facts["cutoff_tail"][10] < Fraction(1, 100_000),


### PR DESCRIPTION
## Scope

This stacked review PR gives an explicit finite positive Peter-Weyl packet for the supplied exterior-character O(3) action and carries it through the actual Block229 shared-frame J_r transfer.

It proves the exact 3rq+1 temporal and 2rq half-action census, direct/staged contraction without intermediate retruncation, a complete-kernel sandwich, relative operator and Hilbert--Schmidt bounds, a top-operator-norm comparison, and correctly normalized absolute operator/HS bounds. The cutoff depends explicitly on rq and tolerance.

## Evidence

- primary runner: 22 PASS / 0 FAIL
- independent modes: 16 PASS / 0 FAIL
- exact q=2 Z2 full 8x8 and residual 4x4 matrix controls
- all 25 hostile mutations exit nonzero with exactly one intended failure
- canonical runner cache fresh and fingerprinted
- vocabulary and strict audit lint pass with no errors
- independent hostile review: PASS on exact head

## Boundaries

This is conditional on the supplied action, Haar measure, temporal extension, projector, and Block229 parent. It does not select the action, identify physical time, prove a continuum limit, or derive Lorentzian gravity or matter dynamics. Generic Poissonized character truncation is prior art; the incremental content is the improper-safe O(3) packet on the actual J_r/shared-frame operator with explicit rq error accounting.

## Stack

Depends on unmerged Block229 PR #7782. Review only; do not merge out of order.