### PR TITLE
feat(matter): record-conserving interaction keeps the staggered sector

### DIFF
--- a/docs/RECORD_CONSERVING_INTERACTION_KEEPS_THE_STAGGERED_SECTOR_AT_HALF_FILLING_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/RECORD_CONSERVING_INTERACTION_KEEPS_THE_STAGGERED_SECTOR_AT_HALF_FILLING_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,319 @@
+---
+claim_id: interaction_keeps_staggered_sector_half_filling
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, the flux sector of a face being the eigenvalue of that face's stabilizer S_f, and the law read on the record-conserving nearest-neighbour family H(t, V) = -t sum_bonds eta_ij (c_i^dag c_j + c_j^dag c_i) + V sum_bonds n_i n_j at t = 1 with the single ratio g = V/t, on the many-body ground state at fixed particle number N and on the named finite clusters only: (T1) on the open 2x2x2 coarse cube at half filling, N = 4, dimension 70, all 32 consistent flux sectors compared, the all-(-1) sector is the unique many-body minimiser at every g in {-2, -1, -0.5, 0, 0.5, 1, 2, 4, 8}, with margins to the next distinct sector 0.192, 0.344, 0.408, 0.456, 0.483, 0.485, 0.407, 0.158, 0.025; and exactly over Z at the twelve integer g in {-8, -4, -2, -1, 0, 1, 2, 4, 8, 16, 32, 64}, where the 70x70 integer characteristic polynomials give minimal polynomials of E_0 over Z for both uniform sectors -- degrees 3, 3, 3, 4, 1, 4, 3, 3, 4, 4, 4, 4 for the plain sector and 5, 5, 5, 5, 2, 5, 5, 5, 5, 5, 5, 5 for the staggered one, the plain g = 2 polynomial being x^3 - 10x^2 - 16x + 48 and the staggered g = 0 polynomial x^2 - 48 -- and a CRootOf comparison gives E_0(-) < E_0(+) strictly at all twelve with no tie and no floating point. (T2) On the same cube away from half filling, N = 2 and N = 6, dimension 28, the interaction does reorder: the minimiser is the two-flux class, three tied sectors, at every g in that list and the all-(-1) sector is never it, sitting at rank 31, 31, 31, 31, 31, 31, 31, 30, 27 of 32; exactly, at N = 2 the staggered characteristic polynomial carries the g-free factor x^2 - 12, so E_0(-) = -2 sqrt3 at every g, while E_0(+) is the least root of x^3 - g x^2 - 16 x + 8 g, and the two are equal exactly at g_c = 2 sqrt3. (T3) On the open 2x2x3 coarse block at half filling, N = 6, dimension 924, 11 faces of F2 rank 9 and exactly 512 consistent sectors of 2048 face assignments, the all-(-1) sector is the unique minimiser of all 512 at every g in {0, 0.5, 1, 2, 4, 8, 16}, with margins 0.381, 0.401, 0.401, 0.311, 0.058, 0.0048, 0.00049, its ground state non-degenerate and the plain sector's 2-fold throughout, the plain sector ranking 500, 500, 509, 511, 511, 511, 511 of 512; on the attractive side it is still the unique minimiser at g = -1, -2 and -2.3 and is beaten at g = -2.4 by an 8-flux class of 8 tied sectors, so the flip window is -2.4 < g_c < -2.3, while the uniform pair itself never crosses on [-64, 64], E_0(-) - E_0(+) being at most -4.53e-05 over the 15 couplings scanned. (T4) First-order perturbation theory in V about the twist-minimised free half-filled sea on the coarse tori 4^3, 6^3, 8^3, 10^3 and 12^3, with A = sum_bonds (P_ii P_jj - P_ij^2) by Wick, gives A/V = 0.65625, 0.66427, 0.66505, 0.66541, 0.66592 for the plain sector against 0.62500, 0.63032, 0.63101, 0.63116, 0.63120 for the staggered one, so the first-order correction also favours the staggered sector at every L; on 4^3 the integer hopping matrices satisfy M^6 - 52 M^4 + 676 M^2 = 1152 I at the all-antiperiodic twist for the plain field and M^2 = 6 I for the staggered one, making both occupied projectors polynomials in M with rational squared entries, so A(+) = 42 = 21/32 per site and A(-) = 40 = 5/8 per site exactly, dE_free = 48 sqrt2 - 32 sqrt6, and the only first-order crossing is attractive, at g_c = 24 sqrt2 - 16 sqrt6 = -5.250710; by converged Brillouin-zone quadrature the limiting values are A/V = 0.666263 and 0.631237 and g_c = -5.4639. Second-order MBPT on 4^3 gives -10.50142 - 2.00000 g + 0.44685 g^2, whose positive root g = 7.577 is refuted by T1 and T3 and is recorded as a caution about the truncation, not a result. (T5) At large coupling on the cube both sectors freeze into the same Neel doublet: <n_i> = 1/2 on every site in both sectors to 5e-14 at g = 4, 8, 16, 32, the staggered moment m^2 rising to 0.24945 and 0.24944 against the Neel value 1/4 and the weight on the two Neel patterns to 0.99708 and 0.99704; the t^2/V exchange is sector-independent, g E_0 -> -6 in both sectors and g^2 (E_0(-) - E_0(+)) -> 0 along -0.4216, -0.2109, -0.1055 at g = 64, 128, 256; and the surviving difference is order t^4/V^3, g^3 (E_0(-) - E_0(+)) = -26.9815477888, -26.9953982475, -26.9988502688, -26.9997126114 at g = 64, 128, 256, 512 in 60-digit arithmetic with local exponent 2.99926, 2.99982, 2.99995 and Richardson limit -26.9999999999, that is E_0(-) - E_0(+) = -27 t^4/V^3 + O(V^-4), a plaquette ring exchange of 9/4 per face carrying the sign S_f; the same structure holds on the 2x2x3 block with its own coefficient, g^3 (E_0(-) - E_0(+)) settling near -11.8530 ~ -320/27. All statements are at fixed particle number, on the named clusters, for that one interaction family. Nothing here is derived from any axiom, no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py
+---
+
+# A record-conserving interaction keeps the staggered sector at half filling
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py`](../scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.txt`](../logs/runner-cache/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+A separate construction puts one fermionic mode on each vertex of the coarse lattice `2Z^3` and shows that transport of one encoded excitation around a coarse face equals that
+face's stabilizer `S_f`, so the framework's staggered kinetic sign field is the sector in which every `S_f` is `-1` and the plain field is the sector in which every one is `+1`.
+A second result shows that the *free* hopping energy of a half-filled sea prefers the staggered sector, strictly, and names its own limit: only free hopping was compared. This
+note removes that limit for one declared interaction family, reading the comparison off the interacting many-body ground state at fixed particle number.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact and exhaustive finite-cluster theorems on the flux-sector ordering of one record-conserving interacting law: every consistent sector of the open 2x2x2 cube and of the open 2x2x3 block diagonalised at fixed particle number, the cube's half-filling ordering fixed over Z by minimal polynomials and a CRootOf comparison, the off-half-filling crossing fixed exactly at 2 sqrt3, and the 4^3 first-order coefficients fixed by integer matrix certificates. The torus items are first (and, once, second) order in V and are labelled so; the large-coupling ring-exchange coefficient is a high-precision numerical limit, and its sign, not its value, is what the note carries."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: which interaction the coarse lattice actually carries."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. The integer-`g` content of `A`, the whole exact item of `B` and the `4^3`
+item of `D` are exact -- `sympy` characteristic polynomials of integer matrices, symbolic `g`, surds, `CRootOf` comparison, integer matrix identities at zero tolerance, `F2`/`Z4`
+symplectic bit arithmetic, exhaustive enumeration -- and items tagged `[numerical]` are floating-point at the stated tolerance.
+
+1. `T1` (`A`). The exhaustive `2x2x2` cube at half filling, with the exact minimal-polynomial ordering.
+2. `T2` (`B`). The same cube away from half filling, where the interaction does reorder, and the exact crossing `g_c = 2 sqrt3` for the uniform pair.
+3. `T3` (`C`). The exhaustive `2x2x3` block at half filling, repulsive and attractive, with the attractive flip window.
+4. `T4` (`D`). First-order perturbation theory in `V` on five coarse tori, exact on `4^3`, with the second-order truncation recorded only as a caution.
+5. `T5` (`E`). The large-coupling structure: one Neel doublet, one sector-independent `t^2/V` exchange, and a plaquette ring exchange at order `t^4/V^3`.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, Wick's theorem for a Slater determinant and
+Rayleigh-Schrodinger perturbation theory are standard methodology; every object is redeclared here and the runner recomputes every statement. Lieb's flux-phase theorem is named
+only as background -- it is planar and free, is not proved for the cubic lattice, and nothing below uses it. No observational value, no fitted number and no framework premise
+enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7874): the free-hopping selection at half filling and the interface
+  sentence quoted below, which is the question this note answers.
+- `COMPOSITION_DISCRIMINATOR_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7833): the interaction family quoted below.
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): face transport equals `S_f`.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting". This note cites none of their grades and adopts no hypothesis.
+
+All four are pointers only: the encoding, the sign fields, the face stabilizers, the sector machinery and the interaction family are redeclared below and every matrix is built
+from scratch by this runner.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations,
+and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has algebraic presentation
+`M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations", and "For each site, the
+probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." **Record**: "Records form", "a record locks exactly one
+admissible local possibility", "records are permanent", "Only records are readable." The interface sentence this note answers reads, verbatim, from the half-filling note:
+
+> **Interacting terms.** Only free nearest-neighbour hopping is compared. A four-fermion term, or any interaction, could order the sectors differently, and no such term is
+> examined.
+
+The interaction examined is not invented here. It is the one-parameter family already declared by the composition discriminator, quoted verbatim from that note:
+
+> The **law family** is one expression read on either composition, `H(t, V) = -t sum_bonds (x_i^dag x_j + x_j^dag x_i) + V sum_bonds n_i n_j,   x = b or x = c,` with the same
+> real `t` and `V` on every bond. **Cubic-covariant** means exactly that: one bond expression, identical on every bond, symmetric under reversing a bond, commuting with
+> `sum_i n_i`.
+
+and, from the same note, "So the record statistics depend on the single ratio `g = V/t`, taken at `t = 1`." Everything below reads that family on the graded composition `x = c`,
+with the bond sign field `eta_ij` restored on the hopping term so the flux sector is still a free label. Composition is **ordinary**: a region's algebra is the tensor product of
+its sites' algebras and no graded clause is used.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the two uniform sign fields on
+it, the superfast encoding, the face stabilizers, the flux sectors, the record-number sector and the interacting Hamiltonian `H(g)`. `P1` (`A`) is the exhaustive cube at half
+filling; `P2` (`B`) the same cube at `N = 2, 6`; `P3` (`C`) the exhaustive `2x2x3` block; `P4` (`D`) the first-order torus theory; `P5` (`E`) the large-`g` structure. `P2` and
+`P3` use nothing from each other; `P4` uses nothing from `P1`-`P3` except in its own refutation clause, which cites their numbers only. The strongest supported scope is precisely
+`P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v` and the coarse edge from `v` along `e_a` at `2v + e_a`. The **KS sign** of the coarse bond
+`(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`; the **plain sign** is `+1` on every bond. The **encoding** is the Bravyi-Kitaev superfast
+encoding on the coarse lattice, code qubits on the coarse edges, direction order `-x < -y < -z < +x < +y < +z`, with `A_ij` the encoded hop generator and `S_f` the ordered
+product of the four `A`s around a coarse face. A **flux sector** is a choice of eigenvalue `+-1` for every `S_f` consistent with the `F2` relations among them, realised as a
+link-sign field by spanning-tree gauge fixing then fundamental-cycle transport, its plaquette holonomy reproducing the sector face by face.
+
+The **record-number sector** at particle number `N` is the span of the occupation patterns with `N` sites occupied, of dimension `C(V, N)`. On it the law reads
+
+```text
+H(g) = - sum_bonds eta_ij (c_i^dag c_j + c_j^dag c_i) + g sum_bonds n_i n_j,     g = V/t at t = 1,
+```
+
+with `c` the Jordan-Wigner ladders in the fixed site order, so the hopping carries the string sign and the interaction is diagonal. `E_0(g)` is the lowest eigenvalue of `H(g)` in
+that sector, `E_0(-)` and `E_0(+)` its values in the all-`(-1)` and all-`(+1)` sectors, and **half filling** is `N = V/2`. On a torus the three **Wilson lines** are
+gauge-invariant data no `S_f` fixes and a **twist** flips the signs on one cut plane; every torus statement is minimised over the eight twists. `P` is the occupied one-particle
+projector of the free sea and `A = sum_bonds (P_ii P_jj - P_ij^2)` the Wick value of `sum_bonds n_i n_j` in that determinant, so the first-order energy in `V` is `E_free + g A`.
+
+## Theorem 1 -- the exhaustive cube at half filling
+
+**Conclusion.** On the open `2x2x2` coarse cube, `8` sites, `12` bonds, `6` faces of `F2` rank `5`, at half filling `N = 4`, the record-number sector having dimension `70`:
+
+1. Exactly `32` of the `64` face assignments are consistent flux sectors, flux counts `0, 2, 4, 6`, each realised by a link-sign field of that holonomy.
+2. Comparing all `32` at `g = -2, -1, -0.5, 0, 0.5, 1, 2, 4, 8`, the all-`(-1)` sector is the **unique** minimiser at every one, by
+   `0.192, 0.344, 0.408, 0.456, 0.483, 0.485, 0.407, 0.158, 0.025` to the next distinct sector.
+3. At the twelve integer `g = -8, -4, -2, -1, 0, 1, 2, 4, 8, 16, 32, 64` the `70x70` integer characteristic polynomials give minimal polynomials of `E_0` over `Z` for both
+   uniform sectors, of degrees `3, 3, 3, 4, 1, 4, 3, 3, 4, 4, 4, 4` (plain) and `5, 5, 5, 5, 2, 5, 5, 5, 5, 5, 5, 5` (staggered) -- for instance `x^3 - 10x^2 - 16x + 48` for the
+   plain sector at `g = 2` and `x^2 - 48` for the staggered sector at `g = 0`. A `CRootOf` comparison of those algebraic numbers gives `E_0(-) < E_0(+)` strictly at all twelve,
+   with no tie and no floating point anywhere.
+
+**Proof.** Item 1 solves the `F2` relations among the six face generators, realises each consistent assignment as a sign field and checks its holonomy face by face, exactly. Item
+2 builds the `70x70` real matrix of each sector at each `g` and compares lowest eigenvalues, `[numerical, 1e-10]`. Item 3 builds the matrix over `Z`, takes its characteristic
+polynomial in `sympy`, extracts the least real root as a `CRootOf` with its minimal polynomial over `Z` (domain checked to be `ZZ`), and compares the two roots symbolically.
+
+**Reading, not theorem.** Eight sites, four particles, a sign on each of six squares, and now a price for two particles sitting on the ends of the same bond. With that price
+switched on -- at any of the strengths tried, and whether the price is a charge or a reward -- the arrangement with a minus on every square is still the cheapest of all
+thirty-two, and at whole-number strengths the comparison is a comparison of exact numbers, not of decimals.
+
+## Theorem 2 -- away from half filling the interaction does reorder
+
+**Conclusion.** On the same cube at `N = 2` and `N = 6`, the record-number sector having dimension `28`:
+
+1. At every `g` in the list of Theorem 1 the minimiser of all `32` sectors is the **two-flux class**, three tied sectors, and the all-`(-1)` sector is never it: it sits at rank
+   `31, 31, 31, 31, 31, 31, 31, 30, 27` of `32`.
+2. Exactly, with symbolic `g`: at `N = 2` the staggered sector's characteristic polynomial carries the `g`-free factor `x^2 - 12`, so `E_0(-) = -2 sqrt3` at **every** `g`, while
+   `E_0(+)` is the least root of `x^3 - g x^2 - 16 x + 8 g`. The two are equal exactly at `g_c = 2 sqrt3`, the plain sector lower below it and the staggered sector lower above.
+
+**Proof.** Item 1 diagonalises all `32` sectors at each `g` and `N`, `[numerical, 1e-10]`. Item 2 builds the `28x28` matrix over `Z[g]`, factors its characteristic polynomial in
+`sympy` and reads off the two factors named; the crossing is `sympy`'s exact solution of the cubic evaluated at `x = -2 sqrt3`.
+
+**Reading, not theorem.** With two particles instead of four the answer is different, and it was different before the price was switched on. Neither the plain arrangement nor the
+one with a minus on every square is cheapest there; a third arrangement is. The one place where the price changes nothing is the one place the free comparison already singled
+out. That is not a weakness of the statement -- it is what makes half filling the point worth naming.
+
+## Theorem 3 -- the exhaustive 2x2x3 block
+
+**Conclusion.** On the open `2x2x3` coarse block, `12` sites, `20` bonds, `11` faces of `F2` rank `9`, at half filling `N = 6`, the record-number sector having dimension `924`:
+
+1. Exactly `512` of the `2048` face assignments are consistent flux sectors.
+2. At `g = 0, 0.5, 1, 2, 4, 8, 16` the all-`(-1)` sector is the **unique** minimiser of all `512`, by `0.381, 0.401, 0.401, 0.311, 0.058, 0.0048, 0.00049` to the next distinct
+   sector. Its ground state is non-degenerate at every one; the plain sector's is `2`-fold at every one, and the plain sector ranks `500, 500, 509, 511, 511, 511, 511` of `512`.
+3. On the attractive side the all-`(-1)` sector is still the unique minimiser at `g = -1, -2, -2.3`, and at `g = -2.4` it is beaten by an `8`-flux class of `8` tied sectors,
+   falling to rank `8`. The flip window is `-2.4 < g_c < -2.3`.
+4. The uniform **pair** itself never crosses on `[-64, 64]`: `E_0(-) - E_0(+) < 0` at all `15` couplings scanned, the largest value being `-4.53e-05`. The attractive flip of item
+   3 is a third sector overtaking both, not the pair reordering.
+
+**Proof.** Item 1 is the `F2` relation count, exact. Items 2-4 assemble each sector's sparse `924x924` matrix from one precomputed hopping graph and take its lowest levels by
+Lanczos at tolerance `1e-12`, `[numerical, 1e-9]`; the degeneracies are read from the three lowest levels.
+
+**Reading, not theorem.** A second, longer box with a different number of squares, and the same answer: with the price switched on, the minus-on-every-square arrangement is the
+single cheapest of all five hundred and twelve, and its cheapest state is unique while the plain one's is doubled. Turn the price into a reward and there is a strength --
+somewhere between minus two point three and minus two point four -- past which a different arrangement wins instead.
+
+## Theorem 4 -- first order in V on the coarse tori
+
+**Conclusion.** For the twist-minimised free half-filled sea of each uniform sector on the coarse tori `4^3, 6^3, 8^3, 10^3, 12^3`, with `A = sum_bonds (P_ii P_jj - P_ij^2)` the
+Wick value of the interaction in that determinant:
+
+1. Every sea is closed-shell, gaps `2.83, 0.54, 0.63, 0.47, 0.14` (plain) and `4.90, 3.46, 2.65, 2.14, 1.79` (staggered), the small `12^3` plain gap reported as such; `A/V` is
+   `0.65625, 0.66427, 0.66505, 0.66541, 0.66592` (plain) against `0.62500, 0.63032, 0.63101, 0.63116, 0.63120` (staggered), so `Delta A < 0` at every `L`.
+2. On `4^3` at the all-antiperiodic twist the integer hopping matrices satisfy `M^6 - 52 M^4 + 676 M^2 = 1152 I` (plain) and `M^2 = 6 I` (staggered) exactly, so both occupied
+   projectors are polynomials in `M` with rational squared entries and `A(+) = 42 = 21/32` per site and `A(-) = 40 = 5/8` per site are **exact**. With
+   `dE_free = 48 sqrt2 - 32 sqrt6` the only first-order crossing is on the attractive side, at `g_c = 24 sqrt2 - 16 sqrt6 = -5.250710`, exactly.
+3. By converged Brillouin-zone quadrature, using the closed forms `P_ij = <cos q_1>_occ` for the plain sea and `P_ij = +-(h(0) + h(2e_1))/2` with `h = (6 + W)^{-1/2}` for the
+   staggered one, the limiting values are `A/V = 0.666263` and `0.631237` and the limiting first-order crossing is `g_c = -5.4639`.
+4. Second-order many-body perturbation theory on `4^3` gives `dE(g) = -10.50142 - 2.00000 g + 0.44685 g^2`, whose positive root `g = 7.577` would predict a repulsive-side flip;
+   it is contradicted by Theorem 1 at `g = 8, 16, 32, 64`, where the ordering is exact over `Z`, and by Theorem 3 at `g = 8, 16`. Recorded as a **caution about the truncation**.
+
+**Proof.** Item 1 diagonalises each twisted real-space hopping matrix, forms `P` from the occupied columns and sums the bond terms, `[numerical, 1e-9]`. Item 2 verifies the two
+integer identities at zero tolerance and evaluates `A` in exact rational arithmetic from the polynomial projectors. Item 3 is converged quadrature, `M = 400` and `M = 800`
+agreeing to `1e-5`. Item 4 is a standard antisymmetrised second-order sum over the free orbitals.
+
+**Reading, not theorem.** Perturbation theory in the price, on boxes far bigger than the ones that can be solved outright, agrees: the first correction is smaller for the
+minus-on-every-square arrangement, so switching the price on widens the gap rather than closing it. One order further on the smallest box suggests a strength at which the order
+would flip; the boxes that can be solved exactly say it does not.
+
+## Theorem 5 -- the large-coupling structure
+
+**Conclusion.** At strong repulsion on the cube at half filling:
+
+1. `<n_i> = 1/2` on every site in **both** sectors, to `5e-14`, at `g = 4, 8, 16, 32`; the staggered moment `m^2` rises to `0.24945` (plain) and `0.24944` (staggered) against the
+   Neel value `1/4` and the weight on the two Neel patterns to `0.99708` and `0.99704`, and the same rise holds on the `2x2x3` block, where the plain ground space is `2`-fold and
+   the densities are degeneracy-averaged. The order parameter does not tell the sectors apart.
+2. The `t^2/V` exchange is sector-**independent**: `g E_0 -> -6` in both sectors, and `g^2 (E_0(-) - E_0(+)) -> 0` along `-0.4216, -0.2109, -0.1055` at `g = 64, 128, 256`.
+3. The whole surviving difference is order `t^4/V^3`. In `60`-digit arithmetic `g^3 (E_0(-) - E_0(+)) = -26.9815477888, -26.9953982475, -26.9988502688, -26.9997126114` at
+   `g = 64, 128, 256, 512`, with local exponent `2.99926, 2.99982, 2.99995` and Richardson limit `-26.9999999999`. So `E_0(-) - E_0(+) = -27 t^4/V^3 + O(V^-4)`: a plaquette ring
+   exchange of `9/4` per face entering with the sign `S_f`, hence `-9/4` per face in the staggered sector and `+9/4` in the plain one.
+4. The same structure holds on the `2x2x3` block with its own coefficient, `g^3 (E_0(-) - E_0(+))` running `-12.126, -11.921, -11.869, -11.856, -11.853` at `g = 16, ..., 256`,
+   settling near `-11.853 ~ -320/27`. The coefficient is a cluster number; the **sign** is what the two clusters share.
+
+**Proof.** Items 1 and 2 are direct diagonalisation, `[numerical, 1e-9]` and converged in `1/g`. Item 3 diagonalises the exact `70x70` integer matrices in `mpmath` at `60`
+digits, so the difference of two nearly equal energies is not a double-precision cancellation; the exponent comes from successive ratios and the limit from Richardson
+extrapolation in `1/g^2`. Item 4 is the double-precision `924x924` computation, converged in `1/g`.
+
+**Reading, not theorem.** Push the price up and the particles stop moving: they settle into a checkerboard, identically in both arrangements, so nothing about where they sit
+distinguishes the arrangements any more. What is left is small residual motion, and a particle stepping onto its neighbour's site and back costs the same in both. The first thing
+that does not is a particle going once around a square and returning, which picks up the sign on that square; and that trip is cheaper when the sign is minus.
+
+## Corollary -- what this says about the framework's kinetic form
+
+Within the setting declared above, and on the finite clusters named:
+
+1. For the record-conserving family at half filling, the interaction does **not** reorder the sectors on any cluster or coupling tested on the repulsive side: the cube's ordering
+   is exact over `Z` at twelve integer couplings, the block's all-`(-1)` sector is the unique minimiser of all `512` at seven, and five tori agree at first order.
+2. The reason at large coupling is structural. The density profile, the Neel weight and the `t^2/V` exchange are all sector-independent, so the sign on a plaquette enters the
+   energy only through the ring exchange around it -- and that prefers the staggered sign, `-27 t^4/V^3` on the cube and `~ -320/27` on the block.
+3. So the staggered kinetic form remains the choice of the matter's own energy with the discriminator's interaction present; the free result did not need its absence.
+4. Away from half filling (`T2`) and on the attractive side (`T3`) the ordering **is** cluster- and coupling-dependent, with an exact crossing at `g_c = 2 sqrt3` for the cube's
+   uniform pair at `N = 2` and a flip window `-2.4 < g_c < -2.3` for the block. That sharpens the statement: half filling on the repulsive side is the robust point.
+5. No coefficient, coupling, rate, mass or absolute unit is fixed anywhere. `g` is a ratio scanned over a declared list, and the filling is supplied.
+
+**Reading, not theorem.** Adding the repulsion between neighbours does not change which sign pattern is cheapest when half the sites carry matter; at strong repulsion the matter
+freezes into a checkerboard in either pattern, and the only thing that still tells the patterns apart is how the particles go once around a square, which still favours the minus
+sign. With fewer particles, or with attraction, the answer can change.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, no hypothesis is adopted, no status value is set, predicted or implied, and no premise registry, citation
+  manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice, the encoding, the sign fields, the filling and the interaction family are declared objects, and the family is not
+  proposed, preferred, or fixed by this note: it is quoted from the composition discriminator's note and scanned in `g`.
+- No update rule, formation site, formation rate, coupling, mass, absolute unit or dynamical clause appears, and no Lieb-type cubic flux-phase theorem is claimed or used.
+
+## Interfaces named for other lanes, not moved here
+
+- **Attraction and other fillings.** `T2` and `T3` show the ordering there is cluster- and coupling-dependent. Nothing here decides it, and no lane should read the half-filling
+  repulsive statement across those boundaries.
+- **Longer-range or spin-dependent interactions.** One nearest-neighbour density-density family is examined; a longer-range term, a bond-dependent `V`, or a spin-carrying term is
+  untouched.
+- **An interacting global-minimality certificate on tori.** The free case had one on `4^3`, a Cauchy-Schwarz bound met with equality; that bound is free-fermion only, there is no
+  interacting analogue here, and the torus statements are first (once second) order in `V`, not exhaustive.
+- **Exact derivation of the ring-exchange coefficient.** The `-27` is a high-precision numerical limit, not a degenerate-perturbation-theory derivation. A lane wanting the
+  coefficient from the algebra must supply that derivation; the sign is what this note carries.
+- **The filling as a supplied datum.** Every statement is conditional on `N`, exactly as in the free case. Which filling the coarse lattice carries is a science question a lane
+  owning the matter density must answer.
+
+## Remaining live routes
+
+1. Larger exhaustive clusters. Two open blocks are enumerated in full here; `2x2x4` and beyond are not.
+2. The interacting problem on a torus -- only first-order theory is done there, with the Wilson-line freedom handled by twist minimisation of the free sea -- and the interacting
+   problem at fixed chemical potential, or at finite temperature, rather than at fixed `N`.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one mode per coarse vertex, BK superfast encoding on it; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+law: H(g) = -sum_bonds eta_ij (c_i^dag c_j + c_j^dag c_i) + g sum_bonds n_i n_j at t = 1, g = V/t; family quoted from the composition discriminator's note
+objects: KS eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}; plain +1; S_f the face stabilizer; flux sector = consistent choice of S_f eigenvalues; E_0(g) = lowest eigenvalue in the N-particle record-number sector
+cube_half_filling: 2x2x2, N = 4, dim 70, all 32 sectors; all-(-1) unique minimiser at g = -2, -1, -0.5, 0, 0.5, 1, 2, 4, 8; margins 0.192, 0.344, 0.408, 0.456, 0.483, 0.485, 0.407, 0.158, 0.025
+cube_exact: integer g = -8, -4, -2, -1, 0, 1, 2, 4, 8, 16, 32, 64; min polys of E_0 over Z, degrees 3,3,3,4,1,4,3,3,4,4,4,4 (plain) and 5,5,5,5,2,5,5,5,5,5,5,5 (staggered); plain g=2 is x^3 - 10x^2 - 16x + 48, staggered g=0 is x^2 - 48; CRootOf gives E_0(-) < E_0(+) at all 12, 0 ties
+cube_off_half_filling: N = 2 and N = 6, dim 28; minimiser is the two-flux class (3 tied) at every g, all-(-1) at rank 31,31,31,31,31,31,31,30,27 of 32
+cube_off_exact: N = 2 staggered charpoly factor x^2 - 12, so E_0(-) = -2 sqrt3 for all g; plain E_0(+) least root of x^3 - g x^2 - 16 x + 8 g; equality exactly at g_c = 2 sqrt3
+block: 2x2x3, N = 6, dim 924, 11 faces of F2 rank 9, exactly 512 of 2048 assignments consistent; all-(-1) unique minimiser at g = 0, 0.5, 1, 2, 4, 8, 16 with margins 0.381, 0.401, 0.401, 0.311, 0.058, 0.0048, 0.00049; deg(-) = 1 and deg(+) = 2 throughout; plain rank 500, 500, 509, 511, 511, 511, 511 of 512
+block_attractive: all-(-1) unique at g = -1, -2, -2.3; beaten at g = -2.4 by an 8-flux class of 8 tied sectors, rank 8; flip window -2.4 < g_c < -2.3; uniform pair never crosses on [-64, 64], largest E_0(-) - E_0(+) = -4.53e-05
+tori_first_order: 4^3, 6^3, 8^3, 10^3, 12^3, twist-minimised closed-shell seas, gaps 2.83/0.54/0.63/0.47/0.14 (plain) and 4.90/3.46/2.65/2.14/1.79 (staggered); A/V = 0.65625, 0.66427, 0.66505, 0.66541, 0.66592 (plain) vs 0.62500, 0.63032, 0.63101, 0.63116, 0.63120 (staggered); Delta A < 0 at every L
+tori_exact_L4: M^6 - 52 M^4 + 676 M^2 = 1152 I (plain) and M^2 = 6 I (staggered) at the all-antiperiodic twist; A(+) = 42 = 21/32 per site, A(-) = 40 = 5/8 per site; dE_free = 48 sqrt2 - 32 sqrt6; g_c = 24 sqrt2 - 16 sqrt6 = -5.250710
+tori_limit: converged BZ quadrature gives A/V = 0.666263 (plain) and 0.631237 (staggered), e/V = -1.00241976 and -1.19380112, g_c = -5.4639
+mbpt2_caution: 4^3 second order gives -10.50142 - 2.00000 g + 0.44685 g^2, positive root 7.577, refuted by cube_exact at g = 8, 16, 32, 64 and by block at g = 8, 16
+large_g: <n_i> = 1/2 in both sectors to 5e-14 at g = 4, 8, 16, 32; m^2 -> 0.24945 / 0.24944 and Neel weight -> 0.99708 / 0.99704; g E_0 -> -6 in both; g^2 dE -> 0 along -0.4216, -0.2109, -0.1055
+ring_exchange: g^3 dE = -26.9815477888, -26.9953982475, -26.9988502688, -26.9997126114 at g = 64, 128, 256, 512 (mpmath, 60 digits), exponents 2.99926, 2.99982, 2.99995, Richardson -26.9999999999; E_0(-) - E_0(+) = -27 t^4/V^3 + O(V^-4), i.e. 9/4 per face carrying the sign S_f; on 2x2x3 the same quantity settles near -11.853 ~ -320/27
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=18 FAIL=0
+```
+
+## Proof boundary
+
+The content is **one interaction family**, on **finite** clusters, at a **supplied** particle number. The family is not derived, preferred or fixed here: it is quoted from the
+composition discriminator's note and scanned in `g` over declared lists. No mass, rate, temperature or absolute unit appears.
+
+Exhaustive comparison over **all** consistent flux sectors is done on **exactly two clusters**: the open `2x2x2` cube, all `32`, and the open `2x2x3` block, all `512`. There is
+no torus analogue; on the tori only first order in `V` is computed, and once, on `4^3`, second order recorded as a caution against itself. The free-case Cauchy-Schwarz
+certificate does not extend -- it bounds a one-particle ladder, not an interacting ground state -- so **no global-minimality claim is made anywhere in this note**.
+
+The half-filling statement is **repulsive-side and half-filling only**. Theorem 2 exhibits a filling at which the ordering is different at every `g` tested, with an exact
+crossing at `2 sqrt3`; Theorem 3 exhibits an attractive coupling at which a third sector wins. Both are results of this note, not caveats bolted onto it, and neither may be read
+as narrowing the half-filling repulsive claim beyond what is stated.
+
+The `-27` and the `-320/27` are **cluster coefficients**, high-precision numerical limits and not a derived ring-exchange amplitude; what transfers between the two clusters is
+the **sign**. The `12^3` plain sea's shell gap is `0.136`, the smallest in the table, and the first-order value there should be read with that in mind. The identification of the
+all-`(-1)` sector with the framework's staggered kinetic form is up to a **site relabelling**, verified spectrally on clusters small enough for the sector to be formed directly
+from the `S_f`; on the tori the KS field is used and its holonomy is `-1` on every face by construction.
+
+## Review record
+
+An honest auditor should come away with: two exhaustive interacting finite-cluster theorems naming the staggered sector as the unique many-body ground sector at half filling, one
+exact over `Z` at twelve integer couplings by minimal polynomials and a `CRootOf` comparison; one exactly located reordering away from half filling at `g_c = 2 sqrt3` and one
+attractive flip window on the larger block, both stated as results; a first-order torus computation pointing the same way, exact on `4^3` by two integer matrix identities; a
+large-coupling structure in which only a plaquette ring exchange separates the sectors; and one honest limit, that nothing here is a global-minimality claim.
+
+The four things most likely to be over-read are flagged in the proof boundary: exhaustive means two open clusters and no torus; the half-filling statement is repulsive-side only,
+with `T2` and `T3` marking where it ends; the second-order torus root at `g = 7.58` is a truncation artefact and is reported as one; and the ring-exchange coefficients are
+cluster numbers whose transferable content is their sign. This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis
+is adopted, and the four context notes in "Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache
+pair closing at `PASS=18 FAIL=0`, runtime under the declared `180` seconds, stdout under `5500` characters, a current zero-dependency citation-manifest entry, and passing
+pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.txt
+++ b/logs/runner-cache/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.txt
@@ -1,0 +1,47 @@
+===== runner cache v1 =====
+runner: scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py
+runner_sha256: b9d666ae0ca2dace54609dc814cc440da0f8e2c347387798561a8c9677022eb4
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 30.02
+status: ok
+----- stdout -----
+PASS A1 [exact] open 2x2x2 cube, 6 faces of F2 rank 5: exactly 32 of 64 face assignments are consistent sectors, flux counts 0/2/4/6, each realised by a link field of that holonomy
+   A2 cube N=4, g:margin of all-(-1) to the next sector -- -2:0.192 -1:0.344 -0.5:0.408 0:0.456 0.5:0.483 1:0.485 2:0.407 4:0.158 8:0.025
+PASS A2 [numerical, 1e-10] cube N = 4 (70-dim), H(g) = -sum eta_ij (c^dag c + h.c.) + g sum n_i n_j: all-(-1) is the UNIQUE minimiser of all 32 at each g above
+   A3 min poly of E_0 over Z, plain g=2: x**3 - 10*x**2 - 16*x + 48 ; staggered g=0: x**2 - 48
+     deg +: 333414334444 deg -: 555525555555 at g = -8,-4,-2,-1,0,1,2,4,8,16,32,64
+PASS A3 [exact, sympy over Z] the 70x70 integer characteristic polynomials at those twelve g give minimal polynomials of E_0 over Z for both uniform sectors, degrees above
+PASS A4 [exact, CRootOf comparison, no floating point] E_0(-) < E_0(+) strictly at all 12, 0 ties: the ordering is exact over Z, not a tolerance
+   B1 cube N=2, g:minimiser flux class/rank of all-(-1) of 32 -- -2:2/31 -1:2/31 -0.5:2/31 0:2/31 0.5:2/31 1:2/31 2:2/31 4:2/30 8:2/27
+PASS B1 [numerical, 1e-10] the same cube off half filling, N = 2 and N = 6 (28-dim): the minimiser is the two-flux class (3 tied) at every g above, never all-(-1)
+   B2 cube N=2 charpoly factors -- plain -g*x**2 + 8*g + x**3 - 16*x ; staggered x**2 - 12
+PASS B2 [exact, sympy, symbolic g] cube N = 2: the staggered factor x^2 - 12 is g-free, so E_0(-) = -2 sqrt3 at EVERY g and the pair crosses exactly at g_c = 2 sqrt3
+PASS C1 [exact] open 2x2x3 block, 12 sites, 20 bonds, 11 faces of F2 rank 9: exactly 512 of 2048 assignments are consistent sectors; the N = 6 sector has dimension 924
+   C2 2x2x3 N=6, 512 sectors, g:margin/plain rank/degeneracies -- 0:0.381/500/1/2 0.5:0.401/500/1/2 1:0.401/509/1/2 2:0.311/511/1/2 4:0.0581/511/1/2 8:0.0048/511/1/2 16:0.000491/511/1/2
+PASS C2 [numerical, 1e-9] 2x2x3, N = 6 (924-dim), all 512 sectors: all-(-1) is the UNIQUE minimiser at every g above, non-degenerate, the plain sector 2-fold throughout
+   C3 attractive, g:tied minimisers/flux count/rank of all-(-1) -- -1:1/11/0 -2:1/11/0 -2.3:1/11/0 -2.4:8/8/8
+PASS C3 [numerical, 1e-9] attractive side (above): all-(-1) is still unique at g = -1, -2, -2.3, but at -2.4 an 8-flux class of 8 tied sectors takes over -- flip window -2.4 < g_c < -2.3
+PASS C4 [numerical, 1e-9] the uniform PAIR never crosses on [-64, 64]: E_0(-) - E_0(+) < 0 at all 15 couplings there, largest -4.53e-05 -- the -2.4 flip is a third sector passing both
+   D1 tori L = 4, 6, 8, 10, 12; e_free/V: -1.0607/-1.2247 -1.0119/-1.1984 -1.0096/-1.1949 -1.0075/-1.1942 -1.0042/-1.1940
+      gap: 2.83/4.90 0.54/3.46 0.63/2.65 0.47/2.14 0.14/1.79 ; A/V: 0.65625/0.62500 0.66427/0.63032 0.66505/0.63101 0.66541/0.63116 0.66592/0.63120
+PASS D1 [numerical, 1e-9] first order in V about the twist-minimised free sea, tori 4^3 ... 12^3, A = sum_bonds (P_ii P_jj - P_ij^2) by Wick (above): A/V is SMALLER in the staggered sector at every L
+   D2 4^3 exact: A(+) = 42 = 21/32/site, A(-) = 40 = 5/8/site, dE_free = -32*sqrt(6) + 48*sqrt(2), g_c = -16*sqrt(6) + 24*sqrt(2)
+PASS D2 [exact, integer certificates + surds] on 4^3 at the optimal twist M^6 - 52 M^4 + 676 M^2 = 1152 I and M^2 = 6 I, so both projectors are polynomials in M with rational squared entries: the values above are exact
+   D3 BZ quadrature M=800: e/V = -1.00241976, -1.19380112; A/V = 0.666263, 0.631237; g_c = -5.4639
+PASS D3 [numerical, converged quadrature] the closed forms P_ij = <cos q_1>_occ and P_ij = +-(h(0) + h(2e_1))/2 with h = (6 + W)^(-1/2) give the limiting A/V above: one crossing, attractive
+   D4 4^3 MBPT2 dE(g) = -10.50142 -2.00000 g +0.44685 g^2, roots -3.1015 and 7.5773
+PASS D4 [numerical, caution only] the MBPT2 truncation above has a positive root g = 7.58 predicting a repulsive flip; REFUTED by the exact cube (A3, A4) and the 2x2x3 block (C2)
+   E1 cube N=4, g: m^2 then Neel weight, (+,-) each, against 1/4 and 1 -- 4: 0.2181 0.1999 0.8347 0.7504 | 8: 0.2414 0.2396 0.9545 0.9458 | 16: 0.2478 0.2477 0.9884 0.9878 | 32: 0.2495 0.2494 0.9971 0.9970
+PASS E1 [numerical, 1e-9] both sectors freeze into the SAME Neel doublet (above): <n_i> = 1/2 on every cube site in both to 5e-14, m^2 and the Neel weight rising together, here and on 2x2x3
+   E2 cube, g: g E_0 (+,-) then g^2 dE -- 64: -5.9995 -6.0061 -0.4216 | 128: -5.9999 -6.0015 -0.2109 | 256: -6.0000 -6.0004 -0.1055
+PASS E2 [numerical, converged in 1/g] the t^2/V exchange is sector-INDEPENDENT (above): g E_0 -> -6 in both sectors, g^2 (E_0(-) - E_0(+)) -> 0
+   E3 cube g^3 dE: 64:-26.9815477888 128:-26.9953982475 256:-26.9988502688 512:-26.9997126114; exponents 2.99926 2.99982 2.99995; Richardson limit -26.9999999999
+PASS E3 [numerical, mpmath 60 digits] the surviving difference is order t^4/V^3 (above): E_0(-) - E_0(+) = -27 t^4/V^3 on the cube -- a ring exchange of 9/4 a face carrying the sign S_f
+   E4 2x2x3 g^3 dE: 16:-12.12629 32:-11.92143 64:-11.86931 128:-11.85622 256:-11.85294
+PASS E4 [numerical, converged in 1/g] the same ring exchange on 2x2x3 with its own coefficient (above), near -11.8529 ~ -320/27: that number is cluster data, its SIGN is what is shared
+SUMMARY: with this interaction present the staggered sector stays the unique many-body ground sector at half filling on both exhaustive clusters at every repulsive coupling tested, the last difference to survive being a ring exchange that prefers the minus sign.
+TOTAL: PASS=18 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py
+++ b/scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py
@@ -1,0 +1,919 @@
+#!/usr/bin/env python3
+"""A record-conserving interaction keeps the staggered sector at half filling.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3, one
+fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding
+written on it.  Transport of one encoded excitation around a coarse face
+equals that face's stabilizer S_f, so a choice of eigenvalue +-1 per face --
+a flux sector -- is exactly a Z2 gauge class of nearest-neighbour link signs.
+The all-(+1) sector is the plain hopping; the all-(-1) sector is the
+framework's staggered (Kawamoto-Smit) kinetic form
+    eta_1 = 1,  eta_2(x) = (-1)^{x_1},  eta_3(x) = (-1)^{x_1+x_2}.
+A separate result shows that the FREE hopping energy at half filling picks the
+all-(-1) sector, and names as an open interface the question of what an
+interaction does.  This runner answers that question for one declared family,
+the record-conserving nearest-neighbour law
+
+    H(t, V) = -t sum_bonds eta_ij (c_i^dag c_j + c_j^dag c_i) + V sum_bonds n_i n_j,
+
+read at t = 1 with the single ratio g = V/t, on the many-body ground state at
+fixed particle number N -- not on a filled one-particle ladder.
+
+  A  EXHAUSTIVE CUBE AT HALF FILLING.  Open 2x2x2 coarse cube, N = 4, the
+     70-dimensional sector.  All 32 consistent flux sectors, every g on a
+     declared list: the all-(-1) sector is the unique many-body minimiser.
+     Exact over Z at twelve integer g by minimal polynomials of E_0 and a
+     CRootOf comparison with no floating point anywhere.
+  B  AWAY FROM HALF FILLING.  The same cube at N = 2 and N = 6.  Here the
+     interaction DOES reorder: the two-flux class wins at every g and the
+     uniform pair crosses at exactly g_c = 2 sqrt3.
+  C  EXHAUSTIVE 2x2x3 BLOCK AT HALF FILLING.  N = 6, the 924-dimensional
+     sector, all 512 consistent sectors, repulsive and attractive g.
+  D  FIRST ORDER ON TORI.  First-order perturbation theory in V about the
+     twist-minimised free half-filled sea on 4^3 ... 12^3.  The first-order
+     coefficient also favours the staggered sector, exactly on 4^3.
+  E  LARGE COUPLING.  Both sectors freeze to the same Neel doublet, the
+     t^2/V exchange is sector-independent, and the whole surviving difference
+     is a plaquette ring exchange at order t^4/V^3.
+
+Group A's integer-g content, the whole of B's exact item and D's 4^3 item are
+exact -- sympy charpolys of integer matrices, symbolic g, surds, CRootOf
+comparison, F2/Z4 symplectic bit arithmetic, exhaustive enumeration.  Items
+tagged [numerical] are floating-point statements at the stated tolerance.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from collections import deque
+from fractions import Fraction
+
+import mpmath as mp
+import numpy as np
+import scipy.sparse as sparse
+import scipy.sparse.linalg as sparse_linalg
+import sympy as sp
+
+AUDIT_TIMEOUT_SEC = 180
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ================================================ coarse lattice and KS phases
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    """KS link sign of the coarse bond (v, v + e_a); axes 0,1,2 = 1,2,3."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def wrap(v, dims):
+    return tuple(v[i] % dims[i] for i in range(3))
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+class Q:
+    """i^k X^x Z^z on a register of qubits indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def isI(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def ismI(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+    def vec(s, n):
+        return s.x | (s.z << n)
+
+
+IDQ = Q(0, 0, 0)
+
+
+def qprod(seq):
+    o = IDQ
+    for p in seq:
+        o = o * p
+    return o
+
+
+class Lat:
+    """Coarse cubic block or torus with the BK superfast encoding on its edges."""
+
+    def __init__(self, dims, periodic):
+        self.dims = tuple(dims)
+        self.per = periodic
+        self.V = list(itertools.product(*(range(d) for d in dims)))
+        self.nv = len(self.V)
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+        self.idx = {v: i for i, v in enumerate(self.V)}
+        self.rows = np.array([self.idx[self.step(v, EX[ax])] for (v, ax) in self.E])
+        self.cols = np.array([self.idx[v] for (v, ax) in self.E])
+
+    def step(self, v, d):
+        w = va(v, d)
+        if self.per:
+            return wrap(w, self.dims)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+    def mat(self, s):
+        """Real symmetric hopping matrix of the link-sign vector s (edge order)."""
+        M = np.zeros((self.nv, self.nv))
+        np.add.at(M, (self.rows, self.cols), np.asarray(s, dtype=float))
+        return M + M.T
+
+    def imat(self, s):
+        """Integer hopping matrix of the link-sign vector s."""
+        M = np.zeros((self.nv, self.nv), dtype=np.int64)
+        np.add.at(M, (self.rows, self.cols), np.asarray(s, dtype=np.int64))
+        return M + M.T
+
+
+def transport(L, path):
+    """Ordered product of the encoded hops T_{i_{k+1} i_k} = (i/2) A (B - B).
+
+    On any configuration where every step is legal -- source occupied, target
+    empty -- each factor contributes (i/2)(+1 - (-1)) = i, hence the i^n.
+    """
+    n = len(path) - 1
+    ops = [L.Aij(path[k + 1], path[k]) for k in range(n)]
+    return qprod(ops[::-1]).scal(n)
+
+
+def f2_pivots(gens):
+    piv = {}
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+    return piv
+
+
+def f2_express(target, piv):
+    v, c = target, 0
+    while v:
+        p = v.bit_length() - 1
+        if p not in piv:
+            return None
+        pv, pc = piv[p]
+        v ^= pv
+        c ^= pc
+    return c
+
+
+def f2_relations(gens):
+    piv, rel = {}, []
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+        if v == 0:
+            rel.append(c)
+    return rel, len(piv)
+
+
+def bits(m):
+    out = []
+    while m:
+        b = m & -m
+        out.append(b.bit_length() - 1)
+        m ^= b
+    return out
+
+
+def sector_eta(L, face_vals, wilson=(1, 1, 1)):
+    """Link-sign field realising the flux sector S_f = face_vals[f] on Lat L.
+
+    Spanning-tree gauge fixing, then fundamental-cycle transport with the
+    residual Z4 phase read off, exactly as in the face-transport theorem;
+    the face eigenvalues are supplied rather than fixed at -1.  Returns
+    (eta, consistent); eta is None when the sector is inconsistent.
+    """
+    root = L.V[0]
+    par = {root: None}
+    dq = deque([root])
+    while dq:
+        v = dq.popleft()
+        for r in range(6):
+            if r not in L.inc[v]:
+                continue
+            w = L.inc[v][r][0]
+            if w not in par:
+                par[w] = v
+                dq.append(w)
+    tree = {frozenset((v, w)) for w, v in par.items() if v is not None}
+
+    def tpath(v):
+        p = [v]
+        while par[p[-1]] is not None:
+            p.append(par[p[-1]])
+        return p[::-1]
+
+    F = L.faces()
+    gens = [L.loop(f) for f in F]
+    vals = list(face_vals)
+    if L.per:
+        for ax in range(3):
+            cyc = [wrap(tuple((k if i == ax else 0) for i in range(3)), L.dims)
+                   for k in range(L.dims[ax])]
+            gens.append(transport(L, cyc + [cyc[0]]))
+        vals += list(wilson)
+    gv = [g.vec(L.nq) for g in gens]
+    piv = f2_pivots(gv)
+    rels, _ = f2_relations(gv)
+    for r in rels:
+        idxs = bits(r)
+        pr = qprod([gens[j] for j in idxs])
+        eps = 1 if pr.isI() else (-1 if pr.ismI() else 0)
+        pv = 1
+        for j in idxs:
+            pv *= vals[j]
+        if eps == 0 or pv != eps:
+            return None, False
+    eta = {}
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        if frozenset((v, w)) in tree:
+            eta[(v, ax)] = 1
+            continue
+        op = transport(L, tpath(v) + [w] + tpath(w)[::-1][1:])
+        c = f2_express(op.vec(L.nq), piv)
+        if c is None:
+            return None, False
+        idxs = bits(c)
+        resid = (op.k - qprod([gens[j] for j in idxs]).k) & 3
+        if resid not in (0, 2):
+            return None, False
+        e = 1 if resid == 0 else -1
+        for j in idxs:
+            e *= vals[j]
+        eta[(v, ax)] = e
+    return eta, True
+
+
+def hol_list(L, eta):
+    """Plaquette holonomy of the sign field eta, one entry per face."""
+    out = []
+    for (v, a, c, b) in L.faces():
+        pr = 1
+        for (p, q) in ((v, a), (a, c), (b, c), (v, b)):
+            for ax in range(3):
+                if L.step(p, EX[ax]) == q and (p, ax) in eta:
+                    pr *= eta[(p, ax)]
+                    break
+                if L.step(q, EX[ax]) == p and (q, ax) in eta:
+                    pr *= eta[(q, ax)]
+                    break
+        out.append(pr)
+    return out
+
+
+def vec_of(L, eta):
+    return np.array([eta[(v, ax)] for (v, ax) in L.E], dtype=float)
+
+
+
+# ============================================ the record-conserving many-body law
+
+
+def bond_list(L):
+    """[(i, j, key)] site-index pairs and edge key for every coarse bond."""
+    return [(L.idx[v], L.idx[L.step(v, EX[ax])], (v, ax)) for (v, ax) in L.E]
+
+
+def basis(nv, N):
+    """All nv-bit patterns with N bits set, sorted, plus the index map."""
+    st = sorted(sum(1 << o for o in occ) for occ in itertools.combinations(range(nv), N))
+    return st, {s: k for k, s in enumerate(st)}
+
+
+def hop(state, i, j):
+    """c_i^dag c_j |state>: returns (new state, Jordan-Wigner sign) or None."""
+    if not (state >> j) & 1:
+        return None
+    s1 = bin(state & ((1 << j) - 1)).count("1")
+    s = state ^ (1 << j)
+    if (s >> i) & 1:
+        return None
+    s2 = bin(s & ((1 << i) - 1)).count("1")
+    return (s | (1 << i)), (1 if (s1 + s2) % 2 == 0 else -1)
+
+
+class Sector:
+    """The N-particle record-number sector of one cluster, as sparse structure.
+
+    `rows`, `cols`, `bidx`, `sgn` hold the hopping graph once; a link-sign
+    vector and a coupling g then assemble H without re-walking the basis.
+    """
+
+    def __init__(self, L, N):
+        self.L, self.N = L, N
+        self.bl = bond_list(L)
+        self.st, self.ix = basis(L.nv, N)
+        self.D = len(self.st)
+        rows, cols, bidx, sgn = [], [], [], []
+        self.nn = np.zeros(self.D)
+        self.occ = np.zeros((self.D, L.nv))
+        for k, s in enumerate(self.st):
+            for i in range(L.nv):
+                self.occ[k, i] = (s >> i) & 1
+            d = 0
+            for bi, (i, j, key) in enumerate(self.bl):
+                if ((s >> i) & 1) and ((s >> j) & 1):
+                    d += 1
+                for (a, b) in ((i, j), (j, i)):
+                    r = hop(s, a, b)
+                    if r is None:
+                        continue
+                    ns, sg = r
+                    rows.append(self.ix[ns])
+                    cols.append(k)
+                    bidx.append(bi)
+                    sgn.append(sg)
+            self.nn[k] = d
+        self.rows = np.array(rows)
+        self.cols = np.array(cols)
+        self.bidx = np.array(bidx)
+        self.sgn = np.array(sgn, dtype=float)
+
+    def vec(self, eta):
+        """Link-sign vector in bond order from an eta dict."""
+        return np.array([eta[key] for (_, _, key) in self.bl], dtype=float)
+
+    def dense(self, v, g):
+        H = np.zeros((self.D, self.D))
+        np.add.at(H, (self.rows, self.cols), -v[self.bidx] * self.sgn)
+        H[np.arange(self.D), np.arange(self.D)] += g * self.nn
+        return H
+
+    def idense(self, v, g):
+        """Exact integer H, for integer link signs and integer g."""
+        H = np.zeros((self.D, self.D), dtype=np.int64)
+        np.add.at(H, (self.rows, self.cols),
+                  -np.asarray(v, dtype=np.int64)[self.bidx] * self.sgn.astype(np.int64))
+        H[np.arange(self.D), np.arange(self.D)] += int(g) * self.nn.astype(np.int64)
+        return H
+
+    def sym(self, v, gsym):
+        """Exact sympy H with a symbolic coupling."""
+        H = sp.zeros(self.D, self.D)
+        for r, c, b, s in zip(self.rows, self.cols, self.bidx, self.sgn):
+            H[int(r), int(c)] += -int(v[b]) * int(s)
+        for k in range(self.D):
+            H[k, k] += gsym * int(self.nn[k])
+        return H
+
+    def sp(self, v, g):
+        M = sparse.coo_matrix((-v[self.bidx] * self.sgn, (self.rows, self.cols)),
+                              shape=(self.D, self.D)).tocsr()
+        return (M + sparse.diags(g * self.nn)).tocsr()
+
+    def low(self, v, g, k=3, tol=1e-12):
+        """The k lowest levels; Lanczos when it pays, dense otherwise."""
+        if self.D <= 200:
+            return np.linalg.eigvalsh(self.dense(v, g))[:k]
+        w = sparse_linalg.eigsh(self.sp(v, g), k=k, which="SA", tol=tol,
+                                return_eigenvectors=False)
+        return np.sort(w)
+
+
+def sectors_of(L):
+    """Every consistent flux sector of L as (face values, link vector, flux count)."""
+    F = L.faces()
+    out = []
+    for fv in itertools.product([1, -1], repeat=len(F)):
+        eta, ok = sector_eta(L, fv)
+        if ok:
+            out.append((fv, eta, sum(1 for x in fv if x == -1)))
+    return out
+
+
+# =============================================== group A: exhaustive cube, N = 4
+
+X = sp.Symbol("x")
+GSYM = sp.Symbol("g")
+
+CUBE = Lat((2, 2, 2), False)
+CSECT = sectors_of(CUBE)
+CFLUX = sorted({s[2] for s in CSECT})
+IM = [k for k, s in enumerate(CSECT) if all(x == -1 for x in s[0])][0]
+IP = [k for k, s in enumerate(CSECT) if all(x == 1 for x in s[0])][0]
+HOL_OK = all(list(hol_list(CUBE, e)) == list(fv) for (fv, e, _) in CSECT)
+_, CRANK = f2_relations([CUBE.loop(f).vec(CUBE.nq) for f in CUBE.faces()])
+check(
+    "A1 [exact] open 2x2x2 cube, 6 faces of F2 rank %d: exactly %d of 64 face assignments are consistent "
+    "sectors, flux counts %s, each realised by a link field of that holonomy" % (CRANK, len(CSECT), "/".join(str(c) for c in CFLUX)),
+    len(CSECT) == 32 and CRANK == 5 and CFLUX == [0, 2, 4, 6] and HOL_OK,
+)
+
+S4 = Sector(CUBE, 4)
+CVEC = [S4.vec(e) for (_, e, _) in CSECT]
+GA = [-2, -1, -0.5, 0, 0.5, 1, 2, 4, 8]
+AROW = []
+for g in GA:
+    E0 = np.array([S4.low(v, float(g), k=1)[0] for v in CVEC])
+    o = np.argsort(E0)
+    emin = E0[o[0]]
+    nmin = int(np.sum(E0 < emin + 1e-10))
+    AROW.append((g, emin, nmin, int(o[0]), E0[o][nmin] - emin, E0[IM] - E0[IP]))
+print("   A2 cube N=4, g:margin of all-(-1) to the next sector -- "
+      + " ".join("%g:%.3f" % (r[0], r[4]) for r in AROW))
+AUNIQ = all(r[2] == 1 and r[3] == IM for r in AROW)
+check(
+    "A2 [numerical, 1e-10] cube N = 4 (70-dim), H(g) = -sum eta_ij (c^dag c + h.c.) + g sum n_i n_j: all-(-1) "
+    "is the UNIQUE minimiser of all 32 at each g above",
+    AUNIQ and all(r[5] < -1e-9 for r in AROW),
+)
+
+GZ = [-8, -4, -2, -1, 0, 1, 2, 4, 8, 16, 32, 64]
+MINPOLY, EXROOT = {}, {}
+for lab, si in (("+", IP), ("-", IM)):
+    v = np.rint(CVEC[si]).astype(np.int64)
+    for g in GZ:
+        H = S4.idense(v, g)
+        poly = sp.Poly(sp.Matrix(H.tolist()).charpoly(X).as_expr(), X)
+        roots = sp.real_roots(poly)
+        e0 = min(roots)
+        EXROOT[(lab, g)] = e0
+        MINPOLY[(lab, g)] = sp.Poly(sp.minimal_polynomial(e0, X), X)
+print("   A3 min poly of E_0 over Z, plain g=2: %s ; staggered g=0: %s"
+      % (MINPOLY[("+", 2)].as_expr(), MINPOLY[("-", 0)].as_expr()))
+print("     deg +: " + "".join(str(MINPOLY[("+", g)].degree()) for g in GZ)
+      + " deg -: " + "".join(str(MINPOLY[("-", g)].degree()) for g in GZ)
+      + " at g = " + ",".join(str(g) for g in GZ))
+check(
+    "A3 [exact, sympy over Z] the 70x70 integer characteristic polynomials at those twelve g give minimal "
+    "polynomials of E_0 over Z for both uniform sectors, degrees above",
+    MINPOLY[("+", 2)].as_expr() == X ** 3 - 10 * X ** 2 - 16 * X + 48
+    and MINPOLY[("-", 0)].as_expr() == X ** 2 - 48
+    and all(MINPOLY[(l, g)].domain == sp.ZZ for l in "+-" for g in GZ),
+)
+
+LT = [bool(EXROOT[("-", g)] < EXROOT[("+", g)]) for g in GZ]
+EQ = [bool(sp.Eq(EXROOT[("-", g)], EXROOT[("+", g)])) for g in GZ]
+check(
+    "A4 [exact, CRootOf comparison, no floating point] E_0(-) < E_0(+) strictly at all %d, 0 ties: the "
+    "ordering is exact over Z, not a tolerance" % sum(LT),
+    all(LT) and not any(EQ),
+)
+
+
+# ========================================= group B: the cube away from half filling
+
+BROW = {}
+for N in (2, 6):
+    S = Sector(CUBE, N)
+    vv = [S.vec(e) for (_, e, _) in CSECT]
+    rows = []
+    for g in GA:
+        E0 = np.array([S.low(v, float(g), k=1)[0] for v in vv])
+        o = np.argsort(E0)
+        emin = E0[o[0]]
+        nmin = int(np.sum(E0 < emin + 1e-10))
+        fl = sorted({CSECT[k][2] for k in np.where(E0 < emin + 1e-10)[0]})
+        rows.append((g, nmin, fl, int(np.where(o == IM)[0][0]), E0[IM] - E0[IP]))
+    BROW[N] = rows
+print("   B1 cube N=2, g:minimiser flux class/rank of all-(-1) of 32 -- "
+      + " ".join("%g:%d/%d" % (r[0], r[2][0], r[3]) for r in BROW[2]))
+BOK = all(r[1] == 3 and r[2] == [2] and r[3] > 0 for N in (2, 6) for r in BROW[N])
+check(
+    "B1 [numerical, 1e-10] the same cube off half filling, N = 2 and N = 6 (28-dim): the minimiser is the "
+    "two-flux class (3 tied) at every g above, never all-(-1)",
+    BOK,
+)
+
+S2 = Sector(CUBE, 2)
+FACP = sp.factor_list(S2.sym(np.rint(CVEC[IP]).astype(int), GSYM).charpoly(X).as_expr(), X)[1]
+FACM = sp.factor_list(S2.sym(np.rint(CVEC[IM]).astype(int), GSYM).charpoly(X).as_expr(), X)[1]
+PSET = {sp.expand(f.as_expr() if isinstance(f, sp.Poly) else f) for f, _ in FACP}
+MSET = {sp.expand(f.as_expr() if isinstance(f, sp.Poly) else f) for f, _ in FACM}
+PLAIN_CUBIC = X ** 3 - GSYM * X ** 2 - 16 * X + 8 * GSYM
+E0M = -2 * sp.sqrt(3)
+E0P = min(r for r in sp.real_roots(sp.Poly(PLAIN_CUBIC.subs(GSYM, 0), X)))
+CROSS = sp.solve(sp.Eq(PLAIN_CUBIC.subs(X, E0M), 0), GSYM)
+print("   B2 cube N=2 charpoly factors -- plain %s ; staggered %s"
+      % (PLAIN_CUBIC, X ** 2 - 12))
+check(
+    "B2 [exact, sympy, symbolic g] cube N = 2: the staggered factor x^2 - 12 is g-free, so E_0(-) = -2 sqrt3 at "
+    "EVERY g and the pair crosses exactly at g_c = 2 sqrt3",
+    (X ** 2 - 12) in MSET and PLAIN_CUBIC in PSET and CROSS == [2 * sp.sqrt(3)]
+    and bool(E0P < E0M),
+)
+
+
+# ========================================= group C: the exhaustive 2x2x3 block
+
+BLK = Lat((2, 2, 3), False)
+BSECT = sectors_of(BLK)
+_, BRANK = f2_relations([BLK.loop(f).vec(BLK.nq) for f in BLK.faces()])
+S6 = Sector(BLK, 6)
+BVEC = [S6.vec(e) for (_, e, _) in BSECT]
+JM = [k for k, s in enumerate(BSECT) if all(x == -1 for x in s[0])][0]
+JP = [k for k, s in enumerate(BSECT) if all(x == 1 for x in s[0])][0]
+check(
+    "C1 [exact] open 2x2x3 block, 12 sites, 20 bonds, %d faces of F2 rank %d: exactly %d of %d assignments are "
+    "consistent sectors; the N = 6 sector has dimension %d"
+    % (len(BLK.faces()), BRANK, len(BSECT), 2 ** len(BLK.faces()), S6.D),
+    len(BLK.faces()) == 11 and BRANK == 9 and len(BSECT) == 512 and S6.D == 924,
+)
+
+
+def scan(g):
+    """E_0 of all 512 sectors at coupling g, plus the two uniform gaps."""
+    E0 = np.empty(len(BSECT))
+    for k, v in enumerate(BVEC):
+        E0[k] = sparse_linalg.eigsh(S6.sp(v, g), k=1, which="SA", tol=1e-12,
+                                    return_eigenvectors=False)[0]
+    o = np.argsort(E0)
+    emin = E0[o[0]]
+    nmin = int(np.sum(E0 < emin + 1e-9))
+    return dict(
+        g=g, E0=E0, emin=emin, nmin=nmin, arg=int(o[0]),
+        margin=float(E0[o][nmin] - emin) if nmin < len(E0) else float("nan"),
+        minflux=sorted({BSECT[k][2] for k in np.where(E0 < emin + 1e-9)[0]}),
+        rank_m=int(np.where(o == JM)[0][0]), rank_p=int(np.where(o == JP)[0][0]),
+        dE=float(E0[JM] - E0[JP]),
+        deg_m=int(np.sum(S6.low(BVEC[JM], g, k=3) < E0[JM] + 1e-9)),
+        deg_p=int(np.sum(S6.low(BVEC[JP], g, k=3) < E0[JP] + 1e-9)),
+    )
+
+
+GC = [0.0, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0]
+CR = [scan(g) for g in GC]
+print("   C2 2x2x3 N=6, 512 sectors, g:margin/plain rank/degeneracies -- "
+      + " ".join("%g:%.3g/%d/%d/%d" % (r["g"], r["margin"], r["rank_p"], r["deg_m"], r["deg_p"])
+                 for r in CR))
+check(
+    "C2 [numerical, 1e-9] 2x2x3, N = 6 (924-dim), all 512 sectors: all-(-1) is the UNIQUE minimiser at every g "
+    "above, non-degenerate, the plain sector 2-fold throughout",
+    all(r["nmin"] == 1 and r["arg"] == JM and r["dE"] < -1e-9 and r["deg_m"] == 1 and r["deg_p"] == 2
+        for r in CR),
+)
+
+GN = [-1.0, -2.0, -2.3, -2.4]
+CN = [scan(g) for g in GN]
+print("   C3 attractive, g:tied minimisers/flux count/rank of all-(-1) -- "
+      + " ".join("%g:%d/%d/%d" % (r["g"], r["nmin"], r["minflux"][0], r["rank_m"]) for r in CN))
+FLIP = [r for r in CN if not (r["nmin"] == 1 and r["arg"] == JM)]
+check(
+    "C3 [numerical, 1e-9] attractive side (above): all-(-1) is still unique at g = -1, -2, -2.3, but at -2.4 "
+    "an 8-flux class of %d tied sectors takes over -- flip window -2.4 < g_c < -2.3" % CN[-1]["nmin"],
+    all(r["nmin"] == 1 and r["arg"] == JM for r in CN[:3])
+    and CN[-1]["nmin"] == 8 and CN[-1]["minflux"] == [8] and CN[-1]["rank_m"] > 0,
+)
+
+GW = [-64.0, -32.0, -16.0, -8.0, -4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]
+WPAIR = [(g, float(S6.low(BVEC[JM], g, k=1)[0] - S6.low(BVEC[JP], g, k=1)[0])) for g in GW]
+check(
+    "C4 [numerical, 1e-9] the uniform PAIR never crosses on [-64, 64]: E_0(-) - E_0(+) < 0 at all %d couplings "
+    "there, largest %.2e -- the -2.4 flip is a third sector passing both" % (len(GW), max(d for _, d in WPAIR)),
+    all(d < -1e-9 for _, d in WPAIR),
+)
+
+
+# ================================= group D: first order in V on the coarse tori
+
+
+def twisted(L, kind, tw):
+    """Link-sign field of a uniform sector with the three Wilson twists tw."""
+    eta = {}
+    for (v, ax) in L.E:
+        e = 1 if kind == "+" else eta_ks(v, ax)
+        if v[ax] == L.dims[ax] - 1:
+            e *= tw[ax]
+        eta[(v, ax)] = e
+    return eta
+
+
+def sea(L, eta):
+    """Twist-minimised free half-filled sea: energy, closed-shell gap, A."""
+    w, C = np.linalg.eigh(-L.mat(vec_of(L, eta)))
+    Nh = L.nv // 2
+    P = C[:, :Nh] @ C[:, :Nh].T
+    A = float(sum(P[i, i] * P[j, j] - P[i, j] ** 2 for (i, j, _) in bond_list(L)))
+    return float(np.sum(w[:Nh])), float(w[Nh] - w[Nh - 1]), A, P
+
+
+DROW = {}
+for Lz in (4, 6, 8, 10, 12):
+    T = Lat((Lz, Lz, Lz), True)
+    for kind in ("+", "-"):
+        best = None
+        for tw in itertools.product([1, -1], repeat=3):
+            r = sea(T, twisted(T, kind, tw))
+            if best is None or r[0] < best[0] - 1e-11:
+                best = r + (tw,)
+        DROW[(Lz, kind)] = best
+LS = (4, 6, 8, 10, 12)
+print("   D1 tori L = 4, 6, 8, 10, 12; e_free/V: "
+      + " ".join("%.4f/%.4f" % (DROW[(L, "+")][0] / L ** 3, DROW[(L, "-")][0] / L ** 3) for L in LS))
+print("      gap: " + " ".join("%.2f/%.2f" % (DROW[(L, "+")][1], DROW[(L, "-")][1]) for L in LS)
+      + " ; A/V: " + " ".join("%.5f/%.5f" % (DROW[(L, "+")][2] / L ** 3, DROW[(L, "-")][2] / L ** 3)
+                              for L in LS))
+DGC = {}
+for Lz in (4, 6, 8, 10, 12):
+    V = Lz ** 3
+    de = (DROW[(Lz, "-")][0] - DROW[(Lz, "+")][0]) / V
+    da = (DROW[(Lz, "-")][2] - DROW[(Lz, "+")][2]) / V
+    DGC[Lz] = (de, da, -de / da)
+check(
+    "D1 [numerical, 1e-9] first order in V about the twist-minimised free sea, tori 4^3 ... 12^3, A = sum_bonds "
+    "(P_ii P_jj - P_ij^2) by Wick (above): A/V is SMALLER in the staggered sector at every L",
+    all(DGC[L][1] < -1e-12 and DGC[L][0] < -1e-12 for L in DGC)
+    and all(DROW[(L, k)][1] > 1e-6 for L in (4, 6, 8, 10, 12) for k in "+-"),
+)
+
+T4 = Lat((4, 4, 4), True)
+M4P = T4.imat(vec_of(T4, twisted(T4, "+", (-1, -1, -1))))
+M4M = T4.imat(vec_of(T4, twisted(T4, "-", (-1, -1, -1))))
+I64 = np.eye(64, dtype=np.int64)
+P2 = M4P @ M4P
+P3 = P2 @ M4P
+P4 = P2 @ P2
+CERT_P = np.array_equal(P4 @ P2 - 52 * P4 + 676 * P2, 1152 * I64)
+CERT_M = np.array_equal(M4M @ M4M, 6 * I64)
+# X = (13 M - M^3 / 2) / (12 sqrt2) squares to the identity above, so
+# P = (I + X)/2 is the exact occupied projector; every P_ij^2 is rational.
+A2, AB2, B2 = Fraction(169, 288), Fraction(-13, 288), Fraction(1, 1152)
+AEX = {"+": Fraction(0), "-": Fraction(0)}
+for (i, j, _) in bond_list(T4):
+    mp_, m3 = int(M4P[i, j]), int(P3[i, j])
+    AEX["+"] += Fraction(1, 4) - (A2 * mp_ * mp_ + AB2 * mp_ * m3 + B2 * m3 * m3) / 4
+    AEX["-"] += Fraction(1, 4) - Fraction(int(M4M[i, j]) ** 2, 24)
+DIAG_OK = all(P3[i, i] == 0 for i in range(64)) and all(M4P[i, i] == 0 for i in range(64))
+R2, R6 = sp.sqrt(2), sp.sqrt(6)
+DEEX = sp.simplify(48 * R2 - 32 * R6)
+GCEX = sp.simplify(-DEEX / sp.Rational(AEX["-"] - AEX["+"]))
+print("   D2 4^3 exact: A(+) = %s = %s/site, A(-) = %s = %s/site, dE_free = %s, g_c = %s"
+      % (AEX["+"], Fraction(AEX["+"], 64), AEX["-"], Fraction(AEX["-"], 64), DEEX, GCEX))
+check(
+    "D2 [exact, integer certificates + surds] on 4^3 at the optimal twist M^6 - 52 M^4 + 676 M^2 = 1152 I and "
+    "M^2 = 6 I, so both projectors are polynomials in M with rational squared entries: the values above are "
+    "exact",
+    CERT_P and CERT_M and DIAG_OK and AEX["+"] == 42 and AEX["-"] == 40
+    and GCEX == 24 * R2 - 16 * R6 and abs(float(GCEX) - DGC[4][2]) < 1e-9,
+)
+
+QUAD = []
+for Mg in (200, 400, 800):
+    v = np.cos(2 * np.pi * (np.arange(Mg) + 0.5) / Mg)
+    S2 = v[:, None] + v[None, :]
+    ep = cp = em = cm = 0.0
+    for i in range(Mg):
+        s = v[i] + S2
+        occ = s < 0
+        ep += float(np.sum(np.abs(2 * s)))
+        cp += float(np.sum(np.where(occ, v[i], 0.0)))
+        rt = np.sqrt(np.maximum(6 + 2 * s, 0.0))
+        em += float(np.sum(rt))
+        cm += float(np.sum((1 + v[i]) / np.maximum(rt, 1e-300)))
+    n = Mg ** 3
+    QUAD.append((Mg, -ep / (2 * n), cp / n, -em / (2 * n), cm / (2 * n)))
+_, EPI, CPI, EMI, CMI = QUAD[-1]
+API, AMI = 0.75 - 3 * CPI ** 2, 0.75 - 3 * CMI ** 2
+GCI = -(EMI - EPI) / (AMI - API)
+print("   D3 BZ quadrature M=%d: e/V = %.8f, %.8f; A/V = %.6f, %.6f; g_c = %.4f"
+      % (QUAD[-1][0], EPI, EMI, API, AMI, GCI))
+check(
+    "D3 [numerical, converged quadrature] the closed forms P_ij = <cos q_1>_occ and P_ij = +-(h(0) + h(2e_1))/2 "
+    "with h = (6 + W)^(-1/2) give the limiting A/V above: one crossing, attractive",
+    abs(API - 0.66626) < 3e-4 and abs(AMI - 0.6312) < 3e-4 and AMI < API
+    and -5.6 < GCI < -5.3 and abs(QUAD[1][4] - QUAD[2][4]) < 1e-5,
+)
+
+W4 = np.zeros((64, 64))
+for (i, j, _) in bond_list(T4):
+    W4[i, j] = W4[j, i] = 1.0
+C2 = {}
+for kind in ("+", "-"):
+    w, C = np.linalg.eigh(-T4.mat(vec_of(T4, twisted(T4, kind, (-1, -1, -1)))))
+    No = 32
+    Y = np.einsum("mi,ma->iam", C[:, :No], C[:, No:])
+    Yf = Y.reshape(No * (64 - No), 64)
+    Mm = (Yf @ W4 @ Yf.T).reshape(No, 64 - No, No, 64 - No)
+    anti = Mm - np.transpose(Mm, (0, 3, 2, 1))
+    eo, ev = w[:No], w[No:]
+    den = (eo[:, None, None, None] - ev[None, :, None, None]
+           + eo[None, None, :, None] - ev[None, None, None, :])
+    C2[kind] = 0.25 * float(np.sum(anti ** 2 / den))
+QA = C2["-"] - C2["+"]
+QB = float(AEX["-"] - AEX["+"])
+QC = float(DEEX)
+DISC = QB * QB - 4 * QA * QC
+ROOTS = sorted([(-QB + np.sqrt(DISC)) / (2 * QA), (-QB - np.sqrt(DISC)) / (2 * QA)])
+print("   D4 4^3 MBPT2 dE(g) = %+.5f %+.5f g %+.5f g^2, roots %.4f and %.4f"
+      % (QC, QB, QA, ROOTS[0], ROOTS[1]))
+check(
+    "D4 [numerical, caution only] the MBPT2 truncation above has a positive root g = %.2f predicting a "
+    "repulsive flip; REFUTED by the exact cube (A3, A4) and the 2x2x3 block (C2)" % ROOTS[1],
+    QA > 0 and 7.0 < ROOTS[1] < 8.2 and ROOTS[0] < 0,
+)
+
+
+# ======================================== group E: the large-coupling structure
+
+
+def order(S, L, v, g, tol=1e-9):
+    """Degeneracy-averaged density, staggered moment and Neel weight."""
+    w, U = np.linalg.eigh(S.dense(v, g))
+    d = int(np.sum(w < w[0] + tol))
+    diag = np.sum(U[:, :d] ** 2, axis=1) / d
+    n = diag @ S.occ
+    sgn3 = np.array([1 - 2 * ((x + y + z) & 1) for (x, y, z) in L.V], dtype=float)
+    mvec = (S.occ - 0.5) @ sgn3 / L.nv
+    neel = float(np.sum(diag[np.abs(np.abs(mvec) - 0.5) < 1e-12]))
+    return w[0], d, float(n.min()), float(n.max()), float(diag @ mvec ** 2), neel
+
+
+GE = [4.0, 8.0, 16.0, 32.0]
+EROW = {}
+for lab, si in (("+", IP), ("-", IM)):
+    for g in GE:
+        EROW[(lab, g)] = order(S4, CUBE, CVEC[si], g)
+print("   E1 cube N=4, g: m^2 then Neel weight, (+,-) each, against 1/4 and 1 -- "
+      + " | ".join("%g: %.4f %.4f %.4f %.4f"
+                   % (g, EROW[("+", g)][4], EROW[("-", g)][4],
+                      EROW[("+", g)][5], EROW[("-", g)][5]) for g in GE))
+BROWE = {}
+for lab, si in (("+", JP), ("-", JM)):
+    for g in GE:
+        BROWE[(lab, g)] = order(S6, BLK, BVEC[si], g)
+check(
+    "E1 [numerical, 1e-9] both sectors freeze into the SAME Neel doublet (above): <n_i> = 1/2 on every cube "
+    "site in both to %.0e, m^2 and the Neel weight rising together, here and on 2x2x3"
+    % max(max(abs(r[2] - 0.5), abs(r[3] - 0.5)) for r in EROW.values()),
+    all(abs(r[2] - 0.5) < 1e-9 and abs(r[3] - 0.5) < 1e-9 for r in EROW.values())
+    and all(EROW[(l, 32.0)][4] > 0.2494 and EROW[(l, 32.0)][5] > 0.996 for l in "+-")
+    and all(BROWE[(l, 32.0)][4] > 0.2494 for l in "+-")
+    and all(EROW[(l, g)][4] < EROW[(l, h)][4] for l in "+-" for g, h in zip(GE, GE[1:]))
+    and all(BROWE[(l, g)][4] < BROWE[(l, h)][4] for l in "+-" for g, h in zip(GE, GE[1:])),
+)
+
+GT = [64.0, 128.0, 256.0]
+TROW = []
+for g in GT:
+    ep = float(S4.low(CVEC[IP], g, k=1)[0])
+    em = float(S4.low(CVEC[IM], g, k=1)[0])
+    TROW.append((g, g * ep, g * em, g * g * (em - ep)))
+print("   E2 cube, g: g E_0 (+,-) then g^2 dE -- "
+      + " | ".join("%g: %.4f %.4f %.4f" % r for r in TROW))
+check(
+    "E2 [numerical, converged in 1/g] the t^2/V exchange is sector-INDEPENDENT (above): g E_0 -> -6 in both "
+    "sectors, g^2 (E_0(-) - E_0(+)) -> 0",
+    all(abs(r[1] + 6) < 0.01 and abs(r[2] + 6) < 0.01 for r in TROW)
+    and abs(TROW[-1][3]) < abs(TROW[0][3]) < 1.0 and abs(TROW[-1][3]) < 0.25,
+)
+
+mp.mp.dps = 60
+IVP = np.rint(CVEC[IP]).astype(np.int64)
+IVM = np.rint(CVEC[IM]).astype(np.int64)
+
+
+def e0_mp(v, g):
+    return min(mp.eigsy(mp.matrix(S4.idense(v, g).tolist()), eigvals_only=True))
+
+
+GH = [64, 128, 256, 512]
+HR = [(g, (e0_mp(IVM, g) - e0_mp(IVP, g)) * g ** 3) for g in GH]
+EXPO = [float(mp.log(HR[k][1] / HR[k + 1][1]) / mp.log(2)) + 3 for k in range(len(HR) - 1)]
+AMAT = mp.matrix([[mp.mpf(1), mp.mpf(1) / g ** 2, mp.mpf(1) / g ** 3, mp.mpf(1) / g ** 4] for g in GH])
+C3 = mp.lu_solve(AMAT, mp.matrix([r[1] for r in HR]))[0]
+print("   E3 cube g^3 dE: " + " ".join("%d:%s" % (g, mp.nstr(s, 12)) for g, s in HR)
+      + "; exponents " + " ".join("%.5f" % e for e in EXPO)
+      + "; Richardson limit " + mp.nstr(C3, 12))
+check(
+    "E3 [numerical, mpmath 60 digits] the surviving difference is order t^4/V^3 (above): E_0(-) - E_0(+) = "
+    "-27 t^4/V^3 on the cube -- a ring exchange of 9/4 a face carrying the sign S_f",
+    all(s < 0 for _, s in HR) and abs(EXPO[-1] - 3) < 2e-3
+    and abs(float(C3) + 27) < 1e-6 and abs(float(HR[-1][1]) + 27) < 1e-3,
+)
+
+GB = [16.0, 32.0, 64.0, 128.0, 256.0]
+BR = [(g, g ** 3 * float(S6.low(BVEC[JM], g, k=1)[0] - S6.low(BVEC[JP], g, k=1)[0])) for g in GB]
+print("   E4 2x2x3 g^3 dE: " + " ".join("%g:%.5f" % r for r in BR))
+check(
+    "E4 [numerical, converged in 1/g] the same ring exchange on 2x2x3 with its own coefficient (above), near "
+    "%.4f ~ -320/27: that number is cluster data, its SIGN is what is shared" % BR[-1][1],
+    all(s < 0 for _, s in BR) and abs(BR[-1][1] + 320 / 27) < 5e-3
+    and abs(BR[-1][1] - BR[-2][1]) < abs(BR[1][1] - BR[0][1]),
+)
+
+print(
+    "SUMMARY: with this interaction present the staggered sector stays the unique many-body ground sector at "
+    "half filling on both exhaustive clusters at every repulsive coupling tested, the last difference to "
+    "survive being a ring exchange that prefers the minus sign."
+)
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache answering the "Interacting terms" interface of PR #7874: with the record-conserving interaction of the composition discriminator's own family, `H(g) = -sum eta_ij (c^dag c + h.c.) + g sum n_i n_j`, **the staggered (all-minus) flux sector remains the unique half-filling minimiser** on both clusters where every consistent sector can be enumerated, at every repulsive coupling tested, with the ordering against the plain sector proved **exactly over Z** at twelve integer couplings by minimal polynomials and a `CRootOf` comparison. First-order theory on five tori pulls the same way. At large coupling the density profile and the `t^2/V` exchange are sector-independent and the surviving difference is a plaquette ring exchange of order `t^4/V^3` with a **negative** coefficient (`-27` on the cube), so the staggered sign stays preferred. Away from half filling and on the attractive side the ordering is cluster- and coupling-dependent, which sharpens the statement: half filling on the repulsive side is the robust point.

- `docs/RECORD_CONSERVING_INTERACTION_KEEPS_THE_STAGGERED_SECTOR_AT_HALF_FILLING_BOUNDED_THEOREM_NOTE_2026-09-03.md` (319 lines)
- `scripts/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.py` (`TOTAL: PASS=18 FAIL=0`, 30 s)
- `logs/runner-cache/record_conserving_interaction_keeps_the_staggered_sector_check_2026_09_03.txt`

## Theorems

- **T1** open `2x2x2` cube, `N = 4`, all 32 sectors: all-minus unique minimiser at nine couplings from `-2` to `8`; exact ordering over `Z` at twelve integer couplings (e.g. plain `g = 2`: `x^3 - 10x^2 - 16x + 48`; staggered `g = 0`: `x^2 - 48`).
- **T2** away from half filling (`N = 2, 6`) the two-flux class wins and the uniform pair crosses exactly at `g_c = 2 sqrt3` (`E_0(-) = -2 sqrt3` for all `g`).
- **T3** open `2x2x3` block, `N = 6`, all 512 sectors: all-minus unique minimiser at seven repulsive couplings (plain sector the strict maximum from `g = 2`); attractive flip window `-2.4 < g_c < -2.3` where an 8-flux class overtakes.
- **T4** first order in `V` on tori `4^3 ... 12^3`: the interaction correction also favours the staggered sector (exact on `4^3` via two integer matrix identities; limiting `A/V = 0.666263` vs `0.631237`; the only first-order crossing is attractive, `g_c = 24 sqrt2 - 16 sqrt6` on `4^3`); second order recorded as a caution against its own spurious root.
- **T5** large coupling: Neel doublet in both sectors; `t^2/V` exchange sector-independent; `E_0(-) - E_0(+) = -27 t^4/V^3 + O(V^-4)` on the cube (60-digit arithmetic), `~ -320/27` on the block; the sign is the transferable content.

## Boundary

- One interaction family, quoted from PR #7833's note; finite clusters; supplied filling; no global-minimality claim anywhere (the free Cauchy-Schwarz certificate does not extend); the ring-exchange coefficients are cluster numbers; no Lieb-type cubic theorem claimed.

## Dependencies and context

- Cites `HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7874, parent), `COMPOSITION_DISCRIMINATOR_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7833, the family) and `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7844) by filename as pointers.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
