### PR TITLE
science(recovery): classify KCPT full-center unlocks

### DIFF
--- a/docs/KCPT_L4_FULL_CENTER_UNLOCK_DIM76_WEDDERBURN_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/KCPT_L4_FULL_CENTER_UNLOCK_DIM76_WEDDERBURN_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,231 @@
+# KCPT L=4 full-center unlock and dimension-76 Wedderburn classification
+
+**Type:** bounded_theorem
+
+**Date:** 2026-09-03
+
+**Surface:** periodic `L=4`, `N=64` staggered lattice on the `4^3` torus
+
+**Runner:**
+[`scripts/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.py`](../scripts/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.txt`](../logs/runner-cache/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.txt)
+
+## Claim scope
+
+On the fixed finite KCPT surface inherited from the dependencies, let
+
+```text
+A     = Alg_C(D2, J_full, rho(H)),
+A_nat = Alg_C(D2, J_full, S_eps),
+C_g   = Alg_C(D2, J_full, S_eps, g),  g in G_amb,
+```
+
+and let `sep=P_a-P_b` be the difference of the two rank-12 constituent
+projectors on the `m=2` shell.  The 768 elements of `G_amb` form 36
+`H`-conjugacy classes for this census.
+
+The dependency chain supplies
+
+```text
+Z(A)     = C[M] direct-sum span{sep},  dim Z(A)=5,
+Z(A_nat) = C[M],                       dim Z(A_nat)=4.
+```
+
+Fresh execution of the finite construction gives:
+
+1. `dim(C_g intersection Z(A))` is 4 on 33 classes and 5 on three
+   classes.  The three full-center classes are exactly the classes with
+   separator reach `omega(g)=1`.
+2. One representative suffices in each of those three classes.  Their
+   `(class size, dim C_g, order(g))` data are
+   `(4,28,4)`, `(64,76,12)`, and `(64,76,12)`.
+3. Each of the two 76-dimensional extension algebras has center dimension
+   19 and numerically resolves as
+
+   ```text
+   C_g isomorphic to M_2(C) direct-sum ... direct-sum M_2(C)
+                       (19 summands).
+   ```
+
+4. The two non-`H`-conjugate dimension-76 classes have the same abstract
+   algebra and representation profile.  Their six rank-4 minimal central
+   idempotents on shell `m=2` divide three inside `P_a` and three inside
+   `P_b`, so
+
+   ```text
+   sep = (e_a1 + e_a2 + e_a3) - (e_b1 + e_b2 + e_b3).
+   ```
+
+These are numerical finite-matrix statements at the stated tolerances.  They
+do not identify any center element as a physical charge, observable, Record,
+or superselection sector.
+
+## 1. Why the center intersection reduces to one question
+
+The four shell projectors `P_0,...,P_3` span `C[M]` and already belong to
+every `C_g` because `A_nat` is contained in every extension.  The companion
+runner rebuilds
+
+```text
+span(P_0,P_1,P_2,P_3,sep)
+```
+
+at dimension five and checks that all five directions commute with the
+generators of `A`.  The earlier bicommutant theorem supplies the independent
+upper bound `dim Z(A)=5`, so those five directions exhaust the full center.
+
+It follows that an intersection can have only two dimensions here:
+
+```text
+dim(C_g intersection Z(A)) = 4 + indicator[sep belongs to C_g].
+```
+
+The parent census computes the normalized Frobenius projection
+
+```text
+omega(g) = ||Pi_Cg(sep)||_F^2 / ||sep||_F^2.
+```
+
+Thus `omega=1` is precisely the fifth-center-direction membership test.  The
+fresh run separates the three member classes from the other 33 classes by a
+wide residual margin: the largest member residual is below `1e-8`, while the
+smallest nonmember residual is greater than `0.5`.
+
+The runner's deterministic zero-based enumeration labels the three classes
+`14`, `25`, and `27`.  These integers are reproducibility labels, not
+class-invariant names.  The invariant metadata are:
+
+| zero-based runner id | class size | `dim C_g` | representative order |
+|---:|---:|---:|---:|
+| 14 | 4 | 28 | 4 |
+| 25 | 64 | 76 | 12 |
+| 27 | 64 | 76 | 12 |
+
+Because `A_nat` itself has only the four-dimensional center and one supplied
+representative already reaches all five directions, the minimal number of
+added elements within each successful class is one.  This is a word-algebra
+statement; it does not select one class physically.
+
+## 2. The two larger unlock algebras
+
+The earlier census already measured the two order-12, size-64 routes at
+algebra dimension 76 and full separator reach.  Their internal algebra types
+were not classified there.  For each class, the new runner:
+
+1. true-closes `C_g` at complex dimension 76;
+2. solves the commutant equations inside the closed algebra and finds a
+   19-dimensional center;
+3. diagonalizes two independently seeded Hermitian center samples;
+4. obtains 19 separated minimal central spectral projectors on both seeds;
+5. compresses the full algebra into each projector and obtains corner
+   dimension four every time; and
+6. checks completeness, idempotency, Hermiticity, and centrality directly.
+
+For a finite-dimensional complex `*`-algebra, a minimal central corner of
+dimension four is `M_2(C)`.  Nineteen such corners account for the full
+dimension `19*4=76`, resolving
+
+```text
+C_g isomorphic to M_2(C)^19
+```
+
+for both classes at the numerical thresholds.  The largest numerical-null
+center singular value is below `4.7e-14`, the smallest kept value is within
+roundoff of `2`, and the smallest between-cluster gap across both classes and
+both seeds exceeds `1.3e-3`.
+
+## 3. Representation and shell profile
+
+The central-idempotent ranks are
+
+```text
+six rank-2 blocks and thirteen rank-4 blocks.
+```
+
+Since each algebra block is `M_2(C)`, rank two means representation
+multiplicity one and rank four means multiplicity two.  Both dimension-76
+classes give the same detailed profile:
+
+| `M` shell | corner dimension | central-idempotent rank | number of blocks |
+|---:|---:|---:|---:|
+| 0 | 4 | 2 | 2 |
+| 0 | 4 | 4 | 1 |
+| 1 | 4 | 4 | 6 |
+| 2 | 4 | 4 | 6 |
+| 3 | 4 | 2 | 4 |
+
+The rank totals are `8,24,24,8` on shells `0,1,2,3`, reproducing the full
+64-dimensional carrier.  The profile equality proves abstract isomorphism
+and the same represented multiplicities.  It does **not** prove that the two
+extensions are conjugate by a transformation outside `H`; they are distinct
+`H`-classes by construction.
+
+The six shell-2 atoms are especially informative.  Direct multiplication by
+`P_a` and `P_b` assigns all six without remainder: three lie wholly in
+`P_a`, three wholly in `P_b`.  Their signed sum reconstructs `sep` with
+Frobenius residual below `8e-13` in both classes and both center samples.
+
+This distinguishes the larger routes from the 28-dimensional route:
+
+```text
+A_28  isomorphic to M_2(C)^7,
+A_76 isomorphic to M_2(C)^19.
+```
+
+In `A_28`, `P_a` and `P_b` are themselves minimal central idempotents.  In
+either `A_76`, each is refined into three minimal central idempotents.  All
+three routes contain the same five-dimensional center of the full algebra
+`A`, but their own centers and internal resolutions differ.  In particular,
+the extra 14 center directions of `A_76` are central only in that subalgebra;
+they are not additional directions in `Z(A)`.
+
+## 4. Executable evidence and controls
+
+The companion runner re-executes the landed 49-gate parent construction in
+process, captures its stdout, and refuses to proceed green unless the parent
+returns `PASS=49 FAIL=0` and exit code zero.  It then reports
+`TOTAL: PASS=23 FAIL=0` for the recovery delta.
+
+The new gates cover:
+
+- the five independent commuting center directions;
+- the `{4:33,5:3}` intersection histogram and its residual margin;
+- the three full-center class metadata rows and equality with the `omega=1`
+  stratum;
+- true closure and center dimension 19 for both dimension-76 classes;
+- two-seed central clustering, corner dimensions, ranks, and shell profiles;
+- the three-plus/three-minus minimal-idempotent decomposition of `sep`; and
+- two live controls: deleting `sep` collapses the proposed center basis from
+  dimension five to four, while the same block machinery resolves `A_28` as
+  seven rather than 19 `M_2(C)` summands.
+
+No cached PASS line is used as evidence.  The original unlanded scratch probe
+is unavailable; every number in this note was recomputed from the landed
+finite construction on 2026-09-03.
+
+## 5. Boundary and scientific reading
+
+This result is positive structural science on one finite supplied model.  It
+shows that full-center word realization is not unique: one short route reaches
+the center with a 28-dimensional algebra, while two other one-element routes
+reach the same full center and simultaneously resolve a much finer
+19-component subalgebra structure.  Center reach alone therefore does not fix
+the architecture of the realizing algebra.
+
+The result remains limited to the periodic `L=4`, `N=64` carrier, the stated
+KCPT operators, single ambient-element extensions, and numerical rank
+thresholds.  It derives no continuum or thermodynamic limit, dynamics,
+coupling, Standard-Model generation assignment, measurement rule, or Record
+readout.  It adds no axiom and by itself retires no TOE obligation.  Audit
+status and retained classification belong exclusively to the independent
+audit lane; this source note sets neither.
+
+## Dependencies
+
+- [KCPT Dirac-symmetry algebra bicommutant dimension 992](KCPT_DIRAC_SYMMETRY_ALGEBRA_BICOMMUTANT_DIMENSION_992_BOUNDED_THEOREM_NOTE_2026-07-24.md)
+  supplies the full algebra `A`, `dim Z(A)=5`, and its five-block center.
+- [KCPT ind12 separator reach census and minimal unlock](KCPT_IND12_SEPARATOR_REACH_QUANTIZED_CENSUS_MINIMAL_UNLOCK_BOUNDED_THEOREM_NOTE_2026-07-25.md)
+  supplies the fixed construction, `A_nat`, `sep`, the 36-class census, and
+  the 28-dimensional comparison route that the companion runner re-executes.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15752,
- "node_count": 5558,
+ "edge_count": 15754,
+ "node_count": 5559,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -10505,6 +10505,10 @@
   "kcpt_kernel_kreal_readout_face_classification_bounded_theorem_note_2026-07-18": {
    "deps_hash": "50dddb4a2314",
    "out_degree": 4
+  },
+  "kcpt_l4_full_center_unlock_dim76_wedderburn_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "9e1139fa48ae",
+   "out_degree": 2
   },
   "kcpt_l6_ind8_separator_reach_census_surface_comparison_bounded_theorem_note_2026-07-25": {
    "deps_hash": "f7d47710551c",

--- a/logs/runner-cache/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.txt
+++ b/logs/runner-cache/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.txt
@@ -1,0 +1,24 @@
+[PASS] PARENT-REEXECUTION: landed U22 construction reran with PASS=49 FAIL=0 exit_codes=[0] (expected 49/0/[0])
+[PASS] FULL-CENTER-BASIS: dim span(P_0,P_1,P_2,P_3,sep)=5 (=5)
+[PASS] FULL-CENTER-CENTRALITY: maximum Frobenius commutator with generators of A=9.148e-14 (<1e-8)
+[PASS] CENTER-INTERSECTION-HISTOGRAM: class counts by dim(C_g intersection Z(A))={4: 33, 5: 3} (expected {4:33,5:3})
+[PASS] CENTER-MEMBERSHIP-SEPARATION: max full residual=0.000e+00 (<1e-8); min non-full residual=0.816497 (>0.5)
+[PASS] FULL-CENTER-CLASS-IDS: zero-based H-class ids with full center=[14, 25, 27] (expected [14,25,27])
+[PASS] FULL-CENTER-CLASS-METADATA: (id,size,algebra-dim,order)=[(14, 4, 28, 4), (25, 64, 76, 12), (27, 64, 76, 12)]
+[PASS] CENTER-REACH-EQUIVALENCE: full-center classes equal omega=1 classes: [14, 25, 27] == [14, 25, 27]
+[PASS] ONE-ELEMENT-CENTER-UNLOCK: A_nat center dim=4; one added representative reaches dim 5 in 3 classes
+[PASS] DIM76-CLASS-COUNT: dimension-76 full-center class ids=[25, 27] (expected [25,27])
+[PASS] DIM76-TRUE-CLOSURE: all two-class/two-seed profiles closed with algebra dims=[76, 76, 76, 76]
+[PASS] DIM76-CENTER-DIMENSIONS: center dimensions by class/seed=[[19, 19], [19, 19]] (=19)
+[PASS] DIM76-CENTER-SVD-GAPS: max null=4.619e-14; min kept=2.000000
+[PASS] DIM76-TWO-SEED-CENTER-CLUSTERS: clusters=[19, 19, 19, 19]; max intra=6.217e-15; min inter=0.001347
+[PASS] DIM76-WEDDERBURN-TYPE: every minimal central corner has complex dimension 4, resolving M2(C)^19 for both classes and seeds
+[PASS] DIM76-REPRESENTATION-RANKS: central-idempotent ranks are six 2s and thirteen 4s for all profiles=True
+[PASS] DIM76-SHELL-PROFILE: common (corner-dim,rank,shell)->count profile recovered=True
+[PASS] DIM76-CENTRAL-IDEMPOTENTS: max partition/idempotent/Hermitian/orthogonality/central residual=1.911e-12
+[PASS] DIM76-SEPARATOR-SIX-ATOM-SPLIT: (shell-2,+,-,assigned)=[(6, 3, 3, 6), (6, 3, 3, 6), (6, 3, 3, 6), (6, 3, 3, 6)]
+[PASS] DIM76-SEPARATOR-RECONSTRUCTION: max ||sep-(sum three plus atoms - sum three minus atoms)||_F=7.658e-13
+[PASS] DIM76-COMMON-ABSTRACT-PROFILE: the two non-H-conjugate classes have the same M2(C)^19 representation profile
+[PASS] CONTROL-DROP-SEPARATOR: omitting sep collapses the proposed center basis from 5 to 4
+[PASS] CONTROL-A28-IS-DIFFERENT: same machinery resolves A28 as M2(C)^7 (center 7), not M2(C)^19
+TOTAL: PASS=23 FAIL=0

--- a/scripts/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.py
+++ b/scripts/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Recover the missing L=4 KCPT full-center and dim-76 unlock classification.
+
+This runner deliberately re-executes the landed U22 finite-surface construction instead
+of trusting an old scratch transcript.  It then computes only the science delta that was
+not preserved there:
+
+* which single-element extension classes contain the inherited five-dimensional center
+  Z(A) = C[M] plus span{sep}; and
+* the centers, minimal central blocks, representation ranks, shell supports, and separator
+  decompositions of the two 76-dimensional full-center extensions.
+
+All classifications are numerical statements about the fixed L=4, N=64 matrices.  The
+parent runner's stdout is captured so this companion remains below the repository output
+limit, but its PASS/FAIL state is checked before any derived gate can pass.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+
+import numpy as np
+
+
+MEMBER_TOL = 1e-8
+NULL_TOL = 1e-8
+GAP_TOL = 1e-4
+
+passed = 0
+failed = 0
+
+
+def gate(name: str, condition: bool, detail: str) -> None:
+    global passed, failed
+    ok = bool(condition)
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+    if ok:
+        passed += 1
+    else:
+        failed += 1
+
+
+def load_parent() -> tuple[dict, str, list[int]]:
+    """Execute the parent in-process while intercepting its terminal sys.exit."""
+    output = io.StringIO()
+    exit_codes: list[int] = []
+    real_exit = sys.exit
+    try:
+        sys.exit = lambda code=0: exit_codes.append(int(code or 0))
+        with contextlib.redirect_stdout(output):
+            import kcpt_ind12_separator_reach_quantized_census_minimal_unlock_2026_07_25 as parent
+            namespace = vars(parent)
+    finally:
+        sys.exit = real_exit
+    return namespace, output.getvalue(), exit_codes
+
+
+ns, parent_output, parent_exit_codes = load_parent()
+parent_ok = (
+    ns.get("_P", [-1])[0] == 49
+    and ns.get("_F", [-1])[0] == 0
+    and parent_exit_codes == [0]
+    and parent_output.rstrip().endswith("TOTAL: PASS=49 FAIL=0")
+)
+gate(
+    "PARENT-REEXECUTION",
+    parent_ok,
+    f"landed U22 construction reran with PASS={ns.get('_P', [-1])[0]} "
+    f"FAIL={ns.get('_F', [-1])[0]} exit_codes={parent_exit_codes} (expected 49/0/[0])",
+)
+
+D2f = ns["D2f"]
+Jfull = ns["Jfull"]
+Seps = ns["Seps"]
+Hgens_f = ns["Hgens_f"]
+Pf = ns["Pf"]
+Pa = ns["Pa"]
+Pb = ns["Pb"]
+sep = ns["sep"]
+records = ns["records"]
+classes = ns["classes"]
+word_algebra = ns["word_algebra"]
+rowmats = ns["rowmats"]
+center_of = ns["center_of"]
+sv_margins = ns["sv_margins"]
+count_clusters = ns["count_clusters"]
+span_dim = ns["span_dim"]
+frob = ns["frob"]
+orthonormal_basis = ns["orthonormal_basis"]
+
+# U20 identifies this five-dimensional space as the full center Z(A).  Rebuild the
+# candidate basis and directly check centrality against generators of A.
+zfull_rows = orthonormal_basis(Pf + [sep])
+zfull_mats = [row.reshape(64, 64) for row in zfull_rows]
+full_generators = [D2f, Jfull, Seps] + Hgens_f
+max_z_comm = max(frob(g @ z - z @ g) for g in full_generators for z in zfull_mats)
+gate(
+    "FULL-CENTER-BASIS",
+    zfull_rows.shape[0] == 5,
+    f"dim span(P_0,P_1,P_2,P_3,sep)={zfull_rows.shape[0]} (=5)",
+)
+gate(
+    "FULL-CENTER-CENTRALITY",
+    max_z_comm < MEMBER_TOL,
+    f"maximum Frobenius commutator with generators of A={max_z_comm:.3e} (<1e-8)",
+)
+
+# C[M] is already contained in A_nat.  Since Z(A)=C[M] direct-sum span{sep}, each
+# intersection has dimension four plus one exactly when the measured separator residual
+# vanishes.  The omega values were recomputed above by the parent, not copied from cache.
+for record in records:
+    record["sep_residual"] = float(np.sqrt(max(0.0, 1.0 - record["omega"])))
+    record["z_intersection_dim"] = 5 if record["sep_residual"] < MEMBER_TOL else 4
+
+intersection_hist: dict[int, int] = {}
+for record in records:
+    d = record["z_intersection_dim"]
+    intersection_hist[d] = intersection_hist.get(d, 0) + 1
+
+full_rows = [r for r in records if r["z_intersection_dim"] == 5]
+nonfull_rows = [r for r in records if r["z_intersection_dim"] == 4]
+full_ids = [r["idx"] for r in full_rows]
+full_metadata = sorted((r["idx"], r["size"], r["dim"], r["order"]) for r in full_rows)
+omega_one_ids = [r["idx"] for r in records if abs(r["omega"] - 1.0) < 1e-9]
+max_full_residual = max(r["sep_residual"] for r in full_rows)
+min_nonfull_residual = min(r["sep_residual"] for r in nonfull_rows)
+
+gate(
+    "CENTER-INTERSECTION-HISTOGRAM",
+    intersection_hist == {4: 33, 5: 3},
+    f"class counts by dim(C_g intersection Z(A))={intersection_hist} (expected {{4:33,5:3}})",
+)
+gate(
+    "CENTER-MEMBERSHIP-SEPARATION",
+    max_full_residual < MEMBER_TOL and min_nonfull_residual > 0.5,
+    f"max full residual={max_full_residual:.3e} (<1e-8); "
+    f"min non-full residual={min_nonfull_residual:.6f} (>0.5)",
+)
+gate(
+    "FULL-CENTER-CLASS-IDS",
+    full_ids == [14, 25, 27],
+    f"zero-based H-class ids with full center={full_ids} (expected [14,25,27])",
+)
+gate(
+    "FULL-CENTER-CLASS-METADATA",
+    full_metadata == [(14, 4, 28, 4), (25, 64, 76, 12), (27, 64, 76, 12)],
+    f"(id,size,algebra-dim,order)={full_metadata}",
+)
+gate(
+    "CENTER-REACH-EQUIVALENCE",
+    full_ids == omega_one_ids,
+    f"full-center classes equal omega=1 classes: {full_ids} == {omega_one_ids}",
+)
+gate(
+    "ONE-ELEMENT-CENTER-UNLOCK",
+    ns["dimZnat"] == 4 and len(full_rows) == 3,
+    f"A_nat center dim={ns['dimZnat']}; one added representative reaches dim 5 in {len(full_rows)} classes",
+)
+
+
+def central_profile(record: dict, seed: int) -> dict:
+    """Compute one seeded minimal-central-block resolution of a dim-76 extension."""
+    rep = classes[record["idx"]][0].astype(float)
+    basis, closed = word_algebra([D2f, Jfull, Seps, rep])
+    matrices = rowmats(basis)
+    center_dim, center_mats, singular_values = center_of(matrices, [D2f, Jfull, Seps, rep])
+    null_max, kept_min = sv_margins(singular_values)
+    groups, _, vectors, max_intra, min_inter = count_clusters(center_mats, seed)
+    idempotents = [vectors[:, group] @ vectors[:, group].conj().T for group in groups]
+    block_dims = [span_dim([e @ x @ e for x in matrices]) for e in idempotents]
+    ranks = [int(round(np.trace(e).real)) for e in idempotents]
+    supports = [tuple(m for m in range(4) if frob(Pf[m] @ e) > MEMBER_TOL) for e in idempotents]
+    profile: dict[tuple[int, int, tuple[int, ...]], int] = {}
+    for block_dim, rank, support in zip(block_dims, ranks, supports):
+        key = (block_dim, rank, support)
+        profile[key] = profile.get(key, 0) + 1
+
+    identity = np.eye(64, dtype=complex)
+    partition_residual = frob(sum(idempotents, np.zeros_like(identity)) - identity)
+    idempotent_residual = max(frob(e @ e - e) for e in idempotents)
+    hermitian_residual = max(frob(e - e.conj().T) for e in idempotents)
+    orthogonality_residual = max(
+        frob(ei @ ej)
+        for i, ei in enumerate(idempotents)
+        for j, ej in enumerate(idempotents)
+        if i != j
+    )
+    central_residual = max(frob(g @ e - e @ g) for g in [D2f, Jfull, Seps, rep] for e in idempotents)
+
+    shell_two = [e for e, support in zip(idempotents, supports) if support == (2,)]
+    plus_atoms = [e for e in shell_two if frob(Pa @ e - e) < MEMBER_TOL]
+    minus_atoms = [e for e in shell_two if frob(Pb @ e - e) < MEMBER_TOL]
+    assigned = len(plus_atoms) + len(minus_atoms)
+    plus_sum = sum(plus_atoms, np.zeros_like(sep, dtype=complex))
+    minus_sum = sum(minus_atoms, np.zeros_like(sep, dtype=complex))
+    separator_residual = frob(sep - (plus_sum - minus_sum))
+
+    return {
+        "closed": closed,
+        "algebra_dim": basis.shape[0],
+        "center_dim": center_dim,
+        "null_max": null_max,
+        "kept_min": kept_min,
+        "clusters": len(groups),
+        "max_intra": max_intra,
+        "min_inter": min_inter,
+        "block_dims": sorted(block_dims),
+        "ranks": sorted(ranks),
+        "profile": profile,
+        "partition_residual": partition_residual,
+        "idempotent_residual": idempotent_residual,
+        "hermitian_residual": hermitian_residual,
+        "orthogonality_residual": orthogonality_residual,
+        "central_residual": central_residual,
+        "shell_two_atoms": len(shell_two),
+        "plus_atoms": len(plus_atoms),
+        "minus_atoms": len(minus_atoms),
+        "assigned_atoms": assigned,
+        "separator_residual": separator_residual,
+    }
+
+
+dim76_rows = [r for r in full_rows if r["dim"] == 76]
+profiles = {r["idx"]: [central_profile(r, 20260903), central_profile(r, 42)] for r in dim76_rows}
+all_profiles = [profile for pair in profiles.values() for profile in pair]
+expected_ranks = [2] * 6 + [4] * 13
+expected_profile = {
+    (4, 2, (0,)): 2,
+    (4, 4, (0,)): 1,
+    (4, 4, (1,)): 6,
+    (4, 4, (2,)): 6,
+    (4, 2, (3,)): 4,
+}
+max_certificate_residual = max(
+    max(
+        p["partition_residual"],
+        p["idempotent_residual"],
+        p["hermitian_residual"],
+        p["orthogonality_residual"],
+        p["central_residual"],
+    )
+    for p in all_profiles
+)
+central_certificates_ok = max_certificate_residual < MEMBER_TOL
+
+gate(
+    "DIM76-CLASS-COUNT",
+    len(dim76_rows) == 2 and [r["idx"] for r in dim76_rows] == [25, 27],
+    f"dimension-76 full-center class ids={[r['idx'] for r in dim76_rows]} (expected [25,27])",
+)
+gate(
+    "DIM76-TRUE-CLOSURE",
+    all(p["closed"] and p["algebra_dim"] == 76 for p in all_profiles),
+    f"all two-class/two-seed profiles closed with algebra dims={[p['algebra_dim'] for p in all_profiles]}",
+)
+gate(
+    "DIM76-CENTER-DIMENSIONS",
+    all(p["center_dim"] == 19 for p in all_profiles),
+    f"center dimensions by class/seed={[[p['center_dim'] for p in pair] for pair in profiles.values()]} (=19)",
+)
+gate(
+    "DIM76-CENTER-SVD-GAPS",
+    all(p["null_max"] < NULL_TOL and p["kept_min"] > GAP_TOL for p in all_profiles),
+    f"max null={max(p['null_max'] for p in all_profiles):.3e}; "
+    f"min kept={min(p['kept_min'] for p in all_profiles):.6f}",
+)
+gate(
+    "DIM76-TWO-SEED-CENTER-CLUSTERS",
+    all(p["clusters"] == 19 and p["max_intra"] < NULL_TOL and p["min_inter"] > GAP_TOL for p in all_profiles),
+    f"clusters={[p['clusters'] for p in all_profiles]}; max intra={max(p['max_intra'] for p in all_profiles):.3e}; "
+    f"min inter={min(p['min_inter'] for p in all_profiles):.6f}",
+)
+gate(
+    "DIM76-WEDDERBURN-TYPE",
+    all(p["block_dims"] == [4] * 19 for p in all_profiles),
+    "every minimal central corner has complex dimension 4, resolving M2(C)^19 for both classes and seeds",
+)
+gate(
+    "DIM76-REPRESENTATION-RANKS",
+    all(p["ranks"] == expected_ranks for p in all_profiles),
+    "central-idempotent ranks are six 2s and thirteen 4s for all profiles="
+    f"{all(p['ranks'] == expected_ranks for p in all_profiles)}",
+)
+gate(
+    "DIM76-SHELL-PROFILE",
+    all(p["profile"] == expected_profile for p in all_profiles),
+    "common (corner-dim,rank,shell)->count profile recovered="
+    f"{all(p['profile'] == expected_profile for p in all_profiles)}",
+)
+gate(
+    "DIM76-CENTRAL-IDEMPOTENTS",
+    central_certificates_ok,
+    f"max partition/idempotent/Hermitian/orthogonality/central residual="
+    f"{max_certificate_residual:.3e}",
+)
+gate(
+    "DIM76-SEPARATOR-SIX-ATOM-SPLIT",
+    all(
+        p["shell_two_atoms"] == 6
+        and p["plus_atoms"] == 3
+        and p["minus_atoms"] == 3
+        and p["assigned_atoms"] == 6
+        for p in all_profiles
+    ),
+    "(shell-2,+,-,assigned)="
+    f"{[(p['shell_two_atoms'], p['plus_atoms'], p['minus_atoms'], p['assigned_atoms']) for p in all_profiles]}",
+)
+gate(
+    "DIM76-SEPARATOR-RECONSTRUCTION",
+    all(p["separator_residual"] < MEMBER_TOL for p in all_profiles),
+    f"max ||sep-(sum three plus atoms - sum three minus atoms)||_F="
+    f"{max(p['separator_residual'] for p in all_profiles):.3e}",
+)
+primary_profiles = [profiles[idx][0]["profile"] for idx in sorted(profiles)]
+gate(
+    "DIM76-COMMON-ABSTRACT-PROFILE",
+    len(primary_profiles) == 2 and primary_profiles[0] == primary_profiles[1],
+    "the two non-H-conjugate classes have the same M2(C)^19 representation profile",
+)
+
+# Discriminating controls: omitting the separator collapses the proposed full-center basis,
+# and the already-resolved 28-dimensional algebra must not masquerade as the dim-76 type.
+truncated_center_dim = orthonormal_basis(Pf).shape[0]
+gate(
+    "CONTROL-DROP-SEPARATOR",
+    truncated_center_dim == 4 and zfull_rows.shape[0] == 5,
+    f"omitting sep collapses the proposed center basis from {zfull_rows.shape[0]} to {truncated_center_dim}",
+)
+gate(
+    "CONTROL-A28-IS-DIFFERENT",
+    ns["dimZ28"] == 7 and sorted(ns["blockdims"]) == [4] * 7 and ns["dimZ28"] != 19,
+    f"same machinery resolves A28 as M2(C)^7 (center {ns['dimZ28']}), not M2(C)^19",
+)
+
+print(f"TOTAL: PASS={passed} FAIL={failed}")
+sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Summary

- reconstructs the memory-only L=4 KCPT center-intersection census from the landed finite construction
- identifies the three one-element full-center classes and preserves their invariant size/dimension/order data
- newly classifies both dimension-76 unlock algebras as `M_2(C)^19`
- resolves the separator in either larger algebra as three positive minus three negative rank-4 minimal central idempotents
- registers the landed U22 runner as a transitive helper source and acknowledges the two new citation edges

## Fresh result

The original scratch probe is unavailable. This PR does not reuse an old PASS transcript: it re-executes the landed 49-gate construction and recomputes the missing classification.

- center-intersection class histogram: `{4: 33, 5: 3}`
- full-center class metadata: `(size, dim C_g, order) = (4,28,4), (64,76,12), (64,76,12)`
- each dimension-76 center has dimension 19
- every minimal central corner has complex dimension 4
- both classes have six rank-2 and thirteen rank-4 represented central blocks
- the two classes share the same shell profile but remain distinct H-conjugacy classes

## Verification

- `python3 scripts/kcpt_l4_full_center_unlock_dim76_wedderburn_2026_09_03.py`
  - `TOTAL: PASS=23 FAIL=0`
  - internally requires the parent result `PASS=49 FAIL=0`
- fresh output matches the committed cache byte-for-byte
- `python3 docs/audit/scripts/repo_invariants_check.py --check --enforce-links`
  - PASS; zero link or class-F violations; graph delta acknowledged
- `git diff --cached --check`
  - clean before commit

## Boundary

This is positive finite operator-algebra science on the supplied periodic L=4 KCPT surface. It makes no physical charge, readout, dynamics, continuum, axiom, retained-grade, or TOE-score claim. Classification remains the responsibility of the independent audit lane.
