### PR TITLE
feat(matter): half-filling kinetic energy selects the staggered flux sector

### DIFF
--- a/docs/HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md
+++ b/docs/HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md
@@ -1,0 +1,328 @@
+---
+claim_id: half_filling_kinetic_energy_selects_staggered_flux_sector
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with free nearest-neighbour hopping sum_ij eta_ij c_i^dag c_j and no other term, the flux sector of a face being the eigenvalue of that face's stabilizer S_f and E_N the sum of the N lowest one-particle levels, on the named finite blocks and tori only: (T1) the open 2x2x2 coarse cube has exactly 32 consistent flux sectors of the 64 face assignments -- six faces with one F2 relation, so an even number of -1 faces -- confirmed by enumerating all 2^12 link-sign fields, which realise exactly those 32 holonomy patterns with the one-particle spectrum constant on each; the all-(+1) sector has E_N = 0, -3, -4, -5, -6, -5, -4, -3, 0 and the all-(-1) sector E_N = -N sqrt3 for N <= 4 with its mirror, both exact over the integers; at N = 4 the all-(-1) sector is the unique minimiser of all 32, by 0.456067 to the next distinct value and by 4 sqrt3 - 6 to the plain sector, while the unique minimiser is the plain sector at N = 1, 7, the two-flux class at N = 2, 6 and the four-flux class at N = 3, 5, and all 32 tie at N = 0 and 8. (T2) On the coarse tori 4^3, 4x4x6, 6^3 and 8^3 and the open blocks 3^3 and 4^3, sign(E_N(-) - E_N(+)) is + below N*, - on the whole of [N*, V - N*] and + above -- one contiguous window, the difference symmetric under N -> V - N -- with N* = 23, 30, 71, 171, 10, 22 respectively; at L = 4 the spectra are fixed exactly by integer minimal-polynomial and power-trace witnesses, E_32(-) - E_32(+) = 36 - 24 sqrt2 - 8 sqrt3 < 0, E_16(-) - E_16(+) = 48 - 24 sqrt2 - 8 sqrt3 > 0, and the first sign change is at N* = 23 where the difference is 46 - 24 sqrt2 - 8 sqrt3. (T3) The S_f fix no torus Wilson line, so each sector is a family of eight link-sign fields; minimised over the eight twists the half-filling energies are -78.383672 against -67.882251 on 4^3, -116.809009 against -99.882251 on 4x4x6 and -258.857540 against -218.564065 on 6^3, and the all-(-1) sector at its worst twist still beats the all-(+1) sector at its best, by 3.92, 10.15 and 36.58; the twisted Bloch formulas +-sqrt(6 + 2 sum_a cos q_a) and 2 sum_a cos q_a reproduce all 48 twisted real-space spectra of those tori at 1e-9. (T4) The 4^3 coarse torus is bipartite with every degree 6, so for ANY link-sign field on it the integer matrix M has tr M^2 = 2|E| = 6V = 384 and D M D = -M for the colour involution D, hence a spectrum symmetric about 0; the V/2 lowest squared levels therefore sum to 3V = 192 and Cauchy-Schwarz gives E_{V/2} >= -sqrt((V/2)(3V)) = -V sqrt(3/2) = -32 sqrt6 = -78.383672, with equality exactly when every |lambda| = sqrt6; the all-(-1) sector at its optimal twist satisfies M^2 = 6 I exactly as a 64x64 integer identity, its spectrum is +-sqrt6 with multiplicity 32 each, and it attains the bound, so it is a global minimiser at half filling over all 2^192 link-sign fields on that torus; on 4x4x6, 6^3 and 8^3 the same bound is -117.5755, -264.5449 and -627.0694 and the all-(-1) sector misses it by 0.766, 5.687 and 15.26. (T5) At half filling on 4^3 and 4x4x6, 2000 random link-sign fields per torus as drawn and a 500-field subsample with each field minimised over its own eight twists give 0 of 2500 fields beating the all-(-1) sector on either torus; the structured sectors with flux only on the xy, xz or yz plaquettes, xy flux on alternating x planes, and flux on the xz and yz plaquettes together are consistent and all strictly above it, while flux on the even-parity faces, xz+yz on alternating planes and a single-face flip off the all-(-1) sector are inconsistent; greedy single-link descent from 24 random restarts per torus never beats the all-(-1) field at its optimal twist and on 4^3 returns exactly that field; that field is a strict local minimum, every single-link flip raising E_{V/2} by at least 0.426844 on 4^3 and 0.365352 on 4x4x6. (T6) From the exact Bloch formulas the per-site half-filling energies converge to e(+) = -1.00241973 and e(-) = -1.19380112, a difference of -0.19138139 |t| per coarse site, while at quarter filling the difference is +0.07909 at L = 96; the crossing filling n* = N*/V settles to 0.339659 with the window ending at the mirror 1 - n* = 0.660341. T3 and T5 are search results, not theorems. Nothing here is derived from any axiom, no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py
+---
+
+# Half filling selects the staggered flux sector
+
+**Date:** 2026-09-02
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py`](../scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py)
+**Runner cache:**
+[`logs/runner-cache/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.txt`](../logs/runner-cache/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+A separate construction puts one fermionic mode on each vertex of the coarse lattice `2Z^3` and shows that transport of one encoded excitation around a coarse face
+equals that face's stabilizer `S_f`, so the framework's staggered kinetic sign field is the sector in which every `S_f` is `-1` and the plain field is the sector in
+which every one is `+1`. That construction states its own limit: the law as written attaches no coefficient to any face term, so the sector is a free choice under
+the law. This note refines that statement. The law's hopping term *is* supplied, and it is not indifferent: on the finite clusters named below the hopping energy of
+a filled Fermi sea distinguishes the two sectors, strictly, and which one it prefers depends on how much matter is present.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems on the flux-sector dependence of the free coarse-lattice hopping energy: exhaustive enumeration on the open 2x2x2 cube, exact surd spectra on the 4^3 torus, and an integer Cauchy-Schwarz certificate making the staggered sector a global half-filling minimiser there. The sampling, structured-sector and descent items are declared search results, not theorems, and the thermodynamic items are converged quadrature."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: what fixes the coarse-lattice matter density."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the six statements below, exactly the runner's check groups `A`-`F`. Group `A`, the `L = 4` content of `B` and the whole of `D` are
+exact -- exhaustive enumeration, `sympy` surds, integer matrix arithmetic at zero tolerance, `F2`/`Z4` symplectic bit arithmetic -- and the items tagged
+`[numerical]` are floating-point statements at the stated tolerance. Groups `C` and `E` are search results and are labelled as such wherever they appear.
+
+1. `T1` (`A`). The exhaustive `2x2x2` cube: 32 consistent sectors, their `E_N` ladders, and the filling-dependent minimiser.
+2. `T2` (`B`). The two uniform sectors on four tori and two open blocks: one contiguous `pi`-flux window `[N*, V - N*]`, with exact surds at `L = 4`.
+3. `T3` (`C`). The Wilson-line caveat: the `S_f` fix no torus Wilson line, and the ordering survives every twist.
+4. `T4` (`D`). The Cauchy-Schwarz certificate: on the `4^3` torus the staggered sector at its optimal twist is a global half-filling minimiser over all link-sign
+   fields, and the gap by which the bound is missed elsewhere.
+5. `T5` (`E`). Random, structured and greedily optimised sectors, all at half filling. Search results.
+6. `T6` (`F`). The thermodynamic per-site difference and the crossing filling, from the exact Bloch formulas.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering and the tight-binding dispersion are standard
+methodology; every object is redeclared here and the runner recomputes every statement. Lieb's flux-phase theorem is named only as background -- it fixes the
+optimal flux of half-filled bipartite *planar* lattices, is not proved for the cubic lattice, and nothing below uses it or claims a cubic analogue. No observational
+value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): face transport equals `S_f`, and the sentence
+  quoted below. Pointer only; the encoding, the sign fields and the face stabilizers are redeclared here and recomputed by this runner.
+- `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md`: the kinetic-form clause quoted below.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting". This note cites none of their grades and adopts no hypothesis.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has
+algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic
+rotations", and "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." **Record**:
+"Records form", "a record locks exactly one admissible local possibility", "records are permanent", "Only records are readable."
+
+The landed kinetic clause whose sign field is under test reads, verbatim:
+
+> **Kinetic-form clause.** Within the declared kinetic class (the naive-Dirac kinetic form on nearest-neighbor `Z^3` links, made
+> compatible with the matter-statistics clause by site-local spin diagonalization), the kinetic operator is the staggered operator
+> `D = (1/2) Σ_{x,μ} η_μ(x) (χ̄_{x+μ̂} χ_x − χ̄_x χ_{x+μ̂})` with the Kawamoto-Smit phases `η_1 = 1, η_2(x) = (−1)^{x_1},
+> η_3(x) = (−1)^{x_1+x_2}`, unique as a local Z2 gauge class.
+
+and the sentence this note refines, from the face-transport note, reads:
+
+> So the two sectors are a free choice under the law as written; a face term `-J sum_f S_f` with negative `J` would select the staggered
+> sector, and no such term is supplied by anything quoted here.
+
+Everything below reads those sign fields on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, with free nearest-neighbour hopping and nothing else.
+Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras and no graded clause is used anywhere.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the two uniform
+sign fields on it, the superfast encoding, the face stabilizers, the flux sectors and the filling functional `E_N`. `P1` (`A`) is the exhaustive `2x2x2` cube; `P2`
+(`B`) the uniform sectors on the named tori and blocks and the shape of the difference; `P3` (`C`) the Wilson-line freedom; `P4` (`D`) the Cauchy-Schwarz bound and
+its equality case; `P5` (`E`) the searches; `P6` (`F`) the thermodynamic limit. `P4` uses nothing from `P3` but its numbers; `P5` and `P6` use nothing from each
+other. The strongest supported scope is precisely `P0`-`P6`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`, and the coarse edge from `v` along `e_a` sits at the fine site `2v + e_a`. The
+**KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`, the clause's phases read in coarse
+coordinates; the **plain sign** is `+1` on every bond. The **encoding** is the Bravyi-Kitaev superfast encoding on the coarse lattice, code qubits on the coarse
+edges, direction order `-x < -y < -z < +x < +y < +z`, with
+
+```text
+A_ij = X(edge (i,j)) * prod Z(edges ordered before it at i) * prod Z(edges ordered before it at j),  A_ji = -A_ij
+B_i  = product of the Z's on the edges incident to i,   S_f = the ordered product of the four A's around a coarse face f
+```
+
+A **flux sector** is a choice of eigenvalue `+-1` for every `S_f` consistent with the `F2` relations among them; a sector is realised as a link-sign field `eta` by
+spanning-tree gauge fixing followed by fundamental-cycle transport, and the plaquette holonomy of that field reproduces the sector face by face. The **hopping
+matrix** is `M_ij = eta_ij` on nearest-neighbour coarse bonds and `0` elsewhere; `E_N` is the sum of its `N` lowest eigenvalues, the ground-state kinetic energy of
+`N` spinless fermions, and the **filling** is `n = N/V`. On a torus the three **Wilson lines** -- the products of `eta` around the three non-contractible loops --
+are gauge-invariant data that no `S_f` fixes; a **twist** flips the signs on one cut plane and changes one Wilson line without changing any face.
+
+## Theorem 1 -- the exhaustive 2x2x2 cube
+
+**Conclusion.** On the open `2x2x2` coarse cube, 8 sites, 12 links, 6 faces with one `F2` relation:
+
+1. Exactly `32` of the `64` face assignments are consistent flux sectors -- those with an even number of `-1` faces -- and enumerating all `2^12` link-sign fields
+   gives exactly those `32` holonomy patterns, with the one-particle spectrum constant on each pattern.
+2. `E_N` of the all-`(+1)` sector is `0, -3, -4, -5, -6, -5, -4, -3, 0` and of the all-`(-1)` sector is `-N sqrt3` for `N <= 4` with its mirror, both exact.
+3. At half filling `N = 4` the all-`(-1)` sector is the **unique** minimiser of all `32`, by `0.456067` to the next distinct value and by `4 sqrt3 - 6` to the plain
+   sector. The unique minimiser is the plain sector at `N = 1, 7`, the two-flux class at `N = 2, 6` and the four-flux class at `N = 3, 5`; all `32` tie at `N = 0`
+   and `N = 8`.
+
+**Proof.** Item 1 solves the `F2` relations among the six face generators, realises each consistent assignment as a sign field and checks its holonomy face by face,
+then enumerates the `4096` sign fields directly, `[numerical, 1e-12]` for the constancy of the spectrum within a pattern and exact for the pattern count. Item 2
+diagonalises the two exact integer `8x8` matrices in `sympy` and sums the surds. Item 3 compares the `32` exact ladders entry by entry, with the tie counts
+`32, 1, 3, 12, 1, 12, 3, 1, 32` and the minimiser's flux count `all, 0, 2, 4, 6, 4, 2, 0, all` printed by the runner.
+
+**Reading, not theorem.** Eight sites and a choice of sign on each of six squares. With no particles, or with all eight sites full, every choice costs the same.
+With one particle the plain arrangement is cheapest; with four -- one particle for every two sites -- the arrangement with a minus on every square is cheapest, and
+by a clear margin. In between, other arrangements win. The cheapest sign pattern is a function of how many particles there are.
+
+## Theorem 2 -- the uniform sectors on tori and open blocks
+
+**Conclusion.** For the two uniform sectors on the coarse tori `4^3`, `4x4x6`, `6^3` and `8^3` and the open blocks `3^3` and `4^3`:
+
+1. `sign(E_N(-) - E_N(+))` over `N = 1..V-1` is `+` below `N*`, `-` on the whole of `[N*, V - N*]` and `+` above: one contiguous window, and the difference is
+   symmetric under `N -> V - N`. The values are `N* = 23, 30, 71, 171, 10, 22` in that order.
+2. At `L = 4` both spectra are fixed exactly by an integer minimal-polynomial witness and integer power traces: `0 x20, +-2 x15, +-4 x6, +-6 x1` for the plain
+   sector and `0 x8, +-2 x12, +-2sqrt2 x12, +-2sqrt3 x4` for the staggered one. Hence `E_32(-) - E_32(+) = 36 - 24 sqrt2 - 8 sqrt3 < 0` at half filling,
+   `E_16(-) - E_16(+) = 48 - 24 sqrt2 - 8 sqrt3 > 0` at quarter filling, and the first sign change is at `N* = 23`, where the difference is
+   `46 - 24 sqrt2 - 8 sqrt3`.
+3. Where the sector is small enough to be formed from the `S_f` directly, the field read off the all-`(-1)` sector has holonomy `-1` on every plaquette and the same
+   one-particle spectrum as the KS field, so the two labels name the same object here.
+
+**Proof.** Item 2 evaluates the claimed minimal polynomial at the exact integer matrix, which vanishes over `Z`, and checks `tr M^k` for `k = 1..8` against the
+claimed multiset, which fixes the multiplicities; the ladders and their difference are then exact sums of surds. Item 1 is `[numerical, 1e-9]` away from `L = 4`,
+with `E_N = E_{V-N}` from the symmetry of a bipartite spectrum; item 3 likewise, and the `8^3` torus is evaluated from the Bloch formula, not a matrix.
+
+**Reading, not theorem.** The same picture holds on every block tested. Below about a third filling the plain arrangement is cheaper, above about two thirds it
+is cheaper again, and in the whole band between the two the minus-on-every-square arrangement is. The band is a single stretch, symmetric about half filling.
+
+## Theorem 3 -- the Wilson-line caveat
+
+**Conclusion.** The face stabilizers fix none of the three torus Wilson lines, so each sector is a family of eight link-sign fields, related by twists that change no
+face. Minimising each uniform sector over its eight twists gives `E_{V/2} = -78.383672` against `-67.882251` on `4^3`, `-116.809009` against `-99.882251` on
+`4x4x6` and `-258.857540` against `-218.564065` on `6^3`. The staggered sector at its **worst** twist still beats the plain sector at its best, by `3.92`, `10.15`
+and `36.58` respectively. The twisted Bloch formulas `+-sqrt(6 + 2 sum_a cos q_a)` and `2 sum_a cos q_a`, with a half-integer momentum shift on each twisted axis,
+reproduce all 48 twisted real-space spectra of those three tori.
+
+**Proof.** Both statements are `[numerical, 1e-9]`: the eight twisted fields are built explicitly per sector, diagonalised, and compared, and the Bloch spectra are
+compared eigenvalue by eigenvalue against the real-space ones.
+
+**Reading, not theorem.** A sign on each link is not the whole story on a ring: besides the sign around every small square there is a sign around each way through
+the box, and the squares do not fix those. This is a real freedom, and it moves the numbers. It does not move the comparison: the worst way of running the
+minus-on-every-square field around the box is still cheaper than the best way of running the plain one.
+
+## Theorem 4 -- the Cauchy-Schwarz certificate on the 4^3 torus
+
+**Conclusion.**
+
+1. The `4^3` coarse torus is bipartite, coloured by `(-1)^{v_1+v_2+v_3}`, with every degree `6`. So for **any** link-sign field on it the integer hopping matrix
+   satisfies `tr M^2 = 2|E| = 6V = 384` and `D M D = -M` for the colour involution `D`, hence has a spectrum symmetric about `0`.
+2. The `V/2` lowest levels are therefore the negatives of the `V/2` highest, their squares sum to `(1/2) tr M^2 = 3V = 192`, and Cauchy-Schwarz gives
+   `E_{V/2} = -sum |lambda| >= -sqrt((V/2)(3V)) = -V sqrt(3/2) = -32 sqrt6 = -78.383672`, with **equality exactly when every `|lambda| = sqrt6`**.
+3. The all-`(-1)` sector at its optimal twist satisfies `M^2 = 6 I` exactly, as a `64x64` integer matrix identity, so its spectrum is `+-sqrt6` with multiplicity
+   `32` each and its half-filling energy attains the bound. It is therefore a **global minimiser at half filling over all `2^192` link-sign fields on that torus**.
+4. The same bound reads `-117.5755` on `4x4x6`, `-264.5449` on `6^3` and `-627.0694` on `8^3`, and there the all-`(-1)` sector misses it by `0.766`, `5.687` and
+   `15.26`: its spectrum `+-sqrt(6 + 2 sum_a cos q_a)` is not flat on those tori. Global minimality is a theorem on `4^3` and a search result elsewhere.
+
+**Proof.** Items 1 and 3 are zero-tolerance integer matrix identities, item 1 on 52 fields including both uniform ones and item 3 on the single field named. Item
+2 applies Cauchy-Schwarz to the `V/2` numbers `|lambda|`, whose sum of squares item 1 pins. Item 4 evaluates the bound and the exact Bloch energies, `[1e-9]`.
+
+**Reading, not theorem.** Two facts about the box fix a floor no arrangement of signs can go below: every site has six neighbours, so the levels have a fixed total
+spread, and the box is two-colourable, so they come in plus-minus pairs. Spreading a fixed total spread over a fixed number of levels is cheapest when every level
+has the same size. On the smallest box the minus-on-every-square field, run the right way around the box, does exactly that: every level is the same size. So it is
+not merely better than everything tried -- it is as good as anything could be.
+
+## Theorem 5 -- the searches
+
+**Conclusion.** At half filling on the tori `4^3` and `4x4x6`, all `[numerical, 1e-9]` and all **search results, not theorems**:
+
+1. `2000` random link-sign fields per torus, each realising a consistent sector as drawn, and a `500`-field subsample with each field minimised over its own eight
+   twists: `0` of `2500` beats the all-`(-1)` sector on either torus.
+2. The structured sectors with flux only on the `xy`, `xz` or `yz` plaquettes, `xy` flux on alternating `x` planes, and flux on the `xz` and `yz` plaquettes
+   together are consistent and all strictly above the all-`(-1)` sector. Flux on the even-parity faces, `xz+yz` on alternating planes, and a single-face flip off
+   the all-`(-1)` sector are **inconsistent**: every face lies in two cube relations, so no sector differs from another in one face alone.
+3. Greedy single-link descent from `24` random restarts per torus never beats the all-`(-1)` field at its optimal twist. On `4^3` its best equals that field
+   exactly, `3` of `24` restarts reaching it. On `4x4x6` its best stays above, at `-116.134` against `-116.809`.
+4. That field is a strict local minimum: every one of the `192` and `288` single-link flips raises `E_{V/2}`, by at least `0.426844` and `0.365352`.
+
+**Proof.** Direct evaluation of `E_{V/2}` for each field, with the consistency of a structured assignment decided by the `F2` relations among the `S_f` before any
+diagonalisation. The negative statements are statements about the samples drawn and the descent runs made, at the seeds the runner fixes, and are not claims about
+the whole space.
+
+**Reading, not theorem.** Two thousand random arrangements, five patterned ones, and a descent free to change any single link: nothing beats the
+minus-on-every-square arrangement, and on the smallest box the descent walks straight back to it. Away from that box this is evidence, not proof.
+
+## Theorem 6 -- the thermodynamic limit and the crossing filling
+
+**Conclusion.** From the exact Bloch formulas -- `E = +- sqrt(6 + 2 sum_a cos q_a)` for the all-`(-1)` sector, fourfold, and `2 sum_a cos q_a` for the all-`(+1)`
+one -- evaluated at `L = 4, 8, 16, 32, 64, 96` and by converged Brillouin-zone quadrature:
+
+1. At half filling `e(+) = -1.00241973` and `e(-) = -1.19380112`, a difference of `-0.19138139 |t|` per coarse site in favour of the staggered sector.
+2. At quarter filling the difference is `+0.07909` per coarse site at `L = 96`, in favour of the plain sector.
+3. The crossing filling `n* = N*/V` settles to `0.339659` along the sequence `0.3594, 0.3287, 0.3340, 0.3380, 0.3411, 0.3398, 0.3394, 0.3397, 0.3396, 0.3397` at
+   `L = 4, 6, 8, 12, 16, 24, 32, 48, 64, 96`, and the window ends at the mirror `1 - n* = 0.660341`.
+
+**Proof.** Item 1 is `[numerical]` at converged quadrature: the reduced-grid Brillouin-zone integrals at `M = 600, 1200, 2400` agree to `1e-8` in `e(-)` and settle
+to the digits quoted in `e(+)`. Items 2 and 3 are `[numerical, 1e-9]` on the `L = 96` Bloch grid, `n*` read off it by linear interpolation of the difference.
+
+**Reading, not theorem.** In a large box the two arrangements differ by a fixed amount per site, not a vanishing one. Fill a third of the sites or fewer and the
+plain arrangement is cheaper; fill more, up to two thirds, and the other is cheaper, by about a fifth of a hopping unit per site at half filling.
+
+## Corollary -- what this says about the framework's kinetic form
+
+Within the setting declared above, and on the finite blocks and tori named:
+
+1. The law's own hopping term selects the framework's staggered kinetic form at half filling. No face term is supplied, and none is needed: the term already in the
+   law does the selecting, uniquely on the `2x2x2` cube, provably against all link-sign fields on the `4^3` torus, and by a fixed amount per site in the limit.
+2. The selection is a property of the **matter density**. Below `n* ~ 0.3397` and above `1 - n*` the plain sector is cheaper; between them the staggered sector is.
+   At `N = 0` -- the record vacuum, no matter present -- every sector ties exactly, and at `N = V` they tie again.
+3. So the question "which sector" is answered by "how much matter", and the filling is a supplied datum, not something this note derives. What the face-transport
+   note calls a free choice under the law as written is free only until a matter density is named; once one is, the hopping term already in the law fixes the sector.
+4. The `-J sum_f S_f` term that note describes is not needed for the half-filled case and is not supplied here. Nothing below the level of the hopping term is
+   added, and no coefficient, coupling, rate or unit appears anywhere in this note.
+
+**Reading, not theorem.** With no matter present, the sign on the squares costs nothing either way. Put in enough matter, about a third of the sites or more, and
+the arrangement with a minus on every square is the cheapest by a fixed amount per site. That arrangement is the framework's staggered kinetic form: it is not
+chosen by the law's wording; it is chosen by the matter's own energy.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice, the encoding, the sign fields and the filling are declared objects, and the theorems are about them.
+- No update rule, formation site, formation rate, coupling, mass, absolute unit or dynamical clause appears. The filling is supplied, never derived.
+- No claim is made that a Lieb-type flux-phase theorem holds on the cubic lattice. The certificate of Theorem 4 is a Cauchy-Schwarz bound on one named torus.
+
+## Interfaces named for other lanes, not moved here
+
+- **The filling as a supplied datum.** Every statement here is conditional on `N`. Which filling the coarse lattice actually carries is a science question a lane
+  owning the matter density must answer; nothing here narrows it, and Corollary item 3 states exactly what such a lane would have to supply.
+- **Interacting terms.** Only free nearest-neighbour hopping is compared. A four-fermion term, or any interaction, could order the sectors differently, and no such
+  term is examined.
+- **Global minimality beyond `4^3`.** Theorem 4 is a theorem on the `4^3` torus and on the `2x2x2` cube only. On `4x4x6`, `6^3` and `8^3` the bound is missed and
+  the statement is the search result of Theorem 5. A lane wanting global minimality there must supply a different certificate.
+- **The Wilson-line convention.** Theorem 3 makes the twist explicit; which twist a physical setting selects is not decided here.
+- **The many-body energetics.** Only the one-particle ladder `E_N` is used, the ground state of the free problem; what an interacting ground state prefers is
+  untouched.
+
+## Remaining live routes
+
+1. Larger blocks and other geometries. The four tori and two open blocks named are what is proved; nothing is claimed beyond them.
+2. Other fillings on the cube. Theorem 1 names a minimiser for each `N` on the `2x2x2` cube; the corresponding statement on larger clusters is not made.
+3. Finite temperature. Everything here is a ground-state energy at fixed particle number, and `N = 0` and `N = V` tie exactly across all sectors.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one mode per coarse vertex, BK superfast encoding on it, free nearest-neighbour hopping only; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+objects: KS eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}; plain +1; S_f the face stabilizer; flux sector = consistent choice of S_f eigenvalues; E_N = sum of the N lowest levels of M_ij = eta_ij
+cube_2x2x2: 32 of 64 face assignments consistent (flux counts 0, 2, 4, 6), confirmed by all 2^12 link fields giving exactly 32 holonomy patterns; E_N(+1) = 0, -3, -4, -5, -6, -5, -4, -3, 0; E_N(-1) = -N sqrt3 for N <= 4 and mirror
+cube_minimisers: N = 4 unique all-(-1), margin 0.456067 to the next distinct value and 4 sqrt3 - 6 to plain; ties 32, 1, 3, 12, 1, 12, 3, 1, 32 and minimiser flux counts all, 0, 2, 4, 6, 4, 2, 0, all
+uniform_window: tori 4^3, 4x4x6, 6^3, 8^3 and open blocks 3^3, 4^3; sign(E_N(-) - E_N(+)) is + below N*, - on [N*, V - N*], + above, symmetric under N -> V - N; N* = 23, 30, 71, 171, 10, 22
+exact_L4: E_32(-) - E_32(+) = 36 - 24 sqrt2 - 8 sqrt3; E_16(-) - E_16(+) = 48 - 24 sqrt2 - 8 sqrt3 > 0; first sign change N* = 23 at 46 - 24 sqrt2 - 8 sqrt3
+wilson: S_f fix no torus Wilson line; twist-minimised E_{V/2} = -78.383672 vs -67.882251 (4^3), -116.809009 vs -99.882251 (4x4x6), -258.857540 vs -218.564065 (6^3); staggered at its worst twist beats plain at its best by 3.92, 10.15, 36.58
+certificate: 4^3 bipartite, all degrees 6, so tr M^2 = 6V = 384 and D M D = -M for any link field; E_{V/2} >= -V sqrt(3/2) = -32 sqrt6 = -78.383672, equality iff every |lambda| = sqrt6; all-(-1) at its optimal twist has M^2 = 6 I exactly, spectrum +-sqrt6 x32 each, attains the bound: global minimiser over all 2^192 fields
+certificate_gaps: bound -117.5755, -264.5449, -627.0694 on 4x4x6, 6^3, 8^3, missed by 0.766, 5.687, 15.26
+searches: 2000 random fields per torus plus a 500-field Wilson-minimised subsample, 0 of 2500 beating all-(-1) on 4^3 or 4x4x6; five structured sectors consistent and all above; even-parity faces, alternating xz+yz and any one-face flip inconsistent; 24 greedy restarts per torus never beat it and on 4^3 return it; strict local minimum, smallest single-flip rise 0.426844 and 0.365352
+thermodynamic: e(+) = -1.00241973, e(-) = -1.19380112 at half filling, difference -0.19138139 |t| per coarse site; +0.07909 at quarter filling at L = 96; n* -> 0.339659, mirror 0.660341
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=19 FAIL=0
+```
+
+## Proof boundary
+
+The content is **free nearest-neighbour hopping only**, on **finite** clusters, at a **supplied** filling. No interaction, mass, coupling, rate, temperature or
+absolute unit appears, and no dynamical clause is proposed. Nothing here is derived from the four axioms.
+
+Global minimality over all link-sign fields is a **theorem on exactly two clusters**: the open `2x2x2` cube, by exhaustion of all `2^12` fields, and the `4^3`
+coarse torus, by the Cauchy-Schwarz certificate whose equality case the all-`(-1)` sector meets. On `4x4x6`, `6^3` and `8^3` the bound is missed by the stated gaps
+and the corresponding statement is a **search result** -- a statement about the samples drawn and the descent runs made at the runner's fixed seeds, not about the
+whole space. Theorem 3 and Theorem 5 are search results throughout and are labelled so wherever they are used.
+
+No Lieb-type flux-phase theorem is claimed for the cubic lattice. Lieb's theorem is planar; it is named as background only and no step below invokes it.
+
+The three torus **Wilson lines** are gauge-invariant data that no face stabilizer fixes, so "the sector" alone does not name a link-sign field on a torus. Every
+torus comparison here is either at the stated twist or minimised over all eight, and Theorem 3 records both. Theorem 5's `4x4x6` descent result is that the best
+restart stays *above* the all-`(-1)` field, not that it reaches it; only the `4^3` descent returns that field exactly.
+
+The identification of the all-`(-1)` sector with the staggered kinetic form is up to a **site relabelling**, and is verified spectrally here only on the clusters
+small enough for the sector to be formed directly from the `S_f`; on the larger tori the KS field is used and its holonomy is `-1` on every face by construction.
+
+## Review record
+
+An honest auditor should come away with: one exhaustive finite-cluster theorem naming the staggered sector as the unique half-filling minimiser on the `2x2x2`
+cube; one exact-surd statement of where the two uniform sectors cross on four tori and two open blocks, with a single contiguous window symmetric about half
+filling; one genuine certificate -- a Cauchy-Schwarz bound whose equality case the staggered sector meets exactly on the `4^3` torus, making it a global minimiser
+there over all `2^192` link-sign fields; a clearly labelled band of search results away from that torus; and one honest limit, that the whole statement is
+conditional on a filling this note does not derive.
+
+The three things most likely to be over-read are flagged in the proof boundary: global minimality holds as a theorem on two clusters only; the `4x4x6` descent does
+not reach the staggered field, it merely fails to beat it; and no cubic-lattice flux-phase theorem is claimed. This note is self-contained:
+`upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the three context notes in "Imports and authority" are
+plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=19 FAIL=0`, runtime under the
+declared `120` seconds, stdout under `5500` characters, a current zero-dependency citation-manifest entry, and passing pipeline, strict-lint and changed-evidence
+gates; independent audit remains a separate lane.

