### PR TITLE
feat(flavor): corner kernel cubic carriers, C3 split, registered weights

### DIFF
--- a/docs/CORNER_KERNEL_CUBIC_CARRIERS_C3_SPLIT_AND_REGISTERED_BLOCK_WEIGHTS_BOUNDED_THEOREM_NOTE_2026-09-02.md
+++ b/docs/CORNER_KERNEL_CUBIC_CARRIERS_C3_SPLIT_AND_REGISTERED_BLOCK_WEIGHTS_BOUNDED_THEOREM_NOTE_2026-09-02.md
@@ -1,0 +1,299 @@
+---
+claim_id: corner_kernel_cubic_carriers_c3_split_registered_block_weights
+claim_type: bounded_theorem
+claim_scope: "On the eight-dimensional kernel of the Kawamoto-Smit staggered hopping read on the coarse lattice 2Z^3 at the Brillouin-zone corner q = (pi,pi,pi), with the Cl(6) cell algebra Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3), Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3), epsilon = Z_1 Z_2 Z_3 and T = i Gamma_1 Gamma_2 Gamma_3 redeclared here, and for the twelve stipulated bilinears listed in the runner only: (T1) H(pi,pi,pi) = 0 so the whole cell is the corner kernel, the L = 4 coarse torus kernel is eight-dimensional, all 24 proper cubic rotations lift to integer signed permutations whose 576 products close on the nose on that kernel, the characters (E, 8C3, 3C2, 6C4, 6C2') = (8, 2, 0, 4, 0) decompose in exact rational arithmetic as 2 A1 + 2 T1, and the isotypic projectors in the corner basis are exactly P_A1 = diag(1,0,0,0,0,0,0,1) = P_hw0 + P_hw3 and P_T1 = diag(0,1,1,1,1,1,1,0) = P_hw1 + P_hw2, with each Hamming block separately O-invariant carrying characters (1,1,1,1,1) on hw = 0, 3 and (3,0,-1,1,-1) on hw = 1, 2. (T2) The 1+3+3+1 grading is the eigen-grading of the O-invariant Cl(6) bilinear i sum_a Gamma_a Xi_a = Z_1 + Z_2 + Z_3, spectrum 3 - 2 hw; the T1 isotypic is T1 (x) C^2 with a commutant of dimension 4 by the exact rational formula (1/24) sum |chi|^2, four independent commuting elements exhibited, so the group alone does not split it; T is O-invariant, unitary, carries hw = 1 onto hw = 2 and back with rank 3, and anticommutes with epsilon = diag((-1)^hw). (T3) On each triplet the C3[111] restriction U has tr U = 0, U^3 = I and eigenvalues {1, omega, omegabar}; its invariant vector has corner weights exactly (1/3, 1/3, 1/3); against the fixed democratic W = (1,1,1)/sqrt3 the overlaps are 1 and 1/9, a corner-sign gauge artefact removed by rephasing a single corner; the singlet projectors have every entry of modulus 1/3 and P_0, P_1 commute with U. (T4) Each of the twelve bilinears restricts to an exactly circulant operator on each triplet with residual 0 and c = conj(b): sum Gamma_a, sum Xi_a and T restrict to zero, i sum Gamma_a Xi_a gives a = +1 / -1 and epsilon a = -1 / +1 with b = 0, (sum Gamma_a)^2 = (sum Xi_a)^2 = 3I, the p_a^2 coefficient of H(pi+p)^2 is the identity on both, the Gamma-Gamma and Xi-Xi bivector sums give a = 0, |b| = 1, and i sum Gamma_a Xi_{a+1} and i sum Gamma_a Xi_{a+2} give a = 0, |b| = 1 with delta differing by pi between the two triplets; the six O-invariant ones have b = 0 by Schur and the six others have O-average exactly 0 hence a = 0, so no listed operator has a != 0 and b != 0 and every hw-diagonal one registers r = 0; and the restriction map from real C3-invariant Hermitian quadratics onto the circulant algebra has real rank 3 on each triplet, with alpha (sum Z_a) + beta i(sum_cyc Gamma_a Gamma_{a+1}) + gamma i(sum_a Gamma_a Xi_{a+1}) realising every (a, |b|, delta), the triples (2,1,1) and (2,1,0) registering r = 1/2 and r = 1/4 exactly. (T5) All six relabellings of each triplet and all 24 cubic conjugations leave (a, |b|, r) unchanged with circulant residual 0 for all twelve; naming C^2 rather than C the generator sends b to its conjugate, delta to -delta, and fixes (a, |b|, r). (T6) Exactly four of the twelve separate the two triplets -- i sum Gamma_a Xi_a and epsilon by the sign of a, and the two Gamma-Xi cross terms by delta differing by pi -- and no listed operator is C3-invariant with b != 0 on exactly one triplet. No corner is named, no bijection to a labelled 3-set is constructed, no sort key, Vandermonde sign, PDG value or species name appears, no block weight is derived, nothing here is derived from any axiom, no axiom is amended, no status is set and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py
+---
+
+# The corner kernel's two cubic carriers, their C3 split, and the block weight as a registered pattern
+
+**Date:** 2026-09-02
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py`](../scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py)
+**Runner cache:**
+[`logs/runner-cache/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.txt`](../logs/runner-cache/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+The framework's landed corner-structure clause grades the eight Brillouin-zone corner states by Hamming weight as `1 + 3 + 3 + 1` and gives the `hw=1` triplet an
+irreducible `M_3(C)`. That is stated as a fact about the corners, not as representation content, and it does not say why a triplet rather than some other three-dimensional
+space should carry a family of three. This note reads the same eight states as a representation of the proper cubic group and asks two questions of the answer: which
+three-dimensional carriers exist there, and what an operator built from the kinetic form assigns to the three members of one. There are exactly two carriers and they are
+exactly the two Hamming triplets; and the assignment is empty -- every stipulated bilinear either weights the three members equally or gives them no diagonal weight at all,
+while the map from stipulated coefficients onto weights is onto. A block weight on this carrier is supplied, not read off.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-dimensional theorems on an 8x8 algebra: the cubic representation content of the corner kernel, its isotypic projectors, the C3 restriction on each three-dimensional carrier, the exactly circulant restrictions of twelve stipulated bilinears with their block weights, the surjectivity of the restriction map onto the circulant algebra, and a full invariance census. Every statement is symbolic in sympy, exact-rational, or integer and Z[i] matrix arithmetic at zero tolerance; no item is numerical."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-algebra theorem, and route to its owner the science-level question this note does not decide: which sign of the chirality grading selects the carrier a generation-monitored family is read on."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the six statements below, exactly the runner's check groups `A`-`F`: `T1` (`A`) the corner kernel and its two three-dimensional cubic
+carriers; `T2` (`B`) the grading as an eigen-grading, the multiplicity two, and the operator exchanging the carriers; `T3` (`C`) the `C_3[111]` restriction on each carrier
+and its singlet; `T4` (`D`) the circulant restrictions of twelve stipulated bilinears, the absence among them of any operator with both a diagonal and an off-diagonal part,
+and the surjectivity of the restriction map; `T5` (`E`) the invariance census; `T6` (`F`) which operators separate the two carriers. Every group is exact -- `sympy`
+symbolic identities in the three momenta, exact rational character and projector arithmetic, integer and `Z[i]` matrix arithmetic at zero tolerance, exact Gaussian-rational
+circulant decomposition -- and no item is `[numerical]`.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Kawamoto-Smit staggering, the character table of `O`, Schur's lemma and the circulant form of a `Z/3`-equivariant
+operator are standard methodology; every object is redeclared here and the runner recomputes every statement, the table's orthonormality included. No observational value,
+fitted number or framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): the coarse-lattice `Cl(6)` kinetic form and its eight
+  zero modes. Pointer only; the cell algebra is redeclared below and this runner rebuilds it.
+- Quoted below, each for one sentence and no grade: `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md` (the corner-structure clause);
+  `AC_PHI_LAMBDA_PRESERVED_C3_STRUCTURAL_FORECLOSURE_BOUNDED_THEOREM_NOTE_2026-05-10.md` (the circulant form);
+  `PMNS_TM2_TRIMAXIMAL_COLUMN_FROM_RECORD_CENTRAL_SECTOR_NARROW_THEOREM_NOTE_2026-06-05.md` (the singlet and doublet objects);
+  `FLAVOR_HW1_STAGGERED_PROJECTION_DEMOCRATIC_R0_2026-06-02.md` (the landed `r = 0` on the fine cube);
+  `ACPHILAMBDA_SPECIES_BRIDGE_REALIZED_STATE_DECOMPOSITION_NOTE_2026-06-11.md` (the carrier-locus residual and guardrail `G3`);
+  `RECORD_OUTCOME_OBSERVABLE_PRINCIPLE_CANONICAL_PROPOSAL_NOTE_2026-06-05.md` (the within-sector-free guardrail).
+- `STAGGERED_DIRAC_SUBSTEP4_LABELING_NO_GO_NOTE_2026-05-17.md` and
+  `STAGGERED_DIRAC_SUBSTEP4_AMIN_JOINT_C3_AUTOMORPHISM_SELECTOR_INVARIANCE_BRIDGE_NARROW_THEOREM_NOTE_2026-07-05.md`: the labelling lane, pointers only, neither used nor
+  re-attacked. `MINIMAL_AXIOMS_2026-06-29.md`: the four axioms quoted in "Setting"; this note cites none of their grades and adopts no hypothesis.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has algebraic
+presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations", and
+"For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." **Record**: "Records form", "a
+record locks exactly one admissible local possibility", "records are permanent", "Only records are readable."
+
+The landed corner-structure clause under discussion, the generation lane's singlet and doublet objects, and the structural reason for the circulant form read, verbatim:
+
+> **Corner-structure clause.** The free staggered operator has the 8-element BZ-corner (taste-cube) doubler set, decomposing uniquely by Hamming weight as `1 + 3 + 3 + 1`; the hw=1 triplet carries an exact irreducible `M_3(C)` algebra (translations + `C_3[111]`) with no proper exact quotient.
+
+> On the `hw=1` triplet `V_1` with `W = (1,1,1)/sqrt(3)`, let `P_0 = |W><W| = J/3` (the `C_3`-singlet central-sector projector) and `P_1 = I - P_0` (the doublet sector).
+
+> Any operator `H` commuting with `U_{C_3}` is by Schur's lemma a polynomial in `U_{C_3}` itself on each isotype, hence on `ℂ³` is circulant: `H  =  a · I  +  b · U_{C_3}  +  b̄ · U_{C_3}²`
+
+**Guardrails.** Every statement below is written under these, and the runner checks them:
+
+1. **No orbit-separating selector.** No corner is named, no bijection to any labelled 3-set is constructed, no sort key is used, no Vandermonde sign appears, no PDG value
+   appears, and no species name is attached to any corner, carrier or coefficient.
+2. **Invariance is checked, not assumed.** Every reported quantity is verified invariant under all six relabellings of each triplet and all 24 cubic conjugations, with the
+   circulant residual exactly zero throughout.
+3. **A block weight is a registered pattern.** Any `r` here is `r` *of a stipulated operator*, in the sense of the guardrail "`G3`: registered patterns are matched, not
+   derived" and of the within-sector-free guardrail: "Weights/measures inside a sector (e.g. the Koide block-weight `r`, the solar/`theta_13` angles) are *not* the record's
+   content." No `r` here is derived, and none is "the" `r`.
+4. **`epsilon` is not identified with anything, and `AC_phi_lambda` stays exactly where the labelling no-go left it.** `epsilon = Z_1 Z_2 Z_3` is the chirality grading,
+   distinct from `T = i Gamma_1 Gamma_2 Gamma_3` and not identified with any Vandermonde sign; the no-go note is a pointer here, and nothing below narrows it, widens it,
+   or re-attacks it.
+5. **Nothing is derived from the axioms.** The lattice, the sign field, the cell algebra and the twelve bilinears are declared objects; the theorems are about them.
+   Composition is **ordinary** throughout, and every object lives in an `8x8` or `64x64` algebra.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field on it,
+the eight-site cell and the `Cl(6)` set. `P1` (`A`) is the corner kernel and the cubic representation content; `P2` (`B`) the eigen-grading, the multiplicity and the
+exchanging unitary; `P3` (`C`) the `C_3` restriction and its singlet; `P4` (`D`) the circulant restrictions, the structural fact and the surjectivity; `P5` (`E`) the
+census; `P6` (`F`) the carrier-separating operators. The strongest supported scope is exactly `P0`-`P6`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`. The **KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`,
+`eta_3(v) = (-1)^{v_1 + v_2}`. The **cell** is one `2x2x2` block of coarse vertices, eight modes, so the Bloch block of the hopping is an `8x8` matrix `H(q)`; the
+**corner** is `q = (pi, pi, pi)`; the **corner basis** indexes the eight cell states by a three-bit string, and **`hw`** is that string's Hamming weight.
+
+```text
+Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3),   Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3),   epsilon = Z_1 Z_2 Z_3,   T = i Gamma_1 Gamma_2 Gamma_3,
+H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a],   C = the C_3[111] lift.
+```
+
+A **carrier** is a three-dimensional subspace invariant and irreducible under the 24 proper cubic rotations. A **stipulated bilinear** is one of the twelve operators of
+Theorem 4, written by hand from the `Cl(6)` set with no coefficient adjusted to any target. For a `C_3`-invariant Hermitian `M` on a carrier, `(a, b)` are its circulant
+coefficients in `M = a I + b U + bbar U^2`, `delta = arg b`, and the **block weight** is `r = |b|^2 / a^2` when `a != 0`.
+
+## Theorem 1 -- the corner kernel has exactly two cubic carriers, and they are the Hamming triplets
+
+**Conclusion.** (1) `H(pi, pi, pi) = 0`, so the whole eight-dimensional cell is the kernel at the corner; the `L = 4` coarse torus kernel is eight-dimensional and is
+spanned by the corner basis. (2) All 24 proper cubic rotations lift to signed permutations preserving the hopping, and all 576 products close on the nose as integer
+matrices on that kernel: a genuine representation of `O`, not projective. (3) Its characters `(E, 8C3, 3C2, 6C4, 6C2') = (8, 2, 0, 4, 0)` decompose, in exact rational
+arithmetic against a self-checked orthonormal character table, as `2 A1 + 2 T1`, and the isotypic projectors are in the corner basis exactly `P_A1 = diag(1,0,0,0,0,0,0,1) =
+P_hw0 + P_hw3` and `P_T1 = diag(0,1,1,1,1,1,1,0) = P_hw1 + P_hw2`, with `P_A2 = P_E = P_T2 = 0`. (4) Each Hamming block is separately `O`-invariant, with characters
+`(1,1,1,1,1)` on `hw = 0, 3` and `(3,0,-1,1,-1)` on `hw = 1, 2` -- one `A1` and one `T1` each.
+
+**Proof.** Item 1 evaluates the closed form symbolically at the corner momentum and verifies over `Z` that the corner basis is annihilated by the torus operator and has
+Gram `8 I`. Item 2 solves each lift's signs by breadth-first propagation and compares all 576 products as integer matrices, the kernel-basis matrices obtained by exact
+division by `8`. Items 3 and 4 are `Fraction` arithmetic: the orthogonality relations and the projector formula `P_irr = (d/24) sum_R chi_irr(R) M_R`, block by block.
+
+**Reading, not theorem.** The eight corner states sort themselves under the cube's rotations into two singletons and two triplets, and the triplets are exactly the ones the
+earlier grading found. The grading was written down as a fact about bit-counts; it turns out to be the representation content, on the nose.
+
+## Theorem 2 -- the grading is an eigen-grading, and the two carriers are exchanged
+
+**Conclusion.** (1) `i sum_a Gamma_a Xi_a = Z_1 + Z_2 + Z_3` exactly; it commutes with all 24 lifts, and its corner spectrum is `3 - 2 hw`, so the `1 + 3 + 3 + 1` grading
+is the eigen-grading of that one `O`-invariant `Cl(6)` bilinear. (2) The `T1` isotypic is `T1 (x) C^2`: the commutant of the 24 lifts has dimension `8` on the kernel and
+`4` on the `T1` isotypic, by the exact rational formula `(1/24) sum |chi|^2`, and four independent commuting elements `P_hw1`, `P_hw2`, `P_hw2 T P_hw1`, `P_hw1 T P_hw2` are
+exhibited -- the group alone does not split the six-dimensional isotypic. (3) `T = i Gamma_1 Gamma_2 Gamma_3` commutes with all 24 lifts, is unitary, carries `hw = 1` onto
+`hw = 2` and back with rank `3`, and anticommutes with `epsilon = Z_1 Z_2 Z_3 = diag((-1)^hw)`; `T != epsilon`.
+
+**Proof.** Item 1 is a `Z[i]` matrix identity and a diagonal read-off, with commutation checked against all 24 integer lifts at zero tolerance. Item 2 is the character
+formula in `Fraction` arithmetic plus a commutation check and a rank computation for the four exhibited elements. Item 3 is `Z[i]` arithmetic: unitarity, the vanishing of
+`P_hw1 T P_hw1` and `P_hw2 T P_hw2`, the rank of the off-diagonal blocks, and the anticommutator. All exact.
+
+**Reading, not theorem.** The rotations see one six-dimensional space with a two-fold multiplicity, not two separate triplets. What cuts it in two is not the group but the
+chirality grading, and the operator that carries each half onto the other reverses that grading. The two triplets are the same object twice over, told apart by a sign and by nothing else
+the rotations can see. Each of them splits again, under the one rotation that cycles the three axes, into a direction fixed by that rotation -- spread evenly over the three
+members, exactly a third on each, and that even spread survives every relabelling -- and a two-dimensional remainder.
+
+## Theorem 3 -- the C3 restriction and its singlet
+
+**Conclusion.** On each carrier, with `U = C|_{T1}`: (1) `tr U = 0`, `U^3 = I`, eigenvalues `{1, omega, omegabar}` -- each carrier is the regular representation of `Z/3`.
+(2) The `C`-invariant vector has corner weights exactly `(1/3, 1/3, 1/3)` on both carriers; against the *fixed* democratic `W = (1,1,1)/sqrt3` the overlaps are `|<W|v>|^2 =
+1` on one carrier and `1/9` on the other, and that difference is a corner-sign gauge artefact, removed by rephasing a single corner, which carries `U` to the plain 3-cycle
+and `v` to `W`. (3) The singlet projectors `P_0 = |v><v|` have every entry of modulus `1/3` -- `P_0 = J/3` in the gauge that carries `v` to `W` -- are idempotent, and `P_0`
+and `P_1 = I - P_0` both commute with `U`.
+
+**Proof.** Item 1 is exact `3x3` arithmetic over `Z`: the trace, the cube, and the eigenvalues as exact cube roots of unity. Item 2 computes the nullspace of `U - I`
+exactly and evaluates the weights and overlaps as exact rationals, the rephasing being the diagonal sign matrix read off the invariant vector. Item 3 is exact idempotence,
+entrywise modulus and commutation.
+
+## Theorem 4 -- the block weight of every stipulated bilinear, and the surjectivity
+
+**Conclusion.** For the twelve stipulated bilinears:
+
+1. Each restricts to an **exactly** circulant operator on each carrier -- residual exactly `0`, `c = conj(b)` throughout -- with the coefficients the runner tabulates:
+   `sum_a Gamma_a`, `sum_a Xi_a` and `T` restrict to zero; `i sum_a Gamma_a Xi_a` gives `a = +1 / -1` and `epsilon` gives `a = -1 / +1`, both with `b = 0`; `(sum_a
+   Gamma_a)^2 = (sum_a Xi_a)^2 = 3 I`; the `p_a^2` coefficient of `H(pi + p)^2` is the identity on both carriers; the two bivector sums `i(Gamma_x Gamma_y + Gamma_y Gamma_z
+   + Gamma_z Gamma_x)` and its `Xi` counterpart give `a = 0`, `|b| = 1`; and the two `Gamma`-`Xi` cross terms give `a = 0`, `|b| = 1` with `delta` differing by `pi` between
+   the carriers.
+2. **The structural fact.** No listed operator has `a != 0` and `b != 0`. The six that commute with all 24 lifts have `b = 0` by Schur on an irreducible `T1`; the
+   `O`-average of each of the other six is exactly `0`, and `a` depends on the `O`-average alone because the Hamming projectors are `O`-invariant, so `a = 0` there. Hence
+   every hw-diagonal listed operator registers `r = 0` exactly.
+3. **The surjectivity.** The restriction map from real `C_3`-invariant Hermitian quadratics onto the circulant algebra has real rank `3` on each carrier: the three-element
+   family `alpha (sum_a Z_a) + beta i(sum_cyc Gamma_a Gamma_{a+1}) + gamma i(sum_a Gamma_a Xi_{a+1})` maps onto `(a, Re b, Im b)` with rank `3`, so every `(a, |b|, delta)`,
+   hence every `r` in `[0, inf)`, is realised by stipulated coefficients -- `(alpha, beta, gamma) = (2, 1, 1)` registering `r = 1/2` and `(2, 1, 0)` registering `r = 1/4`,
+   exactly and on both carriers. **These are stipulated coefficient choices exhibited as registered patterns; neither is derived, and neither is "the" `r`.**
+
+**Proof.** Item 1 builds each operator over `Z[i]` at zero tolerance, verifies hermiticity and Gaussian-integrality, restricts it and decomposes it exactly by `a = tr M /
+3`, `b = tr(M U^2) / 3`, `c = tr(M U) / 3`, comparing the residual against the zero matrix as an exact symbolic identity; the `p_a^2` coefficient comes from symbolic
+differentiation of `H(pi + p)^2`. Item 2 checks the 24 commutators, forms the exact integer sum `sum_R M_R O M_R^T` and compares it to `0` or to `24 O`. Item 3 is an exact
+rank over the rationals and two exact evaluations.
+
+**Reading, not theorem.** Turning the cube cannot tell the three members of a triplet apart, and no operator built from the kinetic form alone assigns them a weight: it is
+either blind to them and weights them equally, or has nothing on the diagonal to weight them with. A weight has to be supplied -- and once one is willing to supply
+coefficients every weight is available, so a weight carries exactly as much information as the coefficients chosen for it.
+
+## Theorem 5 -- the invariance census
+
+**Conclusion.** For all twelve operators and both carriers: (1) all six relabellings of a carrier's basis leave `(a, |b|, r)` unchanged, with circulant residual `0`; (2)
+all 24 cubic conjugations, `O -> g O g^{-1}` with `C -> g C g^{-1}`, which cover all eight `C_3` elements, leave `(a, |b|, r)` unchanged, with residual `0`; (3) naming
+`C^2` rather than `C` the generator sends `b -> conj(b)`, that is `delta -> -delta`, and leaves `(a, |b|, r)` fixed.
+
+**Proof.** Items 1 and 2 re-run the exact circulant decomposition on the relabelled or conjugated data and compare the coefficients as exact symbolic quantities; item 3
+re-runs it against `U^2` in place of `U`. All exact.
+
+## Theorem 6 -- which operators separate the two carriers
+
+**Conclusion.** Exactly four of the twelve distinguish the two carriers: `i sum_a Gamma_a Xi_a = sum_a Z_a` and `epsilon`, by the sign of `a` -- that is, through the sign
+convention of the chirality grading -- and `i sum_a Gamma_a Xi_{a+1}` and `i sum_a Gamma_a Xi_{a+2}`, with equal `|b|` and `delta` differing by exactly `pi`. The remaining
+eight restrict identically to both. No listed operator is `C_3`-invariant with `b != 0` on exactly one carrier.
+
+**Proof.** A direct comparison of the exact table of Theorem 4 across the two carriers, with the phase difference evaluated as an exact symbolic identity.
+
+**Reading, not theorem.** Nothing reported here depends on which member of a triplet is written first, or on which axis the reader calls the first; the one choice that
+shows is the direction of the cycle, and it flips the sign of one angle and moves nothing else. As for the two triplets, the only things in this list that tell them apart
+are the grading itself and terms mixing the two halves of the Clifford set, and even those give both the same magnitude, differing by a sign or a phase. Nothing here makes
+one triplet the one that carries a weight while the other does not.
+
+## Corollary -- what this says about the corner carrier and about `r`
+
+Within the setting declared above, and on the finite algebra named:
+
+1. **Why a triplet, and which one.** The corner kernel admits exactly two three-dimensional cubic carriers, both Hamming-weight triplets of the landed grading, exchanged
+   by the `O`-invariant unitary `T`, which reverses the chirality grading. So "why a triplet" is forced by the representation -- the rotations offer nothing else of
+   dimension three -- and "which triplet" reduces to the sign of `epsilon`. The species-bridge note's structural residual, "why the generation-monitored family is supported
+   on the `hw=1` triplet at all", is thereby **narrowed to that one sign, and not closed**: its own observation that "the naive dispersion is hw-blind" is reproduced here
+   exactly, as the statement that the `p_a^2` coefficient of `H(pi + p)^2` is the identity on both carriers.
+2. **`r` is registered, never delivered.** On these carriers every stipulated bilinear either registers `r = 0` or has no diagonal part at all, and the restriction map onto
+   the circulant algebra is onto, so the block weight is a free function of stipulated coefficients. This reproduces the landed democratic result -- "this projection route
+   gives `r = |b|^2/a^2 = 0`" -- on a **new carrier**: that note's scope is one operator `K` on the fine `C^8` cube, while this is structural, about twelve operators on the
+   coarse-lattice corner kernel, with a reason (Schur on one side, a vanishing `O`-average on the other) rather than one computation. Guardrail `G3` -- "registered patterns
+   are matched, not derived" -- is here a theorem on this carrier, not a discipline imposed on it.
+3. **Nothing is labelled and nothing moves.** No corner is named, no bijection to a labelled 3-set exists in this note or its runner, and `AC_phi_lambda` stays exactly
+   where the labelling no-go left it.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted; no hypothesis is adopted; no status value is set, predicted, or implied; no premise registry, citation
+  manifest, or axiom-premise node is created or edited; and no update rule, formation site, formation rate, coupling, absolute unit or dynamical clause appears.
+- Nothing here is derived from the axioms: the lattice, the sign field, the cell algebra and the twelve bilinears are declared objects. No corner of the taste cube is
+  identified with any named species, no value of `r` is claimed as a physical one, and the labelling no-go and its joint-automorphism bridge are pointers only, their
+  scope untouched -- this note computes nothing that separates a `C_3` orbit.
+
+## Interfaces named for other lanes, not moved here
+
+- **The sign of `epsilon` as the carrier selector.** Theorem 6 reduces "which of the two carriers" to the sign of the chirality grading. That sign is a **supplied datum**:
+  nothing here derives it, and a lane wanting one carrier rather than the other must supply it and say so -- as Theorem 4 item 3 says what a lane must supply for a nonzero
+  `r`, a coefficient triple, and supplies none.
+- **The many-body content and the labelling lane.** Everything here is one-particle; what the rotations, the grading and the circulant coefficients do to many-body states
+  is untouched. And this note gives representation content and orbit-invariant coefficients, never a labelled bijection: the no-go note states what is not derivable and
+  nothing here narrows or widens it, Theorem 6's "which carrier" being a different question on a different orbit from the no-go's "which corner".
+
+## Remaining live routes
+
+1. Other operator classes. Twelve bilinears are what is tested; quartic terms, interactions, non-Hermitian objects and momentum-dependent operators are not.
+2. Larger cells and other geometries, and the two `A1` singletons. The `L = 4` coarse torus and the one `2x2x2` cell are what is proved, nothing is claimed beyond them,
+   and the `hw = 0` and `hw = 3` states are not examined beyond their characters.
+
+## Executable claim block
+
+```text
+setting: eight-dimensional corner kernel of the KS staggered hopping on 2Z^3 at q = (pi,pi,pi); Cl(6) cell algebra Gamma, Xi, epsilon = Z1Z2Z3, T = i G1G2G3; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+carriers: H(pi,pi,pi) = 0; L=4 torus kernel dim 8; 24 lifts, 576 products exact on the kernel, genuine O; chi = (8,2,0,4,0) = 2 A1 + 2 T1; P_A1 = diag(1,0,0,0,0,0,0,1) = P_hw0 + P_hw3 and P_T1 = diag(0,1,1,1,1,1,1,0) = P_hw1 + P_hw2 exactly; hw blocks O-invariant with chi (1,1,1,1,1) and (3,0,-1,1,-1)
+grading_multiplicity_and_c3_split: i sum Gamma_a Xi_a = Z1+Z2+Z3, spectrum 3 - 2 hw, O-invariant; commutant dim 8 on the kernel and 4 on the T1 isotypic; T O-invariant, unitary, hw1 <-> hw2 at rank 3, anticommutes with epsilon = diag((-1)^hw); tr U = 0, U^3 = I, eigenvalues {1, omega, omegabar}; invariant-vector corner weights exactly (1/3,1/3,1/3) on both; |<W|v>|^2 = 1 and 1/9, a one-corner rephasing apart; P_0 entries of modulus 1/3, [P_0,U] = [P_1,U] = 0
+circulant_table: all 12 restrictions exactly circulant, residual 0, c = conj(b); sum Gamma_a, sum Xi_a, T restrict to 0; i sum Gamma_a Xi_a a = +1/-1, epsilon a = -1/+1, both b = 0; (sum Gamma)^2 = (sum Xi)^2 = 3I; p_a^2 coeff of H(pi+p)^2 = I on both; bivector sums a = 0, |b| = 1; Gamma-Xi cross terms a = 0, |b| = 1, delta differing by pi
+structural_fact_and_surjectivity: 6 O-invariant operators have b = 0 by Schur, the other 6 have O-average exactly 0 hence a = 0, so none has a != 0 and b != 0 and every hw-diagonal one registers r = 0; real rank 3 on each carrier from alpha(sum Z_a) + beta i(sum_cyc G_a G_{a+1}) + gamma i(sum G_a Xi_{a+1}), with (2,1,1) registering r = 1/2 and (2,1,0) registering r = 1/4, both stipulated
+invariance: 6 relabellings x 12 operators x 2 carriers and 24 conjugations x 12 x 2 leave (a,|b|,r) fixed with residual 0; C -> C^2 sends delta -> -delta only
+carrier_locus: exactly 4 of 12 separate the carriers (2 by the sign of a, 2 by delta differing by pi); none is C3-invariant with b != 0 on exactly one carrier
+corners_named_labelled_bijections_pdg_values_axioms_amended_status_values_set: 0, 0, 0, 0, 0
+runner_result: PASS=20 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on the **corner kernel** of the coarse-lattice KS operator: an `8x8` algebra, with the cubic lifts built on the `L = 4` coarse torus, a `64x64`
+construction. Nothing is claimed for other momenta, other lattices, larger cells, or the fine lattice `Z^3`. The content is **representation structure and circulant
+coefficients of stipulated operators**, not dynamics. No coefficient in the twelve is fitted, no coupling, mass, rate or unit appears, and no dynamical clause is supplied.
+The two coefficient triples of Theorem 4 item 3 are registered patterns of stipulated operators -- they show the map onto weights is onto and derive nothing; `Q = 1/3 +
+(2/3) r` is not evaluated here. The surjectivity statement is about the three-element family named there: it establishes that the image of the restriction map is the whole
+real circulant algebra, claims no physical motivation for any member, and supplies no principle for choosing one. The two carriers are distinguished here only by the sign
+of `epsilon`, a convention this note does not fix; every statement above is therefore symmetric under exchanging the two carriers together with the sign of the grading, and
+the runner's tables should be read that way.
+
+## Review record
+
+An honest auditor should come away with: one exact identification, on an `8x8` algebra, of the landed `1 + 3 + 3 + 1` Hamming grading with the isotypic decomposition `2 A1
++ 2 T1` of the proper cubic group on the corner kernel, so the only three-dimensional carriers there are the two Hamming triplets; one multiplicity statement saying the
+group alone does not split them, and one operator exchanging them while reversing the chirality grading; one exact table of twelve stipulated bilinears whose restrictions
+are all circulant and none of which carries both a diagonal and an off-diagonal part, so every hw-diagonal one registers `r = 0`; one surjectivity statement showing the
+weight is a free function of stipulated coefficients; a full invariance census; and two things deliberately not decided -- which sign of the chirality grading selects a
+carrier, and any labelling whatever of the three members of one. The labelling no-go is cited without being used.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the pointers in "Imports and
+authority" carry no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=20 FAIL=0`, runtime under the declared `120` seconds,
+stdout under `8000` characters, a zero-dependency citation-manifest entry, and passing pipeline, strict-lint and changed-evidence gates; independent audit is a separate
+lane.

--- a/logs/runner-cache/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.txt
+++ b/logs/runner-cache/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py
+runner_sha256: 0bd261fbf4f1d3f59f6f7429539976ae4f871aa13ed7e1e6e193bd0af81a230e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 1.02
+status: ok
+----- stdout -----
+PASS A1 [exact, sympy] Gamma = (Y1, Z1Y2, Z1Z2Y3), Xi = (X1, Z1X2, Z1Z2X3) are six anticommuting hermitian involutions, the 2x2x2-cell Bloch block of the KS hopping is sum_a [(1+cos q_a) Xi_a + sin q_a Gamma_a] identically in q, H(q)^2 = (6 + 2 sum_a cos q_a) I, and H(pi,pi,pi) = 0: the whole eight-dimensional cell is the corner kernel
+PASS A2 [exact] the L=4 coarse torus has an 8-dimensional kernel spanned by the corner basis; all 24 proper cubic rotations lift to signed permutations with C_R H C_R^T = H, and all 576 products close on the nose as integer matrices on the corner kernel (0 failures) -- a genuine representation of O, not projective
+PASS A3 [exact] characters on the corner kernel (E, 8C3, 3C2, 6C4, 6C2') = (8, 2, 0, 4, 0) decompose in exact rational arithmetic, against a self-checked orthonormal character table of O, as 2 A1 + 2 T1
+PASS A4 [exact] the isotypic projectors from the character formula in exact rational arithmetic are exactly P_A1 = diag(1,0,0,0,0,0,0,1) = P_hw0 + P_hw3 and P_T1 = diag(0,1,1,1,1,1,1,0) = P_hw1 + P_hw2, with P_A2 = P_E = P_T2 = 0: the two three-dimensional cubic carriers are exactly the two Hamming-weight triplets
+PASS A5 [exact] each Hamming block is separately O-invariant: characters (1,1,1,1,1) on hw = 0 and 3 (one A1 each) and (3,0,-1,1,-1) on hw = 1 and 2 (one T1 each)
+PASS B1 [exact] i sum_a Gamma_a Xi_a = Z_1 + Z_2 + Z_3 exactly, it is O-invariant, and its corner spectrum is 3 - 2 hw: the landed 1 + 3 + 3 + 1 grading is the eigen-grading of that one O-invariant Cl(6) bilinear
+PASS B2 [exact] the T1 isotypic component is T1 (x) C^2: the commutant of the 24 lifts has dimension 8 on the corner kernel and 4 on the T1 isotypic by the exact rational formula (1/24) sum |chi|^2, and four independent commuting elements P_hw1, P_hw2, P_hw2 T P_hw1, P_hw1 T P_hw2 are exhibited -- the group alone does not split it
+PASS B3 [exact] T = i Gamma_1 Gamma_2 Gamma_3 is O-invariant and unitary, carries hw=1 onto hw=2 and back with rank 3, and anticommutes with epsilon = Z_1 Z_2 Z_3 = diag((-1)^hw), T != epsilon: the two T1 copies are O-equivariantly isomorphic and are told apart only by the sign of epsilon
+PASS C1 [exact] the C3[111] restriction U = C|_T1 on each triplet has tr U = 0 and U^3 = I, with eigenvalues {1, omega, omegabar}: each triplet is the regular representation of Z/3
+PASS C2 [exact] the C-invariant vector of each triplet has corner weights exactly (1/3, 1/3, 1/3) -- gauge-invariant trimaximality; against the fixed democratic W = (1,1,1)/sqrt3 the overlaps are |<W|v>|^2 = 1 and 1/9, a corner-sign gauge artefact removed by rephasing a single corner, which carries U to the plain 3-cycle and v to W
+PASS C3 [exact] the C3 singlet projectors P_0 = |v><v| have every entry of modulus 1/3 (P_0 = J/3 in the gauge that carries v to W), are idempotent, and P_0 and P_1 = I - P_0 both commute with U
+  operator restrictions on each cubic carrier (a, |b|, delta/pi, r = |b|^2/a^2; exact):
+    operator                               hw  a      |b|    delta/pi  r        dev
+    sum_a Gamma_a                          1   0      0      --        --       0
+    sum_a Gamma_a                          2   0      0      --        --       0
+    sum_a Xi_a                             1   0      0      --        --       0
+    sum_a Xi_a                             2   0      0      --        --       0
+    i sum_a Gamma_a Xi_a = Z_1+Z_2+Z_3     1   1      0      --        0        0
+    i sum_a Gamma_a Xi_a = Z_1+Z_2+Z_3     2   -1     0      --        0        0
+    (sum_a Gamma_a)^2                      1   3      0      --        0        0
+    (sum_a Gamma_a)^2                      2   3      0      --        0        0
+    (sum_a Xi_a)^2                         1   3      0      --        0        0
+    (sum_a Xi_a)^2                         2   3      0      --        0        0
+    T = i Gamma_1 Gamma_2 Gamma_3          1   0      0      --        --       0
+    T = i Gamma_1 Gamma_2 Gamma_3          2   0      0      --        --       0
+    epsilon = Z_1 Z_2 Z_3                  1   -1     0      --        0        0
+    epsilon = Z_1 Z_2 Z_3                  2   1      0      --        0        0
+    i(G_xG_y + G_yG_z + G_zG_x)            1   0      1      +0.500    --       0
+    i(G_xG_y + G_yG_z + G_zG_x)            2   0      1      +0.500    --       0
+    i(X_xX_y + X_yX_z + X_zX_x)            1   0      1      +0.500    --       0
+    i(X_xX_y + X_yX_z + X_zX_x)            2   0      1      +0.500    --       0
+    p_a^2 coeff of H(pi+p)^2               1   1      0      --        0        0
+    p_a^2 coeff of H(pi+p)^2               2   1      0      --        0        0
+    i sum_a Gamma_a Xi_{a+1}               1   0      1      +1.000    --       0
+    i sum_a Gamma_a Xi_{a+1}               2   0      1      +0.000    --       0
+    i sum_a Gamma_a Xi_{a+2}               1   0      1      +1.000    --       0
+    i sum_a Gamma_a Xi_{a+2}               2   0      1      +0.000    --       0
+PASS D1 [exact] every one of the twelve stipulated bilinears restricts to an exactly circulant operator on each carrier (residual 0, c = conj(b) throughout), with the tabulated (a, |b|, delta, r); the restrictions of sum Gamma_a, sum Xi_a and T are identically zero, and the p_a^2 coefficient of H(pi+p)^2 is the identity on both carriers -- the naive dispersion is hw-blind
+PASS D2 [exact] all twelve commute with C3[111]; the 6 that commute with all 24 lifts have b = 0 on both carriers (Schur on an irreducible T1), and the O-average of each of the other 6 is exactly 0, so their a -- which depends on the O-average alone, the Hamming projectors being O-invariant -- vanishes; no listed operator has a != 0 and b != 0, hence every hw-diagonal one registers r = 0 exactly
+PASS D3 [exact] surjectivity: on each carrier the three real C3-invariant Hermitian quadratics alpha (sum Z_a) + beta i(sum_cyc Gamma_a Gamma_{a+1}) + gamma i(sum_a Gamma_a Xi_{a+1}) map onto (a, Re b, Im b) with real rank 3, so every (a, |b|, delta) -- hence every r in [0, inf) -- is realised by stipulated coefficients
+PASS D4 [exact] registered examples, stipulated and not derived: the coefficient triple (alpha, beta, gamma) = (2, 1, 1) registers r = 1/2 and (2, 1, 0) registers r = 1/4, exactly and on both carriers -- r is a free function of stipulated coefficients, matched not delivered
+PASS E1 [exact] all 6 relabellings of each carrier's basis leave (a, |b|, r) unchanged with circulant residual 0, for every one of the twelve operators: no quantity reported here depends on which member of a triplet is written first
+PASS E2 [exact] all 24 cubic conjugations (O -> g O g^-1 with C -> g C g^-1, covering all eight C3 elements) leave (a, |b|, r) unchanged with circulant residual 0, for every one of the twelve operators
+PASS E3 [exact] naming C^2 rather than C the generator sends b -> conj(b), i.e. delta -> -delta, and leaves (a, |b|, r) fixed on both carriers: the orientation of the cyclic order is a supplied datum, not a computed one
+PASS F1 [exact] exactly 4 of the twelve separate the two carriers: sum Z_a and epsilon, by the sign of a -- the chirality grading's own sign convention -- and the two Gamma-Xi cross terms, with equal |b| and delta differing by exactly pi; the remaining 8 restrict identically to both
+PASS F2 [exact] no listed operator is C3-invariant with b != 0 on exactly one carrier: the off-diagonal part is either absent on both or present on both, so nothing in this list singles out one triplet as the one carrying a weight
+SUMMARY: the corner kernel carries exactly two three-dimensional cubic carriers, the two Hamming-weight triplets, exchanged by the O-invariant unitary T and told apart only by the sign of epsilon; on each, every stipulated bilinear registers r = 0 or has no diagonal part, and the restriction map onto the circulant algebra is onto.
+TOTAL: PASS=20 FAIL=0
+
+----- stderr -----
+

--- a/scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py
+++ b/scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py
@@ -1,0 +1,752 @@
+#!/usr/bin/env python3
+"""The corner kernel's two cubic carriers, the C3 split, and registered block weights.
+
+Self-contained finite-cluster runner.  The carrier is the eight-dimensional
+kernel of the Kawamoto-Smit (KS) staggered hopping written on the coarse
+lattice 2Z^3, at the Brillouin-zone corner q = (pi, pi, pi); the cell algebra
+is the Cl(6) set
+
+    Gamma = (Y1, Z1 Y2, Z1 Z2 Y3),   Xi = (X1, Z1 X2, Z1 Z2 X3),
+    epsilon = Z1 Z2 Z3,              T = i Gamma_1 Gamma_2 Gamma_3.
+
+  A  CARRIERS.  The eight corner states carry a genuine representation of the
+     proper cubic group O with characters (8, 2, 0, 4, 0) = 2 A1 + 2 T1, whose
+     isotypic projectors in the corner basis are exactly P_A1 = P_hw0 + P_hw3
+     and P_T1 = P_hw1 + P_hw2: the two three-dimensional cubic carriers are
+     exactly the two Hamming-weight triplets of the landed grading.
+  B  GRADING AND MULTIPLICITY.  The 1+3+3+1 grading is the eigen-grading of the
+     O-invariant bilinear i sum_a Gamma_a Xi_a = Z1 + Z2 + Z3; the T1 isotypic
+     is T1 (x) C^2 with a four-dimensional commutant, so the group alone does
+     not split it; T is O-invariant, unitary, exchanges the two triplets and
+     anticommutes with epsilon.
+  C  C3 SPLIT.  On each triplet the C3[111] restriction has trace 0 and cube I,
+     its invariant vector has corner weights exactly 1/3, and the singlet and
+     doublet projectors commute with it.
+  D  REGISTERED WEIGHTS.  Twelve stipulated bilinears restrict to exactly
+     circulant operators; none has both a diagonal and an off-diagonal part, so
+     every hw-diagonal one registers r = 0; and the restriction map from real
+     C3-invariant Hermitian quadratics onto the circulant algebra is onto, so
+     every r in [0, inf) is realised by stipulated coefficients.
+  E  INVARIANCE CENSUS.  All six relabellings of each triplet and all 24 cubic
+     conjugations leave (a, |b|, r) unchanged with residual 0; naming C^2 rather
+     than C as the generator sends delta -> -delta and fixes (a, |b|, r).
+  F  CARRIER LOCUS.  Exactly which listed operators separate the two triplets.
+
+Every check is exact: integer and Z[i] matrix arithmetic at zero tolerance,
+exact rational character and projector arithmetic, sympy symbolic identities in
+the three momenta, and exact Gaussian-rational circulant decomposition.
+
+No corner is named, no bijection to a labelled 3-set is built, no sort key, no
+Vandermonde sign, no PDG value and no species name appears.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from collections import deque
+from fractions import Fraction
+
+import numpy as np
+import sympy as sp
+
+AUDIT_TIMEOUT_SEC = 120
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================== KS phases, coarse lattice, cell
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+L4 = 4
+
+
+def eta_ks(v, a):
+    """KS link sign of the coarse bond (v, v + e_a); axes 0,1,2 = 1,2,3."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+I2 = np.eye(2, dtype=complex)
+SX = np.array([[0, 1], [1, 0]], dtype=complex)
+SY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+SZ = np.diag([1, -1]).astype(complex)
+
+
+def kr(*ms):
+    o = np.array([[1.0 + 0j]])
+    for m in ms:
+        o = np.kron(o, m)
+    return o
+
+
+XI = [kr(SX, I2, I2), kr(SZ, SX, I2), kr(SZ, SZ, SX)]
+GAM = [kr(SY, I2, I2), kr(SZ, SY, I2), kr(SZ, SZ, SY)]
+SIX = GAM + XI
+EPS8 = kr(SZ, SZ, SZ)
+HW = [bin(s).count("1") for s in range(8)]
+
+
+def gint(M):
+    """Round to the nearest Gaussian-integer matrix."""
+    return np.rint(M.real) + 1j * np.rint(M.imag)
+
+
+def is_gint(M):
+    return np.array_equal(M, gint(M))
+
+
+# ================================================ group A: the two cubic carriers
+
+qs = sp.symbols("q1 q2 q3", real=True)
+GS = [sp.Matrix(8, 8, lambda i, j: sp.nsimplify(G[i, j])) for G in GAM]
+XS = [sp.Matrix(8, 8, lambda i, j: sp.nsimplify(X[i, j])) for X in XI]
+HSYM = sp.zeros(8, 8)
+for a in range(3):
+    HSYM += (1 + sp.cos(qs[a])) * XS[a] + sp.sin(qs[a]) * GS[a]
+
+
+def bloch_numeric(q):
+    """8x8 Bloch block built from the KS hopping rules, no closed form used."""
+    H = np.zeros((8, 8), dtype=complex)
+    for s in range(8):
+        sv = [(s >> (2 - a)) & 1 for a in range(3)]
+        for a in range(3):
+            e = eta_ks(sv, a)
+            bit = 1 << (2 - a)
+            if sv[a] == 0:
+                t = s | bit
+                H[t, s] += e
+                H[s, t] += e
+            else:
+                t = s & ~bit
+                H[t, s] += e * np.exp(-1j * q[a])
+                H[s, t] += e * np.exp(1j * q[a])
+    return H
+
+
+HSYM_RULES = sp.zeros(8, 8)
+for s in range(8):
+    sv = [(s >> (2 - a)) & 1 for a in range(3)]
+    for a in range(3):
+        e = eta_ks(sv, a)
+        bit = 1 << (2 - a)
+        if sv[a] == 0:
+            t = s | bit
+            HSYM_RULES[t, s] += e
+            HSYM_RULES[s, t] += e
+        else:
+            t = s & ~bit
+            HSYM_RULES[t, s] += e * sp.exp(-sp.I * qs[a])
+            HSYM_RULES[s, t] += e * sp.exp(sp.I * qs[a])
+
+cl6 = all(np.array_equal(A @ A, np.eye(8, dtype=complex)) for A in SIX) and all(
+    np.array_equal(A @ B + B @ A, np.zeros((8, 8), dtype=complex))
+    for i, A in enumerate(SIX)
+    for B in SIX[i + 1:]
+)
+herm = all(np.array_equal(A, A.conj().T) for A in SIX)
+DIFF = sp.Matrix(8, 8, lambda i, j: sp.simplify(sp.expand(
+    (HSYM_RULES[i, j] - HSYM[i, j]).rewrite(sp.cos))))
+form_ok = DIFF.is_zero_matrix
+HSQ = sp.expand_trig(sp.simplify(sp.expand(HSYM * HSYM)))
+sq_ok = sp.simplify(HSQ - (6 + 2 * sum(sp.cos(qs[a]) for a in range(3))) * sp.eye(8)).is_zero_matrix
+corner_zero = sp.simplify(HSYM.subs({qs[a]: sp.pi for a in range(3)})).is_zero_matrix
+check(
+    "A1 [exact, sympy] Gamma = (Y1, Z1Y2, Z1Z2Y3), Xi = (X1, Z1X2, Z1Z2X3) are six anticommuting hermitian involutions, "
+    "the 2x2x2-cell Bloch block of the KS hopping is sum_a [(1+cos q_a) Xi_a + sin q_a Gamma_a] identically in q, "
+    "H(q)^2 = (6 + 2 sum_a cos q_a) I, and H(pi,pi,pi) = 0: the whole eight-dimensional cell is the corner kernel",
+    cl6 and herm and form_ok and sq_ok and corner_zero,
+)
+
+S4 = [v for v in itertools.product(range(L4), repeat=3)]
+IDX4 = {v: i for i, v in enumerate(S4)}
+N4 = len(S4)
+H4 = np.zeros((N4, N4))
+for v in S4:
+    for a in range(3):
+        w = tuple((v[i] + EX[a][i]) % L4 for i in range(3))
+        H4[IDX4[w], IDX4[v]] += eta_ks(v, a)
+        H4[IDX4[v], IDX4[w]] += eta_ks(v, a)
+
+ROTS = []
+for perm in itertools.permutations(range(3)):
+    for sg in itertools.product((1, -1), repeat=3):
+        M = np.zeros((3, 3), dtype=int)
+        for i in range(3):
+            M[i, perm[i]] = sg[i]
+        if round(np.linalg.det(M)) == 1:
+            ROTS.append(M)
+RKEY = {tuple(M.flatten()): i for i, M in enumerate(ROTS)}
+
+
+def rot_act(M, v):
+    return tuple(int(sum(M[i, j] * v[j] for j in range(3))) % L4 for i in range(3))
+
+
+def class_of(M):
+    tr = int(round(np.trace(M)))
+    if tr == 3:
+        return "E"
+    if tr == 0:
+        return "8C3"
+    if tr == 1:
+        return "6C4"
+    return "3C2" if np.count_nonzero(M - np.diag(np.diag(M))) == 0 else "6C2p"
+
+
+def gauge_to(target):
+    g = {(0, 0, 0): 1}
+    dq = deque([(0, 0, 0)])
+    while dq:
+        v = dq.popleft()
+        for a in range(3):
+            for sgn in (1, -1):
+                w = list(v)
+                w[a] += sgn
+                w = tuple(x % L4 for x in w)
+                src = v if sgn == 1 else w
+                r = target(src, a) * eta_ks(src, a)
+                if w in g:
+                    if g[w] != g[v] * r:
+                        return None
+                else:
+                    g[w] = g[v] * r
+                    dq.append(w)
+    return g
+
+
+CS = []
+lift_ok = True
+for M in ROTS:
+    def tgt(v, a, M=M):
+        w = tuple((v[i] + EX[a][i]) % L4 for i in range(3))
+        return H4[IDX4[rot_act(M, v)], IDX4[rot_act(M, w)]]
+
+    g = gauge_to(tgt)
+    if g is None:
+        lift_ok = False
+        continue
+    C = np.zeros((N4, N4))
+    for v in S4:
+        C[IDX4[rot_act(M, v)], IDX4[v]] = g[v]
+    CS.append(C)
+
+KINT = np.zeros((N4, 8), dtype=int)
+for s in range(8):
+    sv = [(s >> (2 - a)) & 1 for a in range(3)]
+    for R in itertools.product(range(2), repeat=3):
+        KINT[IDX4[tuple(2 * R[a] + sv[a] for a in range(3))], s] = (-1) ** sum(R)
+CSI = [np.rint(C).astype(int) for C in CS]
+GRAM = KINT.T @ KINT
+RAW = [KINT.T @ C @ KINT for C in CSI]
+MS = [R // 8 for R in RAW]
+exact_lift = (
+    np.array_equal(GRAM, 8 * np.eye(8, dtype=int))
+    and all(np.array_equal(M * 8, R) for M, R in zip(MS, RAW))
+    and np.array_equal(np.rint(H4).astype(int) @ KINT, np.zeros((N4, 8), dtype=int))
+)
+KER = KINT / np.sqrt(8.0)
+bad = sum(
+    0 if np.array_equal(MS[i] @ MS[j], MS[RKEY[tuple((ROTS[i] @ ROTS[j]).flatten())]]) else 1
+    for i in range(24)
+    for j in range(24)
+)
+check(
+    "A2 [exact] the L=4 coarse torus has an 8-dimensional kernel spanned by the corner basis; all 24 proper cubic "
+    "rotations lift to signed permutations with C_R H C_R^T = H, and all 576 products close on the nose as integer "
+    "matrices on the corner kernel (%d failures) -- a genuine representation of O, not projective" % bad,
+    lift_ok
+    and len(CS) == 24
+    and all(np.allclose(C @ H4 @ C.T, H4) for C in CS)
+    and int(np.sum(np.abs(np.linalg.eigvalsh(H4)) < 1e-9)) == 8
+    and exact_lift
+    and bad == 0
+    and all(set(np.unique(m)).issubset({-1, 0, 1}) and (abs(m).sum(0) == 1).all() for m in MS),
+)
+
+TAB = {
+    "A1": [1, 1, 1, 1, 1],
+    "A2": [1, 1, 1, -1, -1],
+    "E": [2, -1, 2, 0, 0],
+    "T1": [3, 0, -1, 1, -1],
+    "T2": [3, 0, -1, -1, 1],
+}
+ORDER = ["E", "8C3", "3C2", "6C4", "6C2p"]
+CIX = {c: i for i, c in enumerate(ORDER)}
+SIZE = [1, 8, 3, 6, 6]
+tab_ok = all(
+    Fraction(sum(SIZE[i] * TAB[x][i] * TAB[y][i] for i in range(5)), 24) == (1 if x == y else 0)
+    for x in TAB
+    for y in TAB
+)
+CHI = [0] * 5
+for i, M in enumerate(ROTS):
+    CHI[CIX[class_of(M)]] = int(np.trace(MS[i]))
+DEC = {k: Fraction(sum(SIZE[i] * TAB[k][i] * CHI[i] for i in range(5)), 24) for k in TAB}
+check(
+    "A3 [exact] characters on the corner kernel (E, 8C3, 3C2, 6C4, 6C2') = (%d, %d, %d, %d, %d) decompose in exact "
+    "rational arithmetic, against a self-checked orthonormal character table of O, as 2 A1 + 2 T1" % tuple(CHI),
+    tab_ok and DEC == {"A1": 2, "A2": 0, "E": 0, "T1": 2, "T2": 0},
+)
+
+
+def isoproj(irr):
+    d = TAB[irr][0]
+    A = sum(TAB[irr][CIX[class_of(ROTS[i])]] * MS[i] for i in range(24))
+    return np.array([[Fraction(int(A[i, j]) * d, 24) for j in range(8)] for i in range(8)], dtype=object)
+
+
+PI = {k: isoproj(k) for k in TAB}
+PHW = {
+    w: np.array(
+        [[Fraction(1 if (i == j and HW[i] == w) else 0) for j in range(8)] for i in range(8)],
+        dtype=object,
+    )
+    for w in range(4)
+}
+diagA1 = np.array(
+    [[Fraction(1 if (i == j and HW[i] in (0, 3)) else 0) for j in range(8)] for i in range(8)],
+    dtype=object,
+)
+diagT1 = np.array(
+    [[Fraction(1 if (i == j and HW[i] in (1, 2)) else 0) for j in range(8)] for i in range(8)],
+    dtype=object,
+)
+check(
+    "A4 [exact] the isotypic projectors from the character formula in exact rational arithmetic are exactly "
+    "P_A1 = diag(1,0,0,0,0,0,0,1) = P_hw0 + P_hw3 and P_T1 = diag(0,1,1,1,1,1,1,0) = P_hw1 + P_hw2, with "
+    "P_A2 = P_E = P_T2 = 0: the two three-dimensional cubic carriers are exactly the two Hamming-weight triplets",
+    np.array_equal(PI["A1"], diagA1)
+    and np.array_equal(PI["A1"], PHW[0] + PHW[3])
+    and np.array_equal(PI["T1"], diagT1)
+    and np.array_equal(PI["T1"], PHW[1] + PHW[2])
+    and all(not PI[k].any() for k in ("A2", "E", "T2")),
+)
+
+blk_ok = True
+blk_chi = {}
+for w in range(4):
+    Pw = np.array([[1.0 if (i == j and HW[i] == w) else 0.0 for j in range(8)] for i in range(8)])
+    inv = all(np.array_equal(MS[i] @ Pw, Pw @ MS[i]) for i in range(24))
+    ch = [0] * 5
+    for i, M in enumerate(ROTS):
+        ch[CIX[class_of(M)]] = int(round(float(np.trace(MS[i] @ Pw))))
+    dec = {k: Fraction(sum(SIZE[i] * TAB[k][i] * ch[i] for i in range(5)), 24) for k in TAB}
+    blk_chi[w] = tuple(ch)
+    want = {"A1": 1} if w in (0, 3) else {"T1": 1}
+    blk_ok = blk_ok and inv and {k: v for k, v in dec.items() if v} == want
+check(
+    "A5 [exact] each Hamming block is separately O-invariant: characters %s on hw = 0 and 3 (one A1 each) and %s on "
+    "hw = 1 and 2 (one T1 each)" % (str(blk_chi[0]).replace(" ", ""), str(blk_chi[1]).replace(" ", "")),
+    blk_ok and blk_chi[0] == blk_chi[3] == (1, 1, 1, 1, 1) and blk_chi[1] == blk_chi[2] == (3, 0, -1, 1, -1),
+)
+
+# ============================================ group B: grading, multiplicity, T
+
+ZS = gint(1j * sum(GAM[a] @ XI[a] for a in range(3)))
+TOP = gint(1j * GAM[0] @ GAM[1] @ GAM[2])
+zs_ok = (
+    is_gint(1j * sum(GAM[a] @ XI[a] for a in range(3)))
+    and np.array_equal(ZS, kr(SZ, I2, I2) + kr(I2, SZ, I2) + kr(I2, I2, SZ))
+    and np.array_equal(ZS, np.diag([3 - 2 * HW[s] for s in range(8)]).astype(complex))
+    and all(np.array_equal(MS[i] @ ZS, ZS @ MS[i]) for i in range(24))
+)
+check(
+    "B1 [exact] i sum_a Gamma_a Xi_a = Z_1 + Z_2 + Z_3 exactly, it is O-invariant, and its corner spectrum is 3 - 2 hw: "
+    "the landed 1 + 3 + 3 + 1 grading is the eigen-grading of that one O-invariant Cl(6) bilinear",
+    zs_ok,
+)
+
+comm_all = Fraction(sum(SIZE[i] * CHI[i] * CHI[i] for i in range(5)), 24)
+chi_t1iso = [2 * TAB["T1"][i] for i in range(5)]
+comm_t1 = Fraction(sum(SIZE[i] * chi_t1iso[i] * chi_t1iso[i] for i in range(5)), 24)
+P1F = np.array([[1.0 if (i == j and HW[i] == 1) else 0.0 for j in range(8)] for i in range(8)])
+P2F = np.array([[1.0 if (i == j and HW[i] == 2) else 0.0 for j in range(8)] for i in range(8)])
+CMT = [P1F.astype(complex), P2F.astype(complex), P2F @ TOP @ P1F, P1F @ TOP @ P2F]
+cmt_ok = all(np.array_equal(MS[i] @ Xm, Xm @ MS[i]) for Xm in CMT for i in range(24)) and (
+    np.linalg.matrix_rank(np.array([Xm.ravel() for Xm in CMT])) == 4
+)
+check(
+    "B2 [exact] the T1 isotypic component is T1 (x) C^2: the commutant of the 24 lifts has dimension %s on the corner "
+    "kernel and %s on the T1 isotypic by the exact rational formula (1/24) sum |chi|^2, and four independent commuting "
+    "elements P_hw1, P_hw2, P_hw2 T P_hw1, P_hw1 T P_hw2 are exhibited -- the group alone does not split it"
+    % (comm_all, comm_t1),
+    comm_all == 8 and comm_t1 == 4 and cmt_ok,
+)
+
+t_ok = (
+    is_gint(1j * GAM[0] @ GAM[1] @ GAM[2])
+    and np.array_equal(TOP @ TOP.conj().T, np.eye(8, dtype=complex))
+    and all(np.array_equal(MS[i] @ TOP, TOP @ MS[i]) for i in range(24))
+    and np.array_equal(P1F @ TOP @ P1F, np.zeros((8, 8), dtype=complex))
+    and np.array_equal(P2F @ TOP @ P2F, np.zeros((8, 8), dtype=complex))
+    and np.linalg.matrix_rank(P2F @ TOP @ P1F) == 3
+    and np.linalg.matrix_rank(P1F @ TOP @ P2F) == 3
+    and np.array_equal(EPS8, np.diag([(-1) ** HW[s] for s in range(8)]).astype(complex))
+    and np.array_equal(TOP @ EPS8 + EPS8 @ TOP, np.zeros((8, 8), dtype=complex))
+    and not np.array_equal(TOP, EPS8)
+)
+check(
+    "B3 [exact] T = i Gamma_1 Gamma_2 Gamma_3 is O-invariant and unitary, carries hw=1 onto hw=2 and back with rank 3, "
+    "and anticommutes with epsilon = Z_1 Z_2 Z_3 = diag((-1)^hw), T != epsilon: the two T1 copies are O-equivariantly "
+    "isomorphic and are told apart only by the sign of epsilon",
+    t_ok,
+)
+
+# ================================================== group C: the C3[111] split
+
+IC = [i for i, M in enumerate(ROTS) if np.array_equal(M, np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]]))][0]
+C8 = MS[IC]
+BAS = {1: [4, 2, 1], 2: [3, 5, 6]}
+
+
+def rst(O, idx):
+    return sp.Matrix(3, 3, lambda i, j: sp.nsimplify(sp.Rational(int(round(O[idx[i], idx[j]].real)))
+                                                     + sp.I * sp.Rational(int(round(O[idx[i], idx[j]].imag)))))
+
+
+def rsti(O, idx):
+    return sp.Matrix(3, 3, lambda i, j: sp.Integer(int(O[idx[i], idx[j]])))
+
+
+UC = {w: rsti(C8, BAS[w]) for w in (1, 2)}
+c1_ok = True
+for w in (1, 2):
+    U = UC[w]
+    c1_ok = c1_ok and sp.trace(U) == 0 and (U ** 3 == sp.eye(3)) and set(
+        sp.nsimplify(sp.expand(k)) for k in U.eigenvals()
+    ) == set(sp.nsimplify(sp.exp(2 * sp.pi * sp.I * k / 3)) for k in range(3))
+check(
+    "C1 [exact] the C3[111] restriction U = C|_T1 on each triplet has tr U = 0 and U^3 = I, with eigenvalues "
+    "{1, omega, omegabar}: each triplet is the regular representation of Z/3",
+    c1_ok,
+)
+
+SING = {}
+c2_ok = True
+overlaps = {}
+for w in (1, 2):
+    U = UC[w]
+    ns = (U - sp.eye(3)).nullspace()
+    v = sp.simplify(ns[0] / max(abs(sp.Rational(x)) for x in ns[0]))
+    v = v / sp.sqrt((v.T * v)[0, 0])
+    SING[w] = v
+    wt = [sp.simplify(sp.Abs(v[i]) ** 2) for i in range(3)]
+    c2_ok = c2_ok and len(ns) == 1 and all(x == sp.Rational(1, 3) for x in wt)
+    W = sp.Matrix([1, 1, 1]) / sp.sqrt(3)
+    overlaps[w] = sp.simplify(sp.Abs((W.T * v)[0, 0]) ** 2)
+sigma = sp.diag(*[sp.sign(SING[2][i]) for i in range(3)])
+regauged = sp.simplify(sigma * UC[2] * sigma)
+plain3 = sp.Matrix([[0, 1, 0], [0, 0, 1], [1, 0, 0]])
+c2_ok = (
+    c2_ok
+    and overlaps[1] == 1
+    and overlaps[2] == sp.Rational(1, 9)
+    and regauged == plain3
+    and sp.simplify(sigma * SING[2]) == sp.Matrix([1, 1, 1]) / sp.sqrt(3)
+)
+check(
+    "C2 [exact] the C-invariant vector of each triplet has corner weights exactly (1/3, 1/3, 1/3) -- gauge-invariant "
+    "trimaximality; against the fixed democratic W = (1,1,1)/sqrt3 the overlaps are |<W|v>|^2 = %s and %s, a "
+    "corner-sign gauge artefact removed by rephasing a single corner, which carries U to the plain 3-cycle and v to W"
+    % (overlaps[1], overlaps[2]),
+    c2_ok,
+)
+
+P0 = {}
+c3_ok = True
+for w in (1, 2):
+    v = SING[w]
+    P0[w] = sp.simplify(v * v.T)
+    P1m = sp.eye(3) - P0[w]
+    c3_ok = c3_ok and sp.simplify(P0[w] * P0[w] - P0[w]).is_zero_matrix
+    c3_ok = c3_ok and sp.simplify(P0[w] * UC[w] - UC[w] * P0[w]).is_zero_matrix
+    c3_ok = c3_ok and sp.simplify(P1m * UC[w] - UC[w] * P1m).is_zero_matrix
+    c3_ok = c3_ok and all(sp.Abs(P0[w][i, j]) == sp.Rational(1, 3) for i in range(3) for j in range(3))
+check(
+    "C3 [exact] the C3 singlet projectors P_0 = |v><v| have every entry of modulus 1/3 (P_0 = J/3 in the gauge that "
+    "carries v to W), are idempotent, and P_0 and P_1 = I - P_0 both commute with U",
+    c3_ok,
+)
+
+# ============================================= group D: circulant restrictions
+
+SG = gint(sum(GAM))
+SXi = gint(sum(XI))
+SG2 = gint(SG @ SG)
+SX2 = gint(SXi @ SXi)
+BG = gint(1j * sum(GAM[a] @ GAM[(a + 1) % 3] for a in range(3)))
+BX = gint(1j * sum(XI[a] @ XI[(a + 1) % 3] for a in range(3)))
+MG1 = gint(1j * sum(GAM[a] @ XI[(a + 1) % 3] for a in range(3)))
+MG2 = gint(1j * sum(GAM[a] @ XI[(a + 2) % 3] for a in range(3)))
+
+ps = sp.symbols("p1 p2 p3", real=True)
+HSHIFT = HSYM.subs({qs[a]: sp.pi + ps[a] for a in range(3)}, simultaneous=True)
+HSQ2 = sp.expand_trig(sp.expand(HSHIFT * HSHIFT))
+LAPS = [
+    sp.simplify(sp.diff(HSQ2, ps[a], 2).subs({ps[b]: 0 for b in range(3)}) / 2)
+    for a in range(3)
+]
+lap_ok = all(Lm == sp.eye(8) for Lm in LAPS)
+LAP = np.eye(8, dtype=complex)
+
+OPS = [
+    ("sum_a Gamma_a", SG),
+    ("sum_a Xi_a", SXi),
+    ("i sum_a Gamma_a Xi_a = Z_1+Z_2+Z_3", ZS),
+    ("(sum_a Gamma_a)^2", SG2),
+    ("(sum_a Xi_a)^2", SX2),
+    ("T = i Gamma_1 Gamma_2 Gamma_3", TOP),
+    ("epsilon = Z_1 Z_2 Z_3", EPS8),
+    ("i(G_xG_y + G_yG_z + G_zG_x)", BG),
+    ("i(X_xX_y + X_yX_z + X_zX_x)", BX),
+    ("p_a^2 coeff of H(pi+p)^2", LAP),
+    ("i sum_a Gamma_a Xi_{a+1}", MG1),
+    ("i sum_a Gamma_a Xi_{a+2}", MG2),
+]
+
+
+def circ(M3, U):
+    """Exact circulant decomposition M3 = a I + b U + c U^2 with U^3 = I, tr U = 0."""
+    U2 = U * U
+    a = sp.nsimplify(sp.trace(M3) / 3)
+    b = sp.nsimplify(sp.trace(M3 * U2) / 3)
+    c = sp.nsimplify(sp.trace(M3 * U) / 3)
+    R = sp.expand(M3 - (a * sp.eye(3) + b * U + c * U2))
+    return a, b, c, R
+
+
+def rst_c(O, idx):
+    return sp.Matrix(
+        3, 3,
+        lambda i, j: sp.Integer(int(round(O[idx[i], idx[j]].real)))
+        + sp.I * sp.Integer(int(round(O[idx[i], idx[j]].imag))),
+    )
+
+
+TABLE = {}
+d1_ok = (
+    all(is_gint(O) for _, O in OPS)
+    and all(np.array_equal(O, O.conj().T) for _, O in OPS)
+    and lap_ok
+)
+print("  operator restrictions on each cubic carrier (a, |b|, delta/pi, r = |b|^2/a^2; exact):")
+print("    %-38s %-3s %-6s %-6s %-9s %-8s %s" % ("operator", "hw", "a", "|b|", "delta/pi", "r", "dev"))
+for nm, O in OPS:
+    for w in (1, 2):
+        M3 = rst_c(O, BAS[w])
+        a, b, c, R = circ(M3, UC[w])
+        ab = sp.simplify(sp.Abs(b))
+        r = sp.nsimplify(ab ** 2 / a ** 2) if a != 0 else None
+        TABLE[(nm, w)] = (a, b, c, ab, r, R)
+        d1_ok = d1_ok and R.is_zero_matrix and sp.simplify(c - sp.conjugate(b)) == 0
+        dl = "--" if b == 0 else "%+.3f" % float(sp.arg(b) / sp.pi)
+        print(
+            "    %-38s %-3d %-6s %-6s %-9s %-8s %s"
+            % (nm[:38], w, a, ab, dl, "--" if r is None else r, 0 if R.is_zero_matrix else "NONZERO")
+        )
+EXPECT = {
+    ("sum_a Gamma_a", 1): (0, 0), ("sum_a Gamma_a", 2): (0, 0),
+    ("sum_a Xi_a", 1): (0, 0), ("sum_a Xi_a", 2): (0, 0),
+    ("i sum_a Gamma_a Xi_a = Z_1+Z_2+Z_3", 1): (1, 0),
+    ("i sum_a Gamma_a Xi_a = Z_1+Z_2+Z_3", 2): (-1, 0),
+    ("(sum_a Gamma_a)^2", 1): (3, 0), ("(sum_a Gamma_a)^2", 2): (3, 0),
+    ("(sum_a Xi_a)^2", 1): (3, 0), ("(sum_a Xi_a)^2", 2): (3, 0),
+    ("T = i Gamma_1 Gamma_2 Gamma_3", 1): (0, 0), ("T = i Gamma_1 Gamma_2 Gamma_3", 2): (0, 0),
+    ("epsilon = Z_1 Z_2 Z_3", 1): (-1, 0), ("epsilon = Z_1 Z_2 Z_3", 2): (1, 0),
+    ("i(G_xG_y + G_yG_z + G_zG_x)", 1): (0, sp.I), ("i(G_xG_y + G_yG_z + G_zG_x)", 2): (0, sp.I),
+    ("i(X_xX_y + X_yX_z + X_zX_x)", 1): (0, sp.I), ("i(X_xX_y + X_yX_z + X_zX_x)", 2): (0, sp.I),
+    ("p_a^2 coeff of H(pi+p)^2", 1): (1, 0), ("p_a^2 coeff of H(pi+p)^2", 2): (1, 0),
+    ("i sum_a Gamma_a Xi_{a+1}", 1): (0, -1), ("i sum_a Gamma_a Xi_{a+1}", 2): (0, 1),
+    ("i sum_a Gamma_a Xi_{a+2}", 1): (0, -1), ("i sum_a Gamma_a Xi_{a+2}", 2): (0, 1),
+}
+d1_ok = d1_ok and all(
+    TABLE[k][0] == EXPECT[k][0] and sp.simplify(TABLE[k][1] - EXPECT[k][1]) == 0 for k in EXPECT
+)
+zero_rest = all(
+    rst_c(dict(OPS)[nm], BAS[w]).is_zero_matrix
+    for nm in ("sum_a Gamma_a", "sum_a Xi_a", "T = i Gamma_1 Gamma_2 Gamma_3")
+    for w in (1, 2)
+)
+check(
+    "D1 [exact] every one of the twelve stipulated bilinears restricts to an exactly circulant operator on each "
+    "carrier (residual 0, c = conj(b) throughout), with the tabulated (a, |b|, delta, r); the restrictions of "
+    "sum Gamma_a, sum Xi_a and T are identically zero, and the p_a^2 coefficient of H(pi+p)^2 is the identity on both "
+    "carriers -- the naive dispersion is hw-blind",
+    d1_ok and zero_rest,
+)
+
+OINV = {}
+CINV = {}
+for nm, O in OPS:
+    OINV[nm] = all(np.array_equal(MS[i] @ O, O @ MS[i]) for i in range(24))
+    CINV[nm] = np.array_equal(C8 @ O, O @ C8)
+mixed = [
+    nm for nm, _ in OPS for w in (1, 2)
+    if TABLE[(nm, w)][0] != 0 and TABLE[(nm, w)][1] != 0
+]
+schur_ok = all(TABLE[(nm, w)][1] == 0 for nm, _ in OPS if OINV[nm] for w in (1, 2))
+avg_ok = True
+for nm, O in OPS:
+    SUMAVG = gint(sum(MS[i] @ O @ MS[i].T for i in range(24)))
+    if OINV[nm]:
+        avg_ok = avg_ok and np.array_equal(SUMAVG, 24 * O)
+    else:
+        avg_ok = avg_ok and np.array_equal(SUMAVG, np.zeros((8, 8), dtype=complex))
+trace_ok = all(TABLE[(nm, w)][0] == 0 for nm, _ in OPS if CINV[nm] and not OINV[nm] for w in (1, 2))
+allc3 = all(CINV[nm] for nm, _ in OPS)
+r0 = [nm for nm, _ in OPS if TABLE[(nm, 1)][0] != 0]
+check(
+    "D2 [exact] all twelve commute with C3[111]; the %d that commute with all 24 lifts have b = 0 on both carriers "
+    "(Schur on an irreducible T1), and the O-average of each of the other %d is exactly 0, so their a -- which depends "
+    "on the O-average alone, the Hamming projectors being O-invariant -- vanishes; no listed operator has a != 0 and "
+    "b != 0, hence every hw-diagonal one registers r = 0 exactly"
+    % (sum(1 for nm, _ in OPS if OINV[nm]), sum(1 for nm, _ in OPS if CINV[nm] and not OINV[nm])),
+    allc3 and schur_ok and avg_ok and trace_ok and not mixed
+    and all(TABLE[(nm, w)][4] == 0 for nm in r0 for w in (1, 2)),
+)
+
+BASIS3 = [("sum Z_a", ZS), ("i sum_cyc Gamma_a Gamma_{a+1}", BG), ("i sum_a Gamma_a Xi_{a+1}", MG1)]
+d3_ok = True
+for w in (1, 2):
+    rows = []
+    for nm, O in BASIS3:
+        a, b, c, R = circ(rst_c(O, BAS[w]), UC[w])
+        rows.append([sp.re(a), sp.re(b), sp.im(b)])
+    d3_ok = d3_ok and sp.Matrix(rows).rank() == 3
+check(
+    "D3 [exact] surjectivity: on each carrier the three real C3-invariant Hermitian quadratics "
+    "alpha (sum Z_a) + beta i(sum_cyc Gamma_a Gamma_{a+1}) + gamma i(sum_a Gamma_a Xi_{a+1}) map onto (a, Re b, Im b) "
+    "with real rank 3, so every (a, |b|, delta) -- hence every r in [0, inf) -- is realised by stipulated coefficients",
+    d3_ok,
+)
+
+d4_ok = True
+reg = []
+for (al, be, ga), want in (((2, 1, 1), sp.Rational(1, 2)), ((2, 1, 0), sp.Rational(1, 4))):
+    for w in (1, 2):
+        O = gint(al * ZS + be * BG + ga * MG1)
+        a, b, c, R = circ(rst_c(O, BAS[w]), UC[w])
+        rr = sp.nsimplify(sp.Abs(b) ** 2 / a ** 2)
+        d4_ok = d4_ok and R.is_zero_matrix and rr == want
+    reg.append(((al, be, ga), want))
+check(
+    "D4 [exact] registered examples, stipulated and not derived: the coefficient triple (alpha, beta, gamma) = %s "
+    "registers r = %s and %s registers r = %s, exactly and on both carriers -- r is a free function of stipulated "
+    "coefficients, matched not delivered" % (reg[0][0], reg[0][1], reg[1][0], reg[1][1]),
+    d4_ok,
+)
+
+# ================================================== group E: invariance census
+
+e1_ok = True
+for nm, O in OPS:
+    for w in (1, 2):
+        aR, bR, _, abR, _, _ = TABLE[(nm, w)]
+        for perm in itertools.permutations(range(3)):
+            idx = [BAS[w][k] for k in perm]
+            Up = rsti(C8, idx)
+            a, b, c, R = circ(rst_c(O, idx), Up)
+            e1_ok = e1_ok and R.is_zero_matrix and a == aR and sp.simplify(sp.Abs(b) - abR) == 0
+            if aR != 0:
+                e1_ok = e1_ok and sp.nsimplify(sp.Abs(b) ** 2 / a ** 2) == sp.nsimplify(abR ** 2 / aR ** 2)
+check(
+    "E1 [exact] all 6 relabellings of each carrier's basis leave (a, |b|, r) unchanged with circulant residual 0, for "
+    "every one of the twelve operators: no quantity reported here depends on which member of a triplet is written first",
+    e1_ok,
+)
+
+e2_ok = True
+for nm, O in OPS:
+    for w in (1, 2):
+        aR, bR, _, abR, _, _ = TABLE[(nm, w)]
+        for i in range(24):
+            g = MS[i]
+            gi = g.T
+            Og = gint(g @ O @ gi)
+            Cg = g @ C8 @ gi
+            a, b, c, R = circ(rst_c(Og, BAS[w]), rsti(Cg, BAS[w]))
+            e2_ok = e2_ok and R.is_zero_matrix and a == aR and sp.simplify(sp.Abs(b) - abR) == 0
+check(
+    "E2 [exact] all 24 cubic conjugations (O -> g O g^-1 with C -> g C g^-1, covering all eight C3 elements) leave "
+    "(a, |b|, r) unchanged with circulant residual 0, for every one of the twelve operators",
+    e2_ok,
+)
+
+e3_ok = True
+flip = []
+for nm, O in OPS:
+    for w in (1, 2):
+        aR, bR, _, abR, _, _ = TABLE[(nm, w)]
+        a, b, c, R = circ(rst_c(O, BAS[w]), UC[w] * UC[w])
+        e3_ok = e3_ok and R.is_zero_matrix and a == aR and sp.simplify(b - sp.conjugate(bR)) == 0
+        if bR != 0 and sp.simplify(b - bR) != 0:
+            flip.append(nm)
+check(
+    "E3 [exact] naming C^2 rather than C the generator sends b -> conj(b), i.e. delta -> -delta, and leaves "
+    "(a, |b|, r) fixed on both carriers: the orientation of the cyclic order is a supplied datum, not a computed one",
+    e3_ok and flip,
+)
+
+# ==================================================== group F: the carrier locus
+
+sep_a = [nm for nm, _ in OPS if TABLE[(nm, 1)][0] != TABLE[(nm, 2)][0]]
+sep_b = [
+    nm for nm, _ in OPS
+    if sp.simplify(TABLE[(nm, 1)][1] - TABLE[(nm, 2)][1]) != 0
+    and sp.simplify(TABLE[(nm, 1)][3] - TABLE[(nm, 2)][3]) == 0
+]
+same = [nm for nm, _ in OPS if nm not in sep_a and nm not in sep_b]
+delta_pi = all(
+    sp.simplify(sp.Abs(sp.arg(TABLE[(nm, 1)][1]) - sp.arg(TABLE[(nm, 2)][1])) - sp.pi) == 0 for nm in sep_b
+)
+check(
+    "F1 [exact] exactly %d of the twelve separate the two carriers: sum Z_a and epsilon, by the sign of a -- the "
+    "chirality grading's own sign convention -- and the two Gamma-Xi cross terms, with equal |b| and delta differing "
+    "by exactly pi; the remaining %d restrict identically to both" % (len(sep_a) + len(sep_b), len(same)),
+    set(sep_a) == {"i sum_a Gamma_a Xi_a = Z_1+Z_2+Z_3", "epsilon = Z_1 Z_2 Z_3"}
+    and set(sep_b) == {"i sum_a Gamma_a Xi_{a+1}", "i sum_a Gamma_a Xi_{a+2}"}
+    and delta_pi
+    and len(same) == 8,
+)
+
+lopsided = [
+    nm for nm, _ in OPS
+    if CINV[nm] and ((TABLE[(nm, 1)][1] != 0) != (TABLE[(nm, 2)][1] != 0))
+]
+check(
+    "F2 [exact] no listed operator is C3-invariant with b != 0 on exactly one carrier: the off-diagonal part is either "
+    "absent on both or present on both, so nothing in this list singles out one triplet as the one carrying a weight",
+    not lopsided,
+)
+
+print(
+    "SUMMARY: the corner kernel carries exactly two three-dimensional cubic carriers, the two Hamming-weight triplets, "
+    "exchanged by the O-invariant unitary T and told apart only by the sign of epsilon; on each, every stipulated "
+    "bilinear registers r = 0 or has no diagonal part, and the restriction map onto the circulant algebra is onto."
+)
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Small bounded theorem note + exact runner + cache on the **corner kernel** of the coarse-lattice staggered kinetic form (PR #7844): the proper cubic group acts on the eight Brillouin-corner zero modes as `2 A1 + 2 T1`, and the two three-dimensional carriers are **exactly** the Hamming-weight triplets of the landed `1 + 3 + 3 + 1` grading. Each carrier restricts under `C3[111]` to singlet plus doublet with corner weights exactly one third. Every stipulated bilinear restricts to an exact circulant with either `b = 0` (Schur) or `a = 0` (vanishing cubic average), so every diagonal one registers block weight `r = 0`, while the restriction map onto the circulant algebra is onto, so `r` is a free function of stipulated coefficients: registered, never delivered (guardrail G3 as a theorem on this carrier).

- `docs/CORNER_KERNEL_CUBIC_CARRIERS_C3_SPLIT_AND_REGISTERED_BLOCK_WEIGHTS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (299 lines)
- `scripts/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.py` (`TOTAL: PASS=20 FAIL=0`, 1 s, every check `[exact]`)
- `logs/runner-cache/corner_kernel_cubic_carriers_c3_split_registered_block_weights_check_2026_09_02.txt`

## Guardrails (binding, checked by the runner)

No orbit-separating selector: no corner named, no bijection to a labelled 3-set, no sort key, no Vandermonde sign, no PDG value, no species name. Every quantity is verified invariant under all six relabellings of each triplet and all 24 cubic conjugations. `epsilon` is not identified with `T` or any Vandermonde sign. The species-labelling no-go and its C3 selector-invariance bridge are pointers only, neither used nor re-attacked; `AC_phi_lambda` stays where they left it.

## Theorems

- **T1** the corner kernel is a genuine cubic representation `2 A1 + 2 T1`; isotypic projectors are exactly `P_hw0 + P_hw3` and `P_hw1 + P_hw2`.
- **T2** the grading is the eigen-grading of the O-invariant bilinear `i sum Gamma_a Xi_a = Z_1 + Z_2 + Z_3`; the two `T1` copies are O-equivariantly isomorphic, exchanged by the O-invariant unitary `T`, which reverses the chirality grading `epsilon`.
- **T3** `C3` restriction: each carrier is the regular representation of `Z/3`; the invariant vector has corner weights exactly `(1/3, 1/3, 1/3)`.
- **T4** twelve stipulated bilinears restrict to exact circulants; none has both `a != 0` and `b != 0`, so every hw-diagonal one registers `r = 0`; the restriction map has real rank 3 on each carrier, so every `r` in `[0, inf)` is realised by stipulated coefficients (two coefficient triples exhibited as registered patterns, explicitly not derived).
- **T5** invariance census (6 relabellings, 24 conjugations, generator orientation `delta -> -delta` only).
- **T6** exactly four operators separate the two carriers, all through the sign of the chirality grading or a phase of `pi`; none singles out one triplet as a weight carrier.

## Corollary

- "Why a triplet" is forced by the representation; "which triplet" reduces to the sign of `epsilon`, a supplied datum. The species-bridge note's carrier-locus residual is narrowed to that sign, not closed.
- The landed democratic `r = 0` is reproduced structurally on a new carrier; `r` is registered, never delivered.

## Dependencies and context

- Cites the landed staggered-gate, labelling, foreclosure, democratic-`r0`, species-bridge, PMNS-TM2 and record-principle notes verbatim (each re-verified on `origin/main`), and `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7844) as a pointer.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
