### PR TITLE
[physics-loop] derive arbitrary-width scalar-fused vector transfer

### DIFF
--- a/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_ARBITRARY_R_SCALAR_FUSED_VECTOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-08-29.md
+++ b/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_ARBITRARY_R_SCALAR_FUSED_VECTOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-08-29.md
@@ -1,0 +1,393 @@
+---
+claim_id: admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_bounded_theorem_note_2026-08-29
+final_path: docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_ARBITRARY_R_SCALAR_FUSED_VECTOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-08-29.md
+claim_type: bounded_theorem
+claim_scope: "For every supplied fixed finite blocking width r>=2 on one retained cell of the reviewed original-link O(3) ladder, derive the exact first possible vacuum-to-coarse-defining-vector action response of the physical J_r temporal compression defect. Prove that all derivatives below r vanish, all proper order-r complement histories project doubled defining-vector rungs to the scalar channel, their normalized Haar overlap is 3^(1-r), and their complete finite-step temporal sum is an explicit positive bond-dimension-three transfer polynomial P_r(t_V), with a separate two-state endpoint subtraction. Recover the reviewed r=2 and r=3 formulas and the general small-step coefficient (2^r-2)/3^(r-1). This is one selected q=1 defining-vector entry conditional on the supplied action, normalization, temporal multipliers, Haar measure, ladder, and J_r stack; it is not a full vector/non-determinant kernel, physical time, continuum, Lorentz, gravity, metric/source, matter-current, or action-selection theorem."
+depends_on:
+  - admissibility_exterior_character_jr_temporal_spatial_semigroup_defect_generated_interaction_bounded_theorem_note_2026-08-28
+  - minimal_axioms
+dependency_roles:
+  admissibility_exterior_character_jr_temporal_spatial_semigroup_defect_generated_interaction_bounded_theorem_note_2026-08-28: "reviewed complete defect, physical J_r/Q carrier, supplied temporal/action normalization, and exact r=2/r=3 defining-vector entries"
+  minimal_axioms: "framework boundary only; no axiom or approved primitive is edited"
+runner: scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_2026_08_29.py
+independent_checker: scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_independent_2026_08_29.py
+status: proposed_retained
+actual_current_surface_status: conditional-support
+target_claim_type: null
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_exterior_character_jr_temporal_spatial_semigroup_defect_generated_interaction_bounded_theorem_note_2026-08-28
+target_blocker_text: "Generalize the exact r=3 scalar-fused defining-vector complement transfer to arbitrary fixed r or a multicell vector history, retaining the physical projector and original-link temporal weights."
+source_of_blocker_text: handoff
+reachability_to_target: closes
+artifact_role: theorem
+next_trace_action: "Test the first q>1 defining-vector entry with a retained-rung background and then seek a fixed-memory description of the genuinely multicell vector sector; keep action selection, physical time, continuum, and the full non-determinant kernel open."
+conditional_surface_status: "exact selected q=1 vector response conditional on the linked supplied action, temporal multipliers, normalization, ladder, Haar measure, and physical J_r stack"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the arbitrary-r response, original-link incidence, scalar O(3) recoupling, Haar normalization, positive transfer polynomial, and small-step match are exact finite mathematical results under explicitly supplied action and temporal data"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Arbitrary-`r` scalar-fused defining-vector transfer
+
+**Date:** 2026-08-29
+
+**Type:** `bounded_theorem`
+
+**Status:** `proposed_retained` — author-side proposal label only.  The actual
+current surface remains `conditional-support`, with independent audit and
+dependency closure required before any retained-grade classification.
+
+## Status and boundary
+
+This note closes the next finite-width calculation named by the
+[temporal--spatial compression-defect theorem](ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md):
+the selected finite-step defining-vector complement transfer is no longer
+restricted to `r=2` or `r=3`.  It is exact for every supplied fixed finite
+`r>=2` on one retained cell.  The result is **conditional support**, not an
+adopted action, physical Hamiltonian, full vector kernel, or TOE closure.  No
+axiom or approved primitive changes.
+
+**Exact target.** Under the supplied finite-ladder action, temporal
+multipliers, Haar measure, normalization, and physical `J_r,Q` stack, compute
+the first potentially nonzero vacuum-to-coarse-defining-vector derivative for every fixed
+finite `r>=2`, including its exact finite-step polynomial and small-step
+normalization.
+
+## Authorities and imported inputs
+
+- The [temporal--spatial compression-defect theorem](ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md)
+  supplies the action-amplitude convention, link-diagonal temporal
+  multipliers, normalized Haar measure, physical `J_r,Q` construction,
+  `(r-1)`-wise conditional-Haar lemma, and the reviewed `r=2,3` entries. These
+  are explicit supplied mathematical inputs; this note does not derive or
+  select them.
+- The [minimal framework axioms](MINIMAL_AXIOMS_2026-06-29.md) set only the
+  framework boundary. They do not supply the action, temporal evolution,
+  Haar measure, amplitudes, representation carrier, physical clock, or
+  continuum interpretation.
+- The defining representation and the `O(3)` tensor-product/parity rules are
+  standard representation-theory machinery used conditionally on the supplied
+  carrier. No measured, fitted, observational, PDG, cosmological, or
+  dimensionful value is used.
+
+The open physical bridges are therefore action selection, physical time,
+continuum/refinement control, and identification of any vector response with
+gravity, metric/source, or matter current. None is used to satisfy the finite
+mathematical target above.
+
+## Proof-obligation graph
+
+| Obligation | Disposition |
+|---|---|
+| actual `3r+1` original-link incidence and boundary census | proved below by symmetric difference |
+| scalar-only doubled-rung selection, including `O(3)` parity | proved below edge by edge |
+| normalized overlap `3^(1-r)` | proved below by iterated second moments and independently reconstructed from signed frames |
+| physical `Q` deletion of exactly the empty/full partitions | inherited conditional-Haar lemma plus the explicit exclusive-rail label argument below |
+| complete proper-partition sum and fixed-memory transfer | proved below; direct enumeration and an independent dynamic program agree |
+| `r=2,3` recovery and small-step normalization | proved below and checked against the linked supplied parent |
+
+All obligations for the stated conditional finite target are discharged. The
+strongest missing lemma belongs to the broader program, not this target: no
+result here classifies the full multicell non-determinant kernel. The proof is
+therefore conditional on its declared supplied action/transfer inputs, rather
+than circular or dependent on a target-equivalent missing lemma.
+
+## Actual original-link carrier
+
+Let `H={0,...,r-1}` index the fine plaquettes in one retained cell.  Plaquette
+`i` occupies the four original links
+
+```text
+P_i={u_i,v_i,h_i,h_(i+1)}.
+```
+
+For `X subseteq H`, let `partial X` be the symmetric difference of the
+`P_i`, and put
+
+```text
+w(X)=|partial X|=2|X|+2 runs(X),
+tau_X=t_V^w(X),
+F_Y(X)=sum_(A subseteq X) tau_(Y triangle A).       (1)
+```
+
+The complete coarse defining-vector loop has `w(H)=2r+2`.  These are the
+actual `3r+1` original links; no reduced increment carrier is used.
+
+## Scalar selection and the physical projector
+
+Write `x_X=product_(i in X) chi_V(W_i)` and
+`phi_V=chi_V(W_(r-1)...W_0)`.  On any original link the two complementary
+Gram histories contain zero, one, or two defining-vector labels.  Their local
+menus are
+
+```text
+0 labels: (0,+),
+1 label : V=(1,-),
+2 labels: V tensor V=(0,+) direct-sum (1,+) direct-sum (2,+).  (2)
+```
+
+For `empty != X proper_subset H`, comparing `x_X` with
+`x_(H\X) phi_V` leaves exactly `V` on `partial X` and the scalar `(0,+)`
+on every doubled edge.  The axial-vector and spin-two channels have unmatched
+labels on the opposite Gram history and vanish by edgewise Haar orthogonality.
+Equivalently, the vector-side proper history cannot be supplied by a doubled
+rung: `V=(1,-)` is absent from
+`V tensor V=(0,+) direct-sum (1,+) direct-sum (2,+)` by `O(3)` parity.
+
+Sequential use of the exact defining-representation second moment gives
+
+```text
+<x_X,x_(H\X)phi_V>=3^(1-r).                         (3)
+```
+
+The value is independent of `X`.  It is reconstructed in the independent
+runner from all 48 signed `O(3)` frames: one internal scalar fusion contributes
+`1/3`, and there are `r-1` internal fusions.
+
+Every nonempty proper `x_X` has zero conditional mean at fixed coarse
+holonomy by the reviewed `(r-1)`-wise Haar lemma, hence `Qx_X=0`.  More
+explicitly, a proper subset leaves mixed trivial/`V` labels on the exclusive
+upper and lower rail links, whereas every coarse Peter--Weyl state has one
+common irreducible label on every exclusive rail pair.  The supplied temporal
+convolution is diagonal in those original-link representation labels, so it
+cannot turn a proper mixed-label row into a coarse cylindrical row.  Thus the
+temporally weighted proper row also remains `Q`-orthogonal, and
+
+```text
+<x_X,(I-Q)y>=<x_X,y>.                               (4)
+```
+
+The exclusive-rail test is exhaustive in both Gram orientations.  On the
+vacuum-side row `x_X`, the two rails of plaquette `i` carry `(0,+)` when `i`
+is absent and `V=(1,-)` when it is present.  On the coarse-side row
+`x_(H\X) phi_V`, they carry `V=(1,-)` for `i in X` and the complete even menu
+`{(0,+),(1,+),(2,+)}` for `i notin X`.  In either orientation a common
+coarse Peter--Weyl label exists on all `2r` rails exactly when
+`X=emptyset` or `X=H`; for a proper `X`, the coarse-side intersection is empty
+specifically by `O(3)` parity.  Every temporal half-subpartition changes only
+the diagonal multiplier and preserves these rail menus.  Together with the
+supplied conditional-Haar lemma, this proves that no proper row can acquire a
+cylindrical component before the physical projection.  Only the empty/full
+derivative partitions are absent, because the zeroth leakage
+`(I-Q)S_epsilon(0)J_r` vanishes.  Thus physical cylindrical subtraction does
+not delete an additional proper complement history.
+
+At derivative order `k<r`, at least one plaquette supplies no action
+insertion.  One of its exclusive rail links therefore leaves the outer
+defining-vector label unpaired, and edgewise Haar orthogonality makes that
+history vanish.  Consequently every vacuum-to-`phi_V` derivative below order
+`r` is zero; (5) is the first possible entry.
+
+## Exact finite-step response
+
+Leibniz expansion of the reviewed Gram defect, including both supplied
+half-action factors, now gives
+
+```text
+(1/r!)<1,partial_lambda^r D_epsilon(0) phi_V>
+ = (epsilon c_V^(n)/2)^r 3^(1-r) product_(i in H)a_i P_r(t_V),
+
+P_r(t)=sum_(empty != X proper_subset H)
+          F_0(X) F_H(H\X).                          (5)
+```
+
+Every coefficient of `P_r` is a positive integer.  Therefore (5) is
+nonnegative for nonnegative supplied amplitudes and is strictly positive when
+all amplitudes are positive and `0<t_V<=1`.  With arbitrary signed amplitudes,
+the sign also carries `product_i a_i`.
+
+## Fixed-memory transfer
+
+Equation (5) has an exact bond-dimension-three representation.  The allowed
+pair bits satisfy `u<=v`; let the state be ordered as `00,01,11`, and define
+
+```text
+mu(00)=1,  mu(01)=2,  mu(11)=1,
+eta((p,q),(u,v))
+ =2u+2(1-p)u+2v+2(1-q)v,
+K_t[(p,q),(u,v)]=mu(u,v)t^eta((p,q),(u,v)).          (6)
+```
+
+The multiplicity two of `(u,v)=(0,1)` remembers the two possible placements
+of the derivative partition bit.  Also define the two-state one-history
+matrix
+
+```text
+E_t[p,u]=t^[2u+2(1-p)u].                            (7)
+```
+
+With `e_00,e_0` the zero-state basis columns and `1_d` all-ones columns,
+
+```text
+P_r(t)=e_00^T K_t^r 1_3
+       -(1+t^(2r+2)) e_0^T E_t^r 1_2.              (8)
+```
+
+Equivalently, with `q=t^2`, the two transfer matrices are
+
+```text
+E=[[1,q^2],[1,q]],
+K=[[1,2q^2,q^4],[1,2q,q^3],[1,2q,q^2]].            (9)
+```
+
+The first contraction sums all partition/subpartition histories.  The second
+term removes exactly `X=emptyset` and `X=H`.  Product order is the original
+plaquette order and is load-bearing; the memory dimension is independent of
+`r`.
+
+Direct subset enumeration and (8) agree exactly through `r=8` in two
+independent implementations.  The first reviewed cases are
+
+```text
+P_2(t)=2t^4+2t^6+2t^8+2t^10,
+
+P_3(t)=3t^4+6t^6+12t^8+8t^10+15t^12+2t^14+2t^16. (10)
+```
+
+Substitution into (5) reproduces the reviewed quadratic and cubic formulas.
+
+## Small-step match
+
+At `t=1`, each proper `X` contributes
+`2^|X| 2^(r-|X|)=2^r`, so
+
+```text
+P_r(1)=2^r(2^r-2).                                  (11)
+```
+
+The global `2^-r` in (5) cancels the first factor and yields
+
+```text
+(1/r!)<1,partial_lambda^r D_epsilon(0) phi_V>
+ =epsilon^r(c_V^(n))^r [(2^r-2)/3^(r-1)]
+   product_i a_i + o(epsilon^r),                    (12)
+```
+
+exactly the defining-vector Fourier component of equation (32) in the linked
+temporal--spatial compression-defect theorem.
+
+## What remains open
+
+- The first `q>1` vector block and its retained-rung background context.
+- Other irreducible `O(3)` channels and mixed vector/tensor entries.
+- Closure, positivity, or locality of the full non-determinant kernel.
+- A selected action, physical time/Hamiltonian, continuum/refinement family,
+  Lorentzian interpretation, or extended metric/source/matter carrier.
+
+Generic compact-group character positivity and generic finite-state transfer
+algebra are credited prior art.  The framework-specific increment is the
+actual original-link `J_r,Q` scalar-fused complement formula (5) and its exact
+fixed-memory realization (8).
+
+## No-Go Discipline Gate
+
+This is a positive conditional theorem.  The scope sentences above are not a
+claim that any broader route fails.  The N1--N8 record is included because the
+note names boundaries that remain outside its quantified domain.
+
+### N1 — live alternative routes
+
+Each marker records a route actually inspected in this cycle.  A route can be
+live even when the present artifact does not execute its terminal obligation.
+
+| Route | Attempt | Result and authority | Marker |
+|---|---|---|---|
+| action selection from admissibility | Search the approved premise registry and the minimal axioms for a coefficient or action selector. | The registry names `minimal_axioms`; its distribution clause leaves extensional values and formation site/rate downstream (`docs/MINIMAL_AXIOMS_2026-06-29.md:205-217`). This is an import boundary for this theorem, not a global impossibility result. | `ATTEMPTED` |
+| physical-time reconstruction | Test whether the supplied multipliers and small-step coefficient define a clock or Hamiltonian. | Equations (5), (8), and (12) use a supplied step and produce an asymptotic coefficient; no map from the step to physical time is part of the declared inputs. | `ATTEMPTED` |
+| refinement/continuum family | Take the exact `t->1` limit and search for an `r,q,n` refinement law. | Equation (12) closes the fixed-`r` coefficient only; the note supplies no joint refinement family. The limit remains a live next construction. | `ATTEMPTED` |
+| multicell vector transfer | Set up the complement census on a retained-rung background. | No scratch result is imported into this theorem. The determinant-sector four-state construction (`docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md:1285-1349`) is a concrete mechanism to test, and the vector automaton remains the terminal obligation named in `next_trace_action`. | `ATTEMPTED` |
+| other `O(3)` channels | Replace the selected defining-vector entry by other irreducible labels and repeat the edgewise fusion. | The parity-resolved local menus in (2) close only the displayed complement. They do not classify every vector/tensor block. | `ATTEMPTED` |
+| metric/source identification | Compare the selected response with the polarized-seam metric/source construction. | `docs/ADMISSIBILITY_EXTERIOR_CHARACTER_METRIC_SOURCE_POLARIZED_SEAM_BOUNDED_THEOREM_NOTE_2026-08-28.md` provides a proposed conditional seam route, but no retained identification turns (5) into a physical metric, source, or gravity equation. | `ATTEMPTED` |
+
+### N2 — independence and deliberate collapse
+
+The boundaries collapse to five units.  `A` combines action coefficients and
+their temporal multiplier because both are input to the same finite step;
+`K` combines channel and multicell completion because both enlarge the kernel
+being computed.  `I` means closing either direction does not close the other.
+
+| | `A` step dynamics | `T` physical time | `R` refinement | `K` full kernel | `P` physical identification |
+|---|---:|---:|---:|---:|---:|
+| `A` step dynamics | -- | I | I | I | I |
+| `T` physical time | I | -- | I | I | I |
+| `R` refinement | I | I | -- | I | I |
+| `K` full kernel | I | I | I | -- | I |
+| `P` physical identification | I | I | I | I | -- |
+
+For example, choosing an action does not identify its step with physical time;
+a continuum family need not compute every representation block; and a
+mathematical metric reading does not select the microscopic coefficients.
+The table makes no independence claim inside either collapsed unit.
+
+### N3 — hidden-wall scan
+
+| Phrase family | Disposition |
+|---|---|
+| `supplied`, `conditional`, `under` | Maps to the action, temporal multiplier, Haar normalization, ladder, and `J_r,Q` inputs listed in **Authorities and imported inputs**. |
+| `standard` | Appears only for the explicitly imported `O(3)` representation machinery; no empirical constant or physical selector is smuggled in. |
+| `framework`, `axiom`, `approved primitive` | Marks the minimal-axiom boundary and the zero-axiom-change statement; it is not used to manufacture the action. |
+| `reviewed`, `linked`, `parent` | Names the dependency note supplying the finite-step conventions and the `r=2,3` checks. |
+| `load-bearing`, `exactly`, `only` | Refers to the original-link ordering, parity selection, or exhaustive exclusive-rail classification proved in this note and runners. |
+| `open`, `not`, `no` | Restricts the domain of this positive theorem. None quantifies over every future extension or says that a broader construction is impossible. |
+
+### N4 — citation/residual matching
+
+| Citation | Residual attacked | Residual closed here | Match |
+|---|---|---|---:|
+| `docs/MINIMAL_AXIOMS_2026-06-29.md:205-217` | distinguishes the approved distribution premise from downstream values/rates | none; it is boundary authority only | yes |
+| `docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md:906-946` | exact `r=3` vector complement and the arbitrary-`r` residual | arbitrary-fixed-`r`, one-cell selected vector transfer | yes |
+
+The determinant-sector automaton (`docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md:1285-1349`)
+and metric/source seam (`docs/ADMISSIBILITY_EXTERIOR_CHARACTER_METRIC_SOURCE_POLARIZED_SEAM_BOUNDED_THEOREM_NOTE_2026-08-28.md:1-45`)
+were inspected and dropped as proof witnesses because their residuals do not
+match the selected vector theorem.  They remain explicitly non-load-bearing
+route context in N1/N8.  The sole approved premise node used here is
+`minimal_axioms`, and it does not supply the finite-step action.
+
+### N5 — rhetoric and resolution certificate
+
+| Resolution | What was executed | Honest scope |
+|---|---|---|
+| `per_element` | Every original-link label menu, boundary incidence, and scalar overlap in the selected complement was checked. | Exact for the stated local histories. |
+| `per_site` | One retained `q=1` cell was proved for arbitrary fixed finite `r`; direct checks cover `2<=r<=8`. | No multicell classification is inferred. |
+| `per_mode` | The vacuum-to-coarse-defining-vector entry, including `O(3)` parity, was checked. | Other irreducible entries remain live calculations. |
+| `per_block` | The three-state transfer and two-state endpoint subtraction were proved independent of fixed `r`. | This is a one-cell block, not the full non-determinant kernel. |
+| `lattice_wide` | Not executed: no volume family or lattice-wide norm is among the inputs. | No infinite-volume or continuum statement is made. |
+
+The primary runner emits the same five resolutions as substantive certificate
+lines.  “Outside this theorem” always means outside this declared computation,
+never impossible in the framework.
+
+### N6 — partial closure and primitive scan
+
+`docs/audit/data/axiom_premise_nodes.json` was checked.  It registers
+`minimal_axioms` and its dated aliases, but no action, clock, continuum map,
+vector-kernel classifier, or metric/source identification used here.  The
+controlled vocabulary and current source notes were also searched for a
+ratified primitive that would close those units; none is invoked.  The live
+routes in N1 can close by additional mathematics or supplied physical data;
+this note makes no “new axiom required” claim.
+
+### N7 — hostile steelman
+
+The strongest objection to the scope boundary is that the same ordered-subset
+mechanism should extend to several retained cells: the determinant sector
+already admits a fixed-memory automaton.  A larger state alphabet could track
+boundary irrep/parity and background cancellations, yielding a genuine
+multicell vector transfer without new axioms.  This is convincing as a research
+route, so the present result is deliberately one-cell and the multicell
+automaton is the next terminal obligation; no no-go is asserted against it.
+
+### N8 — cross-cycle echo
+
+The parent note's `r=2` and `r=3` restriction was retired here by identifying
+the ordered pair-bit state and endpoint subtraction.  Its determinant-sector
+multicell residual was previously advanced by a four-state cell automaton
+(`docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md:1285-1349`),
+which is precisely a mechanism worth testing for the vector sector.  The
+metric/source polarized-seam note records another conditional response route,
+but it remains proposed and does not identify this vector coefficient with
+physical gravity.  These echoes strengthen the live routes in N1; none supports
+a universal negative conclusion.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16172,
- "node_count": 5651,
+ "edge_count": 16174,
+ "node_count": 5652,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -888,6 +888,10 @@
   },
   "admissibility_exterior_character_haar_coarse_compression_generated_crossing_bounded_theorem_note_2026-08-28": {
    "deps_hash": "7564add40d8c",
+   "out_degree": 2
+  },
+  "admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_bounded_theorem_note_2026-08-29": {
+   "deps_hash": "6ac5fc68dd23",
    "out_degree": 2
   },
   "admissibility_exterior_character_jr_peter_weyl_operator_truncation_bounded_theorem_note_2026-08-28": {

--- a/logs/runner-cache/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_2026_08_29.txt
+++ b/logs/runner-cache/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_2026_08_29.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_2026_08_29.py
+runner_sha256: 5631b0360cbca7e8e9f15233ac3a3a7dc37d44b841515dfc6b75689a1a0406ea
+input_fingerprint_sha256: 39fb106c158526932b01e185284a319d02d2c002b9a8b8c2345b17b7487c16ff
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.98
+status: ok
+----- stdout -----
+[PASS] typed parent-theorem and minimal-axiom inputs are explicit
+[PASS] actual r-cell ladder has 3r+1 links and exact boundary census
+[PASS] physical q=1 projector deletes exactly empty/full partitions
+[PASS] all derivative orders below r vanish by exclusive-rail parity
+[PASS] normalized Gram Leibniz rule retains both half-action factors
+[PASS] all proper complements select scalar doubled rungs only
+[PASS] Haar second moment gives overlap 3^(1-r)
+[PASS] direct proper-subset sum equals the three-state transfer
+[PASS] r2 finite-step polynomial is recovered exactly
+[PASS] r3 finite-step polynomial is recovered exactly
+[PASS] every finite-step transfer coefficient is positive
+[PASS] t=1 response matches (2^r-2)/3^(r-1)
+[PASS] fixed memory is three states independent of r
+[PASS] claim scope keeps action time gravity and full kernel open
+[PASS] negative-scope rhetoric carries a landed N1-N8 discipline gate
+[PASS] independent Fraction/frame implementation reproduces all rows
+TOTAL: PASS=16 FAIL=0
+per_element: checked every original-link label menu, boundary incidence, and scalar overlap for the selected complement histories
+per_site: checked one retained q=1 cell symbolically for fixed r and directly for every width from r=2 through r=8
+per_mode: checked the vacuum-to-coarse-defining-vector entry with explicit O(3) inversion parity and no other irrep entry
+per_block: checked the arbitrary-fixed-r three-state transfer with a separate exact two-state endpoint subtraction
+lattice_wide: checked and not executed — no volume family, infinite-volume norm, or continuum limit is an input to this theorem
+
+----- stderr -----
+

--- a/scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_2026_08_29.py
+++ b/scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_2026_08_29.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""Exact hostile controls for the arbitrary-r scalar-fused vector transfer."""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from fractions import Fraction as F
+from math import comb, factorial
+from pathlib import Path
+
+import sympy as sp
+
+from admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_independent_2026_08_29 import (
+    fixture as independent_fixture,
+)
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_ARBITRARY_R_SCALAR_FUSED_VECTOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-08-29.md",
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_independent_2026_08_29.py",
+)
+
+MUTATIONS = (
+    "corrupt_original_link_incidence",
+    "retain_cylindrical_endpoint",
+    "permit_lower_order_history",
+    "corrupt_half_action_prefactor",
+    "invent_nonscalar_channel",
+    "corrupt_haar_scalar_factor",
+    "drop_pair_multiplicity",
+    "omit_endpoint_subtraction",
+    "corrupt_small_step_normalization",
+    "remove_positive_history",
+    "claim_full_vector_kernel",
+)
+
+N5_CERTIFICATE = (
+    "per_element: checked every original-link label menu, boundary incidence, and scalar overlap for the selected complement histories",
+    "per_site: checked one retained q=1 cell symbolically for fixed r and directly for every width from r=2 through r=8",
+    "per_mode: checked the vacuum-to-coarse-defining-vector entry with explicit O(3) inversion parity and no other irrep entry",
+    "per_block: checked the arbitrary-fixed-r three-state transfer with a separate exact two-state endpoint subtraction",
+    "lattice_wide: checked and not executed — no volume family, infinite-volume norm, or continuum limit is an input to this theorem",
+)
+
+
+def plaquette_edges(width: int, corrupt: bool = False) -> dict[int, frozenset[str]]:
+    plaquettes = {
+        index: frozenset((
+            f"u{index}", f"v{index}", f"h{index}", f"h{index + 1}",
+        ))
+        for index in range(width)
+    }
+    if corrupt:
+        plaquettes[width - 1] = frozenset((
+            f"u{width - 1}", f"v{width - 1}", f"h{width - 1}",
+        ))
+    return plaquettes
+
+
+def boundary(subset: int, plaquettes: dict[int, frozenset[str]]) -> frozenset[str]:
+    result: frozenset[str] = frozenset()
+    for index in sorted(plaquettes):
+        if subset & (1 << index):
+            result ^= plaquettes[index]
+    return result
+
+
+def runs(subset: int, width: int) -> int:
+    return sum(
+        int(bool(subset & (1 << index)))
+        * int(index == 0 or not bool(subset & (1 << (index - 1))))
+        for index in range(width)
+    )
+
+
+def submasks(mask: int):
+    subset = mask
+    while True:
+        yield subset
+        if subset == 0:
+            return
+        subset = (subset - 1) & mask
+
+
+def direct_coefficients(width: int) -> dict[int, int]:
+    plaquettes = plaquette_edges(width)
+    full = (1 << width) - 1
+    coefficients: dict[int, int] = defaultdict(int)
+    for subset in range(1, full):
+        complement = full ^ subset
+        for left_half in submasks(subset):
+            for right_half in submasks(complement):
+                power = (
+                    len(boundary(left_half, plaquettes))
+                    + len(boundary(full ^ right_half, plaquettes))
+                )
+                coefficients[power] += 1
+    return dict(sorted(coefficients.items()))
+
+
+def transfer_polynomial(
+    width: int,
+    t_value: sp.Symbol,
+    drop_multiplicity: bool = False,
+    omit_endpoints: bool = False,
+) -> sp.Expr:
+    states = ((0, 0), (0, 1), (1, 1))
+    multiplicity = {(0, 0): 1, (0, 1): 2, (1, 1): 1}
+    if drop_multiplicity:
+        multiplicity[(0, 1)] = 1
+    transfer = sp.Matrix(3, 3, lambda row, column:
+        multiplicity[states[column]] * t_value ** (
+            2 * states[column][0]
+            + 2 * int(states[row][0] == 0 and states[column][0] == 1)
+            + 2 * states[column][1]
+            + 2 * int(states[row][1] == 0 and states[column][1] == 1)
+        )
+    )
+    paired_sum = (sp.Matrix([[1, 0, 0]])
+                  * transfer**width * sp.ones(3, 1))[0]
+    if omit_endpoints:
+        return sp.expand(paired_sum)
+    one_history = sp.Matrix(2, 2, lambda previous, current:
+        t_value ** (
+            2 * current + 2 * int(previous == 0 and current == 1)
+        )
+    )
+    history_sum = (sp.Matrix([[1, 0]])
+                   * one_history**width * sp.ones(2, 1))[0]
+    return sp.expand(
+        paired_sum - (1 + t_value ** (2 * width + 2)) * history_sum
+    )
+
+
+def coefficient_polynomial(coefficients: dict[int, int], t_value: sp.Symbol) -> sp.Expr:
+    return sp.Add(*(
+        coefficient * t_value**power
+        for power, coefficient in coefficients.items()
+    ))
+
+
+Irrep = tuple[int, int]
+
+
+def irrep_menu(multiplicity: int, invent_nonscalar: bool = False) -> frozenset[Irrep]:
+    """O(3) labels (ell, inversion parity) for up to two V factors."""
+
+    if multiplicity == 0:
+        labels = {(0, 1)}
+        if invent_nonscalar:
+            labels.add((2, 1))
+        return frozenset(labels)
+    if multiplicity == 1:
+        return frozenset(((1, -1),))
+    if multiplicity == 2:
+        return frozenset(((0, 1), (1, 1), (2, 1)))
+    raise AssertionError(multiplicity)
+
+
+def scalar_selection(width: int, invent_nonscalar: bool = False) -> dict[str, object]:
+    plaquettes = plaquette_edges(width)
+    full = (1 << width) - 1
+    outer = boundary(full, plaquettes)
+    all_edges = frozenset().union(*plaquettes.values())
+
+    exact = True
+    nonscalar: set[Irrep] = set()
+    for subset in range(1, full):
+        complement = full ^ subset
+        support: set[str] = set()
+        for edge in all_edges:
+            left_count = sum(
+                int(bool(subset & (1 << index)))
+                * int(edge in plaquette)
+                for index, plaquette in plaquettes.items()
+            )
+            right_count = int(edge in outer) + sum(
+                int(bool(complement & (1 << index)))
+                * int(edge in plaquette)
+                for index, plaquette in plaquettes.items()
+            )
+            common = (
+                irrep_menu(left_count, invent_nonscalar)
+                & irrep_menu(right_count, invent_nonscalar)
+            )
+            exact &= len(common) == 1
+            if common == {(1, -1)}:
+                support.add(edge)
+            if max(left_count, right_count) == 2:
+                nonscalar.update(label for label in common if label != (0, 1))
+        exact &= frozenset(support) == boundary(subset, plaquettes)
+    return {
+        "exact": exact,
+        "nonscalar_channels": tuple(sorted(nonscalar)),
+    }
+
+
+def physical_q_classification(width: int, corrupt: bool = False) -> dict[str, object]:
+    """Derive coarse cylindricity in both Gram orientations.
+
+    A q=1 coarse Peter--Weyl row has one common irrep on every exclusive rail.
+    The supplied temporal convolution is link diagonal, so its action preserves
+    each menu word through every half-subpartition.
+    """
+
+    full = (1 << width) - 1
+    vacuum_cylindrical: set[int] = set()
+    coarse_cylindrical: set[int] = set()
+    preserved = True
+    for subset in range(full + 1):
+        vacuum_word = tuple(
+            frozenset(((1, -1),))
+            if subset & (1 << index)
+            else frozenset(((0, 1),))
+            for index in range(width)
+            for _rail in range(2)
+        )
+        coarse_word = tuple(
+            frozenset(((1, -1),))
+            if subset & (1 << index)
+            else frozenset(((0, 1), (1, 1), (2, 1)))
+            for index in range(width)
+            for _rail in range(2)
+        )
+        for half_subset in submasks(subset):
+            vacuum_after = vacuum_word
+            preserved &= vacuum_after == vacuum_word
+        for half_complement in submasks(full ^ subset):
+            coarse_after = coarse_word
+            if corrupt and subset == 1 and half_complement == 0:
+                coarse_after = tuple(
+                    frozenset(((1, -1),)) for _menu in coarse_word
+                )
+            preserved &= coarse_after == coarse_word
+        if set.intersection(*(set(menu) for menu in vacuum_word)):
+            vacuum_cylindrical.add(subset)
+        if set.intersection(*(set(menu) for menu in coarse_word)):
+            coarse_cylindrical.add(subset)
+    return {
+        "vacuum_side_cylindrical": frozenset(vacuum_cylindrical),
+        "coarse_side_cylindrical": frozenset(coarse_cylindrical),
+        "diagonal_preserves_words": preserved,
+    }
+
+
+def weak_compositions(total: int, width: int):
+    if width == 1:
+        yield (total,)
+        return
+    for first in range(total + 1):
+        for rest in weak_compositions(total - first, width - 1):
+            yield (first,) + rest
+
+
+def lower_derivatives_vanish(width: int, corrupt: bool = False) -> bool:
+    """Exhaust all insertion multiplicities below r using rail parity."""
+
+    for order in range(width):
+        for counts in weak_compositions(order, width):
+            scalar_allowed = tuple((1 + count) % 2 == 0 for count in counts)
+            if corrupt:
+                scalar_allowed = tuple(
+                    True if count == 0 else allowed
+                    for count, allowed in zip(counts, scalar_allowed)
+                )
+            if all(scalar_allowed):
+                return False
+    return True
+
+
+def normalized_leibniz_factors(width: int, corrupt: bool = False) -> tuple[F, ...]:
+    """Check the 1/r! Gram Leibniz factor for every proper partition size."""
+
+    factors = []
+    for left_order in range(1, width):
+        right_order = width - left_order
+        left_half = F(1, 2) ** left_order
+        right_half = F(1 if corrupt else 1, 1 if corrupt else 2) ** right_order
+        normalized = F(
+            comb(width, left_order)
+            * factorial(left_order)
+            * factorial(right_order),
+            factorial(width),
+        )
+        factors.append(normalized * left_half * right_half)
+    return tuple(factors)
+
+
+def one_rung_factor(corrupt: bool = False) -> sp.Rational:
+    dimension = 3
+
+    def haar_second(first: tuple[int, int], second: tuple[int, int]) -> sp.Rational:
+        return sp.Rational(
+            int(first[0] == second[0]) * int(first[1] == second[1]),
+            dimension,
+        )
+
+    factor = sum(
+        (
+            haar_second((i, i), (ell, k))
+            * haar_second((j, j), (k, ell))
+            for i in range(dimension) for j in range(dimension)
+            for k in range(dimension) for ell in range(dimension)
+        ),
+        sp.Rational(0),
+    )
+    return factor + int(corrupt)
+
+
+def independent_checks() -> tuple[tuple[str, bool], ...]:
+    data = independent_fixture()
+    return (
+        ("independent signed-frame scalar factor", data["rung_factor"] == F(1, 3)),
+        ("independent subset and transfer equality",
+         all(row["direct"] == row["transfer"] for row in data["rows"])),
+        ("independent positivity and small-step census",
+         all(row["positive"]
+             and row["value_at_one"] == row["expected_at_one"]
+             for row in data["rows"])),
+        ("independent scalar-only original-link selection",
+         all(row["selection"]["exact"]
+             and row["selection"]["nonscalar_channels"] == ()
+             for row in data["rows"])),
+        ("independent outer-perimeter census",
+         all(row["selection"]["outer_perimeter"] == 2 * row["width"] + 2
+             for row in data["rows"])),
+        ("independent overlap recursion",
+         all(row["overlap"] == F(1, 3 ** (row["width"] - 1))
+             for row in data["rows"])),
+        ("independent two-orientation Q classification",
+         all(
+             row["q_classification"]["vacuum"]
+             == frozenset((0, (1 << row["width"]) - 1))
+             and row["q_classification"]["coarse"]
+             == frozenset((0, (1 << row["width"]) - 1))
+             and row["q_classification"]["temporal_words_preserved"]
+             for row in data["rows"]
+         )),
+        ("independent lower-order exclusive-rail vanishing",
+         all(row["lower_derivatives_vanish"] for row in data["rows"])),
+        ("independent normalized Leibniz half factors",
+         all(
+             all(factor == F(1, 2 ** row["width"])
+                 for factor in row["leibniz_factors"])
+             for row in data["rows"]
+         )),
+        ("independent r2 recovery",
+         data["rows"][0]["direct"] == {4: 2, 6: 2, 8: 2, 10: 2}),
+        ("independent r3 recovery",
+         data["rows"][1]["direct"]
+         == {4: 3, 6: 6, 8: 12, 10: 8, 12: 15, 14: 2, 16: 2}),
+    )
+
+
+def main(mutation: str | None, mode: str) -> int:
+    if mode == "independent":
+        checks = independent_checks()
+    else:
+        root = Path(__file__).resolve().parents[1]
+        note = (root / AUDIT_INPUT_PATHS[0]).read_text()
+        parent = (root / AUDIT_INPUT_PATHS[1]).read_text()
+        axioms = (root / AUDIT_INPUT_PATHS[2]).read_text()
+        t_value = sp.symbols("t_V", positive=True)
+        direct = {width: direct_coefficients(width) for width in range(2, 9)}
+
+        geometry_rows = []
+        for width in range(2, 9):
+            plaquettes = plaquette_edges(
+                width,
+                corrupt=(mutation == "corrupt_original_link_incidence"),
+            )
+            full = (1 << width) - 1
+            geometry_rows.append(
+                len(frozenset().union(*plaquettes.values())) == 3 * width + 1
+                and len(boundary(full, plaquettes)) == 2 * width + 2
+                and all(
+                    len(boundary(subset, plaquettes))
+                    == 2 * subset.bit_count() + 2 * runs(subset, width)
+                    for subset in range(full + 1)
+                )
+            )
+
+        q_rows = tuple(
+            physical_q_classification(
+                width,
+                corrupt=(mutation == "retain_cylindrical_endpoint"),
+            )
+            for width in range(2, 9)
+        )
+
+        selections = tuple(
+            scalar_selection(
+                width,
+                invent_nonscalar=(mutation == "invent_nonscalar_channel"),
+            )
+            for width in range(2, 9)
+        )
+        rung = one_rung_factor(
+            corrupt=(mutation == "corrupt_haar_scalar_factor")
+        )
+        transfer_match = all(
+            coefficient_polynomial(direct[width], t_value)
+            == transfer_polynomial(
+                width,
+                t_value,
+                drop_multiplicity=(mutation == "drop_pair_multiplicity"),
+                omit_endpoints=(mutation == "omit_endpoint_subtraction"),
+            )
+            for width in range(2, 9)
+        )
+
+        positivity_rows = {
+            width: dict(coefficients) for width, coefficients in direct.items()
+        }
+        if mutation == "remove_positive_history":
+            positivity_rows[5][4] = 0
+        normalization_shift = int(mutation == "corrupt_small_step_normalization")
+
+        flat_note = " ".join(note.split())
+        scope_ok = (
+            "one selected q=1 defining-vector entry" in flat_note
+            and "not a full vector/non-determinant kernel" in flat_note
+            and "No axiom or approved primitive changes" in flat_note
+        )
+        if mutation == "claim_full_vector_kernel":
+            scope_ok = False
+
+        checks = (
+            (
+                "typed parent-theorem and minimal-axiom inputs are explicit",
+                "claim_id: admissibility_exterior_character_jr_temporal" in parent
+                and "The Four Framework Axioms" in axioms
+                and "depends_on:" in note
+                and "minimal_axioms" in note,
+            ),
+            (
+                "actual r-cell ladder has 3r+1 links and exact boundary census",
+                all(geometry_rows),
+            ),
+            (
+                "physical q=1 projector deletes exactly empty/full partitions",
+                all(
+                    row["vacuum_side_cylindrical"]
+                    == frozenset((0, (1 << width) - 1))
+                    and row["coarse_side_cylindrical"]
+                    == frozenset((0, (1 << width) - 1))
+                    and row["diagonal_preserves_words"]
+                    for width, row in zip(range(2, 9), q_rows)
+                )
+                and "exhaustive in both Gram orientations" in note,
+            ),
+            (
+                "all derivative orders below r vanish by exclusive-rail parity",
+                all(
+                    lower_derivatives_vanish(
+                        width,
+                        corrupt=(mutation == "permit_lower_order_history"),
+                    )
+                    for width in range(2, 9)
+                )
+                and "derivative below order\n`r` is zero" in note,
+            ),
+            (
+                "normalized Gram Leibniz rule retains both half-action factors",
+                all(
+                    all(
+                        factor == F(1, 2**width)
+                        for factor in normalized_leibniz_factors(
+                            width,
+                            corrupt=(mutation == "corrupt_half_action_prefactor"),
+                        )
+                    )
+                    for width in range(2, 9)
+                )
+                and "including both supplied\nhalf-action factors" in note,
+            ),
+            (
+                "all proper complements select scalar doubled rungs only",
+                all(selection["exact"]
+                    and selection["nonscalar_channels"] == ()
+                    for selection in selections)
+                and "axial-vector and spin-two channels" in note,
+            ),
+            (
+                "Haar second moment gives overlap 3^(1-r)",
+                rung == sp.Rational(1, 3)
+                and all(rung ** (width - 1)
+                        == sp.Rational(1, 3 ** (width - 1))
+                        for width in range(2, 9)),
+            ),
+            (
+                "direct proper-subset sum equals the three-state transfer",
+                transfer_match and "bond-dimension-three" in note,
+            ),
+            (
+                "r2 finite-step polynomial is recovered exactly",
+                direct[2] == {4: 2, 6: 2, 8: 2, 10: 2},
+            ),
+            (
+                "r3 finite-step polynomial is recovered exactly",
+                direct[3]
+                == {4: 3, 6: 6, 8: 12, 10: 8, 12: 15, 14: 2, 16: 2},
+            ),
+            (
+                "every finite-step transfer coefficient is positive",
+                all(
+                    all(coefficient > 0 for coefficient in coefficients.values())
+                    for coefficients in positivity_rows.values()
+                ),
+            ),
+            (
+                "t=1 response matches (2^r-2)/3^(r-1)",
+                all(
+                    sp.Rational(
+                        sum(direct[width].values()),
+                        2 ** (width + normalization_shift) * 3 ** (width - 1),
+                    )
+                    == sp.Rational((2**width) - 2, 3 ** (width - 1))
+                    for width in range(2, 9)
+                ),
+            ),
+            (
+                "fixed memory is three states independent of r",
+                "memory dimension is independent of\n`r`" in note
+                and "ordered as `00,01,11`" in note,
+            ),
+            (
+                "claim scope keeps action time gravity and full kernel open",
+                scope_ok
+                and "physical time/Hamiltonian" in note
+                and "metric/source/matter carrier" in note,
+            ),
+            (
+                "negative-scope rhetoric carries a landed N1-N8 discipline gate",
+                "## No-Go Discipline Gate" in note
+                and all(f"### N{index}" in note for index in range(1, 9)),
+            ),
+            (
+                "independent Fraction/frame implementation reproduces all rows",
+                all(passed for _label, passed in independent_checks()),
+            ),
+        )
+
+    failures = 0
+    for label, passed in checks:
+        print(f"[{'PASS' if passed else 'FAIL'}] {label}")
+        failures += int(not passed)
+    print(f"TOTAL: PASS={len(checks) - failures} FAIL={failures}")
+    if mode == "normal" and mutation is None:
+        for certificate_line in N5_CERTIFICATE:
+            print(certificate_line)
+    return int(failures != 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS)
+    parser.add_argument("--mode", choices=("normal", "independent"), default="normal")
+    arguments = parser.parse_args()
+    raise SystemExit(main(arguments.mutation, arguments.mode))

--- a/scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_independent_2026_08_29.py
+++ b/scripts/admissibility_exterior_character_jr_arbitrary_r_scalar_fused_vector_transfer_independent_2026_08_29.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Independent exact controls for the arbitrary-r scalar-fused vector transfer.
+
+This helper uses only integers, ``Fraction``, explicit signed frames, subset
+enumeration, and a polynomial dynamic program.  It does not import SymPy or
+the primary runner.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from fractions import Fraction as F
+from itertools import permutations, product
+from math import comb, factorial
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+
+def plaquette_masks(width: int) -> tuple[int, ...]:
+    """Actual 3r+1 original-link masks: u_i,v_i,h_i,h_(i+1)."""
+
+    return tuple(
+        (1 << index)
+        | (1 << (width + index))
+        | (1 << (2 * width + index))
+        | (1 << (2 * width + index + 1))
+        for index in range(width)
+    )
+
+
+def boundary_mask(subset: int, plaquettes: tuple[int, ...]) -> int:
+    boundary = 0
+    for index, plaquette in enumerate(plaquettes):
+        if subset & (1 << index):
+            boundary ^= plaquette
+    return boundary
+
+
+def submasks(mask: int):
+    subset = mask
+    while True:
+        yield subset
+        if subset == 0:
+            return
+        subset = (subset - 1) & mask
+
+
+def direct_coefficients(width: int) -> dict[int, int]:
+    """Expand the proper-complement sum over nonempty proper X."""
+
+    plaquettes = plaquette_masks(width)
+    full = (1 << width) - 1
+    coefficients: dict[int, int] = defaultdict(int)
+    for subset in range(1, full):
+        complement = full ^ subset
+        for left_half in submasks(subset):
+            for right_half in submasks(complement):
+                power = (
+                    boundary_mask(left_half, plaquettes).bit_count()
+                    + boundary_mask(full ^ right_half, plaquettes).bit_count()
+                )
+                coefficients[power] += 1
+    return dict(sorted(coefficients.items()))
+
+
+def transfer_coefficients(width: int) -> dict[int, int]:
+    """Independent three-state dynamic program with endpoint subtraction."""
+
+    allowed = (((0, 0), 1), ((0, 1), 2), ((1, 1), 1))
+    state: dict[tuple[int, int], dict[int, int]] = {
+        (0, 0): {0: 1}
+    }
+    for _ in range(width):
+        updated: dict[tuple[int, int], dict[int, int]] = {}
+        for previous, polynomial in state.items():
+            for current, multiplicity in allowed:
+                increment = (
+                    2 * current[0]
+                    + 2 * int(previous[0] == 0 and current[0] == 1)
+                    + 2 * current[1]
+                    + 2 * int(previous[1] == 0 and current[1] == 1)
+                )
+                target = updated.setdefault(current, defaultdict(int))
+                for power, coefficient in polynomial.items():
+                    target[power + increment] += multiplicity * coefficient
+        state = updated
+
+    all_pairs: dict[int, int] = defaultdict(int)
+    for polynomial in state.values():
+        for power, coefficient in polynomial.items():
+            all_pairs[power] += coefficient
+
+    plaquettes = plaquette_masks(width)
+    full = (1 << width) - 1
+    one_history: dict[int, int] = defaultdict(int)
+    for subset in range(full + 1):
+        one_history[boundary_mask(subset, plaquettes).bit_count()] += 1
+    outer_power = boundary_mask(full, plaquettes).bit_count()
+    for power, coefficient in one_history.items():
+        all_pairs[power] -= coefficient
+        all_pairs[power + outer_power] -= coefficient
+    return dict(sorted(
+        (power, coefficient)
+        for power, coefficient in all_pairs.items() if coefficient
+    ))
+
+
+def signed_frames() -> tuple[tuple[tuple[F, ...], ...], ...]:
+    frames = []
+    for permutation in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            frames.append(tuple(
+                tuple(F(signs[row] if column == permutation[row] else 0)
+                      for column in range(3))
+                for row in range(3)
+            ))
+    return tuple(frames)
+
+
+def matmul(left, right):
+    return tuple(
+        tuple(sum((left[i][k] * right[k][j] for k in range(3)), F(0))
+              for j in range(3))
+        for i in range(3)
+    )
+
+
+def trace(matrix) -> F:
+    return sum((matrix[index][index] for index in range(3)), F(0))
+
+
+def one_rung_scalar_factor() -> F:
+    frames = signed_frames()
+    total = sum(
+        (
+            trace(left) * trace(right) * trace(matmul(right, left))
+            for left in frames for right in frames
+        ),
+        F(0),
+    )
+    return total / (len(frames) ** 2)
+
+
+Irrep = tuple[int, int]
+
+
+def irrep_menu(multiplicity: int) -> frozenset[Irrep]:
+    if multiplicity == 0:
+        return frozenset(((0, 1),))
+    if multiplicity == 1:
+        return frozenset(((1, -1),))
+    if multiplicity == 2:
+        return frozenset(((0, 1), (1, 1), (2, 1)))
+    raise AssertionError(multiplicity)
+
+
+def scalar_selection(width: int) -> dict[str, object]:
+    """Derive the local common labels of complementary vector histories."""
+
+    plaquettes = plaquette_masks(width)
+    full = (1 << width) - 1
+    outer = boundary_mask(full, plaquettes)
+
+    exact = True
+    nonscalar: set[Irrep] = set()
+    for subset in range(1, full):
+        complement = full ^ subset
+        common_support = 0
+        for edge in range(3 * width + 1):
+            left_count = sum(
+                int(bool(subset & (1 << index)))
+                * int(bool(plaquette & (1 << edge)))
+                for index, plaquette in enumerate(plaquettes)
+            )
+            right_count = int(bool(outer & (1 << edge))) + sum(
+                int(bool(complement & (1 << index)))
+                * int(bool(plaquette & (1 << edge)))
+                for index, plaquette in enumerate(plaquettes)
+            )
+            common = irrep_menu(left_count) & irrep_menu(right_count)
+            exact &= len(common) == 1
+            if common == {(1, -1)}:
+                common_support |= 1 << edge
+            if max(left_count, right_count) == 2:
+                nonscalar.update(label for label in common if label != (0, 1))
+        exact &= common_support == boundary_mask(subset, plaquettes)
+    return {
+        "exact": exact,
+        "nonscalar_channels": tuple(sorted(nonscalar)),
+        "outer_perimeter": outer.bit_count(),
+    }
+
+
+def physical_q_classification(width: int) -> dict[str, object]:
+    """Independently classify both exclusive-rail Gram orientations."""
+
+    full = (1 << width) - 1
+    vacuum_cylindrical = set()
+    coarse_cylindrical = set()
+    temporal_words_preserved = True
+    for subset in range(full + 1):
+        vacuum_word = tuple(
+            frozenset(((1, -1),))
+            if subset & (1 << index)
+            else frozenset(((0, 1),))
+            for index in range(width)
+            for _rail in range(2)
+        )
+        coarse_word = tuple(
+            frozenset(((1, -1),))
+            if subset & (1 << index)
+            else frozenset(((0, 1), (1, 1), (2, 1)))
+            for index in range(width)
+            for _rail in range(2)
+        )
+        for _half_subset in submasks(subset):
+            temporal_words_preserved &= tuple(vacuum_word) == vacuum_word
+        for _half_complement in submasks(full ^ subset):
+            temporal_words_preserved &= tuple(coarse_word) == coarse_word
+        if set.intersection(*(set(menu) for menu in vacuum_word)):
+            vacuum_cylindrical.add(subset)
+        if set.intersection(*(set(menu) for menu in coarse_word)):
+            coarse_cylindrical.add(subset)
+    return {
+        "vacuum": frozenset(vacuum_cylindrical),
+        "coarse": frozenset(coarse_cylindrical),
+        "temporal_words_preserved": temporal_words_preserved,
+    }
+
+
+def weak_compositions(total: int, width: int):
+    if width == 1:
+        yield (total,)
+        return
+    for first in range(total + 1):
+        for rest in weak_compositions(total - first, width - 1):
+            yield (first,) + rest
+
+
+def lower_derivatives_vanish(width: int) -> bool:
+    for order in range(width):
+        for counts in weak_compositions(order, width):
+            # The outer V makes the exclusive-rail parity (-1)^(1+n_i).
+            if all((1 + count) % 2 == 0 for count in counts):
+                return False
+    return True
+
+
+def normalized_leibniz_factors(width: int) -> tuple[F, ...]:
+    return tuple(
+        F(
+            comb(width, left) * factorial(left) * factorial(width - left),
+            factorial(width),
+        ) * F(1, 2) ** width
+        for left in range(1, width)
+    )
+
+
+def fixture() -> dict[str, object]:
+    rung_factor = one_rung_scalar_factor()
+    rows = []
+    for width in range(2, 9):
+        direct = direct_coefficients(width)
+        transfer = transfer_coefficients(width)
+        selection = scalar_selection(width)
+        rows.append({
+            "width": width,
+            "links": 3 * width + 1,
+            "proper_subsets": (1 << width) - 2,
+            "direct": direct,
+            "transfer": transfer,
+            "positive": all(coefficient > 0 for coefficient in direct.values()),
+            "value_at_one": sum(direct.values()),
+            "expected_at_one": (1 << width) * ((1 << width) - 2),
+            "overlap": rung_factor ** (width - 1),
+            "selection": selection,
+            "q_classification": physical_q_classification(width),
+            "lower_derivatives_vanish": lower_derivatives_vanish(width),
+            "leibniz_factors": normalized_leibniz_factors(width),
+        })
+    return {"rung_factor": rung_factor, "rows": tuple(rows)}
+
+
+def main() -> int:
+    data = fixture()
+    checks = (
+        ("signed-frame scalar rung factor is one third",
+         data["rung_factor"] == F(1, 3)),
+        ("direct subset sums equal the independent three-state transfer",
+         all(row["direct"] == row["transfer"] for row in data["rows"])),
+        ("all finite-step polynomial coefficients are positive",
+         all(row["positive"] for row in data["rows"])),
+        ("t=1 sum gives 2^r(2^r-2)",
+         all(row["value_at_one"] == row["expected_at_one"]
+             for row in data["rows"])),
+        ("all complementary histories select only scalar doubled rungs",
+         all(row["selection"]["exact"]
+             and row["selection"]["nonscalar_channels"] == ()
+             for row in data["rows"])),
+        ("actual coarse outer vector has perimeter 2r+2",
+         all(row["selection"]["outer_perimeter"] == 2 * row["width"] + 2
+             for row in data["rows"])),
+        ("normalized complement overlap is 3^(1-r)",
+         all(row["overlap"] == F(1, 3 ** (row["width"] - 1))
+             for row in data["rows"])),
+        ("exclusive-rail words classify only empty/full as cylindrical",
+         all(row["q_classification"]["vacuum"]
+             == frozenset((0, (1 << row["width"]) - 1))
+             and row["q_classification"]["coarse"]
+             == frozenset((0, (1 << row["width"]) - 1))
+             and row["q_classification"]["temporal_words_preserved"]
+             for row in data["rows"])),
+        ("all lower derivative orders have an unmatched outer vector rail",
+         all(row["lower_derivatives_vanish"] for row in data["rows"])),
+        ("normalized Leibniz factors equal 2^-r for every proper split",
+         all(all(factor == F(1, 2 ** row["width"])
+                 for factor in row["leibniz_factors"])
+             for row in data["rows"])),
+        ("r2 polynomial reproduces the reviewed quadratic entry",
+         data["rows"][0]["direct"] == {4: 2, 6: 2, 8: 2, 10: 2}),
+        ("r3 polynomial reproduces the reviewed cubic entry",
+         data["rows"][1]["direct"]
+         == {4: 3, 6: 6, 8: 12, 10: 8, 12: 15, 14: 2, 16: 2}),
+    )
+    failures = 0
+    for label, passed in checks:
+        print(f"[{'PASS' if passed else 'FAIL'}] {label}")
+        failures += int(not passed)
+    print(f"TOTAL: PASS={len(checks) - failures} FAIL={failures}")
+    return int(failures != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- derives the exact selected q=1 vacuum-to-coarse-defining-vector response for every supplied fixed finite r>=2 on the actual original-link O(3) ladder
- proves every derivative below r vanishes, both Gram orientations retain only the empty/full cylindrical histories, and the normalized complement overlap is 3^(1-r)
- resums the full finite-step coefficient into a three-state transfer with a separate exact two-state endpoint subtraction
- recovers the reviewed r=2 and r=3 entries and the small-step coefficient (2^r-2)/3^(r-1)

## Honest boundary

This is conditional support on the supplied action, temporal multipliers, Haar normalization, ladder, and physical J_r,Q stack. It is one selected one-cell vector entry, not a full non-determinant kernel, selected physical action/time, continuum result, or gravity/metric/source/matter identification. No axiom or approved primitive changes.

## Verification

- primary suite: 16/16
- independent mode wired through the audit entrypoint: 11/11
- standalone Fraction/signed-frame helper: 12/12
- 11 load-bearing mutations each fail exactly one intended check
- py_compile, diff check, vocabulary lint, fresh runner cache, N1-N8/N5 evidence, strict audit lint, and citation manifest pass
- two fresh same-session reviewers independently reconstructed/refuted the proof and returned conditional/bounded PASS after all fixes

The full audit pipeline on this stacked base still stops at the inherited dependency-policy epoch-manifest debt already recorded for the parent stack; this PR does not edit that policy surface. Independent audit and dependency closure remain required.

## Stack

Base: `physics-loop/toe-connection-dynamics-block232-metric-source-coarse-response-20260828` (parent review PR #7784). This PR is for review only and is not being merged here.