### PR TITLE
feat(law): through-lattice role marking, two finite negatives

### DIFF
--- a/docs/THROUGH_LATTICE_ROLE_MARKING_TWO_FINITE_NEGATIVES_BOUNDED_COMPUTATION_NOTE_2026-09-03.md
+++ b/docs/THROUGH_LATTICE_ROLE_MARKING_TWO_FINITE_NEGATIVES_BOUNDED_COMPUTATION_NOTE_2026-09-03.md
@@ -1,0 +1,319 @@
+---
+claim_id: through_lattice_role_marking_two_finite_negatives
+claim_type: bounded_theorem
+claim_scope: "On the cubic lattice Z^3 with one qubit per site, ordinary (commuting) composition throughout, two named classes of star-local rule are evaluated on named finite clusters against the superlattice role patterns of PR #7834, exactly where stated and matrix-free-numerically where tagged. (T1, exact) The 24 proper rotations and the 48-element full cubic group induce the same 20 orbits on the 128 seven-bit star patterns with identical canonical representatives, so every rotation-invariant value-reading star rule is inversion-invariant; and at spacing 2 the 48 templates of the period-(4,2,2) pattern give every corner six free code neighbours and their stars realise all 128 value patterns and all 4 adjacent pairs, so the maximal value-reading star rule is vacuous there. (T2, exact, exhaustive constraint propagation, no SAT solver) On the spaced superlattices with coarse spacing s and one code site per coarse edge at position p, for s = 3 at both code positions (10 marker orbits, 1024 covariant assignments each) and s = 4 midpoint (9 orbits, 512 assignments): accepted set sizes span 28-111, 28-111 and 8-69 of 128 with 0 vacuous; the sound uniform-configuration filter passes 282/1024, 282/1024 and 32/512; and for every one of the 2560 assignments a branch-on-first-undetermined-site propagation search returns a zero-penalty configuration on the s-torus that is no translate or rotation of the intended pattern, 0 junk-free, in 38590 and 16363 branch nodes, at most 133 and 301 for one assignment, with period multiset censuses of the lexicographically least witness 489x(3,3,3) 438x(1,1,1) 73x(1,3,3) 24x(1,1,3) at s = 3 and 321x(1,1,1) 37x(1,2,2) 36x(2,2,2) 33x(1,1,2) 31x(1,1,4) 17x(4,4,4) 15x(1,4,4) 11x(1,2,4) 8x(2,2,4) 3x(2,4,4) at s = 4; each of the 2560 witnesses tiles to the 2s-torus (6^3, 8^3) with penalty 0 and is still no translate or rotation; and the maximum number of code neighbours of a site is 3 at s = 3 and 1 at s = 4 midpoint, never 6, so the spacing-2 vacuity is defeated and the failure has a different mechanism. (T3, exact) For state-reading frustration-free star templates h = 1 - Pi_K, a torus side of length 2 identifies the two +- neighbour slots on that axis and the star term becomes the pullback h = 1 - V^dag Pi_K V, whose diagonal isometry has image span{|00>,|11>} on that pair, holding the pinned product |p>|p> exactly when ab = 0 for |p> = a|0> + b|1>, a Z eigenstate; on the 2D 4x2 torus 30 of 72 (pin pair, variant) cases are vacuous, exactly FULL at all 30 pairs with v != f, and of the 42 live cases 22 are faithful and 20 are not, the unfaithful being exactly those with neither pin a Z eigenstate. (T4, exact) On the 2D 4x2 torus the faithful Z-pin rows carry junk zero modes 12 and 4 at v = f = |0> (dim K 17, nullity 35, 23 intended) and 36 at v = |0>, f = |1> (dim K 24, nullity 64, 28 intended), with no faithful pin choice junk-free; on the non-aliased 2D 4x4 torus, matrix-free with state vectors of length 65536 [numerical], alternating projections reach residual energy at most 9e-14 and the converged zero-energy vectors carry junk fraction 0.85-0.89, 0.31-0.33, 0.91-0.92, 0.65-0.67 and 0.78-0.84 at (+,+) EVEN, (+,+) FULL, (0,1) EVEN, (+,-) EVEN and (0,+) EVEN, with Hutchinson kernel-dimension estimates over 4 probes of 743+-13, 743+-13, 1534+-22, 399+-7 and 690+-17 against 96, 511, 124, 128 and 128 intended [numerical, stochastic, seed fixed]. (T5) The 3D seven-site star has dim K 51-76 of 128 in EVEN and 65-105 in FULL over all 64 pin triples from {0,1,+,-}, none vacuous, and all 16 all-Z triples are faithful on the 4x2x2 torus (exact); there [numerical, matrix-free, seed fixed] junk fractions are 0.56-0.62, 0.53-0.54, 0.74-0.76 and 0.89-0.90 at (0,0,0) EVEN, (0,0,0) FULL, (0,1,0) EVEN and (0,1,1) EVEN with residual energy at most 1e-15. (T6) One 2D and one 3D junk vector have energy at most 2e-15, weight inside the intended span at most 7e-31, Schmidt rank 35 and 31 across a half cut of 256, and every single-site reduced state mixed with purity at most 0.661 and 0.725, so no site is pinned [numerical, matrix-free, seed fixed]; and exactly (exact) the one-dimensional three-site star on an 8-ring is junk-free for the Z pins in the EVEN variant, dim K 3 and nullity 3 against 3 intended, 2 of 8 choices junk-free. These are finite negative results on two named classes over named finite clusters. The s = 4 off-midpoint, s = 5 and s = 6 superlattices and the Haar-pin templates are scratch-only and are not claimed here. No axiom is amended, no status is set, no registry entry is created, and nothing here is derived from any axiom."
+upstream_dependencies: []
+runner: scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py
+---
+
+# Through-lattice role marking: two finite negative results, one on value-reading star rules and one on state-reading star templates
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py`](../scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.txt`](../logs/runner-cache/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+`EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7834) supplies a law on a `5x5x5` window whose zero set is exactly `48`
+superlattice role patterns, and leaves one item open in its Proof boundary: "whether a rule whose direct dependence is on adjacent sites only, longer reach arising through chains of adjacent
+conditions, can select the same zero set is open -- for value-reading star rules Theorem 3 item 2 answers no at this spacing, and for possibility-state rules it is untested here." Its Interfaces
+name the second half again: "A rule whose star constraint reads which local possibilities remain admissible, rather than which value is recorded, is untouched by it." This note answers that item
+for two named classes of star-local rule, on named finite clusters, and for no others. Both answers are negative, both are finite, and the two mechanisms differ and are named. Neither says that a
+rule of adjacent-site direct dependence is unavailable; each says that one class of such rule, on the clusters listed, has no junk-free member.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite negative results on two named classes of star-local rule, over named finite clusters. Groups A and B are exact -- bit arithmetic, exhaustive enumeration, exhaustive constraint propagation with no solver. Group C mixes exact dense linear algebra on 8-qubit and 7-qubit spaces with matrix-free numerical statements on 16-qubit tori; every numerical line is tagged and carries its converged residual, and the two stochastic lines fix their seed and report standard errors."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster result, and route to its owner the question this note leaves open: whether some other adjacent-site rule -- energetic rather than frustration-free, or reading more than one star -- selects the role pattern."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the six statements below, exactly the runner's check groups `A`-`C`.
+
+1. `T1` (`A1`, `A2`). The star-pattern orbit fact, and the spacing-2 vacuity of PR #7834 restated and recomputed.
+2. `T2` (`B1`-`B6`). Value-reading star rules on spaced superlattices, exhaustive at `s = 3` for both code positions and at `s = 4` midpoint, with the period-collapse census and the zoom-out
+   lemma.
+3. `T3` (`C1`, `C2`). The aliasing lemma for state-reading star templates on tori with a side of length `2`.
+4. `T4` (`C3`, `C5`, `C6`) and `T5` (`C4`, `C7`). Two and three dimensions: the exact rows, and the matrix-free rows on the `16`-qubit tori.
+5. `T6` (`C8`, `C9`). The character of the junk, and the one-dimensional contrast, which is junk-free.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. Alternating projection onto an intersection of subspaces and the Hutchinson trace estimator are standard methodology; every object is redeclared
+here and the runner recomputes every statement. No observational value, no fitted number, and no framework premise enters any proof. Non-load-bearing context pointers, plain file names citing no
+grade and consuming no row:
+
+- `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (the `48`-sector role pattern whose open item this note answers for two classes,
+  and the source of the two quotations above).
+- `MINIMAL_AXIOMS_2026-06-29.md` (the four framework axioms quoted in "Setting").
+
+## Setting
+
+The four framework axioms are quoted, not amended, and nothing below is derived from them. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency,
+standard translations, and proper cubic rotations about each site." **Qubit**: each site has a domain of local possibilities whose full one-site possibility domain has algebraic presentation
+`M_2(C)` -- one qubit per site, and no more. **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations."
+**Record**: records form, lock exactly one admissible local possibility, are permanent, and are the only readable thing. Composition here is **ordinary**: the algebra of a region is the tensor
+product of its sites' algebras and operators on disjoint regions commute. The two rule classes below are both of the form Admissibility permits in shape -- one fixed rule, identical at every site,
+covariant under the lattice motions, whose direct dependence is a site and its six neighbours. What is at issue is not their shape but what each of them selects.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the strongest supported scope is precisely `P0`-`P4`.
+
+1. `P0` (declared here): the star, the two rule classes, the role patterns, the spaced superlattices, and what counts as junk.
+2. `P1` (`A`): the orbit fact and the spacing-2 vacuity.
+3. `P2` (`B`): the value-reading result on spaced superlattices, its census, and the zoom-out lemma.
+4. `P3` (`C1`-`C4`): the aliasing lemma, the exact `4x2` rows and the exact star-kernel dimensions; `P4` (`C5`-`C9`): the matrix-free rows, the junk character, and the one-dimensional contrast.
+
+## Definitions
+
+A site's **star** is the site together with its six nearest neighbours: seven sites, seven values, `128` value patterns. A **superlattice role pattern** is a repeating arrangement of pinned site
+values whose period exceeds the lattice spacing, with some sites left free; in PR #7834 the period is `(4, 2, 2)`, corners, faces and cube centres pinned by coordinate parity and coarse edge sites
+free. The lattice itself is unchanged.
+
+A **value-reading star rule** is a predicate on the seven recorded `Z`-values of a star, invariant under the `24` proper rotations; its **penalty** on a configuration is the number of stars it
+rejects. Given an intended arrangement, the **maximal** such rule accepts exactly the star patterns realised in the intended configurations over every filling of the free sites; every other rule
+of the class accepts at least those, so the maximal rule is the most selective member. **Junk** is a zero-penalty configuration on the torus whose values on the pinned sites are no translate and
+no rotation of the intended pattern.
+
+A **spaced superlattice** has coarse spacing `s` and one free code site per coarse edge at position `p` along it: the code sites of the `s`-cell are `(p,0,0)`, `(0,p,0)`, `(0,0,p)` and every other
+site is a pinned marker site, with marker values constant on the orbits of the space-group stabiliser of the code sublattice -- `24` rotations at the midpoint `p = s/2`, `C3` otherwise -- so an
+**assignment** is one bit per marker orbit.
+
+A **state-reading frustration-free star template** is a positive semidefinite operator `h` on the seven-site star, identical at every site, whose kernel contains the intended role-star states; the
+canonical maximal choice is `h = 1 - Pi_K` with `K` the span of those states, and any other template of the class has a kernel at least as large. The zero space of `H = sum_s h_s` is the
+intersection of the star kernels, and **junk** here is a zero-energy state outside the span of the intended global states. The **EVEN** variant restricts the free bits around a pinned centre to
+even parity; the **FULL** variant does not. On a torus with a side of length `2` the `+` and `-` neighbours along that axis are the same physical site, and the star term is the pullback `h = 1 -
+V^dag Pi_K V` through the **diagonal isometry** `V : |b> -> |bb>` on that slot pair.
+
+## Theorem 1 -- the star-pattern orbits, and the spacing-2 vacuity restated
+
+**Conclusion.**
+
+1. The `24` proper rotations and the `48`-element full cubic group induce the **same** `20` orbits on the `128` seven-bit star patterns, with identical canonical representatives. Hence every
+   rotation-invariant value-reading star rule is automatically invariant under the full group, inversions included, and no rule of this class distinguishes a pattern from its mirror image.
+2. At spacing `2`, on the `4x4x4` torus, the `48` templates of the period-`(4, 2, 2)` role pattern give every corner site six free code neighbours; the corner stars realise all `128` value
+   patterns and all `4` adjacent value pairs, so the maximal value-reading star rule at that spacing accepts everything.
+
+**Proof.** Item 1 canonicalises all `128` patterns under both permutation groups of the six neighbour slots and compares the tables entry by entry. Item 2 builds the `48` templates as arrays on
+the torus, counts the free neighbours of every pinned site, and enumerates the realised star patterns and adjacent pairs. Both exact.
+
+**Reading, not theorem.** A rule that sees only the seven values around a point has no way to tell left from right. And where every neighbour of a pinned site is free, the seven values around that
+site take every arrangement there is, so a rule reading them alone has nothing to reject.
+
+## Theorem 2 -- value-reading star rules on spaced superlattices
+
+**Conclusion.** For the spaced superlattices `s = 3` with both code positions (`10` marker orbits, `1024` covariant assignments each) and `s = 4` midpoint (`9` orbits, `512` assignments):
+
+1. **Zoom-out lemma.** The maximum number of code neighbours of any site is `3` at `s = 3` and `1` at `s = 4` midpoint -- never `6`. No site has an all-code star, so the vacuity of Theorem 1 item
+   2 does not apply at either spacing, and any failure below has a different mechanism.
+2. The maximal rule accepts its own intended configurations and is covariant: penalty `0` for all `2560` assignments with every code filling, and for `48` sampled assignments over every rotation
+   and translate as well. Accepted set sizes span `28`-`111`, `28`-`111` and `8`-`69` of `128`, and `0` assignments are vacuous.
+3. The uniform-configuration filter is sound -- if some intended star can be made all-`0` or all-`1` by the code bits, that uniform configuration has penalty `0` and is no translate -- and its
+   pass counts are `282/1024`, `282/1024` and `32/512`.
+4. For every one of the `2560` assignments there is junk on the `s`-torus: `1024`, `1024` and `512` admit it and `0` are junk-free, in `38590` and `16363` branch nodes, at most `133` and `301` for
+   a single assignment. The period multiset census of the lexicographically least witness is `489x(3,3,3) 438x(1,1,1) 73x(1,3,3) 24x(1,1,3)` at `s = 3`, the same for both code positions, and
+   `321x(1,1,1) 37x(1,2,2) 36x(2,2,2) 33x(1,1,2) 31x(1,1,4) 17x(4,4,4) 15x(1,4,4) 11x(1,2,4) 8x(2,2,4) 3x(2,4,4)` at `s = 4`.
+5. Each of the `2560` witnesses tiles to the `2s`-torus, `6^3` and `8^3`, with penalty `0`, and is still no translate or rotation of the intended pattern, so the junk survives the doubled box.
+
+**Proof.** Items 1 to 3 are direct enumerations over the cell and over every assignment. Item 4 is a complete branch-on-first-undetermined-site constraint propagation: at each node the star
+constraints are propagated to a fixed point through a lookup of the accepted-pattern set against the known slot bits, a conflict closes the branch, and a completed configuration is either an
+intended translate -- and the search continues -- or a witness, whose penalty is recomputed from scratch and whose distinctness from every translate and rotation is checked site by site. Branching
+`0` before `1` makes the first witness the lexicographically least one, so the census is a property of the rule and not of a solver. No SAT solver and no external solver is used anywhere. Item 5
+tiles each witness and recomputes penalty and distinctness on the doubled torus. All exact.
+
+**Reading, not theorem.** A rule that looks only at a site and its six neighbours can forbid local arrangements. On every box here it does not force a pattern that repeats every three or more
+sites: some other repeating pattern always fits, most often a flat one, sometimes a columnar or layered rival with a shorter period along one axis, and the census is the shape of that. The wider
+spacing removes the earlier vacuity; what replaces it has a different name.
+
+## Theorem 3 -- the aliasing lemma for state-reading templates
+
+**Conclusion.**
+
+1. On a torus with a side of length `2` the two `+-` neighbour slots along that axis are the same site, so the star term is the pullback `h = 1 - V^dag Pi_K V`, and the image of the diagonal
+   isometry `V` on that slot pair is `span{|00>, |11>}`. The intended star state carries the pinned product `|p>|p>` there, and for `|p> = a|0> + b|1>` that product lies in the diagonal subspace
+   exactly when `ab = 0`, that is, exactly for the `Z` eigenstates. For any other pin `V` delivers an entangled diagonal vector instead, and the intended state is a zero mode only if `K` happens
+   to contain it. Which pins that happens for is item 2, not a consequence of item 1.
+2. On the `2D` `4x2` torus, of the `72` (pin pair, variant) cases, `30` are vacuous -- exactly the `FULL` variant at all `30` pairs with `v != f` -- and of the `42` live cases `22` are faithful,
+   meaning the intended states really are zero modes, and `20` are not. The `20` are exactly those with neither pin a `Z` eigenstate.
+
+**Proof.** Item 1 is two lines of algebra on the expansion of `|p>|p>`, checked on all six named pins. Item 2 constructs `Pi_K` by singular value decomposition on the `32`-dimensional star space,
+compresses it through the isometry, assembles the dense `256x256` Hamiltonian, and evaluates the intended states directly. All exact.
+
+**Reading, not theorem.** When a box is only two sites wide, a site's two neighbours in that direction are one and the same, so the template asks for two copies of one value at once, and only a
+definite value is two copies of itself. That is a fact about the small box, and it is why the three-dimensional rows below keep to definite-value pins.
+
+## Theorem 4 -- two dimensions
+
+**Conclusion.**
+
+1. Exact, `4x2` torus, at the faithful `Z` pins: `v = f = |0>` gives `dim K = 17`, nullity `35` against `23` intended, so `12` junk zero modes in `EVEN` and `4` in `FULL`; `v = |0>`, `f = |1>`
+   gives `dim K = 24`, nullity `64` against `28`, so `36` junk. No faithful pin choice on this torus is junk-free.
+2. Matrix-free, `4x4` torus, no aliasing, state vectors of length `65536` [numerical, seed fixed]: alternating projections from a random start reach residual energy at most `9e-14`, and the
+   converged zero-energy vectors carry junk fraction -- weight outside the intended span -- `0.85`-`0.89` at `(+,+)` `EVEN`, `0.31`-`0.33` at `(+,+)` `FULL`, `0.91`-`0.92` at `(0,1)` `EVEN`,
+   `0.65`-`0.67` at `(+,-)` `EVEN` and `0.78`-`0.84` at `(0,+)` `EVEN`.
+3. Hutchinson kernel-dimension estimates from the same runs, `4` probes, one standard error [numerical, stochastic, seed fixed]: `743+-13`, `743+-13`, `1534+-22`, `399+-7` and `690+-17` against
+   `96`, `511`, `124`, `128` and `128` intended.
+
+**Proof.** Item 1 is dense and exact on `8` qubits. Item 2 applies each star's kernel projector in turn to a block of random vectors, never forming a matrix larger than `32x32` and never storing
+more than `65536 x 4` amplitudes; the residual energy of the converged block is reported, and the weight inside the intended span is computed against the Gram matrix of the intended product
+states, so that span is never materialised either. Item 3 reads the Hutchinson estimator off the same block, the overlap of each start vector with its own limit estimating the diagonal of the
+kernel projector; it is stochastic and reports its standard error.
+
+**Reading, not theorem.** The template is satisfied by far more than the arrangements it was built from, and what sits in the extra room is not another arrangement but a blend of several.
+
+## Theorem 5 -- three dimensions
+
+**Conclusion.**
+
+1. Exact: over all `64` pin triples from `{0, 1, +, -}` and both variants, the `3D` seven-site star has `dim K` between `51` and `76` of `128` in `EVEN` and between `65` and `105` in `FULL`, so no
+   template of this family is vacuous; and all `16` all-`Z` triples are faithful on the `4x2x2` torus.
+2. Matrix-free, `4x2x2` torus, `Z` pins [numerical, seed fixed]: junk fraction `0.56`-`0.62` at `(0,0,0)` `EVEN`, `0.53`-`0.54` at `(0,0,0)` `FULL`, `0.74`-`0.76` at `(0,1,0)` `EVEN` and
+   `0.89`-`0.90` at `(0,1,1)` `EVEN`, with residual energy at most `1e-15` and intended-state energy at most `2e-15`; the Hutchinson estimates are `451+-9`, `756+-16`, `988+-18` and `2260+-14`
+   against `173`, `349`, `252` and `244` intended [numerical, stochastic, seed fixed].
+
+**Proof.** Item 1 is exact singular value decomposition on the `128`-dimensional star space, once per triple and variant, with a direct evaluation of the intended states. Item 2 uses the same
+matrix-free apparatus as Theorem 4 item 2 on a `16`-qubit torus, the aliased stars compressed through the isometry first.
+
+**Reading, not theorem.** The same extra room appears in three dimensions as in two, and the small size of the star is not what opens it: every template here rejects something, and none of them
+rejects the blends.
+
+## Theorem 6 -- what the junk is, and the one-dimensional contrast
+
+**Conclusion.**
+
+1. [numerical, matrix-free, seed fixed] One `2D` and one `3D` junk vector, extracted by removing the intended-span component from a converged zero-energy vector, have energy at most `2e-15` and
+   weight inside the intended span at most `7e-31`. Their Schmidt rank across a half cut is `35` and `31` of a possible `256`, and every single-site reduced state is mixed, with purity at most
+   `0.661` and `0.725`. No site is pinned to any value.
+2. Exact: the one-dimensional analogue -- three-site stars on an `8`-ring -- is junk-free at the `Z` pins in the `EVEN` variant, `dim K = 3` and nullity `3` against `3` intended states. The `|+>`
+   and `|->` pins in `EVEN` give nullity `9` against `4`, and every `FULL` choice gives `47` against `31`. Two of the eight choices are junk-free.
+
+**Proof.** Item 1 reshapes the normalised junk vector into a bipartite matrix across a half cut and takes its singular values, and traces out all but one site for each site in turn. Item 2 is
+dense and exact on `8` qubits.
+
+**Reading, not theorem.** The extra states are superpositions in which a site carries two roles at once, spread across the whole box rather than concentrated anywhere. A template of this kind has
+a subspace for a kernel, and a subspace holds the sums of the arrangements it was built from as well as the arrangements themselves; in one dimension the sums are the arrangements again, and there
+the same construction leaves nothing over.
+
+## Corollary -- what the two classes give, on the clusters tested
+
+Within the setting declared above, and on the finite clusters named:
+
+1. On the classes and clusters tested, no junk-free rule was found -- by exhaustive enumeration and exact linear algebra where the theorems say exact, and by matrix-free evaluation where they say
+   numerical. A star-local rule of either kind does not, on these clusters, select a superlattice role pattern with free code sites.
+2. The two mechanisms are different and both are named. Value-reading rules fail by **period collapse**: a predicate on seven values can forbid local arrangements, and on every box here it does
+   not impose a period of three or more. State-reading frustration-free templates fail by **superposition junk**: their kernels are subspaces, and a subspace holds the sums of the intended
+   arrangements as well as the arrangements.
+3. PR #7834's open item is therefore answered negatively for these two classes, on these clusters, and stays open for others: energetic or otherwise non-frustration-free selection; larger
+   direct-dependence windows; templates reading more than one star; and rules on the pre-record possibility state other than the projector complements used here. The zoom-out meanwhile does what
+   it was meant to: the spacing-2 vacuity of Theorem 1 item 2 is defeated at every spacing here, no site having an all-code star, and the class still admits junk for an unrelated reason.
+
+**Reading, not theorem.** A rule that looks only at a site and its six neighbours can forbid local arrangements, but on every box here it could not force a pattern that repeats every three or more
+sites: some other repeating pattern always slipped through. A rule that looks at the possibilities at those sites rather than their values lets mixtures of two roles through instead. Neither
+result says a nearby-only rule is unavailable; they say these two kinds are not it.
+
+## What does not move
+
+- This decides nothing about what the framework's law is. It declares two rule classes, of a form Admissibility permits in shape, and computes what they select. It supplies no update rule, no
+  formation site, no formation rate, and no values, and no coupling, absolute unit or dynamical clause appears anywhere.
+- It says nothing about rules outside the two classes, about clusters larger than those named, or about the `48`-sector zero set of PR #7834, which is not contradicted anywhere here.
+- No axiom text is amended, extended, reworded, or reinterpreted, no hypothesis is adopted, and no status value is set, predicted, or implied. No premise registry, citation manifest, or
+  axiom-premise node is created or edited.
+
+## Interfaces named for other lanes, not moved here
+
+- **Energetic selection.** Both classes here are frustration-free. A rule that pays energy for the wrong arrangement rather than forbidding it outright is untouched by Theorems 2 and 4 to 6, and a
+  lane taking it up should treat the period census of Theorem 2 item 4 as the rival arrangements its gap has to lift.
+- **Larger windows.** The direct dependence here is one star; a `3x3x3` or `5x5x5` window read as a constraint on values is a different class, and PR #7834 supplies a member of it. A single term
+  supported on two adjacent stars, or a product of star terms, is likewise outside Theorems 3 to 6.
+- **The possibility-state reading beyond projector complements.** `h = 1 - Pi_K` is the maximal frustration-free choice with the intended states in its kernel; a term that reads the possibility
+  state without being a projector complement -- a positive operator with a smaller kernel and a nonzero value on the intended states, or a non-frustration-free sum -- is not covered.
+- **Larger tori for the three-dimensional state-reading case.** The `4x2x2` torus aliases two axes, which is why only `Z` pins are faithful there; a non-aliased three-dimensional torus needs
+  `4x4x4`, `64` qubits, and is not reached by the apparatus here.
+
+## Remaining live routes
+
+1. Spacings and code positions beyond those claimed: the `s = 4` off-midpoint superlattice with its `23` marker orbits, and `s = 5` and `s = 6`.
+2. Other intended arrangements, and the gap between the two classes. Every result here is about the role patterns of PR #7834 and their spaced analogues, and a rule reading values on some sites
+   and possibility states on others is neither class.
+3. Whether the period collapse of Theorem 2 has a proof rather than a census: the runner exhibits junk for every assignment, and no general argument is offered.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the six theorem conclusions.
+
+```text
+setting: one qubit per site of Z^3; ordinary (commuting) composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md; nothing derived from them
+class_1_value_reading: a rotation-invariant predicate on the 7 recorded Z-values of a star; penalty = number of rejected stars; maximal rule = accept every star pattern realised in the intended configurations over all free-site fillings. class_2_state_reading: a PSD operator h on the 7-site star, identical at every site, with the intended role-star states in ker h; canonical maximal choice h = 1 - Pi_K; zero space of sum_s h_s = intersection of star kernels
+star_pattern_orbits: ROT24 and the full 48-element cubic group induce the same 20 orbits on the 128 patterns, identical canonical representatives; every rotation-invariant star rule is inversion-invariant. spacing_2_vacuity: 48 templates of period (4,2,2) on the 4x4x4 torus; every corner has 6 free code neighbours; corner stars realise 128 of 128 value patterns and 4 of 4 adjacent pairs; maximal rule vacuous
+spaced_superlattice_geometry: s=3 p=1 and p=2 |G_pt|=3, 10 marker orbits, 11 star masks, at most 3 code neighbours; s=4 p=2 |G_pt|=24, 9 orbits, 10 masks, at most 1; never 6
+spaced_superlattice_acceptance: penalty 0 on all 2560 assignments with every code filling, and on 48 sampled assignments over every rotation and translate; |A| spans 28-111, 28-111, 8-69 of 128; 0 vacuous; sound uniform filter passes 282/1024, 282/1024, 32/512
+junk_search: exhaustive branch-on-first-undetermined-site constraint propagation, no SAT solver; 1024, 1024, 512 assignments admit junk on the s-torus; 0 junk-free; 38590 and 16363 branch nodes, at most 133 and 301 for one assignment
+period_census_s3: 489x(3,3,3) 438x(1,1,1) 73x(1,3,3) 24x(1,1,3), identical at p=1 and p=2, intended (3,3,3); witness = lexicographically least
+period_census_s4: 321x(1,1,1) 37x(1,2,2) 36x(2,2,2) 33x(1,1,2) 31x(1,1,4) 17x(4,4,4) 15x(1,4,4) 11x(1,2,4) 8x(2,2,4) 3x(2,4,4), intended (4,4,4)
+doubled_box: all 2560 witnesses tile to 6^3 and 8^3 with penalty 0 and are still no translate or rotation
+aliasing_lemma: side length 2 identifies the two +- slots; h = 1 - V^dag Pi_K V; image of V on that pair = span{|00>,|11>}, holding |p>|p> iff ab = 0; 4x2 torus 72 cases, 30 vacuous (FULL at all 30 pairs with v != f), 42 live, 22 faithful, 20 not, the 20 being exactly those with neither pin a Z eigenstate
+two_d_exact: 4x2 torus, v=f=|0> dim K 17, nullity 35 vs 23 intended, junk 12 EVEN and 4 FULL; v=|0> f=|1> dim K 24, nullity 64 vs 28, junk 36; 0 faithful choices junk-free
+two_d_matrix_free: 4x4 torus, vectors of length 65536, residual energy at most 9e-14; junk fractions 0.85-0.89, 0.31-0.33, 0.91-0.92, 0.65-0.67, 0.78-0.84 at (+,+) EVEN, (+,+) FULL, (0,1) EVEN, (+,-) EVEN, (0,+) EVEN [numerical]
+two_d_hutchinson: 743+-13, 743+-13, 1534+-22, 399+-7, 690+-17 against 96, 511, 124, 128, 128 intended, 4 probes [numerical, stochastic, seed fixed]
+three_d_exact: 7-site star, 64 triples from {0,1,+,-}, dim K 51-76 of 128 EVEN and 65-105 FULL, none vacuous; all 16 all-Z triples faithful on 4x2x2
+three_d_matrix_free: 4x2x2, Z pins, junk fractions 0.56-0.62, 0.53-0.54, 0.74-0.76, 0.89-0.90; Hutchinson 451+-9, 756+-16, 988+-18, 2260+-14 vs 173, 349, 252, 244; residual at most 1e-15 [numerical]
+junk_character: energy at most 2e-15, weight inside the intended span at most 7e-31, Schmidt rank 35 and 31 of 256, single-site purity at most 0.661 and 0.725; no site pinned [numerical]
+one_d_contrast: three-site stars on an 8-ring; Z pins EVEN junk-free, dim K 3, nullity 3 = 3 intended; |+>/|-> EVEN nullity 9 vs 4; FULL 47 vs 31; 2 of 8 junk-free
+not_claimed: s=4 off-midpoint (23 orbits), s=5, s=6, and Haar-random pins; scratch-only, sampled or solver-checked, and claimed nowhere here
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=17 FAIL=0
+```
+
+## Proof boundary
+
+The two classes are **finite and named**, and nothing here extends past them. Class 1 is value-reading star rules; class 2 is frustration-free star templates of the form `h = 1 - Pi_K`. A rule
+that pays energy rather than forbidding, a rule reading a wider window, a term supported on more than one star, and a possibility-state term that is not a projector complement are each outside
+both classes and are named in "Interfaces" for that reason. The clusters are **finite and named**: the `4x4x4` torus for Theorem 1; the `3^3`, `4^3`, `6^3` and `8^3` tori for Theorem 2; the `4x2`
+and `4x4` tori for Theorems 3 and 4; the `4x2x2` torus and the `7`-qubit star for Theorem 5; the `4x4` and `4x2x2` tori and the `8`-ring for Theorem 6. Nothing is claimed for infinite lattices or
+larger boxes.
+
+Three superlattice families were examined in scratch and are **not claimed**: `s = 4` off-midpoint with `23` marker orbits, `s = 5`, and `s = 6`. At `s = 6` midpoint the scratch pass covered
+`9501` of the `10090` uniform-filter survivors and the `s = 4` off-midpoint pass sampled; both used a SAT solver that is not a repository dependency, and neither is reproduced by the runner or
+asserted anywhere here, as the Haar-random pin templates of the state-reading class are likewise scratch-only. Where this note says exhaustive it means exhaustive in the runner, over the
+assignment space stated. The junk **census** is a property of a stated witness rule, not of a solver: branching value `0` before `1` on the first undetermined site makes the returned witness the
+lexicographically least zero-penalty non-intended configuration, and a different witness rule gives a different census with the same totals -- `2560` of `2560` admitting junk, `0` junk-free --
+which is what the conclusion rests on.
+
+Three lines are **numerical**, and every one is tagged in the runner: the matrix-free `4x4` and `4x2x2` rows, and the junk-character row. Each reports the converged residual energy of its
+zero-energy vector, at most `9e-14`, and the weight of that vector outside the intended span. Two of those lines are additionally **stochastic** -- the Hutchinson kernel-dimension estimates -- and
+fix their seed and report a standard error; no conclusion here depends on a Hutchinson number, which is why they are reported as estimates and used nowhere else. The exact lines use integer and
+bit arithmetic, exhaustive enumeration, exhaustive constraint propagation, and dense linear algebra on spaces of dimension at most `256`. Nothing here is derived from the four axioms: they are
+quoted in "Setting" to fix the lattice, the one-qubit site, the covariance and the record, and the two rule classes are declared, not deduced. No claim is made about the framework's law, and PR
+#7834's construction is not contradicted; its rule reads a `5x5x5` window, outside both classes tested here.
+
+## Review record
+
+An honest auditor should come away with: two finite negative results on two named classes, over named finite clusters; two named mechanisms, period collapse and superposition junk; one junk-free
+contrast in one dimension, which shows the failure is not an artefact of the construction; a clearly marked line between the exact and the numerical and between the numerical and the stochastic;
+and a list of what stays open, headed by energetic selection and wider windows. The strongest thing this note says is that two kinds of adjacent-site rule, on the boxes named, have no junk-free
+member; it does not say that a rule of adjacent-site direct dependence is unavailable, and no sentence here should be read that way.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the two context notes in "Imports and authority" are
+plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=17 FAIL=0` with runtime under the declared `300` seconds and stdout
+under `5500` characters, and passing repository pipeline, strict-lint, and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.txt
+++ b/logs/runner-cache/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.txt
@@ -1,0 +1,30 @@
+===== runner cache v1 =====
+runner: scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py
+runner_sha256: d2e9bcfe2b429db2ef0bb7464d27ba8a54b8c150a037d84896f2377e52fd256e
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 25.02
+status: ok
+----- stdout -----
+PASS A1 [exact] the 24 proper rotations and the full 48-element cubic group induce the SAME 20 orbits on the 128 seven-bit star patterns, with identical canonical representatives, so every rotation-invariant value-reading star rule is inversion-invariant and no such rule encodes a chirality
+PASS A2 [exact] spacing 2, the vertex-star argument of PR #7834 recomputed: on the 4x4x4 torus the 48 templates (16 translates x 3 orientations of period (4,2,2)) give every corner six free code neighbours, and corner stars realise all 128 of the 128 value patterns and 4 of the 4 adjacent pairs, so the maximal value-reading star rule is vacuous there
+PASS B1 [exact] zoom-out lemma: s=3 p=1 |G_pt|=3 orbits=10 masks=11 code_nbrs<=3 ; s=3 p=2 |G_pt|=3 orbits=10 masks=11 code_nbrs<=3 ; s=4 p=2 |G_pt|=24 orbits=9 masks=10 code_nbrs<=1 -- no site has an all-code star, the count being 1 or 3, never 6, so the spacing-2 vacuity of A2 is defeated at every spacing tested and any failure below has another mechanism
+PASS B2 [exact] the maximal rule accepts its own intended configurations and is covariant: penalty 0 for all 1024 + 1024 + 512 assignments with every code filling, and for 48 sampled ones over every rotation and translate too; accepted sizes |A| of 128 span 28-111, 28-111, 8-69, and 0 are vacuous
+PASS B3 [exact] the uniform-configuration filter is sound -- if some intended star can be made all-0 or all-1 by the code bits, that uniform configuration has penalty 0 and is no translate -- with pass counts 282/1024, 282/1024, 32/512
+PASS B4 [exact, exhaustive propagation, no SAT] s=3, both code positions, all 1024 assignments each: 1024 and 1024 admit junk, 0 are junk-free; the period multiset census of the lexicographically least junk witness is the same for both, count x abc = 489x333 438x111 73x133 24x113 (intended 333); 38590 branch nodes, 133 at worst
+PASS B5 [exact, exhaustive propagation, no SAT] s=4 midpoint, all 512 assignments: 512 admit junk, 0 junk-free; census count x abc = 321x111 37x122 36x222 33x112 31x114 17x444 15x144 11x124 8x224 3x244 (intended 444); 16363 branch nodes, 301 at worst
+PASS B6 [exact] each of the 2560 witnesses tiles to the 2s-torus (6^3 and 8^3) with penalty 0, still no translate or rotation of the intended pattern, so junk survives the doubled box, 2560 of 2560: no covariant maximal value-reading star rule tested is junk-free
+PASS C1 [exact] aliasing lemma, algebraic half: a side of length 2 identifies the two +- neighbour slots on that axis, so the star term is the pullback h = 1 - V^dag Pi_K V and the image of the diagonal isometry V on that pair is span{|00>,|11>}, holding the pinned product |p>|p> exactly when ab = 0 for |p> = a|0> + b|1>, a Z eigenstate; on all 6 pins
+PASS C2 [exact] aliasing lemma, computed half, 2D 4x2 torus in full: of the 72 (pin pair, variant) cases 30 are vacuous -- exactly FULL at all 30 pairs with v != f -- and of the 42 live cases 22 are faithful and 20 not, the unfaithful being exactly those with neither pin a Z eigenstate
+PASS C3 [exact] 2D 4x2 torus, faithful Z-pin rows: v=f=|0> gives dim K = 17, nullity 35 against 23 intended, so 12 junk zero modes in EVEN and 4 in FULL; v=|0> f=|1> gives dim K = 24, nullity 64 against 28, so 36 junk. No faithful pin choice on this torus is junk-free
+PASS C4 [exact] 3D seven-site star, all 64 pin triples from {0,1,+,-} and both variants: dim K runs 51-76 of 128 in EVEN and 65-105 in FULL, so no template is vacuous, and all 16 all-Z triples are faithful on the 4x2x2 torus -- which is why the 3D rows use Z pins only
+PASS C5 [numerical, matrix-free, seed fixed] 2D 4x4 torus, no aliasing, state vectors of length 65536: alternating projections from a random start reach residual energy at most 9e-14 and carry junk fraction (weight outside the intended span) ++ E 0.85-0.89 ; ++ F 0.31-0.33 ; 01 E 0.91-0.92 ; +- E 0.65-0.67 ; 0+ E 0.78-0.84
+PASS C6 [numerical, stochastic, seed fixed] the same runs give Hutchinson trace estimates of the kernel dimension, 4 probes, one standard error: ++ E 743+-13 vs 96 intended ; ++ F 743+-13 vs 511 intended ; 01 E 1534+-22 vs 124 intended ; +- E 399+-7 vs 128 intended ; 0+ E 690+-17 vs 128 intended -- each far above its intended count
+PASS C7 [numerical, matrix-free, seed fixed] 3D 4x2x2 torus, Z pins, the faithful case: 000 E dimK=51 junkfrac 0.56-0.62 est 451+-9 vs 173 ; 000 F dimK=65 junkfrac 0.53-0.54 est 756+-16 vs 349 ; 010 E dimK=69 junkfrac 0.74-0.76 est 988+-18 vs 252 ; 011 E dimK=69 junkfrac 0.89-0.90 est 2260+-14 vs 244; residual energy at most 1e-15, intended-state energy at most 2e-15
+PASS C8 [numerical, matrix-free, seed fixed] the junk is a superposition of role assignments, not a rival pattern: the extracted vector has energy at most 2e-15, weight inside the intended span at most 7e-31, Schmidt rank 35 and 31 across a half cut of 256, every single-site reduced state mixed with purity at most 0.661 and 0.725 -- no site is pinned
+PASS C9 [exact] the one-dimensional contrast, three-site stars on an 8-ring: Z pins in the EVEN variant are junk-free, dim K = 3 and nullity 3 equal to the 3 intended states, while |+> and |-> in EVEN give nullity 9 against 4 and every FULL choice 47 against 31; 2 of 8 junk-free, so the failure above is no artefact of the construction
+SUMMARY: on the classes and clusters tested no junk-free star-local rule of either kind was found; value-reading rules fail by period collapse, state-reading ones by superposition junk.
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py
+++ b/scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py
@@ -1,0 +1,1061 @@
+#!/usr/bin/env python3
+"""Through-lattice role marking: two finite negative results on named classes.
+
+PR #7834 leaves one item open in its Proof boundary: whether a rule whose
+direct dependence is on adjacent sites only -- longer reach arising through
+chains of adjacent conditions -- can select a superlattice role pattern with
+free code sites.  Its Theorem 3 item 2 answers "no" for value-reading star
+rules at spacing 2, by a vacuity argument: every corner site has six free code
+neighbours there, so the corner star realises all 128 value patterns and the
+maximal star rule accepts everything.
+
+This runner tests the two named classes of star-local rule on clusters where
+that vacuity argument does not apply.
+
+  A  STAR PATTERNS.  The 24 proper rotations and the 48-element full cubic
+     group induce the same 20 orbits on the 128 seven-bit star patterns, with
+     identical canonical representatives, so every rotation-invariant star
+     rule is automatically inversion-invariant.  The spacing-2 vacuity of
+     PR #7834 restated and recomputed.
+
+  B  VALUE-READING STAR RULES ON SPACED SUPERLATTICES.  A rule is a predicate
+     on the seven Z-values of a site's star, invariant under the 24 proper
+     rotations.  On a spaced superlattice with coarse spacing s and one code
+     site per coarse edge at position p, the marker values are covariant under
+     the space-group stabiliser of the code sublattice; the MAXIMAL rule
+     accepts exactly the star patterns realised in the intended configurations
+     over every code filling.  Junk = a zero-penalty configuration on the
+     torus whose markers are not a translate or rotation of the intended
+     pattern.  Exhaustive over every covariant assignment at s = 3 (both code
+     positions) and s = 4 midpoint; the junk witness is found by exhaustive
+     branch-on-first-undetermined-site constraint propagation with backtracking
+     and an explicit node count.  No SAT solver and no external solver is used
+     anywhere.
+
+  C  STATE-READING FRUSTRATION-FREE STAR TEMPLATES.  A rule is a PSD operator
+     h on the seven-site star, identical at every site, with the intended
+     role-star states in its kernel K; the canonical maximal choice is
+     h = 1 - Pi_K.  The zero space of H = sum_s h_s is the intersection of the
+     star kernels.  Aliasing lemma for tori with a side of length 2; exact
+     dense results on the 2D 4x2 torus and for the 7-qubit 3D star; matrix-free
+     alternating projections on the 16-qubit 2D 4x4 and 3D 4x2x2 tori, with
+     Hutchinson nullity estimates; the character of the junk; and the 1D
+     contrast, which is junk-free.
+
+Group A and group B are exact: integer and bit arithmetic, exhaustive
+enumeration, exhaustive constraint propagation.  Group C mixes exact linear
+algebra (dense, on 8-qubit and 7-qubit spaces) with matrix-free numerical
+statements on 16-qubit tori; every numerical line is tagged, carries its
+converged residual, and fixes its seed.  Every array is at most 65536 x 16.
+
+These are finite negative results on two named classes over named finite
+clusters.  Nothing here says a nearby-only rule of some other kind is
+unavailable, and nothing here is derived from the framework axioms.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from collections import Counter
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 300
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================================ cubic group, stars
+
+DIRS = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+DIDX = {d: i for i, d in enumerate(DIRS)}
+
+
+def _mats():
+    out = []
+    for perm in itertools.permutations(range(3)):
+        for sg in itertools.product((1, -1), repeat=3):
+            M = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+            for i in range(3):
+                M[i][perm[i]] = sg[i]
+            out.append(tuple(tuple(r) for r in M))
+    return out
+
+
+ALL48 = _mats()
+
+
+def det3(M):
+    return (M[0][0] * (M[1][1] * M[2][2] - M[1][2] * M[2][1])
+            - M[0][1] * (M[1][0] * M[2][2] - M[1][2] * M[2][0])
+            + M[0][2] * (M[1][0] * M[2][1] - M[1][1] * M[2][0]))
+
+
+ROT24 = [M for M in ALL48 if det3(M) == 1]
+
+
+def mvec(M, v):
+    return (M[0][0] * v[0] + M[0][1] * v[1] + M[0][2] * v[2],
+            M[1][0] * v[0] + M[1][1] * v[1] + M[1][2] * v[2],
+            M[2][0] * v[0] + M[2][1] * v[1] + M[2][2] * v[2])
+
+
+def mtrans(M):
+    return tuple(tuple(M[j][i] for j in range(3)) for i in range(3))
+
+
+DP24 = sorted(set(tuple(DIDX[mvec(M, d)] for d in DIRS) for M in ROT24))
+DP48 = sorted(set(tuple(DIDX[mvec(M, d)] for d in DIRS) for M in ALL48))
+
+
+def canon_table(perms):
+    """Canonical representative of every 7-bit star pattern under `perms`."""
+    T = np.zeros(128, dtype=np.int64)
+    for p in range(128):
+        c = (p >> 6) & 1
+        best = 999
+        for pm in perms:
+            q = 0
+            for i in range(6):
+                if (p >> i) & 1:
+                    q |= 1 << pm[i]
+            best = min(best, q)
+        T[p] = (c << 6) | best
+    return T
+
+
+CANON24 = canon_table(DP24)
+CANON48 = canon_table(DP48)
+
+
+# ---- propagation tables over 7-slot star patterns (built once, globally) ----
+MSET = {}
+for _km in range(128):
+    for _kv in range(128):
+        if (_kv & _km) != _kv:
+            continue
+        _m = 0
+        for _p in range(128):
+            if (_p & _km) == _kv:
+                _m |= 1 << _p
+        MSET[(_km, _kv)] = _m
+BIT1 = [sum(1 << p for p in range(128) if (p >> b) & 1) for b in range(7)]
+BIT0 = [sum(1 << p for p in range(128) if not ((p >> b) & 1)) for b in range(7)]
+
+
+def star_codes(cfg):
+    """The 7-bit star pattern at every site of a periodic 0/1 configuration."""
+    q = cfg.astype(np.int64) << 6
+    for i, d in enumerate(DIRS):
+        q |= (np.roll(cfg, shift=(-d[0], -d[1], -d[2]),
+                      axis=(0, 1, 2)).astype(np.int64) << i)
+    return q
+
+
+def penalty(cfg, acc):
+    return int(np.count_nonzero(~acc[star_codes(cfg)]))
+
+
+# =========================================================== A: star patterns
+
+def role_of(c):
+    """0 corner, 1 edge, 2 face, 3 cube centre, by coordinate parity."""
+    return sum(x & 1 for x in c)
+
+
+def spacing2_templates(L=4):
+    """The 48 templates of the period-(4,2,2) role pattern on the LxLxL torus.
+
+    Value -1 marks a free (code) site: the coarse edge sites.
+    """
+    out = []
+    for ax in range(3):
+        for t in itertools.product(range(L), repeat=3):
+            V = np.zeros((L, L, L), dtype=np.int8)
+            for c in itertools.product(range(L), repeat=3):
+                u = tuple((c[i] + t[i]) % L for i in range(3))
+                r = role_of(u)
+                if r == 0:
+                    V[c] = (u[ax] // 2) % 2
+                elif r == 1:
+                    V[c] = -1
+                elif r == 2:
+                    V[c] = 0
+                else:
+                    V[c] = 1
+            out.append((ax, V))
+    uniq = {}
+    for ax, V in out:
+        uniq[(ax, V.tobytes())] = V
+    return [uniq[k] for k in sorted(uniq)]
+
+
+def group_A():
+    same_partition = (len(set(CANON24.tolist())) == len(set(CANON48.tolist()))
+                      == 20 and np.array_equal(CANON24, CANON48))
+    check("A1 [exact] the 24 proper rotations and the full 48-element cubic group "
+          "induce the SAME %d orbits on the 128 seven-bit star patterns, with "
+          "identical canonical representatives, so every rotation-invariant "
+          "value-reading star rule is inversion-invariant and no such rule encodes "
+          "a chirality" % len(set(CANON24.tolist())), same_partition)
+
+    T = spacing2_templates(4)
+    L = 4
+    seen = set()
+    pairs = set()
+    maxnb = 0
+    for V in T:
+        for c in itertools.product(range(L), repeat=3):
+            nb = [tuple((c[i] + d[i]) % L for i in range(3)) for d in DIRS]
+            maxnb = max(maxnb, sum(1 for x in nb if V[x] < 0))
+            if V[c] < 0:
+                continue
+            free = [j for j, x in enumerate(nb) if V[x] < 0]
+            if len(free) != 6:
+                continue
+            for r in range(64):
+                seen.add((int(V[c]) << 6) | r)
+            for x in nb:
+                for b in (0, 1):
+                    pairs.add((int(V[c]), b))
+    check("A2 [exact] spacing 2, the vertex-star argument of PR #7834 recomputed: on "
+          "the 4x4x4 torus the %d templates (16 translates x 3 orientations of "
+          "period (4,2,2)) give every corner six free code neighbours, and corner "
+          "stars realise all %d of the 128 value patterns and %d of the 4 adjacent "
+          "pairs, so the maximal value-reading star rule is vacuous there"
+          % (len(T), len(seen), len(pairs)),
+          len(T) == 48 and len(seen) == 128 and len(pairs) == 4 and maxnb == 6)
+
+
+# ============================== B: value-reading rules on spaced superlattices
+
+class Geom:
+    """One spaced superlattice: coarse spacing s, code site at offset p."""
+
+    def __init__(self, s, p):
+        self.s, self.p = s, p
+        self.cell = [(x, y, z) for x in range(s) for y in range(s)
+                     for z in range(s)]
+        self.fidx = {c: i for i, c in enumerate(self.cell)}
+        self.C = frozenset([(p % s, 0, 0), (0, p % s, 0), (0, 0, p % s)])
+        G = []
+        for R in ROT24:
+            for t in self.cell:
+                img = frozenset(tuple((mvec(R, c)[i] + t[i]) % s for i in range(3))
+                                for c in self.C)
+                if img == self.C:
+                    G.append((R, t))
+        self.G = G
+        self.point_part = sorted(set(R for R, _ in G))
+        orb_id, orbits = {}, []
+        for x in self.cell:
+            if x in orb_id:
+                continue
+            o = sorted(set(tuple((mvec(R, x)[i] + t[i]) % s for i in range(3))
+                           for (R, t) in G))
+            k = len(orbits)
+            orbits.append(o)
+            for y in o:
+                orb_id[y] = k
+        self.orbits, self.orb_id = orbits, orb_id
+        self.morb = [k for k, o in enumerate(orbits) if o[0] not in self.C]
+        assert all(y not in self.C for k in self.morb for y in orbits[k])
+        self.n = len(self.morb)
+        self.mpos = {k: i for i, k in enumerate(self.morb)}
+        M = -np.ones((s, s, s), dtype=np.int64)
+        for x in self.cell:
+            if orb_id[x] in self.mpos:
+                M[x] = self.mpos[orb_id[x]]
+        self.MORB = M
+        masks = set()
+        for c in self.cell:
+            m = 0
+            for sl in [c] + [tuple((c[i] + d[i]) % s for i in range(3))
+                             for d in DIRS]:
+                if orb_id[sl] in self.mpos:
+                    m |= 1 << self.mpos[orb_id[sl]]
+            masks.add(m)
+        self.masks = sorted(masks)
+        idx = np.arange(s ** 3).reshape(s, s, s)
+        self.slotidx = [idx] + [np.roll(idx, shift=(-d[0], -d[1], -d[2]),
+                                        axis=(0, 1, 2)) for d in DIRS]
+        self.PRE24 = self._pre(ROT24)
+        cen = {}
+        for c in self.cell:
+            cen.setdefault(orb_id[c], sum(
+                1 for d in DIRS
+                if tuple((c[i] + d[i]) % s for i in range(3)) in self.C))
+        self.maxcodenb = max(cen.values())
+        self.codeidx = [self.fidx[c] for c in sorted(self.C)]
+
+    def _pre(self, rots):
+        """Index maps realising m_g(x) = m(R^{-1}(x - t) mod s) for all (R, t)."""
+        s = self.s
+        rows = []
+        for R in rots:
+            Ri = mtrans(R)
+            for t in self.cell:
+                row = np.empty(s ** 3, dtype=np.int32)
+                for x in self.cell:
+                    y = mvec(Ri, tuple((x[i] - t[i]) % s for i in range(3)))
+                    row[self.fidx[x]] = self.fidx[tuple(y[i] % s for i in range(3))]
+                rows.append(row)
+        return np.array(rows, dtype=np.int32)
+
+    def val_cell(self, a):
+        """Assignment bitmask over marker orbits -> cell values, -1 on code."""
+        bits = np.array([(int(a) >> i) & 1 for i in range(self.n)], dtype=np.int8)
+        return np.where(self.MORB >= 0, bits[np.maximum(self.MORB, 0)],
+                        -1).astype(np.int8)
+
+
+def accepted_raw(g, valcell):
+    """The maximal rule: accept every star class realised in an intended config."""
+    v = valcell.ravel().astype(np.int64)
+    base = np.zeros(g.s ** 3, dtype=np.int64)
+    free = np.zeros(g.s ** 3, dtype=np.int64)
+    for j, si in enumerate(g.slotidx):
+        bit = (1 << 6) if j == 0 else (1 << (j - 1))
+        vv = v[si.ravel()]
+        base |= np.where(vv == 1, bit, 0)
+        free |= np.where(vv < 0, bit, 0)
+    acc = np.zeros(128, dtype=bool)
+    for k in np.unique(base * 128 + free).tolist():
+        b, f = k // 128, k % 128
+        fb = [bit for bit in ((1 << 6) if i == 0 else (1 << (i - 1))
+                              for i in range(7)) if f & bit]
+        for r in range(1 << len(fb)):
+            q = b
+            for i, bit in enumerate(fb):
+                if (r >> i) & 1:
+                    q |= bit
+            acc[CANON24[q]] = True
+    return acc[CANON24]
+
+
+def torus_stars(L):
+    idx = np.arange(L ** 3).reshape(L, L, L)
+    sl = [idx] + [np.roll(idx, shift=(-d[0], -d[1], -d[2]), axis=(0, 1, 2))
+                  for d in DIRS]
+    S = np.stack([x.ravel() for x in sl], axis=1)
+    return [tuple(int(u) for u in row) for row in S]
+
+
+def dpll_junk(acc, N, stars, site_stars, intended, cap=2000000):
+    """Lexicographically least zero-penalty configuration that is not intended.
+
+    Exhaustive: branch on the first undetermined site, propagate every star
+    constraint to a fixed point, backtrack on conflict.  Returns
+    (configuration or None, node count).  No SAT solver.
+    """
+    accbits = 0
+    for p in range(128):
+        if acc[p]:
+            accbits |= 1 << p
+    assign = [-1] * N
+    nodes = [0]
+
+    def propagate(queue, trail):
+        while queue:
+            s0 = queue.pop()
+            for si in site_stars[s0]:
+                slots = stars[si]
+                km = kv = 0
+                for j, site in enumerate(slots):
+                    v = assign[site]
+                    if v >= 0:
+                        bit = (1 << 6) if j == 0 else (1 << (j - 1))
+                        km |= bit
+                        if v == 1:
+                            kv |= bit
+                cons = accbits & MSET[(km, kv)]
+                if cons == 0:
+                    return False
+                if km == 127:
+                    continue
+                for j, site in enumerate(slots):
+                    if assign[site] >= 0:
+                        continue
+                    b = 6 if j == 0 else (j - 1)
+                    if cons & BIT1[b] == 0:
+                        val = 0
+                    elif cons & BIT0[b] == 0:
+                        val = 1
+                    else:
+                        continue
+                    assign[site] = val
+                    trail.append(site)
+                    queue.append(site)
+        return True
+
+    def rec():
+        k = -1
+        for i in range(N):
+            if assign[i] < 0:
+                k = i
+                break
+        if k < 0:
+            cfg = list(assign)
+            return cfg if not intended(cfg) else None
+        nodes[0] += 1
+        if nodes[0] > cap:
+            raise RuntimeError("node cap")
+        for val in (0, 1):
+            trail = [k]
+            assign[k] = val
+            if propagate([k], trail):
+                r = rec()
+                if r is not None:
+                    for s0 in trail:
+                        assign[s0] = -1
+                    return r
+            for s0 in trail:
+                assign[s0] = -1
+        return None
+
+    sys.setrecursionlimit(20000)
+    return rec(), nodes[0]
+
+
+def intended_rows(g, L):
+    """Every intended marker pattern on the L-torus: (site index, values)."""
+    s = g.s
+    rep = L // s
+    rows = np.unique(g._base[g.PRE24], axis=0)
+    out = []
+    for row in rows:
+        full = np.tile(row.reshape(s, s, s), (rep, rep, rep)).ravel()
+        keep = np.flatnonzero(full >= 0)
+        out.append((keep, full[keep].astype(np.int8)))
+    return out
+
+
+def periods_of(cfg, L):
+    A = np.array(cfg).reshape(L, L, L)
+    per = []
+    for ax in range(3):
+        for k in range(1, L + 1):
+            if L % k == 0 and np.array_equal(A, np.roll(A, k, axis=ax)):
+                per.append(k)
+                break
+        else:
+            per.append(L)
+    return tuple(sorted(per))
+
+
+def sweep_superlattice(g, nsample):
+    """Exhaustive sweep over every covariant assignment on one superlattice.
+
+    Acceptance and covariance: the base intended configuration with every code
+    filling is checked for every assignment; the full rotation-and-translation
+    orbit of the intended configuration, again with every code filling, is
+    checked on `nsample` evenly spaced assignments.
+    """
+    s = g.s
+    L = s
+    N = L ** 3
+    stars = torus_stars(L)
+    site_stars = [[] for _ in range(N)]
+    for si, sl in enumerate(stars):
+        for site in set(sl):
+            site_stars[site].append(si)
+    tot = 1 << g.n
+    npass = sum(1 for a in range(tot)
+                if all((a & m) != 0 and (a & m) != m for m in g.masks))
+    accsz = []
+    cnt = Counter()
+    njunk = nvac = nlift = 0
+    totnodes = maxnodes = 0
+    covar_ok = True
+    fill = list(itertools.product((0, 1), repeat=len(g.codeidx)))
+    step = max(1, tot // nsample)
+    sample = set(range(0, tot, step))
+    for a in range(tot):
+        g._base = g.val_cell(a).ravel()
+        acc = accepted_raw(g, g.val_cell(a))
+        accsz.append(int(acc.sum()))
+        if acc.all():
+            nvac += 1
+        rows = (np.unique(g._base[g.PRE24], axis=0) if a in sample
+                else g._base.reshape(1, -1))
+        for row in rows:
+            free = np.flatnonzero(row < 0)
+            for bits in fill:
+                cfg = row.copy()
+                cfg[free] = np.array(bits, dtype=np.int8)[:len(free)]
+                if penalty(cfg.reshape(s, s, s), acc) != 0:
+                    covar_ok = False
+        IR = intended_rows(g, L)
+
+        def is_int(cfg, IR=IR):
+            c = np.array(cfg, dtype=np.int8)
+            return any(np.array_equal(c[k], v) for k, v in IR)
+
+        cfg, nodes = dpll_junk(acc, N, stars, site_stars, is_int)
+        totnodes += nodes
+        maxnodes = max(maxnodes, nodes)
+        if cfg is None:
+            continue
+        njunk += 1
+        assert penalty(np.array(cfg).reshape(L, L, L), acc) == 0
+        cnt[periods_of(cfg, L)] += 1
+        big = np.tile(np.array(cfg).reshape(L, L, L), (2, 2, 2))
+        IR2 = intended_rows(g, 2 * L)
+        bb = big.ravel()
+        if penalty(big, acc) == 0 and not any(
+                np.array_equal(bb[k], v) for k, v in IR2):
+            nlift += 1
+    return dict(tot=tot, npass=npass, accsz=accsz, cnt=cnt, njunk=njunk,
+                nvac=nvac, nlift=nlift, nodes=totnodes, maxnodes=maxnodes,
+                covar=covar_ok, nsample=len(sample), nimg=len(g.PRE24))
+
+
+def group_B():
+    cases = [(3, 1), (3, 2), (4, 2)]
+    geoms = {c: Geom(*c) for c in cases}
+    res = {}
+    for c in cases:
+        res[c] = sweep_superlattice(geoms[c], 16)
+
+    geo = " ; ".join(
+        "s=%d p=%d |G_pt|=%d orbits=%d masks=%d code_nbrs<=%d"
+        % (c[0], c[1], len(geoms[c].point_part), geoms[c].n,
+           len(geoms[c].masks), geoms[c].maxcodenb) for c in cases)
+    check("B1 [exact] zoom-out lemma: %s -- no site has an all-code star, the count "
+          "being 1 or 3, never 6, so the spacing-2 vacuity of A2 is defeated at every "
+          "spacing tested and any failure below has another mechanism" % geo,
+          all(geoms[c].maxcodenb in (1, 3) for c in cases))
+
+    check("B2 [exact] the maximal rule accepts its own intended configurations and is "
+          "covariant: penalty 0 for all %d + %d + %d assignments with every code "
+          "filling, and for %d sampled ones over every rotation and translate too; "
+          "accepted sizes |A| of 128 span %d-%d, %d-%d, %d-%d, and %d are vacuous"
+          % (res[(3, 1)]["tot"], res[(3, 2)]["tot"], res[(4, 2)]["tot"],
+             sum(res[c]["nsample"] for c in cases),
+             min(res[(3, 1)]["accsz"]), max(res[(3, 1)]["accsz"]),
+             min(res[(3, 2)]["accsz"]), max(res[(3, 2)]["accsz"]),
+             min(res[(4, 2)]["accsz"]), max(res[(4, 2)]["accsz"]),
+             sum(res[c]["nvac"] for c in cases)),
+          all(res[c]["covar"] for c in cases)
+          and sum(res[c]["nvac"] for c in cases) == 0)
+
+    check("B3 [exact] the uniform-configuration filter is sound -- if some intended "
+          "star can be made all-0 or all-1 by the code bits, that uniform "
+          "configuration has penalty 0 and is no translate -- with pass counts "
+          "%d/%d, %d/%d, %d/%d"
+          % (res[(3, 1)]["npass"], res[(3, 1)]["tot"],
+             res[(3, 2)]["npass"], res[(3, 2)]["tot"],
+             res[(4, 2)]["npass"], res[(4, 2)]["tot"]),
+          res[(3, 1)]["npass"] == 282 and res[(3, 2)]["npass"] == 282
+          and res[(4, 2)]["npass"] == 32)
+
+    def cen(r):
+        return " ".join("%dx%d%d%d" % (v, k[0], k[1], k[2])
+                        for k, v in sorted(r["cnt"].items(), key=lambda kv: -kv[1]))
+
+    r1, r2, r3 = res[(3, 1)], res[(3, 2)], res[(4, 2)]
+    check("B4 [exact, exhaustive propagation, no SAT] s=3, both code positions, all "
+          "%d assignments each: %d and %d admit junk, %d are junk-free; the period "
+          "multiset census of the lexicographically least junk witness is the same "
+          "for both, count x abc = %s (intended 333); %d branch nodes, %d at worst"
+          % (r1["tot"], r1["njunk"], r2["njunk"],
+             r1["tot"] - r1["njunk"] + r2["tot"] - r2["njunk"], cen(r1),
+             r1["nodes"] + r2["nodes"], max(r1["maxnodes"], r2["maxnodes"])),
+          r1["njunk"] == r1["tot"] and r2["njunk"] == r2["tot"]
+          and cen(r1) == cen(r2))
+    check("B5 [exact, exhaustive propagation, no SAT] s=4 midpoint, all %d "
+          "assignments: %d admit junk, %d junk-free; census count x abc = %s "
+          "(intended 444); %d branch nodes, %d at worst"
+          % (r3["tot"], r3["njunk"], r3["tot"] - r3["njunk"], cen(r3),
+             r3["nodes"], r3["maxnodes"]), r3["njunk"] == r3["tot"])
+
+    tot = sum(res[c]["njunk"] for c in cases)
+    lift = sum(res[c]["nlift"] for c in cases)
+    check("B6 [exact] each of the %d witnesses tiles to the 2s-torus (6^3 and 8^3) "
+          "with penalty 0, still no translate or rotation of the intended pattern, so "
+          "junk survives the doubled box, %d of %d: no covariant maximal "
+          "value-reading star rule tested is junk-free"
+          % (tot, lift, tot), lift == tot and tot == 2560)
+
+
+# ================================= C: state-reading star templates (quantum)
+
+R2 = 1.0 / np.sqrt(2.0)
+PST = {"0": np.array([1, 0], dtype=complex),
+       "1": np.array([0, 1], dtype=complex),
+       "+": np.array([R2, R2], dtype=complex),
+       "-": np.array([R2, -R2], dtype=complex),
+       "i": np.array([R2, 1j * R2], dtype=complex),
+       "j": np.array([R2, -1j * R2], dtype=complex)}
+NAMES = ["0", "1", "+", "-", "i", "j"]
+
+
+def kron_list(vs):
+    out = np.array([1.0 + 0j])
+    for v in vs:
+        out = np.kron(out, v)
+    return out
+
+
+def eb(b):
+    return PST["0"] if b == 0 else PST["1"]
+
+
+def K_basis_2d(v, f, variant):
+    """Intended role-star states, 2D: slots c, +x, -x, +y, -y."""
+    V = []
+    for bits in itertools.product((0, 1), repeat=4):
+        if variant == "EVEN" and sum(bits) % 2:
+            continue
+        V.append(kron_list([v] + [eb(b) for b in bits]))
+    for bits in itertools.product((0, 1), repeat=4):
+        V.append(kron_list([f] + [eb(b) for b in bits]))
+    for cb in (0, 1):
+        V.append(kron_list([eb(cb), v, v, f, f]))
+        V.append(kron_list([eb(cb), f, f, v, v]))
+    return np.array(V)
+
+
+def K_basis_3d(v, f, c, variant):
+    V = []
+    for bits in itertools.product((0, 1), repeat=6):
+        if variant == "EVEN" and sum(bits) % 2:
+            continue
+        V.append(kron_list([v] + [eb(b) for b in bits]))
+    V.append(kron_list([c] + [f] * 6))
+    for ax in range(3):
+        for bits in itertools.product((0, 1), repeat=4):
+            nb = [None] * 6
+            it = iter(bits)
+            for a in range(3):
+                if a == ax:
+                    nb[2 * a] = c
+                    nb[2 * a + 1] = c
+                else:
+                    nb[2 * a] = eb(next(it))
+                    nb[2 * a + 1] = eb(next(it))
+            V.append(kron_list([f] + nb))
+    for ax in range(3):
+        for cb in (0, 1):
+            nb = []
+            for a in range(3):
+                nb += [v, v] if a == ax else [f, f]
+            V.append(kron_list([eb(cb)] + nb))
+    return np.array(V)
+
+
+def K_basis_1d(v, variant):
+    V = []
+    for bits in itertools.product((0, 1), repeat=2):
+        if variant == "EVEN" and sum(bits) % 2:
+            continue
+        V.append(kron_list([v, eb(bits[0]), eb(bits[1])]))
+    for cb in (0, 1):
+        V.append(kron_list([eb(cb), v, v]))
+    return np.array(V)
+
+
+def projector(rows, tol=1e-9):
+    M = np.array(rows).T
+    U, s, _ = np.linalg.svd(M, full_matrices=False)
+    r = int((s > tol * max(1.0, s[0])).sum())
+    B = U[:, :r]
+    return B @ B.conj().T, r
+
+
+def lattice(shape):
+    dim = len(shape)
+    coords = list(itertools.product(*[range(L) for L in shape]))
+    index = {c: i for i, c in enumerate(coords)}
+    stars = []
+    for c in coords:
+        slots = [c]
+        for a in range(dim):
+            p = list(c)
+            p[a] = (c[a] + 1) % shape[a]
+            slots.append(tuple(p))
+            m = list(c)
+            m[a] = (c[a] - 1) % shape[a]
+            slots.append(tuple(m))
+        stars.append([index[t] for t in slots])
+    return coords, index, stars
+
+
+def compress(Pi, slots, nslots):
+    """Pull Pi back through the diagonal isometry V of the repeated slots."""
+    dist = sorted(set(slots))
+    k = len(dist)
+    pos = {s: j for j, s in enumerate(dist)}
+    idx = np.zeros(2 ** k, dtype=int)
+    for p in range(2 ** k):
+        bits = [(p >> (k - 1 - j)) & 1 for j in range(k)]
+        si = 0
+        for i, s in enumerate(slots):
+            si |= bits[pos[s]] << (nslots - 1 - i)
+        idx[p] = si
+    return dist, Pi[np.ix_(idx, idx)]
+
+
+def star_projectors(shape, Pi, nslots):
+    coords, index, stars = lattice(shape)
+    out = []
+    aliased = False
+    for slots in stars:
+        if len(set(slots)) == nslots:
+            out.append((list(slots), Pi))
+            continue
+        aliased = True
+        dist, A = compress(Pi, slots, nslots)
+        w, U = np.linalg.eigh(A)
+        sel = w > 1 - 1e-9
+        out.append((dist, U[:, sel] @ U[:, sel].conj().T))
+    return coords, len(coords), out, aliased
+
+
+def apply_local(M, sites, n, X):
+    m = X.shape[1]
+    k = len(sites)
+    T = X.reshape([2] * n + [m])
+    T = np.moveaxis(T, sites, range(k))
+    sh = T.shape
+    T = (M @ T.reshape(2 ** k, -1)).reshape(sh)
+    T = np.moveaxis(T, range(k), sites)
+    return T.reshape(2 ** n, m)
+
+
+def energy(projs, n, X):
+    Y = np.zeros_like(X)
+    for ax, Q in projs:
+        Y += X - apply_local(Q, ax, n, X)
+    return np.real(np.einsum("ij,ij->j", X.conj(), Y))
+
+
+def intended_products(shape, pins, variant):
+    """The intended global states as lists of single-site factors."""
+    dim = len(shape)
+    coords, index, stars = lattice(shape)
+    out = []
+    for off in itertools.product((0, 1), repeat=dim):
+        roles = [sum((c[a] + off[a]) % 2 for a in range(dim)) for c in coords]
+        edges = [i for i, r in enumerate(roles) if r == 1]
+        epos = {s: j for j, s in enumerate(edges)}
+        cons = []
+        if variant == "EVEN":
+            for i, r in enumerate(roles):
+                if r:
+                    continue
+                cntd = {}
+                for s in stars[i][1:]:
+                    cntd[s] = cntd.get(s, 0) + 1
+                mask = [epos[s] for s, ct in cntd.items() if ct % 2]
+                if mask:
+                    cons.append(mask)
+        for bits in itertools.product((0, 1), repeat=len(edges)):
+            if any(sum(bits[j] for j in cs) % 2 for cs in cons):
+                continue
+            out.append([eb(bits[epos[i]]) if roles[i] == 1 else pins[roles[i]]
+                        for i in range(len(coords))])
+    return out
+
+
+def span_tools(pl):
+    """Rank and pseudo-inverse Gram of the intended span, without materialising it."""
+    N = len(pl)
+    G = np.ones((N, N), dtype=complex)
+    for i in range(len(pl[0])):
+        col = np.array([p[i] for p in pl])
+        G *= col.conj() @ col.T
+    w, U = np.linalg.eigh(G)
+    keep = w > 1e-8 * max(w.max(), 1.0)
+    r = int(keep.sum())
+    return r, (U[:, keep] * (1.0 / w[keep])) @ U[:, keep].conj().T
+
+
+def overlaps(pl, X):
+    C = np.empty((len(pl), X.shape[1]), dtype=complex)
+    for a, p in enumerate(pl):
+        C[a] = kron_list(p).conj() @ X
+    return C
+
+
+def intended_err(projs, n, pl, seed=3, k=4):
+    idx = np.random.default_rng(seed).choice(len(pl), size=min(k, len(pl)),
+                                             replace=False)
+    Y = np.array([kron_list(pl[i]) for i in idx]).T.copy()
+    return float(np.abs(energy(projs, n, Y)).max())
+
+
+def dense_case(shape, Kb, pins, variant, nslots):
+    """Exact dense nullity on a small torus (at most 8 qubits)."""
+    Pi, dimK = projector(Kb)
+    if dimK == 2 ** nslots:
+        return dict(dimK=dimK, vacuous=True)
+    coords, n, projs, aliased = star_projectors(shape, Pi, nslots)
+    d = 2 ** n
+    H = np.zeros((d, d), dtype=complex)
+    I = np.eye(d, dtype=complex)
+    for ax, Q in projs:
+        H += I - apply_local(Q, ax, n, I)
+    w = np.linalg.eigvalsh(H)
+    pl = intended_products(shape, pins, variant)
+    r, _ = span_tools(pl)
+    return dict(dimK=dimK, vacuous=False, nullity=int((w < 1e-9).sum()),
+                expected=r, ierr=intended_err(projs, n, pl), aliased=aliased)
+
+
+def pocs_case(shape, Kb, pins, variant, nslots, M=4, maxsweeps=400,
+              tol=1e-13, seed=20260903):
+    """Matrix-free: alternating projections onto the intersection of star kernels."""
+    Pi, dimK = projector(Kb)
+    coords, n, projs, aliased = star_projectors(shape, Pi, nslots)
+    pl = intended_products(shape, pins, variant)
+    r, Ginv = span_tools(pl)
+    rng = np.random.default_rng(seed)
+    X = (rng.standard_normal((2 ** n, M))
+         + 1j * rng.standard_normal((2 ** n, M))) / np.sqrt(2.0)
+    X0 = X.copy()
+    it = 0
+    while it < maxsweeps:
+        for ax, Q in projs:
+            X = apply_local(Q, ax, n, X)
+        it += 1
+        if it % 10 == 0:
+            nrm2 = np.maximum(np.linalg.norm(X, axis=0) ** 2, 1e-300)
+            if (energy(projs, n, X) / nrm2).max() < tol:
+                break
+    nrm2 = np.maximum(np.linalg.norm(X, axis=0) ** 2, 1e-300)
+    resid = float((energy(projs, n, X) / nrm2).max())
+    ov = np.real(np.einsum("ij,ij->j", X0.conj(), X))
+    C = overlaps(pl, X)
+    inside = np.real(np.einsum("ai,ab,bi->i", C.conj(), Ginv, C)) / nrm2
+    return dict(dimK=dimK, expected=r, resid=resid, sweeps=it,
+                est=float(ov.mean()), se=float(ov.std(ddof=1) / np.sqrt(M)),
+                jlo=float(1 - inside.max()), jhi=float(1 - inside.min()),
+                ierr=intended_err(projs, n, pl))
+
+
+def junk_character(shape, Kb, pins, variant, nslots, seed=5, sweeps=200,
+                   tol=1e-13):
+    Pi, dimK = projector(Kb)
+    coords, n, projs, aliased = star_projectors(shape, Pi, nslots)
+    pl = intended_products(shape, pins, variant)
+    r, Ginv = span_tools(pl)
+    rng = np.random.default_rng(seed)
+    x = (rng.standard_normal((2 ** n, 1))
+         + 1j * rng.standard_normal((2 ** n, 1))) / np.sqrt(2.0)
+    it = 0
+    while it < sweeps:
+        for ax, Q in projs:
+            x = apply_local(Q, ax, n, x)
+        it += 1
+        if it % 10 == 0:
+            if float(energy(projs, n, x)[0]) / max(
+                    float(np.linalg.norm(x) ** 2), 1e-300) < tol:
+                break
+    a = Ginv @ overlaps(pl, x)
+    proj = np.zeros_like(x)
+    for i, p in enumerate(pl):
+        proj[:, 0] += a[i, 0] * kron_list(p)
+    v = x - proj
+    v /= np.linalg.norm(v)
+    E = float(energy(projs, n, v)[0])
+    C = overlaps(pl, v)
+    ins = float(np.real(C.conj().T @ Ginv @ C)[0, 0])
+    T = v.reshape([2] * n)
+    half = n // 2
+    sv = np.linalg.svd(T.reshape(2 ** half, 2 ** half), compute_uv=False)
+    sr = int((sv > 1e-8 * sv[0]).sum())
+    pur = []
+    for i in range(n):
+        A = np.moveaxis(T, i, 0).reshape(2, -1)
+        rho = A @ A.conj().T
+        pur.append(float(np.real(np.trace(rho @ rho))))
+    return dict(E=E, inside=ins, rank=sr, dim=2 ** half, maxpur=max(pur))
+
+
+def group_C():
+    diag = np.array([[1, 0], [0, 0], [0, 0], [0, 1]], dtype=complex).T
+    ok = True
+    for nm in NAMES:
+        p = PST[nm]
+        w = np.kron(p, p)
+        res = np.linalg.norm(w - diag.T @ (diag.conj() @ w))
+        if (res < 1e-12) != (nm in "01"):
+            ok = False
+    check("C1 [exact] aliasing lemma, algebraic half: a side of length 2 identifies "
+          "the two +- neighbour slots on that axis, so the star term is the pullback "
+          "h = 1 - V^dag Pi_K V and the image of the diagonal isometry V on that pair "
+          "is span{|00>,|11>}, holding the pinned product |p>|p> exactly when ab = 0 "
+          "for |p> = a|0> + b|1>, a Z eigenstate; on all %d pins"
+          % len(NAMES), ok)
+
+    rows = {}
+    nvac = nfaith = nunf = 0
+    unf_nonZ = True
+    for vn in NAMES:
+        for fn in NAMES:
+            for var in ("EVEN", "FULL"):
+                r = dense_case((4, 2), K_basis_2d(PST[vn], PST[fn], var),
+                               {0: PST[vn], 2: PST[fn]}, var, 5)
+                if r["vacuous"]:
+                    nvac += 1
+                    if not (var == "FULL" and vn != fn):
+                        unf_nonZ = False
+                    continue
+                if r["ierr"] < 1e-9:
+                    nfaith += 1
+                    rows[(vn, fn, var)] = r
+                else:
+                    nunf += 1
+                    if vn in "01" or fn in "01":
+                        unf_nonZ = False
+    jz = [rows[k]["nullity"] - rows[k]["expected"]
+          for k in [("0", "0", "EVEN"), ("0", "0", "FULL"), ("0", "1", "EVEN")]]
+    check("C2 [exact] aliasing lemma, computed half, 2D 4x2 torus in full: of the 72 "
+          "(pin pair, variant) cases %d are vacuous -- exactly FULL at all 30 pairs "
+          "with v != f -- and of the %d live cases %d are faithful and %d not, the "
+          "unfaithful being exactly those with neither pin a Z eigenstate"
+          % (nvac, nfaith + nunf, nfaith, nunf),
+          nvac == 30 and nfaith == 22 and nunf == 20 and unf_nonZ)
+
+    check("C3 [exact] 2D 4x2 torus, faithful Z-pin rows: v=f=|0> gives dim K = %d, "
+          "nullity %d against %d intended, so %d junk zero modes in EVEN and %d in "
+          "FULL; v=|0> f=|1> gives dim K = %d, nullity %d against %d, so %d junk. No "
+          "faithful pin choice on this torus is junk-free"
+          % (rows[("0", "0", "EVEN")]["dimK"], rows[("0", "0", "EVEN")]["nullity"],
+             rows[("0", "0", "EVEN")]["expected"], jz[0], jz[1],
+             rows[("0", "1", "EVEN")]["dimK"], rows[("0", "1", "EVEN")]["nullity"],
+             rows[("0", "1", "EVEN")]["expected"], jz[2]),
+          jz == [12, 4, 36] and all(rows[k]["nullity"] > rows[k]["expected"]
+                                    for k in rows))
+
+    dk = {"EVEN": [], "FULL": []}
+    zfaith = True
+    for vn in "01+-":
+        for fn in "01+-":
+            for cn in "01+-":
+                for var in ("EVEN", "FULL"):
+                    Kb = K_basis_3d(PST[vn], PST[fn], PST[cn], var)
+                    Pi, d = projector(Kb)
+                    dk[var].append(d)
+                    if vn in "01" and fn in "01" and cn in "01":
+                        coords, n, projs, al = star_projectors((4, 2, 2), Pi, 7)
+                        pl = intended_products(
+                            (4, 2, 2), {0: PST[vn], 2: PST[fn], 3: PST[cn]}, var)
+                        if intended_err(projs, n, pl) > 1e-9:
+                            zfaith = False
+    check("C4 [exact] 3D seven-site star, all 64 pin triples from {0,1,+,-} and both "
+          "variants: dim K runs %d-%d of 128 in EVEN and %d-%d in FULL, so no "
+          "template is vacuous, and all 16 all-Z triples are faithful on the 4x2x2 "
+          "torus -- which is why the 3D rows use Z pins only"
+          % (min(dk["EVEN"]), max(dk["EVEN"]), min(dk["FULL"]), max(dk["FULL"])),
+          min(dk["EVEN"]) == 51 and max(dk["EVEN"]) == 76
+          and min(dk["FULL"]) == 65 and max(dk["FULL"]) == 105
+          and max(dk["EVEN"] + dk["FULL"]) < 128 and zfaith)
+
+    c2d = [(("+", "+"), "EVEN"), (("+", "+"), "FULL"), (("0", "1"), "EVEN"),
+           (("+", "-"), "EVEN"), (("0", "+"), "EVEN")]
+    r2d = {}
+    for (vn, fn), var in c2d:
+        r2d[(vn, fn, var)] = pocs_case(
+            (4, 4), K_basis_2d(PST[vn], PST[fn], var),
+            {0: PST[vn], 2: PST[fn]}, var, 5)
+    frs = [(r2d[k]["jlo"], r2d[k]["jhi"]) for k in r2d]
+    txt = " ; ".join("%s%s %s %.2f-%.2f" % (k[0], k[1], k[2][0], v["jlo"], v["jhi"])
+                     for k, v in r2d.items())
+    check("C5 [numerical, matrix-free, seed fixed] 2D 4x4 torus, no aliasing, state "
+          "vectors of length 65536: alternating projections from a random start reach "
+          "residual energy at most %.0e and carry junk fraction (weight outside the "
+          "intended span) %s"
+          % (max(v["resid"] for v in r2d.values()), txt),
+          max(v["resid"] for v in r2d.values()) < 1e-12
+          and min(f[0] for f in frs) > 0.25 and max(v["ierr"] for v in r2d.values()) < 1e-9)
+
+    est = " ; ".join("%s%s %s %.0f+-%.0f vs %d intended"
+                     % (k[0], k[1], k[2][0], v["est"], v["se"], v["expected"])
+                     for k, v in r2d.items())
+    check("C6 [numerical, stochastic, seed fixed] the same runs give Hutchinson trace "
+          "estimates of the kernel dimension, %d probes, one standard error: %s -- "
+          "each far above its intended count" % (4, est),
+          all(v["est"] - 3 * v["se"] > v["expected"] for v in r2d.values()))
+
+    c3d = [(("0", "0", "0"), "EVEN"), (("0", "0", "0"), "FULL"),
+           (("0", "1", "0"), "EVEN"), (("0", "1", "1"), "EVEN")]
+    r3d = {}
+    for (vn, fn, cn), var in c3d:
+        r3d[(vn, fn, cn, var)] = pocs_case(
+            (4, 2, 2), K_basis_3d(PST[vn], PST[fn], PST[cn], var),
+            {0: PST[vn], 2: PST[fn], 3: PST[cn]}, var, 7)
+    t3 = " ; ".join("%s%s%s %s dimK=%d junkfrac %.2f-%.2f est %.0f+-%.0f vs %d"
+                    % (k[0], k[1], k[2], k[3][0], v["dimK"], v["jlo"], v["jhi"],
+                       v["est"], v["se"], v["expected"]) for k, v in r3d.items())
+    check("C7 [numerical, matrix-free, seed fixed] 3D 4x2x2 torus, Z pins, the "
+          "faithful case: %s; residual energy at most %.0e, intended-state energy at "
+          "most %.0e" % (t3, max(v["resid"] for v in r3d.values()),
+                         max(v["ierr"] for v in r3d.values())),
+          max(v["resid"] for v in r3d.values()) < 1e-12
+          and min(v["jlo"] for v in r3d.values()) > 0.4
+          and all(v["est"] - 3 * v["se"] > v["expected"] for v in r3d.values()))
+
+    j2 = junk_character((4, 4), K_basis_2d(PST["+"], PST["+"], "EVEN"),
+                        {0: PST["+"], 2: PST["+"]}, "EVEN", 5)
+    j3 = junk_character((4, 2, 2), K_basis_3d(PST["0"], PST["0"], PST["0"], "EVEN"),
+                        {0: PST["0"], 2: PST["0"], 3: PST["0"]}, "EVEN", 7)
+    check("C8 [numerical, matrix-free, seed fixed] the junk is a superposition of "
+          "role assignments, not a rival pattern: the extracted vector has energy at "
+          "most %.0e, weight inside the intended span at most %.0e, Schmidt rank %d "
+          "and %d across a half cut of %d, every single-site reduced state mixed with "
+          "purity at most %.3f and %.3f -- no site is pinned"
+          % (max(j2["E"], j3["E"]), max(j2["inside"], j3["inside"]), j2["rank"],
+             j3["rank"], j2["dim"], j2["maxpur"], j3["maxpur"]),
+          max(j2["E"], j3["E"]) < 1e-12 and max(j2["inside"], j3["inside"]) < 1e-12
+          and j2["rank"] > 1 and j3["rank"] > 1
+          and max(j2["maxpur"], j3["maxpur"]) < 0.8)
+
+    out = []
+    jf = []
+    for var in ("EVEN", "FULL"):
+        for vn in "01+-":
+            r = dense_case((8,), K_basis_1d(PST[vn], var), {0: PST[vn]}, var, 3)
+            j = r["nullity"] - r["expected"]
+            out.append((vn, var, r["dimK"], r["nullity"], r["expected"], j))
+            if j == 0 and r["ierr"] < 1e-9:
+                jf.append((vn, var))
+    check("C9 [exact] the one-dimensional contrast, three-site stars on an 8-ring: Z "
+          "pins in the EVEN variant are junk-free, dim K = 3 and nullity 3 equal to "
+          "the 3 intended states, while |+> and |-> in EVEN give nullity 9 against 4 "
+          "and every FULL choice 47 against 31; %d of 8 junk-free, so the failure "
+          "above is no artefact of the construction" % len(jf),
+          sorted(jf) == [("0", "EVEN"), ("1", "EVEN")]
+          and [o[3:] for o in out if o[1] == "EVEN" and o[0] == "0"] == [(3, 3, 0)])
+
+
+def main():
+    group_A()
+    group_B()
+    group_C()
+    print("SUMMARY: on the classes and clusters tested no junk-free star-local rule "
+          "of either kind was found; value-reading rules fail by period collapse, "
+          "state-reading ones by superposition junk.")
+    print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Bounded computation note + exact runner + cache answering PR #7834's open locality item for two named classes of star-local rule, negatively and on named finite clusters: **value-reading** star rules (a rotation-invariant predicate on the seven Z-values of a site's star) and **state-reading frustration-free** star templates (`h = 1 - Pi_K` with the intended role-star states in its kernel). Neither selects a superlattice role pattern with free code sites on the clusters tested. Value-reading rules fail by **period collapse** (exhaustive over all 2560 covariant marker assignments at spacings 3 and 4, no SAT solver: a rival repeating pattern of shorter period always fits, and the zoom-out defeats the spacing-2 vacuity without curing this). State-reading templates fail by **superposition junk** (kernels are subspaces, so blends of role assignments slip through; exact on 8 qubits, matrix-free on 16-qubit tori). Both are finite negatives, not no-gos; the interfaces list what remains open (energetic selection, larger windows, multi-star templates, non-projector state readings).

- `docs/THROUGH_LATTICE_ROLE_MARKING_TWO_FINITE_NEGATIVES_BOUNDED_COMPUTATION_NOTE_2026-09-03.md` (319 lines)
- `scripts/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.py` (`TOTAL: PASS=17 FAIL=0`, 25 s; no external solver; numerical lines tagged with converged residuals; stochastic lines seeded with standard errors)
- `logs/runner-cache/through_lattice_role_marking_two_finite_negatives_check_2026_09_03.txt`

## Theorems

- **T1** the 24 proper rotations and the 48-element cubic group induce the same 20 orbits on the 128 star patterns (every rotation-invariant star rule is inversion-invariant); the spacing-2 vacuity of PR #7834 recomputed.
- **T2** spaced superlattices `s = 3` (both code positions, 1024 assignments each) and `s = 4` midpoint (512): no site has an all-code star (zoom-out lemma), the maximal rule is never vacuous, yet every one of the 2560 assignments admits junk, with a canonical period census, and every witness survives tiling to the doubled torus.
- **T3** the aliasing lemma for length-2 tori (exact algebraic half and exact computed half).
- **T4** 2D: exact `4x2` rows all carry junk; on the non-aliased `4x4` torus every tested pin choice carries junk fractions 0.31 to 0.92 with kernel dimensions far above the intended count.
- **T5** 3D: no template vacuous; on the faithful `4x2x2` Z-pin rows junk fractions 0.53 to 0.90.
- **T6** the junk is a superposition of role assignments (Schmidt rank ~35, no site pinned); the 1D analogue with Z pins is junk-free.

## Boundary

- Scratch-only and NOT claimed: `s = 4` off-midpoint, `s = 5`, `s = 6`, Haar-random pins (sampled / SAT-checked in scratch). Non-aliased 3D state-reading tori are not reached. No general argument for period collapse is offered.

## Dependencies and context

- Cites `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7834) as the source of the open item, by filename as a pointer.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
