### PR TITLE
feat(readout): record statistics of the half-filled sea are determinantal

### DIFF
--- a/docs/RECORD_STATISTICS_OF_THE_HALF_FILLED_SEA_ARE_DETERMINANTAL_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/RECORD_STATISTICS_OF_THE_HALF_FILLED_SEA_ARE_DETERMINANTAL_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,324 @@
+---
+claim_id: record_statistics_half_filled_sea_determinantal
+claim_type: bounded_theorem
+claim_scope: "CONDITIONAL on three separately supplied things and on nothing else -- the designed fermion law of EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md, which that note declares a supplier model derived from no axiom; the supplied vacuum of MATTER_ABOVE_THE_HALF_FILLED_SEA_ODD_AND_EVEN_DENSITIES_AND_THE_VACUUM_QUESTION_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md, namely the half-filled staggered sea at its energy-minimising twist with the Kawamoto-Smit sign field; and Lueders conditioning as the update clause, STIPULATED here and not derived -- on the two named open clusters and the three named finite tori and nowhere else, writing P for the sea's one-particle projector: (T1) the finished set of records carries a determinantal law with kernel P. On the open 2x2x2 cube (8 modes, N = 4) and the open 2x2x3 block (12 modes, N = 6) the many-body ground state built in the Jordan-Wigner Fock sector, not from a Slater form, has |<S|psi>|^2 = |det phi_i(s_j)|^2 = det P_S on all 70 and all 924 patterns and every 1-, 2- and 3-point marginal equal to det P_S at 1e-15; exactly, over Q(sqrt3) where M^2 = 3I gives P = (I - M/sqrt3)/2 and over Q(sqrt2) where the spectrum {+-2, +-sqrt2} gives P by spectral idempotents, P = P^2 = P^T with tr P = N and P_vv = 1/2 at every site, sum over full patterns of det P_S = 1 with 8 of 70 and 120 of 924 exact zeros and no negative value, the marginal identity sum_{S contains T} det P_S = det P_T holds on all 1-, 2- and 3-subsets with 0 mismatches, the cube's value multiset is {1/144 x30, 1/48 x24, 0 x8, 1/36 x6, 1/16 x2}, and no pair minor vanishes on either cluster, the largest off-diagonal entry being 0.2887 and 0.3018 against the 1/2 a forbidden pair needs. (T2) The 12 forbidden corner pairs of RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md are determinantal zeros in closed form: for the plain-sector N = 2, E = -4 Slater state on that note's cube, det P_uv = P_uu P_vv - P_uv^2 takes the two exact values 0 (12 pairs) and 1/16 (16 pairs), which pushed through the parity dictionary's 128 cosets of fibre 32 gives exactly that note's support of 512 uniform at 1/512 and its 384 cancellation zeros, while the rank-4 projector onto the whole E = -4 manifold has 0 vanishing pair minors of 28, smallest 3/16. (T3) Conditioning is the Schur complement: for records at an occupied set O and an empty set E the conditional odds are the diagonal of the Schur complement of P on O and of I - P on E, verified against explicit Lueders conditioning of the exact state on 16 and 112 conditions of the cube (112 and 672 odds, ranges [1/3, 2/3] and [1/6, 5/6]) and 24 and 264 conditions of the block (ranges [0.3179, 0.6821] and [0.1357, 0.8643]) with 0 mismatches at 1e-15; on every case the joint law is P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B} and each conditional kernel is an exact projector of rank N - |O|. Edge records push forward through the parity dictionary: on the BKSF cube the encoded state is uniform within each of the 128 fibres with fibre total det P_S at 1e-17, one or two edge records leave every vertex odds at 1/2 at 1e-14, and a full vertex star induces the determinantal conditional on n_v = parity(star) at 1e-14. All 12 Z_e commute exactly, and 448 three-record sets in all 6 orders give 0 mismatches. (T4) The reach on the tori 4^3, 6^3 and 8^3 at optimal twist: one record shifts the odds at every other site by exactly 2 P_vu^2, down if occupied and up if empty, against the Schur complement on 126, 430 and 1022 cases at 1e-15; the largest |P_vu| at separation 1, 3, 5, 7 is 0.204124 then 0 on 4^3, 0.199736, 0.037805, 0.008097, 0.002368 on 6^3 and 0.199157, 0.023936, 0.007268, 0.003154 on 8^3, with sum over u != v of P_vu^2 exactly 1/4 on every torus by idempotency; P_vu is nonzero exactly when the separation has one odd component and no even component equal to L/2, 6 of 63, 81 of 215 and 108 of 511 with 0 mismatches; and on a 96^3 momentum grid validated against the exact 8^3 torus to 6e-16 the local slope tends to -3.02 with a fit of -3.04 over 10 <= |r| <= 30 and mean |P| |r|^3 = 0.21, so |P_vu| falls as |u - v|^-3. (T5) P restricted to the six neighbours is exactly I/2, one sublattice, so the Schur complement is additive and the odds are 1/2 - 2 sum_occ P_vu^2 + 2 sum_empty P_vu^2 over all 64 six-neighbour patterns at 9e-16; the range is [0, 1] on 4^3 with 2 of 64 forcing, where M^2 = 6I is an exact integer identity and the kernel row's support IS the star, and [0.021268, 0.978732] and [0.024036, 0.975964] with 0 forcing on 6^3 and 8^3; the exact criterion is that the support sum of P_vu^2 equals 1/4, so a record set forces a value if and only if it covers the whole support of the kernel's row -- 6, 81 and 108 sites, exactly 0 or 1 when covered and 8.3e-02, 1.1e-05 and 2.0e-05 one site short; and beyond the star on 8^3 with the six neighbours occupied a further record at separation 2 to 7 still shifts the odds by up to 4.5e-03, 1.1e-03, 3.6e-05, 1.1e-04, 2.6e-06 and 2.0e-05 and by exactly 0 at separation 8 and beyond, while with alternating neighbours a separation-2 record reaches 5.9e-02 although P_vu is exactly 0 there and the whole separation-2 shell empty gives 0.9704. WHICH STATE IS THE FRAMEWORK'S VACUUM IS NOT DECIDED HERE; the contrast with the empty vacuum is stated and the choice is left where its own note left it. Nothing is derived from any axiom, no formation dynamics is supplied, no axiom is amended, no status is set, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py
+---
+
+# Record statistics of the half-filled sea are determinantal
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem, explicitly conditional on one supplied law, one supplied vacuum and one stipulated update clause
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py`](../scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.txt`](../logs/runner-cache/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.txt)
+**Parents:** none in the dependency sense. The supplied law, the supplied vacuum and the stipulated update clause are quoted in "Setting" as conditions, not consumed as graded rows.
+
+A landed result in this lane asked what the record axiom's own quantities look like on the **empty** vacuum of a parity encoding, and found them entirely combinatorial: the odds at a site are one half or forced and never
+between, a record elsewhere changes nothing unless it closes a parity around one corner, and which sets of records settle a site is the cut structure of the graph. A second landed result put a different state under the same
+encoding -- the **half-filled staggered sea** -- and named which state the framework calls its vacuum as an open decision. This note asks the first question of the second state. The answer is a different law of records
+altogether: not uniform on a subspace of `F2^V` but **determinantal**, with the sea's own one-particle projector `P` as its kernel. Every record in the lattice enters the odds at every site, the six neighbours additively and
+the rest through a Schur complement, with a weight that falls as the sixth power of the distance and vanishes exactly on separations of the wrong parity.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems plus finite floating-point computations, every one conditional on one named supplied law, one named supplied vacuum and one stipulated update clause and on nothing else. Group A's exact half, group B and the commutation clause of group C are integer matrices, `Fraction` arithmetic and exact arithmetic in Q(sqrt3) and Q(sqrt2) at zero tolerance; groups C, D, E and the Fock half of A are finite floating-point computations on integer data, each reporting its residual against a tolerance declared before the run, and the decay exponent is a fitted local slope on a finite momentum grid and is labelled as such."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this conditional finite-cluster theorem, and route to its owner the science-level question it sharpens without deciding: the vacuum decision now carries a law-of-records consequence, because the empty state and the half-filled sea give two different and explicitly computed distributions at a site."
+conditional_surface_status: conditional-support
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`: `T1` (`A`) the finished set of records is determinantal with kernel `P`; `T2` (`B`) the empty vacuum's forbidden pairs are
+determinantal zeros in closed form; `T3` (`C`) conditioning is the Schur complement, with the joint formula, the edge-record push-forward and order independence; `T4` (`D`) the reach -- the one-record shift `2 P_vu^2`, the
+selection rule, and the inverse-cube decay; `T5` (`E`) six-neighbour additivity, the forcing criterion, and the influence beyond the star. Each carries its own tag: `[exact]` where the arithmetic is integer, rational or in a
+quadratic field, and `[numerical]` with a stated tolerance where it is floating point.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. Determinantal point processes, the fact that a free-fermion ground state's occupation law is one, the Schur-complement form of its conditionals, the Bravyi-Kitaev superfast
+encoding, the Kawamoto-Smit staggering and the Bloch reduction of a periodic hopping matrix are standard methodology; every object is redeclared here and the runner recomputes every statement from the hopping matrix up,
+building the many-body ground state in the Fock sector rather than assuming a Slater form so that the determinantal identity is a result and not a definition. The one supplied law, the one supplied vacuum and the stipulated
+update clause are declared and quoted in "Setting"; they are conditions of the result, not graded dependencies, and this note cites no grade of any of them and consumes no row. Non-load-bearing context pointers, plain file
+names carrying no grade and no dependency weight: `MINIMAL_AXIOMS_2026-06-29.md`, from which the four axioms and two reading notes in "Setting" are quoted verbatim;
+`RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7858), whose results are quoted below as the contrast this note is drawn against and whose cube, encoding and forbidden
+pairs Theorem 2 recomputes; and `HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md`, the source of the filling and of the `M^2 = 6I` identity Theorem 5 uses.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations
+about each site." **Qubit / Site Possibility**: "Each site has a domain of local possibilities," whose "full one-site possibility domain has algebraic presentation `M_2(C)`."
+
+**Admissibility / Local Constraint.** "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." "For each site, the probability distribution over the
+possibilities is determined by, and varies with, the nearest-neighbor conditions." Two of its reading notes (interpretive, non-governing) are exactly what this note instantiates and are quoted with it: "(2) Read with Record,
+the distribution concerns which possibility a forming record locks, conditional on formation at that site; it does not supply the formation site, probability, or rate." "(3) The distribution is a probability measure on the
+local possibility domain; "available"/"admissible" denotes its support -- on finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may have zero singleton measure;
+Record locks a supported realization."
+
+**Record / Fixed Reality.** "Records form." "When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are permanent." "Only records are readable. A readout value
+is determined by record content alone. A site with no record cannot be read."
+
+**The record ontology, as used.** Nothing below is read that is not a record. A record at a coarse site registers occupancy there; it does not report a value the site already carried. In the encoded picture the occupancy at a
+coarse vertex is a readout of the six records on that vertex's incident coarse edge sites, `n_v = (1 - B_v)/2` with `B_v` the product of their six `Z` values, so a vertex condition is a condition on six records and on nothing
+else. Every distribution below is law-level in the sense of reading note (2) -- it says which value a record forming at that site locks, given the records already present -- and the support is the support in the sense of
+reading note (3).
+
+**Supplied condition one -- the fermion law.** From
+`origin/physics-loop/emergent-3d-fermion-superlattice-existence:docs/EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md`, its Proof boundary verbatim and outranking
+every summary: "The law of Theorems 1 to 3 is a **designed supplier model**: Admissibility fixes that there is one covariant nearest-neighbour rule and leaves its form to the supplier, and this note supplies one form and
+computes its consequences, deriving that form from no axiom and claiming for it no privileged status." Everything below inherits that conditional.
+
+**Supplied condition two -- the vacuum.** From
+`origin/physics-loop/matter-above-the-half-filled-sea:docs/MATTER_ABOVE_THE_HALF_FILLED_SEA_ODD_AND_EVEN_DENSITIES_AND_THE_VACUUM_QUESTION_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7879), verbatim: "the
+half-filled staggered sea at its energy-minimising twist has `E_sea = -78.383672`, `-258.857540` and `-611.811768` on `4^3`, `6^3` and `8^3`", and "`<n_v> = 1/2` at EVERY site, exactly, because the bipartite grading
+`eps_v = (-1)^{v1+v2+v3}` satisfies `eps M eps = -M` as a zero-residual integer identity, so `P_vv + (eps P eps)_vv = 1` and `P_vv = 1/2`." And, verbatim, what that note leaves open: "WHICH STATE IS THE FRAMEWORK'S VACUUM IS
+NOT DECIDED HERE: it is named as a decision about the framework, for its owner, and the exact consequences of each choice are supplied." This note supplies one more consequence and decides nothing.
+
+**The contrast, quoted.** From `origin/physics-loop/record-formation-emergent-vacuum:docs/RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7858), on the **empty**
+vacuum of the same encoding, verbatim: its allowed set "is uniform on a LINEAR subspace of `F2^E` of dimension `E - V + 1` -- `32` of `4096` at `p = 1/32` on the cube"; "The odds that a forming record locks the value `1` at a
+site, given the records already present in its neighbourhood, are `1/2` or forced to `0` or `1` and never anything between"; "over all `66` cube site pairs x `4` values the odds elsewhere change in exactly the `96` cases where
+the two records close a vertex star and never in the other `168`"; "Forcing is the cocircuit structure of the graph"; "The finished set of records carries the same odds whatever order the records formed in"; and, for the
+coherent state, "the Slater ground state at `E = -4` has support `512 = 16` cosets uniform at `1/512` with `384` cancellation zeros = `12` cosets, exactly the corner pairs on one `x`-face". Those six statements are the
+baseline every theorem below is set against.
+
+**The update clause is stipulated, not derived.** When a record forms with a given value, this note conditions the state in the Lueders form: restrict to the eigenspace of that value at that site and renormalize. That is a
+choice declared here, of a shape the record axiom permits, and it is the same clause PR #7858 stipulated, so the two notes are compared on equal terms. Nothing below claims it is taken from an axiom, and nothing below supplies
+a formation site, probability or rate.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is precisely `P0`-`P5`. `P0`, declared here and conditional: the supplied law, the supplied vacuum,
+the KS sign field, the twists, the two open clusters, the three tori and the stipulated Lueders update clause. `P1` (`A`): the determinantal law and its kernel. `P2` (`B`): the empty vacuum's forbidden pairs as determinantal
+zeros. `P3` (`C`): conditioning as the Schur complement, the edge push-forward, order independence. `P4` (`D`): the reach. `P5` (`E`): additivity, forcing, and the influence beyond the star. `P4` and `P5` use `P1` for the
+kernel and `P3` for the conditional form; `P2` uses `P1`'s closed form only.
+
+## Definitions
+
+A **cluster** is either of two finite open blocks with Kawamoto-Smit signs and no wrap -- `cube`, the `2x2x2` block (`8` modes, `N = 4`, `70` patterns), and `block`, the `2x2x3` block (`12`, `6`, `924`) -- or one of the three
+tori `4^3`, `6^3`, `8^3` with those signs and the energy-minimising twist. The **KS sign** of the bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`; a **twist** on axis `a` flips the
+bonds crossing `v_a = L-1 -> 0`. `M` is the symmetric integer hopping matrix, `N = V/2`, and
+
+```text
+P     = the orthogonal projector onto the N lowest eigenvectors of M          the half-filled sea's kernel
+P_S   = the |S| x |S| principal submatrix of P on the mode set S
+n_v   = (1 - B_v)/2, B_v the product of the Z's on the six edge sites at v    the parity dictionary
+```
+
+A **record** at a mode registers occupancy there, so a full set of records is an occupation pattern `S`. The **odds at a site** are the probability that a record forming there locks the value `1`, given the records already
+present. A law on patterns is **determinantal with kernel `K`** when `P(all of T occupied) = det K_T` for every set `T`. The **Schur complement** of `K` on a set `R` is `K_{rest} - K_{rest,R} (K_R)^{-1} K_{R,rest}`; conditioning
+on `O` occupied uses it on `P`, and on `E` empty uses it on the hole kernel `I - P` and returns `I` minus the result. The **support of the kernel's row at `v`** is the set of `u != v` with `P_vu != 0`. A record set **forces**
+the value at `v` when the conditional odds there are `0` or `1`. The **BKSF encoding** is the one PR #7858 declares, with qubits on the edge sites, `A_ij = X(edge ij)` times the `Z`'s ordered before it at both endpoints,
+`B_v` the product of the `Z`'s incident to `v`, and the face loops as stabilizers; a **fibre** is one coset of its cycle space.
+
+## Theorem 1 -- the finished set of records carries a determinantal law with kernel P
+
+**Conclusion.** On the open `2x2x2` cube and the open `2x2x3` block:
+
+1. `[numerical, 1e-15]` The many-body ground state built in the Jordan-Wigner Fock sector -- assembled from `H = sum_ij M_ij c^dag_i c_j` and diagonalized there, **not** from a Slater form -- is non-degenerate and satisfies
+   `|<S|psi>|^2 = |det phi_i(s_j)|^2 = det P_S` on all `70` and all `924` patterns, and every `1`-, `2`- and `3`-point marginal `P(T occupied)` equals `det P_T`.
+2. `[exact]` Over `Q(sqrt3)`, where `M^2 = 3I` is an integer identity and hence `P = (I - M/sqrt3)/2`, and over `Q(sqrt2)`, where the spectrum `{+-2, +-sqrt2}` gives `P` by spectral idempotents: `P = P^2 = P^T`, `tr P = N`,
+   and `P_vv = 1/2` at **every** site.
+3. `[exact]` The sum of `det P_S` over full patterns is exactly `1`, no value is negative, and the marginal identity `sum_{S contains T} det P_S = det P_T` holds on every `1`-, `2`- and `3`-subset (`8 + 28 + 56` and
+   `12 + 66 + 220`) with `0` mismatches. So the law is a genuine probability law and it is the determinantal one.
+4. `[exact]` The cube's value multiset is `{1/144 x30, 1/48 x24, 0 x8, 1/36 x6, 1/16 x2}`; the exact zeros are `8` of `70` and `120` of `924`. No **pair** minor vanishes on either cluster: a forbidden pair needs
+   `|P_uv| = 1/2` and the largest off-diagonal entry is `0.2887` and `0.3018`.
+
+**Proof.** The hopping matrices are integer, so `M` is exact; the Fock sector is built combinatorially with Jordan-Wigner signs and diagonalized, and its ground vector's squared amplitudes are compared entrywise against the
+Slater determinant and against `det P_S`. The exact half rebuilds `P` in a quadratic field -- on the cube from the verified identity `M^2 = 3I`, on the block from the four spectral idempotents -- and every determinant, sum
+and marginal is a Gaussian elimination over `Q(sqrt d)` with `Fraction` coefficients, with no floating point anywhere in items 2 to 4.
+
+**Reading, not theorem.** On this vacuum the finished set of records has a law with a single object behind it: the sea's own projector. Which patterns of records the law allows, and with what weight, is read off from
+determinants of that one matrix, and the sites are no longer independent of each other in the way a parity subspace makes them.
+
+## Theorem 2 -- the empty vacuum's forbidden pairs are determinantal zeros, in closed form
+
+**Conclusion.** For the plain-adjacency `2x2x2` cube of PR #7858 in its `N = 2` sector, whose many-body ground energy is `-4` with degeneracy `3` over the `28` cosets:
+
+1. `[exact]` Each of the three `E = -4` Slater states has a rank-`2` kernel whose pair minors take exactly two values, `det P_uv = 0` on `12` pairs and `1/16` on `16`, in the closed form `det P_uv = P_uu P_vv - P_uv^2`. For
+   the `(chi_111, chi_011)` state the `12` vanishing pairs are exactly the corner pairs sharing an `x`-face -- PR #7858's own list.
+2. `[exact]` Pushed through the parity dictionary, whose `128` cosets are a bijection onto the even-parity vertex patterns and each of which is a fibre of `32` edge-record patterns, the `16` nonvanishing vertex patterns give
+   support `512` uniform at `1/512` and the `12` vanishing ones give `384` cancellation zeros: PR #7858's census, recovered from `P` alone.
+3. `[exact]` The rank-`4` projector onto the whole `E = -4` manifold has `0` vanishing pair minors of `28`, the smallest being `3/16`.
+
+**Proof.** The kernels are `Phi Phi^T` for hypercube characters `chi_S/sqrt8`, so every entry is a rational with denominator `8` and every minor is computed with `Fraction`; the closed form is checked against the direct
+`2 x 2` determinant on all `28` pairs of all three states; the fibre size and the bijection are read from the encoding's stabilizer group by exhaustion. All exact.
+
+**Reading, not theorem.** PR #7858 found that a record pattern can fail to form for two different reasons, one belonging to the model and one to the state, and that its second kind of zero belonged to the state. Here the
+second kind has a formula: a pair is forbidden exactly when the `2 x 2` determinant of the state's kernel on that pair vanishes. The two vacua share the mechanism and differ in whether it fires.
+
+## Theorem 3 -- conditioning is the Schur complement
+
+**Conclusion.** Under the stipulated Lueders clause:
+
+1. `[numerical, 1e-15]` For records at an occupied set `O` and an empty set `E`, the conditional odds at every remaining site equal the diagonal of the Schur complement -- of `P` for the occupied records, of `I - P` for the
+   empty ones. Against explicit Lueders conditioning of the exact state: `16` and `112` conditions on the cube (`112` and `672` odds compared, ranges `[1/3, 2/3]` and `[1/6, 5/6]`), `24` and `264` on the block (ranges
+   `[0.3179, 0.6821]` and `[0.1357, 0.8643]`), `0` mismatches.
+2. `[numerical, 1e-15]` On every one of those cases the joint law is `P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B}`, the odds are the determinant ratio `P(A + v, B) / P(A, B)`, and each conditional kernel is itself an
+   exact projector of rank `N - |O|`: conditioning on a record returns a state of the same kind, one particle smaller.
+3. `[numerical, 1e-17 / 1e-14]` The same law at the edge sites. On the BKSF cube the encoded state is uniform **within** each of the `128` fibres with fibre total `det P_S`; one edge record (`24` cases) leaves mass exactly
+   `1/2` and two (`264` cases) mass exactly `1/4`, and in both the odds at every vertex stay at `1/2`; a full vertex **star** of edge records (`64` assignments, all reachable) induces exactly the determinantal conditional on
+   `n_v = parity(star)` and nothing beyond it.
+4. `[exact + numerical, 1e-14]` All `12` `Z_e` commute pairwise in the symplectic representation, and sequential Schur conditioning on all `448` three-record sets in all `6` orders gives `2240` comparisons with `0`
+   mismatches: the finished set of records carries the same odds whatever order the records formed in.
+
+**Proof.** The exact state is held explicitly, restricted to each record pattern and renormalized, and its site marginals are compared entrywise against the Schur-complement diagonal and against the determinant ratio; the
+joint identity is evaluated as a signed determinant on the union; idempotency and trace of each conditional kernel are checked directly. The edge-level statements build the encoded state on all `4096` patterns from the
+encoding's own coset structure with a fixed pseudorandom phase per coset, and condition on edge records by restriction. The commutation is exact in the symplectic representation; the order census walks each order explicitly.
+
+**Reading, not theorem.** A record joins what the site can see, and the way it enters is fixed: the kernel is reduced by a Schur complement. Two records taken in either order leave the same odds, and a set of edge records
+smaller than a full star around a corner leaves the odds at that corner exactly where they were.
+
+## Theorem 4 -- the reach: every record enters, with weight 2 P_vu^2 and an inverse-cube kernel
+
+**Conclusion.** On the tori `4^3`, `6^3`, `8^3` at their optimal twists `(1,1,1)`, `(0,0,0)`, `(1,1,1)`, with `E_sea = -78.383672`, `-258.857540`, `-611.811768` and `P_vv = 1/2` everywhere:
+
+1. `[numerical, 1e-15]` A single record shifts the odds at every other site by exactly `2 P_vu^2`: `odds(v occ | u occ) = 1/2 - 2 P_vu^2` and `odds(v occ | u empty) = 1/2 + 2 P_vu^2`, against the Schur complement on `126`,
+   `430` and `1022` cases.
+2. `[numerical, 1e-13]` The largest `|P_vu|` at separation `1, 3, 5, 7` is `0.204124` then `0` on `4^3`, `0.199736, 0.037805, 0.008097, 0.002368` on `6^3`, and `0.199157, 0.023936, 0.007268, 0.003154` on `8^3`; and
+   `sum_{u != v} P_vu^2 = 1/4` exactly on every torus, which is idempotency at `v` written out.
+3. `[numerical, 1e-12]` **Selection rule.** `P_vu` is nonzero exactly when the separation has one odd component and no even component equal to `L/2`: `6` of `63`, `81` of `215`, `108` of `511`, with `0` mismatches.
+4. `[numerical, fitted local slope]` From an `8 x 8` Bloch block per momentum on a `96^3` grid -- no `V x V` object is formed -- validated against the exact `8^3` torus to `6e-16` on the spectrum and on every kernel entry:
+   the local slope `d log|P| / d log n` tends to `-3.02`, and a fit over `10 <= |r| <= 30` gives `|P| ~ |r|^-3.04` with `mean |P| |r|^3 = 0.21`. The kernel falls as the inverse cube of the separation, so the odds shift falls
+   as its inverse **sixth** power.
+
+**Proof.** Each torus is built with the KS signs, its optimal twist found by minimising the half-filling energy over all eight twists, and `P` taken as the projector onto the lower half of the spectrum. Item 1 compares the
+closed form against a Schur complement site by site; item 2 sums a row of `P` squared; item 3 is an exhaustive census against the stated predicate at a threshold declared before the run; item 4 diagonalizes the `8`-site-cell
+Bloch matrix on a momentum grid, inverse-Fourier-transforms it, and validates the whole construction against the exact torus before any exponent is read.
+
+**Reading, not theorem.** A record anywhere in the lattice enters the odds at every other site. The weight it carries is the square of one kernel entry, and that entry falls as the inverse cube of the distance and is exactly
+zero on separations of the wrong parity. The neighbourhood is not a shell of six; it is whatever the kernel's row reaches, which is everything the selection rule allows.
+
+## Theorem 5 -- the six neighbours add up, and forcing means covering the kernel row's support
+
+**Conclusion.**
+
+1. `[numerical, 9e-16]` The six neighbours of a site all lie on the other sublattice, so `P` restricted to them is exactly `I/2` and the Schur complement is **additive**: over all `64` six-neighbour record patterns on all
+   three tori the odds are `1/2 - 2 sum_occ P_vu^2 + 2 sum_empty P_vu^2`.
+2. `[numerical, 1e-12]` The range over those `64` is `[0, 1]` on `4^3` with `2` patterns forcing, `[0.021268, 0.978732]` on `6^3` and `[0.024036, 0.975964]` on `8^3` with none. The smallest torus forces because there
+   `M^2 = 6I` is an exact integer identity, so the kernel row's support **is** the star.
+3. `[numerical, 1e-12]` **The forcing criterion.** The support sum of `P_vu^2` is exactly `1/4`, so the odds reach `0` or `1` if and only if the record set covers the whole support of the kernel's row: `6`, `81` and `108`
+   sites, giving exactly `0` or `1` when covered, and `8.3e-02`, `1.1e-05` and `2.0e-05` one site short.
+4. `[numerical, 1e-15]` **Beyond the star.** On `8^3` with the six neighbours occupied (odds `0.024036`), one further record at separation `2` to `7` still shifts the odds by up to `4.5e-03`, `1.1e-03`, `3.6e-05`, `1.1e-04`,
+   `2.6e-06`, `2.0e-05`, and by exactly `0` at separation `8` and beyond. With alternating neighbours a separation-`2` record reaches `5.9e-02` **although `P_vu` is exactly `0` there**: that influence arrives through the
+   Schur complement alone. The whole separation-`2` shell empty gives `0.9704`.
+
+**Proof.** Item 1 checks `P` on the six-neighbour block against `I/2` and compares the additive closed form against the Schur complement on every one of `64 x 3` patterns. Item 2 reads the range and the forcing count off
+those same patterns and recomputes `M^2 - 6I` as an integer residual. Item 3 collects the row's support at a threshold declared before the run, sums its squared entries, and conditions on the whole support and on the support
+minus its single weakest site. Item 4 conditions on the star plus one further record at every remaining site of the torus, exhaustively rather than by sampling, and reports the largest shift per distance shell.
+
+**Reading, not theorem.** Six neighbours together can push the odds close to certain but never to certain, unless the box is so small that they are the whole of what the site can see. And a record that the kernel cannot reach
+at all can still change the odds, because what conditioning reduces is not one entry but the whole kernel.
+
+## Corollary -- what Admissibility's distribution looks like on this vacuum
+
+Within the setting declared above, on the two clusters and the three tori named:
+
+1. Admissibility's law-level distribution at a site is here an explicit function of **all** the records present, through the one kernel `P`. The six neighbours enter additively with weight `2 P_vu^2`; every other record
+   enters through the Schur complement, with a weight falling as the sixth power of the distance and vanishing exactly on separations of the wrong parity. Reading note (2)'s "which possibility a forming record locks" is
+   instantiated exactly, and reading note (3)'s support is the set of patterns of nonzero `det P_S`.
+2. **The neighbourhood's reach is not capped, and it is not extra structure.** It arrives through the lattice's own kernel: the same matrix that fixes the sea fixes how far a record is felt. No finite set of records forces a
+   value unless it covers the whole support of the kernel's row, which on the tori examined happens only on the smallest.
+3. **The contrast with the empty vacuum is a contrast of laws.** On PR #7858's state the odds are `1/2` or forced, a record changes nothing unless a parity closes around one corner, forcing is a cocircuit, and the zeros are
+   cosets: a uniform law on an `F2` subspace. On the half-filled sea the odds take a continuum of values, every record is felt, forcing is a covering condition on a kernel row, and the zeros are vanishing determinants: a
+   determinantal law with kernel `P`. The two are not variants of one description. **The vacuum decides which law of records holds**, and that decision is not made here.
+4. Both vacua agree on one thing this note re-establishes independently: the finished set of records carries the same odds whatever order the records formed in.
+
+## Reading, not theorem -- the whole thing in plain words
+
+On the half-filled sea a record anywhere in the lattice nudges the odds at every other site, by an amount that falls off as the sixth power of the distance and vanishes exactly for separations of the wrong parity. Six
+neighbours together can push the odds close to certain but never to certain, unless the box is so small that they are the whole of what the site can see. On the empty vacuum the same encoding gives one half or a certainty and
+nothing in between. Which of the two the framework means is a question about the framework, and the answer changes what a record at a site can be.
+
+## Interfaces named for other lanes, not settled here
+
+- **The vacuum decision.** This note supplies one more exact consequence of the choice PR #7879 named -- the law of records itself -- and does not make the choice. A lane deciding it inherits the two explicit distributions
+  above, not a preference between them.
+- **Interactions.** The determinantal structure is a **free-hopping** fact. Nothing here says what survives when the law is not quadratic in the modes, and no interaction term appears anywhere above.
+- **The formation clause.** The site at which a record forms, the probability that it forms there, and the rate are all outside this note, exactly as they were outside PR #7858. Theorems 3 and 4 are the behaviour a
+  formation clause would have to reproduce on this vacuum; they do not supply one.
+- **The infinite-volume statement.** Everything here is finite: three tori and two open clusters. The inverse-cube decay is read from a finite momentum grid as a fitted local slope, validated against one exact torus. An
+  infinite-volume theorem about that exponent is not attempted.
+
+## Remaining live routes
+
+1. Whether the forcing criterion survives away from half filling and away from the KS sign field. Both the additivity of the six neighbours and the `1/4` support sum lean on `P_vv = 1/2` and on the bipartite structure, and
+   neither is checked at any other filling here.
+2. Whether the two zero mechanisms stay distinct on this vacuum as they did on the empty one. Theorem 1 exhibits determinantal zeros and Theorem 2 identifies the empty vacuum's cancellation zeros with them; no state is
+   offered whose zeros are of neither kind, and none is forbidden.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the five theorem conclusions.
+
+```text
+conditions: designed fermion law (supplier model, derived from no axiom); supplied vacuum = the half-filled staggered sea, KS signs, optimal twist; Lueders conditioning STIPULATED as the update clause, not derived
+clusters: open 2x2x2 cube (8 modes, N=4, 70 patterns), open 2x2x3 block (12, 6, 924); tori 4^3, 6^3, 8^3 at twists (1,1,1), (0,0,0), (1,1,1), E_sea = -78.383672, -258.857540, -611.811768
+kernel: P = projector onto the N lowest eigenvectors of the KS hopping matrix M; P = P^2 = P^T, tr P = N, P_vv = 1/2 at every site
+determinantal: |<S|psi>|^2 from the JW Fock ground state (NOT a Slater form) = |det phi_i(s_j)|^2 = det P_S on all 70 and 924 patterns at 1e-15; every 1-, 2-, 3-point marginal = det P_T
+exact_arithmetic: over Q(sqrt3) from M^2 = 3I giving P = (I - M/sqrt3)/2, and over Q(sqrt2) from the spectrum {+-2, +-sqrt2}: sum of det P_S over full patterns = 1 exactly, 0 negative values, exact zeros 8 of 70 and 120 of 924, marginal identity sum_{S contains T} det P_S = det P_T with 0 mismatches on 8+28+56 and 12+66+220 subsets
+cube_multiset: {1/144 x30, 1/48 x24, 0 x8, 1/36 x6, 1/16 x2}; forbidden pairs 0 on both clusters, max |P_uv| = 0.2887 and 0.3018 against the 1/2 a forbidden pair needs
+pr7858_pairs: plain-cube N=2 E=-4 (degeneracy 3 of 28): det P_uv = P_uu P_vv - P_uv^2 in {0 x12, 1/16 x16}; the 12 zeros are the corner pairs on one x-face; through 128 cosets of fibre 32 this is support 512 uniform at 1/512 with 384 cancellation zeros; rank-4 manifold projector 0 vanishing pair minors of 28, smallest 3/16
+conditioning: Lueders on the exact state == Schur complement of P (occupied) and of I - P (empty); cube 16 and 112 conditions, 112 and 672 odds, ranges [1/3,2/3] and [1/6,5/6]; block 24 and 264 conditions, ranges [0.3179,0.6821] and [0.1357,0.8643]; 0 mismatches at 1e-15
+joint_law: P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B} on every case; odds = det ratio P(A+v,B)/P(A,B); each conditional kernel an exact projector of rank N - |O|
+edge_records: BKSF cube, 12 edge sites, 128 cosets, fibre 32; encoded state uniform within a fibre with fibre total det P_S at 1e-17; 1 or 2 edge records leave every vertex odds at 1/2 at 1e-14; a full vertex star induces the DPP conditional on n_v = parity(star) at 1e-14
+order_independence: all 12 Z_e commute exactly; 448 three-record sets x 6 orders, 2240 comparisons, 0 mismatches
+one_record_shift: odds(v occ | u occ) = 1/2 - 2 P_vu^2, (| u empty) = 1/2 + 2 P_vu^2, vs Schur on 126, 430, 1022 cases at 1e-15
+kernel_profile: largest |P_vu| at separation 1,3,5,7 = 0.204124 then 0 (4^3); 0.199736, 0.037805, 0.008097, 0.002368 (6^3); 0.199157, 0.023936, 0.007268, 0.003154 (8^3); sum_{u != v} P_vu^2 = 1/4 exactly on every torus
+selection_rule: P_vu != 0 iff the separation has exactly one odd component and no even component equal to L/2; 6 of 63, 81 of 215, 108 of 511; 0 mismatches
+decay: 8x8 Bloch block per momentum on a 96^3 grid, validated against the exact 8^3 to 6e-16; local slope -> -3.02, fit -3.04 on 10 <= |r| <= 30, mean |P| |r|^3 = 0.21, i.e. |P_vu| ~ |u - v|^-3 and the odds shift ~ |u - v|^-6
+six_neighbours: P on the six = I/2 exactly, so odds = 1/2 - 2 sum_occ P_vu^2 + 2 sum_empty P_vu^2 at 9e-16; range [0,1] on 4^3 with 2 of 64 forcing (M^2 = 6I exact), [0.021268, 0.978732] and [0.024036, 0.975964] with 0 forcing
+forcing_criterion: the row support sum of P_vu^2 = 1/4 exactly, so a record set forces iff it covers the WHOLE support of the kernel's row -- 6, 81, 108 sites; covered gives exactly 0 or 1, one site short gives 8.3e-02, 1.1e-05, 2.0e-05
+beyond_the_star: 8^3, six neighbours occupied (odds 0.024036): one further record at d = 2..7 shifts by at most 4.5e-03, 1.1e-03, 3.6e-05, 1.1e-04, 2.6e-06, 2.0e-05 and by exactly 0 at d >= 8; with alternating neighbours a d = 2 record reaches 5.9e-02 although P_vu = 0 there; the whole d = 2 shell empty gives 0.9704
+vacuum_decision: NOT made here; the contrast with the empty vacuum is stated and the choice is left where PR #7879 left it
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=28 FAIL=0
+```
+
+## Proof boundary
+
+The fermion law is a **designed supplier model**, in that note's own words "deriving that form from no axiom and claiming for it no privileged status"; the vacuum is **supplied**, taken from a note that explicitly declines to
+decide whether it is the framework's; and **Lueders conditioning is stipulated** here as this note's update clause. Every statement above inherits all three: if any one is not the framework's, nothing above survives except as
+a statement about what was supplied. Nothing here is derived from any axiom.
+
+Every result is at **finite volume** and on **free hopping**. The clusters are the open `2x2x2` and `2x2x3` blocks and the tori `4^3`, `6^3`, `8^3`, and nothing is claimed for larger boxes, other boundary conditions, other
+sign fields, other fillings, or any law that is not quadratic in the modes. The `E = -4` statements of Theorem 2 are on PR #7858's own plain-adjacency cube in its `N = 2` sector and are not statements about the sea.
+
+The **decay exponent is a fitted local slope on a finite momentum grid**, not a proof. It is read from an `8 x 8` Bloch block per momentum on a `96^3` grid, after that construction is validated against the exact `8^3` torus
+to `6e-16`; the local slope and the two fits are reported as outcomes, with the residual spread of a Euclidean fit over anisotropic separations reported rather than hidden. The selection rule and the forcing criterion are
+exhaustive censuses at thresholds declared before the run, not samples.
+
+The arithmetic split is stated on every line. Theorem 1 items 2-4, all of Theorem 2, and the commutation clause of Theorem 3 are **exact** -- integer matrices, `Fraction` arithmetic, and Gaussian elimination over `Q(sqrt3)`
+and `Q(sqrt2)` with no floating point. Theorem 1 item 1 and the rest of Theorems 3, 4 and 5 are double precision on integer-derived data at `1e-12` to `1e-17`, each residual printed.
+
+**Nothing about formation dynamics follows.** No formation site, probability or rate is supplied, and none is implied; every "odds" statement is a statement about the stipulated clause applied to the supplied state. No mass,
+no coupling, no absolute unit and no dynamical clause appears anywhere. No axiom text is amended, extended, reworded or reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is
+created or edited.
+
+## Review record
+
+An honest auditor should come away with: a conditional computation on a supplied vacuum under a stipulated update clause, not a derivation of the framework's readout; five statements on two named open clusters and three named
+finite tori, with the determinantal identity established from a Fock-sector ground state rather than assumed from a Slater form, so that it is a result; an exact arithmetic core in two quadratic fields carrying the structural
+claims, and every floating-point clause labelled with the residual it reports; a closed form that recovers a landed sibling note's forbidden pairs and its exact zero census from the kernel alone; one exhaustive forcing
+criterion, with its one exception -- the smallest torus -- exhibited rather than smoothed away; and a contrast between two vacua stated as a contrast, with the choice between them left to the lane that owns it. Nothing here is
+a fitted number except the decay exponent, which is labelled as a fitted local slope in the front matter, the theorem, the claim block and the proof boundary alike. The note is self-contained in the sense that matters for
+replay: `upstream_dependencies` is empty, every object is declared in "Definitions", the runner imports nothing from the repository, and the conditioning law, the conditioning vacuum and the contrast note are quoted verbatim
+with paths rather than consumed as graded rows. Hard landing conditions are a fresh runner and cache pair closing at `PASS=28 FAIL=0` with runtime under the declared `120` seconds and stdout under `5500` characters, and
+passing repository pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.txt
+++ b/logs/runner-cache/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py
+runner_sha256: 66e9816d6b1b62685b78aa0a0531781b9fba6adf6e8f88c64888f9fc42e51f54
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 7.94
+status: ok
+----- stdout -----
+PASS A1 [exact] open 2x2x2 cube, KS signs: M^2 = 3I exactly, so P = (I - M/sqrt3)/2 over Q(sqrt3), with P = P^2 = P^T, tr P = 4 = N and P_vv = 1/2 at EVERY site
+PASS A2 [exact] cube: sum of det P_S over all 70 patterns = 1, negatives 0, exact zeros 8; value multiset {1/144 x30, 1/48 x24, 0 x8, 1/36 x6, 1/16 x2}: True
+PASS A3 [exact] open 2x2x3 block, spectrum {+-2, +-sqrt2}: P by spectral idempotents over Q(sqrt2), P = P^2 = P^T, tr P = 6 = N, P_vv = 1/2; sum over 924 = 1, negatives 0, zeros 120
+PASS A4 [exact] the marginal identity sum_{S contains T} det P_S = det P_T on every 1-, 2-, 3-subset (8+28+56, 12+66+220): 0 + 0 mismatches, no minor vanishing for k <= 3
+PASS A5 [exact] FORBIDDEN PAIRS: det P_uv = 0 for 0 pairs on the cube and 0 on the block -- one needs |P_uv| = 1/2 and the largest off-diagonal is 0.2887, 0.3018
+PASS A6 [numerical, 1e-15] the JW Fock ground state (dims 70, 924; degeneracy 1, 1) has |<S|psi>|^2 = |det phi_i(s_j)|^2 = det P_S on EVERY pattern (1.1e-16, 7.6e-17) and every marginal = det P_S (7.8e-16)
+PASS B1 [numerical, 1e-12] the PLAIN cube of PR #7858 (all-(+1) adjacency): N = 2 ground energy -4.000000 with degeneracy 3 over the 28 cosets
+PASS B2 [exact] each E = -4 Slater state has det P_uv = P_uu P_vv - P_uv^2 in {0 (12 pairs), 1/16 (16)}; the (chi_111, chi_011) zeros are the corner pairs sharing an x-face: True
+PASS B3 [exact] through the parity dictionary (128 cosets, fibre 32, a bijection onto the even patterns: True): the 16 nonzero patterns give support 512 at 1/512, the 12 zeros 384 cancellation zeros
+PASS B4 [exact] the rank-4 E = -4 manifold projector has 0 vanishing pair minors of 28 (smallest 3/16): the forbidden pairs are the state's kernel, not the manifold's
+PASS C1 [numerical, 1e-15] cube: over 16 one- and 112 two-record conditions Lueders conditioning = the Schur complement of P on 112 + 672 odds, 0 mismatches (1.3e-15); [1/3, 2/3], [1/6, 5/6]
+PASS C2 [numerical, 1e-15] block: the same over 24 and 264 conditions, 0 mismatches (1.6e-15); odds ranges [0.3179, 0.6821] and [0.1357, 0.8643]
+PASS C3 [numerical, 1e-15] on every case P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B} (8.9e-16), the odds are P(A + v, B)/P(A, B) (1.6e-15), each kernel an exact projector of rank N - |O| (3.6e-15)
+PASS C4 [numerical, 1e-17] BKSF cube, 12 edge sites: 128 cosets, every fibre 2^5 = 32 patterns, the encoded state uniform WITHIN a fibre with fibre total det P_S (1.4e-17)
+PASS C5 [numerical, 1e-14] ONE edge record (24 cases) leaves mass 1/2 and TWO (264) mass 1/4, both with the vertex odds UNCHANGED at 1/2 (6.3e-15, 5.3e-15): below a star, no vertex condition
+PASS C6 [numerical, 1e-14] a full vertex STAR of edge records (64 assignments, all reachable) induces exactly the determinantal conditional on n_v = parity(star) (4.4e-15)
+PASS C7 [exact + numerical, 1e-14] ORDER INDEPENDENCE: all 12 Z_e commute pairwise (True), and Schur conditioning on 448 three-record sets in 6 orders gives 2240 comparisons, 0 mismatches (4.4e-16)
+PASS D1 [numerical, 1e-15] the vacuum on 4^3, 6^3, 8^3 at optimal twist (1, 1, 1), (0, 0, 0), (1, 1, 1): E_sea = -78.383672, -258.857540, -611.811768; P_vv = 1/2 and P = I/2 on each sublattice (7.8e-16)
+PASS D2 [numerical, 1e-15] ONE record shifts the odds at every other site by exactly 2 P_vu^2 (down if occupied, up if empty), against Schur on 126, 430, 1022 cases (7.8e-16)
+PASS D3 [numerical, 1e-13] largest |P_vu| at d = 1, 3, 5, 7: 0.204124 then 0 on 4^3; 0.199736 0.037805 0.008097 0.002368 on 6^3; 0.199157 0.023936 0.007268 0.003154 on 8^3; sum_{u != v} P_vu^2 = 1/4 exactly (5.0e-16)
+PASS D4 [numerical, 1e-12] SELECTION RULE: P_vu != 0 iff the separation has one odd component and no even one equal to L/2 -- 6 of 63, 81 of 215, 108 of 511, 0 mismatches
+PASS D5 [numerical, 1e-14] the Bloch-block machinery (8 x 8 per momentum) reproduces the exact 8^3 torus: spectra to 3.6e-15, every kernel entry to 6.1e-16
+PASS D6 [numerical, fitted slope, 96^3 grid] the kernel decays as an inverse CUBE: local slope -> -3.02 at n = 19; a fit on 5571 separations, 10 <= |r| <= 30, gives |P| ~ |r|^-3.04, mean |P| |r|^3 = 0.21
+PASS E1 [numerical, 9e-16] the six neighbours lie on the other sublattice, so P on them is exactly I/2 (5.6e-16) and the odds are ADDITIVE: 1/2 - 2 sum_occ P_vu^2 + 2 sum_empty P_vu^2 over 64 x 3 (8.9e-16)
+PASS E2 [numerical, 1e-12] range over the 64: [0.000000, 1.000000] on 4^3 with 2 forcing; [0.021268, 0.978732] on 6^3, 0; [0.024036, 0.975964] on 8^3, 0 -- forcing only where M^2 = 6I exactly (0.0e+00)
+PASS E3 [numerical, 1e-12] FORCING: the row support sum of P_vu^2 = 1/4 exactly (3.9e-16), so a set forces iff it covers the WHOLE support -- 6, 81, 108 sites, giving odds 2.2e-16; one short leaves 8.3e-02, 1.1e-05, 2.0e-05
+PASS E4 [numerical, 1e-15] BEYOND THE STAR, 8^3, six neighbours occupied (0.0240): one more record at d = 2..7 shifts at most 4.5e-03, 1.1e-03, 3.6e-05, 1.1e-04, 2.6e-06, 2.0e-05, and by 0.0e+00 at d >= 8
+PASS E5 [numerical, 1e-15] with the neighbours ALTERNATING (0.5000) a d = 2 record reaches 5.9e-02 though P_vu = 0 there (2.0e-17): influence through the Schur complement alone; the d = 2 shell empty gives 0.9704
+SUMMARY: the finished set of records is determinantal with kernel P, conditioning is the Schur complement, and no record set forces a value unless it covers the kernel row's support.
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py
+++ b/scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py
@@ -1,0 +1,1165 @@
+#!/usr/bin/env python3
+"""Record statistics of the half-filled sea are determinantal.
+
+Class-A finite-cluster runner, self-contained. The vacuum is the half-filled
+staggered sea of the designed free-hopping law: one coarse mode per site,
+Kawamoto-Smit link signs, half filling, optimal twist on the tori. A record at
+a coarse site registers occupancy there; the update clause throughout is
+Lueders conditioning on the value a forming record locks, STIPULATED here and
+not derived. Writing P for the sea's one-particle projector, the runner
+establishes:
+
+  A  DETERMINANTAL.  On the open 2x2x2 cube (8 modes, N = 4) and the open
+     2x2x3 block (12 modes, N = 6) the many-body ground state built in the
+     Jordan-Wigner Fock sector -- not from a Slater form -- carries
+     |<S|psi>|^2 = |det phi_i(s_j)|^2 = det P_S on every pattern, and every
+     k-point marginal is det P_S. Exactly, over Q(sqrt3) and Q(sqrt2):
+     P = P^2 = P^T, tr P = N, P_vv = 1/2 at every site, sum det P_S = 1, the
+     marginal identity holds with 0 mismatches, and the value multiset and the
+     zero census are read off.
+  B  THE FORBIDDEN PAIRS.  PR #7858's 12 forbidden corner pairs of the plain
+     N = 2, E = -4 cube state are determinantal zeros:
+     det P_uv = P_uu P_vv - P_uv^2 in {0, 1/16}, reproducing the 16 allowed
+     cosets at 1/512 and the 384 cancellation zeros; the rank-4 manifold
+     projector has none.
+  C  CONDITIONING IS THE SCHUR COMPLEMENT.  Explicit Lueders conditioning of
+     the exact state equals the Schur complement of P (P for an occupied
+     record, I - P for an empty one), with the joint formula
+     P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B}; each conditional
+     kernel is an exact projector of rank N - |O|. Edge records push forward
+     through the parity dictionary, and the finished set is order-blind.
+  D  THE REACH.  On the tori 4^3, 6^3, 8^3 one record shifts the odds at every
+     other site by exactly 2 P_vu^2, P_vu is nonzero only on the separations a
+     parity selection rule allows, and |P_vu| decays as |u - v|^-3.
+  E  ADDITIVITY AND FORCING.  The six neighbours enter additively; a record set
+     forces a value if and only if it covers the whole support of the kernel's
+     row, which happens on the smallest torus only; records beyond the star
+     still shift the odds.
+
+Groups A (exact half) and B are exact: integer matrices, `Fraction`
+arithmetic, and exact arithmetic in Q(sqrt3) and Q(sqrt2). Groups C, D, E and
+the Fock half of A are finite floating-point computations on integer data,
+each reporting its residual against a tolerance declared before the run. Every
+line is tagged [exact] or [numerical].
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from fractions import Fraction as Fr
+from functools import reduce
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 120
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ==================================================== lattices and the sea
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    """Kawamoto-Smit link sign of the coarse bond (v, v + e_a)."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def build_open(dims):
+    """Open block with KS staggered signs and no wrap."""
+    sites = list(itertools.product(*[range(d) for d in dims]))
+    idx = {v: i for i, v in enumerate(sites)}
+    M = np.zeros((len(sites), len(sites)))
+    for v in sites:
+        for a in range(3):
+            w = tuple(v[i] + EX[a][i] for i in range(3))
+            if w not in idx:
+                continue
+            s = eta_ks(v, a)
+            M[idx[w], idx[v]] += s
+            M[idx[v], idx[w]] += s
+    return M, sites, idx
+
+
+def build_torus(L, twist):
+    """L^3 torus, KS signs, twist[a] = 1 flips the bonds crossing v_a = L-1 -> 0."""
+    sites = list(itertools.product(range(L), repeat=3))
+    idx = {v: i for i, v in enumerate(sites)}
+    M = np.zeros((len(sites), len(sites)))
+    for v in sites:
+        for a in range(3):
+            w = tuple((v[i] + EX[a][i]) % L for i in range(3))
+            if w == v:
+                continue
+            s = eta_ks(v, a)
+            if twist[a] and v[a] == L - 1:
+                s = -s
+            M[idx[w], idx[v]] += s
+            M[idx[v], idx[w]] += s
+    return M, sites, idx
+
+
+def sea_projector(M, N=None):
+    w, U = np.linalg.eigh(M)
+    if N is None:
+        N = M.shape[0] // 2
+    Phi = U[:, :N]
+    return Phi @ Phi.T, Phi, w
+
+
+def fock_H(M, N):
+    """Many-body H = sum_ij M_ij c^dag_i c_j in the N-particle JW-ordered sector."""
+    V = M.shape[0]
+    basis = list(itertools.combinations(range(V), N))
+    pos = {s: i for i, s in enumerate(basis)}
+    H = np.zeros((len(basis), len(basis)))
+    for bi, S in enumerate(basis):
+        Sset = set(S)
+        for j in S:
+            for i in range(V):
+                if M[i, j] == 0 or (i != j and i in Sset):
+                    continue
+                jl = S.index(j)
+                sgn = (-1) ** jl
+                rest = S[:jl] + S[jl + 1:]
+                k = 0
+                while k < len(rest) and rest[k] < i:
+                    k += 1
+                H[pos[rest[:k] + (i,) + rest[k:]], bi] += M[i, j] * sgn * ((-1) ** k)
+    return H, basis, pos
+
+
+def det_minor(K, S):
+    if len(S) == 0:
+        return 1.0
+    ix = np.array(S)
+    return float(np.linalg.det(K[np.ix_(ix, ix)]))
+
+
+def joint_prob(P, A, B):
+    """P(all of A occupied, all of B empty) = (-1)^|B| det (P - 1_B)_{A u B}."""
+    U = sorted(set(A) | set(B))
+    if not U:
+        return 1.0
+    ix = np.array(U)
+    K = P[np.ix_(ix, ix)].copy()
+    Bs = set(B)
+    for a, u in enumerate(U):
+        if u in Bs:
+            K[a, a] -= 1.0
+    return ((-1) ** len(B)) * float(np.linalg.det(K))
+
+
+def schur_condition(P, O, E):
+    """Conditional kernel on the complement of O u E: Schur complement of P on the
+    occupied records, then of the hole kernel I - K on the empty ones."""
+    V = P.shape[0]
+    rest = [i for i in range(V) if i not in set(O) | set(E)]
+    if O:
+        Oi = np.array(sorted(O))
+        keep = np.array(sorted(set(range(V)) - set(O)))
+        A = P[np.ix_(Oi, Oi)]
+        K1 = P[np.ix_(keep, keep)] - P[np.ix_(keep, Oi)] @ np.linalg.solve(A, P[np.ix_(Oi, keep)])
+        kmap = {v: a for a, v in enumerate(keep)}
+    else:
+        K1 = P.copy()
+        kmap = {v: v for v in range(V)}
+    keep2 = np.array([kmap[v] for v in rest])
+    if E:
+        Ei = np.array([kmap[v] for v in sorted(E)])
+        Q = np.eye(K1.shape[0]) - K1
+        A = Q[np.ix_(Ei, Ei)]
+        Q2 = Q[np.ix_(keep2, keep2)] - Q[np.ix_(keep2, Ei)] @ np.linalg.solve(A, Q[np.ix_(Ei, keep2)])
+        K2 = np.eye(len(rest)) - Q2
+    else:
+        K2 = K1[np.ix_(keep2, keep2)]
+    return K2, rest
+
+
+# ==================================================== exact arithmetic in Q(sqrt d)
+
+class QF:
+    """a + b sqrt(d) with a, b rational."""
+
+    __slots__ = ("a", "b", "d")
+
+    def __init__(s, a, b, d):
+        s.a = Fr(a)
+        s.b = Fr(b)
+        s.d = d
+
+    def _c(x, y):
+        return y if isinstance(y, QF) else QF(y, 0, x.d)
+
+    def __add__(x, y):
+        y = x._c(y)
+        return QF(x.a + y.a, x.b + y.b, x.d)
+
+    def __sub__(x, y):
+        y = x._c(y)
+        return QF(x.a - y.a, x.b - y.b, x.d)
+
+    def __mul__(x, y):
+        y = x._c(y)
+        return QF(x.a * y.a + x.d * x.b * y.b, x.a * y.b + x.b * y.a, x.d)
+
+    def inv(x):
+        n = x.a * x.a - x.d * x.b * x.b
+        if n == 0:
+            raise ZeroDivisionError
+        return QF(x.a / n, -x.b / n, x.d)
+
+    def iszero(x):
+        return x.a == 0 and x.b == 0
+
+    def __eq__(x, y):
+        y = x._c(y)
+        return x.a == y.a and x.b == y.b
+
+    def __hash__(x):
+        return hash((x.a, x.b, x.d))
+
+    def __repr__(x):
+        if x.b == 0:
+            return str(x.a)
+        return "%s%s%s*sqrt%d" % (x.a, "+" if x.b > 0 else "-", abs(x.b), x.d)
+
+    def val(x):
+        return float(x.a) + float(x.b) * (x.d ** 0.5)
+
+
+def qzero(d):
+    return QF(0, 0, d)
+
+
+def qone(d):
+    return QF(1, 0, d)
+
+
+def qmatmul(A, B, d):
+    n, m, k = len(A), len(B[0]), len(B)
+    return [[sum((A[i][t] * B[t][j] for t in range(k)), qzero(d)) for j in range(m)]
+            for i in range(n)]
+
+
+def qdet(Mx, d):
+    """Exact Gaussian elimination over Q(sqrt d)."""
+    n = len(Mx)
+    if n == 0:
+        return qone(d)
+    A = [row[:] for row in Mx]
+    sign = 1
+    out = qone(d)
+    for c in range(n):
+        p = None
+        for r in range(c, n):
+            if not A[r][c].iszero():
+                p = r
+                break
+        if p is None:
+            return qzero(d)
+        if p != c:
+            A[c], A[p] = A[p], A[c]
+            sign = -sign
+        piv = A[c][c]
+        out = out * piv
+        inv = piv.inv()
+        for r in range(c + 1, n):
+            if A[r][c].iszero():
+                continue
+            f = A[r][c] * inv
+            for cc in range(c, n):
+                A[r][cc] = A[r][cc] - f * A[c][cc]
+    return out if sign == 1 else QF(-out.a, -out.b, d)
+
+
+def qeye(n, d):
+    return [[qone(d) if i == j else qzero(d) for j in range(n)] for i in range(n)]
+
+
+def qscal(A, c):
+    return [[x * c for x in row] for row in A]
+
+
+def qadd(A, B):
+    return [[A[i][j] + B[i][j] for j in range(len(A[0]))] for i in range(len(A))]
+
+
+# ==================================================== Pauli algebra and BKSF
+
+def pc(n):
+    return bin(n).count("1")
+
+
+class Pau:
+    """i^k prod_q X_q^{x_q} Z_q^{z_q}, X written before Z on every qubit."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(s, k, x, z):
+        s.k = k % 4
+        s.x = x
+        s.z = z
+
+    def __mul__(a, b):
+        return Pau(a.k + b.k + 2 * pc(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(s):
+        return Pau(s.k + 2, s.x, s.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+
+PID = Pau(0, 0, 0)
+PH = [1 + 0j, 1j, -1 + 0j, -1j]
+
+
+def pcomm(a, b):
+    return (pc(a.x & b.z) + pc(a.z & b.x)) % 2 == 0
+
+
+def pact(p, y):
+    return y ^ p.x, PH[p.k] * ((-1) ** (pc(p.z & y) % 2))
+
+
+class Enc:
+    """Bravyi-Kitaev superfast encoding on the cube graph; qubits on the edge sites."""
+
+    def __init__(self, V, EDGES, FACES):
+        self.V = V
+        self.EDGES = list(EDGES)
+        self.FACES = list(FACES)
+        self.NQ = len(EDGES)
+        self.DIM = 1 << self.NQ
+        self.EIDX = {}
+        for q, (i, j) in enumerate(self.EDGES):
+            self.EIDX[(i, j)] = q
+            self.EIDX[(j, i)] = q
+        self.NBR = {i: sorted(j for (a, b) in self.EDGES
+                              for j in ((b,) if a == i else ((a,) if b == i else ())))
+                    for i in range(V)}
+        self.STAR = {i: [self.EIDX[(i, k)] for k in self.NBR[i]] for i in range(V)}
+        self.STARMASK = {i: reduce(lambda a, b: a | (1 << b), self.STAR[i], 0) for i in range(V)}
+
+    def A(self, i, j):
+        x = 1 << self.EIDX[(i, j)]
+        z = 0
+        for k in self.NBR[i]:
+            if k != j and k < j:
+                z ^= 1 << self.EIDX[(i, k)]
+        for l in self.NBR[j]:
+            if l != i and l < i:
+                z ^= 1 << self.EIDX[(j, l)]
+        p = Pau(pc(x & z) % 2, x, z)
+        return p if i < j else p.neg()
+
+    def B(self, i):
+        return Pau(0, 0, self.STARMASK[i])
+
+    def loop(self, cyc):
+        out = PID
+        for a in range(len(cyc)):
+            out = out * self.A(cyc[a], cyc[(a + 1) % len(cyc)])
+        return out
+
+    def record(self, z):
+        return tuple(pc(z & self.STARMASK[i]) % 2 for i in range(self.V))
+
+
+def cube_cluster():
+    return 8, sorted((s, s ^ bit) for s in range(8) for bit in (4, 2, 1) if s ^ bit > s)
+
+
+def cube_faces():
+    out = []
+    for ax in range(3):
+        bits = [4, 2, 1]
+        fb = bits[ax]
+        ob = [b for b in bits if b != fb]
+        for val in (0, fb):
+            out.append((val, val | ob[1], val | ob[0] | ob[1], val | ob[0]))
+    return out
+
+
+def stabilizer_group(En):
+    """Independent face-loop generators (Gaussian elimination on X-parts) and their group."""
+    S = [En.loop(f) for f in En.FACES]
+    gens, basis = [], []
+    for s in S:
+        v = s.x
+        for b in basis:
+            v = min(v, v ^ b)
+        if v != 0:
+            basis.append(v)
+            basis.sort(reverse=True)
+            gens.append(s)
+    grp = []
+    for m in range(1 << len(gens)):
+        p = PID
+        for t in range(len(gens)):
+            if (m >> t) & 1:
+                p = p * gens[t]
+        grp.append(p)
+    return S, gens, grp
+
+
+def code_space(En, grp):
+    """Cosets of the cycle space; phi[z] is the unit coefficient of |z> in its coset."""
+    phi = np.zeros(En.DIM, dtype=complex)
+    cid = -np.ones(En.DIM, dtype=np.int64)
+    reps = []
+    for z0 in range(En.DIM):
+        if cid[z0] >= 0:
+            continue
+        c = len(reps)
+        reps.append(z0)
+        for g in grp:
+            b, a = pact(g, z0)
+            cid[b] = c
+            phi[b] = a
+    recs = [En.record(reps[c]) for c in range(len(reps))]
+    return cid, phi, reps, recs
+
+
+# ==================================================== Bloch machinery
+
+SUB = list(itertools.product((0, 1), repeat=3))
+SI = {s: i for i, s in enumerate(SUB)}
+
+
+def eta_s(s, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (s[0] & 1) else 1
+    return -1 if ((s[0] + s[1]) & 1) else 1
+
+
+def bloch_batch(K):
+    """K: (..., 3) cell momenta -> (..., 8, 8) Bloch matrix of the KS hopping."""
+    sh = K.shape[:-1]
+    H = np.zeros(sh + (8, 8), dtype=complex)
+    for s in SUB:
+        for a in range(3):
+            t = list(s)
+            t[a] ^= 1
+            t = tuple(t)
+            ph = np.exp(-1j * K[..., a]) if s[a] == 1 else np.ones(sh, dtype=complex)
+            H[..., SI[t], SI[s]] += eta_s(s, a) * ph
+            H[..., SI[s], SI[t]] += eta_s(s, a) * np.conj(ph)
+    return H
+
+
+def kernel_field(nc):
+    """Infinite-volume kernel P(R)_{s' s} from an nc^3 cell-momentum grid.
+    Only 8 x 8 objects are formed per momentum."""
+    kk = 2 * np.pi * (np.arange(nc) + 0.5) / nc
+    K = np.stack(np.meshgrid(kk, kk, kk, indexing="ij"), axis=-1)
+    w, U = np.linalg.eigh(bloch_batch(K))
+    Um = U[..., :4]
+    Pk = Um @ np.conj(np.swapaxes(Um, -1, -2))
+    Pr = np.fft.ifftn(Pk, axes=(0, 1, 2))
+    Rg = np.stack(np.meshgrid(*[np.arange(nc)] * 3, indexing="ij"), axis=-1)
+    return Pr * np.exp(1j * np.pi * Rg.sum(-1) / nc)[..., None, None], w
+
+
+# ==================================================== A: the law of records is determinantal
+
+def exact_P_cube(Mq, V, d):
+    """M^2 = 3I on the open cube, so P = (I - M/sqrt3)/2 exactly over Q(sqrt3)."""
+    M2 = qmatmul(Mq, Mq, d)
+    assert all(M2[i][j] == (QF(3, 0, d) if i == j else qzero(d))
+               for i in range(V) for j in range(V)), "M^2 != 3I"
+    B = qscal(Mq, QF(0, Fr(1, 3), d))            # M / sqrt3
+    return qscal(qadd(qeye(V, d), qscal(B, QF(-1, 0, d))), QF(Fr(1, 2), 0, d))
+
+
+def exact_P_block(Mq, V, d):
+    """Spectrum {+-2, +-sqrt2} on the open 2x2x3 block; P = E_{-2} + E_{-sqrt2}
+    by spectral idempotents over Q(sqrt2)."""
+    M2 = qmatmul(Mq, Mq, d)
+    I = qeye(V, d)
+    A = qadd(M2, qscal(I, QF(-2, 0, d)))
+    Em2 = qscal(qmatmul(A, qadd(Mq, qscal(I, QF(-2, 0, d))), d), QF(Fr(-1, 8), 0, d))
+    B = qadd(M2, qscal(I, QF(-4, 0, d)))
+    Es2 = qscal(qmatmul(B, qadd(Mq, qscal(I, QF(0, -1, d))), d), QF(0, Fr(1, 8), d))
+    return qadd(Em2, Es2)
+
+
+EXACT = {}
+
+
+def exact_case(dims, d, builder, N):
+    M, _, _ = build_open(dims)
+    V = M.shape[0]
+    Mi = M.astype(int)
+    assert np.max(np.abs(M - Mi)) == 0
+    Pq = builder([[QF(int(x), 0, d) for x in row] for row in Mi], V, d)
+    PP = qmatmul(Pq, Pq, d)
+    proj = all(PP[i][j] == Pq[i][j] and Pq[i][j] == Pq[j][i] for i in range(V) for j in range(V))
+    tr = sum((Pq[i][i] for i in range(V)), qzero(d))
+    half = all(Pq[i][i] == QF(Fr(1, 2), 0, d) for i in range(V))
+    pats = [(S, qdet([[Pq[i][j] for j in S] for i in S], d))
+            for S in itertools.combinations(range(V), N)]
+    tot = sum((x for _, x in pats), qzero(d))
+    zeros = sum(1 for _, x in pats if x.iszero())
+    neg = sum(1 for _, x in pats if x.val() < -1e-30)
+    marg = {}
+    bad = 0
+    for k in (1, 2, 3):
+        for T in itertools.combinations(range(V), k):
+            Ts = set(T)
+            lhs = sum((x for S, x in pats if Ts <= set(S)), qzero(d))
+            rhs = qdet([[Pq[i][j] for j in T] for i in T], d)
+            if not lhs == rhs:
+                bad += 1
+            marg[T] = rhs
+    pairzero = sum(1 for T, x in marg.items() if len(T) == 2 and x.iszero())
+    offmax = max(abs(Pq[i][j].val()) for i in range(V) for j in range(V) if i != j)
+    mult = {}
+    for _, x in pats:
+        mult[repr(x)] = mult.get(repr(x), 0) + 1
+    EXACT[dims] = dict(P=Pq, pats=pats, proj=proj, tr=tr, half=half, tot=tot, zeros=zeros,
+                       neg=neg, bad=bad, mult=mult, pairzero=pairzero, offmax=offmax,
+                       V=V, N=N, d=d)
+    return EXACT[dims]
+
+
+def fock_case(dims):
+    """The many-body ground state built in the JW Fock sector, not from a Slater form."""
+    M, sites, idx = build_open(dims)
+    V = M.shape[0]
+    N = V // 2
+    P, Phi, w = sea_projector(M, N)
+    H, basis, pos = fock_H(M, N)
+    ev, evec = np.linalg.eigh(H)
+    psi = evec[:, 0]
+    probs = psi ** 2
+    e_slater = e_dpp = 0.0
+    for bi, S in enumerate(basis):
+        e_slater = max(e_slater, abs(probs[bi] - np.linalg.det(Phi[np.array(S), :]) ** 2))
+        e_dpp = max(e_dpp, abs(probs[bi] - det_minor(P, S)))
+    e_marg = 0.0
+    for k in (1, 2, 3):
+        for S in itertools.combinations(range(V), k):
+            emp = sum(probs[bi] for bi, T in enumerate(basis) if set(S) <= set(T))
+            e_marg = max(e_marg, abs(emp - det_minor(P, S)))
+    return dict(M=M, P=P, basis=basis, probs=probs, V=V, N=N, ev=ev, w=w,
+                deg=int(np.sum(ev < ev[0] + 1e-9)), e_slater=e_slater, e_dpp=e_dpp,
+                e_marg=e_marg, half=float(np.max(np.abs(np.diag(P) - 0.5))),
+                idx=idx, sites=sites)
+
+
+FOCK = {}
+
+
+def group_A():
+    c = exact_case((2, 2, 2), 3, exact_P_cube, 4)
+    b = exact_case((2, 2, 3), 2, exact_P_block, 6)
+    FOCK[(2, 2, 2)] = fc = fock_case((2, 2, 2))
+    FOCK[(2, 2, 3)] = fb = fock_case((2, 2, 3))
+
+    check("A1 [exact] open 2x2x2 cube, KS signs: M^2 = 3I exactly, so P = (I - M/sqrt3)/2 over Q(sqrt3), "
+          "with P = P^2 = P^T, tr P = %s = N and P_vv = 1/2 at EVERY site" % c["tr"], c["proj"] and c["tr"] == QF(4, 0, 3) and c["half"])
+    check("A2 [exact] cube: sum of det P_S over all 70 patterns = %s, negatives %d, exact zeros %d; value "
+          "multiset {1/144 x30, 1/48 x24, 0 x8, 1/36 x6, 1/16 x2}: %s"
+          % (c["tot"], c["neg"], c["zeros"],
+             c["mult"] == {"1/144": 30, "1/48": 24, "0": 8, "1/36": 6, "1/16": 2}),
+          c["tot"] == qone(3) and c["neg"] == 0 and c["zeros"] == 8
+          and c["mult"] == {"1/144": 30, "1/48": 24, "0": 8, "1/36": 6, "1/16": 2})
+    check("A3 [exact] open 2x2x3 block, spectrum {+-2, +-sqrt2}: P by spectral idempotents over Q(sqrt2), "
+          "P = P^2 = P^T, tr P = %s = N, P_vv = 1/2; sum over 924 = %s, negatives %d, zeros %d"
+          % (b["tr"], b["tot"], b["neg"], b["zeros"]),
+          b["proj"] and b["tr"] == QF(6, 0, 2) and b["half"] and b["tot"] == qone(2)
+          and b["neg"] == 0 and b["zeros"] == 120)
+    check("A4 [exact] the marginal identity sum_{S contains T} det P_S = det P_T on every 1-, 2-, 3-subset "
+          "(8+28+56, 12+66+220): %d + %d mismatches, no minor vanishing for k <= 3"
+          % (c["bad"], b["bad"]),
+          c["bad"] == 0 and b["bad"] == 0)
+    check("A5 [exact] FORBIDDEN PAIRS: det P_uv = 0 for %d pairs on the cube and %d on the block -- one needs "
+          "|P_uv| = 1/2 and the largest off-diagonal is %.4f, %.4f"
+          % (c["pairzero"], b["pairzero"], c["offmax"], b["offmax"]),
+          c["pairzero"] == 0 and b["pairzero"] == 0
+          and abs(c["offmax"] - 0.2887) < 5e-5 and abs(b["offmax"] - 0.3018) < 5e-5)
+    check("A6 [numerical, 1e-15] the JW Fock ground state (dims 70, 924; degeneracy %d, %d) has "
+          "|<S|psi>|^2 = |det phi_i(s_j)|^2 = det P_S on EVERY pattern (%.1e, %.1e) and every marginal "
+          "= det P_S (%.1e)"
+          % (fc["deg"], fb["deg"], fc["e_slater"], fb["e_slater"],
+             max(fc["e_marg"], fb["e_marg"])),
+          fc["deg"] == 1 and fb["deg"] == 1 and max(fc["e_slater"], fb["e_slater"]) < 1e-15
+          and max(fc["e_dpp"], fb["e_dpp"]) < 1e-15 and max(fc["e_marg"], fb["e_marg"]) < 1e-15)
+
+
+# ==================================================== B: PR #7858's forbidden pairs
+
+def chi(S, x):
+    return (-1) ** pc(S & x)
+
+
+def rational_kernel(cols):
+    """P = Phi Phi^T for Phi's columns the hypercube characters chi_S / sqrt8: exact over Q."""
+    return [[sum(Fr(chi(S, u) * chi(S, v), 8) for S in cols) for v in range(8)]
+            for u in range(8)]
+
+
+def group_B():
+    Mp = np.zeros((8, 8))
+    for s in range(8):
+        for b in (1, 2, 4):
+            Mp[s, s ^ b] = 1.0
+    Hp, basp, _ = fock_H(Mp, 2)
+    evp = np.linalg.eigvalsh(Hp)
+    deg = int(np.sum(evp < evp[0] + 1e-9))
+    check("B1 [numerical, 1e-12] the PLAIN cube of PR #7858 (all-(+1) adjacency): N = 2 ground energy %.6f "
+          "with degeneracy %d over the 28 cosets" % (evp[0], deg),
+          abs(evp[0] + 4.0) < 1e-12 and deg == 3 and len(basp) == 28)
+
+    zero_sets = []
+    census_ok = True
+    closed_ok = True
+    for Sset in (3, 5, 6):
+        P = rational_kernel((7, Sset))
+        e = sum(chi(7, x) * Mp[x, y] * chi(7, y) + chi(Sset, x) * Mp[x, y] * chi(Sset, y)
+                for x in range(8) for y in range(8)) / 8.0
+        cnt = {}
+        zs = []
+        for u, v in itertools.combinations(range(8), 2):
+            dm = P[u][u] * P[v][v] - P[u][v] * P[v][u]
+            dm2 = P[u][u] * P[v][v] - P[u][v] ** 2
+            if dm != dm2:
+                closed_ok = False
+            cnt[dm] = cnt.get(dm, 0) + 1
+            if dm == 0:
+                zs.append((u, v))
+        zero_sets.append(zs)
+        if cnt != {Fr(0): 12, Fr(1, 16): 16} or abs(e + 4.0) > 1e-12:
+            census_ok = False
+    xface = all((u >> 2) == (v >> 2) for u, v in zero_sets[0])
+    check("B2 [exact] each E = -4 Slater state has det P_uv = P_uu P_vv - P_uv^2 in {0 (12 pairs), 1/16 "
+          "(16)}; the (chi_111, chi_011) zeros are the corner pairs sharing an x-face: %s"
+          % xface, census_ok and closed_ok and xface and all(len(z) == 12 for z in zero_sets))
+
+    P = rational_kernel((7, 3))
+    pats = {S: P[S[0]][S[0]] * P[S[1]][S[1]] - P[S[0]][S[1]] ** 2
+            for S in itertools.combinations(range(8), 2)}
+    nz = [S for S, x in pats.items() if x != 0]
+    V, EDGES = cube_cluster()
+    En = Enc(V, EDGES, cube_faces())
+    S_loops, gens, grp = stabilizer_group(En)
+    k = len(gens)
+    cid, phi, reps, recs = code_space(En, grp)
+    fib = 1 << k
+    even = {r for r in itertools.product((0, 1), repeat=8) if sum(r) % 2 == 0}
+    inj = len(set(recs)) == len(reps) and set(recs) == even
+    sup = len(nz) * fib
+    canc = (len(pats) - len(nz)) * fib
+    unif = {x / fib for x in pats.values() if x != 0}
+    check("B3 [exact] through the parity dictionary (%d cosets, fibre %d, a bijection onto the even "
+          "patterns: %s): the %d nonzero patterns give support %d at %s, the 12 zeros %d cancellation "
+          "zeros"
+          % (len(reps), fib, inj, len(nz), sup, sorted(str(x) for x in unif)[0], canc),
+          inj and len(reps) == 128 and fib == 32 and len(nz) == 16 and sup == 512
+          and canc == 384 and unif == {Fr(1, 512)})
+
+    Pm = rational_kernel((7, 3, 5, 6))
+    mins = [Pm[u][u] * Pm[v][v] - Pm[u][v] ** 2 for u, v in itertools.combinations(range(8), 2)]
+    check("B4 [exact] the rank-4 E = -4 manifold projector has %d vanishing pair minors of 28 (smallest %s): "
+          "the forbidden pairs are the state's kernel, not the manifold's"
+          % (sum(1 for x in mins if x == 0), min(mins)),
+          sum(1 for x in mins if x == 0) == 0 and min(mins) == Fr(3, 16))
+
+
+# ==================================================== C: conditioning is the Schur complement
+
+def conditioning_case(dims, nrecs):
+    """Explicit Lueders conditioning of the exact state against the Schur complement of P."""
+    F = FOCK[dims]
+    P, basis, probs, V, N = F["P"], F["basis"], F["probs"], F["V"], F["N"]
+    out = {}
+    for nrec in nrecs:
+        nbad = nbadd = ncase = 0
+        worst = worstd = worstj = 0.0
+        projdev = 0.0
+        lo, hi = 1.0, 0.0
+        nconds = 0
+        for R in itertools.combinations(range(V), nrec):
+            for vals in itertools.product((0, 1), repeat=nrec):
+                cond = dict(zip(R, vals))
+                O = [v for v, b in cond.items() if b == 1]
+                E = [v for v, b in cond.items() if b == 0]
+                nconds += 1
+                keep = [bi for bi, S in enumerate(basis)
+                        if all(((v in set(S)) == bool(b)) for v, b in cond.items())]
+                tot = float(sum(probs[bi] for bi in keep))
+                pj = joint_prob(P, O, E)
+                worstj = max(worstj, abs(tot - pj))
+                if tot < 1e-14:
+                    continue
+                odds = np.zeros(V)
+                for bi in keep:
+                    for v in basis[bi]:
+                        odds[v] += probs[bi]
+                odds /= tot
+                K2, rest = schur_condition(P, O, E)
+                projdev = max(projdev, float(np.max(np.abs(K2 @ K2 - K2))),
+                              abs(float(np.trace(K2)) - (N - len(O))))
+                for a, v in enumerate(rest):
+                    ncase += 1
+                    d1 = abs(odds[v] - K2[a, a])
+                    worst = max(worst, d1)
+                    nbad += d1 > 1e-12
+                    d2 = abs(odds[v] - joint_prob(P, O + [v], E) / pj)
+                    worstd = max(worstd, d2)
+                    nbadd += d2 > 1e-12
+                    lo, hi = min(lo, odds[v]), max(hi, odds[v])
+        out[nrec] = dict(nconds=nconds, ncase=ncase, nbad=nbad, nbadd=nbadd, worst=worst,
+                         worstd=worstd, worstj=worstj, projdev=projdev, lo=lo, hi=hi)
+    return out
+
+
+def group_C():
+    cu = conditioning_case((2, 2, 2), (1, 2))
+    bl = conditioning_case((2, 2, 3), (1, 2))
+    check("C1 [numerical, 1e-15] cube: over %d one- and %d two-record conditions Lueders conditioning = the "
+          "Schur complement of P on %d + %d odds, %d mismatches (%.1e); [1/3, 2/3], [1/6, 5/6]"
+          % (cu[1]["nconds"], cu[2]["nconds"], cu[1]["ncase"], cu[2]["ncase"],
+             cu[1]["nbad"] + cu[2]["nbad"], max(cu[1]["worst"], cu[2]["worst"])),
+          cu[1]["nconds"] == 16 and cu[2]["nconds"] == 112 and cu[1]["ncase"] == 112
+          and cu[2]["ncase"] == 672 and cu[1]["nbad"] + cu[2]["nbad"] == 0
+          and abs(cu[1]["lo"] - 1 / 3) < 1e-12 and abs(cu[1]["hi"] - 2 / 3) < 1e-12
+          and abs(cu[2]["lo"] - 1 / 6) < 1e-12 and abs(cu[2]["hi"] - 5 / 6) < 1e-12)
+    check("C2 [numerical, 1e-15] block: the same over %d and %d conditions, %d mismatches (%.1e); odds "
+          "ranges [%.4f, %.4f] and [%.4f, %.4f]"
+          % (bl[1]["nconds"], bl[2]["nconds"], bl[1]["nbad"] + bl[2]["nbad"],
+             max(bl[1]["worst"], bl[2]["worst"]), bl[1]["lo"], bl[1]["hi"], bl[2]["lo"], bl[2]["hi"]),
+          bl[1]["nconds"] == 24 and bl[2]["nconds"] == 264 and bl[1]["nbad"] + bl[2]["nbad"] == 0
+          and abs(bl[1]["lo"] - 0.3179) < 5e-5 and abs(bl[1]["hi"] - 0.6821) < 5e-5
+          and abs(bl[2]["lo"] - 0.1357) < 5e-5 and abs(bl[2]["hi"] - 0.8643) < 5e-5)
+    wj = max(cu[1]["worstj"], cu[2]["worstj"], bl[1]["worstj"], bl[2]["worstj"])
+    wd = max(cu[1]["worstd"], cu[2]["worstd"], bl[1]["worstd"], bl[2]["worstd"])
+    pd = max(cu[1]["projdev"], cu[2]["projdev"], bl[1]["projdev"], bl[2]["projdev"])
+    check("C3 [numerical, 1e-15] on every case P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B} (%.1e), "
+          "the odds are P(A + v, B)/P(A, B) (%.1e), each kernel an exact projector of rank N - |O| (%.1e)"
+          % (wj, wd, pd),
+          wj < 1e-14 and wd < 1e-14 and pd < 1e-10)
+
+
+def group_C_edges():
+    """The vertex-level determinantal law pushed to the edge sites of the BKSF cube."""
+    M, sites, idx = build_open((2, 2, 2))
+    Psea, _, _ = sea_projector(M, 4)
+    assert all(idx[v] == 4 * v[0] + 2 * v[1] + v[2] for v in sites)
+    pat = {tuple(1 if v in S else 0 for v in range(8)): det_minor(Psea, S)
+           for S in itertools.combinations(range(8), 4)}
+    V, EDGES = cube_cluster()
+    En = Enc(V, EDGES, cube_faces())
+    S_loops, gens, grp = stabilizer_group(En)
+    k = len(gens)
+    cid, phi, reps, recs = code_space(En, grp)
+    rec_of = {c: recs[c] for c in range(len(reps))}
+    rng = np.random.default_rng(11)
+    phase = {c: np.exp(2j * np.pi * rng.random()) for c in range(len(reps))}
+    amp = np.zeros(En.DIM, dtype=complex)
+    for z in range(En.DIM):
+        c = cid[z]
+        amp[z] = np.sqrt(max(pat.get(rec_of[c], 0.0), 0.0) / (1 << k)) * phi[z] * phase[c]
+    q = np.abs(amp) ** 2
+    dev = 0.0
+    for c in range(len(reps)):
+        mem = [z for z in range(En.DIM) if cid[z] == c]
+        vals = q[mem]
+        dev = max(dev, vals.max() - vals.min(), abs(vals.sum() - pat.get(rec_of[c], 0.0)))
+
+    def vodds(cond):
+        keep = [z for z in range(En.DIM) if all(((z >> e) & 1) == b for e, b in cond.items())]
+        m = float(q[keep].sum())
+        if m < 1e-14:
+            return 0.0, None
+        o = np.zeros(8)
+        for z in keep:
+            r = rec_of[cid[z]]
+            for v in range(8):
+                if r[v]:
+                    o[v] += q[z]
+        return m, o / m
+    base = vodds({})[1]
+    w1 = w2 = 0.0
+    n1 = n2 = 0
+    for e in range(En.NQ):
+        for b in (0, 1):
+            m, o = vodds({e: b})
+            n1 += 1
+            w1 = max(w1, abs(m - 0.5), float(np.max(np.abs(o - base))))
+    for e, f in itertools.combinations(range(En.NQ), 2):
+        for b1, b2 in itertools.product((0, 1), repeat=2):
+            m, o = vodds({e: b1, f: b2})
+            n2 += 1
+            w2 = max(w2, abs(m - 0.25), float(np.max(np.abs(o - base))))
+    check("C4 [numerical, 1e-17] BKSF cube, %d edge sites: %d cosets, every fibre 2^%d = %d patterns, the "
+          "encoded state uniform WITHIN a fibre with fibre total det P_S (%.1e)"
+          % (En.NQ, len(reps), k, 1 << k, dev),
+          En.NQ == 12 and len(reps) == 128 and (1 << k) == 32 and dev < 1e-16
+          and bool(np.allclose(base, 0.5, atol=1e-13)))
+    check("C5 [numerical, 1e-14] ONE edge record (%d cases) leaves mass 1/2 and TWO (%d) mass 1/4, both with "
+          "the vertex odds UNCHANGED at 1/2 (%.1e, %.1e): below a star, no vertex condition"
+          % (n1, n2, w1, w2), n1 == 24 and n2 == 264 and w1 < 1e-14 and w2 < 1e-14)
+
+    w3 = 0.0
+    nstar = 0
+    for v in range(8):
+        star = En.STAR[v]
+        for assign in itertools.product((0, 1), repeat=len(star)):
+            m, o = vodds(dict(zip(star, assign)))
+            if m < 1e-14:
+                continue
+            b = sum(assign) % 2
+            K2, rest = schur_condition(Psea, [v] if b == 1 else [], [] if b == 1 else [v])
+            pred = np.array(base)
+            for a, u in enumerate(rest):
+                pred[u] = K2[a, a]
+            pred[v] = float(b)
+            w3 = max(w3, float(np.max(np.abs(o - pred))))
+            nstar += 1
+    Zs = [Pau(0, 0, 1 << qq) for qq in range(En.NQ)]
+    zcomm = all(pcomm(a, b) for a, b in itertools.combinations(Zs, 2))
+    check("C6 [numerical, 1e-14] a full vertex STAR of edge records (%d assignments, all reachable) induces "
+          "exactly the determinantal conditional on n_v = parity(star) (%.1e)"
+          % (nstar, w3), nstar == 64 and w3 < 1e-14)
+
+    bad = ncase = 0
+    worst = 0.0
+    nsets = 0
+    for T in itertools.combinations(range(8), 3):
+        for vals in itertools.product((0, 1), repeat=3):
+            nsets += 1
+            ref = None
+            for perm in itertools.permutations(range(3)):
+                Ks = Psea.copy()
+                labels = list(range(8))
+                ok = True
+                for t in perm:
+                    site, b = T[t], vals[t]
+                    j = labels.index(site)
+                    A = Ks if b == 1 else (np.eye(len(labels)) - Ks)
+                    if abs(A[j, j]) < 1e-13:
+                        ok = False
+                        break
+                    keep = [a for a in range(len(labels)) if a != j]
+                    An = A[np.ix_(keep, keep)] - np.outer(A[keep, j], A[j, keep]) / A[j, j]
+                    Ks = An if b == 1 else (np.eye(len(keep)) - An)
+                    labels = [labels[a] for a in keep]
+                if not ok:
+                    continue
+                if ref is None:
+                    ref = Ks.copy()
+                else:
+                    ncase += 1
+                    d = float(np.max(np.abs(Ks - ref)))
+                    worst = max(worst, d)
+                    bad += d > 1e-11
+    check("C7 [exact + numerical, 1e-14] ORDER INDEPENDENCE: all %d Z_e commute pairwise (%s), and Schur "
+          "conditioning on %d three-record sets in 6 orders gives %d comparisons, %d mismatches (%.1e)"
+          % (En.NQ, zcomm, nsets, ncase, bad, worst),
+          zcomm and nsets == 448 and bad == 0 and worst < 1e-14)
+
+
+# ==================================================== D: the reach of a record
+
+SEA = {}
+NBR6 = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+
+
+def l1(u, L):
+    return sum(min(u[a] % L, (-u[a]) % L) for a in range(3))
+
+
+def build_seas():
+    for L in (4, 6, 8):
+        best = None
+        for tw in itertools.product((0, 1), repeat=3):
+            Mx, _, _ = build_torus(L, tw)
+            E = float(np.sum(np.linalg.eigvalsh(Mx)[:L ** 3 // 2]))
+            if best is None or E < best[1] - 1e-12:
+                best = (tw, E)
+        tw, E = best
+        M, sites, idx = build_torus(L, tw)
+        P, _, w = sea_projector(M)
+        eps = np.array([(-1) ** sum(v) for v in sites])
+        i0 = idx[(0, 0, 0)]
+        same = np.where(eps == eps[i0])[0]
+        SEA[L] = dict(M=M, P=P, sites=sites, idx=idx, tw=tw, E=E, w=w, i0=i0,
+                      V=L ** 3, N=L ** 3 // 2,
+                      m2=float(np.max(np.abs(M @ M - 6 * np.eye(L ** 3)))),
+                      halfdev=float(np.max(np.abs(np.diag(P) - 0.5))),
+                      samedev=float(np.max(np.abs(P[np.ix_(same, same)]
+                                                  - 0.5 * np.eye(len(same))))))
+
+
+def group_D():
+    build_seas()
+    ok = all(SEA[L]["halfdev"] < 1e-15 and SEA[L]["samedev"] < 1e-15 for L in (4, 6, 8))
+    check("D1 [numerical, 1e-15] the vacuum on 4^3, 6^3, 8^3 at optimal twist %s, %s, %s: E_sea = "
+          "%.6f, %.6f, %.6f; P_vv = 1/2 and P = I/2 on each sublattice (%.1e)"
+          % (SEA[4]["tw"], SEA[6]["tw"], SEA[8]["tw"], SEA[4]["E"], SEA[6]["E"], SEA[8]["E"],
+             max(max(SEA[L]["halfdev"], SEA[L]["samedev"]) for L in (4, 6, 8))),
+          ok and abs(SEA[4]["E"] + 78.383672) < 1e-5 and abs(SEA[6]["E"] + 258.857540) < 1e-5
+          and abs(SEA[8]["E"] + 611.811768) < 1e-5)
+
+    worst = 0.0
+    ns = []
+    for L in (4, 6, 8):
+        S = SEA[L]
+        P, i0 = S["P"], S["i0"]
+        n = 0
+        for j in range(S["V"]):
+            if j == i0:
+                continue
+            for b in (1, 0):
+                K2, rest = schur_condition(P, [j] if b else [], [] if b else [j])
+                pred = 0.5 - (1 if b else -1) * 2 * P[i0, j] ** 2
+                worst = max(worst, abs(K2[rest.index(i0)][rest.index(i0)] - pred))
+                n += 1
+        ns.append(n)
+    check("D2 [numerical, 1e-15] ONE record shifts the odds at every other site by exactly 2 P_vu^2 (down if "
+          "occupied, up if empty), against Schur on %d, %d, %d cases (%.1e)"
+          % (ns[0], ns[1], ns[2], worst),
+          ns == [126, 430, 1022] and worst < 1e-15)
+
+    axis = {}
+    sums = []
+    for L in (4, 6, 8):
+        S = SEA[L]
+        P, sites, i0 = S["P"], S["sites"], S["i0"]
+        shell = {}
+        for j, u in enumerate(sites):
+            d = l1(u, L)
+            if d:
+                shell[d] = max(shell.get(d, 0.0), abs(P[i0, j]))
+        axis[L] = [shell.get(d, 0.0) for d in (1, 3, 5, 7)]
+        sums.append(float(np.sum(P[i0, :] ** 2) - P[i0, i0] ** 2))
+    check("D3 [numerical, 1e-13] largest |P_vu| at d = 1, 3, 5, 7: %.6f then 0 on 4^3; %s on 6^3; %s "
+          "on 8^3; sum_{u != v} P_vu^2 = 1/4 exactly (%.1e)"
+          % (axis[4][0], " ".join("%.6f" % x for x in axis[6]),
+             " ".join("%.6f" % x for x in axis[8]), max(abs(x - 0.25) for x in sums)),
+          all(abs(x - 0.25) < 1e-13 for x in sums)
+          and abs(axis[4][0] - 0.204124) < 5e-7 and max(axis[4][1:]) < 1e-13
+          and abs(axis[6][1] - 0.037805) < 5e-7 and abs(axis[6][2] - 0.008097) < 5e-7
+          and abs(axis[6][3] - 0.002368) < 5e-7 and abs(axis[8][1] - 0.023936) < 5e-7
+          and abs(axis[8][2] - 0.007268) < 5e-7 and abs(axis[8][3] - 0.003154) < 5e-7)
+
+    census = []
+    for L in (4, 6, 8):
+        S = SEA[L]
+        P, i0, sites = S["P"], S["i0"], S["sites"]
+        bad = nz = npred = 0
+        for j, u in enumerate(sites):
+            if j == i0:
+                continue
+            nodd = sum(1 for a in range(3) if u[a] % 2 == 1)
+            halfs = sum(1 for a in range(3) if u[a] == L // 2 and u[a] % 2 == 0)
+            pred = (nodd == 1) and (halfs == 0)
+            big = abs(P[i0, j]) > 1e-12
+            nz += big
+            npred += pred
+            bad += (big != pred)
+        census.append((S["V"] - 1, npred, nz, bad))
+    check("D4 [numerical, 1e-12] SELECTION RULE: P_vu != 0 iff the separation has one odd component and no "
+          "even one equal to L/2 -- %d of %d, %d of %d, %d of %d, %d mismatches"
+          % (census[0][2], census[0][0], census[1][2], census[1][0], census[2][2], census[2][0],
+             sum(c[3] for c in census)),
+          sum(c[3] for c in census) == 0
+          and [c[2] for c in census] == [6, 81, 108] and [c[1] for c in census] == [6, 81, 108])
+
+
+def group_D_decay():
+    """The decay exponent from a Bloch-block momentum grid, validated against the exact 8^3."""
+    S = SEA[8]
+    nc = 4
+    kk = 2 * np.pi * (np.arange(nc) + 0.5) / nc
+    K = np.stack(np.meshgrid(kk, kk, kk, indexing="ij"), axis=-1)
+    w8, U8 = np.linalg.eigh(bloch_batch(K))
+    Um = U8[..., :4]
+    Pk = Um @ np.conj(np.swapaxes(Um, -1, -2))
+    Pr8 = np.fft.ifftn(Pk, axes=(0, 1, 2))
+    Rg = np.stack(np.meshgrid(*[np.arange(nc)] * 3, indexing="ij"), axis=-1)
+    Pr8 = Pr8 * np.exp(1j * np.pi * Rg.sum(-1) / nc)[..., None, None]
+    espec = float(np.max(np.abs(np.sort(w8.reshape(-1)) - np.sort(S["w"]))))
+    ek = 0.0
+    for R in itertools.product(range(nc), repeat=3):
+        for s in SUB:
+            for sp in SUB:
+                u = tuple((2 * R[a] + sp[a]) % 8 for a in range(3))
+                ek = max(ek, abs(Pr8[R][SI[sp], SI[s]] - S["P"][S["idx"][u], S["idx"][tuple(s)]]))
+    check("D5 [numerical, 1e-14] the Bloch-block machinery (8 x 8 per momentum) reproduces "
+          "the exact 8^3 torus: spectra to %.1e, every kernel entry to %.1e" % (espec, ek),
+          espec < 1e-14 and ek < 1e-14)
+
+    nc = 48
+    Pr, _ = kernel_field(nc)
+    rs = list(range(1, nc, 2))
+    vs = [abs(Pr[(n // 2, 0, 0)][SI[(n % 2, 0, 0)], SI[(0, 0, 0)]]) for n in rs]
+    loc = [(rs[i], np.log(vs[i + 1] / vs[i]) / np.log(rs[i + 1] / rs[i]))
+           for i in range(len(rs) - 1) if vs[i] > 0 and vs[i + 1] > 0]
+    slope19 = [x for r, x in loc if r == 19][0]
+    pts = []
+    for R in itertools.product(range(nc // 2), repeat=3):
+        for sp in SUB:
+            r = np.array([2 * R[a] + sp[a] for a in range(3)], float)
+            rn = float(np.linalg.norm(r))
+            if rn < 1e-9:
+                continue
+            v = abs(Pr[R][SI[sp], SI[(0, 0, 0)]])
+            if v > 1e-13:
+                pts.append((rn, v))
+    use = [(r, v) for r, v in pts if 10 <= r <= 30]
+    sl, ic = np.polyfit(np.log([r for r, _ in use]), np.log([v for _, v in use]), 1)
+    mean3 = float(np.mean([v * r ** 3 for r, v in use]))
+    check("D6 [numerical, fitted slope, %d^3 grid] the kernel decays as an inverse CUBE: local slope -> %.2f "
+          "at n = 19; a fit on %d separations, 10 <= |r| <= 30, gives |P| ~ |r|^%.2f, mean "
+          "|P| |r|^3 = %.2f"
+          % (2 * nc, slope19, len(use), sl, mean3),
+          abs(slope19 + 3.02) < 0.02 and abs(sl + 3.04) < 0.03 and abs(mean3 - 0.21) < 0.01)
+
+
+# ==================================================== E: additivity, forcing, and reach beyond the star
+
+def group_E():
+    six = {}
+    stardev = 0.0
+    adddev = 0.0
+    rng = {}
+    forced = {}
+    for L in (4, 6, 8):
+        S = SEA[L]
+        P, idx, i0 = S["P"], S["idx"], S["i0"]
+        nb = [idx[tuple(o[a] % L for a in range(3))] for o in NBR6]
+        stardev = max(stardev, float(np.max(np.abs(P[np.ix_(nb, nb)] - 0.5 * np.eye(6)))))
+        vals = []
+        for m in range(64):
+            O = [nb[t] for t in range(6) if (m >> t) & 1]
+            E = [nb[t] for t in range(6) if not (m >> t) & 1]
+            K2, rest = schur_condition(P, O, E)
+            o = float(K2[rest.index(i0)][rest.index(i0)])
+            closed = 0.5 - 2 * sum(P[i0, u] ** 2 for u in O) + 2 * sum(P[i0, u] ** 2 for u in E)
+            adddev = max(adddev, abs(o - closed))
+            vals.append((o, m))
+        vals.sort()
+        six[L] = (nb, vals)
+        rng[L] = (vals[0][0], vals[-1][0])
+        forced[L] = sum(1 for o, _ in vals if o < 1e-12 or o > 1 - 1e-12)
+    check("E1 [numerical, 9e-16] the six neighbours lie on the other sublattice, so P on them is exactly I/2 "
+          "(%.1e) and the odds are ADDITIVE: 1/2 - 2 sum_occ P_vu^2 + 2 sum_empty P_vu^2 over 64 x 3 (%.1e)" % (stardev, adddev), stardev < 1e-15 and adddev < 1e-15)
+    check("E2 [numerical, 1e-12] range over the 64: [%.6f, %.6f] on 4^3 with %d forcing; [%.6f, %.6f] on "
+          "6^3, %d; [%.6f, %.6f] on 8^3, %d -- forcing only where M^2 = 6I exactly (%.1e)"
+          % (rng[4][0], rng[4][1], forced[4], rng[6][0], rng[6][1], forced[6],
+             rng[8][0], rng[8][1], forced[8], SEA[4]["m2"]),
+          forced[4] == 2 and forced[6] == 0 and forced[8] == 0 and SEA[4]["m2"] == 0.0
+          and abs(rng[6][0] - 0.021268) < 5e-7 and abs(rng[8][0] - 0.024036) < 5e-7
+          and rng[4][0] < 1e-12 and rng[4][1] > 1 - 1e-12)
+
+    supp_n = []
+    supp_s = []
+    whole = []
+    minus = []
+    for L in (4, 6, 8):
+        S = SEA[L]
+        P, i0 = S["P"], S["i0"]
+        supp = [j for j in range(S["V"]) if j != i0 and abs(P[i0, j]) > 1e-12]
+        supp_n.append(len(supp))
+        supp_s.append(float(np.sum(P[i0, supp] ** 2)))
+        K2, rest = schur_condition(P, supp, [])
+        whole.append(float(K2[rest.index(i0)][rest.index(i0)]))
+        drop = sorted(supp, key=lambda j: -abs(P[i0, j]))[:-1]
+        K3, rest3 = schur_condition(P, drop, [])
+        minus.append(float(K3[rest3.index(i0)][rest3.index(i0)]))
+    check("E3 [numerical, 1e-12] FORCING: the row support sum of P_vu^2 = 1/4 exactly (%.1e), so a set forces "
+          "iff it covers the WHOLE support -- %d, %d, %d sites, giving odds %.1e; one short leaves "
+          "%.1e, %.1e, %.1e"
+          % (max(abs(x - 0.25) for x in supp_s), supp_n[0], supp_n[1], supp_n[2],
+             max(abs(x) for x in whole), minus[0], minus[1], minus[2]),
+          all(abs(x - 0.25) < 1e-13 for x in supp_s) and supp_n == [6, 81, 108]
+          and all(abs(x) < 1e-12 for x in whole) and minus[0] > 1e-3
+          and abs(minus[1] - 1.12e-5) < 1e-6 and abs(minus[2] - 1.99e-5) < 1e-6)
+
+    L = 8
+    S = SEA[L]
+    P, idx, sites, i0 = S["P"], S["idx"], S["sites"], S["i0"]
+    nb, _ = six[L]
+    rows = {}
+    for lbl, m0 in (("occ", 63), ("alt", 0b010101)):
+        O = [nb[t] for t in range(6) if (m0 >> t) & 1]
+        E = [nb[t] for t in range(6) if not (m0 >> t) & 1]
+        K2, rest = schur_condition(P, O, E)
+        o0 = float(K2[rest.index(i0)][rest.index(i0)])
+        per_d = {}
+        for j, u in enumerate(sites):
+            if j == i0 or j in nb:
+                continue
+            d = l1(u, L)
+            best = 0.0
+            for b in (1, 0):
+                OO, EE = (O + [j], E) if b else (O, E + [j])
+                if abs(joint_prob(P, OO, EE)) < 1e-14:
+                    continue
+                K3, r3 = schur_condition(P, OO, EE)
+                best = max(best, abs(float(K3[r3.index(i0)][r3.index(i0)]) - o0))
+            per_d[d] = max(per_d.get(d, 0.0), best)
+        rows[lbl] = (o0, per_d)
+    o_occ, pd_occ = rows["occ"]
+    o_alt, pd_alt = rows["alt"]
+    far = max(pd_occ[d] for d in pd_occ if d >= 8)
+    check("E4 [numerical, 1e-15] BEYOND THE STAR, 8^3, six neighbours occupied (%.4f): one more record at "
+          "d = 2..7 shifts at most %.1e, %.1e, %.1e, %.1e, %.1e, %.1e, and by %.1e at d >= 8"
+          % (o_occ, pd_occ[2], pd_occ[3], pd_occ[4], pd_occ[5], pd_occ[6], pd_occ[7], far),
+          abs(o_occ - 0.024036) < 5e-7 and far == 0.0 and pd_occ[2] > 4e-3 and pd_occ[7] < 1e-4)
+
+    d2 = [idx[u] for u in sites if l1(u, L) == 2]
+    maxP2 = max(abs(P[i0, j]) for j in d2)
+    K4, r4 = schur_condition(P, [nb[t] for t in range(6) if (0b010101 >> t) & 1],
+                             [nb[t] for t in range(6) if not (0b010101 >> t) & 1] + d2)
+    shell = float(K4[r4.index(i0)][r4.index(i0)])
+    check("E5 [numerical, 1e-15] with the neighbours ALTERNATING (%.4f) a d = 2 record reaches %.1e though "
+          "P_vu = 0 there (%.1e): influence through the Schur complement alone; the d = 2 shell empty "
+          "gives %.4f"
+          % (o_alt, pd_alt[2], maxP2, shell),
+          abs(o_alt - 0.5) < 1e-12 and pd_alt[2] > 5e-2 and maxP2 < 1e-15
+          and abs(shell - 0.9704) < 5e-5)
+
+
+def main():
+    group_A()
+    group_B()
+    group_C()
+    group_C_edges()
+    group_D()
+    group_D_decay()
+    group_E()
+    print("SUMMARY: the finished set of records is determinantal with kernel P, conditioning is the "
+          "Schur complement, and no record set forces a value unless it covers the kernel row's support.")
+    print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Conditional bounded theorem note + exact runner + cache: **on the half-filled staggered sea, the record statistics of the emergent fermion form a determinantal point process whose kernel is the sea's own one-particle projector `P`.** The finished set of records at `S` has odds `det P_S` (exact over `Q(sqrt3)` and `Q(sqrt2)` on the two open clusters, and verified against the Jordan-Wigner ground state pattern by pattern); the odds at a site given any records elsewhere are the **Schur complement** of `P` (0 mismatches against explicit Lueders conditioning); PR #7858's twelve forbidden corner pairs are determinantal zeros in closed form, `det P_uv = 0`; a record at separation `d` shifts a site's odds by exactly `2 P_vu^2`, with `|P_vu|` falling as the inverse cube of the distance and vanishing exactly on separations of the wrong parity; the six neighbours enter additively; and no finite record set forces a value unless it covers the whole support of the kernel's row. Admissibility's "distribution determined by the neighbourhood conditions" is, on this vacuum, an explicit kernel formula whose reach is not capped and arrives through the lattice.

- `docs/RECORD_STATISTICS_OF_THE_HALF_FILLED_SEA_ARE_DETERMINANTAL_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (324 lines)
- `scripts/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.py` (`TOTAL: PASS=28 FAIL=0`, 8 s)
- `logs/runner-cache/record_statistics_of_the_half_filled_sea_are_determinantal_check_2026_09_03.txt`

