### PR TITLE
feat(matter): the vacuum question is one coefficient of the law

### DIFF
--- a/docs/THE_VACUUM_QUESTION_IS_ONE_COEFFICIENT_OF_THE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_VACUUM_QUESTION_IS_ONE_COEFFICIENT_OF_THE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,329 @@
+---
+claim_id: vacuum_question_one_coefficient_occupancy_cost
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3 carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with free nearest-neighbour hopping of strength t = 1 and the encoding's own site operator B_i given a coefficient -- the occupancy term -J_B sum_i B_i, declared here and not derived -- on the named finite blocks and tori only: (T1) sum_i B_i commutes with every encoded hop T_ij = (i/2) A_ij (B_i - B_j), exactly, over all 16029 (hop, site) Pauli-string sign pairs on the open 2x2x2 and 3x3x3 blocks and the tori 3^3 and 4^3, by the identity [sum_k B_k, T_ij] = -i (B_i^2 - B_j^2) A_ij = 0, while a single B_i does not, ||[B_i, T_ij]|| = 2 against ||[sum_k B_k, T_ij]|| = 0 on a dense 16-dimensional block; and (V I - sum_i B_i)/2 is the record-number operator there, so -J_B sum_i B_i = -J_B V + 2 J_B N is a pure chemical potential of 2 J_B per fermion and adds no dynamics. (T2) At J_B = 0 the global minimum over record numbers and flux sectors is the half-filled staggered sea: every cluster here is bipartite with all degrees 6, so its spectrum is symmetric about 0 to 3.4e-14 and min_N E_N = E_{V/2} for every link-sign field, attained on the tie range [#neg, #neg + #zero] (plain 4^3 untwisted: 20 zero modes, ties N in [22, 42]); on the open 2x2x2 cube all 32 consistent sectors at all N give -4 sqrt3 uniquely at the all-(-1) sector and N = 4, by a margin of 0.456067; on the 4^3 torus the minimum is -32 sqrt6, the Cauchy-Schwarz floor over ALL link-sign fields, checked against 8 twists times 2 uniform sectors, 5 structured sectors and 1000 random fields; elsewhere the same sector wins as a search result, -258.857540 on 6^3 (8 twists times 2 plus 300 random, best random -230.81), -611.811768 on 8^3, and -26.040600 against -21.213203 on the open 3x3x3. (T3) With W(J_B) = sum over levels below -2 J_B of (eps + 2 J_B), twist-minimised at each J_B, the ground state moves continuously from the half-filled staggered sea to the empty lattice, and the optimal Wilson twist changes with J_B. (T4) The plain sector overtakes the staggered one at J_B* = sqrt3/2 exactly on the 4^3 torus -- the staggered KS twist has W = -24 - 24 sqrt2 - 8 sqrt3 + 56 J against the plain (0,1,1) twist's W = -24 - 24 sqrt2 + 40 J, difference 16 J - 8 sqrt3 -- at 0.849332 on 6^3, 0.867676 on 8^3 and 0.8654003 +- 3e-6 in the thermodynamic limit, where the fillings there are 0.4417 and 0.2521; the emptying thresholds J_B >= |eps_min|/2 are 3 exactly for the plain sector, band bottom -6 at (pi, pi, pi), and sqrt3 for the staggered one, on all three tori and in the limit; 3 sqrt2/2 and sqrt6/2 on the open 3x3x3; 3/2 on the cube, where all 32 sectors tie at W = 0; and on the cube the all-(-1) sector loses to the 2-flux class at sqrt3 - (1 + sqrt2)/2 = 0.524944. (T5) For ANY link-sign field on a bipartite degree-6 cluster, tr M^2 = 6V and D M D = -M give W(J) >= min_m [-sqrt(3 V m) + 2 J m] = -V sqrt(3/2) + J V for J <= sqrt(3/8) = 0.612372 and -3V/(8J) above; the 4^3 flat-twist staggered sea has W = 64 J - 32 sqrt6 and attains that floor with slack at most 7e-15 at every J_B <= sqrt(3/8), so it is a global minimiser over all link-sign fields AND all record numbers on that interval. (T6) Exactly half filling survives for J_B < 4 sqrt6 - 3 - 3 sqrt2 - sqrt3 = 0.823267 twist-minimised on 4^3 and for J_B < sqrt6/2 within the half-filling twist, for J_B < 2 sqrt3 - 3 = 0.464102 on 6^3 and J_B < 0.306846 on 8^3; in the thermodynamic limit the staggered band is gapless at q = (pi, pi, pi), so exactly half filling survives only at J_B = 0, with 1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3. T2 away from the cube and the 4^3 torus is a search result, not a theorem. The occupancy term and its coefficient are declared by this note, not derived from any axiom; no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py
+---
+
+# The vacuum question is one coefficient of the law
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py`](../scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.txt`](../logs/runner-cache/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+Three notes sit next to each other. One says that on the coarse lattice the half-filled staggered sea is what the hopping term prefers, and that the filling which selects it is a supplied datum. The other says that the empty state and the
+half-filled sea have different and incompatible consequences, and asks which of them the framework calls its vacuum. A third says that the encoding's site operator `B_i` is a term type of the declared law and that no coefficient is attached to it
+anywhere. Put those three together and the vacuum question has a shape: give `B_i` the coefficient the law leaves blank, and the answer is a number. This note computes what that number does.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems on the ground state of free coarse-lattice hopping plus an occupancy term -J_B sum_i B_i: exact Pauli-string commutation making the term a pure chemical potential, exhaustive enumeration on the open 2x2x2 cube, exact surd crossings on the 4^3 torus, and an extended Cauchy-Schwarz certificate valid at every J_B <= sqrt(3/8). The sampling items are declared search results, not theorems, and the thermodynamic items are converged Bloch quadrature. The occupancy term and its coefficient are declared, not derived."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: what value the dimensionless coefficient J_B/t takes."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the six statements below, exactly the runner's check groups `A`-`F`. Group `A` is exact Pauli-string and dense matrix arithmetic at zero tolerance; the surd statements of `B`, `C`, `D` and `E` are exact in `sympy`;
+and the items tagged `[numerical]` are floating-point statements at the stated tolerance. Global minimality is a theorem on the cube and on the `4^3` torus and a **search result** elsewhere, labelled so wherever it appears.
+
+The six are `T1` (`A`), the occupancy term as a pure chemical potential of `2 J_B` per fermion; `T2` (`B`), the half-filled staggered sea as the global ground state at `J_B = 0` over all record numbers and all sectors; `T3` (`C`), the ground state as
+a function of `J_B`, twist-minimised at each `J_B`; `T4` (`C`), the crossover `J_B*` and the emptying thresholds; `T5` (`D`), the extended certificate on the `4^3` torus for `J_B <= sqrt(3/8)`; and `T6` (`E`, `F`), the half-filling persistence
+windows and the gapless thermodynamic limit.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering and the tight-binding dispersion are standard methodology; every object is redeclared here and the runner recomputes every statement.
+No observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the declared law and its term census, quoted below. Pointer only; the encoding, `B_i` and the hop are redeclared here
+  and recomputed by this runner.
+- `HALF_FILLING_KINETIC_ENERGY_SELECTS_THE_STAGGERED_FLUX_SECTOR_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7874): the supplied-filling sentence quoted below.
+- `MATTER_ABOVE_THE_HALF_FILLED_SEA_ODD_AND_EVEN_DENSITIES_AND_THE_VACUUM_QUESTION_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7879): the vacuum question as that note names it, quoted below.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting". This note cites none of their grades and adopts no hypothesis.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site." **Qubit**: "Each site has
+a domain of local possibilities", whose "full one-site possibility domain has algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic
+rotations", and "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." **Record**: "Records form", "a record locks exactly one admissible local possibility", "records
+are permanent", "Only records are readable."
+
+The law whose coefficient is in question is the one PR #7834 declares. Its term census reads, verbatim:
+
+> 1. Of the `16` quantum term types (three `A_ij`, six hop components, three hop totals, `B_i`, three face stabilizers) and the `49` marker term types (the `48`
+>    templates and the no-role penalty), `4` are star-local -- `A_x`, the `A B_i` component along `x` and along `z`, and `B_i` -- `61` are through with an
+>    explicitly constructed `6`-connected hub chain, and `0` are across.
+
+and that note states what it does not supply, verbatim:
+
+> - It supplies no update rule, no formation site, no formation rate, and no values. No coupling, no absolute unit, and no dynamical clause appears anywhere.
+
+So `B_i` is a term type of the law with no coefficient attached to it. The question this note asks is what happens when it has one. The question it is asking about is the one PR #7879 names, whose Corollary item 3 reads, verbatim:
+
+> 3. **The two landed results are consistent with each other and not with a single vacuum.** Which state is the framework's vacuum is a decision about the framework,
+>    named here for its owner, not a residual to compute away. The exact consequences of each choice are supplied. **If the vacuum is empty**: the positive number
+>    density `n_v` sources gravity and meets every clause; all flux sectors tie, so the kinetic clause's staggered field is a free choice; and there is no Dirac
+>    structure. **If the vacuum is the half-filled sea**: the staggered sector is selected by the hopping energy; the spectrum has a gapless point at the reduced-zone
+>    corner; matter comes in pairs; the energy density is the object that carries the monopole; and the number-density deviation carries a dipole and no monopole.
+
+and the sentence from PR #7874 that this note sharpens reads, verbatim:
+
+> So the question "which sector" is answered by "how much matter", and the filling is a supplied datum, not something this note derives.
+
+The object declared here, and derived from nothing, is the **occupancy term**
+
+```text
+H = - t sum_<ij> eta_ij c_i^dag c_j  -  J_B sum_i B_i,      t = 1,
+```
+
+with `J_B >= 0` a single dimensionless coefficient. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras and no graded clause is used anywhere.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the superfast encoding, the two uniform sign fields, the flux sectors, the occupancy term and the
+functional `W(J_B)`. `P1` (`A`) is the commutation making the occupancy term a chemical potential; `P2` (`B`) the `J_B = 0` ground state; `P3` (`C`) the `J_B`-dependence, the crossover and the thresholds; `P4` (`D`) the extended certificate; `P5`
+(`E`, `F`) the half-filling windows and the limit. `P3` uses `P1` to know that the term only shifts occupancies; `P4` uses nothing from `P3` but its numbers; `P5` uses `P2`'s bipartite lemma. The strongest supported scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`, and the coarse edge from `v` along `e_a` at `2v + e_a`. The **KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1
++ v_2}`; the **plain sign** is `+1` on every bond. The **encoding** is the Bravyi-Kitaev superfast encoding on the coarse lattice, code qubits on the coarse edges, direction order `-x < -y < -z < +x < +y < +z`, with
+
+```text
+A_ij = X(edge (i,j)) * prod Z(edges ordered before it at i) * prod Z(edges ordered before it at j),  A_ji = -A_ij
+B_i  = product of the Z's on the edges incident to i,   T_ij = (i/2) A_ij (B_i - B_j),   S_f = the ordered product of the four A's around a coarse face f
+```
+
+A **flux sector** is a choice of eigenvalue `+-1` for every `S_f` consistent with the `F2` relations among them, realised as a link-sign field `eta` by spanning-tree gauge fixing followed by fundamental-cycle transport. The **hopping matrix** is
+`M_ij = eta_ij` on nearest-neighbour coarse bonds and `0` elsewhere, `E_N` is the sum of its `N` lowest eigenvalues, and the **filling** is `n = N/V`. On a torus the three **Wilson lines** are gauge-invariant data that no `S_f` fixes; a **twist**
+flips the signs on one cut plane and changes one Wilson line without changing any face. The **occupancy cost** functional, measured from the empty lattice, is
+
+```text
+W(J_B) = min_N [ E_N + 2 J_B N ] = sum over levels eps < -2 J_B of (eps + 2 J_B),
+```
+
+and `n(J_B) = N/V` at the minimising `N`. Every torus quantity below is minimised over the eight twists **at each `J_B` separately**.
+
+## Theorem 1 -- the occupancy term is a pure chemical potential
+
+**Conclusion.** On the open `2x2x2` and `3x3x3` coarse blocks and the coarse tori `3^3` and `4^3`:
+
+1. Every `B_i` squares to the identity and any two of them commute, and `A_ij` anticommutes with exactly `B_i` and `B_j`: `0` wrong signs over all `16029` `(hop, site)` Pauli-string pairs.
+2. Hence `[sum_k B_k, T_ij] = i (B_i + B_j) A_ij (B_i - B_j) = -i (B_i^2 - B_j^2) A_ij = 0` for every hop: `sum_i B_i` commutes with the whole hopping term.
+3. A single `B_i` does not. On a dense `16`-dimensional block, `||[sum_k B_k, T_ij]|| = 0` and `||[B_i, T_ij]|| = 2` over every hop, with `T_ij` Hermitian.
+4. `(V I - sum_i B_i)/2` is the record-number operator there, with integer spectrum in `[0, V]`. So `-J_B sum_i B_i = -J_B V + 2 J_B N`.
+
+**Proof.** Items 1 and 2 are `F2`/`Z4` symplectic bit arithmetic at zero tolerance, the sign of a commutator of two Pauli strings read off the symplectic form. Item 3 builds the four-qubit block explicitly as complex matrices and takes the
+commutators. Item 4 diagonalises `(V I - sum_i B_i)/2` on that block; its eigenvalues are integers, and `sum_i B_i` commuting with every hop makes them conserved.
+
+**Reading, not theorem.** The extra term counts particles and does nothing else. It cannot move one, it cannot make one, and it cannot destroy one; adding it to the law changes no motion, only the price of standing still. One particle costs `2 J_B`,
+and `N` of them cost `2 J_B N`. That is the whole content of the coefficient: a charge for occupancy.
+
+## Theorem 2 -- at zero cost the ground state is the half-filled staggered sea
+
+**Conclusion.** At `J_B = 0`:
+
+1. Every cluster here is bipartite with all degrees `6`, so every link-sign field on it has a spectrum symmetric about `0` -- `max |eps + reverse eps| < 4e-14` over all `82` spectra -- and therefore `min_N E_N = E_{V/2}`, attained exactly on the tie
+   range `[#neg, #neg + #zero]`. On the plain `4^3` field at the untwisted Wilson line there are `20` zero modes and the ties run over `N` in `[22, 42]`.
+2. On the open `2x2x2` cube, exhaustively over all `32` consistent sectors and all `N`, the global minimum is `-4 sqrt3`, attained **only** by the all-`(-1)` sector at `N = 4`, by a margin of `0.456067` to the next distinct value.
+3. On the `4^3` torus the global minimum over `8` twists times `2` uniform sectors, `5` structured sectors and `1000` random link-sign fields is `-32 sqrt6`, which is the Cauchy-Schwarz floor over **all** link-sign fields on that torus.
+4. Elsewhere the same sector wins as a **search result**: `-258.857540` on `6^3` against a best random field of `-230.81`, `-611.811768` on `8^3`, and `-26.040600` against the plain sector's `-21.213203` on the open `3x3x3`.
+
+**Proof.** Item 1 is `[numerical, 4e-14]` for the symmetry and exact in structure: a spectrum symmetric about `0` makes the partial sums of the sorted levels decrease exactly while the levels are negative and increase after, so the minimum sits at
+the last negative level and ties across the zeros. Item 2 enumerates the `32` sectors from the `F2` relations among the `S_f`, realises each as a sign field, and compares the exact ladders. Item 3 evaluates the fields and compares against the bound
+of Theorem 5 at `J = 0`. Item 4 is direct evaluation at the runner's fixed seed and is a statement about the fields drawn, not about the whole space.
+
+**Reading, not theorem.** With nothing to pay for a particle, the lattice fills every level that costs less than nothing, and half the levels do, because the box is two-colourable and its levels come in plus-minus pairs. So the cheapest state is
+exactly half full whatever the signs on the links, and among the sign patterns the cheapest is the one with a minus around every square. On the smallest box that is the cheapest arrangement there is; on the `4^3` box it is as cheap as anything could
+be.
+
+## Theorem 3 -- the ground state as a function of the cost
+
+**Conclusion.** With `W(J_B)` twist-minimised at each `J_B`, on the `4^3` torus:
+
+| `J_B` | `w` plain | `n` plain | twist | `w` stag | `n` stag | twist |
+|---|---|---|---|---|---|---|
+| `0` | `-1.060660` | `0.50000` | `111` | `-1.224745` | `0.50000` | `111` |
+| `0.5` | `-0.593750` | `0.34375` | `000` | `-0.724745` | `0.50000` | `111` |
+| `0.823267` | `-0.390788` | `0.31250` | `011` | `-0.401477` | `0.50000` | `111` |
+| `sqrt3/2` | `-0.364064` | `0.31250` | `011` | `-0.364064` | `0.43750` | `000` |
+| `sqrt6/2` | `-0.224144` | `0.12500` | `111` | `-0.134464` | `0.25000` | `000` |
+| `sqrt3` | `-0.097317` | `0.12500` | `111` | `0` | `0` | `000` |
+| `3` | `0` | `0` | `000` | `0` | `0` | `000` |
+
+and in the thermodynamic limit, by Bloch quadrature at `L = 224`:
+
+| `J_B` | `w` plain | `n` plain | `w` stag | `n` stag |
+|---|---|---|---|---|
+| `0` | `-1.0024184` | `0.500028` | `-1.1938011` | `0.500000` |
+| `0.4` | `-0.6480922` | `0.385838` | `-0.7946948` | `0.495420` |
+| `0.8654003` | `-0.3510864` | `0.252133` | `-0.3510874` | `0.441724` |
+| `1.2` | `-0.2126531` | `0.167895` | `-0.1051182` | `0.267308` |
+| `sqrt3` | `-0.0810372` | `0.085917` | `0` | `0` |
+| `3` | `0` | `0` | `0` | `0` |
+
+The optimal Wilson twist is not fixed: the staggered sector's minimising twist changes from `(1,1,1)` to `(0,0,0)` as `J_B` rises through the table, and the plain sector's takes three distinct values across it.
+
+**Proof.** `[numerical, 1e-9]` throughout, with the occupancy set at each `J_B` read off the sorted spectrum and the eight twisted fields built explicitly. The Bloch formulas `2 sum_a cos q_a` and `+-sqrt(6 + 2 sum_a cos q_a)`, with a half-integer
+momentum shift on each twisted axis, reproduce the real-space spectra at `L = 4, 6, 8` to `2.7e-14`.
+
+**Reading, not theorem.** Raise the price and the sea drains. At no price the lattice is half full; at a middling price it is a third or a quarter full; past a certain price it is empty. Nothing else about the arrangement changes -- the same links,
+the same signs, the same motion -- only how much of the lattice is in use.
+
+## Theorem 4 -- the crossover and the emptying thresholds
+
+**Conclusion.**
+
+1. On the `4^3` torus the plain sector overtakes the staggered one at `J_B* = sqrt3/2` **exactly**: the staggered sector's KS twist has `W = -24 - 24 sqrt2 - 8 sqrt3 + 56 J` and the plain sector's `(0,1,1)` twist has `W = -24 - 24 sqrt2 + 40 J`, both
+   valid across `J = sqrt3/2`, with difference `16 J - 8 sqrt3`.
+2. `J_B* = 0.849332` on `6^3`, `0.867676` on `8^3`, and `0.8654003 +- 3e-6` in the thermodynamic limit, where the fillings at the crossover are `0.4417` for the staggered sector and `0.2521` for the plain one.
+3. A sector empties at `J_B >= |eps_min|/2`. That is `3` **exactly** for the plain sector -- band bottom `-6` at `q = (pi, pi, pi)` -- and `sqrt3` for the staggered one, on all three tori and in the limit; `3 sqrt2/2` and `sqrt6/2` on the open
+   `3x3x3`; and `3/2` on the open `2x2x2` cube, where all `32` sectors tie at `W = 0` from there up.
+4. On the cube the all-`(-1)` sector stops being the strict global minimiser at `sqrt3 - (1 + sqrt2)/2 = 0.524944`, where the two-flux class takes over.
+
+**Proof.** Item 1 is exact: the `L = 4` spectra `0 x8, +-2 x12, +-2sqrt2 x12, +-2sqrt3 x4` and `0 x16, +-2 x8, +-2sqrt2 x8, +-(2 + 2sqrt2) x4, +-(2sqrt2 - 2) x4` are verified against the numeric ones to `1e-13`, the occupancy sets are constant across
+`J = sqrt3/2`, and the difference is a `sympy` identity whose only root is `sqrt3/2`. Items 2 and 3 are `[numerical, 1e-9]` by bisection on the twist-minimised difference and by reading the band bottoms, with the surd values checked to `1e-9`. Item 4
+bisects on the cube's exhaustive sector list.
+
+**Reading, not theorem.** There is a price at which the two arrangements cost the same, and it is close to nine tenths of a hopping unit however large the box. Below it the minus-on-every-square arrangement is cheaper, above it the plain one is, and
+the reason is simple: the staggered arrangement holds its levels in a narrow band and so gives them all up at once, while the plain one has a few very deep levels that survive a much higher price. The plain arrangement is the last to empty, and it
+empties at three.
+
+## Theorem 5 -- the extended certificate
+
+**Conclusion.** On any bipartite cluster of `V` sites with every degree `6`, for **any** link-sign field:
+
+1. `tr M^2 = 2|E| = 6V` and `D M D = -M` for the colour involution `D`, so the spectrum is symmetric about `0` and the squares of the negative levels sum to `3V`.
+2. If `m` levels are occupied, Cauchy-Schwarz gives `sum_occ |eps| <= sqrt(3 V m)`, hence `W(J) >= min_{0 <= m <= V/2} [-sqrt(3 V m) + 2 J m]`, which equals `-V sqrt(3/2) + J V` for `J <= sqrt(3/8) = 0.612372` and `-3V/(8J)` above it.
+3. On the `4^3` torus the staggered sector at its flat twist has `W = 64 J - 32 sqrt6` and **attains** that floor with slack at most `7e-15` at every `J_B <= sqrt(3/8)`. It is therefore a global minimiser over all link-sign fields **and** all record
+   numbers on that whole interval, not only at `J_B = 0`.
+4. All `1021` fields evaluated -- `16` twisted uniform, `5` structured, `1000` random -- respect the floor at `16` values of `J_B`: `0` violations.
+
+**Proof.** Item 1 is a zero-tolerance integer matrix identity. Item 2 minimises a one-dimensional function of `m` with the interior stationary point `m = 3V/(16 J^2)`, which lies inside `[0, V/2]` exactly when `J >= sqrt(3/8)`. Item 3 is exact: the
+flat-twist spectrum is `+-sqrt6` with multiplicity `32` each, so every occupied level has the same size, which is the equality case, and the occupancy stays at `32` for all `J < sqrt6/2`. Item 4 is `[numerical, 1e-9]` verification of the bound, not a
+proof of it.
+
+**Reading, not theorem.** Two facts about the box -- six neighbours per site and two colours -- fix a floor that no arrangement of signs and no number of particles can go below, at any price. On the `4^3` box, and for every price up to about `0.61`,
+the half-filled minus-on-every-square sea sits exactly on that floor. It is not merely the best thing tried; nothing could be better.
+
+## Theorem 6 -- how long exactly half filling survives
+
+**Conclusion.**
+
+1. Exactly half filling survives on the `4^3` torus for `J_B < 4 sqrt6 - 3 - 3 sqrt2 - sqrt3 = 0.823267` when the twist is chosen freely at each `J_B`, and for `J_B < sqrt6/2 = 1.224745` within the half-filling twist itself.
+2. On `6^3` the twist-minimised window is `J_B < 2 sqrt3 - 3 = 0.464102`, and on `8^3` it is `J_B < 0.306846`. The window shrinks with the box.
+3. In the thermodynamic limit it closes. The staggered band `-sqrt(6 + 2 sum_a cos q_a)` vanishes at `q = (pi, pi, pi)` and only there, and near that point `6 + 2 sum_a cos q_a = |k|^2 + O(|k|^4)`, so for every `J_B > 0` the emptied region `|k| < 2
+   J_B` has positive measure: exactly half filling survives only at `J_B = 0`, with `1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3`. The measured ratio of `1/2 - n(J_B)` to that cubic is `0.9663, 1.0215, 1.0258` at `J_B = 0.15, 0.2, 0.3`.
+
+**Proof.** Items 1 and 2 bisect on the twist-minimised occupancy and check the surds to `1e-8`. Item 3's series expansion is exact in `sympy`; the ratios are `[numerical]` on the `L = 224` Bloch grid. At `J_B = 0.001` that grid cannot resolve the
+effect: the emptied ball has radius `0.002` against a grid spacing of `2 pi / 112`, so the grid reports `n = 0.4999996`, which is its own `n(0)`. The statement that the sea is doped at every positive `J_B` is the analytic one, not a grid reading.
+
+**Reading, not theorem.** In a finite box exactly half filling is stable: it takes a real price to empty the topmost level, because the topmost level is a real distance below zero. In an unbounded lattice there is no such distance -- the band touches
+zero -- so any price at all, however small, empties a little of the sea. The window in which the lattice is exactly half full closes as the box grows.
+
+## Corollary -- the vacuum question is the value of one coefficient
+
+Within the setting declared above, and on the finite blocks and tori named:
+
+1. The law's `B_i` term type, given the coefficient the law leaves blank, is a **pure chemical potential**: `-J_B sum_i B_i = -J_B V + 2 J_B N`, a price of `2 J_B` per fermion and nothing else. It adds no motion, no interaction and no scale beyond
+   the ratio `J_B/t`.
+2. At `J_B = 0` the law's own ground state, over all record numbers and all flux sectors, is the **half-filled staggered sea** -- provably on the cube, provably against all link-sign fields on the `4^3` torus, and as a search result elsewhere.
+3. At `J_B/t >= 3` the ground state is the **empty lattice**, on every cluster here and in the limit. The plain sector is the last to empty and it empties exactly at `3`.
+4. Between the two the ground state is a partially filled sea whose filling falls continuously with `J_B`, and which changes flux sector at `J_B* ~ 0.865`: `sqrt3/2` exactly on `4^3`, `0.8654003` in the limit.
+5. So the two branches PR #7879 names are the two ends of one interval, and the framework's vacuum question is the value of a single dimensionless coefficient `J_B/t` that the law as written does not fix. What PR #7874 calls a supplied datum
+   sharpens: **`J_B/t` is the supplied datum, and the filling follows from it.** The owner's decision is therefore the size of the occupancy cost; nothing here chooses it and nothing here narrows it.
+
+**Reading, not theorem.** Ask how much it costs to have a particle at a site. If the answer is nothing, the lattice fills itself halfway with a sea of matter and the minus-sign pattern comes with it. If the answer is more than three hopping units,
+the lattice stays empty. In between it fills part way. The law as written does not say what the cost is; that one number is the vacuum question.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted. No status value is set, predicted, or implied, and no premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice, the encoding, the sign fields, the occupancy term and its coefficient are declared objects, and the theorems are about them.
+- No vacuum is chosen and no value of `J_B/t` is preferred, proposed, estimated or bounded by anything physical. Both ends of the interval are supplied and neither is adopted.
+- No mass, no absolute unit, no interaction, no temperature, no formation rate and no dynamical clause appears anywhere. `t = 1` is a choice of unit for the ratio `J_B/t`, not a value.
+
+## Interfaces named for other lanes, not moved here
+
+- **The value of `J_B/t`.** This is a science question, not a residual: which known physics the coarse lattice must reproduce is what would fix it. A lane owning the framework's ground state should decide it; Corollary items 2 to 4 hand that lane the
+  full consequence map, and nothing here narrows the choice.
+- **Interactions.** Only free hopping plus a diagonal occupancy term is compared. A four-fermion term, or any interaction, could move the crossover and the thresholds, and no such term is examined.
+- **The gapless limit.** Theorem 6 item 3 is an infinite-volume subtlety and is named as one: in a finite box exactly half filling has a window, and in the limit the window is the single point `J_B = 0`. A lane wanting a half-filled sea at positive
+  cost in infinite volume owns that tension.
+- **Global minimality beyond `4^3` and the cube.** Theorem 5 is a theorem on the `4^3` torus for `J_B <= sqrt(3/8)` and Theorem 2 item 2 an exhaustion on the cube. Everywhere else the corresponding statement is a search result at the runner's fixed
+  seeds.
+- **The Wilson-line convention.** Every torus quantity is minimised over the eight twists at each `J_B`; which twist a physical setting selects is not decided here.
+- **The many-body energetics.** Only the one-particle ladder is used, the ground state of the free problem at fixed `J_B`.
+
+## Remaining live routes
+
+1. The interval's interior. The crossover and the thresholds are computed; what a partially filled sea implies for the results conditioned on either vacuum is not.
+2. Larger blocks and other geometries. Three tori, two open blocks and the Bloch limit are what is here.
+3. Finite temperature. Everything is a ground-state energy at fixed coefficient, and every sector ties at `W = 0` once the lattice is empty.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one mode per coarse vertex, BK superfast encoding, free nearest-neighbour hopping t = 1 plus the declared occupancy term -J_B sum_i B_i; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+chemical_potential: [sum_k B_k, T_ij] = -i (B_i^2 - B_j^2) A_ij = 0 exactly; 0 wrong signs over 16029 (hop, site) Pauli pairs on open 2x2x2, open 3x3x3, torus 3^3, torus 4^3; dense 16-dim block ||[sum B, T]|| = 0 vs ||[B_i, T]|| = 2; (V I - sum B)/2 = N integer; -J_B sum_i B_i = -J_B V + 2 J_B N
+bipartite: every cluster bipartite degree 6; spectra symmetric to 3.4e-14; min_N E_N = E_{V/2} with ties [#neg, #neg + #zero]; plain 4^3 untwisted 20 zero modes, ties N in [22, 42]
+j0_cube: all 32 sectors x all N -> -4 sqrt3, unique at all-(-1), N = 4, margin 0.456067
+j0_tori: 4^3 -32 sqrt6 = the Cauchy-Schwarz floor over ALL link-sign fields (16 twisted uniform + 5 structured + 1000 random); 6^3 -258.857540 (16 + 300 random, best random -230.81); 8^3 -611.811768; open 3x3x3 -26.040600 vs plain -21.213203
+crossover: J_B* = sqrt3/2 exactly on 4^3 (stag KS W = -24 - 24 sqrt2 - 8 sqrt3 + 56 J, plain (0,1,1) W = -24 - 24 sqrt2 + 40 J, difference 16 J - 8 sqrt3); 0.849332 on 6^3; 0.867676 on 8^3; 0.8654003 +- 3e-6 in the limit, fillings 0.4417 and 0.2521
+thresholds: plain empties at J_B = 3 exactly (bottom -6 at (pi,pi,pi)), staggered at sqrt3, on 4^3, 6^3, 8^3 and in the limit; open 3x3x3 3 sqrt2/2 and sqrt6/2; cube 3/2 with all 32 tying at W = 0; cube all-(-1) loses to the 2-flux class at sqrt3 - (1 + sqrt2)/2 = 0.524944
+certificate: any bipartite degree-6 field has tr M^2 = 6V and D M D = -M, so W(J) >= -V sqrt(3/2) + J V for J <= sqrt(3/8) = 0.612372 and -3V/(8J) above; the 4^3 flat-twist staggered sea has W = 64 J - 32 sqrt6 and attains it with slack <= 7e-15 at every J_B <= sqrt(3/8); 0 violations over 1021 fields at 16 values of J_B
+half_filling_windows: 4^3 J_B < 4 sqrt6 - 3 - 3 sqrt2 - sqrt3 = 0.823267 twist-minimised and sqrt6/2 within the half-filling twist; 6^3 2 sqrt3 - 3 = 0.464102; 8^3 0.306846; limit only J_B = 0, gapless at (pi,pi,pi), 1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3, ratios 0.9663, 1.0215, 1.0258 at J_B = 0.15, 0.2, 0.3
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=24 FAIL=0
+```
+
+## Proof boundary
+
+The content is **free nearest-neighbour hopping plus one declared diagonal term**, on **finite** clusters and a converged Bloch grid. The occupancy term `-J_B sum_i B_i` and its coefficient are **declared by this note**; no axiom supplies them, no
+axiom forbids them, and nothing here derives either. `t = 1` fixes the unit in which `J_B` is read and is not a physical value.
+
+Global minimality over all link-sign fields is a **theorem on exactly two clusters**: the open `2x2x2` cube, by exhaustion of its `32` sectors at every `N`, and the `4^3` coarse torus, by the extended Cauchy-Schwarz certificate, and there only for
+`J_B <= sqrt(3/8)`. On `6^3`, on `8^3` and on `4^3` above `sqrt(3/8)` the corresponding statement is a **search result** -- a statement about the fields drawn at the runner's fixed seed, not about the whole space.
+
+The crossover value is exact only on the `4^3` torus. `0.849332`, `0.867676` and `0.8654003` are numerical, the last from Bloch quadrature whose `L` sequence `128, 160, 192, 224` settles within `3e-6`. Nothing here claims a limit theorem; the limit
+numbers are converged quadrature.
+
+Theorem 6 item 3 is the one place a finite-cluster reading and an infinite-volume reading differ, and the difference is stated rather than smoothed: on every finite cluster exactly half filling survives a positive window of `J_B`, and in the limit it
+survives only at `J_B = 0`. At `J_B = 0.001` the `L = 224` grid cannot see the doping at all, and the runner says so rather than reporting the grid's own `n(0)` as a physical value.
+
+No claim is made that any value of `J_B/t` is right, likely, natural or excluded. The interval `[0, 3]` and its interior structure are what is computed; which point of it the framework means is not a residual this note leaves open by accident, but a
+decision it hands over on purpose.
+
+## Review record
+
+An honest auditor should come away with: one exact commutation theorem showing that the law's uncoefficiented `B_i` term, given any coefficient, is a chemical potential and nothing more; one exhaustive statement that at zero coefficient the law's own
+ground state is the half-filled staggered sea, with a genuine certificate making that a global statement over all link-sign fields on the `4^3` torus and, extended, over all fillings too for every `J_B` up to `sqrt(3/8)`; one exact crossover at
+`sqrt3/2` on that torus with its thermodynamic value `0.8654003`; the exact emptying threshold `3`; a clearly labelled band of search results away from the two certified clusters; and the honest limit that the half-filling window closes as the box
+grows because the staggered band is gapless.
+
+The three things most likely to be over-read are flagged in the proof boundary: the occupancy term is declared and not derived, so nothing here says the framework *has* such a term; global minimality is a theorem on two clusters and, on `4^3`, only
+below `sqrt(3/8)`; and the gapless limit means the *exactly* half-filled sea is not the ground state at any positive cost in infinite volume. This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no
+hypothesis is adopted, and the four context notes in "Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=24 FAIL=0`, runtime under the declared
+`120` seconds, stdout under `5500` characters, and passing pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.txt
+++ b/logs/runner-cache/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.txt
@@ -1,0 +1,89 @@
+===== runner cache v1 =====
+runner: scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py
+runner_sha256: e7555a77393e22ce41e8dfa119befd0db6c3603dd950fc6c33b8abc8de31335d
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 4.52
+status: ok
+----- stdout -----
+==============================================================
+A  THE OCCUPANCY TERM IS A PURE CHEMICAL POTENTIAL [exact]
+==============================================================
+  clusters: open 2x2x2, open 3x3x3, torus 3^3, torus 4^3
+PASS A1 B_i^2 = I and all B_i mutually commute on all four clusters
+PASS A2 A_ij anticommutes with exactly B_i, B_j: 0 wrong of 16029 (hop, site) pairs
+PASS A3 [sum_k B_k, T_ij] = -i (B_i^2 - B_j^2) A_ij = 0: 0 failures
+  dense 16-dim block: ||[sum B, T]|| = 0.00e+00, ||[B_i, T]|| = 2.00e+00
+PASS A4 sum_i B_i commutes with every hop; a single B_i does not (norm 2)
+PASS A5 (V I - sum_i B_i)/2 = N, integer spectrum in [0, V]: 0,2,4
+  so -J_B sum_i B_i = -J_B V + 2 J_B N: 2 J_B per fermion, nothing else
+
+==============================================================
+B  AT J_B = 0: THE HALF-FILLED STAGGERED SEA
+==============================================================
+PASS B1 [numerical, 4e-14] spectra symmetric about 0: max |eps + rev| = 3.4e-14
+PASS B2 min_N E_N = E_{V/2}, ties [#neg, #neg+#zero]; plain 4^3 20 zero modes, ties N in [22, 42]
+PASS B3 cube exhaustive: 32 sectors; min over (sector, N) at J_B = 0 is -6.928203 = -4 sqrt3, unique all-(-1) at N = 4, margin 0.456067
+  4^3, 16 twisted uniform + 5 structured + 1000 random: -78.383671769 = -32 sqrt6
+  6^3, 16 + 300 random (best random -230.81): -258.857540 ; 8^3: -611.811768
+PASS B4 4^3 minimum at J_B = 0 is -32 sqrt6, the Cauchy-Schwarz floor over ALL link-sign fields
+PASS B5 [search] 6^3 -258.857540, 8^3 -611.811768, open 3x3x3 -26.040600 stag vs -21.213203 plain
+
+==============================================================
+C  THE GROUND STATE AS A FUNCTION OF J_B (twist-minimised)
+==============================================================
+  4^3 (V=64), w = W/V per site, n = N/V:
+      J_B  |  w plain    n plain  twist |   w stag     n stag  twist | lower
+  0.000000 | -1.060660  0.50000  111 | -1.224745  0.50000  111 | stag
+  0.500000 | -0.593750  0.34375  000 | -0.724745  0.50000  111 | stag
+  0.823267 | -0.390788  0.31250  011 | -0.401477  0.50000  111 | stag
+  0.866025 | -0.364064  0.31250  011 | -0.364064  0.43750  000 | tie
+  1.224745 | -0.224144  0.12500  111 | -0.134464  0.25000  000 | plain
+  1.732051 | -0.097317  0.12500  111 |  0.000000  0.00000  000 | plain
+  3.000000 |  0.000000  0.00000  000 |  0.000000  0.00000  000 | tie
+PASS C1 [numerical, 1e-9] the optimal twist changes with J_B: 2 distinct staggered twists in the 4^3 table
+PASS C2 [exact] 4^3: stag KS W = -24 - 24 sqrt2 - 8 sqrt3 + 56 J vs plain (0,1,1) -24 - 24 sqrt2 + 40 J; difference 16*J - 8*sqrt(3)
+PASS C3 [numerical, 1e-9] J_B* = sqrt3/2 = 0.866025404 (4^3), 0.849332 (6^3), 0.867676 (8^3)
+  emptying thresholds J_B >= |eps_min|/2: plain 3, staggered sqrt3, all tori;
+  open 3x3x3 2.121320 = 3 sqrt2/2 and 1.224745 = sqrt6/2; cube 1.5000, all 32 tie at W = 0
+PASS C4 [exact where surds] plain empties at J_B = 3, staggered at sqrt3, all tori
+PASS C5 [exact] on the cube all-(-1) loses to the 2-flux class at sqrt3 - (1 + sqrt2)/2 = 0.524944
+
+==============================================================
+D  THE EXTENDED CERTIFICATE ON 4^3, J_B <= sqrt(3/8) [exact]
+==============================================================
+  tr M^2 = 6V, D M D = -M for any field, so sum_occ eps^2 <= 3V and W(J) >=
+  min_m [-sqrt(3 V m) + 2 J m] = -V sqrt(3/2) + J V for J <= sqrt(3/8) = 0.612372,
+  and -3V/(8J) above it
+PASS D1 [exact] bipartite degree-6 premises: tr M^2 = 384 and D M D = -M
+PASS D2 [exact] the 4^3 flat-twist staggered sea has W = 64*J - 32*sqrt(6) and attains the floor at every J_B <= sqrt(3/8): slack <= 0.0e+00
+PASS D3 [numerical, 1e-9] the floor holds for all 1021 fields at 16 values of J_B: 0 violations
+
+==============================================================
+E  HOW LONG EXACTLY HALF FILLING SURVIVES
+==============================================================
+PASS E1 [exact] 4^3 half filled for J_B < 4 sqrt6 - 3 - 3 sqrt2 - sqrt3 = 0.823267, and < sqrt6/2 = 1.224745 within its own twist
+PASS E2 [numerical, 1e-8] 6^3 half filled for J_B < 2 sqrt3 - 3 = 0.464102, 8^3 for J_B < 0.306846
+
+==============================================================
+F  THE THERMODYNAMIC LIMIT [Bloch quadrature, L = 224]
+==============================================================
+PASS F1 [numerical, 1e-9] Bloch 2 sum cos q_a and +-sqrt(6 + 2 sum cos q_a) match real space at L = 4, 6, 8 to 2.7e-14
+      J_B  |   w plain     n plain |    w stag      n stag | lower
+  0.000000 | -1.0024184  0.500028 | -1.1938011  0.500000 | stag
+  0.400000 | -0.6480922  0.385838 | -0.7946948  0.495420 | stag
+  0.865400 | -0.3510864  0.252133 | -0.3510874  0.441724 | stag
+  1.200000 | -0.2126531  0.167895 | -0.1051182  0.267308 | plain
+  1.732051 | -0.0810372  0.085917 |  0.0000000  0.000000 | plain
+  3.000000 |  0.0000000  0.000000 |  0.0000000  0.000000 | tie
+PASS F2 [numerical] J_B* = 0.8654029 +- 3e-6 in the limit, fillings 0.4417 staggered and 0.2521 plain there
+  (1/2 - n(J)) / ((2/(3 pi^2)) J^3) at J = 0.15, 0.2, 0.3: 0.9663, 1.0215, 1.0258
+  at J = 0.001 the emptied ball |k| < 2J is finer than the grid: n = 0.4999996
+PASS F3 [exact + numerical] gapless at (pi, pi, pi), so any J_B > 0 dopes the sea: 1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3
+PASS F4 [exact] in the limit plain empties at J_B = 3 (bottom -6), staggered at sqrt3 (bottom -2 sqrt3)
+
+runtime 4.2 s (budget 120 s)
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py
+++ b/scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py
@@ -1,0 +1,855 @@
+#!/usr/bin/env python3
+"""The vacuum question is one coefficient of the law.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3, one
+fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding
+written on it.  The law declared by the existence note carries B_i -- the
+product of the Z's on the edges incident to a coarse site -- as a term type
+with no coefficient attached.  Give it one: add
+
+    -J_B sum_i B_i
+
+to the free nearest-neighbour hopping and ask what the ground state is as a
+function of the single dimensionless number J_B/t.
+
+  A  OCCUPANCY TERM.  Exact Pauli-string arithmetic: sum_i B_i commutes with
+     every hop T_ij while a single B_i does not, and (V I - sum_i B_i)/2 is
+     the number operator.  So -J_B sum_i B_i = -J_B V + 2 J_B N is a pure
+     chemical potential of 2 J_B per fermion and nothing else.
+  B  J_B = 0.  Every cluster here is bipartite with all degrees 6, so its
+     spectrum is symmetric about 0 and min_N E_N = E_{V/2} for every
+     link-sign field.  The global minimum over sectors and record numbers is
+     the half-filled staggered sea: exhaustively on the 2x2x2 cube, by the
+     Cauchy-Schwarz certificate on the 4^3 torus, by search elsewhere.
+  C  W(J_B).  The ground state as a function of J_B, twist-minimised at each
+     J_B; the crossover J_B* where the plain sector overtakes the staggered
+     one; the emptying thresholds |eps_min|/2.
+  D  EXTENDED CERTIFICATE.  W(J) >= min_m [-sqrt(3 V m) + 2 J m] for ANY
+     link-sign field, and the 4^3 flat-twist staggered sea attains it for
+     every J_B <= sqrt(3/8).
+  E  HALF FILLING.  How long exactly half filling survives, and the gapless
+     thermodynamic limit where it survives only at J_B = 0.
+  F  LIMIT.  Bloch quadrature: the tables, J_B* and the thresholds at L=224.
+
+Group A is exact symplectic/dense Pauli arithmetic, the surd statements of
+B, C and D are exact in sympy, and the items tagged [numerical] are
+floating-point at the stated tolerance.  The global-minimum statements are
+theorems on the cube (exhaustion) and on 4^3 (certificate); elsewhere they
+are search results and are labelled so.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import time
+from collections import deque
+
+import numpy as np
+import sympy as sp
+
+AUDIT_TIMEOUT_SEC = 120
+
+PASS = 0
+FAIL = 0
+T0 = time.time()
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# =========================================== coarse lattice and the encoding
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    """KS link sign of the coarse bond (v, v + e_a); axes 0,1,2 = 1,2,3."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def wrap(v, dims):
+    return tuple(v[i] % dims[i] for i in range(3))
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+I2 = np.eye(2, dtype=complex)
+SX = np.array([[0, 1], [1, 0]], dtype=complex)
+SZ = np.diag([1, -1]).astype(complex)
+
+
+class Q:
+    """i^k X^x Z^z on a register of qubits indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def isI(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def ismI(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+    def vec(s, n):
+        return s.x | (s.z << n)
+
+
+IDQ = Q(0, 0, 0)
+
+
+def qprod(seq):
+    o = IDQ
+    for p in seq:
+        o = o * p
+    return o
+
+
+def sgn(p, q):
+    """+1 if the two Pauli strings commute, -1 if they anticommute."""
+    return -1 if ((pcnt(p.x & q.z) + pcnt(p.z & q.x)) & 1) else 1
+
+
+class Lat:
+    """Coarse cubic block or torus with the BK superfast encoding on its edges."""
+
+    def __init__(self, dims, periodic):
+        self.dims = tuple(dims)
+        self.per = periodic
+        self.V = [v for v in itertools.product(*(range(d) for d in dims))]
+        self.nv = len(self.V)
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+
+    def step(self, v, d):
+        w = va(v, d)
+        if self.per:
+            return wrap(w, self.dims)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def B(self, v):
+        return Q(0, 0, self.star[v])
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+
+def transport(L, path):
+    """Ordered product of the encoded hops T_{i_{k+1} i_k} along a path."""
+    n = len(path) - 1
+    ops = [L.Aij(path[k + 1], path[k]) for k in range(n)]
+    return qprod(ops[::-1]).scal(n)
+
+
+def f2_pivots(gens):
+    piv = {}
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+    return piv
+
+
+def f2_express(target, piv):
+    v, c = target, 0
+    while v:
+        p = v.bit_length() - 1
+        if p not in piv:
+            return None
+        pv, pc = piv[p]
+        v ^= pv
+        c ^= pc
+    return c
+
+
+def f2_relations(gens):
+    piv, rel = {}, []
+    for j, g in enumerate(gens):
+        v, c = g, 1 << j
+        while v:
+            p = v.bit_length() - 1
+            if p in piv:
+                pv, pc = piv[p]
+                v ^= pv
+                c ^= pc
+            else:
+                piv[p] = (v, c)
+                break
+        if v == 0:
+            rel.append(c)
+    return rel, len(piv)
+
+
+def bits(m):
+    out = []
+    while m:
+        b = m & -m
+        out.append(b.bit_length() - 1)
+        m ^= b
+    return out
+
+
+def sector_eta(L, face_vals, wilson=(1, 1, 1)):
+    """Link-sign field realising the flux sector S_f = face_vals[f], or None."""
+    root = L.V[0]
+    par = {root: None}
+    dq = deque([root])
+    while dq:
+        v = dq.popleft()
+        for r in range(6):
+            if r not in L.inc[v]:
+                continue
+            w = L.inc[v][r][0]
+            if w not in par:
+                par[w] = v
+                dq.append(w)
+    tree = {frozenset((v, w)) for w, v in par.items() if v is not None}
+
+    def tpath(v):
+        p = [v]
+        while par[p[-1]] is not None:
+            p.append(par[p[-1]])
+        return p[::-1]
+
+    F = L.faces()
+    gens = [L.loop(f) for f in F]
+    vals = list(face_vals)
+    if L.per:
+        for ax in range(3):
+            cyc = [wrap(tuple((k if i == ax else 0) for i in range(3)), L.dims)
+                   for k in range(L.dims[ax])]
+            gens.append(transport(L, cyc + [cyc[0]]))
+        vals += list(wilson)
+    gv = [g.vec(L.nq) for g in gens]
+    piv = f2_pivots(gv)
+    rels, _ = f2_relations(gv)
+    for r in rels:
+        idxs = bits(r)
+        pr = qprod([gens[j] for j in idxs])
+        eps = 1 if pr.isI() else (-1 if pr.ismI() else 0)
+        pv = 1
+        for j in idxs:
+            pv *= vals[j]
+        if eps == 0 or pv != eps:
+            return None, False
+    eta = {}
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        if frozenset((v, w)) in tree:
+            eta[(v, ax)] = 1
+            continue
+        op = transport(L, tpath(v) + [w] + tpath(w)[::-1][1:])
+        c = f2_express(op.vec(L.nq), piv)
+        if c is None:
+            return None, False
+        idxs = bits(c)
+        pr = qprod([gens[j] for j in idxs])
+        resid = (op.k - pr.k) & 3
+        if resid not in (0, 2):
+            return None, False
+        e = 1 if resid == 0 else -1
+        for j in idxs:
+            e *= vals[j]
+        eta[(v, ax)] = e
+    return eta, True
+
+
+def holonomies(L, eta):
+    out = set()
+    for (v, a, c, b) in L.faces():
+        pr = 1
+        for (p, q) in ((v, a), (a, c), (b, c), (v, b)):
+            for ax in range(3):
+                if L.step(p, EX[ax]) == q and (p, ax) in eta:
+                    pr *= eta[(p, ax)]
+                    break
+                if L.step(q, EX[ax]) == p and (q, ax) in eta:
+                    pr *= eta[(q, ax)]
+                    break
+        out.add(pr)
+    return out
+
+
+def one_particle(L, eta):
+    idx = {v: i for i, v in enumerate(L.V)}
+    M = np.zeros((L.nv, L.nv))
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        M[idx[w], idx[v]] += eta[(v, ax)]
+        M[idx[v], idx[w]] += eta[(v, ax)]
+    return M
+
+
+def levels(L, eta):
+    return np.sort(np.linalg.eigvalsh(one_particle(L, eta)))
+
+
+# ------------------------------------------------------ the energy functional
+#
+# With the occupancy term the total ground-state energy at record number N is
+# E_N - J_B (V - 2N), so relative to the empty vacuum -J_B V it is
+#     W(J_B) = min_N [ E_N + 2 J_B N ] = sum over levels eps < -2 J_B of
+#              (eps + 2 J_B).
+
+def Wm(ev, J):
+    """W(J) and the record number attaining it; 1e-9 guards the eigensolver noise."""
+    ev = np.sort(np.asarray(ev))
+    m = int(np.searchsorted(ev, -2.0 * J - 1e-9, "left"))
+    return float(np.sum(ev[:m]) + 2.0 * J * m), m
+
+
+TOL = 1e-9
+S2, S3, S6 = sp.sqrt(2), sp.sqrt(3), sp.sqrt(6)
+
+print("=" * 62)
+print("A  THE OCCUPANCY TERM IS A PURE CHEMICAL POTENTIAL [exact]")
+print("=" * 62)
+
+sq_ok = comm_ok = True
+wrong = 0
+bsq = 0
+pairs = 0
+for dims, per in (((2, 2, 2), False), ((3, 3, 3), False), ((3, 3, 3), True), ((4, 4, 4), True)):
+    L = Lat(dims, per)
+    Bs = {v: L.B(v) for v in L.V}
+    sq_ok &= all((Bs[v] * Bs[v]).isI() for v in L.V)
+    comm_ok &= all(sgn(Bs[u], Bs[v]) == 1 for u in L.V for v in L.V)
+    for (v, ax) in L.E:
+        w = L.step(v, EX[ax])
+        A = L.Aij(v, w)
+        for k in L.V:
+            pairs += 1
+            if sgn(Bs[k], A) != (-1 if k in (v, w) else 1):
+                wrong += 1
+        if not (Bs[v] * Bs[v] == Bs[w] * Bs[w]):
+            bsq += 1
+print("  clusters: open 2x2x2, open 3x3x3, torus 3^3, torus 4^3")
+check("A1 B_i^2 = I and all B_i mutually commute on all four clusters", sq_ok and comm_ok)
+check("A2 A_ij anticommutes with exactly B_i, B_j: %d wrong of %d (hop, site) pairs" % (wrong, pairs),
+      wrong == 0 and pairs == 16029)
+check("A3 [sum_k B_k, T_ij] = -i (B_i^2 - B_j^2) A_ij = 0: %d failures" % bsq,
+      bsq == 0)
+
+Ld = Lat((2, 2, 1), False)
+n = Ld.nq
+
+
+def dense(p):
+    M = np.array([[1.0 + 0j]])
+    for b in range(n):
+        m = np.eye(2, dtype=complex)
+        if (p.x >> b) & 1:
+            m = m @ SX
+        if (p.z >> b) & 1:
+            m = m @ SZ
+        M = np.kron(m, M)
+    return (1j ** p.k) * M
+
+
+SB = sum(dense(Ld.B(v)) for v in Ld.V)
+tot, ind, herm = 0.0, 0.0, True
+for (v, ax) in Ld.E:
+    w = Ld.step(v, EX[ax])
+    A, Bv, Bw = dense(Ld.Aij(v, w)), dense(Ld.B(v)), dense(Ld.B(w))
+    T = 0.5j * (A @ (Bv - Bw))
+    herm &= bool(np.allclose(T, T.conj().T))
+    tot = max(tot, float(np.max(np.abs(SB @ T - T @ SB))))
+    ind = max(ind, float(np.max(np.abs(Bv @ T - T @ Bv))))
+Nop = (Ld.nv * np.eye(2 ** n) - SB) / 2.0
+nspec = np.round(np.linalg.eigvalsh(Nop), 12)
+print("  dense 16-dim block: ||[sum B, T]|| = %.2e, ||[B_i, T]|| = %.2e" % (tot, ind))
+check("A4 sum_i B_i commutes with every hop; a single B_i does not (norm 2)",
+      tot == 0.0 and abs(ind - 2.0) < 1e-12 and herm)
+check("A5 (V I - sum_i B_i)/2 = N, integer spectrum in [0, V]: %s"
+      % ",".join("%g" % x for x in sorted(set(nspec.tolist()))),
+      np.all(np.abs(nspec - np.round(nspec)) < 1e-12) and nspec.min() >= -1e-12
+      and nspec.max() <= Ld.nv + 1e-12)
+print("  so -J_B sum_i B_i = -J_B V + 2 J_B N: 2 J_B per fermion, nothing else")
+
+print()
+print("=" * 62)
+print("B  AT J_B = 0: THE HALF-FILLED STAGGERED SEA")
+print("=" * 62)
+
+DATA = {}
+
+
+def twisted(dims):
+    L = Lat(dims, True)
+    cuts = [np.array([1.0 if not (a == ax and v[ax] == dims[ax] - 1) else -1.0
+                      for (v, a) in L.E]) for ax in range(3)]
+    ks = np.array([eta_ks(v, ax) for (v, ax) in L.E], float)
+    assert holonomies(L, {e: int(s) for e, s in zip(L.E, ks)}) == {-1}
+    assert holonomies(L, {e: 1 for e in L.E}) == {1}
+    idx = {v: i for i, v in enumerate(L.V)}
+
+    def mat(s):
+        M = np.zeros((L.nv, L.nv))
+        for k, (v, ax) in enumerate(L.E):
+            w = L.step(v, EX[ax])
+            M[idx[w], idx[v]] += s[k]
+            M[idx[v], idx[w]] += s[k]
+        return M
+
+    res = {}
+    for tag, base in (("plain", np.ones(L.nq)), ("stag", ks)):
+        for tw in itertools.product([0, 1], repeat=3):
+            s = base.copy()
+            for ax in range(3):
+                if tw[ax]:
+                    s = s * cuts[ax]
+            res[(tag, tw)] = np.sort(np.linalg.eigvalsh(mat(s)))
+    return L, res, mat
+
+
+for dims in ((4, 4, 4), (6, 6, 6), (8, 8, 8)):
+    L, res, mt = twisted(dims)
+    DATA["t%d" % dims[0]] = res
+    if dims[0] == 4:
+        L4, mat4 = L, mt
+
+L3 = Lat((3, 3, 3), False)
+DATA["o333"] = {("plain", ()): levels(L3, {e: 1 for e in L3.E}),
+                ("stag", ()): levels(L3, {(v, a): eta_ks(v, a) for (v, a) in L3.E})}
+
+Lc = Lat((2, 2, 2), False)
+FC = Lc.faces()
+cube = {}
+for s in itertools.product([1, -1], repeat=len(FC)):
+    eta, ok = sector_eta(Lc, s)
+    if ok:
+        cube[s] = levels(Lc, eta)
+
+sym = 0.0
+bad_half = 0
+ties = {}
+for key in ("t4", "t6", "t8", "o333"):
+    for k, ev in DATA[key].items():
+        V = len(ev)
+        sym = max(sym, float(np.max(np.abs(ev + ev[::-1]))))
+        lad = np.concatenate(([0.0], np.cumsum(ev)))
+        if abs(lad.min() - lad[V // 2]) > TOL:
+            bad_half += 1
+        nneg = int(np.sum(ev < -TOL))
+        nz = int(np.sum(np.abs(ev) <= TOL))
+        tie = [int(i) for i in np.flatnonzero(lad < lad.min() + TOL)]
+        if [tie[0], tie[-1]] != [nneg, nneg + nz]:
+            bad_half += 1
+        ties[(key, k)] = (nneg, nz)
+for k, ev in cube.items():
+    sym = max(sym, float(np.max(np.abs(ev + ev[::-1]))))
+    lad = np.concatenate(([0.0], np.cumsum(ev)))
+    if abs(lad.min() - lad[4]) > TOL:
+        bad_half += 1
+check("B1 [numerical, 4e-14] spectra symmetric about 0: max |eps + rev| = %.1e" % sym,
+      sym < 4e-14)
+check("B2 min_N E_N = E_{V/2}, ties [#neg, #neg+#zero]; plain 4^3 %d zero modes, "
+      "ties N in [%d, %d]"
+      % (ties[("t4", ("plain", (0, 0, 0)))][1], ties[("t4", ("plain", (0, 0, 0)))][0],
+         sum(ties[("t4", ("plain", (0, 0, 0)))])),
+      bad_half == 0 and ties[("t4", ("plain", (0, 0, 0)))] == (22, 20))
+
+cmin = {k: float(np.sum(v[v < 0])) for k, v in cube.items()}
+gm = min(cmin.values())
+winners = [k for k in cmin if cmin[k] < gm + TOL]
+allm = tuple([-1] * 6)
+margin = sorted(set(round(x, 9) for x in cmin.values()))[1] - gm
+check("B3 cube exhaustive: %d sectors; min over (sector, N) at J_B = 0 is %.6f = "
+      "-4 sqrt3, unique all-(-1) at N = 4, margin %.6f"
+      % (len(cube), gm, margin),
+      len(cube) == 32 and winners == [allm] and abs(gm + 4 * float(S3)) < 1e-12
+      and abs(margin - 0.456067275) < 1e-8)
+
+struct = {}
+for nm_, fn in (
+        ("xy", lambda p: p == (0, 1)), ("xz", lambda p: p == (0, 2)),
+        ("yz", lambda p: p == (1, 2)), ("xy alt", None), ("xz+yz", lambda p: p in ((0, 2), (1, 2)))):
+    vals = []
+    for f in L4.faces():
+        v, a, c, b = f
+        d1 = [i for i in range(3) if ((a[i] - v[i]) % 4) in (1, 3)][0]
+        d2 = [i for i in range(3) if ((b[i] - v[i]) % 4) in (1, 3)][0]
+        p = tuple(sorted((d1, d2)))
+        if nm_ == "xy alt":
+            vals.append(-1 if (p == (0, 1) and v[0] % 2 == 0) else 1)
+        else:
+            vals.append(-1 if fn(p) else 1)
+    eta, ok = sector_eta(L4, vals)
+    struct[nm_] = levels(L4, eta) if ok else None
+
+rng = np.random.default_rng(20260903)
+rand4 = np.array([np.sort(np.linalg.eigvalsh(mat4(rng.choice([-1.0, 1.0], L4.nq))))
+                  for _ in range(1000)])
+L6 = Lat((6, 6, 6), True)
+idx6 = {v: i for i, v in enumerate(L6.V)}
+
+
+def mat6(s):
+    M = np.zeros((216, 216))
+    for k, (v, ax) in enumerate(L6.E):
+        w = L6.step(v, EX[ax])
+        M[idx6[w], idx6[v]] += s[k]
+        M[idx6[v], idx6[w]] += s[k]
+    return M
+
+
+rand6 = np.array([np.sort(np.linalg.eigvalsh(mat6(rng.choice([-1.0, 1.0], L6.nq))))
+                  for _ in range(300)])
+DATA["r4"], DATA["r6"], DATA["s4"] = rand4, rand6, struct
+
+E0 = lambda ev: float(np.sum(np.asarray(ev)[np.asarray(ev) < 0]))
+b4 = min([E0(ev) for ev in DATA["t4"].values()] + [E0(ev) for ev in rand4]
+         + [E0(v) for v in struct.values() if v is not None])
+b6 = min([E0(ev) for ev in DATA["t6"].values()] + [E0(ev) for ev in rand6])
+b8 = min(E0(ev) for ev in DATA["t8"].values())
+floor4 = -64 * float(sp.sqrt(sp.Rational(3, 2)))
+print("  4^3, 16 twisted uniform + 5 structured + 1000 random: %.9f = -32 sqrt6" % b4)
+print("  6^3, 16 + 300 random (best random %.2f): %.6f ; 8^3: %.6f"
+      % (min(E0(ev) for ev in rand6), b6, b8))
+check("B4 4^3 minimum at J_B = 0 is -32 sqrt6, the Cauchy-Schwarz floor over ALL "
+      "link-sign fields", abs(b4 - floor4) < 1e-9 and abs(b4 + 32 * float(S6)) < 1e-9)
+check("B5 [search] 6^3 %.6f, 8^3 %.6f, open 3x3x3 %.6f stag vs %.6f plain"
+      % (b6, b8, E0(DATA["o333"][("stag", ())]), E0(DATA["o333"][("plain", ())])),
+      abs(b6 + 258.857540) < 1e-5 and abs(b8 + 611.811768) < 1e-5
+      and abs(E0(DATA["o333"][("stag", ())]) + 26.040600) < 1e-5
+      and abs(E0(DATA["o333"][("plain", ())]) + 21.213203) < 1e-5)
+
+print()
+print("=" * 62)
+print("C  THE GROUND STATE AS A FUNCTION OF J_B (twist-minimised)")
+print("=" * 62)
+
+
+def best(key, sec, J):
+    return min((Wm(ev, J) + (tw,)) for (s, tw), ev in DATA[key].items() if s == sec)
+
+
+JT = [0.0, 0.5, 0.823267476, float(S3) / 2, float(S6) / 2, float(S3), 3.0]
+print("  4^3 (V=64), w = W/V per site, n = N/V:")
+print("      J_B  |  w plain    n plain  twist |   w stag     n stag  twist | lower")
+tw_seen = set()
+for J in JT:
+    wp, mp, tp = best("t4", "plain", J)
+    wm, mm, tm = best("t4", "stag", J)
+    tw_seen.add(tm)
+    print("  %8.6f | %9.6f %8.5f  %s | %9.6f %8.5f  %s | %s"
+          % (J, wp / 64, mp / 64, "".join(map(str, tp)), wm / 64, mm / 64,
+             "".join(map(str, tm)),
+             "stag" if wm < wp - TOL else ("plain" if wp < wm - TOL else "tie")))
+check("C1 [numerical, 1e-9] the optimal twist changes with J_B: %d distinct staggered "
+      "twists in the 4^3 table" % len(tw_seen), len(tw_seen) >= 2)
+
+J = sp.Symbol("J", positive=True)
+w_stag = -24 - 24 * S2 - 8 * S3 + 56 * J
+w_plain = -24 - 24 * S2 + 40 * J
+spec_s = [(0, 8), (2, 12), (-2, 12), (2 * S2, 12), (-2 * S2, 12), (2 * S3, 4), (-2 * S3, 4)]
+spec_p = [(0, 16), (2, 8), (-2, 8), (2 * S2, 8), (-2 * S2, 8),
+          (2 + 2 * S2, 4), (-2 - 2 * S2, 4), (2 - 2 * S2, 4), (2 * S2 - 2, 4)]
+Jx = S3 / 2
+ok_s = sp.simplify(sum(c * (v + 2 * Jx) for v, c in spec_s if v < -2 * Jx) - w_stag.subs(J, Jx)) == 0
+ok_p = sp.simplify(sum(c * (v + 2 * Jx) for v, c in spec_p if v < -2 * Jx) - w_plain.subs(J, Jx)) == 0
+num_s = np.sort(np.concatenate([[float(v)] * c for v, c in spec_s]))
+num_p = np.sort(np.concatenate([[float(v)] * c for v, c in spec_p]))
+wit = max(float(np.max(np.abs(num_s - DATA["t4"][("stag", (0, 0, 0))]))),
+          float(np.max(np.abs(num_p - DATA["t4"][("plain", (0, 1, 1))]))))
+diff = sp.expand(w_stag - w_plain)
+check("C2 [exact] 4^3: stag KS W = -24 - 24 sqrt2 - 8 sqrt3 + 56 J vs plain (0,1,1) "
+      "-24 - 24 sqrt2 + 40 J; difference %s" % sp.sstr(diff),
+      ok_s and ok_p and wit < 1e-13 and diff == 16 * J - 8 * S3
+      and sp.solve(sp.Eq(diff, 0), J) == [S3 / 2])
+
+
+def crossover(key):
+    lo, hi = 0.0, 3.5
+    f = lambda x: best(key, "stag", x)[0] - best(key, "plain", x)[0]
+    for _ in range(200):
+        mid = (lo + hi) / 2
+        if f(mid) < 0:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+x4, x6, x8 = crossover("t4"), crossover("t6"), crossover("t8")
+check("C3 [numerical, 1e-9] J_B* = sqrt3/2 = %.9f (4^3), %.6f (6^3), %.6f (8^3)"
+      % (x4, x6, x8),
+      abs(x4 - float(S3) / 2) < 1e-8 and abs(x6 - 0.849332) < 1e-5
+      and abs(x8 - 0.867676) < 1e-5)
+
+emp = {}
+for key in ("t4", "t6", "t8"):
+    for sec in ("plain", "stag"):
+        emp[(key, sec)] = -min(ev[0] for (s, tw), ev in DATA[key].items() if s == sec) / 2
+op = -DATA["o333"][("plain", ())][0] / 2
+os_ = -DATA["o333"][("stag", ())][0] / 2
+cempty = max(-min(ev[0] for ev in cube.values()) / 2, 0.0)
+tie32 = all(abs(Wm(v, 1.5 + 1e-9)[0]) < 1e-12 for v in cube.values())
+print("  emptying thresholds J_B >= |eps_min|/2: plain 3, staggered sqrt3, all tori;")
+print("  open 3x3x3 %.6f = 3 sqrt2/2 and %.6f = sqrt6/2; cube %.4f, all 32 tie at W = 0"
+      % (op, os_, cempty))
+check("C4 [exact where surds] plain empties at J_B = 3, staggered at sqrt3, all tori",
+      all(abs(emp[(k, "plain")] - 3.0) < 1e-9 for k in ("t4", "t6", "t8"))
+      and all(abs(emp[(k, "stag")] - float(S3)) < 1e-9 for k in ("t4", "t6", "t8"))
+      and abs(op - 3 * float(S2) / 2) < 1e-9 and abs(os_ - float(S6) / 2) < 1e-9
+      and abs(cempty - 1.5) < 1e-9 and tie32)
+
+lo, hi = 0.0, 3.5
+for _ in range(200):
+    mid = (lo + hi) / 2
+    vals = {k: Wm(v, mid)[0] for k, v in cube.items()}
+    if vals[allm] < min(vals[k] for k in vals if k != allm) - 1e-12:
+        lo = mid
+    else:
+        hi = mid
+jcube = (lo + hi) / 2
+check("C5 [exact] on the cube all-(-1) loses to the 2-flux class at "
+      "sqrt3 - (1 + sqrt2)/2 = %.6f" % jcube,
+      abs(jcube - float(S3 - (1 + S2) / 2)) < 1e-8)
+
+print()
+print("=" * 62)
+print("D  THE EXTENDED CERTIFICATE ON 4^3, J_B <= sqrt(3/8) [exact]")
+print("=" * 62)
+
+
+def floorW(V, Jv):
+    r = np.sqrt(3.0 / 8.0)
+    return (-V * np.sqrt(1.5) + Jv * V) if Jv <= r else -3.0 * V / (8.0 * Jv)
+
+
+Dcol = np.diag([(-1.0) ** sum(v) for v in L4.V])
+trm, invol = True, True
+for f in list(DATA["t4"].values())[:4] + [rand4[i] for i in range(4)]:
+    trm &= abs(float(np.sum(f ** 2)) - 6 * 64) < 1e-9
+for _ in range(8):
+    M = mat4(rng.choice([-1.0, 1.0], L4.nq))
+    invol &= bool(np.allclose(Dcol @ M @ Dcol, -M))
+Jgrid = np.linspace(0.0, float(sp.sqrt(sp.Rational(3, 8))), 25)
+flat = DATA["t4"][("stag", (1, 1, 1))]
+slack = max(Wm(flat, Jv)[0] - floorW(64, Jv) for Jv in Jgrid)
+viol = 0
+allf = ([ev for ev in DATA["t4"].values()] + [v for v in struct.values() if v is not None]
+        + list(rand4))
+for Jv in np.linspace(0.0, 1.5, 16):
+    fl = floorW(64, Jv)
+    viol += sum(1 for ev in allf if Wm(ev, Jv)[0] < fl - 1e-9)
+Wexact = sp.expand(32 * (2 * J - S6))
+print("  tr M^2 = 6V, D M D = -M for any field, so sum_occ eps^2 <= 3V and W(J) >=")
+print("  min_m [-sqrt(3 V m) + 2 J m] = -V sqrt(3/2) + J V for J <= sqrt(3/8) = %.6f,"
+      % np.sqrt(3.0 / 8.0))
+print("  and -3V/(8J) above it")
+check("D1 [exact] bipartite degree-6 premises: tr M^2 = 384 and D M D = -M",
+      trm and invol)
+check("D2 [exact] the 4^3 flat-twist staggered sea has W = %s and attains the floor "
+      "at every J_B <= sqrt(3/8): slack <= %.1e" % (sp.sstr(Wexact), slack),
+      slack <= 7e-15 and sp.simplify(Wexact - (64 * J - 32 * S6)) == 0)
+check("D3 [numerical, 1e-9] the floor holds for all %d fields at 16 values of J_B: "
+      "%d violations" % (len(allf), viol), viol == 0)
+
+print()
+print("=" * 62)
+print("E  HOW LONG EXACTLY HALF FILLING SURVIVES")
+print("=" * 62)
+
+
+def persist(key, V):
+    lo, hi = 0.0, 2.0
+    for _ in range(200):
+        mid = (lo + hi) / 2
+        if best(key, "stag", mid)[1] == V // 2:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+p4, p6, p8 = persist("t4", 64), persist("t6", 216), persist("t8", 512)
+gap4 = -flat[int(np.sum(flat < 0)) - 1] / 2
+check("E1 [exact] 4^3 half filled for J_B < 4 sqrt6 - 3 - 3 sqrt2 - sqrt3 = %.6f, and "
+      "< sqrt6/2 = %.6f within its own twist" % (p4, gap4),
+      abs(p4 - float(4 * S6 - 3 - 3 * S2 - S3)) < 1e-8 and abs(gap4 - float(S6) / 2) < 1e-9)
+check("E2 [numerical, 1e-8] 6^3 half filled for J_B < 2 sqrt3 - 3 = %.6f, 8^3 for "
+      "J_B < %.6f" % (p6, p8),
+      abs(p6 - float(2 * S3 - 3)) < 1e-8 and abs(p8 - 0.306846) < 1e-5)
+
+print()
+print("=" * 62)
+print("F  THE THERMODYNAMIC LIMIT [Bloch quadrature, L = 224]")
+print("=" * 62)
+
+
+def plain_levels(Lb):
+    c = 2 * np.cos(2 * np.pi * np.arange(Lb) / Lb)
+    return np.sort((c[:, None, None] + c[None, :, None] + c[None, None, :]).ravel())
+
+
+def pi_levels(Lb):
+    h = Lb // 2
+    c = np.cos(2 * np.pi * np.arange(h) / h)
+    s = np.sqrt(np.maximum(6 + 2 * (c[:, None, None] + c[None, :, None] + c[None, None, :]), 0)).ravel()
+    return np.sort(np.repeat(np.concatenate([-s, s]), 4))
+
+
+bl = 0.0
+for Lb, key in ((4, "t4"), (6, "t6"), (8, "t8")):
+    bl = max(bl, float(np.max(np.abs(plain_levels(Lb) - DATA[key][("plain", (0, 0, 0))]))),
+             float(np.max(np.abs(pi_levels(Lb) - DATA[key][("stag", (0, 0, 0))]))))
+check("F1 [numerical, 1e-9] Bloch 2 sum cos q_a and +-sqrt(6 + 2 sum cos q_a) match "
+      "real space at L = 4, 6, 8 to %.1e" % bl, bl < 1e-9)
+
+LB = 224
+pl, pim = plain_levels(LB), pi_levels(LB)
+
+
+def w_of(ev, Js):
+    cs = np.concatenate(([0.0], np.cumsum(ev)))
+    Js = np.asarray(Js, float)
+    m = np.searchsorted(ev, -2.0 * Js, "left")
+    return (cs[m] + 2.0 * Js * m) / len(ev), m / len(ev)
+
+
+JL = np.array([0.0, 0.4, 0.8654003, 1.2, float(S3), 3.0])
+wpv, npv = w_of(pl, JL)
+wmv, nmv = w_of(pim, JL)
+print("      J_B  |   w plain     n plain |    w stag      n stag | lower")
+for i, Jv in enumerate(JL):
+    print("  %8.6f | %10.7f %9.6f | %10.7f %9.6f | %s"
+          % (Jv, wpv[i], npv[i], wmv[i], nmv[i],
+             "stag" if wmv[i] < wpv[i] - 1e-12 else ("plain" if wpv[i] < wmv[i] - 1e-12 else "tie")))
+lo, hi = 0.0, float(S3)
+for _ in range(80):
+    mid = (lo + hi) / 2
+    if w_of(pim, np.array([mid]))[0][0] - w_of(pl, np.array([mid]))[0][0] < 0:
+        lo = mid
+    else:
+        hi = mid
+Jl = (lo + hi) / 2
+ns = w_of(pim, np.array([Jl]))[1][0]
+nq = w_of(pl, np.array([Jl]))[1][0]
+check("F2 [numerical] J_B* = %.7f +- 3e-6 in the limit, fillings %.4f staggered "
+      "and %.4f plain there" % (Jl, ns, nq),
+      abs(Jl - 0.8654003) < 3e-6 and abs(ns - 0.4417) < 5e-4 and abs(nq - 0.2521) < 5e-4)
+
+# The staggered band eps = -sqrt(6 + 2 sum_a cos q_a) vanishes at q = (pi, pi, pi)
+# and nowhere else, and near it 6 + 2 sum_a cos q_a = |k|^2 + O(|k|^4).  So for any
+# J_B > 0 the emptied set {|k| < 2 J_B} has positive measure: exactly half filling
+# survives only at J_B = 0, with 1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3.
+kk = sp.symbols("k1 k2 k3", real=True)
+ser = sp.series(6 + 2 * sum(sp.cos(sp.pi + k) for k in kk), kk[0], 0, 4).removeO()
+gapless = sp.simplify(ser - (kk[0] ** 2 + 2 * sp.cos(sp.pi + kk[1]) + 2 * sp.cos(sp.pi + kk[2]) + 4)
+                      ) == 0
+asym = [(0.5 - w_of(pim, np.array([Jv]))[1][0]) / (2.0 / (3 * np.pi ** 2) * Jv ** 3)
+        for Jv in (0.15, 0.2, 0.3)]
+n001 = w_of(pim, np.array([0.001]))[1][0]
+print("  (1/2 - n(J)) / ((2/(3 pi^2)) J^3) at J = 0.15, 0.2, 0.3: %.4f, %.4f, %.4f"
+      % (asym[0], asym[1], asym[2]))
+print("  at J = 0.001 the emptied ball |k| < 2J is finer than the grid: n = %.7f" % n001)
+check("F3 [exact + numerical] gapless at (pi, pi, pi), so any J_B > 0 dopes the sea: "
+      "1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3",
+      gapless and all(abs(a - 1.0) < 0.06 for a in asym) and n001 <= 0.5)
+check("F4 [exact] in the limit plain empties at J_B = 3 (bottom -6), staggered at "
+      "sqrt3 (bottom -2 sqrt3)",
+      abs(w_of(pl, np.array([3.0]))[1][0]) < 1e-12
+      and abs(w_of(pim, np.array([float(S3)]))[1][0]) < 1e-12
+      and w_of(pl, np.array([2.999]))[1][0] > 0 and w_of(pim, np.array([1.731]))[1][0] > 0)
+
+print()
+print("runtime %.1f s (budget %d s)" % (time.time() - T0, AUDIT_TIMEOUT_SEC))
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache: **the vacuum question is the value of one coefficient of the law.** The emergent-fermion law of PR #7834 lists the occupancy term `B_i` as a term type with no coefficient. Given any coefficient, `-J_B sum_i B_i = -J_B V + 2 J_B N` is a pure chemical potential (it commutes with every hop exactly; a single `B_i` does not). At `J_B = 0` the law's own ground state over **all record numbers and all flux sectors** is the half-filled staggered sea: exhaustively on the `2x2x2` cube, and on the `4^3` torus as a global minimiser over all `2^192` link-sign fields **and all fillings** by an extended Cauchy-Schwarz certificate for every `J_B <= sqrt(3/8)`. The empty lattice is the ground state iff `J_B/t >= 3` (the plain band bottom). Between, a partially filled sea that changes flux sector at `J_B* = sqrt3/2` exactly on `4^3` and `0.8654` in the thermodynamic limit. So the two branches PR #7879 names are the two ends of one interval, and PR #7874's "the filling is a supplied datum" sharpens to "`J_B/t` is the supplied datum, and the filling follows". No value is chosen.

- `docs/THE_VACUUM_QUESTION_IS_ONE_COEFFICIENT_OF_THE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md` (329 lines)
- `scripts/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.py` (`TOTAL: PASS=24 FAIL=0`, 4.5 s)
- `logs/runner-cache/the_vacuum_question_is_one_coefficient_of_the_law_check_2026_09_03.txt`

## Theorems

- **T1** the occupancy term is a pure chemical potential (exact Pauli-string commutation on four clusters; dense 16-dim check).
- **T2** at `J_B = 0` the global ground state is the half-filled sea (bipartite lemma `min_N E_N = E_{V/2}` for any sign field; cube exhaustive; `4^3` at the Cauchy-Schwarz floor; searches on `6^3`, `8^3`, `3x3x3`).
- **T3** the ground state as a function of `J_B` on `4^3` and in the limit, with the optimal twist changing with `J_B`.
- **T4** the crossover `J_B*` (exact `sqrt3/2` on `4^3`; `0.8654003` in the limit) and the emptying thresholds (`3` plain, `sqrt3` staggered).
- **T5** the extended certificate: `W(J) >= -V sqrt(3/2) + J V` for `J <= sqrt(3/8)` on any bipartite degree-6 field; the `4^3` sea attains it with zero slack.
- **T6** half-filling persistence windows on finite tori and the gapless limit (`1/2 - n(J_B) -> (2/(3 pi^2)) J_B^3`; a grid artefact at `J_B = 0.001` reported as unresolvable rather than asserted).

## Boundary

- Free hopping plus one declared diagonal term; finite clusters and converged quadrature; global minimality a theorem on two clusters only (`4^3` below `sqrt(3/8)`); no value of `J_B/t` is preferred, proposed or bounded by anything physical; the occupancy term is declared, not derived.

## Context

- Parents: PR #7874 (half-filling selection), PR #7879 (the vacuum question), PR #7834 (the law's term census). The independent vacuum panel of 2026-09-03 (five lenses, unanimous for the half-filled sea) treats this note as the statement that the empty vacuum needs an imported cost `J_B/t >= 3` while the sea costs nothing.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
