### PR TITLE
feat(matter): finite edge-qubit parity dictionary occupation zeros

### DIFF
--- a/docs/EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-02.md
+++ b/docs/EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-02.md
@@ -1,0 +1,329 @@
+---
+claim_id: emergent_dictionary_selection_rule_zeros_3d
+claim_type: bounded_theorem
+claim_scope: "On three finite open graphs -- the 2x2x2 cube graph (8 vertices, 12 edges, 6 faces), the 3x3 grid graph (9 vertices, 12 edges, 4 faces), and the 3x3 grid with one pendant auxiliary mode at vertex 0 (10 vertices, 13 edges, 4 faces) -- qubits are placed on the EDGE sites, the sites compose ordinarily (tensor product, operators on disjoint regions commute, no graded clause anywhere), and vertex occupancy is read out by the parity dictionary n_i = (1 - B_i)/2 with B_i the product of the Z's on the edges incident to vertex i. With no floating point in any exact statement: (T1) the encoding A_ij = X(edge ij) times the Z's ordered before it at both endpoints, A_ji = -A_ij, B_i, and the ordered four-A face loops satisfies relations R0-R4 pair by pair; the cube's 6 face loops carry exactly one relation, the product of all six being +I, leaving 5 independent generators, the two grids carry none and leave 4; the stabilizer groups 2^5, 2^4, 2^4 contain no -I and have code dimension 2^12/2^5 = 128, 2^12/2^4 = 256, 2^13/2^4 = 512, in each case 2^(V-1); and prod_i B_i = +I identically, so the dictionary registers an EVEN record number on every one of the 4096, 4096 and 8192 edge patterns and the coset-to-record map is injective on the 128, 256 and 512 code states, which is why an odd record target uses one pendant mode. (T2) In the record-number sectors of dimensions 70 (cube, N=4), 84 (grid3x3, N=6) and 84 (pendant, n_aux=1 and N_grid=3) the encoded matrix H_enc of the law -t sum_edges (hop) + V sum_edges n_i n_j has diagonals equal to the fermionic bond counts, 2^k H_enc is a Gaussian-integer matrix of max modulus 32, 16, 16, and an exact diagonal gauge D with entries in {1, i, -1, -i} satisfies D H_enc D^dag = H_F entrywise against the Jordan-Wigner matrix of the same law on the same occupation patterns; the gauge is a unitary diagonal, so spectra and record statistics agree at every coupling exactly. (T3) At g = V/t = 0 the record statistics recomputed independently from exact Slater determinants over Q(sqrt2) are: cube ground energy -6, value multiset 0 x12, 1/64 x56, 1/16 x2, the 12 zeros exactly the 6 occupied cube faces and the 6 patterns of two disjoint adjacent pairs; grid at N_grid = 3 ground energy -4 sqrt2, multiset 0 x8, 1/256 x12, 1/128 x32, 1/64 x20, 1/32 x8, 9/256 x4, the 8 zeros exactly the 3 rows, 3 columns and 2 diagonals; grid at N = 6 the same multiset with the 8 zeros exactly the complements of those, the particle-hole image. Each of the 70, 84 and 84 vertex patterns carries a constant fibre of 2^k = 32, 16, 16 edge records with |phi(y)| = 1 throughout, so the edge-record probability is the vertex probability divided by the fibre size and the 384, 128 and 128 edge records over a zero are themselves exactly zero. (T4) As a floating-point witness at g in {0, 0.5, 1, 2} the encoded and fermionic record statistics agree to L1 at most 3.4e-15, the zero sets coincide (12/12/12/12 on the cube, 8/4/4/4 on both grids), the ground state is simple at every point with smallest gaps 0.573988, 0.788251 and 1.293567, and the zeros surviving every g in {0.5, 1, 2} are all 12 on the cube and exactly 4 of 8 on the grid, the four lines through the centre at N_grid = 3 and their complements at N = 6. (T5) Every off-diagonal amplitude in the edge-record basis is exactly +i or -i, 15360 of them split 7680/7680 on the cube and 8064 split 4032/4032 on the grid; the Z-support of A_ij B_i lies inside star(i) U star(j), and sign(y) = s_e (-1)^{|y & Z(A_ij B_i)|} holds for every edge and all 4096 records, so every sign is a parity of the record over one vertex's incident edges; the gauge-invariant four-cycle flux of the configuration graph is -1 on 144 of 444 cube cycles and 80 of 344 grid cycles, identical for H_F, and a spanning-tree gauge leaves 90 of 240 and 80 of 252 entries at +1. (T6) The control that puts a bare X_e in place of A_ij anticommutes with 16 of 60 and 12 of 48 (term, stabilizer generator) pairs, so it leaves the code space; it still conserves the record on edge sectors of dimension 2240 and 1344, where a diagonal unit gauge turns all 7680 and 4032 off-diagonal entries into -1 on a graph of one connected component, so by Perron-Frobenius its ground vector is simple and strictly positive at every real g, and numerically at g in {0, 0.5, 1, 2} all 70 and 84 vertex patterns carry probability at least 1.4861e-03 and 2.3740e-04 with 0 exact zeros. This note declares a dictionary and computes with it; no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.py
+---
+
+# The emergent dictionary reproduces the three-dimensional selection-rule zeros, from single-vertex neighbourhood conditions alone
+
+**Date:** 2026-09-02
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.py`](../scripts/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.py)
+**Runner cache:**
+[`logs/runner-cache/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.txt`](../logs/runner-cache/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+A separate finite test found record patterns that a graded nearest-neighbour law gives probability exactly zero while every ungraded member of the same family
+gives them positive probability; that test lives on vertices and reads occupancy directly. This note asks whether the same zeros are available on a lattice
+whose sites compose ordinarily and whose readout is a **dictionary**: qubits on the edges, vertex occupancy computed from the records of the edges at that one
+vertex. They are, in three dimensions and in two, with the same zero sets and value multisets, from a parity over a single vertex's incident edges.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems on three named open graphs -- encoding relations and code dimensions, an exact diagonal unit gauge identifying the encoded and fermionic matrices entrywise, the exact zero sets and their fibres, the exact sign structure and flux, and the exact Perron-Frobenius control -- together with one floating-point persistence witness, labelled as such wherever it appears."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: whether the framework's readout is a dictionary of this kind."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the six statements below, exactly the runner's check groups `A`-`G`. `T1`, `T2`, `T3`, `T5` and the structural half of `T6`
+are exact -- integer and `F2`/`Z4` bit arithmetic, Gaussian-integer amplitudes, `Fraction` and `Q(sqrt2)` arithmetic; `T4` and the confirming half of `T6` are
+floating-point witnesses at `1e-12`, labelled `[numerical]` wherever they appear.
+
+1. `T1` (`A`). Encoding: `R0`-`R4`, the face relations, code dimension `2^(V-1)`, and `prod_i B_i = +I`, so an odd target uses one pendant mode.
+2. `T2` (`B`). Unit gauge: an exact diagonal `D` with `D H_enc D^dag = H_F` entrywise, hence identical spectra and record statistics at every coupling.
+3. `T3` (`C`, `E`). Zeros at `g = 0`: the exact value multisets and zero sets, recomputed from Slater determinants, and the fibre carrying them to the records.
+4. `T4` (`D`). Persistence: agreement, equal zero sets and simplicity at `g != 0`, and the four lines through the centre.
+5. `T5` (`F`). Sign structure: every negative amplitude is a parity of the record over one vertex's incident edges, with the flux witness.
+6. `T6` (`G`). Control: the bare edge-flip law leaves the code space and is sign-uniform on what it preserves, so its statistics are strictly positive.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Jordan-Wigner transform, Slater determinants and the
+Perron-Frobenius theorem are standard methodology; every object is redeclared here and the runner recomputes every statement, the encoding's defining relations
+included. No observational value, no fitted number, and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade or weight:
+
+- `COMPOSITION_DISCRIMINATOR_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7833 -- the finite test whose zero sets are reproduced here) and
+  `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834 -- the operator-level
+  construction of the same encoding on `Z^3`).
+- `RECURRENT_ENDPOINT_INCIDENCE_PHYSICAL_M2_COMPILER_TOURNAMENT_CYCLE703_NOTE_2026-07-25.md`,
+  `ENDPOINT_LOCALIZATION_THREE_ROUTE_DISCRIMINATOR_CYCLE705_NOTE_2026-07-26.md`, `ENERGY_GAUSS_CONSTRAINT_OBSTRUCTION_ROUTE_B_NOTE_2026-07-08.md` and
+  `ROUTE_B_TYPED_SPECTATOR_RADIUS_ONE_SYNTHESIS_CYCLE822_BOUNDED_THEOREM_NOTE_2026-07-30.md` (earlier superfast, bosonization and route-B surveys).
+- `FINITE_FLAT_LINK_EVEN_CAR_SUPPORT_CENSUS_BOUNDED_THEOREM_NOTE_2026-07-23.md`, `RING_MONODROMY_DOES_NOT_FORCE_CAR_NOTE_2026-06-04.md` (the earlier ring and
+  chain probes) and `MINIMAL_AXIOMS_2026-06-29.md` (the four axioms quoted in "Setting"). This note cites none of their grades, consumes no row, and adopts no
+  hypothesis.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`", with nearest-neighbor adjacency,
+standard translations, and proper cubic rotations about each site. **Qubit**: each site has a domain of local possibilities whose full one-site possibility
+domain has algebraic presentation `M_2(C)`. **Admissibility**: there is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and
+proper cubic rotations. **Record**: when present, a record locks exactly one admissible local possibility, a site never carries more than one record, records
+are permanent, and only records are readable.
+
+Composition here is **ordinary**: the algebra of a region is the tensor product of its sites' algebras, operators on disjoint regions commute, and no graded or
+signed composition clause is used anywhere. The clusters below are finite open subgraphs of that lattice, drawn as graphs so "edge site" and "vertex" have
+their graph meanings. The **record ontology** is used as declared: records register, they do not read. The parity dictionary of "Definitions" is a **readout
+map** from edge-site records to the occupancy of a vertex, a condition on the records of that one vertex's incident edges and not a claim about anything else.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is precisely `P0`-`P6`.
+
+1. `P0` (declared here): the three graphs, the edge-site qubits, the encoding, the parity dictionary, the law, and the control.
+2. `P1` (`A`): the encoding relations, the face relations, the code dimension, and the even-number identity.
+3. `P2` (`B`): the exact diagonal unit gauge. `P3` (`C`, `E`): the `g = 0` record statistics, the zero sets, and the constant fibre.
+4. `P4` (`D`): persistence at `g != 0` and the four centre lines. `P5` (`F`): the sign structure and the flux witness. `P6` (`G`): the control.
+
+## Definitions
+
+A **cluster** is a finite open graph: `cube` is the `2x2x2` cube graph, vertex `s = 4a + 2b + c`, `8/12/6` vertices, edges, four-cycle faces; `grid3x3` is the
+`3x3` grid graph, vertex `3r + c`, `9/12/4`; `pendant` is `grid3x3` with an extra vertex `9` joined to vertex `0`, `10/13/4`. One qubit sits on each **edge
+site**, neighbours of a vertex ordered by vertex index. For an ordered edge `(i, j)`,
+
+```text
+A_ij = X(edge ij) * prod Z(edges at i ordered before j) * prod Z(edges at j ordered before i),   A_ji = -A_ij,
+B_i  = prod of the Z's on the edges incident to i,     S_f = the ordered product of the A's around a face f,
+H(t, V) = -t sum_edges ( hop across the edge ) + V sum_edges n_i n_j,      g = V/t at t = 1.
+```
+
+The **code space** is the joint `+1` eigenspace of the face loops. The **parity dictionary** is the readout map `n_i(y) = (1 - B_i)/2` on the edge
+record `y`, which is `|y intersect star(i)| mod 2` with `star(i)` the edges incident to `i`; the **record number** is `N = sum_i n_i` and a **record
+pattern** the vector `(n_0, ..., n_{V-1})`. In `H(t, V)` the encoded hop across `(i, j)` is `T_ij = (i/2) A_ij (B_i - B_j)`, and the fermionic
+reference `H_F` uses the Jordan-Wigner ladders on the same occupation patterns. The **record statistics** of a law are the occupation-basis diagonal
+of its lowest-energy state in a fixed record-number sector, the normalized ground-space projector diagonal if degenerate. The **control** replaces
+`A_ij` by the bare edge flip `X_e`.
+
+## Theorem 1 -- the encoding, and why an odd record number needs one more site
+
+**Conclusion.** On all three clusters:
+
+1. Relations `R0`-`R4` hold pair by pair: `A_ij` well defined, `A_ji = -A_ij`, `A` and `B` Hermitian involutions, the `B`'s commuting and anticommuting with
+   `A_ij` exactly at `i` and `j`, two `A`'s anticommuting exactly when they share a vertex, the face loops involutions commuting with every `A`, `B` and each
+   other.
+2. The cube's `6` face loops carry exactly one relation, the product of all six being `+I`, so `5` are independent; each grid's `4` carry none. The groups of
+   order `2^5`, `2^4`, `2^4` contain no `-I` and only the identity has trivial `X`-part, so the code dimensions are `128`, `256`, `512`, each `2^(V-1)`.
+3. `prod_i B_i = +I` identically, so the dictionary registers an **even** record number on every one of the `4096`, `4096` and `8192` edge patterns and the
+   coset-to-record map is injective on the `128`, `256` and `512` code states.
+4. Consequently the odd sector `N = 3` of `grid3x3` is not carried by its `12` edge qubits; one pendant auxiliary mode at vertex `0`, whose edge carries no term
+   of the law, makes `n_aux = 1` and `N_grid = 3` available with the same face structure.
+
+**Proof.** Items 1 and 2 are exhaustive symplectic computations with `Z4` phases, every relation checked pair by pair rather than assumed, the face relations
+obtained by exhausting all products of subsets of the face loops, the code dimension read off a Gaussian elimination on the `X`-parts. Item 3 is immediate from
+every edge appearing in exactly two stars and is confirmed on every edge pattern; item 4 is a construction plus the same audit re-run. All exact.
+
+**Reading, not theorem.** Under this readout the cluster can only ever show an even number of records. That is not a choice made when the readout was written
+down; it is forced by the readout, because each edge record counts at both of its ends. An odd count needs one more site, and the pendant is it.
+
+## Theorem 2 -- the encoded law and the fermionic law are the same matrix up to a diagonal unit gauge
+
+**Conclusion.** In the record-number sectors of dimension `70` (cube, `N = 4`), `84` (`grid3x3`, `N = 6`) and `84` (pendant, `n_aux = 1` and `N_grid = 3`):
+
+1. The diagonal of `H_enc` is the fermionic bond count on every pattern, and `2^k H_enc` a Gaussian-integer matrix of maximum modulus `32`, `16`, `16`.
+2. There is an exact diagonal `D` with all entries in `{1, i, -1, -i}` -- `38`, `40` and `44` of them non-real -- with `D H_enc D^dag = H_F` **entrywise**, no
+   residual whatsoever. `D` is unitary, so the two matrices have identical spectra, identical ground spaces up to that phase, and identical record statistics
+   at every real `g`.
+
+**Proof.** The sector matrix is assembled from the encoded hop acting on every edge pattern of every kept coset, and its exactness certified by multiplying
+through by `2^k` and checking integrality of real and imaginary parts with zero residual. The gauge is found by a spanning-tree walk on the off-diagonal
+support: the support sets are compared first, each entry then fixes one phase relative to its neighbour, every remaining entry is a consistency test rather than
+a free choice, and the identity is finally verified entrywise. Conjugation by a diagonal unitary preserves the spectrum and every diagonal probability.
+
+**Reading, not theorem.** Two descriptions that look different -- one about records on edges, one about occupancy on vertices -- are the same description up to
+a phase attached to each pattern, and such a phase changes no probability. So the two agree on everything readable, at every coupling, not only at the one
+point where the answer is available in closed form.
+
+## Theorem 3 -- the zero sets at `g = 0`, and the records that carry them
+
+**Conclusion.** At `g = 0`, recomputed independently from exact Slater determinants over `Q(sqrt2)` after verifying the orbitals are eigenvectors and the
+ground determinant unique across a strict single-particle gap:
+
+1. Cube, `N = 4`: ground energy `-6`, normalization `1`, value multiset `0 x12`, `1/64 x56`, `1/16 x2`. The `12` zeros are exactly the `6` occupied cube faces
+   and the `6` patterns of two disjoint adjacent pairs, `0` other.
+2. Pendant, `N_grid = 3`: `E0 = -4 sqrt2`, normalization `1`, multiset `0 x8`, `1/256 x12`, `1/128 x32`, `1/64 x20`, `1/32 x8`, `9/256 x4`; the `8` zeros are
+   exactly the `3` rows, `3` columns and `2` diagonals. `grid3x3` at `N = 6` on the plain `12`-qubit code has the same multiset, its `8` zeros exactly the
+   complements of those -- the particle-hole image.
+3. Every vertex pattern carries a constant fibre of `2^k = 32`, `16`, `16` edge records, with `|phi(y)| = 1` throughout, so an edge record's probability is its
+   vertex pattern's divided by the fibre size and the `384`, `128` and `128` edge records over a zero are exactly zero.
+
+**Proof.** The single-particle orbitals are exhibited and checked to be exact eigenvectors of the cluster adjacency over `Q(sqrt2)`; each pattern's Slater
+amplitude is the determinant of the occupied rows, taken by Gaussian elimination in the field `Q(sqrt2)` with `Fraction` coefficients, so no floating point
+enters. The vector is verified to satisfy `H_F v = E v` exactly against the integer matrix and to have `<v|v> = 1`, uniqueness following from the strict gap
+between the highest filled and lowest empty single-particle level. The zero-set classifications are exhaustive enumerations, and item 3 follows from the coset
+structure -- every coset has exactly `2^k` members, each coefficient a unit -- both halves checked directly. All exact.
+
+**Reading, not theorem.** Some record patterns never form. Which ones is decided by the shape of the whole pattern: on the cube the six faces and the six pairs
+of opposite edges, on the grid the eight straight lines. The exclusion is visible in the records themselves, since every edge-level record reading out to an
+excluded pattern has probability exactly zero too.
+
+## Theorem 4 -- the zeros at other couplings, and the four lines through the centre
+
+**Conclusion.** As a floating-point witness at tolerance `1e-12`, over `g in {0, 0.5, 1, 2}`:
+
+1. The encoded and fermionic record statistics agree to `L1` distance at most `2.0e-15` (cube), `3.4e-15` (`grid3x3`, `N = 6`) and `2.6e-15` (pendant), their
+   zero sets coincide at every point, and the ground state is simple throughout, with smallest gaps `0.573988`, `0.788251` and `1.293567`.
+2. The zero counts are `12/12/12/12` on the cube, `8/4/4/4` on both grid sectors.
+3. The zeros surviving every `g in {0.5, 1, 2}` are all `12` on the cube -- the whole `g = 0` set -- and exactly `4` of `8` on the grid: the four centre lines
+   `(3,4,5)`, `(1,4,7)`, `(0,4,8)`, `(2,4,6)` at `N_grid = 3`, and their complements at `N = 6`.
+
+**Proof.** Both matrices are formed at each coupling and diagonalised; the ground-space projector diagonal is compared entry by entry, the zero sets taken at
+`1e-12`, the degeneracy read at `1e-9`, and the surviving set obtained as the intersection over the non-zero couplings and compared with the named line set.
+This is a numerical witness, labelled as such; the exact statement that the two laws agree at every coupling is Theorem 2, of which this is a confirmation at
+four points rather than a substitute.
+
+**Reading, not theorem.** Four of the grid's eight zeros persist once the two-site term carries weight and four do not; the four that persist are the four
+straight lines through the centre. What the coupling leaves alone is the part of the pattern a symmetry of the cluster already fixes.
+
+## Theorem 5 -- every negative amplitude is a parity over one vertex's incident edges
+
+**Conclusion.** In the edge-record basis of the sector:
+
+1. Every off-diagonal amplitude is exactly `+i` or `-i` -- `15360` of them on the cube, split `7680/7680`, and `8064` on `grid3x3`, split `4032/4032`.
+2. The `Z`-support of `A_ij B_i` lies inside `star(i) U star(j)`, and `sign(y) = s_e (-1)^{|y intersect Z(A_ij B_i)|}` with one constant `s_e` per edge, for
+   every edge and every one of the `4096` records, so each sign is a parity of the record over **single-vertex incident-edge sets**.
+3. The signs are not a relabelling. The gauge-invariant product of amplitudes around a four-cycle of the configuration graph is `-1` on `144` of the cube's
+   `444` cycles and `80` of the grid's `344`, identical for `H_F`; in a spanning-tree gauge `90` of `240` and `80` of `252` entries remain `+1`, so no diagonal
+   gauge makes either law sign-uniform.
+
+**Proof.** Item 1 is collected while the sector matrix is assembled, each amplitude asserted to be a unit purely imaginary Gaussian integer. Item 2 tests mask
+containment on every edge and evaluates the closed form on every record of the full edge space, fixing `s_e` from the first non-vanishing record. Item 3
+computes a quantity invariant under diagonal rephasing -- the product around a closed four-step circuit -- so no artefact of a convention. All exact.
+
+**Reading, not theorem.** Whether a record pattern can form depends on the parity of the records around single sites. Every minus sign in the law is one of
+those parities, and no larger region is consulted. Nor are those signs bookkeeping: a quantity no relabelling can change is negative on `144` of `444` circuits.
+
+## Theorem 6 -- the control: the bare edge flip has no zeros at any coupling
+
+**Conclusion.** Replacing `A_ij` by the bare edge flip `X_e`:
+
+1. The bare term anticommutes with `16` of the `60` and `12` of the `48` (term, stabilizer generator) pairs on the cube and on `grid3x3`, so it does not
+   preserve the code space.
+2. It still conserves the record, and on the preserved edge sectors -- dimension `2240` and `1344` -- a diagonal unit gauge turns all `7680` and `4032`
+   off-diagonal entries into `-1` on a configuration graph of exactly one connected component.
+3. Hence by Perron-Frobenius its lowest state is simple and strictly positive at every real `g`, and its pushforward through the dictionary sums positive
+   numbers. Numerically at `g in {0, 0.5, 1, 2}` all `70` and `84` patterns carry probability at least `1.4861e-03` and `2.3740e-04`, with `0` exact zeros.
+
+**Proof.** Item 1 is a pairwise commutation test against the stabilizer generators. Item 2 builds the bare sector explicitly, verifies Hermiticity and record
+conservation on every basis element, then runs a spanning-tree gauge whose residual counts are exhibited: all entries land on `-1` and the walk visits the
+whole graph, which is the irreducibility hypothesis. Item 3 is Perron-Frobenius with both hypotheses checked. Items 1 and 2 are exact; the confirming
+diagonalisation is a labelled numerical witness.
+
+**Reading, not theorem.** Take away the one ingredient that is a condition on a whole neighbourhood and the exclusions vanish entirely. The control is not a
+weaker version of the law: it does not respect the constraints that make the readout well defined, and on the part it does respect every pattern has positive
+probability.
+
+## Corollary -- the readable shadow, produced in three dimensions by ordinary composition
+
+Within the setting declared above, and on the three finite clusters named:
+
+1. The zero sets that `COMPOSITION_DISCRIMINATOR_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7833) identifies as the readable shadow of a
+   cross-site sign -- `12` of `70` on the cube, `8` of `84` on the `3x3` grid, same value multisets -- are reproduced here on an **ordinary-composition**
+   edge-site lattice, the plain tensor product throughout with no graded clause anywhere.
+2. The only non-trivial ingredient is a **single-vertex neighbourhood condition**: the readout is a parity over one vertex's incident edges, by Theorem 5 every
+   sign in the law is such a parity as well, and nothing in the construction reads a region larger than one vertex's star.
+3. This is the record-level face of the operator-level construction in
+   `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): that note establishes the
+   same encoding's exchange statistics on `Z^3` as an operator statement, this one what the encoding does to the probabilities a record readout returns on
+   finite clusters. Neither derives the other; they check different quantities of one declared construction.
+4. What the dictionary supplies is a translation, not an explanation: the zeros are reproduced because Theorem 2 makes the two matrices the same matrix, and
+   why the exclusion law holds is untouched by that and stated as open in "Proof boundary".
+
+## What does not move
+
+- This does not decide what the framework's readout is: it declares one dictionary, of a form the record axiom permits, and computes with it. It supplies no
+  update rule, no formation site, no formation rate, and no values; no absolute unit and no dynamical clause appears anywhere, and it says nothing about larger
+  clusters, periodic boundaries, infinite lattices, or law families other than the one in "Definitions". No axiom text is amended, extended, reworded, or
+  reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is created or edited.
+
+## Interfaces named for other lanes, not moved here
+
+- The exclusion law itself. This note reproduces a zero set and derives no exclusion principle; a lane wanting one should treat Theorem 3 as the target to
+  explain and Theorem 5 as the structure available to explain it with.
+- The pendant construction. Theorem 1 item 3 makes the even record number an identity of the readout; whether a dictionary registering odd record numbers
+  without an auxiliary site exists is untouched, as is whether an analogue of Theorem 4's four centre lines survives on larger grids or on `3x3x3`.
+
+## Remaining live routes
+
+1. Bigger clusters and periodic boundaries. The face relations, and with them the code dimension, change on a torus; nothing here covers that case, and only
+   the one nearest-neighbour family of "Definitions" is read -- a longer-range or multi-site family is another question.
+2. The coupling scan. Theorem 4 is a witness at four points; an exact statement about which zeros persist at every `g` would supersede it. The readout's
+   uniqueness is likewise open: the parity dictionary is one readout map among many, and no minimality is claimed for it.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the six theorem conclusions.
+
+```text
+setting: qubits on the EDGE sites of three finite open graphs; ordinary (commuting) composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+clusters: cube 2x2x2 V/E/F 8/12/6; grid3x3 9/12/4; grid3x3+pendant at vertex 0 10/13/4
+encoding: A_ij = X(edge ij) * Z's ordered before it at both endpoints; A_ji = -A_ij; B_i the Z's incident to i; S_f the ordered four-A face loop
+dictionary: n_i = (1 - B_i)/2 = |y intersect star(i)| mod 2, a condition on one vertex's incident edges
+relations_and_code: R0-R4 pair by pair; faces 6 with one relation (product of all six) = +I so k=5, 4 with none so k=4, 4 with none so k=4; no -I in any group
+code_dimensions: 2^12/2^5 = 128, 2^12/2^4 = 256, 2^13/2^4 = 512, each equal to 2^(V-1); sectors cube N=4 dim 70, grid3x3 N=6 dim 84, pendant N_grid=3 dim 84
+even_record_identity: prod_i B_i = +I identically; even record number on all 4096/4096/8192 edge patterns; record map injective on 128/256/512 code states
+unit_gauge: 2^k H_enc Gaussian-integer of max modulus 32/16/16; D in {1,i,-1,-i}, 38/40/44 non-real, D H_enc D^dag = H_F entrywise
+g0_cube: E0 = -6; values 0 x12, 1/64 x56, 1/16 x2; zeros = 6 occupied faces + 6 two-disjoint-adjacent-pair patterns, 0 other
+g0_grid: E0 = -4 sqrt2; values 0 x8, 1/256 x12, 1/128 x32, 1/64 x20, 1/32 x8, 9/256 x4; zeros at N_grid=3 = 3 rows + 3 columns + 2 diagonals; at N=6 their complements
+fibres: |phi(y)| = 1 everywhere; constant fibre 2^k = 32/16/16; 70x32 = 2240, 84x16 = 1344 twice in the sector; 384/128/128 records over a zero, all exactly 0
+persistence_numerical: g in {0, 0.5, 1, 2}; L1 <= 2.0e-15 / 3.4e-15 / 2.6e-15; zero counts 12/12/12/12 and 8/4/4/4; ground simple; gaps 0.573988 / 0.788251 / 1.293567
+persistent_zeros: cube 12 of 12; grid 4 of 8, the lines (3,4,5) (1,4,7) (0,4,8) (2,4,6) at N_grid=3 and their complements at N=6
+sign_structure: 15360 amplitudes split 7680/7680 (cube) and 8064 split 4032/4032 (grid), each exactly +i or -i; Z(A_ij B_i) inside star(i) U star(j); sign(y) = s_e (-1)^{|y & Z(A_ij B_i)|} on all 4096 records
+flux_witness: four-cycle flux -1 on 144 of 444 (cube) and 80 of 344 (grid), identical for H_F; spanning-tree gauge leaves 90 of 240 and 80 of 252 entries at +1
+control: bare X_e anticommutes with 16 of 60 and 12 of 48 (term, generator) pairs; preserved sectors 2240 and 1344; unit gauge makes all 7680 and 4032 entries -1 on 1 component; Perron-Frobenius simple and strictly positive at every real g; min probability 1.4861e-03 and 2.3740e-04, 0 exact zeros
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=25 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **four finite open clusters at fixed record number**: cube `N = 4` (dimension `70`), `grid3x3` `N = 6` (`84`), `grid3x3`
+with a pendant mode at `n_aux = 1` and `N_grid = 3` (`84`), and the control's edge sectors of dimension `2240` and `1344`. Nothing is claimed for larger
+clusters, periodic boundaries, infinite lattices, or any law family other than the one written in "Definitions".
+
+This note supplies a **dictionary, not a derivation of the exclusion law**. Theorem 2 shows the encoded and the fermionic matrix are the same matrix up to a
+diagonal unit gauge, so the zero sets have to agree; that is a translation between two descriptions, and it explains why the numbers match without explaining
+why the numbers are zero. The exclusion is imported from the structure of the encoding, not deduced from any axiom.
+
+The encoding is **chosen** so that the Majorana relations `R0`-`R4` hold, and the face constraints are exactly what makes that choice consistent: the code
+space is the joint `+1` eigenspace of the face loops, and outside it the encoded hop is not the operator computed here. The `12`-qubit lattices carry an even
+record number only, `prod_i B_i = +I` being an identity of the readout rather than a property of a state, so the odd target `N = 3` uses one pendant mode whose
+edge carries no term of the law -- an auxiliary device, declared as such, with the `N = 6` sector reported alongside it precisely so the same zero set is
+exhibited without any auxiliary mode, as the particle-hole image.
+
+Theorem 4 and the confirming half of Theorem 6 are **floating-point witnesses at `1e-12`** over four couplings; the exact content of the coupling statement is
+Theorem 2's unit-gauge identity, which holds at every real `g` without approximation, and the four surviving grid zeros are the intersection over the three
+non-zero couplings tested, not a proof that no further coupling changes the set. The sign structure of Theorem 5 is about **this** encoding's amplitudes in
+**this** basis: the closed form is verified on every record rather than sampled and the flux is invariant under diagonal rephasing, so neither depends on the
+ordering convention, but a different encoding or neighbour ordering is a different computation. No axiom is amended, no status set, no registry entry made.
+
+## Review record
+
+An honest auditor should come away with: a dictionary and its consequences, not a claim about the framework's readout; five exact theorems and one numerical
+witness on named finite clusters; one open question stated as open (why the exclusion law holds at all, as against why these two descriptions agree); and one
+device declared as a device (the pendant mode). Floating point is confined to Theorem 4 and item 3 of Theorem 6, both labelled `[numerical]` on every runner
+line where they appear, and no exact statement rests on them.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the context notes in
+"Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at
+`PASS=25 FAIL=0` with runtime under the declared `300` seconds and stdout under `5500` characters, a current zero-dependency citation-manifest entry, and
+passing pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.txt
+++ b/logs/runner-cache/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.py
+runner_sha256: 242c91d77959606b4ba1fa66d87e0e540f7e07ed90cbf8fee176317f62e62cd8
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 4.40
+status: ok
+----- stdout -----
+PASS A1 [exact] cube edge-site code V=8 E=12: R0-R4 hold, 6 face loops, 1 relation (all six) = +I, k=5, group 2^5 free of -I, code dim 2^12/2^5 = 128 = 2^(V-1)
+PASS A2 [exact] grid3x3 edge-site code V=9 E=12: R0-R4 hold, 4 face loops, 0 relations (none), k=4, group 2^4 free of -I, code dim 2^12/2^4 = 256 = 2^(V-1)
+PASS A3 [exact] grid3x3+pendant edge-site code V=10 E=13: R0-R4 hold, 4 face loops, 0 relations (none), k=4, group 2^4 free of -I, code dim 2^13/2^4 = 512 = 2^(V-1)
+PASS A4 [exact] prod_i B_i = +I identically: n_i = (1-B_i)/2 registers an EVEN record number on all 4096/4096/8192 edge patterns, and is injective on the 128/256/512 code states, so an odd target needs the pendant mode
+PASS B1 [exact] cube N=4: dim 70, diagonals equal the fermionic bond counts, 2^5 H_enc a Gaussian-integer matrix of max modulus 32, and a unit gauge D (38 of 70 entries in {i,-i}) gives D H_enc D^dag = H_F
+PASS B2 [exact] grid3x3 N=6: dim 84, diagonals equal the fermionic bond counts, 2^4 H_enc a Gaussian-integer matrix of max modulus 16, and a unit gauge D (40 of 84 entries in {i,-i}) gives D H_enc D^dag = H_F
+PASS B3 [exact] grid3x3+pendant n_aux=1, N_grid=3: dim 84, diagonals equal the fermionic bond counts, 2^4 H_enc a Gaussian-integer matrix of max modulus 16, and a unit gauge D (44 of 84 entries in {i,-i}) gives D H_enc D^dag = H_F
+PASS C1 [exact] cube N=4 at g=0: orbitals are exact eigenvectors, the Slater ground state over Q(sqrt2) has H_F v = -6 v and <v|v> = 1, levels -1 | 1 across the cut so it is unique; statistics 0 x12, 1/64 x56, 1/16 x2
+PASS C2 [exact] the cube's 12 zeros of 70 are exactly the 6 occupied cube faces and the 6 patterns of two disjoint adjacent pairs, 0 other; every zero is an exact cancellation, not a small number
+PASS C3 [exact] grid3x3+pendant N_grid=3 at g=0: H_F v = -4 sqrt2 v, <v|v> = 1, levels -sqrt2 | 0; statistics 0 x8, 1/256 x12, 1/128 x32, 1/64 x20, 1/32 x8, 9/256 x4; the 8 zeros are exactly the 3 rows, 3 columns, 2 diagonals
+PASS C4 [exact] grid3x3 N=6 on the 12-qubit code at g=0: H_F v = -4 sqrt2 v, <v|v> = 1, levels 0 | sqrt2, the same value multiset; its 8 zeros are exactly the complements of the N_grid=3 zeros, the particle-hole image
+PASS D1 [numerical, 1e-12] cube N=4 at g in {0, 0.5, 1, 2}: encoded and fermionic statistics agree to L1 <= 2.0e-15, zero counts 12/12/12/12 identical, ground simple throughout, smallest gap 0.573988
+PASS D2 [numerical, 1e-12] grid3x3 N=6 at g in {0, 0.5, 1, 2}: encoded and fermionic statistics agree to L1 <= 3.4e-15, zero counts 8/4/4/4 identical, ground simple throughout, smallest gap 0.788251
+PASS D3 [numerical, 1e-12] grid3x3+pendant n_aux=1, N_grid=3 at g in {0, 0.5, 1, 2}: encoded and fermionic statistics agree to L1 <= 2.6e-15, zero counts 8/4/4/4 identical, ground simple throughout, smallest gap 1.293567
+PASS D4 [numerical, 1e-12] zeros surviving every g in {0.5, 1, 2}: cube 12 of 12, the whole g=0 set; grid3x3 4 of 8 at N_grid=3, exactly the four lines through the centre, and 4 of 8 at N=6, their complements
+PASS E1 [exact] cube: |phi(y)| = 1 on all 4096 edge records, every coset holds exactly 2^5 = 32, so the probability is P(pattern)/32 on the fibre; 70x32 = 2240 in the sector, 12x32 = 384 over a zero, all exactly 0
+PASS E2 [exact] grid3x3: |phi(y)| = 1 on all 4096 edge records, every coset holds exactly 2^4 = 16, so the probability is P(pattern)/16 on the fibre; 84x16 = 1344 in the sector, 8x16 = 128 over a zero, all exactly 0
+PASS E3 [exact] grid3x3+pendant: |phi(y)| = 1 on all 8192 edge records, every coset holds exactly 2^4 = 16, so the probability is P(pattern)/16 on the fibre; 84x16 = 1344 in the sector, 8x16 = 128 over a zero, all exactly 0
+PASS F1 [exact] cube: all 15360 off-diagonal edge-basis amplitudes are exactly +i or -i, split 7680/7680; Z(A_ij B_i) sits inside star(i) U star(j), and sign(y) = s_e (-1)^{|y & Z(A_ij B_i)|} on all 4096 records
+PASS F2 [exact] grid3x3: all 8064 off-diagonal edge-basis amplitudes are exactly +i or -i, split 4032/4032; Z(A_ij B_i) sits inside star(i) U star(j), and sign(y) = s_e (-1)^{|y & Z(A_ij B_i)|} on all 4096 records
+PASS F3 [exact] four-cycle flux: cube 144 of 444 carry -1, grid3x3 80 of 344, identical for H_F (144/444, 80/344); in a spanning-tree gauge 90 of 240 and 80 of 252 entries stay +1, so no gauge makes either law sign-uniform
+PASS G1 [exact] cube control: bare X_e in place of A_ij anticommutes with 16 of 60 (term, generator) pairs, leaving the code space; it conserves the record on a 2240-dim sector where a gauge makes all 7680 entries -1, 1 component
+PASS G2 [numerical, 1e-12] cube control on that sector at g in {0, 0.5, 1, 2}: ground simple, all 70 patterns strictly positive, smallest 1.4861e-03, 0 exact zeros -- the Perron-Frobenius consequence of that gauge
+PASS G3 [exact] grid3x3 control: bare X_e in place of A_ij anticommutes with 12 of 48 (term, generator) pairs, leaving the code space; it conserves the record on a 1344-dim sector where a gauge makes all 4032 entries -1, 1 component
+PASS G4 [numerical, 1e-12] grid3x3 control on that sector at g in {0, 0.5, 1, 2}: ground simple, all 84 patterns strictly positive, smallest 2.3740e-04, 0 exact zeros -- the Perron-Frobenius consequence of that gauge
+SUMMARY: ordinary composition plus a single-vertex parity dictionary reproduces the graded selection-rule zeros exactly; the bare edge-flip control has none.
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.py
+++ b/scripts/emergent_dictionary_selection_rule_zeros_three_dimensions_check_2026_09_02.py
@@ -1,0 +1,966 @@
+#!/usr/bin/env python3
+"""The emergent dictionary reproduces the three-dimensional selection-rule zeros.
+
+Class-A finite-cluster runner. Qubits sit on the EDGE sites of three finite
+graphs; the sites compose ordinarily (tensor product, operators on disjoint
+regions commute, no graded clause anywhere). A parity dictionary reads vertex
+occupancy off the edge records,
+
+    n_i = (1 - B_i) / 2,      B_i = product of the Z's on the edges at vertex i,
+
+so the readout at a vertex is a condition on the records of that one vertex's
+incident edges. The runner establishes, on the 2x2x2 cube graph (8 vertices,
+12 edges), the 3x3 grid graph (9 vertices, 12 edges) and the 3x3 grid with one
+pendant auxiliary mode at vertex 0 (10 vertices, 13 edges):
+
+  A  ENCODING.  The Bravyi-Kitaev superfast relations R0-R4 for
+         A_ij = X(edge ij) * prod Z(edges ordered before it at i and at j),
+         A_ji = -A_ij,   B_i = the product of the Z's incident to i,
+         S_f  = the ordered product of the A's around a face,
+     the face relations, the stabilizer group, and the code dimension
+     2^(V-1); prod_i B_i = +I identically, so the dictionary registers an even
+     record number only, which is why an odd target needs a pendant mode.
+  B  UNIT GAUGE.  An exact diagonal gauge D with entries in {1, i, -1, -i}
+     with D H_enc D^dag = H_F entrywise, H_F the Jordan-Wigner matrix of the
+     same nearest-neighbour law on the same occupation patterns. Spectra and
+     record statistics therefore agree at every coupling, exactly.
+  C  ZEROS AT g = 0.  The record statistics recomputed independently from
+     exact Slater determinants over Q(sqrt2), and the exact zero sets.
+  D  PERSISTENCE.  A numerical witness at g != 0: agreement to 1e-12, equal
+     zero sets, ground-state simplicity, and the zeros that survive.
+  E  FIBRES.  Each vertex pattern carries a constant fibre of 2^k edge
+     patterns, and every edge pattern over a zero is exactly zero.
+  F  SIGN STRUCTURE.  Every off-diagonal amplitude in the edge-record basis is
+     exactly +i or -i, split evenly, with the closed form
+         sign(y) = s_e * (-1)^{|y & Z(A_ij B_i)|},
+     the Z-support lying inside star(i) U star(j); and the gauge-invariant
+     four-cycle flux of the configuration graph.
+  G  CONTROL.  The bare edge-flip law with X_e in place of A_ij leaves the
+     code space, and on what it does preserve it is gaugeable to a uniform -1
+     on a connected configuration graph, so Perron-Frobenius makes its record
+     statistics strictly positive with no zero at any coupling.
+
+Groups A, B, C, E, F, G are exact: Pauli algebra in the symplectic
+representation with phases mod 4, Gaussian-integer amplitudes, rational and
+Q(sqrt2) arithmetic over Fraction. Group D and the confirming line of group G
+are floating-point witnesses and are labelled [numerical]. Every line is
+tagged [exact] or [numerical].
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from fractions import Fraction
+from functools import reduce
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 300
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================================== Pauli algebra
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+class P:
+    """i^k * prod_q X_q^{x_q} Z_q^{z_q}, X written before Z on every qubit."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(s, k, x, z):
+        s.k = k % 4
+        s.x = x
+        s.z = z
+
+    def __mul__(a, b):
+        return P(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(s):
+        return P(s.k + 2, s.x, s.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def is_herm(s):
+        return s.k % 2 == pcnt(s.x & s.z) % 2
+
+    def is_id(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def is_mid(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+
+ID = P(0, 0, 0)
+PH = [1 + 0j, 1j, -1 + 0j, -1j]
+
+
+def comm(a, b):
+    return (pcnt(a.x & b.z) + pcnt(a.z & b.x)) % 2 == 0
+
+
+def pact(p, y):
+    """p|y> = amp |y ^ p.x> with amp a unit Gaussian integer."""
+    return y ^ p.x, PH[p.k] * ((-1) ** (pcnt(p.z & y) % 2))
+
+
+# =================================================== exact arithmetic Q(sqrt2)
+
+class S2:
+    """a + b*sqrt(2) with a and b rational; exact, no floating point."""
+
+    __slots__ = ("a", "b")
+
+    def __init__(s, a=0, b=0):
+        s.a = Fraction(a)
+        s.b = Fraction(b)
+
+    def __add__(s, t):
+        return S2(s.a + t.a, s.b + t.b)
+
+    def __sub__(s, t):
+        return S2(s.a - t.a, s.b - t.b)
+
+    def __mul__(s, t):
+        return S2(s.a * t.a + 2 * s.b * t.b, s.a * t.b + s.b * t.a)
+
+    def neg(s):
+        return S2(-s.a, -s.b)
+
+    def inv(s):
+        d = s.a * s.a - 2 * s.b * s.b
+        return S2(s.a / d, -s.b / d)
+
+    def zero(s):
+        return s.a == 0 and s.b == 0
+
+    def __eq__(s, t):
+        return s.a == t.a and s.b == t.b
+
+    def __hash__(s):
+        return hash((s.a, s.b))
+
+    def txt(s):
+        if s.b == 0:
+            return str(s.a)
+        return "%s%+s*sqrt2" % (s.a, s.b) if s.a else "%s*sqrt2" % s.b
+
+
+S0 = S2(0)
+S1 = S2(1)
+
+
+def s2_det(M):
+    """Exact determinant over Q(sqrt2) by Gaussian elimination in the field."""
+    n = len(M)
+    M = [row[:] for row in M]
+    sgn = 1
+    det = S1
+    for c in range(n):
+        p = None
+        for r in range(c, n):
+            if not M[r][c].zero():
+                p = r
+                break
+        if p is None:
+            return S0
+        if p != c:
+            M[c], M[p] = M[p], M[c]
+            sgn = -sgn
+        piv = M[c][c]
+        det = det * piv
+        inv = piv.inv()
+        for r in range(c + 1, n):
+            f = M[r][c] * inv
+            if f.zero():
+                continue
+            for kk in range(c, n):
+                M[r][kk] = M[r][kk] - f * M[c][kk]
+    return det if sgn > 0 else det.neg()
+
+
+# ==================================================================== clusters
+
+def grid_cluster(nr, nc):
+    idx = {(r, c): nc * r + c for r in range(nr) for c in range(nc)}
+    B = []
+    for r in range(nr):
+        for c in range(nc):
+            if c + 1 < nc:
+                B.append((idx[(r, c)], idx[(r, c + 1)]))
+            if r + 1 < nr:
+                B.append((idx[(r, c)], idx[(r + 1, c)]))
+    return nr * nc, sorted((min(u, v), max(u, v)) for u, v in B)
+
+
+def grid_faces(nr, nc):
+    idx = {(r, c): nc * r + c for r in range(nr) for c in range(nc)}
+    return [(idx[(r, c)], idx[(r, c + 1)], idx[(r + 1, c + 1)], idx[(r + 1, c)])
+            for r in range(nr - 1) for c in range(nc - 1)]
+
+
+def cube_cluster():
+    """Vertex s = 4a + 2b + c of the 2x2x2 cube; edges flip one coordinate."""
+    B = [(s, s ^ bit) for s in range(8) for bit in (4, 2, 1) if s ^ bit > s]
+    return 8, sorted(B)
+
+
+def cube_faces():
+    out = []
+    for ax in range(3):
+        bits = [4, 2, 1]
+        fb = bits[ax]
+        ob = [b for b in bits if b != fb]
+        for val in (0, fb):
+            out.append((val, val | ob[1], val | ob[0] | ob[1], val | ob[0]))
+    return out
+
+
+# ==================================================================== encoding
+
+class Enc:
+    """Superfast encoding on the edge sites of a graph."""
+
+    def __init__(self, V, EDGES, FACES, name):
+        self.name = name
+        self.V = V
+        self.EDGES = list(EDGES)
+        self.FACES = list(FACES)
+        self.NQ = len(self.EDGES)
+        self.DIM = 1 << self.NQ
+        self.EIDX = {}
+        for q, (i, j) in enumerate(self.EDGES):
+            self.EIDX[(i, j)] = q
+            self.EIDX[(j, i)] = q
+        self.NBR = {i: sorted(j for (a, b) in self.EDGES
+                              for j in ((b,) if a == i else ((a,) if b == i else ())))
+                    for i in range(V)}
+        self.STAR = {i: [self.EIDX[(i, k)] for k in self.NBR[i]] for i in range(V)}
+        self.STARMASK = {i: reduce(lambda a, b: a | (1 << b), self.STAR[i], 0)
+                         for i in range(V)}
+
+    def A_unsigned(self, i, j):
+        x = 1 << self.EIDX[(i, j)]
+        z = 0
+        for k in self.NBR[i]:
+            if k != j and k < j:
+                z ^= 1 << self.EIDX[(i, k)]
+        for l in self.NBR[j]:
+            if l != i and l < i:
+                z ^= 1 << self.EIDX[(j, l)]
+        return P(pcnt(x & z) % 2, x, z)
+
+    def A(self, i, j):
+        p = self.A_unsigned(i, j)
+        return p if i < j else p.neg()
+
+    def B(self, i):
+        return P(0, 0, self.STARMASK[i])
+
+    def loop(self, cyc):
+        out = ID
+        n = len(cyc)
+        for a in range(n):
+            out = out * self.A(cyc[a], cyc[(a + 1) % n])
+        return out
+
+    def record(self, z):
+        """The parity dictionary: n_i = (1 - B_i)/2 read off the edge record."""
+        return tuple(pcnt(z & self.STARMASK[i]) % 2 for i in range(self.V))
+
+    def hop_pauli(self, i, j):
+        A = self.A(i, j)
+        return A * self.B(i), A * self.B(j)
+
+    def hop_amp(self, P1, P2, y):
+        b1, a1 = pact(P1, y)
+        b2, a2 = pact(P2, y)
+        assert b1 == b2
+        v = 0.5j * (a1 - a2)
+        return b1, complex(round(v.real), round(v.imag))
+
+
+def audit(E):
+    """R0-R4 pair by pair, the face relations, and the code dimension."""
+    R = {}
+    A = {e: E.A(*e) for e in E.EDGES}
+    Bv = {i: E.B(i) for i in range(E.V)}
+    R["R0"] = (all(E.A_unsigned(i, j) == E.A_unsigned(j, i) for (i, j) in E.EDGES)
+               and all(E.A(j, i) == E.A(i, j).neg() for (i, j) in E.EDGES))
+    R["R1"] = (all(A[e].is_herm() and (A[e] * A[e]).is_id() for e in E.EDGES)
+               and all(Bv[i].is_herm() and (Bv[i] * Bv[i]).is_id() for i in range(E.V)))
+    r2 = all(comm(Bv[i], Bv[j]) for i, j in itertools.combinations(range(E.V), 2))
+    for e in E.EDGES:
+        for v in range(E.V):
+            r2 = r2 and (comm(A[e], Bv[v]) != (v in e))
+    R["R2"] = bool(r2)
+    R["R3"] = all(comm(A[e], A[f]) != (len(set(e) & set(f)) == 1)
+                  for e, f in itertools.combinations(E.EDGES, 2))
+    S = [E.loop(f) for f in E.FACES]
+    r4 = True
+    for s in S:
+        r4 = r4 and s.is_herm() and (s * s).is_id()
+        for e in E.EDGES:
+            r4 = r4 and comm(s, A[e])
+        for v in range(E.V):
+            r4 = r4 and comm(s, Bv[v])
+    for a, b in itertools.combinations(S, 2):
+        r4 = r4 and comm(a, b)
+    R["R4"] = bool(r4)
+    R["prodB"] = reduce(lambda a, b: a * b, [Bv[i] for i in range(E.V)])
+    gens, basis = [], []
+    for s in S:
+        v = s.x
+        for b in basis:
+            v = min(v, v ^ b)
+        if v != 0:
+            basis.append(v)
+            basis.sort(reverse=True)
+            gens.append(s)
+    R["k"] = len(gens)
+    R["gens"] = gens
+    rel = []
+    for r in range(2, len(S) + 1):
+        for sub in itertools.combinations(range(len(S)), r):
+            p = reduce(lambda a, b: a * b, [S[t] for t in sub])
+            if p.x == 0 and p.z == 0:
+                rel.append((sub, "+I" if p.k == 0 else "-I" if p.k == 2 else "?"))
+    R["relations"] = rel
+    grp = []
+    for m in range(1 << len(gens)):
+        p = ID
+        for t in range(len(gens)):
+            if (m >> t) & 1:
+                p = p * gens[t]
+        grp.append(p)
+    R["grp"] = grp
+    R["grp_ok"] = ((not any(g.is_mid() for g in grp))
+                   and sum(1 for g in grp if g.x == 0) == 1)
+    R["code_dim"] = E.DIM >> len(gens)
+    return R
+
+
+def code_space(E, R):
+    """Cosets of the stabilizer group; phi[y] the unit coefficient of |y>."""
+    grp = R["grp"]
+    phi = np.zeros(E.DIM, dtype=complex)
+    cid = -np.ones(E.DIM, dtype=np.int64)
+    reps = []
+    for y0 in range(E.DIM):
+        if cid[y0] >= 0:
+            continue
+        c = len(reps)
+        reps.append(y0)
+        for g in grp:
+            b, a = pact(g, y0)
+            assert cid[b] < 0
+            cid[b] = c
+            phi[b] = a
+    assert (cid >= 0).all()
+    recs = [E.record(reps[c]) for c in range(len(reps))]
+    for y in range(E.DIM):
+        assert E.record(y) == recs[cid[y]]
+    return cid, phi, reps, recs
+
+
+def sector_matrix(E, R, cid, phi, reps, recs, keep, HE):
+    """Exact H_enc on the code space, rows and columns the kept cosets."""
+    k = R["k"]
+    grp = R["grp"]
+    sel = [c for c in range(len(reps)) if keep(recs[c])]
+    pos = {c: a for a, c in enumerate(sel)}
+    n = len(sel)
+    Hoff = np.zeros((n, n), dtype=complex)
+    hp = {e: E.hop_pauli(*e) for e in HE}
+    bond = np.zeros(n)
+    stats = {"pos": 0, "neg": 0}
+    for c in sel:
+        a = pos[c]
+        rec = recs[c]
+        bond[a] = sum(1 for (u, v) in HE if rec[u] and rec[v])
+        for g in grp:
+            y, ay = pact(g, reps[c])
+            assert abs(phi[y] - ay) < 1e-12
+            for e in HE:
+                yy, amp = E.hop_amp(hp[e][0], hp[e][1], y)
+                if amp == 0:
+                    continue
+                assert amp.real == 0 and abs(amp.imag) == 1
+                stats["pos" if amp.imag > 0 else "neg"] += 1
+                cc = cid[yy]
+                if cc not in pos:
+                    continue
+                Hoff[pos[cc], a] += (2.0 ** (-k)) * np.conj(phi[yy]) * amp * phi[y]
+    Q = Hoff * (2.0 ** k)
+    exact = bool(np.all(np.abs(Q - np.round(Q.real) - 1j * np.round(Q.imag)) == 0))
+    Hoff = (np.round(Q.real) + 1j * np.round(Q.imag)) / (2.0 ** k)
+    return sel, pos, Hoff, bond, stats, exact, int(np.max(np.abs(Q)))
+
+
+# ================================================== Jordan-Wigner reference
+
+def jw_sign(S, src, dst):
+    lo, hi = min(src, dst), max(src, dst)
+    return (-1) ** sum(1 for kk in range(lo + 1, hi) if kk in S)
+
+
+def fermi_sector(EDGES, patterns):
+    """Graded (Jordan-Wigner) hopping matrix and bond-count diagonal."""
+    idx = {p: i for i, p in enumerate(patterns)}
+    n = len(patterns)
+    T = np.zeros((n, n))
+    D = np.zeros(n)
+    for p in patterns:
+        S = frozenset(i for i, b in enumerate(p) if b)
+        i0 = idx[p]
+        D[i0] = sum(1 for (u, v) in EDGES if u in S and v in S)
+        for (u, v) in EDGES:
+            for (src, dst) in ((u, v), (v, u)):
+                if src in S and dst not in S:
+                    T2 = frozenset((S - {src}) | {dst})
+                    tp = tuple(1 if q in T2 else 0 for q in range(len(p)))
+                    T[idx[tp], i0] += -jw_sign(S, src, dst)
+    assert np.array_equal(T, T.T)
+    return idx, T, D
+
+
+def unit_index(c):
+    for kk, u in enumerate(PH):
+        if abs(c - u) < 1e-9:
+            return kk
+    return None
+
+
+def gauge_match(Hs, Hf):
+    """Diagonal D with entries in {1,i,-1,-i} and conj(D) Hs D = Hf entrywise."""
+    n = Hs.shape[0]
+    ss = {(a, b) for a in range(n) for b in range(n)
+          if a != b and abs(Hs[a, b]) > 1e-9}
+    sf = {(a, b) for a in range(n) for b in range(n)
+          if a != b and abs(Hf[a, b]) > 1e-9}
+    if ss != sf:
+        return None
+    e = [None] * n
+    for root in range(n):
+        if e[root] is not None:
+            continue
+        e[root] = 0
+        st = [root]
+        while st:
+            a = st.pop()
+            for b in range(n):
+                if b == a or abs(Hs[a, b]) < 1e-9:
+                    continue
+                s, f = unit_index(Hs[a, b]), unit_index(Hf[a, b])
+                if s is None or f is None:
+                    return None
+                want = (e[a] + f - s) % 4
+                if e[b] is None:
+                    e[b] = want
+                    st.append(b)
+                elif e[b] != want:
+                    return None
+    d = np.array([PH[t] for t in e])
+    M = np.conj(d)[:, None] * Hs * d[None, :]
+    return d if np.max(np.abs(M - Hf)) == 0 else None
+
+
+def tree_gauge(H):
+    """Spanning-tree gauge; returns (components, entries, counts by i^k)."""
+    n = H.shape[0]
+    val = {(a, b): unit_index(H[a, b]) for a in range(n) for b in range(n)
+           if a != b and abs(H[a, b]) > 1e-9}
+    assert all(v is not None for v in val.values())
+    adj = {a: [] for a in range(n)}
+    for (a, b) in val:
+        adj[a].append(b)
+    e = [None] * n
+    ncomp = 0
+    for root in range(n):
+        if e[root] is not None:
+            continue
+        ncomp += 1
+        e[root] = 0
+        st = [root]
+        while st:
+            a = st.pop()
+            for b in adj[a]:
+                if e[b] is None:
+                    e[b] = (e[a] + 2 - val[(a, b)]) % 4
+                    st.append(b)
+    cnt = {0: 0, 1: 0, 2: 0, 3: 0}
+    for (a, b) in val:
+        if a > b:
+            continue
+        cnt[(val[(a, b)] + e[b] - e[a]) % 4] += 1
+    return ncomp, len(val) // 2, cnt, np.array([PH[t] for t in e])
+
+
+def flux4(H):
+    """Gauge-invariant product of H around every four-cycle."""
+    n = H.shape[0]
+    A = (np.abs(H) > 1e-9) & (~np.eye(n, dtype=bool))
+    nb = [np.where(A[a])[0] for a in range(n)]
+    tot = frus = 0
+    for a in range(n):
+        for b in nb[a]:
+            if b <= a:
+                continue
+            for c in nb[b]:
+                if c <= a:
+                    continue
+                for d in nb[c]:
+                    if d <= a or d == b or d >= b or not A[d, a]:
+                        continue
+                    tot += 1
+                    if (H[a, b] * H[b, c] * H[c, d] * H[d, a]).real < 0:
+                        frus += 1
+    return tot, frus
+
+
+# ================================================== single-particle orbitals
+
+HALF = S2(Fraction(1, 2), 0)
+RT2H = S2(0, Fraction(1, 2))
+NHALF = S2(Fraction(-1, 2), 0)
+NRT2H = S2(0, Fraction(-1, 2))
+W1 = [HALF, RT2H, HALF]
+W2 = [RT2H, S0, NRT2H]
+W3 = [HALF, NRT2H, HALF]
+O2 = [RT2H, RT2H]
+M2 = [RT2H, NRT2H]
+
+
+def prod_orb(fs):
+    out = []
+    for t in itertools.product(*[range(len(f)) for f in fs]):
+        e = S1
+        for f, kk in zip(fs, t):
+            e = e * f[kk]
+        out.append(e)
+    return out
+
+
+def s2_adj_check(V, EDGES, orb, ev):
+    """(A o)_i = ev * o_i exactly, A the 0/1 adjacency."""
+    for i in range(V):
+        acc = S0
+        for (u, v) in EDGES:
+            if u == i:
+                acc = acc + orb[v]
+            elif v == i:
+                acc = acc + orb[u]
+        if not (acc - ev * orb[i]).zero():
+            return False
+    return True
+
+
+def slater(patterns, orbs):
+    """Exact Slater amplitudes: det of the occupied rows of the orbital matrix."""
+    N = len(orbs)
+    out = []
+    for p in patterns:
+        rows = [i for i, b in enumerate(p) if b]
+        assert len(rows) == N
+        out.append(s2_det([[orbs[y][rows[x]] for y in range(N)] for x in range(N)]))
+    return out
+
+
+# ==================================================================== clusters
+
+VC, EC = cube_cluster()
+ENC_C = Enc(VC, EC, cube_faces(), "cube")
+VG, EG = grid_cluster(3, 3)
+ENC_G = Enc(VG, EG, grid_faces(3, 3), "grid3x3")
+AUX = 9
+ENC_GP = Enc(10, EG + [(0, AUX)], grid_faces(3, 3), "grid3x3+pendant")
+
+ORB_C = [prod_orb([O2, O2, O2]), prod_orb([M2, O2, O2]),
+         prod_orb([O2, M2, O2]), prod_orb([O2, O2, M2])]
+EV_C = [S2(3), S1, S1, S1]
+ORB_G6 = [prod_orb([W1, W1]), prod_orb([W1, W2]), prod_orb([W2, W1]),
+          prod_orb([W1, W3]), prod_orb([W3, W1]), prod_orb([W2, W2])]
+EV_G6 = [S2(0, 2), S2(0, 1), S2(0, 1), S0, S0, S0]
+ORB_G3 = [prod_orb([W1, W1]), prod_orb([W1, W2]), prod_orb([W2, W1])]
+EV_G3 = [S2(0, 2), S2(0, 1), S2(0, 1)]
+ORB_GP = [o + [S0] for o in ORB_G3] + [[S0] * 9 + [S1]]
+
+LINES = set()
+for r in range(3):
+    LINES.add(tuple(3 * r + c for c in range(3)))
+    LINES.add(tuple(3 * c + r for c in range(3)))
+LINES.add((0, 4, 8))
+LINES.add((2, 4, 6))
+CENTRE_LINES = {(3, 4, 5), (1, 4, 7), (0, 4, 8), (2, 4, 6)}
+
+CASES = {}
+
+
+def build(tag, E, keep, HE, orbs, evs, E0, ndesc):
+    """Encoding audit, code space, sector matrix, gauge, exact ground state."""
+    R = audit(E)
+    cid, phi, reps, recs = code_space(E, R)
+    sel, pos, Hoff, bond, stats, exact, mx = sector_matrix(
+        E, R, cid, phi, reps, recs, keep, HE)
+    pats = [recs[c] for c in sel]
+    n = len(sel)
+    fidx, T, D = fermi_sector(HE, pats)
+    order = [fidx[p] for p in pats]
+    T = T[np.ix_(order, order)]
+    D = D[order]
+    d = gauge_match(Hoff, T)
+    v = slater(pats, orbs)
+    Ti = [[int(round(T[a, b])) for b in range(n)] for a in range(n)]
+    eig = True
+    for a in range(n):
+        acc = S0
+        for b in range(n):
+            if Ti[a][b]:
+                acc = acc + S2(Ti[a][b], 0) * v[b]
+        eig = eig and (acc - E0 * v[a]).zero()
+    nrm = S0
+    prob = []
+    for a in range(n):
+        q = v[a] * v[a]
+        prob.append(q)
+        nrm = nrm + q
+    rational = all(q.b == 0 for q in prob)
+    zeros = [pats[a] for a in range(n) if prob[a].zero()]
+    vals = sorted(set(prob), key=lambda q: float(q.a) + 1.4142135623730951 * float(q.b))
+    counts = [(vals[t].txt(), sum(1 for q in prob if q == vals[t]))
+              for t in range(len(vals))]
+    ctxt = ", ".join("%s x%d" % kv for kv in counts)
+    orth = all(s2_adj_check(E.V, HE, orbs[t], evs[t]) for t in range(len(orbs)))
+    CASES[tag] = dict(E=E, R=R, cid=cid, phi=phi, reps=reps, recs=recs, sel=sel,
+                      pos=pos, Hoff=Hoff, bond=bond, stats=stats, exact=exact,
+                      mx=mx, T=T, D=D, d=d, pats=pats, n=n, prob=prob,
+                      zeros=zeros, counts=counts, nrm=nrm, eig=eig,
+                      rational=rational, orth=orth, HE=HE, keep=keep,
+                      ndesc=ndesc, ctxt=ctxt)
+    return CASES[tag]
+
+
+# ==================================================================== group A
+
+def group_A():
+    C = build("cube", ENC_C, lambda r: sum(r) == 4, EC, ORB_C, EV_C, S2(-6), "N=4")
+    G = build("grid", ENC_G, lambda r: sum(r) == 6, EG, ORB_G6, EV_G6,
+              S2(0, -4), "N=6")
+    Pd = build("pend", ENC_GP, lambda r: r[AUX] == 1 and sum(r[:9]) == 3, EG,
+               ORB_GP, EV_G3 + [S0], S2(0, -4), "n_aux=1, N_grid=3")
+    for tag, res, nrel in (("cube", C, 1), ("grid", G, 0), ("pend", Pd, 0)):
+        R = res["R"]
+        E = res["E"]
+        rel = R["relations"]
+        check("A%d [exact] %s edge-site code V=%d E=%d: R0-R4 hold, %d face loops, "
+              "%d relation%s %s, k=%d, group 2^%d free of -I, code dim 2^%d/2^%d = %d "
+              "= 2^(V-1)"
+              % (1 + ("cube", "grid", "pend").index(tag), E.name, E.V, len(E.EDGES),
+                 len(E.FACES), len(rel), "" if len(rel) == 1 else "s",
+                 "(all six) = %s" % rel[0][1] if rel else "(none)",
+                 R["k"], R["k"], E.NQ, R["k"], R["code_dim"]),
+              R["R0"] and R["R1"] and R["R2"] and R["R3"] and R["R4"]
+              and R["grp_ok"] and len(rel) == nrel
+              and R["code_dim"] == (1 << (E.V - 1)))
+    par = all(sum(CASES[t]["E"].record(y)) % 2 == 0
+              for t in ("cube", "grid", "pend")
+              for y in range(CASES[t]["E"].DIM))
+    inj = all(len(set(CASES[t]["recs"])) == len(CASES[t]["recs"])
+              for t in ("cube", "grid", "pend"))
+    check("A4 [exact] prod_i B_i = +I identically: n_i = (1-B_i)/2 registers an EVEN "
+          "record number on all %d/%d/%d edge patterns, and is injective on the %d/%d/%d "
+          "code states, so an odd target needs the pendant mode"
+          % (ENC_C.DIM, ENC_G.DIM, ENC_GP.DIM, C["R"]["code_dim"],
+             G["R"]["code_dim"], Pd["R"]["code_dim"]),
+          all(CASES[t]["R"]["prodB"].is_id() for t in ("cube", "grid", "pend"))
+          and par and inj)
+
+
+# ==================================================================== group B
+
+def group_B():
+    for t, (tag, dim) in enumerate((("cube", 70), ("grid", 84), ("pend", 84))):
+        res = CASES[tag]
+        d = res["d"]
+        ok = (d is not None and res["exact"] and res["n"] == dim
+              and np.array_equal(res["bond"], res["D"])
+              and bool(np.all(np.abs(np.abs(d) - 1) == 0)))
+        nsu = int(np.sum(np.abs(d.imag) > 0.5)) if d is not None else -1
+        check("B%d [exact] %s %s: dim %d, diagonals equal the fermionic bond counts, "
+              "2^%d H_enc a Gaussian-integer matrix of max modulus %d, and a unit gauge "
+              "D (%d of %d entries in {i,-i}) gives D H_enc D^dag = H_F"
+              % (t + 1, res["E"].name, res["ndesc"], res["n"], res["R"]["k"],
+                 res["mx"], nsu, res["n"]), ok)
+
+
+# ==================================================================== group C
+
+def group_C():
+    C, G, Pd = CASES["cube"], CASES["grid"], CASES["pend"]
+    check("C1 [exact] cube N=4 at g=0: orbitals are exact eigenvectors, the Slater "
+          "ground state over Q(sqrt2) has H_F v = -6 v and <v|v> = %s, levels -1 | 1 "
+          "across the cut so it is unique; statistics %s"
+          % (C["nrm"].txt(), C["ctxt"]),
+          C["orth"] and C["eig"] and C["nrm"] == S1 and C["rational"]
+          and C["counts"] == [("0", 12), ("1/64", 56), ("1/16", 2)])
+    faces, pairs, other = [], [], []
+    for p in C["zeros"]:
+        occ = tuple(i for i, b in enumerate(p) if b)
+        trip = [(s >> 2 & 1, s >> 1 & 1, s & 1) for s in occ]
+        ed = [(u, v) for u, v in itertools.combinations(occ, 2) if pcnt(u ^ v) == 1]
+        if any(len({q[ax] for q in trip}) == 1 for ax in range(3)):
+            faces.append(occ)
+        elif len(ed) == 2 and len(set(ed[0]) | set(ed[1])) == 4:
+            pairs.append(occ)
+        else:
+            other.append(occ)
+    check("C2 [exact] the cube's %d zeros of %d are exactly the %d occupied cube faces "
+          "and the %d patterns of two disjoint adjacent pairs, %d other; every zero is "
+          "an exact cancellation, not a small number"
+          % (len(C["zeros"]), C["n"], len(faces), len(pairs), len(other)),
+          len(C["zeros"]) == 12 and len(faces) == 6 and len(pairs) == 6 and not other)
+    got3 = {tuple(i for i, b in enumerate(p) if b and i < 9) for p in Pd["zeros"]}
+    check("C3 [exact] grid3x3+pendant N_grid=3 at g=0: H_F v = -4 sqrt2 v, <v|v> = %s, "
+          "levels -sqrt2 | 0; statistics %s; the %d zeros are exactly the 3 rows, "
+          "3 columns, 2 diagonals"
+          % (Pd["nrm"].txt(), Pd["ctxt"], len(Pd["zeros"])),
+          Pd["orth"] and Pd["eig"] and Pd["nrm"] == S1 and Pd["rational"]
+          and got3 == LINES
+          and Pd["counts"] == [("0", 8), ("1/256", 12), ("1/128", 32),
+                               ("1/64", 20), ("1/32", 8), ("9/256", 4)])
+    got6 = {tuple(i for i, b in enumerate(p) if b) for p in G["zeros"]}
+    comp = {tuple(sorted(set(range(9)) - set(l))) for l in got3}
+    check("C4 [exact] grid3x3 N=6 on the 12-qubit code at g=0: H_F v = -4 sqrt2 v, "
+          "<v|v> = %s, levels 0 | sqrt2, the same value multiset; its %d zeros are "
+          "exactly the complements of the N_grid=3 zeros, the particle-hole image"
+          % (G["nrm"].txt(), len(G["zeros"])),
+          G["orth"] and G["eig"] and G["nrm"] == S1 and G["rational"]
+          and got6 == comp and G["counts"] == Pd["counts"])
+
+
+# ==================================================================== group D
+
+GVALS = (0.5, 1.0, 2.0)
+
+
+def scan(res):
+    out = []
+    persist = None
+    for g in (0.0,) + GVALS:
+        He = res["Hoff"] + g * np.diag(res["bond"])
+        Hf = res["T"] + g * np.diag(res["D"])
+        we, Ve = np.linalg.eigh(He)
+        wf, Vf = np.linalg.eigh(Hf)
+        me = int(np.sum(we < we[0] + 1e-9))
+        mf = int(np.sum(wf < wf[0] + 1e-9))
+        pe = (np.abs(Ve[:, :me]) ** 2).sum(axis=1) / me
+        pf = (np.abs(Vf[:, :mf]) ** 2).sum(axis=1) / mf
+        ze = frozenset(np.where(pe < 1e-12)[0])
+        zf = frozenset(np.where(pf < 1e-12)[0])
+        out.append((g, float(np.abs(pe - pf).sum()), we[1] - we[0], me, mf, ze, zf))
+        if g != 0.0:
+            persist = ze if persist is None else (persist & ze)
+    return out, persist
+
+
+def group_D():
+    keep = {}
+    for t, tag in enumerate(("cube", "grid", "pend")):
+        res = CASES[tag]
+        rows, persist = scan(res)
+        keep[tag] = (rows, persist)
+        ok = all(r[1] < 1e-12 and r[5] == r[6] and r[3] == 1 and r[4] == 1
+                 for r in rows)
+        check("D%d [numerical, 1e-12] %s %s at g in {0, 0.5, 1, 2}: encoded and fermionic "
+              "statistics agree to L1 <= %.1e, zero counts %s identical, ground simple "
+              "throughout, smallest gap %.6f"
+              % (t + 1, res["E"].name, res["ndesc"], max(r[1] for r in rows),
+                 "/".join(str(len(r[5])) for r in rows),
+                 min(r[2] for r in rows)), ok)
+    pc_, pg_, pp_ = (keep["cube"][1], keep["grid"][1], keep["pend"][1])
+    cl6 = {tuple(sorted(set(range(9)) - set(l))) for l in CENTRE_LINES}
+    gg = {tuple(i for i, b in enumerate(CASES["grid"]["pats"][a]) if b) for a in pg_}
+    pp = {tuple(i for i, b in enumerate(CASES["pend"]["pats"][a]) if b and i < 9)
+          for a in pp_}
+    check("D4 [numerical, 1e-12] zeros surviving every g in {0.5, 1, 2}: cube %d of %d, "
+          "the whole g=0 set; grid3x3 %d of %d at N_grid=3, exactly the four lines "
+          "through the centre, and %d of %d at N=6, their complements"
+          % (len(pc_), len(CASES["cube"]["zeros"]), len(pp_),
+             len(CASES["pend"]["zeros"]), len(pg_), len(CASES["grid"]["zeros"])),
+          len(pc_) == 12 and pp == CENTRE_LINES and gg == cl6)
+
+
+# ==================================================================== group E
+
+def group_E():
+    for t, tag in enumerate(("cube", "grid", "pend")):
+        res = CASES[tag]
+        E, R = res["E"], res["R"]
+        fib = 1 << R["k"]
+        sizes = np.bincount(res["cid"])
+        nz = sum(1 for q in res["prob"] if not q.zero())
+        ok = (bool(np.all(sizes == fib))
+              and bool(np.all(np.abs(np.abs(res["phi"]) - 1) == 0))
+              and nz + len(res["zeros"]) == res["n"])
+        check("E%d [exact] %s: |phi(y)| = 1 on all %d edge records, every coset holds "
+              "exactly 2^%d = %d, so the probability is P(pattern)/%d on the fibre; "
+              "%dx%d = %d in the sector, %dx%d = %d over a zero, all exactly 0"
+              % (t + 1, E.name, E.DIM, R["k"], fib, fib, res["n"], fib,
+                 res["n"] * fib, len(res["zeros"]), fib, len(res["zeros"]) * fib), ok)
+
+
+# ==================================================================== group F
+
+def sign_form(E, HE):
+    """sign(y) = s_e * (-1)^{|y & Z(A_ij B_i)|}, Z-support in star(i) U star(j)."""
+    inside = True
+    okform = True
+    for (i, j) in HE:
+        A = E.A(i, j)
+        P1 = A * E.B(i)
+        P2 = A * E.B(j)
+        inside = inside and (P1.z & ~(E.STARMASK[i] | E.STARMASK[j])) == 0
+        s_e = None
+        for y in range(E.DIM):
+            b1, a1 = pact(P1, y)
+            b2, a2 = pact(P2, y)
+            amp = 0.5j * (a1 - a2)
+            if amp == 0:
+                continue
+            s = int(round(amp.imag))
+            pred = (-1) ** (pcnt(y & P1.z) % 2)
+            if s_e is None:
+                s_e = s * pred
+            okform = okform and (s == s_e * pred)
+    return inside, okform
+
+
+def group_F():
+    for t, tag in enumerate(("cube", "grid")):
+        res = CASES[tag]
+        E = res["E"]
+        st = res["stats"]
+        tot = st["pos"] + st["neg"]
+        inside, okform = sign_form(E, res["HE"])
+        check("F%d [exact] %s: all %d off-diagonal edge-basis amplitudes are exactly "
+              "+i or -i, split %d/%d; Z(A_ij B_i) sits inside star(i) U star(j), and "
+              "sign(y) = s_e (-1)^{|y & Z(A_ij B_i)|} on all %d records"
+              % (t + 1, E.name, tot, st["pos"], st["neg"], E.DIM),
+              inside and okform and st["pos"] == st["neg"] and st["pos"] > 0)
+    tc, fc = flux4(CASES["cube"]["Hoff"])
+    tcf, fcf = flux4(CASES["cube"]["T"].astype(complex))
+    tg, fg = flux4(CASES["grid"]["Hoff"])
+    tgf, fgf = flux4(CASES["grid"]["T"].astype(complex))
+    ncc, mec, cc, _ = tree_gauge(CASES["cube"]["Hoff"])
+    ncg, meg, cg, _ = tree_gauge(CASES["grid"]["Hoff"])
+    check("F3 [exact] four-cycle flux: cube %d of %d carry -1, grid3x3 %d of %d, "
+          "identical for H_F (%d/%d, %d/%d); in a spanning-tree gauge %d of %d and %d of "
+          "%d entries stay +1, so no gauge makes either law sign-uniform"
+          % (fc, tc, fg, tg, fcf, tcf, fgf, tgf, cc[0], mec, cg[0], meg),
+          (tc, fc) == (tcf, fcf) and (tg, fg) == (tgf, fgf) and fc > 0 and fg > 0
+          and cc[0] > 0 and cg[0] > 0 and cc[1] == cc[3] == cg[1] == cg[3] == 0)
+
+
+# ==================================================================== group G
+
+def bare_sector(E, R, keep, HE):
+    """The bare edge-flip law (i/2) X_e (B_i - B_j) on the preserved sector."""
+    bad = 0
+    for (i, j) in HE:
+        Xe = P(0, 1 << E.EIDX[(i, j)], 0)
+        p1, p2 = Xe * E.B(i), Xe * E.B(j)
+        for s in R["gens"]:
+            if not (comm(p1, s) and comm(p2, s)):
+                bad += 1
+    keepz = [y for y in range(E.DIM) if keep(E.record(y))]
+    zpos = {y: a for a, y in enumerate(keepz)}
+    m = len(keepz)
+    H = np.zeros((m, m), dtype=complex)
+    D = np.zeros(m)
+    for y in keepz:
+        a = zpos[y]
+        rec = E.record(y)
+        D[a] = sum(1 for (u, v) in HE if rec[u] and rec[v])
+        for (i, j) in HE:
+            Xe = P(0, 1 << E.EIDX[(i, j)], 0)
+            b1, a1 = pact(Xe * E.B(i), y)
+            b2, a2 = pact(Xe * E.B(j), y)
+            amp = 0.5j * (a1 - a2)
+            if amp == 0:
+                continue
+            assert b1 in zpos
+            H[zpos[b1], a] += amp
+    assert np.max(np.abs(H - H.conj().T)) == 0
+    return bad, len(R["gens"]) * len(HE), keepz, zpos, H, D
+
+
+BARE = {}
+
+
+def group_G():
+    for t, tag in enumerate(("cube", "grid")):
+        res = CASES[tag]
+        E, R = res["E"], res["R"]
+        bad, npair, keepz, zpos, H, D = bare_sector(E, R, res["keep"], res["HE"])
+        ncomp, ment, cnt, gv = tree_gauge(H)
+        Hr = np.real(np.conj(gv)[:, None] * H * gv[None, :])
+        BARE[tag] = (keepz, zpos, Hr, D, len(res["pats"]))
+        check("G%d [exact] %s control: bare X_e in place of A_ij anticommutes with %d "
+              "of %d (term, generator) pairs, leaving the code space; it conserves the "
+              "record on a %d-dim sector where a gauge makes all %d entries -1, "
+              "%d component"
+              % (2 * t + 1, E.name, bad, npair, len(keepz), ment, ncomp),
+              bad > 0 and ncomp == 1 and cnt[2] == ment and cnt[0] == 0
+              and cnt[1] == 0 and cnt[3] == 0)
+        rows = []
+        for g in (0.0,) + GVALS:
+            w, V = np.linalg.eigh(Hr + g * np.diag(D))
+            mm = int(np.sum(w < w[0] + 1e-9))
+            pz = (np.abs(V[:, :mm]) ** 2).sum(axis=1) / mm
+            pv = {}
+            for y in keepz:
+                r = E.record(y)
+                pv[r] = pv.get(r, 0.0) + pz[zpos[y]]
+            rows.append((mm, len(pv), min(pv.values()),
+                         sum(1 for q in pv.values() if q < 1e-12)))
+        check("G%d [numerical, 1e-12] %s control on that sector at g in {0, 0.5, 1, 2}: "
+              "ground simple, all %d patterns strictly positive, smallest %.4e, %d exact "
+              "zeros -- the Perron-Frobenius consequence of that gauge"
+              % (2 * t + 2, E.name, rows[0][1], min(r[2] for r in rows),
+                 max(r[3] for r in rows)),
+              all(r[0] == 1 and r[1] == len(res["pats"]) and r[2] > 1e-9 and r[3] == 0
+                  for r in rows))
+
+
+def main():
+    for g in (group_A, group_B, group_C, group_D, group_E, group_F, group_G):
+        g()
+    print("SUMMARY: ordinary composition plus a single-vertex parity dictionary "
+          "reproduces the graded selection-rule zeros exactly; the bare edge-flip "
+          "control has none.")
+    print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Review-loop landing disposition

The original proposal was reviewed cumulatively and landed only after a four-iteration narrowing/fix cycle. Its physical-emergence, physical-3D, framework-Record, and symmetry-selection-rule readings were withdrawn.

The landed result is a conditional finite-model theorem for supplied cube, open-grid, and grid-plus-pendant graphs: a supplied Bravyi-Kitaev superfast edge-qubit encoding and incidence-parity dictionary have the checked finite code/fibre properties; their named fixed-sector matrices are exactly diagonal-phase equivalent to supplied Jordan-Wigner reference matrices; and the note reports only the exact free-point zeros and explicitly tolerance-qualified four-coupling/control witnesses established by the runner.

Landed artifacts:

- `docs/FINITE_EDGE_QUBIT_PARITY_DICTIONARY_OCCUPATION_ZEROS_BOUNDED_THEOREM_NOTE_2026-09-02.md`
- `scripts/finite_edge_qubit_parity_dictionary_occupation_zeros_check_2026_09_02.py`
- `logs/runner-cache/finite_edge_qubit_parity_dictionary_occupation_zeros_check_2026_09_02.txt`
- citation-graph topology acknowledgment

Landing SHA: `faa8b12efc48473bc4906522324ee5597ce55b05`.

Audit status remains `unaudited`; independent audit is a separate post-landing lane. The detailed same-session review and landing provenance is recorded in the review-loop comment below.
