### PR TITLE
[review-loop salvaged and landed] finite BKSF pi-flux sign class

### DIFF
--- a/docs/EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md
+++ b/docs/EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md
@@ -1,0 +1,338 @@
+---
+claim_id: emergent_fermion_pi_flux_sector_staggered_kinetic_form
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(x) = (-1)^{x_1}, eta_3(x) = (-1)^{x_1+x_2} of the landed staggered kinetic-form clause read on that lattice, and on the named finite blocks and tori only: (T1) with one 2x2x2 cell of coarse sites as the unit cell the hopping has Bloch Hamiltonian H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a], Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3) and Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3) a Cl(6) set of anticommuting hermitian involutions, hence H(q)^2 = (6 + 2 sum_a cos q_a) I and tr H(q) = 0 symbolically; the coarse torus L = 4 spectrum is exactly -2sqrt3 x4, -2sqrt2 x12, -2 x12, 0 x8 with its mirror over 64 modes, and L = 6 (216 modes, 0 zero modes) and L = 8 (512 modes, 8 zero modes) reproduce the same Bloch prediction eigenvalue by eigenvalue at 1e-9. (T2) The intertwiner U with U Gamma_a U^dag = +- sigma_a (x) T, T = diag(1,1,-1,-1), and U Xi_a U^dag = I (x) B_a, B = (XX, XY, XZ), exists with entries in Z[i] by Clifford averaging and satisfies U U^dag = 16 I; the 384x64 intertwining system has rank 63 over a prime field with a square root of -1, so each branch nullspace is exactly one-dimensional and U is unique up to a phase; U H(pi + p) U^dag = sum_a sin p_a (sigma_a (x) T) + sum_a (1 - cos p_a)(I (x) B_a) over 300 random p at 1e-12, the taste-mixing term carrying the identity on the spin factor. (T3) Every plaquette holonomy of the KS signs is -1: all 24 coordinate-parity-class and plane combinations, and all 192, 648 and 1536 plaquettes of the coarse tori L = 4, 6, 8; no site gauge carries the plain signs to them, by loop invariance and by exhaustion of all 2^8 sign patterns on the open 2x2x2 coarse block; the fine-mod-2 role pattern of a coarse cell takes exactly 1 value over all coarse sites while the KS sign varies, and the KS sign is a function of the fine coordinates 2v mod 4 over an 8^3 coarse block. (T4) All 24 proper cubic rotations lift to signed permutations with C_R H C_R^T = H on the L = 4 coarse torus, all 576 products close exactly at the 64x64 level and all 576 on the eight zero modes with 0 pairs carrying -1, a genuine representation of O; its characters (E, 8C3, 3C2, 6C4, 6C2') = (8, 2, 0, 4, 0) decompose as 2 A1 + 2 T1 against a character table checked orthonormal in the runner; in the B basis every lift factorises as a 2x2 spin factor times a 4x4 taste factor at singular-value ratio 9e-17, both factors carrying one and the same sign cocycle with 208 of the 576 pairs at -1 under the runner's determinant normalisation, and that cocycle is not a coboundary, so each factor is individually projective while the product is genuine. (T5) epsilon = Z_1 Z_2 Z_3 anticommutes with all six generators, hence with H(q) at every q, and U epsilon U^dag = I (x) (+- T B_1 B_2 B_3) on the two branches and never +- I (x) T. (T6) (B_j - B_i) = 2 on exactly the legal steps, so the encoded hop T_ji = (i/2) A_ji (B_j - B_i) acts there as i A_ji, and the ordered product of four encoded hops around a coarse face equals the face stabilizer S_f exactly with its Z4 phase on 6, 36, 81 and 192 faces of the open 2x2x2, the open 3x3x3 and the tori 3^3 and 4^3; every F2 relation among the S_f has ordered product exactly +I on all twelve blocks and tori tested, so the sector S_f = -1 for every f is consistent exactly when every relation has even support, which holds on every open block and on an L1xL2xL3 coarse torus exactly when every pairwise product L_a L_b is even, verified against an independent F2 solve for a pi-flux edge sign field over all 2424 faces of the twelve; the sign field eta' read off that sector with no input from KS has holonomy -1 on every plaquette and admits a gauge witness s(v) carrying it to the KS signs on the open 2x2x2, 3x3x3 and 4x4x4 blocks and the 4x4x4 coarse torus, with 4, 7, 32 and 24 sites at s = -1, and the one-particle spectra of eta' and of KS agree there at 1e-9. (T7) On the open 2x2x2 coarse cube with 12 edge qubits and dimension 4096, prod_i B_i = +I, the six face stabilizers have F2 rank 5, the joint S_f = -1 eigenspace is one-dimensional on each of the 128 B-configurations giving 128 = 2^(V-1) states, and the encoded hopping restricted there matches the even-parity many-body spectrum of sum_ij eta'_ij c_i^dag c_j on all 128 levels at 1e-13. Nothing here is derived from any axiom, no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py
+---
+
+# The staggered kinetic form is the other flux sector of the emergent fermion's own gauge structure
+
+**Date:** 2026-09-02
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py`](../scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py)
+**Runner cache:**
+[`logs/runner-cache/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.txt`](../logs/runner-cache/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+The framework's landed staggered kinetic clause fixes a sign on every nearest-neighbour link and calls the resulting sign field unique as a local `Z2` gauge class. A
+separate construction supplies a fermion on the coarse sublattice `2Z^3`, one mode per coarse vertex, with a `Z2` gauge structure of its own whose gauge-invariant
+content on a face is a face stabilizer of eigenvalue `+-1`. The question this note answers is whether those two sign structures are the same object. They are:
+transport of one encoded excitation around a coarse face equals that face's stabilizer exactly, phase included, so the staggered sign field is the sector in which
+every face stabilizer is `-1`, and the plain field is the sector in which every one is `+1`.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems identifying the landed staggered kinetic sign field with the all-minus face-stabilizer sector of the coarse-lattice emergent fermion, together with the exact Clifford, spin-taste, point-group and chirality structure of that kinetic form. Every statement is symbolic, integer, Z[i], F2/Z4 or exhaustive; the tagged numerical items are cross-checks of statements already established exactly."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: which flux sector a dynamical clause would select."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the seven statements below, exactly the runner's check groups `A`-`G`. Groups `A`-`C`, `E` and the structural content of `F` are
+exact -- symbolic identities in `sympy`, integer and `Z[i]` matrix arithmetic at zero tolerance, rank over a finite field, `F2` and `Z4` symplectic bit arithmetic,
+exhaustive enumeration -- and the items tagged `[numerical]` are floating-point cross-checks, at the stated tolerance, of what those groups establish.
+
+1. `T1` (`A`). The kinetic form: a `Cl(6)` operator on the eight-site coarse cell, with its exact square, trace and torus spectra.
+2. `T2` (`B`). The spin-taste split: an exact intertwiner, unique up to a phase, taking the operator to `sum sin p (sigma (x) T) + sum (1 - cos p)(I (x) B)`.
+3. `T3` (`C`). The sign field is a flux class, not a local gauge choice, and is a function of the fine coordinates mod `4`.
+4. `T4` (`D`). The proper cubic group on the eight zero modes is the genuine representation `2 A1 + 2 T1`, factorising into individually projective factors.
+5. `T5` (`E`). The chirality grading is `I (x) (+- T B_1 B_2 B_3)`, distinct from the taste pseudoscalar.
+6. `T6` (`F`). Face transport equals the face stabilizer, the all-`(-1)` sector exists exactly when at most one coarse period is odd, and in it the encoded hopping
+   is in the staggered local gauge class, with a witness and the same one-particle spectrum.
+7. `T7` (`G`). The many-body cross-check on the open `2x2x2` coarse cube.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, the Dirac-Kahler spin-taste basis and the
+character table of `O` are standard methodology; every object is redeclared here and the runner recomputes every statement, the table's orthonormality included. No
+observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the role pattern, the coarse
+  sublattice `2Z^3` and the superfast encoding on it. Pointer only; the encoding is redeclared below and recomputed by this runner.
+- `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md`: the kinetic-form clause and the corner-structure clause quoted below.
+- `CHIRAL_CONTENT_IS_THE_EPSILON_D_CHIRALITY_IMPORT_DISTINCT_FROM_ORIENTATION_NARROW_THEOREM_NOTE_2026-06-08.md`: the chirality-grading row quoted below.
+- `STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md`: the labelling no-go, cited as a pointer only.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting". This note cites none of their grades and adopts no hypothesis.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has
+algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic
+rotations", and "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." **Record**:
+"Records form", "a record locks exactly one admissible local possibility", "records are permanent", "Only records are readable."
+
+The landed kinetic clause under test reads, verbatim:
+
+> **Kinetic-form clause.** Within the declared kinetic class (the naive-Dirac kinetic form on nearest-neighbor `Z^3` links, made
+> compatible with the matter-statistics clause by site-local spin diagonalization), the kinetic operator is the staggered operator
+> `D = (1/2) Σ_{x,μ} η_μ(x) (χ̄_{x+μ̂} χ_x − χ̄_x χ_{x+μ̂})` with the Kawamoto-Smit phases `η_1 = 1, η_2(x) = (−1)^{x_1},
+> η_3(x) = (−1)^{x_1+x_2}`, unique as a local Z2 gauge class.
+
+and its corner-structure clause reads:
+
+> **Corner-structure clause.** The free staggered operator has the 8-element BZ-corner (taste-cube) doubler set, decomposing uniquely
+> by Hamming weight as `1 + 3 + 3 + 1`; the hw=1 triplet carries an exact irreducible `M_3(C)` algebra (translations + `C_3[111]`)
+> with no proper exact quotient.
+
+Everything below reads that sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex. Composition is **ordinary** throughout: the algebra of a
+region is the tensor product of its sites' algebras and no graded clause is used anywhere.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field
+on it, the eight-site cell, the superfast encoding, the encoded hop and the face stabilizers. `P1` (`A`) is the `Cl(6)` form, its square and trace and the torus
+spectra; `P2` (`B`) the intertwiner, its uniqueness and the spin-taste Hamiltonian; `P3` (`C`) the flux class and the mod-`4` structure of the sign; `P4` (`D`) the
+cubic lift, its closure, characters and factorisation; `P5` (`E`) the chirality grading and its image; `P6` (`F`) face transport, the sector's existence condition,
+the induced sign field and its gauge witness; `P7` (`G`) the many-body cross-check. The strongest supported scope is precisely `P0`-`P7`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`, and the coarse edge from `v` along `e_ax` sits at the fine site `2v + e_ax`. The
+**KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`, the clause's phases read in coarse coordinates.
+The **plain sign** is `+1` on every bond.
+
+The **cell** is one `2x2x2` block of coarse vertices, eight modes, so the Bloch Hamiltonian of the KS hopping is an `8x8` matrix `H(q)`. The **encoding** is the
+Bravyi-Kitaev superfast encoding on the coarse lattice, code qubits on the coarse edges, direction order `-x < -y < -z < +x < +y < +z`.
+
+```text
+Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3),  Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3),  epsilon = Z_1 Z_2 Z_3,  T = diag(1,1,-1,-1),  B = (XX, XY, XZ)
+A_ij = X(edge (i,j)) * prod Z(edges ordered before it at i) * prod Z(edges ordered before it at j),  A_ji = -A_ij
+B_i  = product of the Z's on the edges incident to i,   S_f = the ordered product of the four A's around a coarse face f
+```
+
+`B_i = -1` marks the excitation; the **encoded hop** across `(i, j)` is `T_ji = (i/2) A_ji (B_j - B_i)`. A step is **legal** on a configuration when its source is
+occupied and its target empty. A **flux sector** is a choice of eigenvalue `+-1` for every `S_f` that is consistent with the `F2` relations among them.
+
+## Theorem 1 -- the kinetic form is a Clifford operator with an exact spectrum
+
+**Conclusion.** On the coarse lattice with the KS signs, with one `2x2x2` cell as unit cell:
+
+1. `Gamma_x, Gamma_y, Gamma_z, Xi_x, Xi_y, Xi_z` are six mutually anticommuting hermitian involutions -- a `Cl(6)` set -- and the Bloch block built from the hopping
+   rules equals `H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a]` identically in `q`.
+2. Hence `H(q)^2 = (6 + 2 sum_a cos q_a) I` and `tr H(q) = 0`, so `E(q) = +- sqrt(6 + 2 sum_a cos q_a)`, each eigenvalue fourfold.
+3. On the coarse torus `L = 4`, `64` modes, the spectrum is exactly `-2sqrt3` with multiplicity `4`, `-2sqrt2` with `12`, `-2` with `12`, `0` with `8`, and its
+   mirror. On `L = 6` (`216` modes) and `L = 8` (`512` modes) the real-space spectra reproduce the same Bloch prediction eigenvalue by eigenvalue, with `0` and `8`
+   zero modes.
+
+**Proof.** Item 1 is an exact matrix identity over `Z[i]` for the Clifford relations and a symbolic identity in the three momenta for the closed form, expanded term
+by term against the hopping rules. Item 2 follows because a real combination `sum_k c_k M_k` of anticommuting involutions squares to `(sum_k c_k^2) I`, and here
+`sum_a [(1 + cos q_a)^2 + sin^2 q_a] = 6 + 2 sum_a cos q_a`; the `8x8` product and the trace are also verified symbolically, and item 3 evaluates item 2 at the
+allowed cell momenta with exact surds. Items 1 and 2 exact; item 3 exact at `L = 4` and `[numerical, 1e-9]` at `L = 6, 8`.
+
+**Reading, not theorem.** The eight modes of one small cube carry an algebra with six independent anticommuting directions. That is exactly the algebra a Dirac
+operator needs, and it is here without being put in by hand: it is what the alternating signs on the links leave behind.
+
+## Theorem 2 -- an exact spin-taste split, with the mixing term a spin singlet
+
+**Conclusion.** With `T = diag(1,1,-1,-1)` and `B = (XX, XY, XZ)`:
+
+1. `sigma_a (x) T` and `I (x) B_a` are a `Cl(6)` set, and Clifford averaging produces `U` with entries in `Z[i]` and `U U^dag = 16 I`, satisfying
+   `U Gamma_a U^dag = +- sigma_a (x) T` and `U Xi_a U^dag = I (x) B_a` exactly, one `U` for each sign branch.
+2. The `384x64` linear system of the intertwining equations has rank `63` over a prime field carrying a square root of `-1`, so its nullity over `C` is at most `1`;
+   the exact `U` is a nonzero solution, so the branch nullspace is exactly one-dimensional and `U` is unique up to a phase.
+3. `U H(pi + p) U^dag = sum_a sin p_a (sigma_a (x) T) + sum_a (1 - cos p_a)(I (x) B_a)`. The first sum is the free Dirac operator in the spin factor; the second
+   carries the identity on the spin factor, so the taste-mixing term is a spin singlet.
+
+**Proof.** Item 1 uses `U = sum_S N_S M G_S^dag` over the `64` Clifford words, which intertwines because both sets satisfy the same relations with the same structure
+constants, with the elementary `M` that makes `U` invertible; all entries are sums of at most `64` terms from `{0, +-1, +-i}`, checked at zero tolerance. Item 2 uses
+that rank can only drop under reduction to a finite field, so rank `63` there forces rank at least `63` over `C`; irreducibility of `Cl(6)_C = M_8(C)` on `C^8` is
+the structural reason. Item 3 follows from item 1 at `q = pi + p`, checked `[numerical, 1e-12]` over `300` random momenta.
+
+**Reading, not theorem.** One `2x2x2` cell holds a two-component spin and a four-component taste label, and the operator splits along that seam without remainder.
+What mixes the taste labels does not touch the spin.
+
+## Theorem 3 -- the sign is a flux class, and it lives on the fine coordinates mod 4
+
+**Conclusion.**
+
+1. Every plaquette holonomy of the KS signs is `-1`: all `24` combinations of coordinate-parity class and plane, and all `192`, `648` and `1536` plaquettes of the
+   coarse tori `L = 4, 6, 8`.
+2. No site relabelling `c_v -> s(v) c_v` carries the plain signs to the KS signs. Each `s(v)` occurs twice in any closed loop, so every loop holonomy is gauge
+   invariant; plain gives `+1` and KS gives `-1` on every plaquette. Exhaustion of all `2^8` sign patterns on the open `2x2x2` coarse block finds none.
+3. Every coarse site `2v` is a fine corner and the fine-mod-`2` role pattern of its cell takes exactly `1` value over all coarse sites, so any function of that
+   pattern is constant, while the KS sign is not. The KS sign is instead a function of the fine coordinates `2v mod 4`, verified over an `8^3` coarse block.
+
+**Proof.** Item 1 is a symbolic evaluation over the eight parity classes and three planes, then an exhaustive plaquette sweep on the three tori. Item 2 is the
+loop-invariance argument with an exhaustive `2^8` search. Item 3 enumerates the role patterns of every coarse cell and the sign at every coarse site of an `8^3`
+block against the four-row `mod 4` table the runner prints. All exact.
+
+**Reading, not theorem.** A sign on each link is not itself meaningful, because a relabelling of the modes can move it around. What survives relabelling is the
+product around a small square. For the staggered field that product is minus one on every square, and no relabelling of the plain field can reach it.
+
+## Theorem 4 -- the proper cubic group on the eight zero modes
+
+**Conclusion.** On the `L = 4` coarse torus:
+
+1. All `24` proper cubic rotations lift to signed permutations with `C_R H C_R^T = H`, each orthogonal with entries in `{0, +1, -1}` and one nonzero entry per row
+   and column.
+2. All `576` products close on the nose, `C_R C_R' = C_{RR'}`, both at the `64x64` level and on the eight zero modes: a genuine representation of `O`, not
+   projective.
+3. Its characters `(E, 8C3, 3C2, 6C4, 6C2') = (8, 2, 0, 4, 0)` decompose as `2 A1 + 2 T1` against a character table of `O` whose orthonormality the runner checks.
+4. In the `B` basis every lift factorises as a `2x2` spin factor times a `4x4` taste factor. With determinant-normalised factors the two carry one and the same sign
+   cocycle, `208` of the `576` pairs at `-1` under the runner's normalisation, and that cocycle is not a coboundary: each factor is individually projective while the
+   product is genuine.
+
+**Proof.** Item 1 solves for each lift's signs by breadth-first propagation, then verifies the symmetry and the orthogonality directly. Item 2 compares all `576`
+products against the composed rotation with both signs. Item 3 projects onto the exact kernel basis at the corner momentum, checked orthonormal and annihilated by
+`H`, and applies the orthogonality relations. Item 4 is a rank-one reshaping test, `[numerical, singular-value ratio 9e-17]`, and an `F2` coboundary test on the sign
+cocycle; the count of `-1` pairs depends on the branch chosen per factor, the cocycle **class** does not.
+
+**Reading, not theorem.** The landed clause grades the eight corner states by Hamming weight, `1 + 3 + 3 + 1`. Under the rotations themselves those eight states
+carry two invariant directions and two vector triples. The vector triples are the `3`s of the grading; the two invariants are the `1`s.
+
+## Theorem 5 -- the chirality grading is not the pseudoscalar
+
+**Conclusion.** `epsilon = Z_1 Z_2 Z_3` anticommutes with all six `Cl(6)` generators, hence with `H(q)` at every momentum, and on the two branches
+`U epsilon U^dag = I (x) (+- T B_1 B_2 B_3)` -- never `+- I (x) T`.
+
+**Proof.** Both statements are exact matrix identities over `Z[i]`, and the anticommutation with `H(q)` follows from the anticommutation with each generator.
+
+This is the coarse-lattice form of the landed narrow theorem's row
+
+> | `epsilon(x)=(-1)^(x+y+z)` | spatial `Z^3` site grading | even | staggered chirality grading; anticommutes with the tested nearest-neighbor Dirac hop |
+
+and is consistent with its conclusion that "`omega = sign(Vandermonde) = epsilon` is not a valid identity": the grading and the pseudoscalar of the taste factor are
+different operators here too.
+
+## Theorem 6 -- the staggered field is the all-minus face sector
+
+**Conclusion.** For the superfast encoding on the coarse lattice:
+
+1. `(B_j - B_i) = 2` on exactly the legal steps, so the encoded hop `T_ji = (i/2) A_ji (B_j - B_i)` acts there as `i A_ji`, and the ordered product of four encoded
+   hops around a coarse face equals `S_f` exactly, `Z4` phase `i^4 = +1` included: `6` faces on the open `2x2x2`, `36` on the open `3x3x3`, `81` on the torus `3^3`
+   and `192` on the torus `4^3`.
+2. Every `F2` relation among the `S_f` has ordered product exactly `+I`, on all twelve blocks and tori tested. So the sector `S_f = -1` for every `f` is consistent
+   exactly when every relation has even support.
+3. That holds on every open block, and on an `L1xL2xL3` coarse torus exactly when every pairwise product `L_a L_b` is even -- at most one odd period. Over the nine
+   tori `3^3`, `3x3x4`, `3x4x5`, `4^3`, `4x4x5`, `4x4x6`, `4x5x6`, `5^3`, `5x5x6` this reproduces an independent `F2` solve for a `pi`-flux edge sign field.
+4. The sign field `eta'` read off that sector -- spanning-tree gauge fixing, then fundamental-cycle transport, with no input from the KS phases -- has holonomy `-1`
+   on every plaquette, and a gauge witness `s(v)` carries it to the KS signs on the open `2x2x2`, `3x3x3` and `4x4x4` blocks and the `4x4x4` coarse torus, with `4`,
+   `7`, `32` and `24` sites at `s = -1`. The one-particle spectra of `eta'` and of KS agree on all four.
+
+**Proof.** Item 1 is a `Z4` symplectic identity checked face by face, with an exact integer evaluation of the diagonal `(B_j - B_i)` over all `4096` configurations
+of the open `2x2x2` cube: it is `2` on the legal steps, `-2` on their reverses and `0` elsewhere, so a legal traversal contributes `i` per step and `i^4 = +1` around
+a face, while any other configuration is annihilated at some step. Item 2 computes the `F2` nullspace of the face-to-edge incidence and evaluates the ordered product
+of each relation. Item 3 reads the parity of every relation's support and, independently, solves the face equations "the four edge signs sum to `1`". Item 4
+expresses each fundamental-cycle transport operator in the stabilizer generators, reads its residual `Z4` phase -- real in every case -- and multiplies in the sector
+values; the witness is found by breadth-first propagation and verified edge by edge. All exact but the spectra, `[numerical, 1e-9]`.
+
+**Reading, not theorem.** Carry the particle once around a small square and it comes back with the square's own sign. Choosing that sign to be minus on every square
+is the framework's staggered kinetic form; choosing plus is the plain one. The law as written does not choose.
+
+## Theorem 7 -- the many-body cross-check
+
+**Conclusion.** On the open `2x2x2` coarse cube, `12` edge qubits, dimension `4096`: `prod_i B_i = +I`, the six face stabilizers have `F2` rank `5`, the joint
+`S_f = -1` eigenspace is one-dimensional on each of the `128` `B`-configurations, `128 = 2^(V-1)` states in all -- the even-parity Fock space of the eight coarse
+modes -- and the encoded hopping restricted there is hermitian with its `128` levels equal to the even-parity spectrum of `sum_ij eta'_ij c_i^dag c_j`.
+
+**Proof.** The stabilizer projection is applied by sparse Pauli action on state vectors, never by forming a dense operator; the sector states are checked to be `-1`
+eigenvectors of all six faces, and the restricted hopping is compared against the free-fermion prediction built from the one-particle spectrum of `eta'`. Exact for
+the dimensions and the rank, `[numerical, 1e-13]` for the level-by-level comparison.
+
+## Corollary -- what this says about the framework's kinetic form
+
+Within the setting declared above, and on the finite clusters named:
+
+1. The framework's staggered kinetic form on the coarse lattice is the same one-qubit-per-site law as the plain form, read in the other flux sector of the fermion's
+   own `Z2` gauge structure: the two differ by the eigenvalue of one gauge-invariant quantity per face, and by nothing else.
+2. The law as written attaches no coefficient to any face term, and the role-pattern note states its own scope in the same terms: "The dynamical clause. This note
+   gives a law and its zero-energy configurations, not a tick." So the two sectors are a free choice under the law as written; a face term `-J sum_f S_f` with
+   negative `J` would select the staggered sector, and no such term is supplied by anything quoted here.
+3. The staggered gate's residual "**Spin-statistics support tier.** Substep 1's bosonic exclusion rests on the spin-statistics support input", whose "full
+   spin-statistics statement remains a support-tier authority pending its own audit chain", is supplied by construction on the coarse lattice: the modes of Theorem
+   6 belong to an encoding whose excitations already exchange with `-1`. Whether that changes the residual's status is an audit question, not one this note answers.
+4. The corner content sharpens: the eight zero modes carry `2 A1 + 2 T1` under the proper rotations, refining the landed `1 + 3 + 3 + 1` Hamming grading into
+   representation content. No corner is thereby labelled; see the interfaces below.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice, the encoding and the sign fields are declared objects, and the theorems are about them.
+- No update rule, formation site, formation rate, coupling, or absolute unit appears. No dynamical clause is supplied, and no flux sector is selected.
+- No corner of the taste cube is identified with any named species. `STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md` is a pointer only.
+
+## Interfaces named for other lanes, not moved here
+
+- **The mod-4 structure versus the role pattern.** The KS sign is a function of the fine coordinates `mod 4`; the role pattern of PR #7834 has period `(4, 2, 2)`
+  along one axis. Both carry a period of `4`. They are **not** shown here to be the same object, and a lane wanting them identified must supply that.
+- **The many-body symmetry content.** Theorem 4 is the one-particle point-group content. What the proper rotations do to the many-body states of the encoded model,
+  and whether the projective factors have a many-body shadow, is untouched.
+- **The carrier locus of the labelling lane.** Theorem 4 gives representation content on the eight zero modes, not a labelled bijection; the no-go note states what
+  is not derivable and nothing here narrows or widens it.
+- **The choice of flux sector.** Which sector a dynamical clause selects is a science question this note leaves open, and Corollary item 2 states exactly what such a
+  clause would have to supply.
+
+## Remaining live routes
+
+1. Larger blocks and other geometries. The twelve blocks and tori named are what is proved; nothing is claimed beyond them.
+2. Interacting terms. Only free hopping is compared; a four-fermion term could distinguish the sectors differently.
+3. Mass and species. One spinless `Z2`-charged mode per coarse vertex is what the encoding supplies; no mass term, second species, or coupling appears.
+4. The odd-parity sector. The encoded model carries `prod_i B_i = +I` and so has no odd-parity states; the bare staggered fermion has them.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one fermionic mode per coarse vertex, BK superfast encoding on it; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+sign_fields_and_cell_algebra: KS eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, plain +1 on every bond; Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3), Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3), epsilon = Z_1 Z_2 Z_3, T = diag(1,1,-1,-1), B = (XX, XY, XZ); H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a] a Cl(6) form with H^2 = (6 + 2 sum cos q_a) I and tr H = 0
+spectra: L=4 exact -2sqrt3 x4, -2sqrt2 x12, -2 x12, 0 x8 and mirror over 64 modes; L=6 216 modes 0 zero modes; L=8 512 modes 8 zero modes
+intertwiner_and_spin_taste: U with Z[i] entries, U U^dag = 16 I, from a 384x64 system of rank 63, nullity 1 per branch, unique up to a phase; U H(pi+p) U^dag = sum sin p_a (sigma_a x T) + sum (1 - cos p_a)(I x B_a), the taste-mixing term a spin singlet
+flux_class_and_mod4: all 24 parity-class/plane holonomies -1; 192, 648, 1536 plaquettes of L = 4, 6, 8 all -1; no site gauge from plain to KS by 2^8 exhaustion; 1 fine-mod-2 role pattern over all coarse cells; KS sign a function of 2v mod 4 on an 8^3 block
+cubic_group_and_factorisation: 24 signed-permutation lifts; 576 + 576 products exact, 0 with -1; characters (8, 2, 0, 4, 0) = 2 A1 + 2 T1; spin (x) taste at singular-value ratio 9e-17, one shared sign cocycle, 208 of 576 pairs -1, not a coboundary
+chirality: epsilon anticommutes with all six generators and with H(q); U epsilon U^dag = I (x) (+- T B_1 B_2 B_3), never +- I (x) T
+face_transport: (B_j - B_i) = 2 on exactly the legal steps; four-hop product = S_f exactly with Z4 phase on 6, 36, 81, 192 faces
+relations_and_sector: every F2 relation among the S_f has ordered product +I on all 12 blocks and tori; sector exists on open blocks always and on an L1xL2xL3 torus iff every pairwise L_a L_b is even; independent F2 solve agrees over all 2424 faces
+gauge_witness: eta' holonomy -1 everywhere; witness to KS on open 2x2x2, 3x3x3, 4x4x4 and torus 4x4x4 with 4, 7, 32, 24 minus sites; spectra equal
+many_body: open 2x2x2, 12 edge qubits, dim 4096; prod B = +I; face rank 5; 128 B-configurations, 128 = 2^(V-1) sector states; levels match to 1e-13
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=23 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on the **coarse** lattice `2Z^3` only. Nothing is claimed for the fine lattice `Z^3`, for infinite lattices, or beyond the open `2x2x2`,
+`3x3x3`, `4x4x4` blocks and the tori `3^3`, `3x3x4`, `3x4x5`, `4^3`, `4x4x5`, `4x4x6`, `4x5x6`, `5^3`, `5x5x6` named above; tori with a side of length `2` are
+excluded as multigraphs, on which `A_ij` is not determined by its endpoint pair.
+
+The content is **sign classes and free-hopping spectra**, not dynamics. No coefficient, coupling, mass, rate or unit appears; the statement that a face term would
+select a sector names what such a term would do and supplies none. Nothing here is derived from the four axioms: the law is a declared object.
+
+The identification of the encoded hopping with the staggered kinetic form is up to a **site relabelling**, which is exactly what a local `Z2` gauge class means; the
+witness `s(v)` is exhibited on four blocks and is not claimed on any other. The encoded model carries `prod_i B_i = +I`, so it has no odd-parity sector, which the
+bare staggered fermion does have; every many-body comparison in Theorem 7 is inside the even sector for that reason.
+
+Theorem 4's count of `-1` pairs is normalisation-dependent -- the determinant normalisation fixes each factor only up to a sign -- while the statement that the
+cocycle is not a coboundary is not. Only the latter is used.
+
+## Review record
+
+An honest auditor should come away with: one identification, proved on named finite clusters, between the framework's staggered sign field on the coarse lattice and
+the all-minus face-stabilizer sector of a fermion construction already on the table; the exact Clifford, spin-taste, point-group and chirality structure of that
+kinetic form; one existence condition, at most one odd coarse period, coinciding with the periodicity condition of the phases themselves; and one thing deliberately
+not decided -- which sector a dynamical clause would pick. The one normalisation-dependent number is flagged in the proof boundary, and the labelling lane's no-go is
+cited without being used.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the five context notes in
+"Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at
+`PASS=23 FAIL=0`, runtime under the declared `300` seconds, stdout under `5500` characters, a current zero-dependency citation-manifest entry, and passing
+pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.txt
+++ b/logs/runner-cache/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.txt
@@ -1,0 +1,46 @@
+===== runner cache v1 =====
+runner: scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py
+runner_sha256: ef9489416019d2e8accced5a2e7767cdec2bcddd406dc44959d1859ad3964cae
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 1.29
+status: ok
+----- stdout -----
+PASS A1 [exact, sympy] Gamma = (Y1, Z1Y2, Z1Z2Y3), Xi = (X1, Z1X2, Z1Z2X3) are a Cl(6) set, and the 2x2x2-cell Bloch block of KS hopping is sum_a (1+cos q_a) Xi_a + sin q_a Gamma_a in q
+PASS A2 [exact, sympy] H(q)^2 = (6 + 2 sum_a cos q_a) I and tr H(q) = 0, so the cell spectrum is E(q) = +- sqrt(6 + 2 sum_a cos q_a), each fourfold
+PASS A3 [exact, sympy] coarse torus L=4, 64 modes: the eight cell blocks give exactly the spectrum -2sqrt3 x4, -2sqrt2 x12, -2 x12, 0 x8 and its mirror
+PASS A4 [numerical, 1e-9] coarse tori L=6 (216 modes) and L=8 (512) reproduce the same Bloch prediction eigenvalue by eigenvalue, with 0 and 8 zero modes
+PASS B1 [exact] sigma_a (x) T, I (x) B_a (T = diag(1,1,-1,-1); B = XX, XY, XZ) is a Cl(6) set, and Clifford averaging gives U with Z[i] entries, U U^dag = 16 I, intertwining exactly on both branches
+PASS B2 [exact rank] the 384x64 intertwining system has rank 63 over F_p, p = 1 mod 4, and U is a nonzero exact solution, so each branch nullspace is 1-dimensional and U is unique up to a phase
+PASS B3 [numerical, 1e-12] U H(pi+p) U^dag = sum_a sin p_a (sigma_a (x) T) + (1 - cos p_a)(I (x) B_a) over 300 random p, max dev 9.4e-16; the taste-mixing term carries I on spin, a singlet
+PASS C1 [exact] every plaquette holonomy of the KS signs is -1: all 24 parity-class/plane holonomies, and all 192, 648 and 1536 plaquettes of the coarse tori L = 4, 6, 8
+PASS C2 [exact] no site gauge c_v -> s(v) c_v carries plain to KS: loop holonomy is gauge invariant, plain gives +1 and KS -1 on each plaquette, and all 2^8 patterns on the open 2x2x2 fail
+PASS C3 [exact] every coarse 2v is a corner and its cell's fine-mod-2 role pattern takes 1 value, so any function of it is constant while the KS sign varies; that sign is a function of 2v mod 4 on 8^3
+  2v mod 4 in (x, y) -> (eta_x, eta_y, eta_z), independent of z:
+    (0,0) -> (+,+,+)
+    (0,2) -> (+,+,-)
+    (2,0) -> (+,-,-)
+    (2,2) -> (+,-,+)
+PASS D1 [exact] all 24 proper cubic rotations lift to signed permutations of the L=4 torus with C_R H C_R^T = H, each orthogonal with entries in {0, +-1}, one nonzero per row and column
+PASS D2 [exact] the lift closes on the nose: all 576 products C_R C_R' = C_{RR'} at the 64x64 level and all 576 on the 8 zero modes, 0 carrying -1 -- a genuine representation of O, not projective
+PASS D3 [exact] characters on the eight zero modes (E, 8C3, 3C2, 6C4, 6C2') = (8, 2, 0, 4, 0) decompose, against a self-checked table of O, as 2 A1 + 2 T1, sharpening the landed 1 + 3 + 3 + 1 grading
+PASS D4 [numerical, svd ratio 9e-17] in the B basis every lift factorises as (2x2 spin) (x) (4x4 taste); det-normalised, both carry one cocycle, 208 of 576 pairs -1, no coboundary: each factor projective, the product genuine
+PASS E1 [exact] epsilon = Z1 Z2 Z3 anticommutes with all six generators, hence with H(q) at every q, and U epsilon U^dag = I (x) (+- T B1 B2 B3) on the two branches, never +- I (x) T
+PASS F1 [exact, symplectic] (B_j - B_i) = 2 on exactly the legal steps, so T_ji = (i/2) A_ji (B_j - B_i) acts there as i A_ji, and the ordered four-hop product round a face equals S_f exactly, Z4 phase included, on 6, 36, 81, 192 faces
+PASS F2 [exact] every F2 relation among the face stabilizers has ordered product exactly +I on all 12 blocks and tori, so S_f = -1 for all f is consistent iff every relation has even support
+PASS F3 [exact] the all-(-1) face sector exists on every open block, and on an L1xL2xL3 torus iff every pairwise product L_a L_b is even -- at most one odd period, the KS periodicity condition
+  V/faces/rank/rel, supports, all-(-1):
+   o222 8/6/5/1 6 YES | o333 27/36/28/8 6,10 YES | o444 64/108/81/27 6,10,14 YES
+   3x3x3 27/81/52/29 6,9,10,12,13,15,17,18,21 no | 3x3x4 36/108/70/38 6,9,10,12,16,18,20,24 no | 3x4x5 60/180/118/62 6,10,12,15,18,20,21,24,27,28,33 no
+   4x4x4 64/192/126/66 6,10,14,16,20,24,28,32,40 YES | 4x4x5 80/240/158/82 6,10,14,16,20,24,28,32,36,44 YES | 4x4x6 96/288/190/98 6,10,14,16,24,28,32,36,40,48 YES
+   4x5x6 120/360/238/122 6,10,14,16,20,24,30,32,34,38,40,42,48,56 YES | 5x5x5 125/375/248/127 6,10,14,18,20,25,29,30,33,35,37,40,41,45,50,55,65 no | 5x5x6 150/450/298/152 6,10,14,18,20,25,30,34,38,40,42,46,50,60,70 no
+PASS F4 [exact] an independent F2 test, solving 'four edge signs sum to 1' for a pi-flux sign field over all 2424 faces of the twelve, is solvable on exactly the blocks of F3
+PASS F5 [exact] eta', read off the all-(-1) sector by spanning-tree gauge fixing and cycle transport with no KS input, has holonomy -1 on every plaquette and a gauge witness s(v) to KS on the open 2x2x2, 3x3x3, 4x4x4 and the 4x4x4 torus (4, 7, 32, 24 minus sites)
+PASS F6 [numerical, 1e-9] the one-particle spectra of eta' and KS agree eigenvalue by eigenvalue on all four blocks: the flux-sector hopping is the staggered form up to a relabelling
+PASS G1 [exact] open 2x2x2 cube, 12 edge qubits, dimension 4096: prod_i B_i = +I, faces of F2 rank 5, and the joint S_f = -1 eigenspace is 1-dimensional on each of the 128 B-configurations -- 128 = 2^(V-1) states, the even-parity Fock space
+PASS G2 [numerical, 1e-13] the encoded hopping there is hermitian and its 128 levels equal the even-parity spectrum of sum_ij eta'_ij c_i^dag c_j, max deviation 4.9e-15
+SUMMARY: on the coarse lattice 2Z^3 the staggered kinetic form is a Cl(6) operator with an exact spin x taste split, its KS sign a pi-flux class, and it is the all-(-1) face sector of the fermion's Z2 gauge structure.
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py
+++ b/scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py
@@ -1,0 +1,1329 @@
+#!/usr/bin/env python3
+"""The staggered kinetic form as the pi-flux sector of the emergent fermion.
+
+Self-contained finite-cluster runner. The coarse lattice is 2Z^3 -- the
+sublattice carrying one fermionic mode per coarse vertex in the
+Bravyi-Kitaev superfast encoding written on it -- and the object under test
+is the Kawamoto-Smit (KS) link sign field
+    eta_1 = 1,  eta_2(x) = (-1)^{x_1},  eta_3(x) = (-1)^{x_1+x_2}
+of the landed staggered kinetic-form clause, read on that coarse lattice.
+
+  A  KINETIC FORM.  With one 2x2x2 cell of coarse sites as the unit cell the
+     KS hopping has Bloch Hamiltonian
+        H(q) = sum_a [ (1 + cos q_a) Xi_a + sin q_a Gamma_a ],
+        Gamma = (Y1, Z1 Y2, Z1 Z2 Y3),   Xi = (X1, Z1 X2, Z1 Z2 X3),
+     six anticommuting hermitian involutions -- a Cl(6) set -- so that
+     H(q)^2 = (6 + 2 sum_a cos q_a) I and tr H(q) = 0.  Exact torus spectra.
+  B  SPIN AND TASTE.  The exact intertwiner U with
+        U Gamma_a U^dag = sigma_a (x) T,   U Xi_a U^dag = I (x) B_a,
+     T = diag(1,1,-1,-1), B = (XX, XY, XZ), built by Clifford averaging so
+     its entries lie in Z[i]; unique up to a phase; the taste-mixing term is
+     a spin singlet.
+  C  PI-FLUX CLASS.  Every plaquette holonomy of the KS signs is -1, no site
+     gauge carries the plain signs to them, and the sign is a function of the
+     fine coordinates mod 4, not of the fine-mod-2 role pattern.
+  D  CUBIC GROUP.  All 24 proper rotations lift to signed permutations
+     preserving H; the lift is a genuine representation of O; on the eight
+     zero modes it is 2 A1 + 2 T1 and factorises into individually projective
+     spin and taste factors.
+  E  CHIRALITY.  epsilon = Z1 Z2 Z3 is the chirality grading and maps to
+     I (x) (+- T B1 B2 B3), not to the pseudoscalar I (x) T.
+  F  FLUX SECTOR.  Transport of one encoded excitation around a coarse face
+     equals the face stabilizer S_f exactly, Z4 phase included; the all-(-1)
+     face sector exists exactly when every F2 relation among the S_f has even
+     support; in that sector the encoded hopping is in the KS local gauge
+     class, with an explicit witness and the same one-particle spectrum.
+  G  MANY-BODY CROSS-CHECK.  Dense check on the open 2x2x2 coarse cube.
+
+Groups A-C, E and F are exact: Z[i] and integer matrix arithmetic, sympy
+symbolic identities, F2/Z4 symplectic bit arithmetic and exhaustive search.
+The tagged [numerical] items are floating-point cross-checks of exact
+statements already established, at the stated tolerance.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from collections import Counter, deque
+
+import numpy as np
+import sympy as sp
+
+AUDIT_TIMEOUT_SEC = 300
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ========================================================== KS phases, lattice
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    """KS link sign of the coarse bond (v, v + e_a); axes 0,1,2 = 1,2,3."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def wrap(v, dims):
+    return tuple(v[i] % dims[i] for i in range(3))
+
+
+# ================================================== one-cell 8-dimensional algebra
+
+I2 = np.eye(2, dtype=complex)
+SX = np.array([[0, 1], [1, 0]], dtype=complex)
+SY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+SZ = np.diag([1, -1]).astype(complex)
+
+
+def kr(*ms):
+    o = np.array([[1.0 + 0j]])
+    for m in ms:
+        o = np.kron(o, m)
+    return o
+
+
+XI = [kr(SX, I2, I2), kr(SZ, SX, I2), kr(SZ, SZ, SX)]
+GAM = [kr(SY, I2, I2), kr(SZ, SY, I2), kr(SZ, SZ, SY)]
+SIX = GAM + XI
+EPS8 = kr(SZ, SZ, SZ)
+TT = np.diag([1, 1, -1, -1]).astype(complex)
+BB = [kr(SX, SX), kr(SX, SY), kr(SX, SZ)]
+SIG = [SX, SY, SZ]
+
+
+def bloch_numeric(q):
+    """8x8 Bloch block built from the KS hopping rules, no closed form used."""
+    H = np.zeros((8, 8), dtype=complex)
+    for s in range(8):
+        sv = [(s >> (2 - a)) & 1 for a in range(3)]
+        for a in range(3):
+            e = eta_ks(sv, a)
+            bit = 1 << (2 - a)
+            if sv[a] == 0:
+                t = s | bit
+                H[t, s] += e
+                H[s, t] += e
+            else:
+                t = s & ~bit
+                H[t, s] += e * np.exp(-1j * q[a])
+                H[s, t] += e * np.exp(1j * q[a])
+    return H
+
+
+def bloch_closed(q):
+    return sum((1 + np.cos(q[a])) * XI[a] + np.sin(q[a]) * GAM[a] for a in range(3))
+
+
+# ============================================================== group A: Cl(6)
+
+RNG = np.random.default_rng(20260902)
+
+is_clifford_set = (
+    all(np.array_equal(A @ A, np.eye(8, dtype=complex)) for A in SIX)
+    and all(np.array_equal(A, A.conj().T) for A in SIX)
+    and all(
+        np.array_equal(A @ B + B @ A, np.zeros((8, 8), dtype=complex))
+        for i, A in enumerate(SIX)
+        for B in SIX[i + 1:]
+    )
+)
+
+QS = sp.symbols("q1 q2 q3", real=True)
+sXs = sp.Matrix([[0, 1], [1, 0]])
+sYs = sp.Matrix([[0, -sp.I], [sp.I, 0]])
+sZs = sp.Matrix([[1, 0], [0, -1]])
+sIs = sp.eye(2)
+
+
+def krs(*ms):
+    o = sp.Matrix([[1]])
+    for m in ms:
+        o = sp.Matrix(sp.kronecker_product(o, m))
+    return o
+
+
+XIS = [krs(sXs, sIs, sIs), krs(sZs, sXs, sIs), krs(sZs, sZs, sXs)]
+GAMS = [krs(sYs, sIs, sIs), krs(sZs, sYs, sIs), krs(sZs, sZs, sYs)]
+HS = sp.zeros(8, 8)
+for a in range(3):
+    HS += (1 + sp.cos(QS[a])) * XIS[a] + sp.sin(QS[a]) * GAMS[a]
+
+HD = sp.zeros(8, 8)
+for s in range(8):
+    sv = [(s >> (2 - a)) & 1 for a in range(3)]
+    for a in range(3):
+        e = eta_ks(sv, a)
+        bit = 1 << (2 - a)
+        ph = sp.cos(QS[a]) + sp.I * sp.sin(QS[a])
+        if sv[a] == 0:
+            t = s | bit
+            HD[t, s] += e
+            HD[s, t] += e
+        else:
+            t = s & ~bit
+            HD[t, s] += e * sp.conjugate(ph)
+            HD[s, t] += e * ph
+closed_form_exact = sp.expand(HD - HS) == sp.zeros(8, 8)
+
+check(
+    "A1 [exact, sympy] Gamma = (Y1, Z1Y2, Z1Z2Y3), Xi = (X1, Z1X2, Z1Z2X3) are a Cl(6) set, and the 2x2x2-cell Bloch "
+    "block of KS hopping is sum_a (1+cos q_a) Xi_a + sin q_a Gamma_a in q",
+    is_clifford_set and closed_form_exact,
+)
+
+SQ = sp.expand_trig(sp.expand(HS * HS))
+TARG = 6 + 2 * sum(sp.cos(QS[a]) for a in range(3))
+sq_ok = sp.simplify(SQ - TARG * sp.eye(8)) == sp.zeros(8, 8)
+tr_ok = sp.simplify(HS.trace()) == 0
+check(
+    "A2 [exact, sympy] H(q)^2 = (6 + 2 sum_a cos q_a) I and tr H(q) = 0, so the cell spectrum is "
+    "E(q) = +- sqrt(6 + 2 sum_a cos q_a), each fourfold",
+    sq_ok and tr_ok,
+)
+
+
+def exact_torus_spectrum(L):
+    """Exact multiset of eigenvalues from the Cl(6) identity of A2."""
+    out = Counter()
+    for m in itertools.product(range(L // 2), repeat=3):
+        s = 6 + 2 * sum(sp.cos(sp.Rational(4 * mi, L) * sp.pi) for mi in m)
+        E = sp.sqrt(sp.nsimplify(sp.simplify(s)))
+        out[sp.simplify(E)] += 4
+        out[sp.simplify(-E)] += 4
+    return out
+
+
+spec4 = exact_torus_spectrum(4)
+want4 = Counter()
+for val, mult in ((-2 * sp.sqrt(3), 4), (-2 * sp.sqrt(2), 12), (-2, 12), (0, 8)):
+    want4[sp.simplify(val)] += mult
+    if val != 0:
+        want4[sp.simplify(-val)] += mult
+    else:
+        want4[sp.simplify(val)] += 0
+spec4_ok = spec4 == want4 and sum(spec4.values()) == 64
+check(
+    "A3 [exact, sympy] coarse torus L=4, 64 modes: the eight cell blocks give exactly the spectrum "
+    "-2sqrt3 x4, -2sqrt2 x12, -2 x12, 0 x8 and its mirror",
+    spec4_ok,
+)
+
+
+def ks_matrix(dims, periodic, signs=None):
+    sites = [v for v in itertools.product(*(range(d) for d in dims))]
+    idx = {v: i for i, v in enumerate(sites)}
+    M = np.zeros((len(sites), len(sites)))
+    for v in sites:
+        for a in range(3):
+            w = list(v)
+            w[a] += 1
+            if periodic:
+                w[a] %= dims[a]
+            elif w[a] >= dims[a]:
+                continue
+            w = tuple(w)
+            e = eta_ks(v, a) if signs is None else signs[(v, a)]
+            M[idx[w], idx[v]] += e
+            M[idx[v], idx[w]] += e
+    return M, sites, idx
+
+
+def spec_pairs(M, dec=6):
+    e = np.round(np.linalg.eigvalsh(M), dec) + 0.0
+    v, c = np.unique(e, return_counts=True)
+    return list(zip(["%+.6f" % x for x in v], c.tolist()))
+
+
+def bloch_prediction(L, dec=6):
+    pred = []
+    for m in itertools.product(range(L // 2), repeat=3):
+        q = [4 * np.pi * mi / L for mi in m]
+        E = np.sqrt(max(0.0, 6 + 2 * sum(np.cos(x) for x in q)))
+        pred += [E] * 4 + [-E] * 4
+    v, c = np.unique(np.round(sorted(pred), dec) + 0.0, return_counts=True)
+    return list(zip(["%+.6f" % x for x in v], c.tolist()))
+
+
+num_ok = True
+zmodes = []
+for L in (6, 8):
+    M, _, _ = ks_matrix((L, L, L), True)
+    num_ok = num_ok and spec_pairs(M) == bloch_prediction(L)
+    zmodes.append(int(np.sum(np.abs(np.linalg.eigvalsh(M)) < 1e-9)))
+check(
+    "A4 [numerical, 1e-9] coarse tori L=6 (216 modes) and L=8 (512) reproduce the same Bloch prediction "
+    "eigenvalue by eigenvalue, with %d and %d zero modes" % tuple(zmodes),
+    num_ok and zmodes == [0, 8],
+)
+
+# ================================================== group B: spin and taste split
+
+
+def targets(sg):
+    return [sg * np.kron(SIG[a], TT) for a in range(3)] + [np.kron(I2, BB[a]) for a in range(3)]
+
+
+def averaging_intertwiner(N):
+    """U = sum_S N_S M G_S^dag: exact Z[i] intertwiner, U G_k = N_k U."""
+    pg, pn = {}, {}
+    for m in range(64):
+        g = np.eye(8, dtype=complex)
+        n = np.eye(8, dtype=complex)
+        for k in range(6):
+            if (m >> k) & 1:
+                g = g @ SIX[k]
+                n = n @ N[k]
+        pg[m] = g.conj().T
+        pn[m] = n
+    for r in range(8):
+        for c in range(8):
+            M = np.zeros((8, 8), dtype=complex)
+            M[r, c] = 1
+            U = sum(pn[m] @ M @ pg[m] for m in range(64))
+            if abs(np.linalg.det(U)) > 1e-6:
+                return U
+    return None
+
+
+UEX = {}
+b_ok = True
+for sg in (1, -1):
+    N = targets(sg)
+    U = averaging_intertwiner(N)
+    if U is None:
+        b_ok = False
+        continue
+    gauss = all(
+        float(z.real).is_integer() and float(z.imag).is_integer() for z in U.ravel()
+    )
+    inter = all(np.array_equal(U @ SIX[k], N[k] @ U) for k in range(6))
+    UU = U @ U.conj().T
+    scal = UU[0, 0].real
+    unit = np.array_equal(UU, scal * np.eye(8, dtype=complex)) and scal > 0
+    b_ok = b_ok and gauss and inter and unit
+    UEX[sg] = U / np.sqrt(scal)
+target_cl = all(
+    np.array_equal(A @ A, np.eye(8, dtype=complex))
+    for A in targets(1)
+) and all(
+    np.array_equal(A @ B + B @ A, np.zeros((8, 8), dtype=complex))
+    for i, A in enumerate(targets(1))
+    for B in targets(1)[i + 1:]
+)
+check(
+    "B1 [exact] sigma_a (x) T, I (x) B_a (T = diag(1,1,-1,-1); B = XX, XY, XZ) is a Cl(6) set, and Clifford averaging "
+    "gives U with Z[i] entries, U U^dag = 16 I, intertwining exactly on both branches",
+    b_ok and target_cl,
+)
+
+FP = 998244353
+IFP = pow(3, (FP - 1) // 4, FP)
+
+
+def to_fp(M):
+    return (
+        np.rint(M.real).astype(np.int64) % FP
+        + (np.rint(M.imag).astype(np.int64) % FP) * IFP
+    ) % FP
+
+
+def rank_fp(A):
+    A = A.copy() % FP
+    m, n = A.shape
+    r = 0
+    for c in range(n):
+        piv = None
+        for i in range(r, m):
+            if A[i, c] % FP:
+                piv = i
+                break
+        if piv is None:
+            continue
+        A[[r, piv]] = A[[piv, r]]
+        A[r] = (A[r] * pow(int(A[r, c]), FP - 2, FP)) % FP
+        col = A[:, c].copy()
+        col[r] = 0
+        A = (A - np.outer(col, A[r])) % FP
+        r += 1
+        if r == m:
+            break
+    return r
+
+
+ranks = []
+for sg in (1, -1):
+    N = targets(sg)
+    rows = [
+        np.kron(np.eye(8, dtype=complex), SIX[k].T) - np.kron(N[k], np.eye(8, dtype=complex))
+        for k in range(6)
+    ]
+    ranks.append(rank_fp(to_fp(np.vstack(rows))))
+check(
+    "B2 [exact rank] the 384x64 intertwining system has rank %d over F_p, p = 1 mod 4, and U is a nonzero exact "
+    "solution, so each branch nullspace is 1-dimensional and U is unique up to a phase" % ranks[0],
+    ranks == [63, 63],
+)
+
+maxdev = 0.0
+Um = UEX[-1]
+tG = [np.kron(SIG[a], TT) for a in range(3)]
+tB = [np.kron(I2, BB[a]) for a in range(3)]
+for _ in range(300):
+    p = RNG.uniform(-np.pi, np.pi, 3)
+    lhs = Um @ bloch_numeric(np.pi + p) @ Um.conj().T
+    rhs = sum(np.sin(p[a]) * tG[a] + (1 - np.cos(p[a])) * tB[a] for a in range(3))
+    maxdev = max(maxdev, float(np.abs(lhs - rhs).max()))
+spin_singlet = all(np.array_equal(tB[a], np.kron(I2, BB[a])) for a in range(3))
+check(
+    "B3 [numerical, 1e-12] U H(pi+p) U^dag = sum_a sin p_a (sigma_a (x) T) + (1 - cos p_a)(I (x) B_a) over 300 random "
+    "p, max dev %.1e; the taste-mixing term carries I on spin, a singlet" % maxdev,
+    maxdev < 1e-12 and spin_singlet,
+)
+
+# ============================================== group C: the KS sign is a flux class
+
+parity_hol = set()
+for par in itertools.product((0, 1), repeat=3):
+    for (a, b) in ((0, 1), (0, 2), (1, 2)):
+        parity_hol.add(
+            eta_ks(par, a) * eta_ks(va(par, EX[a]), b) * eta_ks(va(par, EX[b]), a) * eta_ks(par, b)
+        )
+torus_hol = {}
+for L in (4, 6, 8):
+    hs = set()
+    for v in itertools.product(range(L), repeat=3):
+        for (a, b) in ((0, 1), (0, 2), (1, 2)):
+            hs.add(
+                eta_ks(v, a)
+                * eta_ks(wrap(va(v, EX[a]), (L, L, L)), b)
+                * eta_ks(wrap(va(v, EX[b]), (L, L, L)), a)
+                * eta_ks(v, b)
+            )
+    torus_hol[L] = hs
+check(
+    "C1 [exact] every plaquette holonomy of the KS signs is -1: all 24 parity-class/plane holonomies, and all "
+    "192, 648 and 1536 plaquettes of the coarse tori L = 4, 6, 8",
+    parity_hol == {-1} and all(v == {-1} for v in torus_hol.values()),
+)
+
+open_sites = [v for v in itertools.product(range(2), repeat=3)]
+open_links = []
+for v in open_sites:
+    for a in range(3):
+        w = va(v, EX[a])
+        if all(c < 2 for c in w):
+            open_links.append((v, w, a))
+brute = None
+for m in range(256):
+    s = {v: (1 if not ((m >> i) & 1) else -1) for i, v in enumerate(open_sites)}
+    if all(s[v] * s[w] * 1 == eta_ks(v, a) for (v, w, a) in open_links):
+        brute = s
+        break
+check(
+    "C2 [exact] no site gauge c_v -> s(v) c_v carries plain to KS: loop holonomy is gauge invariant, plain gives +1 and "
+    "KS -1 on each plaquette, and all 2^8 patterns on the open 2x2x2 fail",
+    brute is None,
+)
+
+roles = set()
+for v in itertools.product(range(4), repeat=3):
+    roles.add(
+        tuple(
+            tuple((2 * v[i] + d[i]) % 2 for i in range(3))
+            for d in itertools.product((0, 1), repeat=3)
+        )
+    )
+mod4_tab = {}
+for v in itertools.product(range(2), repeat=2):
+    f = (2 * v[0] % 4, 2 * v[1] % 4)
+    mod4_tab[f] = (eta_ks((v[0], v[1], 0), 0), eta_ks((v[0], v[1], 0), 1), eta_ks((v[0], v[1], 0), 2))
+mod4_ok = True
+for v in itertools.product(range(8), repeat=3):
+    if (eta_ks(v, 0), eta_ks(v, 1), eta_ks(v, 2)) != mod4_tab[(2 * v[0] % 4, 2 * v[1] % 4)]:
+        mod4_ok = False
+eta_varies = len({eta_ks(v, 1) for v in itertools.product(range(4), repeat=3)}) == 2
+check(
+    "C3 [exact] every coarse 2v is a corner and its cell's fine-mod-2 role pattern takes %d value, so any function of it "
+    "is constant while the KS sign varies; that sign is a function of 2v mod 4 on 8^3" % len(roles),
+    len(roles) == 1 and eta_varies and mod4_ok,
+)
+print("  2v mod 4 in (x, y) -> (eta_x, eta_y, eta_z), independent of z:")
+for f in sorted(mod4_tab):
+    print("    (%d,%d) -> (%s,%s,%s)" % (f[0], f[1], *("+" if t > 0 else "-" for t in mod4_tab[f])))
+
+# ==================================================== group D: the cubic group
+
+L4 = 4
+S4 = [v for v in itertools.product(range(L4), repeat=3)]
+IDX4 = {v: i for i, v in enumerate(S4)}
+N4 = len(S4)
+H4 = np.zeros((N4, N4))
+for v in S4:
+    for a in range(3):
+        w = wrap(va(v, EX[a]), (L4,) * 3)
+        H4[IDX4[w], IDX4[v]] += eta_ks(v, a)
+        H4[IDX4[v], IDX4[w]] += eta_ks(v, a)
+
+ROTS = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        M = np.zeros((3, 3), dtype=int)
+        for i in range(3):
+            M[i, perm[i]] = sg[i]
+        if round(np.linalg.det(M)) == 1:
+            ROTS.append(M)
+RKEY = {tuple(M.flatten()): i for i, M in enumerate(ROTS)}
+
+
+def rot_act(M, v):
+    return tuple(int(sum(M[i, j] * v[j] for j in range(3))) % L4 for i in range(3))
+
+
+def class_of(M):
+    tr = int(round(np.trace(M)))
+    if tr == 3:
+        return "E"
+    if tr == 0:
+        return "8C3"
+    if tr == 1:
+        return "6C4"
+    return "3C2" if np.count_nonzero(M - np.diag(np.diag(M))) == 0 else "6C2p"
+
+
+def gauge_to(target):
+    g = {(0, 0, 0): 1}
+    dq = deque([(0, 0, 0)])
+    while dq:
+        v = dq.popleft()
+        for a in range(3):
+            for sgn in (1, -1):
+                w = list(v)
+                w[a] += sgn
+                w = tuple(x % L4 for x in w)
+                src = v if sgn == 1 else w
+                r = target(src, a) * eta_ks(src, a)
+                if w in g:
+                    if g[w] != g[v] * r:
+                        return None
+                else:
+                    g[w] = g[v] * r
+                    dq.append(w)
+    return g
+
+
+CS = []
+lift_ok = True
+for M in ROTS:
+    def tgt(v, a, M=M):
+        return H4[IDX4[rot_act(M, v)], IDX4[rot_act(M, wrap(va(v, EX[a]), (L4,) * 3))]]
+
+    g = gauge_to(tgt)
+    if g is None:
+        lift_ok = False
+        continue
+    C = np.zeros((N4, N4))
+    for v in S4:
+        C[IDX4[rot_act(M, v)], IDX4[v]] = g[v]
+    CS.append(C)
+lift_ok = (
+    lift_ok
+    and len(CS) == 24
+    and all(np.allclose(C @ H4 @ C.T, H4) for C in CS)
+    and all(
+        np.allclose(C @ C.T, np.eye(N4)) and set(np.unique(C)).issubset({-1.0, 0.0, 1.0})
+        for C in CS
+    )
+)
+check(
+    "D1 [exact] all 24 proper cubic rotations lift to signed permutations of the L=4 torus with "
+    "C_R H C_R^T = H, each orthogonal with entries in {0, +-1}, one nonzero per row and column",
+    lift_ok,
+)
+
+KER = np.zeros((N4, 8))
+for s in range(8):
+    sv = [(s >> (2 - a)) & 1 for a in range(3)]
+    for R in itertools.product(range(2), repeat=3):
+        KER[IDX4[tuple(2 * R[a] + sv[a] for a in range(3))], s] = (-1) ** sum(R)
+KER /= np.linalg.norm(KER[:, 0])
+MS = [KER.T @ C @ KER for C in CS]
+ker_ok = (
+    np.allclose(KER.T @ KER, np.eye(8))
+    and abs(H4 @ KER).max() < 1e-12
+    and int(np.sum(np.abs(np.linalg.eigvalsh(H4)) < 1e-9)) == 8
+    and max(abs(CS[i] @ KER - KER @ MS[i]).max() for i in range(24)) < 1e-12
+)
+
+
+def closure_counts(reps, tol=1e-9):
+    bad = neg = 0
+    for i in range(24):
+        for j in range(24):
+            k = RKEY[tuple((ROTS[i] @ ROTS[j]).flatten())]
+            P = reps[i] @ reps[j]
+            if np.allclose(P, reps[k], atol=tol):
+                continue
+            if np.allclose(P, -reps[k], atol=tol):
+                neg += 1
+            else:
+                bad += 1
+    return bad, neg
+
+
+badN, negN = closure_counts(CS)
+bad8, neg8 = closure_counts(MS)
+check(
+    "D2 [exact] the lift closes on the nose: all 576 products C_R C_R' = C_{RR'} at the 64x64 level and all 576 on the "
+    "8 zero modes, %d carrying -1 -- a genuine representation of O, not projective" % (negN + neg8),
+    ker_ok and (badN, negN, bad8, neg8) == (0, 0, 0, 0),
+)
+
+CHARS = {}
+for i, M in enumerate(ROTS):
+    CHARS.setdefault(class_of(M), set()).add(round(float(np.trace(MS[i])), 6))
+TAB = {
+    "A1": [1, 1, 1, 1, 1],
+    "A2": [1, 1, 1, -1, -1],
+    "E": [2, -1, 2, 0, 0],
+    "T1": [3, 0, -1, 1, -1],
+    "T2": [3, 0, -1, -1, 1],
+}
+ORDER = ["E", "8C3", "3C2", "6C4", "6C2p"]
+SZ = [1, 8, 3, 6, 6]
+tab_ok = all(
+    abs(sum(SZ[i] * TAB[x][i] * TAB[y][i] for i in range(5)) / 24 - (1 if x == y else 0)) < 1e-9
+    for x in TAB
+    for y in TAB
+)
+chi = [sorted(CHARS[c])[0] for c in ORDER]
+decomp = {k: round(sum(SZ[i] * TAB[k][i] * chi[i] for i in range(5)) / 24, 9) for k in TAB}
+check(
+    "D3 [exact] characters on the eight zero modes (E, 8C3, 3C2, 6C4, 6C2') = (%d, %d, %d, %d, %d) decompose, against a "
+    "self-checked table of O, as 2 A1 + 2 T1, sharpening the landed 1 + 3 + 3 + 1 grading"
+    % tuple(int(x) for x in chi),
+    tab_ok
+    and [len(CHARS[c]) for c in ORDER] == [1] * 5
+    and chi == [8.0, 2.0, 0.0, 4.0, 0.0]
+    and decomp == {"A1": 2.0, "A2": 0.0, "E": 0.0, "T1": 2.0, "T2": 0.0},
+)
+
+
+def kron_factor(M):
+    A = M.reshape(2, 4, 2, 4).transpose(0, 2, 1, 3).reshape(4, 16)
+    u, s, vh = np.linalg.svd(A)
+    return u[:, 0].reshape(2, 2), (s[0] * vh[0]).reshape(4, 4), s[1] / s[0]
+
+
+SPIN, TASTE = [], []
+worst_ratio = 0.0
+fac_ok = True
+for i in range(24):
+    Mst = Um @ MS[i] @ Um.conj().T
+    S, T, ratio = kron_factor(Mst)
+    worst_ratio = max(worst_ratio, float(ratio))
+    fac_ok = fac_ok and np.allclose(np.kron(S, T), Mst, atol=1e-9)
+    f = S.ravel()
+    k0 = int(np.argmax(np.abs(f)))
+    ph = np.conj(f[k0]) / abs(f[k0])
+    S, T = S * ph, T / ph
+    lam = np.sqrt(np.linalg.det(S))
+    SPIN.append(S / lam)
+    TASTE.append(T * lam)
+
+
+def cocycle(reps, tol=1e-8):
+    cc = {}
+    bad = 0
+    for i in range(24):
+        for j in range(24):
+            k = RKEY[tuple((ROTS[i] @ ROTS[j]).flatten())]
+            P = reps[i] @ reps[j]
+            if np.allclose(P, reps[k], atol=tol):
+                cc[(i, j)] = 0
+            elif np.allclose(P, -reps[k], atol=tol):
+                cc[(i, j)] = 1
+            else:
+                bad += 1
+    return cc, bad
+
+
+def is_coboundary(cc):
+    piv = {}
+    for (i, j), c in cc.items():
+        k = RKEY[tuple((ROTS[i] @ ROTS[j]).flatten())]
+        r = 0
+        for t in (i, j, k):
+            r ^= 1 << t
+        while r:
+            b = r & -r
+            p = b.bit_length() - 1
+            if p in piv:
+                pr, pc = piv[p]
+                r ^= pr
+                c ^= pc
+            else:
+                piv[p] = (r, c)
+                r = 0
+                break
+        else:
+            if c:
+                return False
+    return True
+
+
+ccs, bs = cocycle(SPIN)
+cct, bt = cocycle(TASTE)
+negs, negt = sum(ccs.values()), sum(cct.values())
+spin_chi = {}
+for i in range(24):
+    spin_chi.setdefault(class_of(ROTS[i]), set()).add(round(abs(np.trace(SPIN[i])), 6))
+spinor = [sorted(spin_chi[c])[0] for c in ORDER] == [2.0, 1.0, 0.0, round(2 ** 0.5, 6), 0.0]
+check(
+    "D4 [numerical, svd ratio %.0e] in the B basis every lift factorises as (2x2 spin) (x) (4x4 taste); det-normalised, "
+    "both carry one cocycle, %d of 576 pairs -1, no coboundary: each factor projective, the product genuine"
+    % (worst_ratio, negs),
+    fac_ok
+    and (bs, bt) == (0, 0)
+    and negs == negt
+    and negs > 0
+    and not is_coboundary(ccs)
+    and not is_coboundary(cct)
+    and spinor,
+)
+
+# ================================================ group E: the chirality grading
+
+eps_anti = all(
+    np.array_equal(EPS8 @ A + A @ EPS8, np.zeros((8, 8), dtype=complex)) for A in SIX
+)
+TBBB = TT @ BB[0] @ BB[1] @ BB[2]
+img = {}
+for sg in (1, -1):
+    U = UEX[sg]
+    im = U @ EPS8 @ U.conj().T
+    img[sg] = (
+        np.allclose(im, np.kron(I2, TBBB), atol=1e-9),
+        np.allclose(im, -np.kron(I2, TBBB), atol=1e-9),
+        any(np.allclose(im, t * np.kron(I2, TT), atol=1e-9) for t in (1, -1)),
+    )
+check(
+    "E1 [exact] epsilon = Z1 Z2 Z3 anticommutes with all six generators, hence with H(q) at every q, and "
+    "U epsilon U^dag = I (x) (+- T B1 B2 B3) on the two branches, never +- I (x) T",
+    eps_anti
+    and all(img[sg][0] != img[sg][1] for sg in (1, -1))
+    and all(img[sg][0] or img[sg][1] for sg in (1, -1))
+    and not any(img[sg][2] for sg in (1, -1)),
+)
+
+# ============================ group F: the flux sector of the superfast encoding
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+class Q:
+    """i^k X^x Z^z on a register of qubits indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def herm(s):
+        return (s.k & 1) == (pcnt(s.x & s.z) & 1)
+
+    def isI(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def ismI(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+    def vec(s, n):
+        return s.x | (s.z << n)
+
+
+IDQ = Q(0, 0, 0)
+
+
+def qprod(seq):
+    o = IDQ
+    for p in seq:
+        o = o * p
+    return o
+
+
+class Lat:
+    """Coarse cubic block or torus with the BK superfast encoding on its edges."""
+
+    def __init__(self, dims, periodic):
+        self.dims = tuple(dims)
+        self.per = periodic
+        self.V = [v for v in itertools.product(*(range(d) for d in dims))]
+        self.nv = len(self.V)
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+
+    def step(self, v, d):
+        w = va(v, d)
+        if self.per:
+            return wrap(w, self.dims)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def B(self, v):
+        return Q(0, 0, self.star[v])
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+
+def transport(L, path):
+    """Ordered product of the encoded hops T_{i_{k+1} i_k} = (i/2) A (B - B) along path.
+
+    On any configuration where every step is legal -- source occupied, target
+    empty -- each factor contributes (i/2)(+1 - (-1)) = i, hence the i^n.
+    """
+    n = len(path) - 1
+    ops = [L.Aij(path[k + 1], path[k]) for k in range(n)]
+    return qprod(ops[::-1]).scal(n)
+
+
+def f2_pivots(gens):
+    piv = {}
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+    return piv
+
+
+def f2_express(target, piv):
+    v, c = target, 0
+    while v:
+        p = v.bit_length() - 1
+        if p not in piv:
+            return None
+        pv, pc = piv[p]
+        v ^= pv
+        c ^= pc
+    return c
+
+
+def f2_relations(gens):
+    piv, rel = {}, []
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+        if v == 0:
+            rel.append(c)
+    return rel, len(piv)
+
+
+def bits(m):
+    out = []
+    while m:
+        b = m & -m
+        out.append(b.bit_length() - 1)
+        m ^= b
+    return out
+
+
+def solve_f2(rows, nunk):
+    mask = (1 << nunk) - 1
+    piv, R = [], []
+    for r in rows:
+        for i, p in enumerate(piv):
+            if (r >> p) & 1:
+                r ^= R[i]
+        low = r & mask
+        if low == 0:
+            if r:
+                return None
+            continue
+        p = low.bit_length() - 1
+        for i in range(len(R)):
+            if (R[i] >> p) & 1:
+                R[i] ^= r
+        R.append(r)
+        piv.append(p)
+    sol = 0
+    for i, p in enumerate(piv):
+        if (R[i] >> nunk) & 1:
+            sol |= 1 << p
+    return sol
+
+
+FACE_BLOCKS = [
+    ((2, 2, 2), False, "o222"),
+    ((3, 3, 3), False, "o333"),
+    ((4, 4, 4), False, "o444"),
+    ((3, 3, 3), True, "3x3x3"),
+    ((3, 3, 4), True, "3x3x4"),
+    ((3, 4, 5), True, "3x4x5"),
+    ((4, 4, 4), True, "4x4x4"),
+    ((4, 4, 5), True, "4x4x5"),
+    ((4, 4, 6), True, "4x4x6"),
+    ((4, 5, 6), True, "4x5x6"),
+    ((5, 5, 5), True, "5x5x5"),
+    ((5, 5, 6), True, "5x5x6"),
+]
+
+hop_face_ok = True
+hop_counts = []
+for dims, per, tag in FACE_BLOCKS[:2] + [((3, 3, 3), True, "T3"), ((4, 4, 4), True, "T4")]:
+    L = Lat(dims, per)
+    F = L.faces()
+    for f in F:
+        Sf = L.loop(f)
+        Wf = transport(L, [f[0], f[1], f[2], f[3], f[0]])
+        if not (Wf == Sf and Sf.herm() and (Sf * Sf).isI()):
+            hop_face_ok = False
+    hop_counts.append(len(F))
+
+L222 = Lat((2, 2, 2), False)
+nq222 = L222.nq
+ar222 = np.arange(1 << nq222, dtype=np.int64)
+
+
+def popc64(a):
+    c = np.zeros_like(a)
+    for i in range(16):
+        c += (a >> i) & 1
+    return c
+
+
+BD = {v: (1 - 2 * (popc64(ar222 & L222.star[v]) & 1)).astype(np.int64) for v in L222.V}
+legal_ok = True
+D_LEGAL = (1 << nq222) // 4
+for (v, ax) in L222.E:
+    w = L222.step(v, EX[ax])
+    diff = BD[w] - BD[v]
+    legal = (BD[v] == -1) & (BD[w] == 1)
+    back = (BD[v] == 1) & (BD[w] == -1)
+    rest = ~(legal | back)
+    if not (
+        np.all(diff[legal] == 2)
+        and np.all(diff[back] == -2)
+        and np.all(diff[rest] == 0)
+        and legal.sum() == D_LEGAL
+    ):
+        legal_ok = False
+check(
+    "F1 [exact, symplectic] (B_j - B_i) = 2 on exactly the legal steps, so T_ji = (i/2) A_ji (B_j - B_i) acts there as "
+    "i A_ji, and the ordered four-hop product round a face equals S_f exactly, Z4 phase included, on %d, %d, %d, %d faces"
+    % tuple(hop_counts),
+    hop_face_ok and legal_ok,
+)
+
+rel_rows = []
+prod_ok = True
+consistency = {}
+f2_agree = True
+for dims, per, tag in FACE_BLOCKS:
+    L = Lat(dims, per)
+    F = L.faces()
+    S = [L.loop(f) for f in F]
+    rels, rk = f2_relations([s.vec(L.nq) for s in S])
+    sizes, cons = set(), True
+    for r in rels:
+        idxs = bits(r)
+        pr = qprod([S[j] for j in idxs])
+        if not pr.isI():
+            prod_ok = False
+        sizes.add(len(idxs))
+        if len(idxs) % 2:
+            cons = False
+    rows = []
+    for f in F:
+        m = 0
+        for k in range(4):
+            p, q = f[k], f[(k + 1) % 4]
+            for ax in range(3):
+                if L.step(p, EX[ax]) == q:
+                    m ^= 1 << L.ei[(p, ax)]
+                    break
+                if L.step(q, EX[ax]) == p:
+                    m ^= 1 << L.ei[(q, ax)]
+                    break
+        rows.append(m | (1 << L.nq))
+    solvable = solve_f2(rows, L.nq) is not None
+    if solvable != cons:
+        f2_agree = False
+    consistency[tag] = (L.nv, L.nq, len(F), rk, len(rels), sorted(sizes), cons)
+    rel_rows.append((tag, L.dims, per, cons))
+check(
+    "F2 [exact] every F2 relation among the face stabilizers has ordered product exactly +I on all %d blocks and tori, "
+    "so S_f = -1 for all f is consistent iff every relation has even support" % len(FACE_BLOCKS),
+    prod_ok,
+)
+
+pair_rule = {}
+for tag, dims, per, cons in rel_rows:
+    if per:
+        want = all((dims[a] * dims[b]) % 2 == 0 for a, b in ((0, 1), (0, 2), (1, 2)))
+    else:
+        want = True
+    pair_rule[tag] = (want == cons)
+check(
+    "F3 [exact] the all-(-1) face sector exists on every open block, and on an L1xL2xL3 torus iff every pairwise product "
+    "L_a L_b is even -- at most one odd period, the KS periodicity condition",
+    all(pair_rule.values()),
+)
+line = []
+for tag in consistency:
+    nv, nq, nf, rk, nr, sizes, cons = consistency[tag]
+    line.append(
+        "%s %d/%d/%d/%d %s %s"
+        % (tag, nv, nf, rk, nr, ",".join(str(x) for x in sizes), "YES" if cons else "no")
+    )
+print("  V/faces/rank/rel, supports, all-(-1):")
+for i in range(0, len(line), 3):
+    print("   " + " | ".join(line[i:i + 3]))
+check(
+    "F4 [exact] an independent F2 test, solving 'four edge signs sum to 1' for a pi-flux sign field over all %d faces "
+    "of the twelve, is solvable on exactly the blocks of F3" % sum(c[2] for c in consistency.values()),
+    f2_agree,
+)
+
+
+def induced_eta(L, wilson=(1, 1, 1)):
+    """Sign field read off the sector S_f = -1, with no input from KS."""
+    root = L.V[0]
+    par = {root: None}
+    dq = deque([root])
+    while dq:
+        v = dq.popleft()
+        for r in range(6):
+            if r not in L.inc[v]:
+                continue
+            w = L.inc[v][r][0]
+            if w not in par:
+                par[w] = v
+                dq.append(w)
+    tree = {frozenset((v, w)) for w, v in par.items() if v is not None}
+
+    def tpath(v):
+        p = [v]
+        while par[p[-1]] is not None:
+            p.append(par[p[-1]])
+        return p[::-1]
+
+    gens = [L.loop(f) for f in L.faces()]
+    vals = [-1] * len(gens)
+    if L.per:
+        for ax in range(3):
+            cyc = [wrap(tuple((k if i == ax else 0) for i in range(3)), L.dims) for k in range(L.dims[ax])]
+            gens.append(transport(L, cyc + [cyc[0]]))
+        vals += list(wilson)
+    gv = [g.vec(L.nq) for g in gens]
+    piv = f2_pivots(gv)
+    cons = True
+    rels, _ = f2_relations(gv)
+    for r in rels:
+        idxs = bits(r)
+        pr = qprod([gens[j] for j in idxs])
+        eps = 1 if pr.isI() else (-1 if pr.ismI() else 0)
+        pv = 1
+        for j in idxs:
+            pv *= vals[j]
+        if eps == 0 or pv != eps:
+            cons = False
+    eta = {}
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        if frozenset((v, w)) in tree:
+            eta[(v, ax)] = 1
+            continue
+        pv, pw = tpath(v), tpath(w)
+        op = transport(L, pv + [w] + pw[::-1][1:])
+        c = f2_express(op.vec(L.nq), piv)
+        if c is None:
+            return None, False
+        idxs = bits(c)
+        pr = qprod([gens[j] for j in idxs])
+        resid = (op.k - pr.k) & 3
+        if resid not in (0, 2):
+            return None, False
+        e = 1 if resid == 0 else -1
+        for j in idxs:
+            e *= vals[j]
+        eta[(v, ax)] = e
+    return eta, cons
+
+
+def holonomies(L, eta):
+    out = set()
+    for f in L.faces():
+        v, a, c, b = f
+        pr = 1
+        for (p, q) in ((v, a), (a, c), (b, c), (v, b)):
+            for ax in range(3):
+                if L.step(p, EX[ax]) == q and (p, ax) in eta:
+                    pr *= eta[(p, ax)]
+                    break
+                if L.step(q, EX[ax]) == p and (q, ax) in eta:
+                    pr *= eta[(q, ax)]
+                    break
+        out.add(pr)
+    return out
+
+
+def gauge_witness(L, e1, e2):
+    s = {L.V[0]: 1}
+    dq = deque([L.V[0]])
+    adj = {}
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        adj.setdefault(v, []).append((w, v, ax))
+        adj.setdefault(w, []).append((v, v, ax))
+    while dq:
+        v = dq.popleft()
+        for (w, src, ax) in adj.get(v, []):
+            r = e1[(src, ax)] * e2[(src, ax)]
+            if w in s:
+                if s[w] != s[v] * r:
+                    return None
+            else:
+                s[w] = s[v] * r
+                dq.append(w)
+    return s if len(s) == L.nv else None
+
+
+def one_particle(L, eta):
+    idx = {v: i for i, v in enumerate(L.V)}
+    M = np.zeros((L.nv, L.nv))
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        M[idx[w], idx[v]] += eta[(v, ax)]
+        M[idx[v], idx[w]] += eta[(v, ax)]
+    return M
+
+
+GAUGE_BLOCKS = [((2, 2, 2), False), ((3, 3, 3), False), ((4, 4, 4), False), ((4, 4, 4), True)]
+gauge_ok = True
+spec_ok = True
+neg_sites = []
+ETA222 = None
+for dims, per in GAUGE_BLOCKS:
+    L = Lat(dims, per)
+    eta, cons = induced_eta(L)
+    ks = {(v, ax): eta_ks(v, ax) for (v, ax) in L.E}
+    s = gauge_witness(L, eta, ks)
+    ok = (
+        cons
+        and holonomies(L, eta) == {-1}
+        and holonomies(L, ks) == {-1}
+        and s is not None
+        and all(s[v] * s[L.step(v, EX[ax])] * eta[(v, ax)] == ks[(v, ax)] for (v, ax) in L.E)
+    )
+    gauge_ok = gauge_ok and ok
+    neg_sites.append(0 if s is None else sum(1 for v in L.V if s[v] < 0))
+    spec_ok = spec_ok and np.allclose(
+        np.sort(np.linalg.eigvalsh(one_particle(L, eta))),
+        np.sort(np.linalg.eigvalsh(one_particle(L, ks))),
+        atol=1e-9,
+    )
+    if dims == (2, 2, 2) and not per:
+        ETA222 = eta
+check(
+    "F5 [exact] eta', read off the all-(-1) sector by spanning-tree gauge fixing and cycle transport with no KS input, "
+    "has holonomy -1 on every plaquette and a gauge witness s(v) to KS on the open 2x2x2, 3x3x3, 4x4x4 and the 4x4x4 "
+    "torus (%d, %d, %d, %d minus sites)" % tuple(neg_sites),
+    gauge_ok,
+)
+check(
+    "F6 [numerical, 1e-9] the one-particle spectra of eta' and KS agree eigenvalue by eigenvalue on all four blocks: the "
+    "flux-sector hopping is the staggered form up to a relabelling",
+    spec_ok,
+)
+
+# ============================================ group G: many-body cross-check
+
+D222 = 1 << nq222
+IPOW = np.array([1, 1j, -1, -1j])
+
+
+def apply_q(op, psi):
+    j = ar222 ^ op.x
+    return IPOW[op.k] * (1 - 2 * (popc64(j & op.z) & 1)) * psi[j]
+
+
+prodB = qprod([L222.B(v) for v in L222.V]).isI()
+FACES222 = L222.faces()
+S222 = [L222.loop(f) for f in FACES222]
+gv222 = [s.vec(nq222) for s in S222]
+indep, seen = [], []
+for j, g in enumerate(gv222):
+    _, rk_with = f2_relations(seen + [g])
+    _, rk_without = f2_relations(seen)
+    if rk_with > rk_without:
+        seen.append(g)
+        indep.append(j)
+cfg = np.zeros(D222, dtype=np.int64)
+for i, v in enumerate(L222.V):
+    cfg |= ((1 - BD[v]) // 2) << i
+groups = {int(c): np.where(cfg == c)[0] for c in np.unique(cfg)}
+states = {}
+proj_ok = True
+for c, ix in groups.items():
+    psi = np.zeros(D222, dtype=complex)
+    psi[ix] = RNG.normal(size=len(ix))
+    for j in indep:
+        psi = (psi - apply_q(S222[j], psi)) / 2
+    nr = np.linalg.norm(psi)
+    if nr < 1e-9:
+        proj_ok = False
+        continue
+    psi /= nr
+    for j in range(len(S222)):
+        if not np.allclose(apply_q(S222[j], psi), -psi, atol=1e-9):
+            proj_ok = False
+    states[c] = psi
+check(
+    "G1 [exact] open 2x2x2 cube, %d edge qubits, dimension %d: prod_i B_i = +I, faces of F2 rank %d, and the joint "
+    "S_f = -1 eigenspace is 1-dimensional on each of the %d B-configurations -- %d = 2^(V-1) states, the even-parity "
+    "Fock space" % (nq222, D222, len(indep), len(groups), len(states)),
+    prodB and proj_ok and len(states) == 128 and len(indep) == 5,
+)
+
+keys = sorted(states)
+Psi = np.array([states[c] for c in keys])
+cols = []
+for c in keys:
+    out = np.zeros(D222, dtype=complex)
+    for (v, ax) in L222.E:
+        w = L222.step(v, EX[ax])
+        Aop = L222.Aij(v, w)
+        out += 0.5j * apply_q(Aop * L222.B(v), states[c]) - 0.5j * apply_q(Aop * L222.B(w), states[c])
+    cols.append(out)
+Hm = Psi.conj() @ np.array(cols).T
+herm = np.allclose(Hm, Hm.conj().T, atol=1e-9)
+ev = np.sort(np.linalg.eigvalsh(Hm))
+epsv = np.linalg.eigvalsh(one_particle(L222, ETA222))
+pred = np.sort(
+    np.array(
+        [
+            sum(epsv[i] for i in range(8) if (m >> i) & 1)
+            for m in range(256)
+            if bin(m).count("1") % 2 == 0
+        ]
+    )
+)
+dev = float(np.abs(ev - pred).max())
+check(
+    "G2 [numerical, 1e-13] the encoded hopping there is hermitian and its %d levels equal the even-parity spectrum of "
+    "sum_ij eta'_ij c_i^dag c_j, max deviation %.1e" % (len(ev), dev),
+    herm and dev < 1e-13,
+)
+
+print(
+    "SUMMARY: on the coarse lattice 2Z^3 the staggered kinetic form is a Cl(6) operator with an exact spin x taste split, "
+    "its KS sign a pi-flux class, and it is the all-(-1) face sector of the fermion's Z2 gauge structure."
+)
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache: the framework's landed **staggered (Kawamoto-Smit) kinetic form**, read on the coarse sublattice `2Z^3` of the emergent fermion of PR #7834, is **the all-minus face-stabilizer sector of that fermion's own Z2 gauge structure**. Transporting one encoded excitation once around a coarse face equals the face stabilizer exactly, phase included, so the staggered sign field is the sector with every `S_f = -1` and the plain field the sector with every `S_f = +1`. Under the law as written the two sectors are a free choice.

- `docs/EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (338 lines)
- `scripts/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.py` (`TOTAL: PASS=23 FAIL=0`, 1.3 s; symbolic, `Z[i]`, finite-field rank, `F2`/`Z4` symplectic; numerical items are cross-checks)
- `logs/runner-cache/emergent_fermion_pi_flux_sector_staggered_kinetic_form_check_2026_09_02.txt`

## Theorems (coarse lattice `2Z^3`, one fermionic mode per coarse vertex, named finite blocks and tori)

- **T1** the KS-phased hopping on a `2x2x2` cell is a `Cl(6)` operator: `H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a]`, `H^2 = (6 + 2 sum cos q_a) I`, spectrum `+-sqrt(6 + 2 sum cos q_a)` each fourfold; exact torus spectra.
- **T2** an exact intertwiner with `Z[i]` entries, unique up to a phase, gives `U H(pi + p) U^dag = sum sin p_a (sigma_a x T) + sum (1 - cos p_a)(I x B_a)`: an exact spin(2) x taste(4) split whose taste-mixing term is a spin singlet.
- **T3** the KS sign is a pi-flux class (holonomy `-1` on every plaquette), not a local gauge choice, and is a function of the fine coordinates mod 4, not of the mod-2 role pattern.
- **T4** the proper cubic group acts on the eight zero modes as the genuine representation `2 A1 + 2 T1` (sharpening the landed `1 + 3 + 3 + 1` Hamming grading), factorising into individually projective spin (spinor) and taste factors with one shared non-coboundary cocycle.
- **T5** the chirality grading `epsilon` is `I x (+- T B_1 B_2 B_3)`, never the taste pseudoscalar `T` (consistent with the landed narrow theorem).
- **T6** face transport `=` face stabilizer exactly; the all-minus sector exists on every open block and on an `L1 x L2 x L3` torus iff every pairwise product `L_a L_b` is even (at most one odd period, the KS periodicity condition), verified against an independent `F2` pi-flux solve on twelve blocks and tori; in that sector the encoded hopping is in the KS local gauge class with an explicit witness and the same one-particle spectrum.
- **T7** many-body cross-check on the `4096`-dimensional `2x2x2` coarse cube: the `S_f = -1` sector is the even-parity Fock space and the encoded hopping's 128 levels match the free-fermion spectrum with the induced signs.

## Corollary and boundary

- The staggered kinetic form and the plain form are the same one-qubit-per-site law read in the two flux sectors of its own gauge structure; the law attaches no coefficient to any face term, so the sector is a free choice; a face term `-J sum S_f` with `J < 0` would select the staggered sector (none is supplied).
- The staggered gate's spin-statistics support residual is supplied by construction on the coarse lattice (the modes belong to an encoding whose excitations exchange with `-1`); whether that changes its status is an audit question.
- Coarse lattice only; sign classes and free-hopping spectra, not dynamics; nothing derived from the axioms; the encoded model has no odd-parity sector; no corner of the taste cube is labelled (the labelling no-go is cited as a pointer only). The mod-4 structure of the KS sign and the period-(4,2,2) role pattern are not shown to be the same object.

## Dependencies and context

- Cites `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7834) by filename as a pointer; the landed staggered-gate, chirality and labelling notes are quoted verbatim, each re-verified on `origin/main`.
- Independent verification (scratch, not landed): the whole package was re-derived by a second agent with its own code before landing; two of its claims were corrected in the process (a wrong torus criterion in its prose, and a convention-dependent cocycle count now flagged as such).
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k

## Review-loop disposition (2026-09-04)

The original physical/framework claim was rejected by adversarial review. Its durable finite core was rewritten as a self-contained bounded theorem, re-reviewed to PASS, and landed on main as commit a1a64d36bc856c3ae330786972d3f2a02b678c52 (following the paired #7858 salvage commit). Full pipeline, strict lint, and changed-evidence gates passed on the exact current-main train. No audit verdict was applied; independent audit remains separate. The complete review and fix-confirmation record is attached in the comments.