### PR TITLE
[review-loop salvaged and landed] finite edge-qubit cocircuit forcing

### DIFF
--- a/docs/RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md
+++ b/docs/RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md
@@ -1,0 +1,328 @@
+---
+claim_id: record_formation_emergent_vacuum_parity_forced_odds
+claim_type: bounded_theorem
+claim_scope: "On three finite open graphs -- the 2x2x2 cube graph (8 vertices, 12 edge sites, 6 faces), the 3x3 grid graph (9, 12, 4), and the 3x3 grid with one pendant site at vertex 0 (10, 13, 4) -- qubits sit on the EDGE sites, the sites compose ordinarily (tensor product, operators on disjoint regions commute, no graded clause anywhere), a record at an edge site registers a Z-value there, and the vertex-level parity dictionary n_v = (1 - B_v)/2, with B_v the product of the Z's on the edges incident to v, registers occupancy from those records. The update rule throughout is Lueders conditioning on the value a forming record locks; it is STIPULATED here as this note's update clause and is not derived. With no floating point in any exact statement: (T1) the encoding A_ij = X(edge ij) times the Z's ordered before it at both endpoints, A_ji = -A_ij, B_v, and the ordered four-A face loops satisfies R0-R4 pair by pair, the code dimensions are 2^12/2^5 = 128, 2^12/2^4 = 256 and 2^13/2^4 = 512, each 2^(V-1), the cube's one face relation is the product of all six S_f = +I, and the emergent vacuum is on each cluster the unique code state carrying B_v = +1 at every vertex; its allowed set of record patterns is uniform on a LINEAR subspace of F2^E of dimension E - V + 1 -- 32 of 4096 at p = 1/32 on the cube, 16 of 4096 and 16 of 8192 on the two grids -- cut out by the single-vertex parity conditions ALONE, the Z-type subgroup of <S_f, B_v> having rank V - 1 = 7, 8, 9, sign +1 on every element, and equalling <B_v> exactly. (T2) The odds that a forming record locks the value 1 at a site, given the records already present in its neighbourhood, are 1/2 or forced to 0 or 1 and never anything between: on the cube 1/2 at all 12 sites before any record and after any single record, on grid3x3 a record at one of the 8 sites at a degree-2 corner forces its partner there, and on the pendant cluster the bridge site (0,9) carries odds 0 with no record present at all. (T3) A record elsewhere never fixes a site's possibility by itself; over all 66 cube site pairs x 4 values the odds elsewhere change in exactly the 96 cases where the two records close a vertex star and never in the other 168, and the changed site is that vertex's third edge, forced to 0 or 1. (T4) Forcing is the cocircuit structure of the graph: cut spaces of dimension 7, 8, 9, with 63 minimal cocircuits of weights 3-6 (cube, every site forced by exactly 25 inclusion-minimal record sets, the two smallest its endpoints' two-record vertex stars), 53 of weights 2-5 (grid3x3) and 54 of weights 1-5 (pendant); every listed set is deterministic and inclusion-minimal and an exhaustive sweep of all record sets of size <= 3 against the cocircuit prediction gives 0 mismatches. (T5) The finished set of records carries the same odds whatever order the records formed in: 264, 264 and 312 ordered pairs identical either way, 40 shuffled full orders per cluster closing on the same joint odds 1/32, 1/16, 1/16, all Z_e pairwise commuting exactly, and the same census with 0 mismatches on two non-stabilizer states. (T6) A fermion pair, B_v = -1 at two corners, has as its allowed set a genuine coset of the vacuum's subspace -- 32 patterns, uniform, odds 1/2 everywhere, the same 63 cocircuits of weights 3-6 at different forced values -- with the parity on star(v) equal to 1 on every allowed pattern, so n_v = 1 exactly; checked for adjacent, face-diagonal and antipodal pairs. (T7) In the cube's N = 2 sector of 28 cosets the encoded hopping is carried entrywise onto the Jordan-Wigner matrix by an exact diagonal gauge in {1, i, -1, -i}; a superposition ACROSS sectors adds no cancellation zero (support exactly 2 cosets x 32, disjoint), while coherence WITHIN one sector does: the Slater ground state at E = -4 has support 512 = 16 cosets uniform at 1/512 with 384 cancellation zeros = 12 cosets, exactly the corner pairs on one x-face, and a coherent mix of two E = -4 states has 256 = 8 cosets, whereas the projector onto the 3-fold E = -4 manifold has no vanishing diagonal entry, so those zeros belong to the state and not to the manifold. This note declares a model and computes with it; the update clause is stipulated, no formation dynamics is supplied, no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py
+---
+
+# Record formation on the emergent vacuum: the odds at a site are one half or parity-forced
+
+**Date:** 2026-09-02
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py`](../scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py)
+**Runner cache:**
+[`logs/runner-cache/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.txt`](../logs/runner-cache/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+An encoding that puts qubits on the edge sites of a graph and registers vertex occupancy from a parity of one vertex's incident records has an **emergent vacuum**: the one
+code state with `B_v = +1` everywhere. What do the record axiom's own quantities look like on that state -- which record patterns the law allows, the odds at a site, and what
+the records already present do to them? The answers are entirely combinatorial: the allowed set is a linear subspace cut out by single-vertex parity conditions, the odds are
+one half or forced and never between, and the order in which the records formed leaves no trace.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems on three named open graphs -- the allowed set as a linear subspace of F2^E cut out by single-vertex parity conditions, the two-valued odds census, the cocircuit characterisation of forcing with an exhaustive size-3 cross-check, the order-independence census on stabilizer and non-stabilizer states, the pair coset, and the exact cancellation-zero counts -- with one clause labelled [numerical] where a projector diagonal is read at 1e-12."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: what the framework's formation clause is, of which T3 and T5 are the behaviour any candidate must reproduce."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the seven statements below, exactly the runner's check groups `A`-`G`: `T1` (`A`, `B`) the encoding, the emergent vacuum, and its allowed set
+as a coset cut out by single-vertex parity conditions alone; `T2` (`C`) the odds at a site given its neighbourhood records are `1/2` or forced, never between; `T3` (`C`)
+records elsewhere fix nothing by themselves and change the odds exactly when a parity closes, the `96`/`168` census; `T4` (`D`) forcing is the cocircuit structure of the
+graph, with minimal forcing sets and an exhaustive size-`3` cross-check; `T5` (`E`) order independence, on stabilizer and non-stabilizer states alike; `T6` (`F`) a fermion
+pair is a parity condition on the records around two corners, a different coset with `n_v = 1` on every allowed pattern; `T7` (`G`) coherence within a sector adds cancellation
+zeros, across sectors it adds none, and the zeros belong to the state and not to the manifold.
+
+All of `T1`-`T6` and all but one clause of `T7` are exact -- Pauli algebra in the symplectic representation with phases mod `4`, `F2` linear algebra, Gaussian-integer
+amplitudes and `Fraction` arithmetic. The one clause read at `1e-12`, a projector diagonal, is labelled `[numerical]` on its runner line.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Jordan-Wigner transform, Slater determinants, and the cycle/cut-space duality of a
+finite graph are standard methodology; every object is redeclared here and the runner recomputes every statement, the encoding's defining relations included. No observational
+value, no fitted number, and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no weight:
+`EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7842 -- the same three clusters and encoding conventions, computing
+the selection-rule zeros Theorem 7 revisits from the record side), and
+`EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834 -- the operator-level construction of the same
+encoding on `Z^3`, whose coarse superlattice marker sites are not part of these clusters); and `MINIMAL_AXIOMS_2026-06-29.md`, from which the four axioms in "Setting" are
+quoted verbatim. This note cites no grade of any of these, consumes no ledger row, and adopts no hypothesis.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency,
+standard translations, and proper cubic rotations about each site." "No site is privileged. Sites are distinguished by the supplied lattice structure alone." **Qubit / Site
+Possibility**: "Each site has a domain of local possibilities." "The full one-site possibility domain has algebraic presentation `M_2(C)`." "No possibility is privileged.
+Possibilities are distinguished by the supplied algebraic structure alone."
+
+**Admissibility / Local Constraint.** "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." "For each
+site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." Two of its reading notes (interpretive,
+non-governing) are exactly what this note instantiates and are quoted with it: "(2) Read with Record, the distribution concerns which possibility a forming record locks,
+conditional on formation at that site; it does not supply the formation site, probability, or rate." "(3) The distribution is a probability measure on the local possibility
+domain; "available"/"admissible" denotes its support -- on finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may
+have zero singleton measure; Record locks a supported realization."
+
+**Record / Fixed Reality.** "Records form." "When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are
+permanent." "Only records are readable. A readout value is determined by record content alone. A site with no record cannot be read."
+
+Composition here is **ordinary**: the algebra of a region is the tensor product of its sites' algebras, operators on disjoint regions commute, and no graded or signed clause
+is used anywhere. The clusters below are finite open subgraphs of that lattice, drawn as graphs, so "edge site" and "vertex" have their graph meanings. The **record ontology**
+is used as declared: a record at an edge site registers a value there; it does not report one the site already had. Every distribution below is law-level in the sense of
+reading note (2) -- it says which value a record forming at that site locks -- and the **allowed set** is its support in the sense of reading note (3). The **update clause is
+stipulated, not derived**: when a record forms with a given value, this note conditions the state in the Lueders form, restricting to the `Z`-eigenspace of that value at that
+site and renormalizing. That is a choice declared here, of a shape the record axiom permits; nothing below claims it is taken from an axiom. The emergent vacuum is likewise a
+state of this encoding, not of the framework.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is precisely `P0`-`P7`.
+
+1. `P0` (declared here): the three graphs, the edge-site qubits, the encoding, the parity dictionary, the law, and the stipulated Lueders update clause.
+2. `P1` (`A`, `B`): the encoding relations, the code dimension, the emergent vacuum, and its allowed set. `P2` (`C`): the two-valued odds. `P3` (`C`): what a record elsewhere
+   does. `P4` (`D`): forcing as the cocircuit structure. `P5` (`E`): order independence. `P6` (`F`): the pair coset. `P7` (`G`): coherence and the cancellation zeros.
+
+## Definitions
+
+A **cluster** is a finite open graph: `cube`, the `2x2x2` cube graph, vertex `s = 4a + 2b + c`, `8/12/6` vertices, edge sites, faces; `grid3x3`, vertex `3r + c`, `9/12/4`;
+`grid3x3+pendant`, that grid plus a vertex `9` joined to `0`, `10/13/4`. One qubit sits on each **edge site**, neighbours ordered by index:
+
+```text
+A_ij = X(edge ij) * prod Z(edges at i ordered before j) * prod Z(edges at j ordered before i),   A_ji = -A_ij,
+B_v  = prod of the Z's on the edges incident to v,     S_f = the ordered product of the A's around a face f,
+H = -sum_edges ( hop across the edge ),                star(v) = the set of edges incident to v.
+```
+
+The **code space** is the joint `+1` eigenspace of the face loops. A **record** at an edge site registers a `Z`-value there, so a full set of records is a vector `y` in
+`F2^E`; the **parity dictionary** is `n_v(y) = (1 - B_v)/2 = |y intersect star(v)| mod 2`, a condition on the records of that one vertex's incident edges, and the **record
+number** is `N = sum_v n_v`. The **emergent vacuum** is the code state with `B_v = +1` at every vertex. For a state, the **allowed set** is the set of record patterns it gives
+nonzero probability; the **odds at a site** are the probability that a record forming there locks the value `1`, given the records already present; a **neighbourhood
+condition** is one of the single-vertex parity conditions. In `H` the encoded hop across `(i, j)` is `T_ij = (i/2) A_ij (B_i - B_j)`, and the fermionic reference uses the
+Jordan-Wigner ladders on the same occupation patterns. The **cut space** of the allowed set is its `F2`-orthogonal complement, its **minimal cocircuits** the inclusion-minimal
+nonzero members, and a **minimal forcing set** for a site an inclusion-minimal set whose records leave that site's value deterministic.
+
+## Theorem 1 -- the allowed set is a coset cut out by single-vertex parity conditions alone
+
+**Conclusion.** On all three clusters:
+
+1. `R0`-`R4` hold pair by pair; the cube's `6` face loops carry exactly one relation, the product of all six being `+I`, so `k = 5`, and each grid's `4` carry none, so `k` is
+   `4`; no group contains `-I`; the code dimensions are `128`, `256`, `512`, each `2^(V-1)`.
+2. The emergent vacuum is on each cluster the **unique** code state carrying `B_v = +1` at every vertex: one coset of `32`, `16` and `16` edge-site records, on which the
+   parity dictionary registers no record number anywhere.
+3. Its allowed set is **uniform** on that coset -- `32` of `4096` at `p = 1/32`, `16` of `4096` and `16` of `8192` at `p = 1/16` -- and is a **linear subspace of `F2^E`** of
+   dimension `E - V + 1` (`5`, `4`, `4`), exactly the set the `V` single-vertex parity conditions cut out.
+4. The `Z`-type subgroup of `<S_f, B_v>` has rank `V - 1` (`7`, `8`, `9`), carries sign `+1` on every element, and **equals `<B_v>`** exactly: no condition on a region wider
+   than one vertex's star is present, and `prod_v B_v = +I` is the sole dependency among the `V` conditions.
+
+**Proof.** Item 1 is an exhaustive symplectic computation with `Z4` phases, every relation checked pair by pair, the face relations obtained by exhausting all products of
+subsets of the face loops, the code dimension read from a Gaussian elimination on the `X`-parts. For items 2 and 3 the cosets are built explicitly, the all-zero record pattern
+labels exactly one of them, and its member set is compared against the independently generated solution set of the parity conditions and tested for closure under `xor`. Item 4
+takes the `F2` kernel of the `X`-parts of `<S_f, B_v>`, forms each `Z`-type element, reads its phase, and compares its span with the span of the star masks. All exact.
+
+**Reading, not theorem.** What the law permits is decided one vertex at a time, nothing wider ever consulted: a pattern is allowed exactly when the records around each corner
+have even parity, and within that set no pattern is preferred to another.
+
+## Theorem 2 -- the odds at a site are one half or forced, never between
+
+**Conclusion.** Given the records already present in a site's neighbourhood, the odds there take only the values `1/2`, `0` and `1`:
+
+1. Cube: `1/2` at all `12` sites before any record, and in each of the `24` (site, value) cases the allowed set stays uniform on `16` patterns with the odds at the `11` other
+   sites still exactly `1/2`. The table at site `(0,4)`: `1/2` with no record, `1/2` after `(0,1) = 1`, `1/2` after the distant `(6,7) = 1`, `1/2` after `(0,1) = 1` together
+   with `(5,7) = 1`, then `1` after `(0,1) = 1, (0,2) = 0` and `0` after `(0,1) = 1, (0,2) = 1`.
+2. `grid3x3`: all `12` sites start at `1/2`; a record at one of the `8` sites at a degree-`2` corner forces its partner there to `0` or `1` in all `16` cases and changes
+   nothing else; a record at any of the other `4` changes nothing.
+3. `grid3x3+pendant`: the bridge site `(0,9)` carries odds `0` with **no record present at all** -- vertex `9` has degree `1`, so its own parity condition forces the site and
+   a record of value `1` never forms there. The other `12` start at `1/2`.
+
+**Proof.** The allowed set is finite and held explicitly; each odds value is a `Fraction` counting members, every case is enumerated rather than sampled, uniformity is
+inherited from Theorem 1 item 3, and the conditional sets are checked to halve exactly where the odds are `1/2`. All exact.
+
+**Reading, not theorem.** There is no partial pressure on a site. Either the neighbourhood conditions leave it free, and the odds are one half exactly, or they settle it, and
+the odds are zero or one. The pendant shows the extreme case: a site settled before any record has formed anywhere.
+
+## Theorem 3 -- a record elsewhere fixes nothing by itself
+
+**Conclusion.** On the cube, over all `66` site pairs and `4` value combinations each: the odds at a third site change in **exactly the `96` cases** where the two records
+close a vertex star, never in the other `168`; where they change, the site that changes is exactly that vertex's third edge, and its odds become `0` or `1`, never
+intermediate. A single record changes the odds nowhere else at all (Theorem 2 item 1), and a distant record changes nothing unless it completes a star.
+
+**Proof.** Exhaustive enumeration: for each unordered pair of sites and each of the four value combinations the conditioned allowed set is formed and the odds at all remaining
+sites recomputed as `Fraction`s, the changed set compared against the star prediction and each changed value asserted to lie in `{0, 1}`. The tally is reported as the pair
+`(shared vertices, changed sites) -> count`, and comes out `(1,1): 96` and `(0,0): 168` with no other key. All exact.
+
+**Reading, not theorem.** A record at one site fixes nothing at another. It joins that site's neighbourhood, and only when the records around one corner close a parity does
+anything change there -- and then the remaining record at that corner is not merely likelier, it is forced.
+
+## Theorem 4 -- forcing is the cocircuit structure of the graph
+
+**Conclusion.** For the vacuum's allowed set on each cluster, the minimal forcing sets for a site are exactly the minimal cocircuits through it, with that site deleted:
+
+1. Cube: cut space of dimension `7`, `63` minimal cocircuits of weights `3`-`6`, every site forced by exactly `25` inclusion-minimal record sets whose two smallest are its
+   endpoints' two-record vertex stars.
+2. `grid3x3`: dimension `8`, `53` minimal cocircuits of weights `2`-`5`. `grid3x3+pendant`: dimension `9`, `54` of weights `1`-`5`, one of them of weight `1` -- the bridge,
+   forced by the empty record set.
+3. Every listed set is verified deterministic and inclusion-minimal, and an exhaustive sweep of **all** record sets of size at most `3` against the cocircuit prediction gives
+   `0` mismatches on all three clusters.
+
+**Proof.** The cut space is the `F2`-orthogonal complement of the allowed subspace, verified equal to the span of the star masks; its inclusion-minimal nonzero members are the
+minimal cocircuits. Determinism is tested by conditioning on every assignment, minimality by dropping each element in turn and exhibiting an assignment that leaves the target
+free, and the size-`3` sweep tests the prediction directly against conditioning, site by site. All exact.
+
+**Reading, not theorem.** Which collections of records settle a site is not an extra rule but the cut structure of the graph; the smallest are the records around one corner.
+
+## Theorem 5 -- the finished set of records does not remember the order
+
+**Conclusion.** Under the stipulated Lueders update clause: all `264`, `264` and `312` ordered pairs of (site, value) give identical joint odds in either order, with `0`
+mismatches on every cluster; `40` shuffled full orders per cluster, over all `12`, `12` and `13` sites, close on the same joint odds `1/32`, `1/16`, `1/16`; all `Z_e` commute
+pairwise in the symplectic representation, which is the operator-level reason; and the same census gives `0` mismatches on the two **non-stabilizer** states of Theorem 7, so
+this is no artefact of the vacuum's stabilizer form.
+
+**Proof.** Both orders are formed explicitly and compared entrywise; the chain rule is walked along each shuffled order and its product compared against the flat value
+`1/2^k`; the commutation test is done in the symplectic representation, and the census is re-run on the two coherent states. The vector comparisons are in double precision on
+integer-valued data at a `1e-12` threshold; the operator statement they confirm, that the conditionings commute, is exact.
+
+**Reading, not theorem.** The finished set has the same odds whatever order the records formed in; order leaves nothing behind that a later record can find.
+
+## Theorem 6 -- a fermion pair is a parity condition on the records around two corners
+
+**Conclusion.** On the cube, with `B_v = -1` at two corners `v, v'` -- adjacent `(0,1)`, face-diagonal `(0,3)`, antipodal `(0,7)`:
+
+1. The allowed set is `32` of `4096` patterns and a **genuine coset** of the vacuum's subspace: translating it by any one member returns that subspace exactly. It is uniform
+   at `p = 1/32`, with the odds at every one of the `12` sites exactly `1/2` before any record.
+2. The parity of the records on `star(v)` is `1` at both corners on **every** allowed pattern, so `n_v = (1 - B_v)/2 = 1` exactly, with no exception.
+3. The cut space and its `63` minimal cocircuits of weights `3`-`6` are identical to the vacuum's; only the forced values differ. Around vertex `0` the records at `(0,1)` and
+   `(0,2)` send `(0,4)` to `1, 0, 0, 1` here against `0, 1, 1, 0` on the vacuum.
+
+**Proof.** The coset carrying the target record pattern is located by the dictionary, its members translated and compared setwise with the vacuum's, and the star parities
+collected over every member. The cut space and cocircuits are recomputed from the translated subspace, and the forcing table is read by conditioning. All exact.
+
+**Reading, not theorem.** A fermion is a parity condition on the records around a corner: the same allowed patterns, shifted, forced the same way to different values.
+
+## Theorem 7 -- coherence within a sector adds zeros; across sectors it adds none
+
+**Conclusion.** In the cube's `N = 2` sector of `28` cosets, where `2^5 H_enc` is Gaussian-integer and an exact diagonal gauge with entries in `{1, i, -1, -i}` carries it
+entrywise onto the Jordan-Wigner matrix of the same law with no residual:
+
+1. **Across** sectors: `sqrt(a)|vacuum> + sqrt(b)|pair(0,1)>` at `(a,b) = (1/2,1/2)` and `(1/3,2/3)` has support exactly `64` patterns, `2` cosets of `32`, odds exactly `a/32`
+   and `b/32`, and `0` cancellation zeros: disjoint supports add none.
+2. **Within** one sector: the Slater ground state of two particles at `E = -4` has support `512 = 16` cosets, uniform at `1/512`, and `384` cancellation zeros = `12` cosets
+   each carrying a legal weight-`2` record pattern -- exactly the `12` corner pairs on a common `x`-face. A coherent mix of two `E = -4` states has `256 = 8` cosets.
+3. `[numerical, 1e-12]` The projector onto the `3`-fold `E = -4` manifold has `0` vanishing diagonal entries of `28`. The cancellation zeros therefore belong to the particular
+   state, not to the energy manifold.
+
+**Proof.** The sector matrix is assembled from the encoded hop over every edge pattern of every kept coset and certified integral after multiplication by `2^k`; the gauge is
+fixed by a spanning-tree walk and verified entrywise. The Slater vectors are integer vectors built from the hypercube characters and verified exact eigenvectors of the integer
+hopping matrix at `E = -4`. Every probability is then a `Fraction`, and the zero census splits exactly into patterns outside the record-number sector and cancellation zeros
+inside it, the latter classified by their corner pairs. Only item 3, a projector diagonal from a `QR` factorization, is floating point, and it is labelled as such.
+
+**Reading, not theorem.** There are two reasons a record pattern never forms. One is the allowed set: it violates a parity, and no state of this kind gives it weight. The
+other is cancellation: it is allowed, but the amplitudes reaching it in this state sum to nothing. The second goes when the state changes; the first does not.
+
+## Corollary -- concrete instances of the readout root's open items
+
+Within the setting declared above, and on the three finite clusters named:
+
+1. Admissibility's law-level distribution at a site is here **entirely a function of the neighbourhood records**, and takes only two shapes: flat on `{0, 1}`, or a delta.
+   Reading note (2)'s "which possibility a forming record locks" is instantiated exactly, and reading note (3)'s support is Theorem 1's allowed set.
+2. The informal statement that some records cannot form at a site because of neighbour conditions is **exact** here: the forced values of Theorems 2 and 4, with the bridge
+   site of `grid3x3+pendant` the case where a site is settled before any record exists.
+3. The selection-rule zeros of `EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7842) are the **coherent-state zeros of
+   Theorem 7**, and are **not** parity zeros. The two mechanisms are distinct: a pattern can fail to form because the allowed set excludes it, or because the amplitudes cancel
+   on it -- the first a property of the model, the second of the state.
+4. This supplies a worked instance, not a derivation of the framework's readout, and whether that readout is a dictionary of this kind stays open below.
+
+## Reading, not theorem -- the whole thing in plain words
+
+A record at one site fixes nothing at another. It joins that site's neighbourhood, and the odds there change only when the records around one corner close a parity; then the
+last record is forced. Otherwise the odds stay at one half. The finished set of records has the same odds whatever order the records formed in. A fermion is a parity condition
+on the records around a corner.
+
+## Interfaces named for other lanes, not settled here
+
+- **The formation clause.** The site at which a record forms, the probability that it forms there, and the rate are all outside this note. A lane writing that clause should
+  treat Theorem 3 and Theorem 5 as the behaviour its clause has to reproduce: a record elsewhere changes a site's odds only through the neighbourhood conditions, and the
+  finished set is order-blind.
+- **The update clause as a tick.** Lueders conditioning is stipulated here; a lane proposing a different one inherits the same two obligations. **Larger clusters**, periodic
+  boundaries and the `3x3x3` case, where the face relations and hence the code dimension change, are likewise outside this note.
+- **The fine-lattice marker sites.** Only edge sites carry records in this model. The coarse corner, face and cube-centre marker sites of the superlattice construction of
+  `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834) are pinned and are not part of these
+  clusters; what a record on one of them would be is not modelled here.
+
+## Remaining live routes
+
+1. Whether the two-valued odds of Theorem 2 survive on clusters whose cut space is richer, and whether the cocircuit characterisation holds for record patterns outside the
+   vacuum's coset -- Theorem 6 gives one such case unchanged, which is a data point, not a proof.
+2. Whether the two zero mechanisms of Theorem 7 stay disjoint. Here the parity zeros and the cancellation zeros do not overlap on any state examined, but no theorem forbids a
+   state whose cancellation zeros land inside the allowed set's complement, and none is offered.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the seven theorem conclusions.
+
+```text
+setting: qubits on the EDGE sites of three finite open graphs; ordinary (commuting) composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md; clusters cube 2x2x2 V/E/F 8/12/6, grid3x3 9/12/4, grid3x3+pendant at vertex 0 10/13/4
+encoding: A_ij = X(edge ij) * Z's ordered before it at both endpoints; A_ji = -A_ij; B_v the Z's incident to v; S_f the ordered four-A face loop
+dictionary: n_v = (1 - B_v)/2 = |y intersect star(v)| mod 2, a condition on one vertex's incident edges
+update_clause: Lueders conditioning on the value a forming record locks -- STIPULATED by this note, not derived
+relations_and_code: R0-R4 pair by pair; k = 5, 4, 4; no -I in any group; code dims 128, 256, 512, each 2^(V-1); cube's one relation = product of all six S_f = +I
+vacuum: the unique code state with B_v = +1 at every vertex, one coset of 32, 16, 16 records, registering no record number
+allowed_set: uniform, 32 of 4096 at 1/32, 16 of 4096 and 16 of 8192 at 1/16; a LINEAR subspace of F2^E of dim E - V + 1 = 5, 4, 4, cut out by the V single-vertex parity conditions ALONE; Z-type subgroup of <S_f,B_v> rank V-1 = 7, 8, 9, sign +1 throughout, equals <B_v>; prod_v B_v = +I the sole dependency
+odds: 1/2 or forced to 0 or 1, never between; cube 1/2 at all 12 before and after any single record; grid3x3 a degree-2 corner record forces its partner, 16 cases; bridge (0,9) odds 0 with no record present
+census_cube: 66 cube site pairs x 4 values -> odds elsewhere change in exactly 96 (a vertex star closes), never in 168; the changed site is that vertex's third edge, value 0 or 1, never intermediate
+forcing: cut spaces dim 7, 8, 9; minimal cocircuits 63 (weights 3-6), 53 (2-5), 54 (1-5, one of weight 1); cube every site forced by exactly 25 minimal sets, two smallest the endpoints' vertex stars; every listed set deterministic and inclusion-minimal; exhaustive sweep of all record sets of size <= 3 vs the cocircuit prediction = 0 mismatches
+order_independence: 264, 264, 312 ordered pairs identical either way, 0 mismatches; 40 shuffled full orders per cluster close on 1/32, 1/16, 1/16; all Z_e commute exactly; 0 mismatches on 2 non-stabilizer states
+pair_state: B_v = -1 at two corners -> 32 allowed of 4096, a genuine coset of the vacuum's subspace, uniform, odds 1/2 everywhere; parity on star(v) = 1 on EVERY allowed pattern so n_v = 1 exactly; same cut space and same 63 cocircuits of weights 3-6, only forced values differ -- ((0,1),(0,2)) send (0,4) to 1,0,0,1 against 0,1,1,0 on the vacuum; adjacent, face-diagonal and antipodal checked
+gauge_N2: cube N=2 sector 28 cosets; 2^5 H_enc Gaussian-integer; exact diagonal gauge in {1,i,-1,-i} carries it entrywise onto Jordan-Wigner, no residual
+cross_sector: sqrt(a)|vac> + sqrt(b)|pair(0,1)> at (1/2,1/2) and (1/3,2/3): support exactly 64 = 2 cosets x 32, odds a/32 and b/32, 0 cancellation zeros
+within_sector: Slater E=-4 support 512 = 16 cosets uniform at 1/512, 384 cancellation zeros = 12 cosets = the corner pairs on one x-face; a coherent mix of two E=-4 states 256 = 8 cosets
+manifold_numerical: the projector onto the 3-fold E=-4 manifold has 0 vanishing diagonal entries of 28 at 1e-12 -- the zeros are the state's, not the manifold's
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=27 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **three finite open clusters**: the `2x2x2` cube graph (`12` edge sites, `4096` record patterns), the `3x3` grid (`12`, `4096`), and the
+`3x3` grid with one pendant site (`13`, `8192`), plus the cube's `N = 2` sector of `28` cosets. Nothing is claimed for larger clusters, periodic boundaries, infinite lattices,
+or any law family other than the one in "Definitions". The law is **designed**, not derived: the encoding is chosen so that the Majorana relations `R0`-`R4` hold, the face
+constraints are what makes that choice consistent, and the parity dictionary is one readout map among many, with no minimality or uniqueness claimed for either.
+
+**Only edge sites carry records in this model.** The coarse corner, face and cube-centre marker sites of the superlattice construction are pinned, are not part of these
+clusters, and nothing here says what a record on one would be.
+
+**Lueders conditioning is stipulated**, declared as this note's update clause and not derived from any axiom. Consequently every "odds" statement above is a statement about
+that clause applied to the declared state, and **nothing about formation dynamics** follows: no formation site, no formation probability, and no formation rate is supplied,
+and none is implied. Theorems 3 and 5 constrain what a formation clause would have to reproduce; they do not supply one. Nor does this note decide what the framework's readout
+is: it declares one model, of a form the record axiom permits, and computes with it. No absolute unit and no dynamical clause appears anywhere, no axiom text is amended,
+extended, reworded or reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is created or edited.
+
+One clause is a **floating-point witness at `1e-12`**: the vanishing-diagonal count of the `E = -4` manifold's projector in Theorem 7 item 3, labelled `[numerical]` on its
+runner line. Theorem 5's comparisons are in double precision on integer data, and what they confirm -- that all `Z_e` commute, so the conditionings do -- is checked exactly.
+
+## Review record
+
+An honest auditor should come away with: a declared model and its consequences, not a claim about the framework's readout; six exact theorems and one carrying a single
+labelled numerical clause, on named finite clusters; a stipulated update clause declared as stipulated in the front matter, the setting, the claim block and the proof boundary
+alike; two distinct mechanisms for a record pattern never forming, both exhibited; and formation dynamics named as the interface it is.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the pointers in "Imports and authority"
+are plain text carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair at `PASS=27 FAIL=0`, runtime under the declared `120` seconds, stdout
+under `5500` characters, a current zero-dependency citation-manifest entry, and passing pipeline, strict-lint and changed-evidence gates; audit remains a separate lane.

--- a/logs/runner-cache/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.txt
+++ b/logs/runner-cache/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py
+runner_sha256: 1796124f6edbc4a4c8bec4a19d418baa93d9937aadc54fb418d8cbfaf7b9c425
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.51
+status: ok
+----- stdout -----
+PASS A1 [exact] cube V=8 E=12 edge sites: R0-R4 pair by pair, 6 face loops, 1 relation (the product of all six) = +I, k=5, no -I in the group 2^5, code dim 2^12/2^5 = 128 = 2^(V-1)
+PASS A2 [exact] grid3x3 V=9 E=12 edge sites: R0-R4 pair by pair, 4 face loops, 0 relations (none), k=4, no -I in the group 2^4, code dim 2^12/2^4 = 256 = 2^(V-1)
+PASS A3 [exact] grid3x3+pendant V=10 E=13 edge sites: R0-R4 pair by pair, 4 face loops, 0 relations (none), k=4, no -I in the group 2^4, code dim 2^13/2^4 = 512 = 2^(V-1)
+PASS A4 [exact] the emergent vacuum is on each cluster the UNIQUE code state with B_v = +1 at every vertex: one coset of 32, 16 and 16 records, registering no record number
+PASS B1 [exact] cube vacuum: allowed set uniform, 32 of 4096 at p = 1/32, a LINEAR subspace of F2^E, dim 5 = E - V + 1 = 12 - 8 + 1, exactly what the 8 single-vertex conditions cut out
+PASS B2 [exact] grid3x3 vacuum: allowed set uniform, 16 of 4096 at p = 1/16, a LINEAR subspace of F2^E, dim 4 = E - V + 1 = 12 - 9 + 1, exactly what the 9 single-vertex conditions cut out
+PASS B3 [exact] grid3x3+pendant vacuum: allowed set uniform, 16 of 8192 at p = 1/16, a LINEAR subspace of F2^E, dim 4 = E - V + 1 = 13 - 10 + 1, exactly what the 10 single-vertex conditions cut out
+PASS B4 [exact] the Z-type subgroup of <S_f, B_v> has rank V - 1 = 7, 8, 9, sign +1 throughout (phases [0]), and EQUALS <B_v>: no condition wider than a vertex star
+PASS C1 [exact] cube: odds at all 12 sites start at 1/2, and in each of the 24 (site, value) cases the allowed set stays uniform on 16 and the odds at the 11 other sites stay at 1/2
+PASS C2 [exact] cube, odds at (0,4) as records form: [none]1/2 [(0,1)=1]1/2 [(6,7)=1]1/2 [(0,1)=1,(5,7)=1]1/2 [(0,1)=1,(0,2)=0]1 [(0,1)=1,(0,2)=1]0 -- never between, leaving 1/2 only when the star of vertex 0 closes
+PASS C3 [exact] grid3x3: odds at all 12 sites start at 1/2; a record at one of the 8 sites at a degree-2 corner forces its partner to 0 or 1 (16 cases), nothing else; a record at the other 4 changes nothing
+PASS C4 [exact] grid3x3+pendant: the bridge site (0,9) has odds 0 with NO record present -- vertex 9 has degree 1, so its parity condition alone forces the site: a record of value 1 never forms. The other 12 start at 1/2
+PASS C5 [exact] cube, all 66 site pairs x 4 values: odds elsewhere change in exactly the 96 cases where the records close a vertex star, never in the other 168; the changed site is its third edge
+PASS D1 [exact] cube: the allowed set's cut space has dim 7, with 63 cocircuits of weights 3-6, every site forced by exactly 25 minimal record sets, the two smallest its endpoints' two-record vertex stars
+PASS D2 [exact] grid3x3: the allowed set's cut space has dim 8, with 53 cocircuits of weights 2-5, minimal forcing-set counts per site [13, 25]
+PASS D3 [exact] grid3x3+pendant: the allowed set's cut space has dim 9, with 54 cocircuits of weights 1-5, minimal forcing-set counts per site [1, 13, 25]
+PASS D4 [exact] on all three clusters every listed set is deterministic and inclusion-minimal, and an exhaustive sweep of all record sets of size <= 3 against the cocircuit prediction gives 0 mismatches
+PASS E1 [exact] cube and grid3x3: all 264 and 264 ordered (site,value) pairs give identical joint odds either way, 0 and 0 mismatches; 40 and 40 shuffled full orders over 12 sites close on the same 1/32, 1/16
+PASS E2 [exact] grid3x3+pendant: all 312 ordered pairs give identical joint odds, 0 mismatches, and 40 shuffled full orders over 13 sites close on 1/16 -- the bridge site's value is forced alike
+PASS E3 [exact] every Z_e, Z_f pair commutes exactly on all three clusters, so the stipulated Lueders conditionings commute; the same 264 pairs give 0 and 0 mismatches on group G's two NON-stabilizer states
+PASS F1 [exact] cube, a fermion pair at the adjacent corners 0 and 1 (B_v = -1 there): allowed set 32 of 4096, a genuine coset of the vacuum's subspace, uniform at p = 1/32, odds 1/2 at all 12 sites
+PASS F2 [exact] the same for the face-diagonal pair (0,3) and the antipodal (0,7): 32 and 32 allowed patterns, both cosets of the vacuum's subspace, uniform, odds 1/2 all round
+PASS F3 [exact] on every allowed pattern of all three pair states the parity on star(v) is 1 at both corners, so n_v = 1 EXACTLY; cut space and its 63 cocircuits of weights 3-6 are the vacuum's, only forced values differ: ((0,1),(0,2)) send (0,4) to 1,0,0,1 not 0,1,1,0
+PASS G1 [exact] cube N = 2 sector, 28 cosets: 2^5 H_enc is Gaussian-integer and an exact diagonal gauge in {1, i, -1, -i} carries it entrywise onto Jordan-Wigner, no residual
+PASS G2 [exact] ACROSS sectors, sqrt(a)|vacuum> + sqrt(b)|pair(0,1)> at (a,b) = (1/2,1/2) and (1/3,2/3): support exactly 64 and 64 = 2 cosets x 32, odds a/32 and b/32, 0 cancellation zeros: disjoint supports
+PASS G3 [exact] the Slater ground state of two particles at E = -4: support 512 = 16 cosets, uniform at 1/512, 384 CANCELLATION zeros = 12 cosets with a legal weight-2 pattern: exactly the 12 corner pairs on one x-face
+PASS G4 [exact; last clause numerical 1e-12] a coherent mix of two E = -4 states: support 640, 256 cancellation zeros = 8 cosets against 384 = 12 for the single state, while the 3-fold manifold's projector has 0 vanishing diagonal entries of 28: they are the state's
+SUMMARY: the odds at a site are 1/2 or forced, never between; a record elsewhere changes them only when a vertex parity closes; the finished set carries the same odds in any order.
+TOTAL: PASS=27 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py
+++ b/scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py
@@ -1,0 +1,1041 @@
+#!/usr/bin/env python3
+"""Record formation on the emergent vacuum: parity-forced odds.
+
+Class-A finite-cluster runner, self-contained. Qubits sit on the EDGE sites
+of three finite open graphs; the sites compose ordinarily (tensor product,
+operators on disjoint regions commute, no graded clause anywhere). A record
+at an edge site registers a Z-value there, and the vertex-level parity
+dictionary reads occupancy off those records,
+
+    n_v = (1 - B_v) / 2,     B_v = product of the Z's on the edges at v,
+
+so the condition at a vertex concerns the records of that one vertex's
+incident edges. The update rule used throughout is Lueders conditioning on
+the record's value; it is STIPULATED here, not derived, and is applied to
+the state the encoding supplies. The runner establishes, on the 2x2x2 cube
+graph (8 vertices, 12 edge sites), the 3x3 grid graph (9, 12) and the 3x3
+grid with one pendant site at vertex 0 (10, 13):
+
+  A  ENCODING AND VACUUM.  The Bravyi-Kitaev superfast relations R0-R4 for
+         A_ij = X(edge ij) * prod Z(edges ordered before it at i and at j),
+         A_ji = -A_ij,   B_v = the product of the Z's incident to v,
+         S_f  = the ordered product of the A's around a face,
+     the face relations, the code dimension 2^(V-1), and the emergent
+     vacuum as the unique code state carrying B_v = +1 at every vertex.
+  B  THE ALLOWED SET.  The vacuum's record-pattern distribution is uniform
+     on a LINEAR subspace of F2^E of dimension E - V + 1, cut out by the
+     single-vertex parity conditions alone; the Z-type subgroup of
+     <S_f, B_v> has rank V - 1, carries sign +1 throughout, and equals
+     <B_v>, so no longer-than-one-vertex Z-type condition is present.
+  C  ODDS.  The odds at every site before any record are 1/2; after records
+     form they are 1/2 or forced to 0 or 1, never between; and a record
+     elsewhere changes them exactly when the records around one vertex
+     close a parity.
+  D  FORCING.  Forcing is the cocircuit structure of the graph: the minimal
+     forcing record sets are the minimal cocircuits through the site, each
+     deterministic and inclusion-minimal, checked exhaustively to size 3.
+  E  ORDER INDEPENDENCE.  The finished set of records carries the same odds
+     whatever order the records formed in, on stabilizer and on
+     non-stabilizer states, because all Z_e commute.
+  F  A FERMION PAIR.  B_v = -1 at two vertices gives a genuine coset of the
+     vacuum's subspace, with n_v = 1 on every allowed pattern and the same
+     cocircuit forcing at different forced values.
+  G  COHERENCE.  Coherent superposition inside one record-number sector
+     adds cancellation zeros beyond the allowed set; superposition across
+     sectors adds none; and the zeros belong to the state, not to the
+     energy manifold.
+
+Groups A-F and the rational half of G are exact: Pauli algebra in the
+symplectic representation with phases mod 4, F2 linear algebra, Gaussian
+integers and `Fraction`. Two lines are floating-point witnesses at 1e-12 and
+are labelled [numerical]. Every line is tagged [exact] or [numerical].
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from fractions import Fraction
+from functools import reduce
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 120
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================================== Pauli algebra
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+class P:
+    """i^k * prod_q X_q^{x_q} Z_q^{z_q}, X written before Z on every qubit."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(s, k, x, z):
+        s.k = k % 4
+        s.x = x
+        s.z = z
+
+    def __mul__(a, b):
+        return P(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(s):
+        return P(s.k + 2, s.x, s.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def is_herm(s):
+        return s.k % 2 == pcnt(s.x & s.z) % 2
+
+    def is_id(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def is_mid(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+
+ID = P(0, 0, 0)
+PH = [1 + 0j, 1j, -1 + 0j, -1j]
+
+
+def comm(a, b):
+    return (pcnt(a.x & b.z) + pcnt(a.z & b.x)) % 2 == 0
+
+
+def pact(p, y):
+    """p|y> = amp |y ^ p.x> with amp a unit Gaussian integer."""
+    return y ^ p.x, PH[p.k] * ((-1) ** (pcnt(p.z & y) % 2))
+
+
+# ============================================================== F2 linear algebra
+
+def f2_rank(vs):
+    """Rank and a reduced basis of a set of F2 vectors held as ints."""
+    b = []
+    for v in vs:
+        for x in b:
+            v = min(v, v ^ x)
+        if v:
+            b.append(v)
+            b.sort(reverse=True)
+    return len(b), b
+
+
+def f2_span(basis):
+    S = {0}
+    for b in basis:
+        S |= {s ^ b for s in S}
+    return S
+
+
+def f2_kernel(cols):
+    """Kernel of e_j |-> cols[j] over F2, as tags (ints over j)."""
+    piv = {}
+    out = []
+    for j in range(len(cols)):
+        v, t = cols[j], 1 << j
+        while v:
+            h = v.bit_length() - 1
+            if h in piv:
+                pv, pt = piv[h]
+                v ^= pv
+                t ^= pt
+            else:
+                piv[h] = (v, t)
+                t = 0
+                break
+        if v == 0 and t:
+            out.append(t)
+    return out
+
+
+# ==================================================================== clusters
+
+def grid_cluster(nr, nc):
+    idx = {(r, c): nc * r + c for r in range(nr) for c in range(nc)}
+    B = []
+    for r in range(nr):
+        for c in range(nc):
+            if c + 1 < nc:
+                B.append((idx[(r, c)], idx[(r, c + 1)]))
+            if r + 1 < nr:
+                B.append((idx[(r, c)], idx[(r + 1, c)]))
+    return nr * nc, sorted((min(u, v), max(u, v)) for u, v in B)
+
+
+def grid_faces(nr, nc):
+    idx = {(r, c): nc * r + c for r in range(nr) for c in range(nc)}
+    return [(idx[(r, c)], idx[(r, c + 1)], idx[(r + 1, c + 1)], idx[(r + 1, c)])
+            for r in range(nr - 1) for c in range(nc - 1)]
+
+
+def cube_cluster():
+    """Vertex s = 4a + 2b + c of the 2x2x2 cube; edges flip one coordinate."""
+    B = [(s, s ^ bit) for s in range(8) for bit in (4, 2, 1) if s ^ bit > s]
+    return 8, sorted(B)
+
+
+def cube_faces():
+    out = []
+    for ax in range(3):
+        bits = [4, 2, 1]
+        fb = bits[ax]
+        ob = [b for b in bits if b != fb]
+        for val in (0, fb):
+            out.append((val, val | ob[1], val | ob[0] | ob[1], val | ob[0]))
+    return out
+
+
+# ==================================================================== encoding
+
+class Enc:
+    """Superfast encoding on the edge sites of a finite open graph."""
+
+    def __init__(self, V, EDGES, FACES, name):
+        self.name = name
+        self.V = V
+        self.EDGES = list(EDGES)
+        self.FACES = list(FACES)
+        self.NQ = len(self.EDGES)
+        self.DIM = 1 << self.NQ
+        self.EIDX = {}
+        for q, (i, j) in enumerate(self.EDGES):
+            self.EIDX[(i, j)] = q
+            self.EIDX[(j, i)] = q
+        self.NBR = {i: sorted(j for (a, b) in self.EDGES
+                              for j in ((b,) if a == i else ((a,) if b == i else ())))
+                    for i in range(V)}
+        self.STAR = {i: [self.EIDX[(i, k)] for k in self.NBR[i]] for i in range(V)}
+        self.STARMASK = {i: reduce(lambda a, b: a | (1 << b), self.STAR[i], 0)
+                         for i in range(V)}
+
+    def A_unsigned(self, i, j):
+        x = 1 << self.EIDX[(i, j)]
+        z = 0
+        for k in self.NBR[i]:
+            if k != j and k < j:
+                z ^= 1 << self.EIDX[(i, k)]
+        for l in self.NBR[j]:
+            if l != i and l < i:
+                z ^= 1 << self.EIDX[(j, l)]
+        return P(pcnt(x & z) % 2, x, z)
+
+    def A(self, i, j):
+        p = self.A_unsigned(i, j)
+        return p if i < j else p.neg()
+
+    def B(self, i):
+        return P(0, 0, self.STARMASK[i])
+
+    def loop(self, cyc):
+        out = ID
+        n = len(cyc)
+        for a in range(n):
+            out = out * self.A(cyc[a], cyc[(a + 1) % n])
+        return out
+
+    def record(self, z):
+        """The parity dictionary: n_v = (1 - B_v)/2 read off the edge record."""
+        return tuple(pcnt(z & self.STARMASK[i]) % 2 for i in range(self.V))
+
+    def hop_pauli(self, i, j):
+        A = self.A(i, j)
+        return A * self.B(i), A * self.B(j)
+
+    def hop_amp(self, P1, P2, y):
+        b1, a1 = pact(P1, y)
+        b2, a2 = pact(P2, y)
+        assert b1 == b2
+        v = 0.5j * (a1 - a2)
+        return b1, complex(round(v.real), round(v.imag))
+
+
+def audit(E):
+    """R0-R4 pair by pair, the face relations, and the code dimension."""
+    R = {}
+    A = {e: E.A(*e) for e in E.EDGES}
+    Bv = {i: E.B(i) for i in range(E.V)}
+    R["R0"] = (all(E.A_unsigned(i, j) == E.A_unsigned(j, i) for (i, j) in E.EDGES)
+               and all(E.A(j, i) == E.A(i, j).neg() for (i, j) in E.EDGES))
+    R["R1"] = (all(A[e].is_herm() and (A[e] * A[e]).is_id() for e in E.EDGES)
+               and all(Bv[i].is_herm() and (Bv[i] * Bv[i]).is_id() for i in range(E.V)))
+    r2 = all(comm(Bv[i], Bv[j]) for i, j in itertools.combinations(range(E.V), 2))
+    for e in E.EDGES:
+        for v in range(E.V):
+            r2 = r2 and (comm(A[e], Bv[v]) != (v in e))
+    R["R2"] = bool(r2)
+    R["R3"] = all(comm(A[e], A[f]) != (len(set(e) & set(f)) == 1)
+                  for e, f in itertools.combinations(E.EDGES, 2))
+    S = [E.loop(f) for f in E.FACES]
+    r4 = True
+    for s in S:
+        r4 = r4 and s.is_herm() and (s * s).is_id()
+        for e in E.EDGES:
+            r4 = r4 and comm(s, A[e])
+        for v in range(E.V):
+            r4 = r4 and comm(s, Bv[v])
+    for a, b in itertools.combinations(S, 2):
+        r4 = r4 and comm(a, b)
+    R["R4"] = bool(r4)
+    R["S_all"] = S
+    R["prodB"] = reduce(lambda a, b: a * b, [Bv[i] for i in range(E.V)])
+    gens, basis = [], []
+    for s in S:
+        v = s.x
+        for b in basis:
+            v = min(v, v ^ b)
+        if v != 0:
+            basis.append(v)
+            basis.sort(reverse=True)
+            gens.append(s)
+    R["k"] = len(gens)
+    R["gens"] = gens
+    rel = []
+    for r in range(2, len(S) + 1):
+        for sub in itertools.combinations(range(len(S)), r):
+            p = reduce(lambda a, b: a * b, [S[t] for t in sub])
+            if p.x == 0 and p.z == 0:
+                rel.append((sub, "+I" if p.k == 0 else "-I" if p.k == 2 else "?"))
+    R["relations"] = rel
+    grp = []
+    for m in range(1 << len(gens)):
+        p = ID
+        for t in range(len(gens)):
+            if (m >> t) & 1:
+                p = p * gens[t]
+        grp.append(p)
+    R["grp"] = grp
+    R["grp_ok"] = ((not any(g.is_mid() for g in grp))
+                   and sum(1 for g in grp if g.x == 0) == 1)
+    R["code_dim"] = E.DIM >> len(gens)
+    return R
+
+
+def code_space(E, R):
+    """Cosets of the stabilizer group; phi[y] the unit coefficient of |y>."""
+    grp = R["grp"]
+    phi = np.zeros(E.DIM, dtype=complex)
+    cid = -np.ones(E.DIM, dtype=np.int64)
+    reps = []
+    for y0 in range(E.DIM):
+        if cid[y0] >= 0:
+            continue
+        c = len(reps)
+        reps.append(y0)
+        for g in grp:
+            b, a = pact(g, y0)
+            assert cid[b] < 0
+            cid[b] = c
+            phi[b] = a
+    assert (cid >= 0).all()
+    recs = [E.record(reps[c]) for c in range(len(reps))]
+    for y in range(E.DIM):
+        assert E.record(y) == recs[cid[y]]
+    return cid, phi, reps, recs
+
+
+def sector_matrix(E, R, cid, phi, reps, recs, keep, HE):
+    """Exact H_enc on the code space, rows and columns the kept cosets."""
+    k = R["k"]
+    grp = R["grp"]
+    sel = [c for c in range(len(reps)) if keep(recs[c])]
+    pos = {c: a for a, c in enumerate(sel)}
+    n = len(sel)
+    Hoff = np.zeros((n, n), dtype=complex)
+    hp = {e: E.hop_pauli(*e) for e in HE}
+    for c in sel:
+        a = pos[c]
+        for g in grp:
+            y, ay = pact(g, reps[c])
+            assert abs(phi[y] - ay) < 1e-12
+            for e in HE:
+                yy, amp = E.hop_amp(hp[e][0], hp[e][1], y)
+                if amp == 0:
+                    continue
+                assert amp.real == 0 and abs(amp.imag) == 1
+                cc = cid[yy]
+                if cc not in pos:
+                    continue
+                Hoff[pos[cc], a] += (2.0 ** (-k)) * np.conj(phi[yy]) * amp * phi[y]
+    Q = Hoff * (2.0 ** k)
+    exact = bool(np.all(np.abs(Q - np.round(Q.real) - 1j * np.round(Q.imag)) == 0))
+    Hoff = (np.round(Q.real) + 1j * np.round(Q.imag)) / (2.0 ** k)
+    return sel, pos, Hoff, exact
+
+
+# ================================================== Jordan-Wigner reference
+
+def jw_sign(S, src, dst):
+    lo, hi = min(src, dst), max(src, dst)
+    return (-1) ** sum(1 for kk in range(lo + 1, hi) if kk in S)
+
+
+def fermi_sector(EDGES, patterns):
+    """Graded (Jordan-Wigner) hopping matrix on the same occupation patterns."""
+    idx = {p: i for i, p in enumerate(patterns)}
+    n = len(patterns)
+    T = np.zeros((n, n))
+    for p in patterns:
+        S = frozenset(i for i, b in enumerate(p) if b)
+        i0 = idx[p]
+        for (u, v) in EDGES:
+            for (src, dst) in ((u, v), (v, u)):
+                if src in S and dst not in S:
+                    T2 = frozenset((S - {src}) | {dst})
+                    tp = tuple(1 if q in T2 else 0 for q in range(len(p)))
+                    T[idx[tp], i0] += -jw_sign(S, src, dst)
+    assert np.array_equal(T, T.T)
+    return idx, T
+
+
+def unit_index(c):
+    for kk, u in enumerate(PH):
+        if abs(c - u) < 1e-9:
+            return kk
+    return None
+
+
+def gauge_match(Hs, Hf):
+    """Diagonal D with entries in {1,i,-1,-i} and conj(D) Hs D = Hf entrywise."""
+    n = Hs.shape[0]
+    ss = {(a, b) for a in range(n) for b in range(n)
+          if a != b and abs(Hs[a, b]) > 1e-9}
+    sf = {(a, b) for a in range(n) for b in range(n)
+          if a != b and abs(Hf[a, b]) > 1e-9}
+    if ss != sf:
+        return None
+    e = [None] * n
+    for root in range(n):
+        if e[root] is not None:
+            continue
+        e[root] = 0
+        st = [root]
+        while st:
+            a = st.pop()
+            for b in range(n):
+                if b == a or abs(Hs[a, b]) < 1e-9:
+                    continue
+                s, f = unit_index(Hs[a, b]), unit_index(Hf[a, b])
+                if s is None or f is None:
+                    return None
+                want = (e[a] + f - s) % 4
+                if e[b] is None:
+                    e[b] = want
+                    st.append(b)
+                elif e[b] != want:
+                    return None
+    d = np.array([PH[t] for t in e])
+    M = np.conj(d)[:, None] * Hs * d[None, :]
+    return d if np.max(np.abs(M - Hf)) == 0 else None
+
+
+# ================================================== clusters, vacuum, odds
+
+NAMES = ("cube", "grid3x3", "grid3x3+pendant")
+
+
+def make(nm):
+    if nm == "cube":
+        V, E = cube_cluster()
+        F = cube_faces()
+    elif nm == "grid3x3":
+        V, E = grid_cluster(3, 3)
+        F = grid_faces(3, 3)
+    else:
+        V, E = grid_cluster(3, 3)
+        F = grid_faces(3, 3)
+        E = list(E) + [(0, 9)]
+        V = 10
+    return Enc(V, sorted(E), F, nm)
+
+
+CL = {}
+ALLOW = {}
+for _nm in NAMES:
+    _En = make(_nm)
+    _R = audit(_En)
+    _cid, _phi, _reps, _recs = code_space(_En, _R)
+    CL[_nm] = (_En, _R, _cid, _phi, _reps, _recs)
+    _c0 = [c for c in range(len(_reps)) if all(x == 0 for x in _recs[c])]
+    ALLOW[_nm] = (_c0, [z for z in range(_En.DIM) if _cid[z] == _c0[0]])
+
+BITS = {nm: [((np.arange(CL[nm][0].DIM) >> q) & 1) for q in range(CL[nm][0].NQ)]
+        for nm in NAMES}
+
+
+def odds(S, q):
+    """The odds that a record forming at site q locks the value 1."""
+    return Fraction(sum(1 for z in S if (z >> q) & 1), len(S))
+
+
+def cond(S, q, b):
+    """Lueders conditioning of the allowed set on a record of value b at q."""
+    return [z for z in S if ((z >> q) & 1) == b]
+
+
+def cocircuits(S, nq):
+    """Cut space of the allowed set and its minimal (inclusion-minimal) cocircuits."""
+    base = S[0]
+    dim, basis = f2_rank([z ^ base for z in S])
+    dual = [w for w in range(1 << nq) if all(pcnt(w & b) % 2 == 0 for b in basis)]
+    assert len(dual) == 1 << (nq - dim)
+    nz = [w for w in dual if w]
+    cc = [w for w in nz if not any(v and v != w and (v & w) == v for v in nz)]
+    return dim, dual, cc
+
+
+def forcing_sets(cc, q):
+    """The inclusion-minimal record sets that force site q."""
+    sets = [w & ~(1 << q) for w in cc if (w >> q) & 1]
+    sets = [s for s in sets if not any(t != s and (t & s) == t for t in sets)]
+    return sorted(set(sets), key=lambda s: (pcnt(s), s))
+
+
+def lueders(v, bit, b):
+    w = np.where(bit == b, v, 0)
+    n2 = float(np.vdot(w, w).real)
+    return (None if n2 < 1e-24 else w / np.sqrt(n2)), n2
+
+
+def coset_state(nm, amps):
+    """Unit vector with the given complex amplitude on each named coset."""
+    En, R, cid, phi, reps, recs = CL[nm]
+    v = np.zeros(En.DIM, dtype=complex)
+    for c, a in amps.items():
+        sel = cid == c
+        v[sel] = a * phi[sel]
+    return v / np.sqrt(float(np.vdot(v, v).real))
+
+
+def pair_ordered(nm, v):
+    """Ordered-pair order-independence census on one state."""
+    En = CL[nm][0]
+    bits = BITS[nm]
+    bad = npair = 0
+    for q1, q2 in itertools.combinations(range(En.NQ), 2):
+        for b1 in (0, 1):
+            for b2 in (0, 1):
+                npair += 1
+                a = lueders(v, bits[q1], b1)[0]
+                a = None if a is None else lueders(a, bits[q2], b2)[0]
+                c = lueders(v, bits[q2], b2)[0]
+                c = None if c is None else lueders(c, bits[q1], b1)[0]
+                if (a is None) != (c is None):
+                    bad += 1
+                elif a is not None and np.max(np.abs(a - c)) > 1e-12:
+                    bad += 1
+    return npair, bad
+
+
+# =============================================== the cube's two-particle states
+
+def chi(s, u):
+    return -1 if pcnt(s & u) % 2 else 1
+
+
+def cube_two_particle():
+    """The N = 2 sector of the cube, its gauge, and two E = -4 states."""
+    nm = "cube"
+    En, R, cid, phi, reps, recs = CL[nm]
+    sel, pos, Hoff, exact = sector_matrix(
+        En, R, cid, phi, reps, recs, lambda r: sum(r) == 2, En.EDGES)
+    pats = [recs[c] for c in sel]
+    idx, T = fermi_sector(En.EDGES, pats)
+    assert all(idx[p] == pos[sel[a]] for a, p in enumerate(pats))
+    d = gauge_match(Hoff, T)
+    Ti = np.round(T).astype(np.int64)
+    assert np.allclose(Ti, T)
+
+    def slater(s, t):
+        w = np.zeros(len(pats), dtype=np.int64)
+        for a, p in enumerate(pats):
+            u, x = [i for i, b in enumerate(p) if b]
+            w[a] = chi(s, u) * chi(t, x) - chi(s, x) * chi(t, u)
+        return w
+
+    return sel, pos, pats, Hoff, Ti, d, exact, slater
+
+
+def state_from_weights(sel, pos, d, w, k):
+    """Unit vector and exact per-pattern probabilities of an encoded state."""
+    En, R, cid, phi, reps, recs = CL["cube"]
+    n2 = int(w @ w)
+    amps = {sel[a]: complex(w[a]) * np.conj(d[a]) for a in range(len(sel)) if w[a]}
+    v = coset_state("cube", amps)
+    ex = {}
+    for z in range(En.DIM):
+        c = cid[z]
+        ex[z] = (Fraction(int(w[pos[c]]) ** 2, n2 * (1 << k))
+                 if c in pos else Fraction(0))
+    assert max(abs(abs(v[z]) ** 2 - float(ex[z])) for z in range(En.DIM)) < 1e-12
+    return v, ex
+
+
+# ===================================================================== group A
+
+def group_A():
+    for t, nm in enumerate(NAMES):
+        En, R, cid, phi, reps, recs = CL[nm]
+        rel = R["relations"]
+        allsix = len(rel) == 1 and rel[0][0] == tuple(range(len(R["S_all"])))
+        check("A%d [exact] %s V=%d E=%d edge sites: R0-R4 pair by pair, %d face loops, %d "
+              "relation%s, k=%d, no -I in the group 2^%d, code dim 2^%d/2^%d = %d = 2^(V-1)"
+              % (t + 1, nm, En.V, En.NQ, len(En.FACES), len(rel),
+                 " (the product of all six) = +I" if rel else "s (none)",
+                 R["k"], R["k"], En.NQ, R["k"], R["code_dim"]),
+              all(R[q] for q in ("R0", "R1", "R2", "R3", "R4")) and R["grp_ok"]
+              and R["code_dim"] == 1 << (En.V - 1)
+              and (allsix and rel[0][1] == "+I" if nm == "cube" else not rel))
+    ok = True
+    sizes = []
+    for nm in NAMES:
+        En, R = CL[nm][0], CL[nm][1]
+        c0, S = ALLOW[nm]
+        sizes.append(len(S))
+        ok = ok and len(c0) == 1 and len(S) == 1 << R["k"]
+        ok = ok and all(all(pcnt(z & En.STARMASK[v]) % 2 == 0 for v in range(En.V))
+                        for z in S)
+        ok = ok and sum(1 for c in range(len(CL[nm][4]))
+                        if all(x == 0 for x in CL[nm][5][c])) == 1
+    check("A4 [exact] the emergent vacuum is on each cluster the UNIQUE code state with B_v = +1 "
+          "at every vertex: one coset of %d, %d and %d records, registering no record number"
+          % tuple(sizes), ok)
+
+
+# ===================================================================== group B
+
+def group_B():
+    for t, nm in enumerate(NAMES):
+        En, R = CL[nm][0], CL[nm][1]
+        c0, S = ALLOW[nm]
+        Sset = set(S)
+        lin = 0 in Sset and all((a ^ b) in Sset for a in S for b in S)
+        dim = f2_rank(S)[0]
+        pred = [z for z in range(En.DIM)
+                if all(pcnt(z & En.STARMASK[v]) % 2 == 0 for v in range(En.V))]
+        p = Fraction(1, len(S))
+        check("B%d [exact] %s vacuum: allowed set uniform, %d of %d at p = %s, a LINEAR subspace "
+              "of F2^E, dim %d = E - V + 1 = %d - %d + 1, exactly what the %d single-vertex "
+              "conditions cut out"
+              % (t + 1, nm, len(S), En.DIM, p, dim, En.NQ, En.V, En.V),
+              lin and dim == En.NQ - En.V + 1 and set(pred) == Sset
+              and all(odds(S, q) in (Fraction(0), Fraction(1), Fraction(1, 2))
+                      for q in range(En.NQ)))
+    rk, sg, eq = [], set(), True
+    for nm in NAMES:
+        En, R = CL[nm][0], CL[nm][1]
+        G = list(R["S_all"]) + [En.B(v) for v in range(En.V)]
+        Z = []
+        for tag in f2_kernel([g.x for g in G]):
+            q = ID
+            for j in range(len(G)):
+                if (tag >> j) & 1:
+                    q = q * G[j]
+            assert q.x == 0
+            Z.append(q)
+        sg |= {q.k for q in Z}
+        r, bz = f2_rank([q.z for q in Z])
+        rk.append(r)
+        eq = eq and f2_span(bz) == f2_span(f2_rank(
+            [En.STARMASK[v] for v in range(En.V)])[1]) and r == En.V - 1
+    check("B4 [exact] the Z-type subgroup of <S_f, B_v> has rank V - 1 = %d, %d, %d, sign +1 "
+          "throughout (phases %s), and EQUALS <B_v>: no condition wider than a vertex star"
+          % (rk[0], rk[1], rk[2], sorted(sg)), eq and sg == {0})
+
+
+# ===================================================================== group C
+
+def group_C():
+    En, R = CL["cube"][0], CL["cube"][1]
+    S = ALLOW["cube"][1]
+    half = Fraction(1, 2)
+    before = all(odds(S, q) == half for q in range(En.NQ))
+    same = True
+    for q in range(En.NQ):
+        for b in (0, 1):
+            sc = cond(S, q, b)
+            same = same and len(sc) == len(S) // 2 and all(
+                odds(sc, r) == half for r in range(En.NQ) if r != q)
+    check("C1 [exact] cube: odds at all %d sites start at 1/2, and in each of the %d (site, "
+          "value) cases the allowed set stays uniform on %d and the odds at the %d other sites "
+          "stay at 1/2"
+          % (En.NQ, 2 * En.NQ, len(S) // 2, En.NQ - 1), before and same)
+
+    q04 = En.EIDX[(0, 4)]
+    rows = []
+    rows.append(("none", odds(S, q04)))
+    s1 = cond(S, En.EIDX[(0, 1)], 1)
+    rows.append(("(0,1)=1", odds(s1, q04)))
+    rows.append(("(6,7)=1", odds(cond(S, En.EIDX[(6, 7)], 1), q04)))
+    rows.append(("(0,1)=1,(5,7)=1", odds(cond(s1, En.EIDX[(5, 7)], 1), q04)))  # no star closed
+    rows.append(("(0,1)=1,(0,2)=0", odds(cond(s1, En.EIDX[(0, 2)], 0), q04)))
+    rows.append(("(0,1)=1,(0,2)=1", odds(cond(s1, En.EIDX[(0, 2)], 1), q04)))
+    check("C2 [exact] cube, odds at (0,4) as records form: %s -- never between, leaving 1/2 "
+          "only when the star of vertex 0 closes"
+          % " ".join("[%s]%s" % (a, b) for a, b in rows),
+          [str(b) for _, b in rows] == ["1/2", "1/2", "1/2", "1/2", "1", "0"])
+
+    En, R = CL["grid3x3"][0], CL["grid3x3"][1]
+    S = ALLOW["grid3x3"][1]
+    deg2 = [q for q, (u, v) in enumerate(En.EDGES)
+            if len(En.STAR[u]) == 2 or len(En.STAR[v]) == 2]
+    ok = all(odds(S, q) == half for q in range(En.NQ))
+    npart = 0
+    for q in range(En.NQ):
+        for b in (0, 1):
+            sc = cond(S, q, b)
+            ch = [r for r in range(En.NQ) if r != q and odds(sc, r) != half]
+            if q in deg2:
+                u, v = En.EDGES[q]
+                w = u if len(En.STAR[u]) == 2 else v
+                partner = [r for r in En.STAR[w] if r != q]
+                ok = ok and ch == partner and odds(sc, ch[0]) in (Fraction(0), Fraction(1))
+                npart += 1
+            else:
+                ok = ok and ch == []
+    check("C3 [exact] grid3x3: odds at all %d sites start at 1/2; a record at one of the %d "
+          "sites at a degree-2 corner forces its partner to 0 or 1 (%d cases), nothing else; a "
+          "record at the other %d changes nothing"
+          % (En.NQ, len(deg2), npart, En.NQ - len(deg2)), ok)
+
+    En, R = CL["grid3x3+pendant"][0], CL["grid3x3+pendant"][1]
+    S = ALLOW["grid3x3+pendant"][1]
+    qb = En.EIDX[(0, 9)]
+    ok = (odds(S, qb) == Fraction(0) and cond(S, qb, 1) == []
+          and all(odds(S, q) == half for q in range(En.NQ) if q != qb))
+    check("C4 [exact] grid3x3+pendant: the bridge site (0,9) has odds 0 with NO record present "
+          "-- vertex 9 has degree 1, so its parity condition alone forces the site: a record of "
+          "value 1 never forms. The other %d start at 1/2" % (En.NQ - 1), ok)
+
+    En = CL["cube"][0]
+    S = ALLOW["cube"][1]
+    tally = {}
+    ok = True
+    for q1, q2 in itertools.combinations(range(En.NQ), 2):
+        shared = set(En.EDGES[q1]) & set(En.EDGES[q2])
+        for b1 in (0, 1):
+            for b2 in (0, 1):
+                sc = cond(cond(S, q1, b1), q2, b2)
+                ch = [r for r in range(En.NQ)
+                      if r not in (q1, q2) and odds(sc, r) != half]
+                key = (len(shared), len(ch))
+                tally[key] = tally.get(key, 0) + 1
+                if shared:
+                    third = [r for r in En.STAR[list(shared)[0]] if r not in (q1, q2)]
+                    ok = ok and ch == third and all(
+                        odds(sc, r) in (Fraction(0), Fraction(1)) for r in ch)
+                else:
+                    ok = ok and ch == []
+    check("C5 [exact] cube, all %d site pairs x 4 values: odds elsewhere change in exactly "
+          "the %d cases where the records close a vertex star, never in the other %d; the changed "
+          "site is its third edge"
+          % (En.NQ * (En.NQ - 1) // 2, tally.get((1, 1), 0), tally.get((0, 0), 0)),
+          ok and tally == {(1, 1): 96, (0, 0): 168})
+
+
+# ===================================================================== group D
+
+FORCE = {}
+
+
+def group_D():
+    mism = 0
+    detmin = True
+    for t, nm in enumerate(NAMES):
+        En = CL[nm][0]
+        S = ALLOW[nm][1]
+        dim, dual, cc = cocircuits(S, En.NQ)
+        assert set(dual) == f2_span(f2_rank([En.STARMASK[v]
+                                             for v in range(En.V)])[1])
+        F = {q: forcing_sets(cc, q) for q in range(En.NQ)}
+        FORCE[nm] = F
+        for q in range(En.NQ):
+            for s in F[q]:
+                bitsq = [r for r in range(En.NQ) if (s >> r) & 1]
+                det = True
+                for a in range(1 << len(bitsq)):
+                    sc = S
+                    for u, r in enumerate(bitsq):
+                        sc = cond(sc, r, (a >> u) & 1)
+                    if sc and len({(z >> q) & 1 for z in sc}) != 1:
+                        det = False
+                minimal = True
+                for drop in bitsq:
+                    rest = [r for r in bitsq if r != drop]
+                    free = False
+                    for a in range(1 << len(rest)):
+                        sc = S
+                        for u, r in enumerate(rest):
+                            sc = cond(sc, r, (a >> u) & 1)
+                        if sc and len({(z >> q) & 1 for z in sc}) == 2:
+                            free = True
+                    minimal = minimal and free
+                detmin = detmin and det and minimal
+        cnt = sorted({len(F[q]) for q in range(En.NQ)})
+        wts = sorted({pcnt(w) for w in cc})
+        extra = ""
+        if nm == "cube":
+            pair2 = all(set(F[q][:2]) == {En.STARMASK[u] & ~(1 << q),
+                                          En.STARMASK[v] & ~(1 << q)}
+                        and all(pcnt(x) == 2 for x in F[q][:2])
+                        for q, (u, v) in enumerate(En.EDGES))
+            extra = (", every site forced by exactly %d minimal record sets, the two smallest "
+                     "its endpoints' two-record vertex stars" % cnt[0])
+            detmin = detmin and pair2
+        else:
+            extra = ", minimal forcing-set counts per site %s" % cnt
+        check("D%d [exact] %s: the allowed set's cut space has dim %d, with %d cocircuits of "
+              "weights %s%s"
+              % (t + 1, nm, En.NQ - dim, len(cc),
+                 "-".join(str(x) for x in (wts[0], wts[-1])), extra),
+              detmin and En.NQ - dim == En.V - 1)
+        for q in range(En.NQ):
+            others = [r for r in range(En.NQ) if r != q]
+            for sz in (1, 2, 3):
+                for comb in itertools.combinations(others, sz):
+                    mask = reduce(lambda a, b: a | (1 << b), comb, 0)
+                    det = True
+                    for a in range(1 << sz):
+                        sc = S
+                        for u, r in enumerate(comb):
+                            sc = cond(sc, r, (a >> u) & 1)
+                        if sc and len({(z >> q) & 1 for z in sc}) == 2:
+                            det = False
+                    if det != any((s & mask) == s for s in F[q]):
+                        mism += 1
+    check("D4 [exact] on all three clusters every listed set is deterministic and inclusion-"
+          "minimal, and an exhaustive sweep of all record sets of size <= 3 against the cocircuit "
+          "prediction gives %d mismatches" % mism, detmin and mism == 0)
+
+
+# ===================================================================== group E
+
+NONSTAB = {}
+
+
+def group_E():
+    full = {}
+    rng = np.random.default_rng(7)
+    for nm in NAMES:
+        En, R = CL[nm][0], CL[nm][1]
+        S = ALLOW[nm][1]
+        v0 = coset_state(nm, {ALLOW[nm][0][0]: 1.0})
+        npair, bad = pair_ordered(nm, v0)
+        ref = Fraction(1, 1 << R["k"])
+        badfull = 0
+        norders = 0
+        for target in [S[int(x)] for x in rng.integers(len(S), size=4)]:
+            for _ in range(10):
+                order = list(range(En.NQ))
+                rng.shuffle(order)
+                v, p = v0.copy(), 1.0
+                for q in order:
+                    w, n2 = lueders(v, BITS[nm][q], (target >> q) & 1)
+                    p *= n2 / float(np.vdot(v, v).real)
+                    v = w
+                norders += 1
+                if abs(p - float(ref)) > 1e-12:
+                    badfull += 1
+        full[nm] = (npair, bad, norders, badfull, ref)
+    a, b = full["cube"], full["grid3x3"]
+    check("E1 [exact] cube and grid3x3: all %d and %d ordered (site,value) pairs give identical "
+          "joint odds either way, %d and %d mismatches; %d and %d shuffled full orders over %d "
+          "sites close on the same %s, %s"
+          % (a[0], b[0], a[1], b[1], a[2], b[2], CL["cube"][0].NQ, a[4], b[4]),
+          a[1] == 0 and b[1] == 0 and a[3] == 0 and b[3] == 0 and a[0] == 264 and b[0] == 264)
+    c = full["grid3x3+pendant"]
+    check("E2 [exact] grid3x3+pendant: all %d ordered pairs give identical joint odds, %d "
+          "mismatches, and %d shuffled full orders over %d sites close on %s -- the bridge site's "
+          "value is forced alike"
+          % (c[0], c[1], c[2], CL["grid3x3+pendant"][0].NQ, c[4]),
+          c[1] == 0 and c[3] == 0 and c[0] == 312)
+    zok = all(comm(P(0, 0, 1 << q1), P(0, 0, 1 << q2))
+              for nm in NAMES
+              for q1, q2 in itertools.combinations(range(CL[nm][0].NQ), 2))
+    ns = []
+    for lab, v in NONSTAB.items():
+        ns.append((lab,) + pair_ordered("cube", v))
+    check("E3 [exact] every Z_e, Z_f pair commutes exactly on all three clusters, so the "
+          "stipulated Lueders conditionings commute; the same %d pairs give %d and %d mismatches "
+          "on group G's two NON-stabilizer states"
+          % (ns[0][1], ns[0][2], ns[1][2]),
+          zok and all(x[2] == 0 for x in ns) and all(x[1] == 264 for x in ns))
+
+
+# ===================================================================== group F
+
+def group_F():
+    nm = "cube"
+    En, R, cid, phi, reps, recs = CL[nm]
+    byrec = {recs[c]: c for c in range(len(reps))}
+    vac = set(ALLOW[nm][1])
+    dim0, dual0, cc0 = cocircuits(sorted(vac), En.NQ)
+    half = Fraction(1, 2)
+    res = {}
+    for (u, w), lab in (((0, 1), "adjacent"), ((0, 3), "face-diagonal"),
+                        ((0, 7), "antipodal")):
+        c = byrec[tuple(1 if x in (u, w) else 0 for x in range(En.V))]
+        S = [z for z in range(En.DIM) if cid[z] == c]
+        base = S[0]
+        iscoset = sorted(z ^ base for z in S) == sorted(vac)
+        par = {x: {pcnt(z & En.STARMASK[x]) % 2 for z in S} for x in range(En.V)}
+        nv = all(len(par[x]) == 1 for x in range(En.V))
+        nv = nv and par[u] == {1} and par[w] == {1} and all(
+            par[x] == {0} for x in range(En.V) if x not in (u, w))
+        oddsok = all(odds(S, q) == half for q in range(En.NQ))
+        dim, dual, cc = cocircuits(S, En.NQ)
+        q1, q2, q3 = En.STAR[u]
+        tab = {(b1, b2): sorted({(z >> q3) & 1 for z in cond(cond(S, q1, b1), q2, b2)})
+               for b1 in (0, 1) for b2 in (0, 1)}
+        tabv = {(b1, b2): sorted({(z >> q3) & 1
+                                  for z in cond(cond(sorted(vac), q1, b1), q2, b2)})
+                for b1 in (0, 1) for b2 in (0, 1)}
+        res[lab] = (len(S), iscoset, nv, oddsok, dim, len(cc),
+                    sorted({pcnt(x) for x in cc}), tab, tabv)
+    a = res["adjacent"]
+    check("F1 [exact] cube, a fermion pair at the adjacent corners 0 and 1 (B_v = -1 there): "
+          "allowed set %d of %d, a genuine coset of the vacuum's subspace, uniform at p = 1/%d, "
+          "odds 1/2 at all %d sites"
+          % (a[0], En.DIM, a[0], En.NQ), a[1] and a[3] and a[0] == 32)
+    b, c = res["face-diagonal"], res["antipodal"]
+    check("F2 [exact] the same for the face-diagonal pair (0,3) and the antipodal (0,7): %d and "
+          "%d allowed patterns, both cosets of the vacuum's subspace, uniform, odds 1/2 all round"
+          % (b[0], c[0]), b[1] and b[3] and c[1] and c[3] and b[0] == 32 and c[0] == 32)
+    check("F3 [exact] on every allowed pattern of all three pair states the parity on star(v) is "
+          "1 at both corners, so n_v = 1 EXACTLY; cut space and its %d cocircuits of weights %s "
+          "are the vacuum's, only forced values differ: ((0,1),(0,2)) send (0,4) to %s not %s"
+          % (a[5], "-".join(str(x) for x in (a[6][0], a[6][-1])),
+             ",".join(str(a[7][k][0]) for k in sorted(a[7])),
+             ",".join(str(a[8][k][0]) for k in sorted(a[8]))),
+          all(r[2] for r in res.values())
+          and all(r[4] == dim0 and r[5] == len(cc0) for r in res.values())
+          and all(len(v) == 1 for v in a[7].values())
+          and all(a[7][k][0] != a[8][k][0] for k in a[7]))
+
+
+# ===================================================================== group G
+
+G_DATA = {}
+
+
+def prepare_G():
+    """The cube's N = 2 sector, its gauge, and the two coherent states."""
+    nm = "cube"
+    En, R, cid, phi, reps, recs = CL[nm]
+    sel, pos, pats, Hoff, Ti, d, exact, slater = cube_two_particle()
+    k = R["k"]
+    w1 = slater(0, 4)
+    w2 = slater(0, 4) + slater(0, 2)
+    assert np.array_equal(Ti @ w1, -4 * w1) and np.array_equal(Ti @ w2, -4 * w2)
+    v1, e1 = state_from_weights(sel, pos, d, w1, k)
+    v2, e2 = state_from_weights(sel, pos, d, w2, k)
+    NONSTAB["slater"] = v1
+    NONSTAB["mix"] = v2
+    G_DATA.update(sel=sel, pos=pos, pats=pats, Hoff=Hoff, Ti=Ti, d=d,
+                  exact=exact, slater=slater, w1=w1, w2=w2, e1=e1, e2=e2)
+
+
+def zero_census(ex):
+    """Split the zero record patterns into out-of-sector and cancellation zeros."""
+    En = CL["cube"][0]
+    out = canc = sup = 0
+    for z in range(En.DIM):
+        if ex[z] > 0:
+            sup += 1
+        elif sum(En.record(z)) != 2:
+            out += 1
+        else:
+            canc += 1
+    return sup, out, canc
+
+
+def group_G():
+    En, R, cid, phi, reps, recs = CL["cube"]
+    k = R["k"]
+    sel, pos, d = G_DATA["sel"], G_DATA["pos"], G_DATA["d"]
+    check("G1 [exact] cube N = 2 sector, %d cosets: 2^%d H_enc is Gaussian-integer and an exact "
+          "diagonal gauge in {1, i, -1, -i} carries it entrywise onto Jordan-Wigner, no residual"
+          % (len(sel), k),
+          d is not None and G_DATA["exact"] and len(sel) == 28)
+
+    byrec = {recs[c]: c for c in range(len(reps))}
+    c0 = ALLOW["cube"][0][0]
+    c1 = byrec[tuple(1 if x in (0, 1) else 0 for x in range(En.V))]
+    ok = True
+    vals = []
+    for (a, b) in ((Fraction(1, 2), Fraction(1, 2)), (Fraction(1, 3), Fraction(2, 3))):
+        v = coset_state("cube", {c0: np.sqrt(float(a)), c1: np.sqrt(float(b))})
+        p = np.abs(v) ** 2
+        sup = [z for z in range(En.DIM) if p[z] > 1e-15]
+        ex = {c0: Fraction(a, 1 << k), c1: Fraction(b, 1 << k)}
+        ok = ok and len(sup) == 2 * (1 << k)
+        ok = ok and all((p[z] > 1e-15) == (cid[z] in (c0, c1)) for z in range(En.DIM))
+        ok = ok and max(abs(p[z] - float(ex[cid[z]])) for z in sup) < 1e-15
+        vals.append(len(sup))
+    check("G2 [exact] ACROSS sectors, sqrt(a)|vacuum> + sqrt(b)|pair(0,1)> at (a,b) = (1/2,1/2) "
+          "and (1/3,2/3): support exactly %d and %d = 2 cosets x %d, odds a/%d and b/%d, 0 "
+          "cancellation zeros: disjoint supports"
+          % (vals[0], vals[1], 1 << k, 1 << k, 1 << k), ok)
+
+    sup, out, canc = zero_census(G_DATA["e1"])
+    w1 = G_DATA["w1"]
+    van = [G_DATA["pats"][a] for a in range(len(sel)) if w1[a] == 0]
+    pairs = [tuple(i for i, b in enumerate(pp) if b) for pp in van]
+    xface = all((u >> 2) == (v >> 2) for u, v in pairs)
+    ex1 = {G_DATA["e1"][z] for z in range(En.DIM) if G_DATA["e1"][z] > 0}
+    check("G3 [exact] the Slater ground state of two particles at E = -4: support %d = %d "
+          "cosets, uniform at %s, %d CANCELLATION zeros = %d cosets with a legal weight-2 "
+          "pattern: exactly the %d corner pairs on one x-face"
+          % (sup, sup // (1 << k), sorted(str(x) for x in ex1)[0], canc, canc // (1 << k),
+             len(pairs)),
+          sup == 512 and canc == 384 and out == 3200 and ex1 == {Fraction(1, 512)}
+          and len(pairs) == 12 and xface)
+
+    sup2, out2, canc2 = zero_census(G_DATA["e2"])
+    slater = G_DATA["slater"]
+    M = np.stack([slater(0, 4), slater(0, 2), slater(0, 1)]).astype(float)
+    Q = np.linalg.qr(M.T)[0]
+    diag = np.diag(Q @ Q.T)
+    nvan = int(np.sum(np.abs(diag) < 1e-12))
+    check("G4 [exact; last clause numerical 1e-12] a coherent mix of two E = -4 states: support "
+          "%d, %d cancellation zeros = %d cosets against %d = %d for the single state, while the "
+          "3-fold manifold's projector has %d vanishing diagonal entries of %d: they are the "
+          "state's"
+          % (sup2, canc2, canc2 // (1 << k), canc, canc // (1 << k), nvan, len(sel)),
+          sup2 == 640 and canc2 == 256 and nvan == 0)
+
+
+def main():
+    prepare_G()
+    for g in (group_A, group_B, group_C, group_D, group_E, group_F, group_G):
+        g()
+    print("SUMMARY: the odds at a site are 1/2 or forced, never between; a record elsewhere "
+          "changes them only when a vertex parity closes; the finished set carries the same odds "
+          "in any order.")
+    print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache: **record formation on the emergent vacuum**, a worked exact model of the readout root's open items. On the emergent-fermion vacuum of three finite clusters, the law-level distribution at a site is entirely a function of the neighbourhood records and takes only two shapes: one half, or a delta. A record at one site fixes nothing at another; it joins that site's neighbourhood and changes its odds exactly when the records around one corner close a parity. The finished set of records has the same odds whatever order the records formed in. A fermion is a parity condition on the records around a corner.

- `docs/RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (328 lines)
- `scripts/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.py` (`TOTAL: PASS=27 FAIL=0`, 0.5 s; exact except one labelled numerical clause; mutation-tested)
- `logs/runner-cache/record_formation_on_the_emergent_vacuum_parity_forced_odds_check_2026_09_02.txt`

