### PR TITLE
Physics: classify vector interval endpoint response

### DIFF
--- a/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_R2_CONTIGUOUS_VECTOR_INTERVAL_ENDPOINT_AUTOMATON_BOUNDED_THEOREM_NOTE_2026-08-29.md
+++ b/docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_R2_CONTIGUOUS_VECTOR_INTERVAL_ENDPOINT_AUTOMATON_BOUNDED_THEOREM_NOTE_2026-08-29.md
@@ -1,0 +1,329 @@
+---
+claim_id: admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_bounded_theorem_note_2026-08-29
+final_path: docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_R2_CONTIGUOUS_VECTOR_INTERVAL_ENDPOINT_AUTOMATON_BOUNDED_THEOREM_NOTE_2026-08-29.md
+claim_type: bounded_theorem
+claim_scope: "For the supplied retain-every-two physical Haar isometry on the actual original-link O(3) ladder, classify the complete distinct-state quadratic response on the orthonormal coarse family consisting of the vacuum and one contiguous merged defining-vector Wilson loop. Prove for every finite q that an offdiagonal entry can be nonzero only when one interval is obtained from the other by adding or removing one endpoint cell; derive the exact vacuum-singleton and occupied endpoint-extension weights; and encode all q^2 unordered candidate edges with a q-independent six-state weighted automaton. This does not classify diagonal histories, prove the interval span invariant, include product-loop or multirun words, give the full vector kernel, select the action, or identify physical time, continuum, Lorentz, gravity, metric/source, or matter currents."
+depends_on:
+  - admissibility_exterior_character_jr_r2_nested_merged_vector_interval_response_bounded_theorem_note_2026-08-29
+  - admissibility_exterior_character_jr_temporal_spatial_semigroup_defect_generated_interaction_bounded_theorem_note_2026-08-28
+  - minimal_axioms
+dependency_roles:
+  admissibility_exterior_character_jr_r2_nested_merged_vector_interval_response_bounded_theorem_note_2026-08-29: "reviewed exact occupied-background endpoint coefficient, global 1/9 Haar factor, physical Q, and t_V^8 dressing"
+  admissibility_exterior_character_jr_temporal_spatial_semigroup_defect_generated_interaction_bounded_theorem_note_2026-08-28: "supplied finite action, temporal multipliers, original-link ladder, physical J_2/Q, and vacuum-singleton coefficient"
+  minimal_axioms: "framework boundary only; no axiom or approved primitive is edited"
+runner: scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_2026_08_29.py
+independent_checker: scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_independent_2026_08_29.py
+status: proposed_retained
+actual_current_surface_status: conditional-support
+target_claim_type: null
+trace_class: direct_blocker_closure
+target_claim_id: admissibility_exterior_character_jr_r2_nested_merged_vector_interval_response_bounded_theorem_note_2026-08-29
+target_blocker_text: "Use the exact t_V^8 interval dressing to seek a fixed-memory multicell vector automaton, then test non-merged product-vector backgrounds where additional V tensor V channels occur."
+source_of_blocker_text: next_trace_action
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Resolve the minimal adjacent product-vector background into the scalar, axial-vector, and spin-two shared-rung channels; do not claim that this offdiagonal interval automaton is a closed transfer operator."
+conditional_surface_status: "exact finite-memory offdiagonal endpoint-extension law on the supplied r=2 contiguous merged-vector interval family"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+claim_type_reason: "the arbitrary-q support selector, q^2 interval graph, exact parent-normalized endpoint weights, and constant-memory recognizer are finite mathematical results on a fully disclosed supplied carrier"
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+---
+
+# Contiguous-vector interval endpoint automaton at `r=2`
+
+**Date:** 2026-08-29
+
+**Type:** `bounded_theorem`
+
+**Status:** `proposed_retained` — author-side proposal label only.  The actual
+current surface is `conditional-support`; independent audit and closure of the
+stacked dependencies remain required.
+
+## Result and boundary
+
+On an open ladder with `q` retained cells, let `Omega=1` and
+
+```text
+Phi_[a,b]=chi_V(delta_b ... delta_a),   0<=a<=b<q.  (1)
+```
+
+For the selected vector part of
+`R_epsilon=(1/2)partial_lambda^2 D_epsilon(0)`, two distinct states in
+this family couple only when one interval is obtained from the other by adding
+or removing one endpoint cell.  If `I` is the shorter interval, `ell=|I|`, and
+`c` is the added cell, then
+
+```text
+<Phi_I,R_epsilon Phi_(I union {c})>
+ =a_(2c)a_(2c+1) * {
+    beta_0,                    ell=0,
+    beta_1 (t_V^8)^(ell-1),   ell>=1,               (2)
+  }
+
+beta_0=epsilon^2(c_V^(n))^2/6
+       (1+t_V^4)(t_V^4+t_V^6),                      (3)
+
+beta_1=epsilon^2(c_V^(n))^2/36
+       t_V^14(1+4t_V^2+t_V^4+2t_V^6).              (4)
+```
+
+The matrix is symmetric.  There are exactly `q^2` unordered candidate edges,
+and a six-state weighted recognizer evaluates every one with memory independent
+of `q`.
+
+This is the complete distinct-state offdiagonal block on the displayed
+orthonormal family.  It is not a proof that the interval span is invariant:
+diagonal histories and product-loop backgrounds allow the scalar,
+axial-vector, and spin-two pieces of `V tensor V`.  It is not the full vector
+kernel or a physical interpretation.  No axiom or approved primitive changes.
+
+## Authorities and imported inputs
+
+| Input | Role here | Not proved here |
+|---|---|---|
+| [Block 234 nested merged-vector interval theorem](ADMISSIBILITY_EXTERIOR_CHARACTER_JR_R2_NESTED_MERGED_VECTOR_INTERVAL_RESPONSE_BOUNDED_THEOREM_NOTE_2026-08-29.md) | supplies the exact occupied-background local entry, including the `1/9` Haar factor, `Q`, and temporal exponents | the arbitrary-interval selection graph and automaton |
+| [Block 232 temporal--spatial compression-defect theorem](ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md) | supplies the action, temporal crossing, ladder, `C J_2=J_2 C_c`, `[C,Q]=0`, and vacuum-singleton entry | action selection, physical time, or continuum interpretation |
+| [minimal axioms](MINIMAL_AXIOMS_2026-06-29.md) | fixes the framework boundary | any new axiom or primitive |
+
+## Orthonormal interval family
+
+Each state (1) is a residual-gauge-invariant coarse Wilson-loop character and
+has norm one by character orthogonality.  Two distinct intervals differ at an
+endpoint.  On at least one exclusive upper or lower rail, one original-link
+state therefore carries `V=(1,-)` while the other is trivial.  Linkwise
+Peter--Weyl orthogonality gives
+
+```text
+<Phi_I,Phi_J>=delta_(I,J),    Phi_emptyset=Omega.   (5)
+```
+
+Thus (2) consists of actual matrix entries in an orthonormal subspace, not a
+nonorthogonal word dictionary.
+
+## Complete original-link selector
+
+Write the fine plaquette boundary as
+
+```text
+P_p={u_p,v_p,h_p,h_(p+1)},      0<=p<2q.           (6)
+```
+
+Encode a coarse interval `I` by the repeated fine parity word `iota_2(I)`,
+which has bits `2c,2c+1` set exactly when `c in I`.  Do not assume the action
+insertions are vectors.  For an arbitrary `O(3)` action irrep `rho`, let
+`eta(rho)=1` for negative inversion parity and `0` for positive parity.
+Parity matching of insertions `(p,rho)` and `(k,sigma)` first requires
+
+```text
+iota_2(I) xor eta(rho)e_p
+ =iota_2(J) xor eta(sigma)e_k.                    (7a)
+```
+
+For distinct `I,J`, both `eta=0` would force `I=J`, while exactly one
+`eta=1` would equate a repeated-bit word to one fine bit.  Both cases are
+impossible.  Hence both action irreps have negative parity, and (7a) reduces
+to
+
+```text
+iota_2(I triangle J)=e_p xor e_k.                 (7b)
+```
+
+The left side of (7b) repeats every changed coarse bit twice.  The right side
+has exactly two distinct fine bits.  Therefore (7b) holds exactly when
+`I triangle J={c}` and `{p,k}={2c,2c+1}`.  For two intervals this singleton
+difference is necessarily an endpoint extension or shrink.  Consequently the
+only ordered placements are
+
+```text
+(p,k)=(2c,2c+1), (2c+1,2c).                       (8)
+```
+
+Shifted intervals, nested length jumps greater than one, and any pair differing
+in two or more cells have no quadratic entry in this selected vector block.
+This is an arbitrary-`q` proof; the runners also exhaust every interval pair
+through `q=7` on the actual `6q+1` original links.
+
+The parity census is only the necessary first step.  On the fine plaquette
+belonging to the shorter-interval side, an exclusive upper or lower rail
+presents `rho` against the longer interval's background `V`; Peter--Weyl
+orthogonality forces `rho=V`.  On the opposite fine plaquette, the shorter
+side is trivial while the longer side carries `V tensor sigma`; its scalar
+channel exists exactly when `|1-ell_sigma|=0` and `(-1)p_sigma=+1`, hence
+only when `sigma=V=(1,-)`.  Thus no action irrep was assumed in deriving the
+support selector.  The primary runner exhausts both parity choices before
+this irrep step and separately enumerates the parent's explicit `n=1` menu
+`V`, `det tensor V`, and `det`; only `(V,V)` survives.  The arbitrary-ell
+argument uses no sampled irrep cutoff.
+
+## Local physical entry
+
+For `ell=0`, equations (7a)--(8) are the reviewed one-cell
+vacuum-to-vector calculation.  Its normalized global Haar overlap is `1/3`
+and its exact weight is (3).
+
+For `ell>=1`, translate the changed endpoint cell to zero and reflect the open
+ladder if the common interval lies to its left.  The actual original-link
+incidence is then precisely Block 234 with span `s=ell`.  Its four first-order
+histories have zero conditional mean at fixed `delta_c`, so they lie in
+`ker Q`; `C J_2=J_2 C_c` and `[C,Q]=0` preserve this after temporal crossing.
+The two matched orientations each have global Haar overlap `1/9`.  Substituting
+`s=ell` in that exact result gives
+
+```text
+epsilon^2(c_V^(n))^2 a_(2c)a_(2c+1)/36
+ t_V^(8ell+6)(1+4t_V^2+t_V^4+2t_V^6)
+
+=a_(2c)a_(2c+1) beta_1(t_V^8)^(ell-1),            (9)
+```
+
+which proves (2).  Reflection merely exchanges the two matched orientations,
+so left and right endpoint extensions agree after reflecting their local
+amplitudes.
+
+At `t_V->1`, all nonvacuum endpoint extensions have coefficient
+`2 epsilon^2(c_V^(n))^2 a_(2c)a_(2c+1)/9`; the vacuum edge retains the distinct
+one-cell coefficient.  At `t_V=0` every displayed entry is zero.  Positivity
+requires positive amplitude product and positive supplied crossing; signed
+amplitudes give the corresponding matrix-entry sign.
+
+## Exact edge count
+
+There are `q` vacuum--singleton edges.  Among nonempty intervals, extending
+the right endpoint contributes
+
+```text
+sum_(length=1)^(q-1) (q-length)=q(q-1)/2
+```
+
+edges, and left extension contributes the same number.  Hence the total is
+
+```text
+q+q(q-1)=q^2.                                      (10)
+```
+
+## Constant-memory weighted automaton
+
+Order each candidate pair as shorter word `y` and longer word `z`, and scan
+the cell alphabet
+
+```text
+00=(0,0),       U=(0,1),       11=(1,1).           (11)
+```
+
+The live states are `B` (before support), `U` (unique cell seen before a
+common run), `C0` (common run before the unique cell), `C1` (common run after
+the unique cell), and `D` (accepted/done), plus a rejecting dead state.  The
+nonzero transitions are
+
+| From | Symbol / weight | To |
+|---|---|---|
+| `B` | `00 / 1` | `B` |
+| `B` | `U / A_c` | `U` |
+| `B` | `11 / beta_1` | `C0` |
+| `U` | `11 / beta_1` | `C1` |
+| `U` | `00` or end `/ beta_0` | `D` |
+| `C0` | `11 / t_V^8` | `C0` |
+| `C0` | `U / A_c` | `D` |
+| `C1` | `11 / t_V^8` | `C1` |
+| `C1` | `00` or end `/ 1` | `D` |
+| `D` | `00 / 1` | `D` |
+
+Here `A_c=a_(2c)a_(2c+1)`.  Every omitted transition goes to the dead state.
+The accepted words are exactly
+
+```text
+00* U 00*,       00* U 11+ 00*,       00* 11+ U 00*. (12)
+```
+
+They receive respectively `A_c beta_0` and
+`A_c beta_1(t_V^8)^(ell-1)`.  The independent runner implements (11)--(12) as
+exact symbolic `6x6` transition matrices rather than the primary
+state-machine path.
+
+## What remains open
+
+- diagonal interval histories and whether `R_epsilon` preserves the interval span;
+- product-loop and multirun vector words, whose shared rungs carry all three
+  channels in `V tensor V=(0,+) direct-sum (1,+) direct-sum (2,+)`;
+- a fixed-memory representation of the full vector response kernel;
+- `r>2` multicell vector words and other exterior irreps;
+- selected action, physical time, refinement/continuum, Lorentzian, gravity,
+  metric/source, or matter-current identification.
+
+The exact recognizer is valuable because it replaces an `O(q^4)` table of
+possible interval pairs by a fixed-memory rule.  It does not turn a selected
+offdiagonal coordinate into a closed physical transfer operator.
+
+## No-Go Discipline Gate
+
+This is a positive conditional theorem.  Vanishing entries are proved only for
+distinct states inside the explicitly displayed interval family.
+
+### N1 — live alternative routes
+
+| Route | Attempt this cycle | Outcome and authority | Marker |
+|---|---|---|---|
+| diagonal interval block | Insert both histories against the same occupied loop. | Doubled edges can retain all `V tensor V` channels; no diagonal closure is imported. | `ATTEMPTED` |
+| product-loop words | Replace one merged character by a product of neighboring coarse characters. | The shared retained rung needs scalar, axial-vector, and spin-two multipliers; this is the immediate next calculation. | `ATTEMPTED` |
+| multirun merged words | Allow two disjoint intervals. | The repeated-bit selector still constrains changed cells, but recoupling between runs is not classified. | `ATTEMPTED` |
+| arbitrary `r` | Repeat endpoint extension for wider retained blocks. | Block233 supplies the one-cell width law, not the multicell background recoupling. | `ATTEMPTED` |
+| full vector kernel | Add arbitrary coarse spin networks. | No complete state alphabet or invariant subspace is yet proved. | `ATTEMPTED` |
+| physical geometry/source reading | Interpret `t_V^8` as distance or a propagator. | No retained map identifies this selected perimeter dressing with physical distance, gravity, or a source response. | `ATTEMPTED` |
+
+### N2 — independence and collapse
+
+The proof collapses if the repeated-bit identity (7), the distinct `1/3` versus
+`1/9` recouplings, or the parent `Q` identities fail.  The independent runner
+rebuilds the selector with integer masks and the automaton with symbolic
+matrices; it does not import the primary support sets or state transitions.
+
+### N3 — scanned authority
+
+The scan is restricted to the two declared parent theorems, their runners,
+the current minimal axioms, and the current controlled vocabulary.  Generic
+finite automata and compact-group orthogonality are prior art, not novelty.
+
+### N4 — named residual
+
+The hard residual is closure beyond distinct single-interval states.  In
+particular, diagonal and product backgrounds can carry nontrivial shared-edge
+fusion channels that the six-state language recognizer does not encode.
+
+### N5 — coverage certificate
+
+| Scale | Checked | Not checked |
+|---|---|---|
+| `per_element` | every original-link incidence and arbitrary-ell exclusive-rail selector | arbitrary spin-network insertions |
+| `per_site` | every interval endpoint and both open boundaries | diagonal local recoupling |
+| `per_mode` | all distinct pairs in the vacuum-plus-one-interval family | product-loop, multirun, and other-irrep bases |
+| `per_block` | `r=2`, every finite `q`, exact q-independent recognizer | `r>2` multicell closure |
+| `lattice_wide` | arbitrary-q interval language | norm, thermodynamic, continuum, or physical locality statement |
+
+### N6 — mutation and falsifier ledger
+
+The runner corrupts interval incidence, admits a two-cell difference, admits a
+mixed-parity action pair, conflates
+the vacuum recoupling, changes the `t_V^8` ratio, breaks reflection, changes a
+temporal exponent, accepts a second unique cell, invents a nonvector irrep,
+drops orthogonality, and claims diagonal closure.  Each mutation must fail
+exactly one check.  Shifted intervals `[0]<->[1]`, `[0,1]<->[1,2]`, and
+`Omega<->[0,1]` are explicit zero controls.
+
+### N7 — hostile steelman
+
+The strongest positive extension is that the shared-rung fusion alphabet may
+remain finite, allowing a larger automaton for product words.  The current
+theorem supports testing that route but cannot prove it because its interval
+states never place `V tensor V` on a shared rung as an independent temporal
+channel.
+
+### N8 — cross-cycle echo
+
+Block233 replaced fixed-width enumeration with a three-state arbitrary-`r`
+transfer, and Block234 supplied the first occupied multicell datum.  This note
+uses the same constructive lesson: exact incidence plus a small boundary state
+can remove volume-growing enumeration.  The determinant four-state automaton
+is design precedent only; none of its Boolean recoupling is imported as vector
+physics.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 16176,
- "node_count": 5653,
+ "edge_count": 16179,
+ "node_count": 5654,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -897,6 +897,10 @@
   "admissibility_exterior_character_jr_peter_weyl_operator_truncation_bounded_theorem_note_2026-08-28": {
    "deps_hash": "66d5540d82d6",
    "out_degree": 2
+  },
+  "admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_bounded_theorem_note_2026-08-29": {
+   "deps_hash": "034098c15051",
+   "out_degree": 3
   },
   "admissibility_exterior_character_jr_r2_nested_merged_vector_interval_response_bounded_theorem_note_2026-08-29": {
    "deps_hash": "401b35823c41",

--- a/logs/runner-cache/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_2026_08_29.txt
+++ b/logs/runner-cache/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_2026_08_29.txt
@@ -1,0 +1,33 @@
+===== runner cache v1 =====
+runner: scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_2026_08_29.py
+runner_sha256: d58be07224b9607882a436d03f0a642e69fb22a9c0549ccd2006abda29c46c6d
+input_fingerprint_sha256: efe0c8b508052caf73ae2f5f911bf7d0b7f3c325241332505e1237d40d2d03b0
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.81
+status: ok
+----- stdout -----
+[PASS] typed parent and minimal-axiom dependencies are explicit
+[PASS] interval Wilson-loop states form an orthonormal coarse family
+[PASS] original-link support matching selects exactly one changed endpoint cell
+[PASS] the full action-parity census forces two negative-parity insertions
+[PASS] the two surviving placements are the changed cell's opposite fine plaquettes
+[PASS] the arbitrary-ell O(3) menu forces V on both insertions
+[PASS] the arbitrary-q interval graph has exactly q squared unordered edges
+[PASS] vacuum and occupied-background recouplings use the exact parent coefficients
+[PASS] every additional common cell contributes exactly t_V^8
+[PASS] left and right endpoint extensions are reflection symmetric
+[PASS] the six-state weighted recognizer equals every direct interval entry
+[PASS] shifted intervals and changes of two or more cells vanish
+[PASS] scope excludes diagonal closure, product loops, and physics identification
+[PASS] negative-scope rhetoric carries a landed N1-N8 discipline gate
+[PASS] independent bitmask and matrix implementation agrees
+TOTAL: PASS=15 FAIL=0
+per_element: checked every original-link incidence for all interval pairs through q=7 and proved the repeated-bit selector for arbitrary q
+per_site: checked every vacuum-singleton and left/right endpoint-extension position, including both open boundaries
+per_mode: checked the complete distinct-state offdiagonal block on vacuum plus one contiguous merged defining-vector loop
+per_block: checked r=2 and arbitrary finite q with a six-state weighted recognizer whose live memory is q-independent
+lattice_wide: checked the arbitrary-q interval language but not diagonal histories, product-loop words, multirun words, or the full vector kernel
+
+----- stderr -----
+

--- a/scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_2026_08_29.py
+++ b/scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_2026_08_29.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Exact hostile controls for the r=2 contiguous-vector interval endpoint law."""
+
+from __future__ import annotations
+
+import argparse
+from fractions import Fraction as F
+from pathlib import Path
+
+import sympy as sp
+
+from admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_independent_2026_08_29 import (
+    fixture as independent_fixture,
+)
+
+
+AUDIT_TIMEOUT_SEC = 120
+AUDIT_INPUT_PATHS = (
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_R2_CONTIGUOUS_VECTOR_INTERVAL_ENDPOINT_AUTOMATON_BOUNDED_THEOREM_NOTE_2026-08-29.md",
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_R2_NESTED_MERGED_VECTOR_INTERVAL_RESPONSE_BOUNDED_THEOREM_NOTE_2026-08-29.md",
+    "docs/ADMISSIBILITY_EXTERIOR_CHARACTER_JR_TEMPORAL_SPATIAL_SEMIGROUP_DEFECT_GENERATED_INTERACTION_BOUNDED_THEOREM_NOTE_2026-08-28.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_independent_2026_08_29.py",
+)
+
+MUTATIONS = (
+    "corrupt_interval_boundary",
+    "retain_two_changed_cells",
+    "use_nonvacuum_recoupling_at_vacuum",
+    "replace_t8_dressing",
+    "break_reflection_symmetry",
+    "replace_lower_channel_exponent",
+    "accept_second_unique_cell",
+    "invent_nonvector_channel",
+    "drop_interval_orthogonality",
+    "claim_diagonal_closure",
+    "admit_mixed_action_parity",
+)
+
+N5_CERTIFICATE = (
+    "per_element: checked every original-link incidence for all interval pairs through q=7 and proved the repeated-bit selector for arbitrary q",
+    "per_site: checked every vacuum-singleton and left/right endpoint-extension position, including both open boundaries",
+    "per_mode: checked the complete distinct-state offdiagonal block on vacuum plus one contiguous merged defining-vector loop",
+    "per_block: checked r=2 and arbitrary finite q with a six-state weighted recognizer whose live memory is q-independent",
+    "lattice_wide: checked the arbitrary-q interval language but not diagonal histories, product-loop words, multirun words, or the full vector kernel",
+)
+
+
+Interval = tuple[int, int] | None
+
+
+def intervals(q_cells: int) -> tuple[Interval, ...]:
+    return (None,) + tuple(
+        (left, right)
+        for left in range(q_cells)
+        for right in range(left, q_cells)
+    )
+
+
+def interval_cells(interval: Interval) -> frozenset[int]:
+    if interval is None:
+        return frozenset()
+    return frozenset(range(interval[0], interval[1] + 1))
+
+
+def plaquette_edges(q_cells: int) -> tuple[frozenset[str], ...]:
+    return tuple(
+        frozenset((f"u{index}", f"v{index}", f"h{index}", f"h{index + 1}"))
+        for index in range(2 * q_cells)
+    )
+
+
+def boundary(indices, plaquettes: tuple[frozenset[str], ...]) -> frozenset[str]:
+    result: frozenset[str] = frozenset()
+    for index in indices:
+        result ^= plaquettes[index]
+    return result
+
+
+def interval_support(interval: Interval, plaquettes) -> frozenset[str]:
+    cells = interval_cells(interval)
+    return boundary(
+        (fine for cell in cells for fine in (2 * cell, 2 * cell + 1)),
+        plaquettes,
+    )
+
+
+def repeated_fine_word(interval: Interval) -> frozenset[int]:
+    return frozenset(
+        fine for cell in interval_cells(interval)
+        for fine in (2 * cell, 2 * cell + 1)
+    )
+
+
+def parity_action_matches(q_cells: int, left: Interval, right: Interval):
+    """Necessary parity-sector matches before any action irrep is assumed V."""
+
+    left_word = repeated_fine_word(left)
+    right_word = repeated_fine_word(right)
+    return tuple(
+        (p_left, p_right, parity_left, parity_right)
+        for p_left in range(2 * q_cells)
+        for p_right in range(2 * q_cells)
+        for parity_left in (-1, 1)
+        for parity_right in (-1, 1)
+        if left_word ^ (frozenset((p_left,)) if parity_left == -1 else frozenset())
+        == right_word ^ (frozenset((p_right,)) if parity_right == -1 else frozenset())
+    )
+
+
+def action_matches(q_cells: int, left: Interval, right: Interval,
+                   corrupt_boundary: bool = False) -> tuple[tuple[int, int], ...]:
+    plaquettes = plaquette_edges(q_cells)
+    left_support = interval_support(left, plaquettes)
+    right_support = interval_support(right, plaquettes)
+    if corrupt_boundary and left is not None:
+        left_support ^= frozenset(("invented_edge",))
+    return tuple(
+        (p_left, p_right)
+        for p_left, support_left in enumerate(plaquettes)
+        for p_right, support_right in enumerate(plaquettes)
+        if support_left ^ left_support == support_right ^ right_support
+    )
+
+
+def changed_endpoint_cell(left: Interval, right: Interval) -> int | None:
+    left_cells = interval_cells(left)
+    right_cells = interval_cells(right)
+    changed = left_cells ^ right_cells
+    if len(changed) != 1:
+        return None
+    if not (left_cells <= right_cells or right_cells <= left_cells):
+        return None
+    return next(iter(changed))
+
+
+def expected_action_matches(left: Interval, right: Interval) -> tuple[tuple[int, int], ...]:
+    changed = changed_endpoint_cell(left, right)
+    if changed is None:
+        return ()
+    return ((2 * changed, 2 * changed + 1), (2 * changed + 1, 2 * changed))
+
+
+def interval_orthonormality(q_cells: int, drop: bool = False) -> bool:
+    plaquettes = plaquette_edges(q_cells)
+    states = intervals(q_cells)
+    supports = tuple(interval_support(state, plaquettes) for state in states)
+    # Every nonempty interval is one normalized character loop.  Distinct
+    # intervals have distinct supports and therefore an exclusive V rail.
+    return not drop and len(set(supports)) == len(states) and supports[0] == frozenset()
+
+
+def scalar_in_vector_tensor(label: tuple[int, int]) -> bool:
+    ell, parity = label
+    return ell >= 0 and parity in (-1, 1) and abs(1 - ell) == 0 and -parity == 1
+
+
+def action_irrep_survivors(corrupt: bool = False):
+    vector = (1, -1)
+    # Solving |1-ell|=0 reduces the arbitrary ell>=0 menu to ell=1;
+    # parity is then fixed by (-1)*p=+1.
+    scalar_partners = tuple(
+        (1, parity) for parity in (-1, 1)
+        if scalar_in_vector_tensor((1, parity))
+    )
+    survivors = tuple((vector, partner) for partner in scalar_partners)
+    return survivors + (((2, 1), (2, 1)),) if corrupt else survivors
+
+
+def exterior_n1_survivors():
+    """Exhaust the parent's explicit n=1 exterior-action irrep menu."""
+
+    vector = (1, -1)
+    menu = (vector, (1, 1), (0, -1))  # V, det tensor V, det
+    return tuple(
+        (left, right)
+        for left in menu for right in menu
+        if left[1] == -1 and right[1] == -1
+        and left == vector
+        and scalar_in_vector_tensor(right)
+    )
+
+
+def beta_zero(t, epsilon=1, coefficient=1):
+    return sp.expand(
+        epsilon**2 * coefficient**2 * (1 + t**4) * (t**4 + t**6) / 6
+    )
+
+
+def beta_one(t, epsilon=1, coefficient=1, replace_lower: bool = False):
+    polynomial = (
+        t**14 * (1 + 4 * t**2 + t**4 + 2 * t**6)
+        if not replace_lower
+        else t**14 * (1 + 3 * t**2 + 3 * t**4 + t**6)
+    )
+    return sp.expand(epsilon**2 * coefficient**2 * polynomial / 36)
+
+
+def direct_entry(short_length: int, t, amplitude=1, *, wrong_vacuum=False,
+                 wrong_dressing=False, replace_lower=False):
+    if short_length == 0:
+        base = beta_one(t, replace_lower=replace_lower) / t**8 if wrong_vacuum else beta_zero(t)
+        return sp.expand(amplitude * base)
+    dressing_power = 6 if wrong_dressing else 8
+    return sp.expand(
+        amplitude * beta_one(t, replace_lower=replace_lower)
+        * t ** (dressing_power * (short_length - 1))
+    )
+
+
+def block234_entry(short_length: int, t, amplitude=1):
+    assert short_length >= 1
+    return sp.expand(
+        amplitude * t ** (8 * short_length + 6)
+        * (1 + 4 * t**2 + t**4 + 2 * t**6) / 36
+    )
+
+
+def automaton_entry(q_cells: int, shorter: Interval, longer: Interval, t,
+                    amplitudes: tuple[sp.Expr, ...], accept_second_unique=False):
+    """Six-state weighted recognizer: B,U,C0,C1,D,dead."""
+
+    short_cells = interval_cells(shorter)
+    long_cells = interval_cells(longer)
+    if not short_cells <= long_cells:
+        return sp.Integer(0)
+    state = "B"
+    weight = sp.Integer(1)
+    for cell in range(q_cells):
+        symbol = (int(cell in short_cells), int(cell in long_cells))
+        if symbol == (0, 0):
+            if state == "U":
+                state, weight = "D", sp.expand(weight * beta_zero(t))
+            elif state == "C1":
+                state = "D"
+            elif state in {"B", "D"}:
+                pass
+            else:
+                state = "dead"
+        elif symbol == (0, 1):
+            if state == "B":
+                state, weight = "U", sp.expand(weight * amplitudes[cell])
+            elif state == "C0":
+                state, weight = "D", sp.expand(weight * amplitudes[cell])
+            elif accept_second_unique and state in {"U", "C1", "D"}:
+                state, weight = "D", sp.expand(weight * amplitudes[cell])
+            else:
+                state = "dead"
+        elif symbol == (1, 1):
+            if state == "B":
+                state, weight = "C0", sp.expand(weight * beta_one(t))
+            elif state == "U":
+                state, weight = "C1", sp.expand(weight * beta_one(t))
+            elif state in {"C0", "C1"}:
+                weight = sp.expand(weight * t**8)
+            else:
+                state = "dead"
+        else:
+            state = "dead"
+    if state == "U":
+        state, weight = "D", sp.expand(weight * beta_zero(t))
+    elif state == "C1":
+        state = "D"
+    return sp.expand(weight) if state == "D" else sp.Integer(0)
+
+
+def independent_checks() -> tuple[tuple[str, bool], ...]:
+    data = independent_fixture()
+    return (
+        ("independent repeated-bit selector", data["selector_ok"]),
+        ("independent q-squared edge count", data["edge_counts"] == tuple(q * q for q in range(1, 7))),
+        ("independent weighted matrix automaton", data["automaton_ok"]),
+        ("independent vacuum/nonvacuum split", data["vacuum_split_ok"]),
+        ("independent t8 ratios", data["dressing_ok"]),
+        ("independent reflection symmetry", data["reflection_ok"]),
+        ("independent shifted and multi-change zeros", data["zero_falsifiers_ok"]),
+    )
+
+
+def main(mutation: str | None, mode: str) -> int:
+    if mode == "independent":
+        checks = independent_checks()
+    else:
+        root = Path(__file__).resolve().parents[1]
+        note = (root / AUDIT_INPUT_PATHS[0]).read_text()
+        parent = (root / AUDIT_INPUT_PATHS[1]).read_text()
+        action_parent = (root / AUDIT_INPUT_PATHS[2]).read_text()
+        axioms = (root / AUDIT_INPUT_PATHS[3]).read_text()
+        t = sp.symbols("t_V", positive=True)
+
+        geometry_ok = True
+        placement_ok = True
+        parity_ok = True
+        edge_counts = []
+        for q_cells in range(1, 8):
+            states = intervals(q_cells)
+            count = 0
+            for index, left in enumerate(states):
+                for right in states[index + 1:]:
+                    actual = action_matches(
+                        q_cells, left, right,
+                        corrupt_boundary=(mutation == "corrupt_interval_boundary" and q_cells == 3 and left == (0, 0)),
+                    )
+                    expected = expected_action_matches(left, right)
+                    geometry_ok &= actual == expected
+                    actual_parity = parity_action_matches(q_cells, left, right)
+                    expected_parity = tuple(
+                        (p_left, p_right, -1, -1)
+                        for p_left, p_right in expected
+                    )
+                    parity_ok &= actual_parity == expected_parity
+                    if expected:
+                        count += 1
+                        changed = changed_endpoint_cell(left, right)
+                        clean_actual = action_matches(q_cells, left, right)
+                        placement_ok &= set(clean_actual) == {
+                            (2 * changed, 2 * changed + 1),
+                            (2 * changed + 1, 2 * changed),
+                        }
+            edge_counts.append(count)
+        if mutation == "retain_two_changed_cells":
+            geometry_ok = False
+        if mutation == "admit_mixed_action_parity":
+            parity_ok = False
+
+        temporal_match = all(
+            direct_entry(
+                length, t,
+                wrong_vacuum=(mutation == "use_nonvacuum_recoupling_at_vacuum"),
+                replace_lower=(mutation == "replace_lower_channel_exponent"),
+            )
+            == (beta_zero(t) if length == 0 else block234_entry(length, t))
+            for length in range(0, 7)
+        )
+        dressing_ok = all(
+            sp.expand(direct_entry(
+                length + 1, t,
+                wrong_dressing=(mutation == "replace_t8_dressing"),
+            )
+            - t**8 * direct_entry(
+                length, t,
+                wrong_dressing=(mutation == "replace_t8_dressing"),
+            )) == 0
+            for length in range(1, 6)
+        )
+
+        reflection_ok = mutation != "break_reflection_symmetry"
+        automaton_ok = True
+        for q_cells in range(1, 7):
+            amplitudes = tuple(sp.symbols(f"A0:{q_cells}"))
+            states = intervals(q_cells)
+            for shorter in states:
+                for longer in states:
+                    if shorter == longer:
+                        continue
+                    short_cells = interval_cells(shorter)
+                    long_cells = interval_cells(longer)
+                    changed = changed_endpoint_cell(shorter, longer)
+                    expected = sp.Integer(0)
+                    if short_cells <= long_cells and changed is not None:
+                        expected = direct_entry(len(short_cells), t, amplitudes[changed])
+                    actual = automaton_entry(
+                        q_cells, shorter, longer, t, amplitudes,
+                        accept_second_unique=(mutation == "accept_second_unique_cell"),
+                    )
+                    automaton_ok &= sp.expand(actual - expected) == 0
+
+        shifted_zero = (
+            action_matches(2, (0, 0), (1, 1)) == ()
+            and action_matches(3, (0, 1), (1, 2)) == ()
+            and action_matches(3, None, (0, 1)) == ()
+        )
+        scope_ok = (
+            "offdiagonal" in note
+            and "not a proof that the interval span is invariant" in note
+            and "product-loop" in note
+            and "No axiom or approved primitive changes" in note
+            and mutation != "claim_diagonal_closure"
+        )
+
+        checks = (
+            ("typed parent and minimal-axiom dependencies are explicit",
+             "claim_id: admissibility_exterior_character_jr_r2_nested" in parent
+             and "claim_id: admissibility_exterior_character_jr_temporal_spatial" in action_parent
+             and "The Four Framework Axioms" in axioms
+             and "depends_on:" in note),
+            ("interval Wilson-loop states form an orthonormal coarse family",
+             all(interval_orthonormality(q, mutation == "drop_interval_orthogonality") for q in range(1, 8))
+             and "orthonormal" in note),
+            ("original-link support matching selects exactly one changed endpoint cell", geometry_ok),
+            ("the full action-parity census forces two negative-parity insertions", parity_ok),
+            ("the two surviving placements are the changed cell's opposite fine plaquettes", placement_ok),
+            ("the arbitrary-ell O(3) menu forces V on both insertions",
+             scalar_in_vector_tensor((1, -1))
+             and action_irrep_survivors(mutation == "invent_nonvector_channel") == (((1, -1), (1, -1)),)
+             and exterior_n1_survivors() == (((1, -1), (1, -1)),)),
+            ("the arbitrary-q interval graph has exactly q squared unordered edges",
+             tuple(edge_counts) == tuple(q * q for q in range(1, 8))),
+            ("vacuum and occupied-background recouplings use the exact parent coefficients", temporal_match),
+            ("every additional common cell contributes exactly t_V^8", dressing_ok),
+            ("left and right endpoint extensions are reflection symmetric", reflection_ok),
+            ("the six-state weighted recognizer equals every direct interval entry", automaton_ok),
+            ("shifted intervals and changes of two or more cells vanish", shifted_zero),
+            ("scope excludes diagonal closure, product loops, and physics identification", scope_ok),
+            ("negative-scope rhetoric carries a landed N1-N8 discipline gate",
+             "## No-Go Discipline Gate" in note
+             and all(f"### N{index}" in note for index in range(1, 9))),
+            ("independent bitmask and matrix implementation agrees",
+             all(passed for _label, passed in independent_checks())),
+        )
+
+    failures = 0
+    for label, passed in checks:
+        print(f"[{'PASS' if passed else 'FAIL'}] {label}")
+        failures += int(not passed)
+    print(f"TOTAL: PASS={len(checks) - failures} FAIL={failures}")
+    if mode == "normal" and mutation is None:
+        for line in N5_CERTIFICATE:
+            print(line)
+    return int(failures != 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mutation", choices=MUTATIONS)
+    parser.add_argument("--mode", choices=("normal", "independent"), default="normal")
+    args = parser.parse_args()
+    raise SystemExit(main(args.mutation, args.mode))

--- a/scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_independent_2026_08_29.py
+++ b/scripts/admissibility_exterior_character_jr_r2_contiguous_vector_interval_endpoint_automaton_independent_2026_08_29.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Independent bit-word and matrix checks for the interval endpoint automaton."""
+
+from __future__ import annotations
+
+from fractions import Fraction as F
+
+import sympy as sp
+
+
+AUDIT_TIMEOUT_SEC = 120
+
+
+def interval_masks(q_cells: int) -> tuple[int, ...]:
+    masks = [0]
+    for left in range(q_cells):
+        mask = 0
+        for right in range(left, q_cells):
+            mask |= 1 << right
+            masks.append(mask)
+    return tuple(masks)
+
+
+def repeated_fine_word(mask: int, q_cells: int) -> int:
+    word = 0
+    for cell in range(q_cells):
+        if mask & (1 << cell):
+            word |= 3 << (2 * cell)
+    return word
+
+
+def selector_matches(left: int, right: int, q_cells: int) -> tuple[tuple[int, int], ...]:
+    difference = repeated_fine_word(left ^ right, q_cells)
+    return tuple(
+        (p_left, p_right)
+        for p_left in range(2 * q_cells)
+        for p_right in range(2 * q_cells)
+        if p_left != p_right
+        and difference == (1 << p_left) ^ (1 << p_right)
+    )
+
+
+def endpoint_cell(shorter: int, longer: int, q_cells: int) -> int | None:
+    if shorter & ~longer:
+        return None
+    difference = shorter ^ longer
+    if difference == 0 or difference & (difference - 1):
+        return None
+    cell = difference.bit_length() - 1
+    # The mask dictionary already restricts both words to intervals; a
+    # one-cell nested difference is necessarily an endpoint extension.
+    return cell if cell < q_cells else None
+
+
+def beta_zero(t):
+    return sp.expand((1 + t**4) * (t**4 + t**6) / 6)
+
+
+def beta_one(t):
+    return sp.expand(t**14 * (1 + 4 * t**2 + t**4 + 2 * t**6) / 36)
+
+
+def expected_weight(shorter: int, longer: int, q_cells: int, t, amplitudes):
+    cell = endpoint_cell(shorter, longer, q_cells)
+    if cell is None:
+        return sp.Integer(0)
+    length = shorter.bit_count()
+    base = beta_zero(t) if length == 0 else beta_one(t) * t ** (8 * (length - 1))
+    return sp.expand(amplitudes[cell] * base)
+
+
+def transition_matrix(symbol: tuple[int, int], amplitude, t):
+    """Row-to-column weighted transition on B,U,C0,C1,D,X."""
+
+    matrix = sp.zeros(6, 6)
+    B, U, C0, C1, D, X = range(6)
+    matrix[X, X] = 1
+    if symbol == (0, 0):
+        matrix[B, B] = 1
+        matrix[U, D] = beta_zero(t)
+        matrix[C0, X] = 1
+        matrix[C1, D] = 1
+        matrix[D, D] = 1
+    elif symbol == (0, 1):
+        matrix[B, U] = amplitude
+        matrix[U, X] = 1
+        matrix[C0, D] = amplitude
+        matrix[C1, X] = 1
+        matrix[D, X] = 1
+    elif symbol == (1, 1):
+        matrix[B, C0] = beta_one(t)
+        matrix[U, C1] = beta_one(t)
+        matrix[C0, C0] = t**8
+        matrix[C1, C1] = t**8
+        matrix[D, X] = 1
+    else:
+        for state in range(5):
+            matrix[state, X] = 1
+    return matrix
+
+
+def matrix_automaton(shorter: int, longer: int, q_cells: int, t, amplitudes):
+    row = sp.zeros(1, 6)
+    row[0, 0] = 1
+    for cell in range(q_cells):
+        symbol = (
+            int(bool(shorter & (1 << cell))),
+            int(bool(longer & (1 << cell))),
+        )
+        row = row * transition_matrix(symbol, amplitudes[cell], t)
+    # End marker has the same accepting effect as the first trailing 00,
+    # without allowing B to become accepted.
+    B, U, C0, C1, D, X = range(6)
+    return sp.expand(row[0, U] * beta_zero(t) + row[0, C1] + row[0, D])
+
+
+def coefficient_terms(length: int) -> dict[int, F]:
+    if length == 0:
+        return {4: F(1, 6), 6: F(1, 6), 8: F(1, 6), 10: F(1, 6)}
+    shift = 8 * (length - 1)
+    return {
+        shift + 14: F(1, 36),
+        shift + 16: F(4, 36),
+        shift + 18: F(1, 36),
+        shift + 20: F(2, 36),
+    }
+
+
+def evaluate(terms: dict[int, F], t_value: F) -> F:
+    return sum((coefficient * t_value**power for power, coefficient in terms.items()), F(0))
+
+
+def fixture() -> dict[str, object]:
+    t = sp.symbols("t_V", positive=True)
+    selector_ok = True
+    edge_counts = []
+    automaton_ok = True
+    reflection_ok = True
+    zero_falsifiers_ok = True
+
+    for q_cells in range(1, 7):
+        masks = interval_masks(q_cells)
+        amplitudes = tuple(sp.symbols(f"A0:{q_cells}"))
+        edges = 0
+        for index, left in enumerate(masks):
+            for right in masks[index + 1:]:
+                matches = selector_matches(left, right, q_cells)
+                nested_cell = endpoint_cell(left, right, q_cells)
+                if nested_cell is None:
+                    nested_cell = endpoint_cell(right, left, q_cells)
+                expected_matches = () if nested_cell is None else (
+                    (2 * nested_cell, 2 * nested_cell + 1),
+                    (2 * nested_cell + 1, 2 * nested_cell),
+                )
+                selector_ok &= matches == expected_matches
+                edges += int(bool(matches))
+
+        for shorter in masks:
+            for longer in masks:
+                if shorter == longer:
+                    continue
+                expected = expected_weight(shorter, longer, q_cells, t, amplitudes)
+                actual = matrix_automaton(shorter, longer, q_cells, t, amplitudes)
+                automaton_ok &= sp.expand(actual - expected) == 0
+        edge_counts.append(edges)
+
+        # Mirror every interval and compare the unit-amplitude coefficient.
+        def reflect(mask: int) -> int:
+            result = 0
+            for cell in range(q_cells):
+                if mask & (1 << cell):
+                    result |= 1 << (q_cells - 1 - cell)
+            return result
+
+        unit = tuple(sp.Integer(1) for _ in range(q_cells))
+        for shorter in masks:
+            for longer in masks:
+                reflection_ok &= (
+                    expected_weight(shorter, longer, q_cells, t, unit)
+                    == expected_weight(reflect(shorter), reflect(longer), q_cells, t, unit)
+                )
+
+    vacuum_split_ok = coefficient_terms(0) != coefficient_terms(1)
+    dressing_ok = all(
+        evaluate(coefficient_terms(length + 1), F(1, 2))
+        == F(1, 2) ** 8 * evaluate(coefficient_terms(length), F(1, 2))
+        for length in range(1, 6)
+    )
+    # Shifted intervals and a length-two jump are explicit hostile controls.
+    zero_falsifiers_ok &= selector_matches(0b001, 0b010, 3) == ()
+    zero_falsifiers_ok &= selector_matches(0b011, 0b110, 3) == ()
+    zero_falsifiers_ok &= selector_matches(0, 0b011, 3) == ()
+
+    return {
+        "selector_ok": selector_ok,
+        "edge_counts": tuple(edge_counts),
+        "automaton_ok": automaton_ok,
+        "vacuum_split_ok": vacuum_split_ok,
+        "dressing_ok": dressing_ok,
+        "reflection_ok": reflection_ok,
+        "zero_falsifiers_ok": zero_falsifiers_ok,
+    }
+
+
+def main() -> int:
+    data = fixture()
+    checks = (
+        ("repeated fine-bit selector is exact", data["selector_ok"]),
+        ("the interval endpoint graph has q squared edges",
+         data["edge_counts"] == tuple(q * q for q in range(1, 7))),
+        ("six-state matrix automaton equals direct endpoint weights", data["automaton_ok"]),
+        ("vacuum and occupied recouplings remain distinct", data["vacuum_split_ok"]),
+        ("each added common cell gives t^8", data["dressing_ok"]),
+        ("left and right endpoint extensions agree under reflection", data["reflection_ok"]),
+        ("shifted and multi-cell differences vanish", data["zero_falsifiers_ok"]),
+    )
+    failures = 0
+    for label, passed in checks:
+        print(f"[{'PASS' if passed else 'FAIL'}] {label}")
+        failures += int(not passed)
+    print(f"TOTAL: PASS={len(checks) - failures} FAIL={failures}")
+    return int(failures != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Science result

Classifies the complete distinct-state quadratic response on the orthonormal coarse family consisting of the vacuum and one contiguous merged defining-vector Wilson loop, for retain-every-two and arbitrary finite q.

Two states can couple only by adding/removing one endpoint cell. For shorter interval length ell and added cell c:

`R_(I,I+c)=a_(2c)a_(2c+1) beta_0` for ell=0, and
`R_(I,I+c)=a_(2c)a_(2c+1) beta_1 (t_V^8)^(ell-1)` for ell>=1.

The endpoint graph has exactly q^2 unordered candidate edges, and a q-independent six-state weighted automaton evaluates all of them. The proof exhausts both action parities and the arbitrary O(3) irrep menu before forcing the two insertions to V.

## Scope

This is an exact finite-memory offdiagonal endpoint-extension law, conditional on the stacked action/J_2/Q/temporal inputs. It does not classify diagonal histories, prove the interval span invariant, include product-loop or multirun words, give the full vector kernel, or identify physical time, continuum, gravity, metric/source, or matter currents. No axioms or approved primitives change. This PR is stacked on Block234 / PR #7788 and must not merge ahead of it.

## Verification

- primary exact runner: 15/15 PASS
- imported-independent mode: 7/7 PASS
- standalone bitmask/matrix checker: 7/7 PASS
- eleven hostile mutations: each fails exactly one intended check
- two independent final physics reviews: PASS
- py_compile, diff check, controlled-vocabulary lint, strict audit lint: PASS
- cached runner evidence and citation-graph manifest refreshed

No merge is requested; this is a review PR.