### PR TITLE
feat(record): Lüders on the one-site record cell under the grading; permanence is occupation conservation

### DIFF
--- a/docs/LUEDERS_ON_THE_ONE_SITE_RECORD_CELL_BOUNDED_THEOREM_NOTE_2026-09-01.md
+++ b/docs/LUEDERS_ON_THE_ONE_SITE_RECORD_CELL_BOUNDED_THEOREM_NOTE_2026-09-01.md
@@ -1,0 +1,280 @@
+---
+claim_id: lueders_on_the_one_site_record_cell_bounded_theorem_note_2026-09-01
+claim_type: bounded_theorem
+claim_scope: "Under a declared grading hypothesis whose operational half reads outcome operations on a recorded site as parity-even CP maps, the effect of a rank-one locked output on a one-site record cell is that output itself. For a rank-one output P = |p><p| any CP outcome operation with range in P has Kraus operators K = |p><v|, four free real parameters at one site, and effect E_P = sum_j |v_j><v_j|; imposing s3 K s3 = K at the even output P = n forces v0 = 0, leaving two free real parameters, so K_j = c_j n and E_P = (sum_j |c_j|^2) n = lambda P, and symmetrically v1 = 0 at P = 1-n; the completeness equation lambda_1 n + lambda_0 (1-n) = 1 has the unique solution lambda_1 = lambda_0 = 1, so E_P = P at both outputs, which is the Lueders form. The evenness is load-bearing: the odd instrument K_1 = |1><0|, K_0 = |0><1| is a complete instrument on the same two outputs with E_P = 1 - P at each. The conclusion is bounded to one site: on the two-mode cell C^2 (x) K with K = C^2 and output P = |11><11| the even Kraus operators with range in P are |11><v| with <v| in the two-dimensional parity sector span{|00>, |11>}, four free real parameters, so E_P ranges over a real-four-dimensional set of effects, and two complete even instruments with the same output carry E_P = P and E_P = |00><00|. For permanence, the Hermitian solutions of [H, n (x) 1] = 0 are exactly (1-n) (x) B(K) (+) n (x) B(K), of real dimension 8 for dim K = 2 and 18 for dim K = 3, strictly containing 1 (x) B(K) of real dimension 4 and 9; the Jordan-Wigner hopping c_x^dag c_y + h.c. is Hermitian and parity-even yet does not commute with n_x, while n_x, n_x n_y and n (x) A for Hermitian A do. The recordable rank-one frames n and 1-n have rank 2 and span the two-dimensional even algebra, not M_2(C) of rank 4. The grading hypothesis is declared by this note and consumed from no row. No axiom is amended and no status is set."
+upstream_dependencies: []
+runner: scripts/lueders_one_site_record_cell_check_2026_09_01.py
+---
+
+# Lüders on the one-site record cell under the grading; permanence is occupation conservation
+
+**Date:** 2026-09-01
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/lueders_one_site_record_cell_check_2026_09_01.py`](../scripts/lueders_one_site_record_cell_check_2026_09_01.py)
+**Runner cache:**
+[`logs/runner-cache/lueders_one_site_record_cell_check_2026_09_01.txt`](../logs/runner-cache/lueders_one_site_record_cell_check_2026_09_01.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-dimensional theorem on a one-site record cell and on a one-site-plus-one-mode cell: the forced effect of a rank-one locked output under the grading, its failure on the larger cell, and the commutant classification behind permanence."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-dimensional theorem and route the declared grading hypothesis, in particular its operational half, to the owner as a science-level decision."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+One site carries `M_2(C)`; the enlarged cell carries `M_2(C) (x) B(K)` with `K = C^2` or `K = C^3`, and the two-mode cell carries `M_4(C)` in the basis `|00>, |01>,
+|10>, |11>`. The target is the conjunction of the two statements below, which are exactly the two check groups `A` and `B` of the primary runner, seven checks and
+six checks respectively.
+
+1. `T1` (`A`). Under the declared hypothesis, an outcome operation on the one-site record cell with a rank-one locked even output has effect equal to that output:
+   `E_P = P`, the Lüders form. The evenness is load-bearing, since a complete odd instrument on the same two outputs has `E_P = 1 - P`, and the conclusion is
+   bounded to one site, since on the two-mode cell two complete even instruments with the same rank-one output carry different effects.
+2. `T2` (`B`). Under the declared hypothesis, permanence of a record at site `x` is conservation of that site's occupation: the Hermitian solutions of `[H, n_x] =
+   0` are the commutant `(1-n) (x) B(K) (+) n (x) B(K)`, strictly larger than `1 (x) B(K)`; hopping off the recorded site is excluded while phase, density-density
+   and record-conditioned action on `K` survive; and the spanning condition that would give the narrower obstruction is false on the even sector.
+
+## Declared hypothesis
+
+The following is a hypothesis declared by this note. It is not axiom content, it is consumed from no row, and it carries no dependency weight.
+
+```text
+Grading hypothesis (declared): the site algebra M_2(C) carries the parity grading Ad(s3)
+(even = span{E00, E11}, odd = span{E01, E10}); distinct sites compose by the graded
+product; a state is readable only through its parity-even content; and, operationally,
+an outcome operation on a recorded site is a CP map whose Kraus operators are
+parity-even, that is block-diagonal for the grading.
+```
+
+The first three clauses mirror a candidate clause recorded elsewhere as a science-level decision awaiting its owner, plain-text pointer with no grade and no weight:
+`MATTER_GRADED_COMPOSITION_AXIOM_UPDATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-09-01.md`, "no grade, no weight". The fourth clause, the operational reading, is declared
+here in the same way and is the clause that does the work in Theorem 1; it is a hypothesis about which operations are physically available, not a theorem of this
+note. Nothing here amends, extends, or reinterprets an axiom, and nothing here sets a status of any kind. Every theorem below is conditional on the displayed
+hypothesis; read without it, the theorems are statements about the commutant of `s3`, the commutant of `s3 (x) s3`, and the commutant of `n (x) 1`, which is what
+the runner actually computes.
+
+## Context re-declared, not imported
+
+A companion note, plain file name with no grade and no dependency weight,
+`RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md`, proves for a rank-one locked output `P =
+|p><p|` that any CP outcome operation with range in `P` has Kraus operators `K_j = |p><v_j|`, hence `J_P(rho) = Tr(E_P rho) P` with `E_P = sum_j |v_j><v_j|`; states
+that it does not derive `E_P = P`, the Lüders and Born special case needing a separate effect-selection theorem; and derives, under a supplied condition that the
+recordable rank-one frames span `M_2(C)`, a permanence obstruction `H in 1_x (x) B(K)`. This note re-declares that normal form and recomputes it in check `A1a`
+rather than citing it, cites no grade of that note or of any other, and gives the effect-selection theorem the grading hypothesis makes available on the one-site
+cell.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. Kraus decompositions of CP maps, instruments as effect-resolving families, and commutants of projections in finite
+dimension are standard methodology; every object is redeclared here and every statement is recomputed in full by the primary runner. No observational value, no
+fitted number, and no framework premise enters any proof. Non-load-bearing context pointers, plain file names with no grade and no dependency weight:
+
+- `RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md` (whose normal form and whose open
+  effect-selection question this note recomputes and addresses).
+- `MATTER_GRADED_COMPOSITION_AXIOM_UPDATE_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-09-01.md` (whose clause the first three lines of the hypothesis mirror).
+
+This note re-declares everything it uses and cites none of their grades.
+
+## Obligation graph
+
+The proof is acyclic. Each node after `P0` is checked by the correspondingly lettered runner group.
+
+1. `P0` (declared here): the Pauli matrices, the matrix units of `M_2(C)`, `n = E11`, the lowering operator `c = E01`, the grading `Ad(s3)`, the Kraus form of an
+   outcome operation and of an instrument, the two-mode basis, the total parity `s3 (x) s3`, and the Jordan-Wigner pair.
+2. `P1` (`A`): the rank-one normal form, the evenness constraint, the forced effect `lambda P`, the completeness solve, the odd counter-instrument, and the two-mode
+   caveat.
+3. `P2` (`B`): the commutant of `n (x) 1` at `dim K = 2` and `dim K = 3`, the commutant of `M_2(C) (x) 1`, the hopping exclusion, the surviving terms, and the rank
+   of the recordable frames.
+
+The strongest supported scope is precisely `P0`--`P2`.
+
+## Definitions
+
+Write `one` for the `2 x 2` identity, `s1, s2, s3` for the Pauli matrices, and `E00, E01, E10, E11` for the matrix units of `M_2(C)`, with `E01 = |0><1|` and `n =
+E11 = |1><1|`. The **lowering operator** is `c = E01`, so that `c^dagger c = n` and `s3 = 1 - 2n`. The **parity grading** of the site algebra is `Ad(s3)`, whose
+`+1` eigenspace is `span{E00, E11}` and whose `-1` eigenspace is `span{E01, E10}`; an operator `K` is **even** when `s3 K s3 = K` and **odd** when `s3 K s3 = -K`.
+An **outcome operation** is a CP map in Kraus form `J(rho) = sum_j K_j rho K_j^dagger`; it has **range in the output** `P` when `P K_j = K_j` for every `j`, and its
+**effect** is `E = sum_j K_j^dagger K_j`. An **instrument** is a finite family of outcome operations whose effects sum to the unit. A **locked rank-one output** is
+`P = |p><p|`. The **Lüders form** at an output `P` is `E_P = P`.
+
+The **enlarged cell** is `C^2 (x) K` with the record site first and `K = C^2` or `K = C^3`, carrying `n_x = n (x) 1`. The **two-mode cell** is the case `K = C^2`
+read as a second fermionic mode, with basis `|00>, |01>, |10>, |11>`, **total parity** `s3 (x) s3` whose `+1` eigenspace is `span{|00>, |11>}` and whose `-1`
+eigenspace is `span{|01>, |10>}`, and the **Jordan-Wigner pair**
+
+```text
+c_x = c (x) one,   c_y = s3 (x) c,   n_x = c_x^dagger c_x = n (x) one,   n_y = c_y^dagger c_y = one (x) n.
+```
+
+The **hopping** term is `c_x^dagger c_y + c_y^dagger c_x`. Real dimensions of spaces of Hermitian matrices are counted as real dimensions throughout; `B(K)` denotes
+all operators on `K`, and `1 (x) B(K)` its image acting trivially on the record site.
+
+## Theorem 1 — on the one-site record cell the even instrument is the Lüders instrument
+
+**Conclusion.** Under the declared hypothesis: (1) for the rank-one locked output `P = |1><1| = n`, range in `P` alone forces `K = |1><v|` with `<v| = (K_10,
+K_11)`, four free real parameters, effect `E = K^dagger K = |v><v|`, and `K rho K^dagger = Tr(E rho) P` for every Hermitian `rho`, which is the normal form
+re-declared above; (2) adding evenness `s3 K s3 = K` forces `v_0 = 0`, leaving two free real parameters, so `K = c n` and, for any family `K_j = c_j n`,
+
+```text
+E_P = (sum_j |c_j|^2) n = lambda P,    lambda = sum_j |c_j|^2 >= 0,
+```
+
+`lambda` being a sum of squares of real parameters; (3) symmetrically, at the even output `P = 1-n` evenness forces `v_1 = 0`, `K = c (1-n)` and `E_P = |c|^2 (1-n)
+= lambda P`; (4) for the exhaustive even instrument with the two outputs `P_1 = n` and `P_0 = 1-n` the completeness equation `lambda_1 n + lambda_0 (1-n) = 1` has
+the unique solution `lambda_1 = lambda_0 = 1`, hence `E_P = P` at both outputs, which is the Lüders form; (5) the evenness is load-bearing, since the odd instrument
+`K_1 = |1><0| = c^dagger` at output `P_1 = n` and `K_0 = |0><1| = c` at output `P_0 = 1-n` has ranges in its outputs and effects summing to `1`, but satisfies `s3 K
+s3 = -K` and carries `E_{P_1} = 1-n` and `E_{P_0} = n`, that is `E_P = 1 - P` at both outputs; (6) the conclusion is bounded to one site: on the two-mode cell with
+output `P = |11><11|` the even Kraus operators with range in `P` are exactly `|11><v|` with `<v|` supported on the `+1` parity sector `span{|00>, |11>}` of
+dimension `2`, four free real parameters, so `E_P` is supported on that sector and ranges over the whole real-four-dimensional space of Hermitian operators there,
+exhibited by four such effects of real rank `4`; and (7) two complete even instruments on that cell, one with outcome Kraus operator `|11><11|` and one with outcome
+Kraus operator `|11><00|`, share the output `P = |11><11|` and carry the different effects `E_P = P` and `E_P = |00><00|`.
+
+**Proof.** Item 1 solves `P K = K` for a symbolic complex `2 x 2` matrix in independent real parameters: the first row vanishes, the second is `<v|`, and `K =
+|1><v|`, `K^dagger K = |v><v|` and `K rho K^dagger = Tr(E rho) P` are then exact identities on a symbolic Hermitian `rho`. Item 2 adds the linear system `s3 K s3 =
+K` to that solve; the joint solution sets `K_10 = 0`, that is `v_0 = 0`, so `K` is a complex multiple of `n`, and the effect of a family is computed symbolically.
+Item 3 is the same solve at the complementary output. Item 4 solves the two-unknown linear system supplied by items 2 and 3 together with completeness; the solution
+is unique and gives `E_{P_1} = n = P_1` and `E_{P_0} = 1-n = P_0`. Item 5 is a direct computation on the two exhibited Kraus operators, including their oddness and
+the completeness of the pair. Items 6 and 7 solve `P K = K` together with `(s3 (x) s3) K (s3 (x) s3) = K` for a symbolic complex `4 x 4` matrix, exhibit four
+effects whose real span has rank `4`, and verify evenness, range and completeness of both exhibited instruments.
+
+**Reading, not theorem.** Item 4 is the effect-selection statement the companion note leaves open, obtained here from the operational half of the declared
+hypothesis rather than from a new principle: on a cell whose even algebra is two-dimensional and whose even rank-one projectors are the two outputs themselves, an
+even Kraus operator into a rank-one output has nowhere to point except that output. Item 6 says the same fact negatively: the argument uses the smallness of the
+one-site even algebra, so it stops as soon as the even sector is larger than the output. This observes two computations and derives neither.
+
+## Theorem 2 — permanence of a record is conservation of the recorded occupation
+
+**Conclusion.** Under the declared hypothesis, on `C^2 (x) K` with the record at the first factor: (1) for `dim K = 2` the Hermitian solutions of `[H, n (x) 1] = 0`
+are exactly the block-diagonal family `(1-n) (x) B(K) (+) n (x) B(K)`, of real dimension `8 = 2 dim(K)^2`, strictly containing `1 (x) B(K)` of real dimension `4 =
+dim(K)^2`, with `n (x) 1` itself commuting and lying outside `1 (x) B(K)`; (2) for `dim K = 3` the same computation gives real dimension `18 = 2 dim(K)^2` against
+`9 = dim(K)^2`, with the same block-diagonal form and the same strict containment; (3) the narrower obstruction is exactly what the spanning condition would give,
+since the Hermitian solutions of `[H, X (x) 1] = 0` for all `X in M_2(C)` are exactly `1 (x) B(K)`, of real dimension `4` at `dim K = 2`; (4) on the two-mode cell
+the Jordan-Wigner pair anticommutes, `n_x = c_x^dagger c_x` and `n_y = c_y^dagger c_y`, and the hopping `c_x^dagger c_y + c_y^dagger c_x` is Hermitian and
+parity-even yet fails to commute with `n_x`, while `n_y` and `n_x n_y` commute with `n_x`, both occupations being projectors; (5) the freedom that survives is
+strictly larger than an action on `K` alone: the phase term `n_x`, a projector, sits beside the density-density term `n_x n_y` and the record-conditioned term `n
+(x) A` for symbolic Hermitian `A`, the last two Hermitian and commuting with `n_x`, and adjoining `n (x) s1` to a real basis of `1 (x) B(K)` raises the rank from
+`4` to `5`; (6) the spanning condition itself is false on the even sector, the recordable rank-one frames being `n` and `1-n`, of rank `2`, spanning the
+two-dimensional even algebra `span{1, n}` rather than `M_2(C)` of rank `4`, with the odd unit `E01` adjoined raising the rank to `3`.
+
+**Proof.** Items 1 and 2 solve `[H, n (x) 1] = 0` for a symbolic Hermitian matrix in real parameters at `dim K = 2` and `dim K = 3`; in each case every cross-block
+entry vanishes identically, the solved family equals `(1-n) (x) H_0 (+) n (x) H_1` on its two Hermitian blocks, and the real dimension is read off as the rank of
+the basis obtained by switching on one free real parameter at a time, which also establishes that the parameters are independent. The comparison family `1 (x) B(K)`
+is spanned by the images of the `dim(K)^2` Hermitian matrix units, each of which commutes with `n (x) 1`, and the strictness is the rank increase on adjoining `n
+(x) 1`. Item 3 is the same style of solve against the two generators `s1 (x) 1` and `s3 (x) 1`, together with the check that `1, s1, s3, s1 s3` has rank `4` in
+`M_2(C)`. Item 4 computes the anticommutators, the two occupations, the Hermiticity and parity of the hopping, the three commutators and the two projector
+identities, all exact. Item 5 is two commutator computations, two Hermiticity checks, a projector identity and one rank computation. Item 6 is a rank computation on
+the stacked frames.
+
+**Consequence.** The obstruction that permanence places on the generator is `[H, n_x] = 0`, not `H in 1 (x) B(K)`. The recorded site keeps its occupation, so
+nothing may hop off it or onto it; but the generator may still carry a phase on the recorded site, couple its density to the densities of other sites, and act on
+`K` conditionally on the record. Under the hypothesis the difference is not a technicality: it is the whole difference between a record that freezes its cell and a
+record that only freezes its occupation.
+
+## Corollary — what this changes
+
+Under the declared hypothesis, and on the one-site and one-site-plus-one-mode surfaces proved above:
+
+1. The effect-selection question the companion note leaves open,
+   `RECORD_OBSERVABLE_QUOTIENT_AND_RANK_ONE_FORMATION_OUTCOME_OPERATION_NORMAL_FORM_BOUNDED_THEOREM_NOTE_2026-07-11.md` (plain-text pointer, no grade, no weight),
+   is settled on the one-site record cell: `E_P = P`, the Lüders form, by Theorem 1 items 2, 3 and 4. What supplies it is the operational half of the declared
+   hypothesis, not a new selection principle.
+2. That settlement does not extend upward. By Theorem 1 items 6 and 7 the same question is open again on the two-mode cell, where two complete even instruments
+   share an output and carry different effects; a lane needing `E_P = P` on a larger cell needs a further premise and must say which.
+3. The permanence obstruction weakens. Under the spanning condition it reads `H in 1 (x) B(K)`, real dimension `4` at `dim K = 2`; under the hypothesis the
+   recordable frames do not span, and the obstruction is occupation conservation `[H, n_x] = 0`, of real dimension `8` at `dim K = 2` and `18` at `dim K = 3`
+   (Theorem 2 items 1, 2, 3 and 6). Hopping off a recorded site stays excluded; phase, density-density coupling and record-conditioned action on `K` become
+   available.
+
+## What does not move
+
+- No formation rule is supplied: nothing here says when a record forms, at which site, or at what rate.
+- No rate, coupling, or absolute unit appears. The parameters `lambda`, `c_j`, and the Hermitian blocks of Theorem 2 stay free throughout.
+- No site selection is performed. The recorded site is given, not derived.
+- No dynamics beyond the commutant classification is claimed: no Hamiltonian is selected, no evolution is solved, and no time-dependence is computed.
+- No axiom text is amended, extended, reworded, or reinterpreted, and the grading hypothesis, including its operational half, is declared here rather than consumed
+  from a row.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+
+## Interfaces named for other lanes, not moved here
+
+These interfaces are named so that a later note can consume them; nothing here moves them.
+
+- Lanes that need the Lüders form on a record readout: by Theorem 1 item 4 they have it on the one-site cell under the declared hypothesis, and may cite this note
+  in place of an effect-selection premise, provided their cell is one site.
+- Lanes that model a record cell as a site plus an environment mode: by Theorem 1 items 6 and 7 they do not have it, and by Theorem 2 items 1 and 2 their permanence
+  constraint is the occupation commutant, not the narrower algebra.
+- Lanes that build a generator on a lattice with records: by Theorem 2 items 4 and 5 the admissible terms at a recorded site are phase, density-density, and
+  record-conditioned action on the rest of the cell; hopping across the recorded site is not among them.
+
+## Remaining live routes
+
+1. Cells of three or more sites, and record cells whose environment factor carries its own grading beyond `Ad(s3)`: nothing here is claimed there.
+2. A derivation of the operational half of the hypothesis, that outcome operations on a recorded site are parity-even, rather than its declaration. This note proves
+   nothing about whether such a derivation exists.
+3. Outputs of rank higher than one, and instruments with more than two outputs on the one-site cell.
+4. Whether the two-mode freedom of Theorem 1 item 6 is narrowed by a further physical requirement, for instance one restricting Kraus operators to fixed particle
+   number rather than fixed parity.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the two theorem conclusions.
+
+```text
+site_algebra_and_declared_grading: M_2(C) with Ad(s3), even = span{E00,E11}, odd = span{E01,E10}
+locked_output_normal_form: P = |p><p|, K = |p><v|, E_P = sum_j |v_j><v_j|
+range_in_P_free_real_parameters_one_site: 4
+even_kraus_free_parameters_and_constraint_one_site: 2, v0 = 0 at P = n and v1 = 0 at P = 1-n
+even_effect_form_one_site: E_P = lambda P with lambda = sum_j |c_j|^2 >= 0
+completeness_solution_and_uniqueness: lambda_1 = lambda_0 = 1, unique
+lueders_on_the_one_site_cell: E_P = P at both outputs n and 1-n
+odd_instrument_effects: E_P = 1 - P at both outputs
+two_mode_output_and_parity_sector_dimension: P = |11><11|, span{|00>,|11>}, 2
+two_mode_even_kraus_free_real_parameters: 4
+two_mode_effect_freedom_real_dimension: 4
+two_even_instruments_same_output_effects: P and |00><00|
+occupation_commutant_real_dimension_dimK_2_and_3: 8 and 18, equal to 2 dim(K)^2
+inner_algebra_real_dimension_dimK_2_and_3: 4 and 9, equal to dim(K)^2
+commutant_of_M2_tensor_one_real_dimension: 4
+hopping_parity_even_and_commuting_with_n_x: yes and no
+terms_commuting_with_n_x: n_x, n_x n_y, n (x) A
+one_site_inner_basis_rank_with_conditional_term: 4 -> 5
+recordable_frame_rank_and_full_algebra_rank: 2 and 4
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=13 FAIL=0
+```
+
+## Proof boundary
+
+Every statement is proved on one site, on `C^2 (x) K` with `dim K = 2` and `dim K = 3`, and on the two-mode cell, in complex dimensions `2`, `4` and `6`. Nothing is
+claimed about three or more sites, about infinite lattices, or about any algebra other than those. The grading hypothesis is declared, not derived, and every
+theorem is conditional on it; the operational half, that outcome operations on a recorded site are parity-even CP maps, is the load-bearing clause of Theorem 1 and
+is a hypothesis about available operations, not a result. Theorem 1 treats rank-one outputs and the exhaustive two-output instrument, and takes the Kraus form of a
+CP map as the definition of an outcome operation rather than deriving it. Theorem 2 classifies Hermitian generators commuting with a given occupation and says
+nothing about which of them is realized, about time evolution, or about how a record forms. The two-mode statements of Theorem 1 items 6 and 7 are existence
+statements: they exhibit two even instruments, and do not classify all of them beyond the support statement proved. No axiom is amended, no status is set, and no
+registry entry is created.
+
+## Review record
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", the grading hypothesis with its operational half is
+displayed verbatim in "Declared hypothesis" and used nowhere implicitly, and both companion notes named in "Imports and authority" are plain-text pointers carrying
+no grade and no weight, their content re-declared and recomputed here rather than imported. Hard landing conditions are a fresh exact runner and cache pair closing
+at `PASS=13 FAIL=0` with runtime under two seconds and stdout under `5500` characters, a current zero-dependency citation-manifest entry, and passing repository
+pipeline, strict-lint, and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/lueders_one_site_record_cell_check_2026_09_01.txt
+++ b/logs/runner-cache/lueders_one_site_record_cell_check_2026_09_01.txt
@@ -1,0 +1,26 @@
+===== runner cache v1 =====
+runner: scripts/lueders_one_site_record_cell_check_2026_09_01.py
+runner_sha256: b0a8ea28a07469582a751427be35db8068ba76581b782148d4e9a9b9b7b2645a
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.60
+status: ok
+----- stdout -----
+PASS A1a rank-one locked output P = |1><1|: range(K) in P forces K = |1><v| with <v| = (K10, K11), four free real parameters, E = K^dag K = |v><v|, and K rho K^dag = Tr(E rho) P for every symbolic Hermitian rho
+PASS A1b evenness s3 K s3 = K on top of range(K) in P forces v0 = 0, i.e. K = c n with two free real parameters; for any family K_j = c_j n the effect is E_P = (sum_j |c_j|^2) n = lambda P with lambda a sum of squares, so lambda >= 0
+PASS A2 exhaustive even instrument on the one-site cell, outputs P_1 = n and P_0 = 1-n: the effects are lambda_1 n and lambda_0 (1-n) by A1b and A3a, and the completeness equation has the unique solution lambda_1 = lambda_0 = 1, so E_P = P at both outputs
+PASS A3a the even output P = 1-n by the same route: range(K) in P with s3 K s3 = K forces v1 = 0 and K = c (1-n), two free real parameters, E_P = |c|^2 (1-n) = lambda P
+PASS A3b the evenness is load-bearing: the odd instrument K_1 = |1><0| = c^dag, K_0 = |0><1| = c has ranges in P_1 = n and P_0 = 1-n and effects summing to 1, but s3 K s3 = -K and E_{P_1} = 1-n, E_{P_0} = n, i.e. E_P = 1-P at both outputs
+PASS A4a two-mode cell C^2 (x) K, K = C^2, output P = |1><1| (x) |1><1|: even Kraus operators with range in P are |11><v| with <v| in the +1 parity sector span{|00>,|11>} of dimension 2, so E_P is supported there and ranges over all of Herm of that sector, real dimension 4 -- exhibited by four such effects of real rank 4
+PASS A4b Lueders is not forced once the cell is larger than one site: two even instruments on C^2 (x) K, both with the outcome output P = |11><11| and both complete, carry the different effects E_P = P and E_P = |00><00| for that one output
+PASS B1a permanence for a recorded site, dim K = 2: the Hermitian solutions of [H, n (x) 1] = 0 are exactly (1-n) (x) B(K) (+) n (x) B(K), of real dimension 8 = 2 dim(K)^2, strictly containing 1 (x) B(K) of real dimension 4 = dim(K)^2 (n (x) 1 commutes and is outside)
+PASS B1b the same for dim K = 3: real dimension 18 = 2 dim(K)^2 against 9 = dim(K)^2 for 1 (x) B(K); the block-diagonal form and the strict containment are unchanged
+PASS B1c the parent's obstruction under the parent's own condition: if the recordable rank-one frames spanned M_2(C), permanence would read [H, X (x) 1] = 0 for all X, whose Hermitian solutions are exactly 1 (x) B(K), real dimension 4
+PASS B2a Jordan-Wigner two-mode cell, c_x = c (x) one, c_y = s3 (x) c: the pair anticommutes, n_x = c_x^dag c_x and n_y = c_y^dag c_y, and the hopping c_x^dag c_y + h.c. is Hermitian and parity-even yet fails to commute with n_x, while n_y and n_x n_y commute with n_x
+PASS B2b what an admissible H may still do: the phase term n_x, the density-density term n_x n_y and the record-conditioned action n (x) A for symbolic Hermitian A all commute with n_x, n_x being a projector, and n (x) s1 lies outside 1 (x) B(K), so the surviving freedom is strictly larger than an action on K alone
+PASS B3 the parent's spanning condition is false under the hypothesis: the recordable rank-one frames are n and 1-n, of rank 2, spanning the 2-dimensional even algebra span{1, n} and not M_2(C) of rank 4; adjoining the odd unit E01 raises the rank to 3, so the two-frame non-spanning case is the case the hypothesis delivers
+SUMMARY: on the one-site record cell parity-even outcome operations force the Lueders form E_P = P; on a two-mode cell they do not, a two-dimensional sector of effects remaining; and permanence for a recorded site is conservation of its occupation, a commutant of real dimension 2 dim(K)^2 rather than dim(K)^2.
+TOTAL: PASS=13 FAIL=0
+
+----- stderr -----
+

--- a/scripts/lueders_one_site_record_cell_check_2026_09_01.py
+++ b/scripts/lueders_one_site_record_cell_check_2026_09_01.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Lueders on the one-site record cell under the grading; permanence is occupation conservation.
+
+Class-A finite-dimensional runner for the record-cell repair: under the declared
+grading hypothesis the outcome operations on a recorded site are parity-even CP
+maps, and then the effect of a rank-one locked output is forced to be that output
+itself -- the Lueders form -- while the permanence obstruction on the generator
+weakens from `H in 1 (x) B(K)` to conservation of the recorded occupation.
+
+Declared objects (all exact; sympy only, no floats, no sampling):
+
+  * the Pauli matrices s1, s2, s3, the unit one = eye(2), the matrix units
+    E00, E01 = |0><1|, E10, E11 of M_2(C), the occupation n = E11, and the site
+    lowering operator c = E01 with c^dagger c = n and s3 = 1 - 2n;
+  * the parity grading Ad(s3) of the site algebra: even = span{E00, E11},
+    odd = span{E01, E10};
+  * outcome operations in Kraus form J(rho) = sum_j K_j rho K_j^dagger with range
+    in a locked output P, effect E_P = sum_j K_j^dagger K_j, and an instrument as
+    a family of such maps whose effects sum to the unit;
+  * the enlarged cell C^2 (x) K with K = C^2 and K = C^3, total parity s3 (x) s3
+    on the two-mode cell, and the Jordan-Wigner pair c_x = c (x) one,
+    c_y = s3 (x) c with n_x = n (x) one, n_y = one (x) n.
+
+Check groups:
+
+  A  Lueders on the one-site cell: the rank-one normal form K = |p><v| with
+     E = |v><v|, the evenness constraint v0 = 0 forcing K = c n and
+     E_P = lambda P, completeness forcing lambda = 1 at both even outputs, an odd
+     instrument with E_P = 1 - P showing the evenness is load-bearing, and the
+     caveat that on the two-mode cell the even Kraus operators leave a
+     two-dimensional sector of effects free for one and the same output;
+  B  permanence is occupation conservation: the Hermitian commutant of n (x) 1
+     for dim K = 2 and dim K = 3 against the commutant of M_2(C) (x) 1, hopping
+     excluded while phase, density-density and record-conditioned action on K
+     survive, and the failure of the spanning condition on the even sector.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+import sys
+
+import sympy as sp
+from sympy import I, Matrix, eye, zeros, symbols
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one exact check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ---------------------------------------------------------------- notation
+
+s1 = Matrix([[0, 1], [1, 0]])
+s2 = Matrix([[0, -I], [I, 0]])
+s3 = Matrix([[1, 0], [0, -1]])
+one = eye(2)
+
+E00 = Matrix([[1, 0], [0, 0]])
+E01 = Matrix([[0, 1], [0, 0]])
+E10 = Matrix([[0, 0], [1, 0]])
+E11 = Matrix([[0, 0], [0, 1]])
+UNITS = [E00, E01, E10, E11]
+n = E11
+cop = E01
+
+ket0 = Matrix([1, 0])
+ket1 = Matrix([0, 1])
+
+I4 = eye(4)
+Z2 = zeros(2, 2)
+Z4 = zeros(4, 4)
+
+
+def kron(*ms):
+    out = ms[0]
+    for m in ms[1:]:
+        out = sp.kronecker_product(out, m)
+    return Matrix(out)
+
+
+def zero(M):
+    return all(sp.expand(e) == 0 for e in M)
+
+
+def eq(A, B):
+    return zero(A - B)
+
+
+def rows_of(mats):
+    return Matrix([[e for e in M] for M in mats])
+
+
+def rvec(M):
+    out = []
+    for e in M:
+        re_, im_ = sp.expand(e).as_real_imag()
+        out.append(sp.expand(re_))
+        out.append(sp.expand(im_))
+    return out
+
+
+def rrank(mats):
+    return Matrix([rvec(M) for M in mats]).rank()
+
+
+def real_eqs(M):
+    out = []
+    for e in M:
+        re_, im_ = sp.expand(e).as_real_imag()
+        for q in (sp.expand(re_), sp.expand(im_)):
+            if q != 0:
+                out.append(q)
+    return out
+
+
+def cmat(name, r, c):
+    """A symbolic complex r x c matrix in independent real parameters."""
+    re_ = symbols("%sr0:%d" % (name, r * c), real=True)
+    im_ = symbols("%si0:%d" % (name, r * c), real=True)
+    M = Matrix(r, c, lambda i, j: re_[i * c + j] + I * im_[i * c + j])
+    return M, list(re_) + list(im_)
+
+
+def herm(name, dim):
+    """A symbolic Hermitian dim x dim matrix in real parameters."""
+    d = symbols(name + "_d0:%d" % dim, real=True)
+    x = {}
+    y = {}
+    for i in range(dim):
+        for j in range(i + 1, dim):
+            x[(i, j)] = sp.Symbol("%s_x%d%d" % (name, i, j), real=True)
+            y[(i, j)] = sp.Symbol("%s_y%d%d" % (name, i, j), real=True)
+    M = zeros(dim, dim)
+    for i in range(dim):
+        M[i, i] = d[i]
+        for j in range(i + 1, dim):
+            M[i, j] = x[(i, j)] + I * y[(i, j)]
+            M[j, i] = x[(i, j)] - I * y[(i, j)]
+    return M, list(d) + [x[k] for k in sorted(x)] + [y[k] for k in sorted(y)]
+
+
+def herm_basis(d):
+    """The d^2 Hermitian matrix units of M_d(C), a real basis of Herm(d)."""
+    B = []
+    for i in range(d):
+        M = zeros(d, d)
+        M[i, i] = 1
+        B.append(M)
+    for i in range(d):
+        for j in range(i + 1, d):
+            M = zeros(d, d)
+            M[i, j] = 1
+            M[j, i] = 1
+            B.append(M)
+            M = zeros(d, d)
+            M[i, j] = I
+            M[j, i] = -I
+            B.append(M)
+    return B
+
+
+def freesyms(M):
+    return sorted(M.free_symbols, key=sp.default_sort_key)
+
+
+def real_dim(M, fv):
+    """Real dimension of the linear family M(fv), by rank of its basis."""
+    B = [M.subs({t: (1 if t == x else 0) for t in fv}) for x in fv]
+    return rrank(B), B
+
+
+def scalar(name):
+    return sp.Symbol(name + "r", real=True) + I * sp.Symbol(name + "i", real=True)
+
+
+def absq(z):
+    return sp.expand(sp.re(z) ** 2 + sp.im(z) ** 2)
+
+
+# ============================== A: Lueders on the one-site record cell
+
+# --- A1a: the parent's rank-one normal form, re-derived here
+
+Kg, Kp = cmat("k", 2, 2)
+Pn = n
+a1a_sol = sp.solve(real_eqs(Pn * Kg - Kg), Kp, dict=True)
+Kr = Kg.subs(a1a_sol[0])
+vbra = Matrix([[Kr[1, 0], Kr[1, 1]]])
+Er = sp.expand(Kr.H * Kr)
+rho, _rp = herm("rho", 2)
+check("A1a rank-one locked output P = |1><1|: range(K) in P forces K = |1><v| with "
+      "<v| = (K10, K11), four free real parameters, E = K^dag K = |v><v|, and "
+      "K rho K^dag = Tr(E rho) P for every symbolic Hermitian rho",
+      len(a1a_sol) == 1
+      and len(freesyms(Kr)) == 4
+      and eq(Pn, ket1 * ket1.H)
+      and zero(Kr[0, :])
+      and eq(Kr, ket1 * vbra)
+      and eq(Er, vbra.H * vbra)
+      and eq(sp.expand(Kr * rho * Kr.H), sp.expand((Er * rho).trace() * Pn)))
+
+# --- A1b: evenness kills v0, so every even Kraus operator with range in n is c n
+
+a1b_sol = sp.solve(real_eqs(Pn * Kg - Kg) + real_eqs(s3 * Kg * s3 - Kg), Kp, dict=True)
+Ke = Kg.subs(a1b_sol[0])
+ce = Ke[1, 1]
+cs = [scalar("c%d_" % j) for j in range(3)]
+Emulti = sp.expand(sum(((cj * n).H * (cj * n) for cj in cs), Z2))
+lam_multi = sp.expand(sum(absq(cj) for cj in cs))
+check("A1b evenness s3 K s3 = K on top of range(K) in P forces v0 = 0, i.e. K = c n with "
+      "two free real parameters; for any family K_j = c_j n the effect is "
+      "E_P = (sum_j |c_j|^2) n = lambda P with lambda a sum of squares, so lambda >= 0",
+      len(a1b_sol) == 1
+      and len(freesyms(Ke)) == 2
+      and sp.expand(Ke[1, 0]) == 0
+      and eq(Ke, ce * n)
+      and eq(sp.expand(Ke.H * Ke), absq(ce) * n)
+      and sp.expand(absq(ce) - (sp.re(ce) ** 2 + sp.im(ce) ** 2)) == 0
+      and eq(Emulti, lam_multi * n)
+      and sp.expand(lam_multi - sum(sp.re(cj) ** 2 + sp.im(cj) ** 2 for cj in cs)) == 0)
+
+# --- A2: completeness over the two even outputs forces the Lueders form
+
+lam1, lam0 = symbols("lam1 lam0", real=True)
+P1, P0 = n, one - n
+a2_sol = sp.solve(real_eqs(lam1 * P1 + lam0 * P0 - one), [lam1, lam0], dict=True)
+a2 = len(a2_sol) == 1 and a2_sol[0] == {lam1: 1, lam0: 1}
+if a2:
+    a2 = (eq((lam1 * P1).subs(a2_sol[0]), P1)
+          and eq((lam0 * P0).subs(a2_sol[0]), P0)
+          and eq(P1 + P0, one)
+          and eq(P1 * P0, Z2))
+check("A2 exhaustive even instrument on the one-site cell, outputs P_1 = n and P_0 = 1-n: "
+      "the effects are lambda_1 n and lambda_0 (1-n) by A1b and A3a, and the completeness "
+      "equation has the unique solution lambda_1 = lambda_0 = 1, so E_P = P at both outputs",
+      a2)
+
+# --- A3a: the same at the even output 1 - n
+
+a3a_sol = sp.solve(real_eqs(P0 * Kg - Kg) + real_eqs(s3 * Kg * s3 - Kg), Kp, dict=True)
+Ke0 = Kg.subs(a3a_sol[0])
+ce0 = Ke0[0, 0]
+check("A3a the even output P = 1-n by the same route: range(K) in P with s3 K s3 = K forces "
+      "v1 = 0 and K = c (1-n), two free real parameters, E_P = |c|^2 (1-n) = lambda P",
+      len(a3a_sol) == 1
+      and len(freesyms(Ke0)) == 2
+      and sp.expand(Ke0[0, 1]) == 0
+      and eq(Ke0, ce0 * (one - n))
+      and eq(sp.expand(Ke0.H * Ke0), absq(ce0) * (one - n)))
+
+# --- A3b: an odd instrument on the same two outputs has E_P = 1 - P
+
+Kf1 = E10
+Kf0 = E01
+Ef1 = sp.expand(Kf1.H * Kf1)
+Ef0 = sp.expand(Kf0.H * Kf0)
+check("A3b the evenness is load-bearing: the odd instrument K_1 = |1><0| = c^dag, "
+      "K_0 = |0><1| = c has ranges in P_1 = n and P_0 = 1-n and effects summing to 1, but "
+      "s3 K s3 = -K and E_{P_1} = 1-n, E_{P_0} = n, i.e. E_P = 1-P at both outputs",
+      eq(Pn * Kf1, Kf1) and eq((one - n) * Kf0, Kf0)
+      and eq(s3 * Kf1 * s3, -Kf1) and eq(s3 * Kf0 * s3, -Kf0)
+      and eq(Ef1 + Ef0, one)
+      and eq(Ef1, one - n) and eq(Ef0, n)
+      and not eq(Ef1, P1) and not eq(Ef0, P0)
+      and eq(Ef1, one - P1) and eq(Ef0, one - P0))
+
+# --- A4a: on the two-mode cell the even Kraus operators leave a 2-dim sector free
+
+
+def unit4(i, j):
+    M = Z4.copy()
+    M[i, j] = 1
+    return M
+
+
+Ptot = kron(s3, s3)
+P11 = unit4(3, 3)
+ket11 = Matrix([0, 0, 0, 1])
+Qg, Qp = cmat("q", 4, 4)
+a4_sol = sp.solve(real_eqs(P11 * Qg - Qg) + real_eqs(Ptot * Qg * Ptot - Qg), Qp, dict=True)
+Q4 = Qg.subs(a4_sol[0])
+E4 = sp.expand(Q4.H * Q4)
+SEC = [0, 3]
+Pplus = sp.expand((I4 + Ptot) / 2)
+BRAS = [Matrix([[1, 0, 0, 0]]), Matrix([[0, 0, 0, 1]]),
+        Matrix([[1, 0, 0, 1]]), Matrix([[1, 0, 0, I]])]
+EFFS = [sp.expand((ket11 * b).H * (ket11 * b)) for b in BRAS]
+check("A4a two-mode cell C^2 (x) K, K = C^2, output P = |1><1| (x) |1><1|: even Kraus "
+      "operators with range in P are |11><v| with <v| in the +1 parity sector span{|00>,|11>} "
+      "of dimension 2, so E_P is supported there and ranges over all of Herm of that sector, "
+      "real dimension 4 -- exhibited by four such effects of real rank 4",
+      len(a4_sol) == 1
+      and len(freesyms(Q4)) == 4
+      and eq(Q4, ket11 * Matrix([[Q4[3, 0], 0, 0, Q4[3, 3]]]))
+      and all(sp.expand(E4[i, j]) == 0
+              for i in range(4) for j in range(4)
+              if i not in SEC or j not in SEC)
+      and Pplus.rank() == 2
+      and eq(Pplus * ket11, ket11)
+      and all(eq(Ptot * K * Ptot, K) and eq(P11 * K, K)
+              for K in [ket11 * b for b in BRAS])
+      and rrank(EFFS) == 4)
+
+# --- A4b: two even instruments, one output, two different effects
+
+INST_I = [[unit4(3, 3)], [unit4(0, 0), unit4(1, 1), unit4(2, 2)]]
+INST_II = [[unit4(3, 0)], [unit4(1, 1), unit4(2, 2), unit4(3, 3)]]
+
+
+def effect(ks):
+    return sp.expand(sum((K.H * K for K in ks), Z4))
+
+
+def complete(inst):
+    return eq(sp.expand(sum((effect(ks) for ks in inst), Z4)), I4)
+
+
+EI = effect(INST_I[0])
+EII = effect(INST_II[0])
+check("A4b Lueders is not forced once the cell is larger than one site: two even instruments "
+      "on C^2 (x) K, both with the outcome output P = |11><11| and both complete, carry the "
+      "different effects E_P = P and E_P = |00><00| for that one output",
+      all(eq(Ptot * K * Ptot, K) for inst in (INST_I, INST_II) for ks in inst for K in ks)
+      and eq(P11 * INST_I[0][0], INST_I[0][0])
+      and eq(P11 * INST_II[0][0], INST_II[0][0])
+      and complete(INST_I) and complete(INST_II)
+      and eq(EI, P11) and eq(EII, unit4(0, 0))
+      and not eq(EI, EII) and not eq(EII, P11))
+
+# ============================ B: permanence is occupation conservation
+
+
+def commutant_report(d):
+    """Hermitian commutant of n (x) 1 on C^2 (x) C^d, against 1 (x) B(K)."""
+    Hs, hp = herm("h%d" % d, 2 * d)
+    N = kron(n, eye(d))
+    sol = sp.solve(real_eqs(Hs * N - N * Hs), hp, dict=True)
+    Hev = Hs.subs(sol[0])
+    fv = freesyms(Hev)
+    dcom, _ = real_dim(Hev, fv)
+    HB = herm_basis(d)
+    inner = [kron(one, A) for A in HB]
+    dinn = rrank(inner)
+    extra = kron(n, eye(d))
+    ok = (len(sol) == 1
+          and len(fv) == dcom
+          and all(sp.expand(Hev[i, j]) == 0
+                  for i in range(2 * d) for j in range(2 * d)
+                  if (i < d) != (j < d))
+          and eq(Hev, kron(one - n, Hev[0:d, 0:d]) + kron(n, Hev[d:2 * d, d:2 * d]))
+          and all(zero(M * N - N * M) for M in inner)
+          and zero(extra * N - N * extra)
+          and rrank(inner + [extra]) == dinn + 1)
+    return dcom, dinn, ok
+
+
+d2com, d2inn, b1a_ok = commutant_report(2)
+check("B1a permanence for a recorded site, dim K = 2: the Hermitian solutions of "
+      "[H, n (x) 1] = 0 are exactly (1-n) (x) B(K) (+) n (x) B(K), of real dimension %d = "
+      "2 dim(K)^2, strictly containing 1 (x) B(K) of real dimension %d = dim(K)^2 "
+      "(n (x) 1 commutes and is outside)" % (d2com, d2inn),
+      b1a_ok and d2com == 8 and d2inn == 4 and d2com > d2inn)
+
+d3com, d3inn, b1b_ok = commutant_report(3)
+check("B1b the same for dim K = 3: real dimension %d = 2 dim(K)^2 against %d = dim(K)^2 for "
+      "1 (x) B(K); the block-diagonal form and the strict containment are unchanged"
+      % (d3com, d3inn),
+      b1b_ok and d3com == 18 and d3inn == 9 and d3com > d3inn)
+
+Gs, Gp = herm("g", 4)
+b1c_sol = sp.solve(real_eqs(Gs * kron(s1, one) - kron(s1, one) * Gs)
+                   + real_eqs(Gs * kron(s3, one) - kron(s3, one) * Gs), Gp, dict=True)
+Gev = Gs.subs(b1c_sol[0])
+Gfv = freesyms(Gev)
+gdim, _ = real_dim(Gev, Gfv)
+check("B1c the parent's obstruction under the parent's own condition: if the recordable "
+      "rank-one frames spanned M_2(C), permanence would read [H, X (x) 1] = 0 for all X, "
+      "whose Hermitian solutions are exactly 1 (x) B(K), real dimension %d" % gdim,
+      len(b1c_sol) == 1
+      and gdim == 4 and len(Gfv) == 4
+      and eq(Gev, kron(one, Gev[0:2, 0:2]))
+      and rows_of([one, s1, s2, s3]).rank() == 4
+      and rows_of([one, s1, s3, sp.expand(s1 * s3)]).rank() == 4)
+
+# --- B2a: hops are excluded although the hopping is parity-even
+
+cx = kron(cop, one)
+cy = kron(s3, cop)
+nx = kron(n, one)
+ny = kron(one, n)
+hop = sp.expand(cx.H * cy + cy.H * cx)
+check("B2a Jordan-Wigner two-mode cell, c_x = c (x) one, c_y = s3 (x) c: the pair anticommutes, "
+      "n_x = c_x^dag c_x and n_y = c_y^dag c_y, and the hopping c_x^dag c_y + h.c. is Hermitian "
+      "and parity-even yet fails to commute with n_x, while n_y and n_x n_y commute with n_x",
+      eq(cx.H * cx, nx) and eq(cy.H * cy, ny)
+      and zero(cx * cy + cy * cx) and zero(cx * cy.H + cy.H * cx)
+      and eq(cx * cx.H + cx.H * cx, I4)
+      and eq(hop.H, hop)
+      and eq(Ptot * hop * Ptot, hop)
+      and not zero(hop * nx - nx * hop)
+      and zero(ny * nx - nx * ny)
+      and zero((nx * ny) * nx - nx * (nx * ny))
+      and eq(nx * nx, nx) and eq(ny * ny, ny))
+
+# --- B2b: phase, density-density and record-conditioned action on K all survive
+
+Ah, _ap = herm("a", 2)
+cond = kron(n, Ah)
+dens = sp.expand(nx * ny)
+check("B2b what an admissible H may still do: the phase term n_x, the density-density term "
+      "n_x n_y and the record-conditioned action n (x) A for symbolic Hermitian A all commute "
+      "with n_x, n_x being a projector, and n (x) s1 lies outside 1 (x) B(K), so the surviving "
+      "freedom is strictly larger than an action on K alone",
+      eq(nx * nx, nx)
+      and zero(dens * nx - nx * dens)
+      and zero(cond * nx - nx * cond)
+      and eq(cond.H, cond)
+      and eq(dens.H, dens)
+      and rrank([kron(one, A) for A in herm_basis(2)] + [kron(n, s1)]) == 5)
+
+# --- B3: the parent's spanning condition fails on the even sector
+
+FRAMES = [n, one - n]
+check("B3 the parent's spanning condition is false under the hypothesis: the recordable "
+      "rank-one frames are n and 1-n, of rank 2, spanning the 2-dimensional even algebra "
+      "span{1, n} and not M_2(C) of rank 4; adjoining the odd unit E01 raises the rank to 3, "
+      "so the two-frame non-spanning case is the case the hypothesis delivers",
+      rows_of(FRAMES).rank() == 2
+      and rows_of(FRAMES + [one]).rank() == 2
+      and rows_of(UNITS).rank() == 4
+      and rows_of(FRAMES + [E01]).rank() == 3
+      and eq(s3 * n * s3, n) and eq(s3 * (one - n) * s3, one - n)
+      and eq(s3 * E01 * s3, -E01) and eq(s3 * E10 * s3, -E10)
+      and all(M.rank() == 1 and eq(M * M, M) and eq(M.H, M) for M in FRAMES))
+
+print("SUMMARY: on the one-site record cell parity-even outcome operations force the Lueders "
+      "form E_P = P; on a two-mode cell they do not, a two-dimensional sector of effects "
+      "remaining; and permanence for a recorded site is conservation of its occupation, a "
+      "commutant of real dimension 2 dim(K)^2 rather than dim(K)^2.")
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Scope

Repair triple #3 of the graded-composition re-scoping batch. Bounded theorem, self-contained (`upstream_dependencies: []`), exact sympy, `PASS=13 FAIL=0`, under a **declared** grading hypothesis (parity grading of the site algebra, graded composition, parity-even readability, and the operational reading that outcome operations on a recorded site are parity-even CP maps), stated in the note and consumed from no row. It mirrors the candidate clause recorded in PR #7829 and does not depend on that clause being adopted.

## Result

- **Lüders is forced on the one-site record cell.** For a rank-one locked even output `P`, range in `P` plus evenness forces every Kraus operator to `c P`, so `E_P = lambda P`; completeness over the two even outputs forces `lambda = 1`, hence `E_P = P`. The evenness is load-bearing: the odd instrument `(c^dag, c)` is complete with `E_P = 1 - P`.
- **Bounded to one site.** On a two-mode cell two complete even instruments share the output `|11><11|` with effects `P` and `|00><00|`; the free sector has real dimension 4.
- **Permanence is occupation conservation.** `[H, n_x] = 0` has commutant `(1-n)(x)B(K) (+) n(x)B(K)`, real dimension `2 dim(K)^2` (8 and 18) against `dim(K)^2` for `1 (x) B(K)`. Hopping across the recorded site is excluded although parity-even; phase, density-density, and record-conditioned action survive. The spanning condition behind the narrower obstruction is false on the even sector.

## What it changes, under the hypothesis

The effect-selection question left open by the July normal-form note is settled on the one-site cell and reopens on larger cells; the permanence obstruction weakens from a frozen cell to a conserved occupation.

## Boundaries

One site, one site plus one mode. No formation rule, rate, site selection, or dynamics beyond the commutant classification. No axiom, no status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k