--- a/logs/runner-cache/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.txt
+++ b/logs/runner-cache/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.txt
@@ -1,0 +1,44 @@
+===== runner cache v1 =====
+runner: scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py
+runner_sha256: 311a6a400423359d23bca50786976a0746e5ed45858b97a0347a5df54467eb8b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 19.32
+status: ok
+----- stdout -----
+PASS A1 [exact] open 2x2x2 cube, 6 faces with one F2 relation: 32 of 64 face assignments are consistent sectors, flux counts [0, 2, 4, 6]; the 4096 link fields realise exactly those 32 patterns, spectrum constant on each (4e-15)
+PASS A2 [exact, sympy] uniform sectors on the cube, exact integer 8x8 matrices: E_N(+1) = 0, -3, -4, -5, -6, -5, -4, -3, 0; E_N(-1) = -N sqrt3 for N <= 4 and its mirror
+   N=0..8 min E_N: 0.000 -3.000 -4.828 -5.878 -6.928 -5.878 -4.828 -3.000 -0.000
+   ties/flux     : 32/all 1/0 3/2 12/4 1/6 12/4 3/2 1/0 32/all
+PASS A3 [exact] at N = 4 the all-(-1) sector UNIQUELY minimises all 32: margin 0.456067 to the next value, 4 sqrt3 - 6 = 0.928203 to plain. Minimiser: plain at N = 1, 7; two-flux at N = 2, 6; four-flux at N = 3, 5; all 32 tie at N = 0, 8
+PASS B1 [exact, sympy] torus 4^3: integer minimal-polynomial and trace witnesses fix both spectra. E_32 = -60 (plain) and -24*sqrt(2) - 24 - 8*sqrt(3) (staggered); E_N(-) - E_N(+) = c - 24sqrt2 - 8sqrt3 with c = 48 at N = 16 (+0.2025), 36 at N = 32 (-11.7975), 46 at the first sign change N* = 23 (-1.7975)
+   name     V |  E(+) V/4,V/2,3V/4 |  E(-) same        |  N*
+   T4^3    64 |  -48.0  -60.0  -48.0 |  -47.8  -71.8  -47.8 |  23
+   T4x4x6  96 |  -76.0  -96.0  -76.0 |  -69.4 -112.3  -69.4 |  30
+   T6^3   216 | -168.0 -216.0 -168.0 | -149.5 -258.9 -149.5 |  71
+   T8^3   512 | -400.5 -506.6 -400.5 | -357.4 -609.4 -357.4 | 171
+   B3^3    27 |  -15.6  -21.2  -17.0 |  -13.8  -26.0  -15.8 |  10
+   B4^3    64 |  -42.8  -56.0  -42.8 |  -39.7  -66.0  -39.7 |  22
+PASS B2 [numerical, 1e-9] tori 4^3, 4x4x6, 6^3, 8^3 (Bloch) and open blocks 3^3, 4^3: staggered strictly lower at half filling on all six, higher at quarter and three-quarter; the sector read off S_f matches KS spectrally where formed
+PASS B3 [numerical, 1e-9] sign(E_N(-) - E_N(+)) is + below N*, - on all of [N*, V - N*], + above -- one contiguous window, symmetric under N -> V - N -- with N* = (23, 30, 71, 171, 10, 22) in table order
+PASS C1 [numerical, 1e-9] the S_f fix no Wilson line, so a sector is a family of 8 fields. Minimised over them: -78.384 vs -67.882 (4^3, staggered W=---), -116.809 vs -99.882 (4x4x6), -258.858 vs -218.564 (6^3); staggered at its WORST twist beats plain at its best by 3.92, 10.15, 36.58
+PASS C2 [numerical, 1e-9] the Bloch formulas +-sqrt(6 + 2 sum cos q_a) and 2 sum cos q_a, with a half-integer shift per twisted axis, reproduce all 48 twisted real-space spectra of the three tori, max deviation 2.7e-14
+PASS D1 [exact, integer] the 4^3 torus is bipartite (colour (-1)^{|v|}), every degree 6, so ANY link-sign field has tr M^2 = 2|E| = 6V = 384 and D M D = -M, a spectrum symmetric about 0 -- zero-tolerance integer identities on 52 fields
+PASS D2 [exact] the V/2 lowest levels are minus the V/2 highest, so their squares sum to (1/2) tr M^2 = 3V = 192 and Cauchy-Schwarz gives E_{V/2} >= -V sqrt(3/2) = -32 sqrt6 = -78.383672 on 4^3, equality iff every |lambda| = sqrt6
+PASS D3 [exact, integer] the all-(-1) sector at its optimal twist has M^2 = 6 I EXACTLY (64x64 integer identity), spectrum +-sqrt6 x32 each, so E_32 = -32 sqrt6 = -78.383672 attains the bound: a GLOBAL minimiser over all 2^192 link-sign fields
+PASS D4 [numerical, 1e-9] elsewhere the spectrum is not flat and the bound is missed: -117.58 vs -116.81 on 4x4x6 (gap 0.766), -264.54 vs -258.86 on 6^3 (gap 5.687), -627.07 vs -611.81 on 8^3 (gap 15.26)
+PASS E1 [numerical, 1e-9] 2000 random link fields per torus: E_{V/2} min/med/max as drawn -69.5/-67.6/-66.0 (4^3), -103.7/-101.4/-99.2 (4x4x6), and -69.5/-68.0/-66.7, -103.7/-101.8/-99.9 over 500-field Wilson-minimised subsamples; 0 of 2500 beats all-(-1)
+PASS E2 [numerical, 1e-9] structured sectors -- flux only on xy, xz or yz plaquettes, xy on alternating x planes, xz+yz -- are consistent and all above all-(-1); even-parity-face flux, alternating xz+yz and a one-face flip are inconsistent
+PASS E3 [numerical, 1e-9] greedy single-link descent, 24 random restarts per torus, never beats the Wilson-minimised all-(-1) field: best -78.384 on 4^3, exactly that field (3 of 24 reach it); best -116.134 on 4x4x6, above -116.809
+PASS E4 [numerical, 1e-9] the all-(-1) field at its optimal twist is a strict local minimum of E_{V/2}: all 192 and all 288 single-link flips raise it, by at least 0.426844 (4^3) and 0.365352 (4x4x6)
+   L=4..96 e(+)1/2: -0.93750 -0.98937 -1.00075 -1.00217 -1.00238 -1.00240
+           e(-)1/2: -1.12184 -1.19015 -1.19359 -1.19379 -1.19380 -1.19380
+PASS F1 [numerical, 1e-9] exact Bloch formulas at L = 4..96 (above): at half filling staggered is lower at every L, settling at e(-) = -1.19380096 vs e(+) = -1.00240220; at quarter filling higher at every L, by +0.07909 per site
+PASS F2 [numerical, converged quadrature] the BZ integrals of |2 sum cos q| and sqrt(6 + 2 sum cos q) on reduced grids M = 600, 1200, 2400 converge to e(+) = -1.00241973, e(-) = -1.19380112 at half filling; difference -0.19138139 |t| per site
+   n* by L: 4:0.3594 8:0.3340 32:0.3394 96:0.3397
+PASS F3 [numerical, 1e-9] the crossing filling n* = N*/V settles to 0.339659 (above), the window ending at the mirror 1 - n* = 0.660341: plain is cheaper below about a third filling and above its mirror
+SUMMARY: the law's hopping term is not indifferent to the sector -- at half filling the all-(-1) (staggered) sector wins on every block tested; below n* = 0.3397 the plain sector wins.
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py
+++ b/scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py
@@ -1,0 +1,884 @@
+#!/usr/bin/env python3
+"""Half filling selects the staggered flux sector of the emergent fermion.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3, one
+fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding
+written on it.  Transport of one encoded excitation around a coarse face
+equals that face's stabilizer S_f, so a choice of eigenvalue +-1 per face --
+a flux sector -- is exactly a Z2 gauge class of nearest-neighbour link signs.
+The all-(+1) sector is the plain hopping; the all-(-1) sector is the
+framework's staggered (Kawamoto-Smit) kinetic form
+    eta_1 = 1,  eta_2(x) = (-1)^{x_1},  eta_3(x) = (-1)^{x_1+x_2}.
+The law as written attaches no coefficient to any face term, so the sector is
+a free choice under the law.  This runner asks instead what the law's own
+hopping term costs in each sector at a given filling.
+
+  A  EXHAUSTIVE CUBE.  On the open 2x2x2 coarse cube there are exactly 32
+     consistent flux sectors.  E_N = sum of the N lowest one-particle levels
+     for every sector and every N.  At half filling the all-(-1) sector is
+     the unique minimiser of all 32; at other fillings the minimiser is a
+     different flux class.
+  B  UNIFORM SECTORS.  The two uniform sectors on the tori 4^3, 4x4x6, 6^3,
+     8^3 and the open blocks 3^3, 4^3.  sign(E_N(-) - E_N(+)) is one
+     contiguous negative window [N*, V - N*], symmetric under N -> V - N.
+     Exact surds at L = 4.
+  C  WILSON LINES.  The face stabilizers do not fix the three torus Wilson
+     lines.  Each uniform sector is minimised over its eight twists.
+  D  CAUCHY-SCHWARZ CERTIFICATE.  On a bipartite graph with all degrees 6,
+     every link-sign field has tr M^2 = 6V and a symmetric spectrum, so
+     E_{V/2} >= -V sqrt(3/2), with equality iff every |lambda| = sqrt6.  On
+     the 4^3 torus the all-(-1) sector at its optimal twist has M^2 = 6 I
+     exactly, so it attains the bound and is a global minimiser there.
+  E  SEARCH.  Random sectors, structured sectors and greedy single-link
+     descent at half filling: nothing found beats the all-(-1) sector.
+  F  THERMODYNAMIC.  Per-site energies from the exact Bloch formulas and the
+     converged Brillouin-zone quadrature, and the crossing filling n*.
+
+Groups A and the L = 4 content of B are exact -- sympy surds, integer matrix
+arithmetic at zero tolerance, F2/Z4 symplectic bit arithmetic, exhaustive
+enumeration -- and so is group D, whose certificate is an integer matrix
+identity.  Items tagged [numerical] are floating-point statements at the
+stated tolerance.  Groups C and E are search results, not theorems.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from collections import deque
+
+import numpy as np
+import sympy as sp
+
+AUDIT_TIMEOUT_SEC = 120
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ================================================ coarse lattice and KS phases
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    """KS link sign of the coarse bond (v, v + e_a); axes 0,1,2 = 1,2,3."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def wrap(v, dims):
+    return tuple(v[i] % dims[i] for i in range(3))
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+class Q:
+    """i^k X^x Z^z on a register of qubits indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def isI(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def ismI(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+    def vec(s, n):
+        return s.x | (s.z << n)
+
+
+IDQ = Q(0, 0, 0)
+
+
+def qprod(seq):
+    o = IDQ
+    for p in seq:
+        o = o * p
+    return o
+
+
+class Lat:
+    """Coarse cubic block or torus with the BK superfast encoding on its edges."""
+
+    def __init__(self, dims, periodic):
+        self.dims = tuple(dims)
+        self.per = periodic
+        self.V = list(itertools.product(*(range(d) for d in dims)))
+        self.nv = len(self.V)
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+        self.idx = {v: i for i, v in enumerate(self.V)}
+        self.rows = np.array([self.idx[self.step(v, EX[ax])] for (v, ax) in self.E])
+        self.cols = np.array([self.idx[v] for (v, ax) in self.E])
+
+    def step(self, v, d):
+        w = va(v, d)
+        if self.per:
+            return wrap(w, self.dims)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def B(self, v):
+        return Q(0, 0, self.star[v])
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+    def mat(self, s):
+        """Real symmetric hopping matrix of the link-sign vector s (edge order)."""
+        M = np.zeros((self.nv, self.nv))
+        np.add.at(M, (self.rows, self.cols), np.asarray(s, dtype=float))
+        return M + M.T
+
+    def imat(self, s):
+        """Integer hopping matrix of the link-sign vector s."""
+        M = np.zeros((self.nv, self.nv), dtype=np.int64)
+        np.add.at(M, (self.rows, self.cols), np.asarray(s, dtype=np.int64))
+        return M + M.T
+
+    def EN(self, s, N):
+        return float(np.sum(np.sort(np.linalg.eigvalsh(self.mat(s)))[:N]))
+
+
+def transport(L, path):
+    """Ordered product of the encoded hops T_{i_{k+1} i_k} = (i/2) A (B - B).
+
+    On any configuration where every step is legal -- source occupied, target
+    empty -- each factor contributes (i/2)(+1 - (-1)) = i, hence the i^n.
+    """
+    n = len(path) - 1
+    ops = [L.Aij(path[k + 1], path[k]) for k in range(n)]
+    return qprod(ops[::-1]).scal(n)
+
+
+def f2_pivots(gens):
+    piv = {}
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+    return piv
+
+
+def f2_express(target, piv):
+    v, c = target, 0
+    while v:
+        p = v.bit_length() - 1
+        if p not in piv:
+            return None
+        pv, pc = piv[p]
+        v ^= pv
+        c ^= pc
+    return c
+
+
+def f2_relations(gens):
+    piv, rel = {}, []
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+        if v == 0:
+            rel.append(c)
+    return rel, len(piv)
+
+
+def bits(m):
+    out = []
+    while m:
+        b = m & -m
+        out.append(b.bit_length() - 1)
+        m ^= b
+    return out
+
+
+def sector_eta(L, face_vals, wilson=(1, 1, 1)):
+    """Link-sign field realising the flux sector S_f = face_vals[f] on Lat L.
+
+    Spanning-tree gauge fixing, then fundamental-cycle transport with the
+    residual Z4 phase read off, exactly as in the face-transport theorem;
+    the face eigenvalues are supplied rather than fixed at -1.  Returns
+    (eta, consistent); eta is None when the sector is inconsistent.
+    """
+    root = L.V[0]
+    par = {root: None}
+    dq = deque([root])
+    while dq:
+        v = dq.popleft()
+        for r in range(6):
+            if r not in L.inc[v]:
+                continue
+            w = L.inc[v][r][0]
+            if w not in par:
+                par[w] = v
+                dq.append(w)
+    tree = {frozenset((v, w)) for w, v in par.items() if v is not None}
+
+    def tpath(v):
+        p = [v]
+        while par[p[-1]] is not None:
+            p.append(par[p[-1]])
+        return p[::-1]
+
+    F = L.faces()
+    gens = [L.loop(f) for f in F]
+    vals = list(face_vals)
+    if L.per:
+        for ax in range(3):
+            cyc = [wrap(tuple((k if i == ax else 0) for i in range(3)), L.dims)
+                   for k in range(L.dims[ax])]
+            gens.append(transport(L, cyc + [cyc[0]]))
+        vals += list(wilson)
+    gv = [g.vec(L.nq) for g in gens]
+    piv = f2_pivots(gv)
+    rels, _ = f2_relations(gv)
+    for r in rels:
+        idxs = bits(r)
+        pr = qprod([gens[j] for j in idxs])
+        eps = 1 if pr.isI() else (-1 if pr.ismI() else 0)
+        pv = 1
+        for j in idxs:
+            pv *= vals[j]
+        if eps == 0 or pv != eps:
+            return None, False
+    eta = {}
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        if frozenset((v, w)) in tree:
+            eta[(v, ax)] = 1
+            continue
+        op = transport(L, tpath(v) + [w] + tpath(w)[::-1][1:])
+        c = f2_express(op.vec(L.nq), piv)
+        if c is None:
+            return None, False
+        idxs = bits(c)
+        resid = (op.k - qprod([gens[j] for j in idxs]).k) & 3
+        if resid not in (0, 2):
+            return None, False
+        e = 1 if resid == 0 else -1
+        for j in idxs:
+            e *= vals[j]
+        eta[(v, ax)] = e
+    return eta, True
+
+
+def hol_list(L, eta):
+    """Plaquette holonomy of the sign field eta, one entry per face."""
+    out = []
+    for (v, a, c, b) in L.faces():
+        pr = 1
+        for (p, q) in ((v, a), (a, c), (b, c), (v, b)):
+            for ax in range(3):
+                if L.step(p, EX[ax]) == q and (p, ax) in eta:
+                    pr *= eta[(p, ax)]
+                    break
+                if L.step(q, EX[ax]) == p and (q, ax) in eta:
+                    pr *= eta[(q, ax)]
+                    break
+        out.append(pr)
+    return out
+
+
+def vec_of(L, eta):
+    return np.array([eta[(v, ax)] for (v, ax) in L.E], dtype=float)
+
+
+def ladder(ev):
+    """E_N = sum of the N lowest levels, N = 0..V."""
+    return np.concatenate(([0.0], np.cumsum(np.sort(ev))))
+
+
+# ================================================== group A: the 2x2x2 cube
+
+CUBE = Lat((2, 2, 2), False)
+FC = CUBE.faces()
+sectors = {}
+for sgn in itertools.product([1, -1], repeat=len(FC)):
+    eta, ok = sector_eta(CUBE, sgn)
+    if not ok:
+        continue
+    if tuple(hol_list(CUBE, eta)) != tuple(sgn):
+        sectors = None
+        break
+    sectors[sgn] = np.linalg.eigvalsh(CUBE.mat(vec_of(CUBE, eta)))
+
+seen, gauge_dev = {}, 0.0
+for m in range(1 << CUBE.nq):
+    s = np.array([1 - 2 * ((m >> i) & 1) for i in range(CUBE.nq)], dtype=float)
+    eta = {e: s[i] for i, e in enumerate(CUBE.E)}
+    hol = tuple(int(h) for h in hol_list(CUBE, eta))
+    ev = np.linalg.eigvalsh(CUBE.mat(s))
+    if hol in seen:
+        gauge_dev = max(gauge_dev, float(np.abs(seen[hol] - ev).max()))
+    else:
+        seen[hol] = ev
+nflux = sorted({sum(1 for x in k if x < 0) for k in sectors})
+check(
+    "A1 [exact] open 2x2x2 cube, 6 faces with one F2 relation: %d of 64 face assignments are consistent sectors, "
+    "flux counts %s; the 4096 link fields realise exactly those %d patterns, spectrum constant on each (%.0e)" % (len(sectors), nflux, len(seen), gauge_dev),
+    len(sectors) == 32 and set(seen) == set(sectors) and gauge_dev < 1e-12 and nflux == [0, 2, 4, 6],
+)
+
+ALLP = tuple([1] * 6)
+ALLM = tuple([-1] * 6)
+exact_lad = {}
+for tag, sgn in (("+", ALLP), ("-", ALLM)):
+    eta, _ = sector_eta(CUBE, sgn)
+    M = sp.Matrix(CUBE.imat(vec_of(CUBE, eta)).tolist())
+    ev = sorted(sum(([sp.nsimplify(sp.radsimp(k))] * m for k, m in M.eigenvals().items()), []),
+                key=lambda e: float(e))
+    exact_lad[tag] = [sp.simplify(sum(ev[:N])) for N in range(CUBE.nv + 1)]
+plainrow = [sp.Integer(x) for x in (0, -3, -4, -5, -6, -5, -4, -3, 0)]
+sqrt3row = [-min(N, 8 - N) * sp.sqrt(3) for N in range(9)]
+check(
+    "A2 [exact, sympy] uniform sectors on the cube, exact integer 8x8 matrices: E_N(+1) = %s; E_N(-1) = -N sqrt3 "
+    "for N <= 4 and its mirror"
+    % ", ".join(str(x) for x in exact_lad["+"]),
+    [sp.simplify(a - b) == 0 for a, b in zip(exact_lad["+"], plainrow)] == [True] * 9
+    and [sp.simplify(a - b) == 0 for a, b in zip(exact_lad["-"], sqrt3row)] == [True] * 9,
+)
+
+lad = {k: ladder(v) for k, v in sectors.items()}
+mins, ties, gaps, mflux = {}, {}, {}, {}
+for N in range(CUBE.nv + 1):
+    vals = {k: lad[k][N] for k in sectors}
+    mn = min(vals.values())
+    tied = [k for k in vals if vals[k] < mn + 1e-9]
+    distinct = sorted({round(v, 9) for v in vals.values()})
+    mins[N] = mn
+    ties[N] = len(tied)
+    gaps[N] = (distinct[1] - distinct[0]) if len(distinct) > 1 else float("nan")
+    mflux[N] = sorted({sum(1 for x in k if x < 0) for k in tied})
+print("   N=0..8 min E_N: " + " ".join("%.3f" % mins[N] for N in range(9)))
+print("   ties/flux     : " + " ".join(
+    "%d/%s" % (ties[N], "/".join(map(str, mflux[N])) if len(mflux[N]) < 4 else "all") for N in range(9)))
+margin_plain = float(lad[ALLP][4] - lad[ALLM][4])
+check(
+    "A3 [exact] at N = 4 the all-(-1) sector UNIQUELY minimises all 32: margin %.6f to the next value, "
+    "4 sqrt3 - 6 = %.6f to plain. Minimiser: plain at N = 1, 7; two-flux at N = 2, 6; four-flux at N = 3, 5; all "
+    "32 tie at N = 0, 8" % (gaps[4], margin_plain),
+    ties[4] == 1 and mflux[4] == [6] and abs(gaps[4] - 0.456067275) < 1e-8
+    and abs(margin_plain - float(4 * sp.sqrt(3) - 6)) < 1e-12
+    and [mflux[N] for N in range(9)] == [[0, 2, 4, 6], [0], [2], [4], [6], [4], [2], [0], [0, 2, 4, 6]]
+    and [ties[N] for N in (1, 2, 3, 5, 6, 7)] == [1, 3, 12, 12, 3, 1]
+    and ties[0] == 32 and ties[8] == 32,
+)
+
+# ============================ group B: uniform sectors on tori and open blocks
+
+
+def bloch_minus(dims, w=(0, 0, 0)):
+    """all-(-1) sector: E = +- sqrt(6 + 2 sum_a cos q_a), fourfold, on the
+    halved cell lattice, with a half-integer momentum shift per twisted axis."""
+    cs = [np.cos(2 * np.pi * (np.arange(d // 2) + 0.5 * w[a]) / (d // 2))
+          for a, d in enumerate(dims)]
+    s = (cs[0][:, None, None] + cs[1][None, :, None] + cs[2][None, None, :]).ravel()
+    e = np.sqrt(np.maximum(6 + 2 * s, 0.0))
+    return np.sort(np.repeat(np.concatenate([-e, e]), 4))
+
+
+def bloch_plus(dims, w=(0, 0, 0)):
+    """all-(+1) sector: eps(q) = 2 sum_a cos q_a on the site lattice."""
+    cs = [np.cos(2 * np.pi * (np.arange(d) + 0.5 * w[a]) / d) for a, d in enumerate(dims)]
+    return np.sort((2 * (cs[0][:, None, None] + cs[1][None, :, None]
+                         + cs[2][None, None, :])).ravel())
+
+
+TORUS4 = Lat((4, 4, 4), True)
+KS4 = vec_of(TORUS4, {e: eta_ks(*e) for e in TORUS4.E})
+PL4 = np.ones(TORUS4.nq)
+x = sp.symbols("x")
+EXACT = {}
+for tag, s, roots, mult in (
+    ("+", PL4, [sp.Integer(0), sp.Integer(2), sp.Integer(4), sp.Integer(6)], [20, 15, 6, 1]),
+    ("-", KS4, [sp.Integer(0), sp.Integer(2), 2 * sp.sqrt(2), 2 * sp.sqrt(3)], [8, 12, 12, 4]),
+):
+    Mi = TORUS4.imat(s)
+    poly = sp.Poly(sp.expand(sp.prod([(x - r) * (x + r) if r != 0 else x for r in roots])), x)
+    coeffs = [int(c) for c in poly.all_coeffs()[::-1]]
+    P = np.zeros((64, 64), dtype=object)
+    acc = np.eye(64, dtype=object)
+    Mo = Mi.astype(object)
+    for c in coeffs:
+        P = P + c * acc
+        acc = acc.dot(Mo)
+    tr, A = {}, np.eye(64, dtype=object)
+    for k in range(1, 9):
+        A = A.dot(Mo)
+        tr[k] = int(np.trace(A))
+    pred = {k: sum(2 * m * int(sp.nsimplify(r ** k)) for r, m in zip(roots, mult) if r != 0)
+            for k in (2, 4, 6, 8)}
+    full = sorted(sum(([r] * m + ([-r] * m if r != 0 else []) for r, m in zip(roots, mult)), []),
+                  key=lambda e: float(e))
+    EXACT[tag] = (
+        not P.any()
+        and all(tr[k] == pred[k] for k in (2, 4, 6, 8))
+        and all(tr[k] == 0 for k in (1, 3, 5, 7))
+        and len(full) == 64,
+        [sp.simplify(sum(full[:N])) for N in range(65)],
+    )
+okp, Ep = EXACT["+"]
+okm, Em = EXACT["-"]
+dif = [sp.simplify(Em[N] - Ep[N]) for N in range(65)]
+Nstar4 = next(N for N in range(1, 64) if sp.sign(dif[N]) == -1)
+check(
+    "B1 [exact, sympy] torus 4^3: integer minimal-polynomial and trace witnesses fix both spectra. E_32 = "
+    "-60 (plain) and %s (staggered); E_N(-) - E_N(+) = c - 24sqrt2 - 8sqrt3 with c = 48 at N = 16 (%+.4f), 36 at "
+    "N = 32 (%+.4f), 46 at the first sign change N* = %d (%+.4f)"
+    % (Em[32], float(dif[16]), float(dif[32]), Nstar4, float(dif[Nstar4])),
+    okp and okm
+    and [Ep[16], Ep[32], Ep[48]] == [-48, -60, -48]
+    and sp.simplify(dif[16] - (48 - 24 * sp.sqrt(2) - 8 * sp.sqrt(3))) == 0
+    and sp.simplify(dif[32] - (36 - 24 * sp.sqrt(2) - 8 * sp.sqrt(3))) == 0
+    and sp.simplify(dif[Nstar4] - (46 - 24 * sp.sqrt(2) - 8 * sp.sqrt(3))) == 0
+    and Nstar4 == 23,
+)
+
+BLOCKS = [((4, 4, 4), True, "T4^3"), ((4, 4, 6), True, "T4x4x6"), ((6, 6, 6), True, "T6^3"),
+          ((8, 8, 8), True, "T8^3"), ((3, 3, 3), False, "B3^3"), ((4, 4, 4), False, "B4^3")]
+LAD, NSTAR, WINDOW, SECOK = {}, [], True, True
+print("   name     V |  E(+) V/4,V/2,3V/4 |  E(-) same        |  N*")
+for dims, per, tag in BLOCKS:
+    if tag == "T8^3":
+        V = 512
+        lp, lm = ladder(bloch_plus(dims)), ladder(bloch_minus(dims))
+    else:
+        L = Lat(dims, per)
+        V = L.nv
+        ksf = {e: eta_ks(*e) for e in L.E}
+        if V <= 64:
+            eta, ok = sector_eta(L, [-1] * len(L.faces()))
+            SECOK = SECOK and ok and set(hol_list(L, eta)) == {-1} and float(
+                np.abs(np.sort(np.linalg.eigvalsh(L.mat(vec_of(L, eta))))
+                       - np.sort(np.linalg.eigvalsh(L.mat(vec_of(L, ksf))))).max()) < 1e-9
+        if per:
+            SECOK = SECOK and float(np.abs(np.sort(np.linalg.eigvalsh(L.mat(vec_of(L, ksf))))
+                                           - bloch_minus(dims)).max()) < 1e-9
+        lp = ladder(np.linalg.eigvalsh(L.mat(np.ones(L.nq))))
+        lm = ladder(np.linalg.eigvalsh(L.mat(vec_of(L, ksf))))
+    LAD[tag] = (V, lp, lm)
+    d = lm - lp
+    sg = np.sign(np.where(np.abs(d) < 1e-9, 0.0, d))[1:V]
+    ns = int(np.argmax(sg < 0)) + 1
+    NSTAR.append(ns)
+    neg = np.where(sg < 0)[0] + 1
+    WINDOW = (WINDOW and neg[0] == ns and neg[-1] == V - ns
+              and len(neg) == V - 2 * ns + 1 and bool(np.all(sg[:ns - 1] > 0))
+              and bool(np.all(sg[V - ns:] > 0))
+              and float(np.abs((d - d[::-1])[1:V]).max()) < 1e-8)
+    print("   %-6s%4d |%s |%s | %3d"
+          % (tag, V, "".join("%7.1f" % lp[k] for k in (V // 4, V // 2, 3 * V // 4)),
+             "".join("%7.1f" % lm[k] for k in (V // 4, V // 2, 3 * V // 4)), ns))
+check(
+    "B2 [numerical, 1e-9] tori 4^3, 4x4x6, 6^3, 8^3 (Bloch) and open blocks 3^3, 4^3: staggered strictly lower at "
+    "half filling on all six, higher at quarter and three-quarter; the sector read off S_f matches KS spectrally "
+    "where formed",
+    SECOK
+    and all(LAD[t][2][LAD[t][0] // 2] < LAD[t][1][LAD[t][0] // 2] - 1e-9 for t in LAD)
+    and all(LAD[t][2][LAD[t][0] // 4] > LAD[t][1][LAD[t][0] // 4] + 1e-9 for t in LAD),
+)
+check(
+    "B3 [numerical, 1e-9] sign(E_N(-) - E_N(+)) is + below N*, - on all of [N*, V - N*], + above -- one contiguous "
+    "window, symmetric under N -> V - N -- with N* = %s in table order"
+    % (tuple(NSTAR),),
+    WINDOW and NSTAR == [23, 30, 71, 171, 10, 22],
+)
+
+# ==================================================== group C: Wilson lines
+
+
+def twists(L):
+    return [np.array([1.0 if not (a == ax and v[ax] == L.dims[ax] - 1) else -1.0
+                      for (v, a) in L.E]) for ax in range(3)]
+
+
+def wilson_scan(L, base):
+    out = {}
+    cuts = twists(L)
+    for w in itertools.product([0, 1], repeat=3):
+        s = base.copy()
+        for ax in range(3):
+            if w[ax]:
+                s = s * cuts[ax]
+        out[w] = L.EN(s, L.nv // 2)
+    return out
+
+
+TORI = [((4, 4, 4), "4^3"), ((4, 4, 6), "4x4x6"), ((6, 6, 6), "6^3")]
+LATS = {tag: Lat(dims, True) for dims, tag in TORI}
+WMIN, BLOCH_DEV = {}, 0.0
+for dims, tag in TORI:
+    L = LATS[tag]
+    ksf = vec_of(L, {e: eta_ks(*e) for e in L.E})
+    rm, rp = wilson_scan(L, ksf), wilson_scan(L, np.ones(L.nq))
+    wm = min(rm, key=rm.get)
+    WMIN[tag] = (rm[wm], min(rp.values()), wm, max(rm.values()), max(rp.values()))
+    for w in itertools.product([0, 1], repeat=3):
+        s = ksf.copy()
+        sp_ = np.ones(L.nq)
+        for ax in range(3):
+            if w[ax]:
+                s = s * twists(L)[ax]
+                sp_ = sp_ * twists(L)[ax]
+        BLOCH_DEV = max(BLOCH_DEV,
+                        float(np.abs(np.sort(np.linalg.eigvalsh(L.mat(s))) - bloch_minus(dims, w)).max()),
+                        float(np.abs(np.sort(np.linalg.eigvalsh(L.mat(sp_))) - bloch_plus(dims, w)).max()))
+check(
+    "C1 [numerical, 1e-9] the S_f fix no Wilson line, so a sector is a family of 8 fields. Minimised over them: "
+    "%.3f vs %.3f (4^3, staggered W=%s), %.3f vs %.3f (4x4x6), %.3f vs %.3f (6^3); staggered at its WORST twist "
+    "beats plain at its best by %.2f, %.2f, %.2f"
+    % (WMIN["4^3"][0], WMIN["4^3"][1], "".join("-" if b else "+" for b in WMIN["4^3"][2]),
+       WMIN["4x4x6"][0], WMIN["4x4x6"][1], WMIN["6^3"][0], WMIN["6^3"][1],
+       WMIN["4^3"][1] - WMIN["4^3"][3], WMIN["4x4x6"][1] - WMIN["4x4x6"][3],
+       WMIN["6^3"][1] - WMIN["6^3"][3]),
+    all(abs(WMIN[t][0] - v) < 1e-6 for t, v in
+        (("4^3", -78.383672), ("4x4x6", -116.809009), ("6^3", -258.857540)))
+    and all(abs(WMIN[t][1] - v) < 1e-6 for t, v in
+            (("4^3", -67.882251), ("4x4x6", -99.882251), ("6^3", -218.564065)))
+    and all(WMIN[t][0] < WMIN[t][1] - 1e-9 for t in WMIN)
+    and all(WMIN[t][3] < WMIN[t][1] - 1e-9 for t in WMIN),
+)
+check(
+    "C2 [numerical, 1e-9] the Bloch formulas +-sqrt(6 + 2 sum cos q_a) and 2 sum cos q_a, with a half-integer shift "
+    "per twisted axis, reproduce all 48 twisted real-space spectra of the three tori, max deviation %.1e" % BLOCH_DEV,
+    BLOCH_DEV < 1e-9,
+)
+
+# ========================================== group D: the Cauchy-Schwarz bound
+
+T4 = LATS["4^3"]
+V4, E4 = T4.nv, T4.nq
+colour = np.array([1 - 2 * ((sum(v)) & 1) for v in T4.V], dtype=np.int64)
+deg = np.bincount(np.concatenate([T4.rows, T4.cols]), minlength=V4)
+RNG = np.random.default_rng(20260902)
+batch = [KS4, PL4] + [RNG.choice([-1.0, 1.0], E4) for _ in range(50)]
+trace_ok = sym_ok = True
+for s in batch:
+    Mi = T4.imat(s)
+    trace_ok = trace_ok and int(np.trace(Mi.dot(Mi))) == 6 * V4
+    sym_ok = sym_ok and not (colour[:, None] * Mi * colour[None, :] + Mi).any()
+BOUND4 = -V4 * float(np.sqrt(1.5))
+check(
+    "D1 [exact, integer] the 4^3 torus is bipartite (colour (-1)^{|v|}), every degree 6, so ANY link-sign field has "
+    "tr M^2 = 2|E| = 6V = %d and D M D = -M, a spectrum symmetric about 0 -- zero-tolerance integer identities on "
+    "%d fields" % (6 * V4, len(batch)),
+    trace_ok and sym_ok and set(deg.tolist()) == {6} and E4 == 3 * V4,
+)
+check(
+    "D2 [exact] the V/2 lowest levels are minus the V/2 highest, so their squares sum to (1/2) tr M^2 = 3V = %d and "
+    "Cauchy-Schwarz gives E_{V/2} >= -V sqrt(3/2) = -32 sqrt6 = %.6f on 4^3, equality iff every |lambda| = sqrt6" % (3 * V4, BOUND4),
+    abs(BOUND4 + 32 * float(np.sqrt(6))) < 1e-12
+    and abs(BOUND4 + float(np.sqrt((V4 // 2) * 3 * V4))) < 1e-12,
+)
+sopt = KS4.copy()
+for ax in range(3):
+    sopt = sopt * twists(T4)[ax]
+Mopt = T4.imat(sopt)
+flat = not (Mopt.dot(Mopt) - 6 * np.eye(V4, dtype=np.int64)).any()
+evopt = np.sort(np.linalg.eigvalsh(T4.mat(sopt)))
+r6 = float(np.sqrt(6))
+mult_ok = (int(np.sum(np.abs(evopt + r6) < 1e-9)) == 32
+           and int(np.sum(np.abs(evopt - r6) < 1e-9)) == 32)
+Eopt = float(np.sum(evopt[:32]))
+check(
+    "D3 [exact, integer] the all-(-1) sector at its optimal twist has M^2 = 6 I EXACTLY (64x64 integer identity), "
+    "spectrum +-sqrt6 x32 each, so E_32 = -32 sqrt6 = %.6f attains the bound: a GLOBAL minimiser over all 2^%d "
+    "link-sign fields" % (Eopt, E4),
+    flat and mult_ok and abs(Eopt - BOUND4) < 1e-9,
+)
+GAPS = []
+for dims, tag in (((4, 4, 6), "4x4x6"), ((6, 6, 6), "6^3"), ((8, 8, 8), "8^3")):
+    V = dims[0] * dims[1] * dims[2]
+    bm = min(float(np.sum(bloch_minus(dims, w)[:V // 2]))
+             for w in itertools.product([0, 1], repeat=3))
+    GAPS.append((tag, -V * float(np.sqrt(1.5)), bm))
+check(
+    "D4 [numerical, 1e-9] elsewhere the spectrum is not flat and the bound is missed: %.2f vs %.2f on "
+    "4x4x6 (gap %.3f), %.2f vs %.2f on 6^3 (gap %.3f), %.2f vs %.2f on 8^3 (gap %.2f)"
+    % tuple(sum(([b, m, m - b] for _, b, m in GAPS), [])),
+    all(m > b + 1e-6 for _, b, m in GAPS)
+    and abs(GAPS[0][2] - GAPS[0][1] - 0.766498) < 1e-5
+    and abs(GAPS[1][2] - GAPS[1][1] - 5.687352) < 1e-5,
+)
+
+# ==================================================== group E: search results
+
+STRUCT_OK, INCONS_OK, SAMP_OK, GREEDY_OK, LOCAL_OK = True, True, True, True, True
+srow, grow, lrow = [], [], []
+for dims, tag in (((4, 4, 4), "4^3"), ((4, 4, 6), "4x4x6")):
+    L = LATS[tag]
+    V, nE, N = L.nv, L.nq, L.nv // 2
+    ksf = vec_of(L, {e: eta_ks(*e) for e in L.E})
+    cuts = twists(L)
+
+    def emin(s, cuts=cuts, L=L, N=N):
+        best = np.inf
+        for w in itertools.product([0, 1], repeat=3):
+            t = s.copy()
+            for ax in range(3):
+                if w[ax]:
+                    t = t * cuts[ax]
+            best = min(best, L.EN(t, N))
+        return best
+
+    e_ks = L.EN(ksf, N)
+    e_ks_w = WMIN[tag][0]
+    rng = np.random.default_rng(11235 + V)
+    draws = [rng.choice([-1.0, 1.0], nE) for _ in range(2000)]
+    raw = np.array([L.EN(s, N) for s in draws])
+    sub = np.array([emin(s) for s in draws[:500]])
+    SAMP_OK = (SAMP_OK and int(np.sum(raw < e_ks - 1e-9)) == 0
+               and int(np.sum(sub < e_ks_w - 1e-9)) == 0)
+    srow.append((tag, raw.min(), np.median(raw), raw.max(), sub.min(), np.median(sub), sub.max()))
+
+    plane = {(0, 1): "xy", (0, 2): "xz", (1, 2): "yz"}
+    fkey = []
+    for (v, a, c, b) in L.faces():
+        d1 = next(i for i in range(3) if L.step(v, EX[i]) == a)
+        d2 = next(i for i in range(3) if L.step(v, EX[i]) == b)
+        fkey.append((v, plane[(d1, d2)]))
+    STRUCT = [
+        (lambda v, p: -1 if p == "xy" else 1, "xy only"),
+        (lambda v, p: -1 if p == "xz" else 1, "xz only"),
+        (lambda v, p: -1 if p == "yz" else 1, "yz only"),
+        (lambda v, p: -1 if (p == "xy" and v[0] % 2 == 0) else 1, "xy, alternating planes"),
+        (lambda v, p: -1 if p != "xy" else 1, "xz+yz"),
+    ]
+    for fn, name in STRUCT:
+        eta, ok = sector_eta(L, [fn(v, p) for (v, p) in fkey])
+        STRUCT_OK = STRUCT_OK and ok and L.EN(vec_of(L, eta), N) > e_ks + 1e-9
+    for fn, name in ((lambda v, p: -1 if sum(v) % 2 == 0 else 1, "even-parity faces"),
+                     (lambda v, p: 1 if p == "xy" else (-1 if v[0] % 2 == 0 else 1),
+                      "xz+yz, alternating planes")):
+        _, ok = sector_eta(L, [fn(v, p) for (v, p) in fkey])
+        INCONS_OK = INCONS_OK and not ok
+    fv = [-1] * len(L.faces())
+    fv[0] = 1
+    _, ok = sector_eta(L, fv)
+    INCONS_OK = INCONS_OK and not ok
+
+    sw = ksf.copy()
+    for ax in range(3):
+        if WMIN[tag][2][ax]:
+            sw = sw * cuts[ax]
+    rises = [L.EN(sw * np.where(np.arange(nE) == k, -1.0, 1.0), N) - e_ks_w for k in range(nE)]
+    LOCAL_OK = LOCAL_OK and min(rises) > 1e-9
+    lrow.append((tag, min(rises)))
+
+    best, hits, allminus = None, 0, 0
+    for _ in range(24):
+        s = rng.choice([-1.0, 1.0], nE)
+        e = L.EN(s, N)
+        improved = True
+        while improved:
+            improved = False
+            for k in rng.permutation(nE):
+                s[k] *= -1
+                e2 = L.EN(s, N)
+                if e2 < e - 1e-11:
+                    e, improved = e2, True
+                else:
+                    s[k] *= -1
+        if set(hol_list(L, {ed: s[i] for i, ed in enumerate(L.E)})) == {-1.0}:
+            allminus += 1
+        if abs(e - e_ks_w) < 1e-8:
+            hits += 1
+        best = e if best is None else min(best, e)
+    GREEDY_OK = GREEDY_OK and best > e_ks_w - 1e-9 and (tag != "4^3" or abs(best - e_ks_w) < 1e-8)
+    grow.append((tag, best, hits, allminus))
+check(
+    "E1 [numerical, 1e-9] 2000 random link fields per torus: E_{V/2} min/med/max as drawn %.1f/%.1f/%.1f (4^3), "
+    "%.1f/%.1f/%.1f (4x4x6), and %.1f/%.1f/%.1f, %.1f/%.1f/%.1f over 500-field Wilson-minimised subsamples; 0 of "
+    "2500 beats all-(-1)"
+    % (srow[0][1], srow[0][2], srow[0][3], srow[1][1], srow[1][2], srow[1][3],
+       srow[0][4], srow[0][5], srow[0][6], srow[1][4], srow[1][5], srow[1][6]),
+    SAMP_OK,
+)
+check(
+    "E2 [numerical, 1e-9] structured sectors -- flux only on xy, xz or yz plaquettes, xy on alternating x planes, "
+    "xz+yz -- are consistent and all above all-(-1); even-parity-face flux, alternating xz+yz and a one-face flip "
+    "are inconsistent",
+    STRUCT_OK and INCONS_OK,
+)
+check(
+    "E3 [numerical, 1e-9] greedy single-link descent, 24 random restarts per torus, never beats the Wilson-minimised "
+    "all-(-1) field: best %.3f on 4^3, exactly that field (%d of 24 reach it); best %.3f on 4x4x6, above %.3f"
+    % (grow[0][1], grow[0][2], grow[1][1], WMIN["4x4x6"][0]),
+    GREEDY_OK,
+)
+check(
+    "E4 [numerical, 1e-9] the all-(-1) field at its optimal twist is a strict local minimum of E_{V/2}: all 192 and "
+    "all 288 single-link flips raise it, by at least %.6f (4^3) and %.6f (4x4x6)"
+    % (lrow[0][1], lrow[1][1]),
+    LOCAL_OK,
+)
+
+# ================================================ group F: thermodynamic limit
+
+
+half, quarter = {}, {}
+for L in (4, 8, 16, 32, 64, 96):
+    V = L ** 3
+    lp, lm = ladder(bloch_plus((L, L, L))), ladder(bloch_minus((L, L, L)))
+    half[L] = (lp[V // 2] / V, lm[V // 2] / V)
+    quarter[L] = (lp[V // 4] / V, lm[V // 4] / V)
+print("   L=4..96 e(+)1/2: " + " ".join("%8.5f" % half[L][0] for L in (4, 8, 16, 32, 64, 96)))
+print("           e(-)1/2: " + " ".join("%8.5f" % half[L][1] for L in (4, 8, 16, 32, 64, 96)))
+check(
+    "F1 [numerical, 1e-9] exact Bloch formulas at L = 4..96 (above): at half filling staggered is lower at "
+    "every L, settling at e(-) = %.8f vs e(+) = %.8f; at quarter filling higher at every L, by +%.5f per site"
+    % (half[96][1], half[96][0], quarter[96][1] - quarter[96][0]),
+    all(half[L][1] < half[L][0] for L in half) and all(quarter[L][1] > quarter[L][0] for L in quarter)
+    and abs(quarter[96][1] - quarter[96][0] - 0.07908) < 5e-5,
+)
+
+QUAD = []
+for M in (600, 1200, 2400):
+    h = M // 2
+    v = np.cos(2 * np.pi * np.arange(h + 1) / M)
+    w = np.full(h + 1, 2.0)
+    w[0] = w[h] = 1.0
+    W2 = w[:, None] * w[None, :]
+    S2 = v[:, None] + v[None, :]
+    ap = am = 0.0
+    for i in range(h + 1):
+        s = v[i] + S2
+        ap += w[i] * float(np.sum(W2 * np.abs(2 * s)))
+        am += w[i] * float(np.sum(W2 * np.sqrt(np.maximum(6 + 2 * s, 0.0))))
+    QUAD.append((M, -ap / (2 * M ** 3), -am / (2 * M ** 3)))
+ep, em = QUAD[-1][1], QUAD[-1][2]
+check(
+    "F2 [numerical, converged quadrature] the BZ integrals of |2 sum cos q| and sqrt(6 + 2 sum cos q) on reduced "
+    "grids M = 600, 1200, 2400 converge to e(+) = %.8f, e(-) = %.8f at half filling; difference %.8f |t| per site"
+    % (ep, em, em - ep),
+    abs(ep + 1.00241973) < 5e-8 and abs(em + 1.19380112) < 5e-8
+    and abs(em - ep + 0.19138139) < 5e-8
+    and abs(QUAD[1][2] - QUAD[2][2]) < 1e-8,
+)
+
+NSEQ, dd = [], None
+for L in (4, 6, 8, 12, 16, 24, 32, 48, 64, 96):
+    V = L ** 3
+    d = ladder(bloch_minus((L, L, L))) - ladder(bloch_plus((L, L, L)))
+    neg = np.where(d[1:V] < -1e-9)[0] + 1
+    NSEQ.append((L, int(neg[0]), int(neg[0]) / V, int(neg[-1]) / V))
+    if L == 96:
+        dd, i0 = d, int(neg[0])
+nst = ((i0 - 1) + (0 - dd[i0 - 1]) / (dd[i0] - dd[i0 - 1])) / 96 ** 3
+print("   n* by L: " + " ".join("%d:%.4f" % (L, n) for L, _, n, _ in NSEQ if L in (4, 8, 32, 96)))
+check(
+    "F3 [numerical, 1e-9] the crossing filling n* = N*/V settles to %.6f (above), the window ending at the "
+    "mirror 1 - n* = %.6f: plain is cheaper below about a third filling and above its mirror"
+    % (nst, 1 - nst),
+    abs(nst - 0.339659) < 2e-5 and all(abs(r[3] - (1 - r[2])) < 1e-12 for r in NSEQ)
+    and abs(NSEQ[-1][2] - 0.339660) < 1e-5,
+)
+
+print(
+    "SUMMARY: the law's hopping term is not indifferent to the sector -- at half filling the all-(-1) (staggered) "
+    "sector wins on every block tested; below n* = 0.3397 the plain sector wins."
+)
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache: **the fermion's own kinetic energy selects the staggered flux sector at half filling.** PR #7844 showed the framework's staggered (Kawamoto-Smit) kinetic form is the all-minus face-stabilizer sector of the emergent fermion's gauge structure and that the law as written leaves the sector a free choice. This note refines that: the hopping term already in the law is not indifferent. At half filling the all-minus sector is the unique minimiser of all 32 sectors on the `2x2x2` cube, a **global minimiser over all `2^192` link-sign fields on the `4^3` torus by a Cauchy-Schwarz certificate** (`M^2 = 6 I` exactly), and beats every uniform, structured, random and greedy-descent competitor on the other tori, by `0.191 |t|` per coarse site in the thermodynamic limit. The selection is a property of the matter density: the plain sector is cheaper below filling `n* -> 0.3397` and above its mirror; at `N = 0` every sector ties.

- `docs/HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md` (328 lines)
- `scripts/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.py` (`TOTAL: PASS=19 FAIL=0`, 19 s)
- `logs/runner-cache/half_filling_kinetic_energy_selects_the_staggered_flux_sector_check_2026_09_02.txt`

## Theorems

- **T1** exhaustive `2x2x2` cube: 32 consistent sectors; exact ladders `E_N`; unique half-filling minimiser all-minus (margin `0.456` to the next value, `4 sqrt3 - 6` to plain); filling-dependent minimisers at other `N`.
- **T2** uniform sectors on tori `4^3`, `4x4x6`, `6^3`, `8^3` and open blocks `3^3`, `4^3`: one contiguous pi-flux window `[N*, V - N*]` symmetric about half filling; exact surds at `L = 4` (`E_32(-) - E_32(+) = 36 - 24 sqrt2 - 8 sqrt3`).
- **T3** Wilson-line caveat: the face stabilizers fix no torus Wilson line; the staggered sector at its worst twist still beats the plain sector at its best.
- **T4** Cauchy-Schwarz certificate: for any link-sign field on the bipartite degree-6 `4^3` torus, `E_{V/2} >= -V sqrt(3/2)` with equality iff every `|lambda| = sqrt6`; the all-minus sector at its optimal twist has `M^2 = 6 I` exactly and attains it. Elsewhere the bound is missed by stated gaps, so global minimality is a theorem on two clusters and a search result on the rest.
- **T5** searches at half filling: 2500 random fields, five structured sectors and 24 greedy restarts per torus, none beating the all-minus sector; strict local minimum.
- **T6** thermodynamic limit from the exact Bloch formulas: `e(+) = -1.00241973`, `e(-) = -1.19380112` per coarse site at half filling; crossing filling `n* -> 0.339659`.

## Corollary and boundary

- The framework's staggered kinetic form is chosen by the matter's own energy at half filling, with no face term supplied; the filling is a supplied datum.
- Free nearest-neighbour hopping only; finite clusters; no interaction, mass, coupling, rate or temperature; no Lieb-type flux-phase theorem claimed for the cubic lattice; Wilson-line convention made explicit.

## Dependencies and context

- Cites `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7844) as a pointer and quotes its "free choice" sentence as the statement refined; quotes the landed staggered-gate kinetic clause verbatim.
- Two overclaims of the source computation were corrected during landing (Wilson-minimised margins do not uniformly grow; greedy descent returns the staggered field exactly only on `4^3`).
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