## Theorems

- **T1** the finished set's odds are determinantal (cube and block; exact quadratic-field arithmetic; value multiset; the zeros; no pair minor vanishes at half filling).
- **T2** the empty vacuum's forbidden pairs (PR #7858) are determinantal zeros, `det P_uv = P_uu P_vv - P_uv^2 = 0`, recovering the 384 cancellation zeros from `P` alone; the manifold projector has none.
- **T3** conditioning is the Schur complement; the joint law `P(A occ, B empty) = (-1)^|B| det (P - 1_B)_{A u B}`; edge records push forward through constant fibres; order independence.
- **T4** the reach: one-record shift `2 P_vu^2`; `sum_u P_vu^2 = 1/4`; the selection rule (exactly one odd component); inverse-cube decay from a Bloch-block momentum grid validated against the exact `8^3` torus.
- **T5** six-neighbour additivity; the forcing criterion (cover the kernel row's support; only on `4^3` where `M^2 = 6 I`); influence beyond the star through the Schur complement even where `P_vu = 0`.

## Corollary

- The contrast with the empty vacuum is a contrast of laws: uniform on an `F2` subspace with parity-forced odds (PR #7858) versus determinantal with kernel `P`. The vacuum decides which law of records holds; that decision is not made here (PR #7879).

## Dependencies and context

- Conditional on the designed law (PR #7834), the supplied vacuum (PR #7879), and stipulated Lueders conditioning; contrasts with PR #7858; cites the half-filling note by filename. All quotes re-verified.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