## Theorems (2x2x2 cube, 3x3 grid, 3x3 grid + pendant; edge-site records; Lueders conditioning STIPULATED as the update clause)

- **T1** the vacuum's allowed set is a linear subspace of `F2^E` of dimension `E - V + 1`, uniform, cut out by the single-vertex parity conditions alone (the Z-type subgroup of the stabilizer group equals `<B_v>`).
- **T2** the odds at a site given its neighbourhood records are `1/2` or forced to `0`/`1`, never between (the pendant bridge site is forced before any record exists).
- **T3** over all 66 site pairs x 4 values on the cube, odds elsewhere change in exactly the 96 cases where two records close a vertex star and never in the other 168.
- **T4** the minimal forcing sets are exactly the minimal cocircuits of the graph (63 / 53 / 54), verified by an exhaustive sweep of all record sets of size <= 3 with 0 mismatches.
- **T5** order independence: all ordered pairs and 40 shuffled full orders give identical joint odds, on stabilizer and non-stabilizer states alike.
- **T6** a fermion pair is a genuine coset of the vacuum's subspace with `n_v = 1` on every allowed pattern.
- **T7** coherent superposition within a sector adds cancellation zeros beyond the coset (384 of 4096 for the Slater ground state, exactly the corner pairs on a common x-face); superposition across sectors adds none; the zeros belong to the state, not the energy manifold.

## Corollary

- Admissibility's reading notes (2) and (3) are instantiated exactly; "some records cannot form at a site because of neighbour conditions" is exact here.
- The selection-rule zeros of PR #7842 are coherent-state zeros, not parity zeros: two distinct mechanisms for a record pattern never forming.
- A worked instance, not a derivation of the framework's readout; formation site, probability and rate are not supplied.

## Dependencies and context

- Cites `EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7842) and `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7834) by filename as pointers; the axioms and Admissibility's reading notes are quoted verbatim.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k

## Review-loop disposition (2026-09-04)

The original physical Record/fermion claim was rejected by adversarial review. Its durable finite graph-code core was rewritten as a self-contained bounded theorem, re-reviewed to PASS, and landed on main as commit 4c2a0fcfff84ce8cab84dce4d941eb9f8a58e5d5. Full pipeline, strict lint, and changed-evidence gates passed on the exact current-main train. No audit verdict was applied; independent audit remains separate. The complete review and fix-confirmation record is attached in the comments.