### PR TITLE
feat(matter): Lorentz invariance at the Dirac point and the taste census

### DIFF
--- a/docs/EMERGENT_LORENTZ_INVARIANCE_AT_THE_DIRAC_POINT_AND_THE_TASTE_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/EMERGENT_LORENTZ_INVARIANCE_AT_THE_DIRAC_POINT_AND_THE_TASTE_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,329 @@
+---
+claim_id: emergent_lorentz_invariance_dirac_point_taste_census
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, carrying one fermionic mode per coarse vertex, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2} of the landed staggered kinetic-form clause read on that lattice, free nearest-neighbour hopping only, and on the named finite grids and tori only: (T1) the minimal magnetic cell of that sign field is 2x2x1, four coarse sites, on which H4(Q)^2 = (6 + 2 cos Q1 + 2 cos Q2 + 2 cos 2Q3) I with tr H4 = 0 symbolically -- direction 3 carries one site per cell, so its hop is diagonal and enters squared as 4 cos^2 Q3 = 2 + 2 cos 2Q3 -- hence Q = (pi,pi,pi) is not a node, its spectrum being (-2,-2,2,2); E4 = 0 exactly when cos Q1 = cos Q2 = cos 2Q3 = -1, and an exhaustive 60^3 scan of the magnetic BZ finds exactly the two 4-fold touchings Q = (pi,pi,pi/2) and Q = (pi,pi,3pi/2); the 2x2x2 cell folds both onto q = (pi,pi,pi) as one 8-fold touching, its spectrum at (Q1,Q2,2Q3) being the union of the 2x2x1 spectra at Q3 and Q3 + pi at 3.6e-15. (T2) At q = (pi,pi,pi) the velocity matrices are M_a = dH/dp_a = -Gamma_a exactly, all speeds 1, and the chirality operator X = -i m1 m2 m3 with m_a = M_a/v_a has spectrum +1 fourfold and -1 fourfold: two right-handed and two left-handed Weyl fermions of two components each, N_f = 2 four-component Dirac fields, net chirality 0; each 2x2x1 node separately carries 1R + 1L with speeds (1,1,2) in that cell's coordinates; in the intertwiner branch U Gamma_a U^dag = -sigma_a (x) T the transported velocity matrices are exactly sigma_a (x) T, so X = I (x) T exactly and T = +1 is the two right-handed Weyl while T = -1 is the two left-handed, a branch swap exchanging only the labels; the coarse tori L = 4, 6, 8 carry 8, 0, 8 zero modes at 1e-9, matching 'q_a = 4 pi m / L hits pi iff 4 | L'. (T3) E(pi + p)^2 = sum_a (2 - 2 cos p_a) exactly, expanding as |p|^2 - (1/12) sum_a p_a^4 + (1/360) sum_a p_a^6 + O(p^8), so v = E/|p| = 1 - (|p|^2/24) sum_a nhat_a^4 + O(p^4) with no free parameter; the [100]/[111] velocity spread is |p|^2/36 + O(p^4) over |p| = 0.8, 0.4, 0.1, 0.05, 0.0125 with log-log anisotropy exponent 1.998; and U H(pi+p) U^dag = sum_a sin p_a (sigma_a (x) T) + sum_a (1 - cos p_a)(I (x) B_a) to 4e-16, the taste-mixing term being O(p^2) and commuting with every spin generator. (T4) P(q)_{ss'} = delta_{ss'}/2 - H(q)_{ss'}/(2E(q)) has every entry with popcount(s XOR s') != 1 identically zero and P_ss = 1/2, so P_vu = 0 exactly whenever v - u has other than exactly one odd component; on a 288^3 cell-momentum grid the surviving entries satisfy |P_vu| |r|^3 -> (4/pi^2)|nhat_a| = 0.405285 |nhat_a|, with axis ratios 1.0049, 1.0024, 1.0019 at n = 41, 61, 81 and stride-subsampled shell means 0.21145, 0.20353, 0.20213 over 6 <= |r| <= 24, 30 <= |r| <= 50 and 60 <= |r| <= 90 against same-sample prediction means 0.21018, 0.20340, 0.20202, both falling to the sphere average 2/pi^2 = 0.202642. (T5) On the 8^3 coarse torus with one antiperiodic direction and on the 6^3 periodic torus, P_vv = 1/2 at every site and sum_{u != v} P_vu^2 = P_vv - P_vv^2 = 1/4 at 1e-15, and det [[P_vv, P_vu],[P_uv, P_uu]] <= P_uu P_vv on all 262144 ordered pairs with zero excess; on the 8^3 periodic torus the eight zero modes make half filling ambiguous -- proj(E < 0) has rank 252 and P_vv = 252/512 -- and that is reported, not used. Nothing here is derived from any axiom, no axiom is amended, no status is set, and no hypothesis is adopted."
+upstream_dependencies: []
+runner: scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py
+---
+
+# Emergent Lorentz invariance at the Dirac point, and the taste census
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py`](../scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.txt`](../logs/runner-cache/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+A staggered sign field on the coarse lattice `2Z^3` has a gapless point. What sits at that point is the question here, and it has three parts: how
+many touchings the sign field really has and how many modes each carries; whether the modes disperse at one speed in every direction; and whether the
+equal-time correlations they produce carry the coefficient a free massless Dirac field would carry. All three close on named finite grids and tori.
+Along the way one reading of the eight-mode cell is corrected -- not its arithmetic, which stands, but the names attached to the factors.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact and named-grid theorems about the free coarse-lattice staggered hopping: the magnetic cell and its two nodes, the chirality census of the zero modes, the exact dispersion and its single isotropic velocity, the equal-time propagator's exact selection identity and its continuum coefficient, and the projector sum rule with negative association. Groups A-C are symbolic or exhaustive where tagged exact; the tagged numerical items are floating-point evaluations at the stated tolerance on the grids named."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question this note does not decide: whether any clause supplies a mass term, and what the fine-lattice hopping pattern does to the isotropy."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. Groups `A`-`C` are exact where tagged --
+symbolic identities in `sympy`, integer and `Z[i]` matrix arithmetic at zero tolerance, exhaustive scan -- and the items tagged `[numerical]` are
+floating-point evaluations, at the stated tolerance, on the grids and tori named.
+
+1. `T1` (`A`). The magnetic cell of the sign field and the two nodes it carries, and their folding onto one 8-fold touching.
+2. `T2` (`B`). The chirality census of the zero modes, and the relabelling of the eight-mode cell that follows from it.
+3. `T3` (`C`). The exact dispersion at the node, the `-1/12`, the single isotropic velocity and the `|p|^2/36` spread.
+4. `T4` (`D`). The equal-time propagator: an exact selection identity, and the free massless Dirac coefficient.
+5. `T5` (`E`). The projector sum rule and Pauli repulsion in the records.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Kawamoto-Smit staggering, the Dirac-Kahler spin-taste basis, the Nielsen-Ninomiya counting and
+the free massless Dirac equal-time propagator are standard methodology; every object is redeclared here and the runner recomputes every statement. No
+observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency
+weight:
+
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): the coarse lattice, the `Cl(6)`
+  cell algebra, the intertwiner `U` with `T = diag(1,1,-1,-1)`, and the `2 A1 + 2 T1` content of its Theorem 4. Pointer only; the cell algebra and `U`
+  are redeclared below and rebuilt by this runner from scratch.
+- `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md`: the kinetic-form clause and the corner-structure clause quoted below.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four axioms quoted in "Setting". No grade of theirs is cited and no hypothesis is adopted.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full
+one-site possibility domain has algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule,
+covariant under lattice translations and proper cubic rotations", and "For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions." **Record**: "Records form", "a record locks exactly one admissible local
+possibility", "records are permanent", "Only records are readable."
+
+The landed kinetic clause read on the coarse lattice is, verbatim:
+
+> **Kinetic-form clause.** Within the declared kinetic class (the naive-Dirac kinetic form on nearest-neighbor `Z^3` links, made
+> compatible with the matter-statistics clause by site-local spin diagonalization), the kinetic operator is the staggered operator
+> `D = (1/2) Σ_{x,μ} η_μ(x) (χ̄_{x+μ̂} χ_x − χ̄_x χ_{x+μ̂})` with the Kawamoto-Smit phases `η_1 = 1, η_2(x) = (−1)^{x_1},
+> η_3(x) = (−1)^{x_1+x_2}`, unique as a local Z2 gauge class.
+
+and its corner-structure clause reads:
+
+> **Corner-structure clause.** The free staggered operator has the
+> 8-element BZ-corner (taste-cube) doubler set, decomposing uniquely
+> by Hamming weight as `1 + 3 + 3 + 1`; the hw=1 triplet carries an
+> exact irreducible `M_3(C)` algebra (translations + `C_3[111]`)
+> with no proper exact quotient.
+
+Everything below reads that sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, free nearest-neighbour hopping only.
+Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras and no graded clause is used anywhere.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the
+KS sign field on it, the magnetic cells, the cell algebra and the intertwiner. `P1` (`A`) is the magnetic cell and its two nodes; `P2` (`B`) the
+chirality census; `P3` (`C`) the exact dispersion and the velocity; `P4` (`D`) the equal-time projector, its selection identity and its coefficient;
+`P5` (`E`) the sum rule and negative association. `P3`, `P4` use `P1`'s node; `P2`, `P3` share `P0`'s intertwiner. Scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; the **KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`,
+`eta_3(v) = (-1)^{v_1+v_2}`, the clause's phases read in coarse coordinates. The hopping matrix is `H_{wv} = eta_a(v)` on each coarse bond and zero otherwise,
+hermitian, no on-site term.
+
+A **magnetic cell** is a block of coarse vertices on which the sign field is periodic, so that Bloch's theorem applies with that block as unit cell;
+`H(Q)` denotes the corresponding block matrix and `E(Q)` its positive eigenvalue branch. A **node** is a `Q` with `E(Q) = 0`. The **velocity
+matrices** at a node are `M_a = dH/dp_a` there; the **speeds** are `v_a = sqrt((M_a M_a)_{11})`, the **chirality operator** is `X = -i m_1 m_2 m_3`
+with `m_a = M_a / v_a`, and a zero mode is **right-handed** when `X = +1` and **left-handed** when `X = -1`. On a `2x2x2` cell the algebra is
+
+```text
+Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3),  Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3),  T = diag(1,1,-1,-1),  B = (XX, XY, XZ)
+H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a],   U Gamma_a U^dag = -sigma_a (x) T,   U Xi_a U^dag = I (x) B_a
+```
+
+with `U` rebuilt here by Clifford averaging over the `64` words of the generated group. The **equal-time projector** of the half-filled sea is
+`P = proj(E < 0)`, whose Bloch form is `P(q) = (1/2)(I - H(q)/E(q))`; `P_vu` is its coarse-real-space matrix element and `r = v - u`, `nhat = r/|r|`.
+
+## Theorem 1 -- the magnetic cell has two nodes, and they fold onto one
+
+**Conclusion.** For the KS sign field on `2Z^3`:
+
+1. The minimal magnetic cell is `2x2x1`, four coarse sites, and there `H4(Q)^2 = (6 + 2 cos Q_1 + 2 cos Q_2 + 2 cos 2Q_3) I` with `tr H4 = 0`: two
+   doubly degenerate bands `+- E4`.
+2. Direction `3` carries one coarse site per cell, so its hop is diagonal and enters squared, `4 cos^2 Q_3 = 2 + 2 cos 2Q_3`. Hence `Q = (pi, pi, pi)`
+   is **not** a node of the `4x4`: its spectrum there is `(-2, -2, 2, 2)`.
+3. `E4 = 0` exactly when `cos Q_1 = cos Q_2 = cos 2Q_3 = -1`, so there are exactly two nodes in the magnetic BZ, `Q = (pi, pi, pi/2)` and
+   `Q = (pi, pi, 3pi/2)`, each a 4-fold touching. An exhaustive `60^3` scan finds these and no others.
+4. Taking a `2x2x2` cell instead folds both onto the single point `q = (pi, pi, pi)`: the `8x8` spectrum at `(Q_1, Q_2, 2Q_3)` is the union of the
+   `2x2x1` spectra at `Q_3` and `Q_3 + pi`, and the folded point is one 8-fold touching.
+
+**Proof.** Items 1 and 2 are symbolic identities in the three cell momenta, the `4x4` square and trace expanded term by term against the hopping rules
+and the double-angle identity checked in closed form. Item 3 is the observation that each of the three terms is bounded below by `-2`, so the sum
+vanishes only when all three saturate, together with an exhaustive scan of a `60^3` grid over the magnetic BZ and an eigenvalue count at each hit.
+Item 4 evaluates both cells at matched momenta over `60` random points, `[numerical, 1e-11]`, and counts the kernel dimension at the folded point.
+Items 1-3 exact.
+
+**Reading, not theorem.** The alternating signs repeat over a block of four sites, not eight, and that block has two places where the spectrum closes
+rather than one. Writing the same field on the larger block puts both places on top of each other. The larger block is convenient but it is not where
+the touchings are; the count of modes is the same either way.
+
+## Theorem 2 -- the chirality census, and what the eight modes are
+
+**Conclusion.**
+
+1. At `q = (pi, pi, pi)` on the `2x2x2` cell the velocity matrices are `M_a = -Gamma_a` **exactly**, all three speeds are `1`, and the chirality
+   operator has spectrum `+1` fourfold and `-1` fourfold. The eight zero modes are two right-handed and two left-handed Weyl fermions of two
+   components each: `N_f = 2` four-component Dirac fields, net chirality `0`, as Nielsen-Ninomiya requires.
+2. Each `2x2x1` node separately carries `1R + 1L`, with speeds `(1, 1, 2)` in that cell's coordinates. The two nodes together are `2R + 2L`, the same
+   vector-like `N_f = 2`.
+3. In the intertwiner branch `U Gamma_a U^dag = -sigma_a (x) T` the transported velocity matrices are exactly `sigma_a (x) T`, so `X = I (x) T`
+   **exactly** and `H(pi + p) = sum_a p_a (sigma_a (x) T) + O(p^2)`. `T = +1` is the two right-handed Weyl (`det v = +1`) and `T = -1` the two
+   left-handed (`det v = -1`); the other branch exchanges the two labels and nothing else, so the relative assignment is branch-independent.
+4. The coarse tori `L = 4, 6, 8` carry `8, 0, 8` zero modes, exactly the count from `q_a = 4 pi m / L` reaching the node value `pi` precisely when
+   `4 | L`.
+
+**Conclusion, relabelling.** PR #7844's reading of the eight-mode cell as "a two-component spin and a four-component taste label" factors `8 = 2 x 4`.
+The census factors the same `8` as `2` (Weyl components) `x 2` (chiralities) `x 2` (tastes). The multiplicities are unchanged, the `Cl(6)` structure
+is unchanged, and the `2 A1 + 2 T1` decomposition of that note's Theorem 4 is unchanged; what changes is the name of the four-dimensional factor. Its
+`T` grading is the chirality, not an internal quantum number, so the physical taste multiplicity is `2` and not `4`, and the field content is
+`N_f = 2` four-component Dirac fields rather than four of anything.
+
+**Proof.** Item 1's `M_a = -Gamma_a` is a symbolic differentiation of the `8x8` Bloch matrix followed by an exact comparison over `Z[i]` at
+`q = (pi, pi, pi)`; the speeds and the spectrum of `X` follow from the `Cl(6)` relations and are evaluated exactly. Item 2 builds each `2x2x1` node's
+velocity matrices by the same differentiation and reads the census, `[numerical, 1e-12]`. Item 3 rebuilds `U` on both branches by Clifford averaging,
+verifies both intertwining relations and the transported `M_a` at zero tolerance, and reads `X = I (x) T` as an exact matrix identity; the handedness
+is the sign of the determinant of the `3x3` velocity matrix on each two-dimensional spin block. Item 4 diagonalises the three tori directly, `[numerical, 1e-9]`, against the momentum-grid
+count. The relabelling is item 3 read back: nothing is recomputed for it.
+
+**Reading, not theorem.** The eight states at the closing point split into two mirror-image halves, one turning one way and one the other, and each
+half is itself doubled. Counting the halves as a single four-way label hides the mirror. Counted properly there are two copies of one particle, each
+copy carrying its own left and right halves, and the two copies are otherwise identical. The arithmetic that produced the four was right; the four was
+a chirality pair times a genuine pair, not four of one thing.
+
+## Theorem 3 -- one velocity, and where isotropy first fails
+
+**Conclusion.**
+
+1. `E(pi + p)^2 = sum_a (2 - 2 cos p_a)` exactly, with expansion `|p|^2 - (1/12) sum_a p_a^4 + (1/360) sum_a p_a^6 + O(p^8)`. The `O(p^2)` term is
+   exactly isotropic and the leading anisotropy is the unique quartic cubic invariant with coefficient exactly `-1/12`.
+2. Hence `v(nhat, |p|) = E/|p| = 1 - (|p|^2/24) sum_a nhat_a^4 + O(p^4)`: one velocity `v -> 1` in every direction, for every taste and both
+   chiralities, with no free parameter anywhere in the statement.
+3. The `[100]`/`[111]` velocity spread is `|p|^2/36 + O(p^4)`, tabulated at `|p| = 0.8, 0.4, 0.1, 0.05, 0.0125`, with log-log anisotropy exponent
+   `1.998` against the exact value `2`.
+4. `U H(pi + p) U^dag = sum_a sin p_a (sigma_a (x) T) + sum_a (1 - cos p_a)(I (x) B_a)` to `4e-16`. The taste-mixing second sum is `O(p^2)` and
+   commutes with every spin generator -- a spin singlet -- so it does not enter the velocity at leading order.
+
+**Proof.** Items 1 and 2 are `sympy` identities: the closed form of `E^2` at the shifted momentum, its series in a scale parameter along a fixed
+direction, and the resulting series for `E/|p|` on the unit sphere, each residual reported as exactly zero. Item 3 evaluates the exact dispersion
+along three directions and fits the spread, `[numerical]`. Item 4 compares the transported Bloch matrix against the closed form over random momenta at
+three scales, `[numerical, 4e-16]`, and checks the commutator of each `I (x) B_a` with each spin generator at zero tolerance.
+
+**Reading, not theorem.** Near the point where the spectrum closes, the matter travels at one speed in every direction, and it comes in two matched
+copies of the same four-part particle, a left-handed and a right-handed half each. Nothing was tuned to make the speed the same along an axis and
+along a diagonal; it comes out that way from the alternating signs alone. The first place the directions differ is small and known: the difference
+between axis and diagonal grows like the square of the momentum, with the fixed factor `1/36`.
+
+## Theorem 4 -- the equal-time propagator is the free massless Dirac one
+
+**Conclusion.**
+
+1. Every entry of `Xi_a` and `Gamma_a` whose row and column differ in other than exactly one bit vanishes, and their diagonals vanish. Hence
+   `P(q)_{ss'} = delta_{ss'}/2 - H(q)_{ss'}/(2E(q))` is identically zero off the one-odd-component set, and `P_{ss} = 1/2`. So `P_vu = 0` **exactly**
+   whenever `r = v - u` has zero or two or three odd components: an identity of the projector at every momentum, not an asymptotic statement.
+2. On the surviving set, with `a` the unique odd component, `|P_vu| |r|^3 -> (4/pi^2) |nhat_a| = 0.405285 |nhat_a|`. On a `288^3` cell-momentum grid
+   the axis ratios `|P| n^3 pi^2/4` along `(n,0,0)` are `1.0049`, `1.0024`, `1.0019` at `n = 41, 61, 81`.
+3. Stride-subsampled shell means of `|P_vu| |r|^3` are `0.21145`, `0.20353`, `0.20213` over `6 <= |r| <= 24`, `30 <= |r| <= 50` and `60 <= |r| <= 90`,
+   against same-sample means of the prediction `(4/pi^2)|nhat_a|` of `0.21018`, `0.20340`, `0.20202`. Both fall to the sphere average
+   `2/pi^2 = 0.202642`. The landed `d^-3` value `0.21` is the finite-`|r|` value of this same law, not a different one.
+
+**Proof.** Item 1 is an entrywise check of the six generators over all `64` index pairs at zero tolerance, together with the definition of `P(q)`.
+Items 2 and 3 evaluate `P` per momentum on a half-shifted `288^3` grid of cell momenta -- a grid that misses the node exactly -- by one inverse FFT
+per surviving cell-index pair, so no `V x V` object is ever formed; the shells are enumerated with the strides `1`, `2`, `3` recorded in the runner.
+`[numerical]` throughout, on the grid named.
+
+**Reading, not theorem.** The pattern of odds around a particle falls off as the inverse cube of distance with the coefficient a free Dirac field
+would give. It is exactly zero in most directions -- not small, zero -- and where it is not zero it is fixed in size by nothing but the distance and
+the direction. Nothing was fitted to reach that number; it is what the nearest-neighbour hop with the alternating signs produces on its own.
+
+## Theorem 5 -- the sum rule and Pauli repulsion in the records
+
+**Conclusion.** On the `8^3` coarse torus with one antiperiodic direction, which lifts the eight zero modes and leaves an exact half-filled projector,
+and on the `6^3` periodic torus:
+
+1. `P_vv = 1/2` at every site and `sum_{u != v} P_vu^2 = P_vv - P_vv^2 = 1/4` exactly, at `1e-15`. The number variance of the whole torus is zero:
+   perfect screening.
+2. `det [[P_vv, P_vu],[P_uv, P_uu]] <= P_uu P_vv` on all `262144` ordered pairs, with maximum excess exactly `0`. The record process is negatively
+   associated -- repulsive, Pauli.
+3. On the `8^3` **periodic** torus the eight zero modes make half filling ambiguous: `proj(E < 0)` has rank `252` and `P_vv = 252/512` uniformly, so
+   the sum rule closes at `0.2499390` rather than `1/4` while the projector identity itself still holds at `4.4e-16`. That torus is reported here and
+   is not used for the `1/4`.
+
+**Proof.** Direct diagonalisation of each torus hopping matrix, projection onto the negative-energy subspace, and evaluation of the identities
+entrywise. `[numerical, 1e-15]` for items 1 and 2, `[numerical]` for item 3's rank and value. The largest object formed is `512 x 512`.
+
+**Reading, not theorem.** Fill every state below zero and the sites are each half occupied, with the fluctuation in the total exactly cancelled, and two
+sites are never more likely to be occupied together than apart. That is what fermions do, and it is here with no statistics assumption added: it
+follows from the filled sea being a projector.
+
+## Corollary -- what the staggered sector's low-energy content is
+
+Within the setting declared above, on the grids and tori named, and for free hopping only:
+
+1. The low-energy content of the coarse-lattice staggered sector is **two tastes of one four-component Dirac field**, with a single isotropic velocity
+   and a free massless Dirac equal-time propagator: contact with known physics at the level of the free Dirac field, and at that level only.
+2. The content is **vector-like**: net chirality `0` at every node and in total, as Nielsen-Ninomiya requires on a lattice.
+3. PR #7844's multiplicities stand unchanged; its four-dimensional factor is a chirality pair times a taste pair, so the physical taste multiplicity
+   is `2`.
+
+**What this is not.** No chiral sector: the content is vector-like and nothing here produces a chiral one. No generations from tastes: `N_f = 2` is two
+identical copies of one field, with no distinguishing quantum number, no mass splitting and no label attached here. Not a proof of Lorentz symmetry of
+correlators: what is shown is the isotropy of the one-particle dispersion and one equal-time kernel, with no dynamics attached, and boost covariance of
+interacting correlators is untouched. Coarse lattice only: the fine `(4,2,2)` pattern's tetragonal anisotropy is not examined here.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice and the sign field are declared objects and the theorems are about them.
+- No update rule, formation site, rate, coupling, mass, or absolute unit appears, and no dynamical clause is supplied.
+- No corner of the taste cube is identified with any named species; the relabelling names none either.
+
+## Interfaces named for other lanes, not moved here
+
+- **The fine-lattice anisotropy.** The velocity statement is proved for the coarse hopping. The fine `(4,2,2)` role pattern is tetragonal, and what
+  its encoded hopping does to the `|p|^2/36` spread is not examined here. A lane wanting isotropy on the fine lattice must supply it.
+- **Interactions.** Only free hopping is compared; a four-fermion term could move the velocity and either coefficient, and nothing here bounds that.
+- **A mass term.** The spectrum is exactly gapless at the node and no clause quoted here supplies a mass; that is the next lane's question.
+- **The chiral sector.** Absent, by corollary item 2; a lane wanting chiral matter must break the pairing, and nothing here says how.
+
+## Remaining live routes
+
+1. Larger grids and other tori. The `288^3` momentum grid and the tori `4^3`, `6^3`, `8^3` are what is used; nothing is claimed beyond.
+2. Subleading structure. Only the leading `|r|^-3` coefficient is measured, and only the projector's two-point content is examined.
+3. The `8^3` periodic torus. Its zero modes leave half filling ambiguous; a lane wanting the `1/4` there must fix the filling.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one mode per coarse vertex, KS signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, free nearest-neighbour hopping; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+cell_algebra: Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3), Xi = (X_1, Z_1 X_2, Z_1 Z_2 X_3), T = diag(1,1,-1,-1), B = (XX, XY, XZ); H(q) = sum_a [(1 + cos q_a) Xi_a + sin q_a Gamma_a]; U Gamma_a U^dag = -sigma_a (x) T, U Xi_a U^dag = I (x) B_a, rebuilt by Clifford averaging
+magnetic_cell_and_nodes: minimal cell 2x2x1; H4^2 = (6 + 2cos Q1 + 2cos Q2 + 2cos 2Q3) I, tr H4 = 0; (pi,pi,pi) not a node, spectrum (-2,-2,2,2); exactly two 4-fold nodes (pi,pi,pi/2) and (pi,pi,3pi/2) by exhaustive 60^3 scan; 2x2x2 cell folds both onto q = (pi,pi,pi), 8-fold, union of spectra at 3.6e-15
+census: M_a = -Gamma_a exactly, speeds 1, X = -i m1 m2 m3 spectrum +1 x4 / -1 x4 = 2R + 2L Weyl = N_f = 2 four-component Dirac, net chirality 0; each 2x2x1 node 1R + 1L, speeds (1,1,2); X = I (x) T exactly, T = +1 right-handed, T = -1 left-handed, branch swap exchanges labels only; tori L = 4, 6, 8 carry 8, 0, 8 zero modes
+relabelling: landed 8 = 2 (spin) x 4 (taste) reads here as 8 = 2 (Weyl) x 2 (chiralities) x 2 (tastes); multiplicities and 2 A1 + 2 T1 unchanged; physical taste multiplicity 2
+dispersion: E(pi+p)^2 = sum_a (2 - 2cos p_a) exactly = |p|^2 - (1/12) sum p_a^4 + (1/360) sum p_a^6 + O(p^8); v = 1 - (|p|^2/24) sum nhat_a^4 + O(p^4), no free parameter; [100]/[111] spread = |p|^2/36, log-log exponent 1.998; Dirac form to 4e-16, taste-mixing O(p^2) and a spin singlet
+propagator: P(q)_{ss'} = delta/2 - H(q)_{ss'}/(2E) zero off the one-odd-component set exactly, P_ss = 1/2; |P_vu| |r|^3 -> (4/pi^2)|nhat_a| = 0.405285|nhat_a|; axis ratios 1.0049, 1.0024, 1.0019 at n = 41, 61, 81 on 288^3; shell means 0.21145, 0.20353, 0.20213 vs same-sample prediction 0.21018, 0.20340, 0.20202 -> 2/pi^2 = 0.202642; landed 0.21 is the finite-|r| value
+sum_rule: 8^3 with one antiperiodic direction and 6^3 periodic: P_vv = 1/2, sum_{u != v} P_vu^2 = P_vv - P_vv^2 = 1/4 at 1e-15; negative association on all 262144 ordered pairs, max excess 0; 8^3 periodic has 8 zero modes, rank 252, P_vv = 252/512, reported not used
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=18 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on the **coarse** lattice `2Z^3` only, for **free nearest-neighbour hopping** only. Nothing is claimed for the fine lattice
+`Z^3`, for infinite lattices, or beyond the `60^3` scan grid, the `288^3` cell-momentum grid and the tori `4^3`, `6^3`, `8^3` named above. The `288^3`
+grid is a half-shifted grid of cell momenta, which misses the node exactly; the shell means are stride-subsampled with the strides `1`, `2`, `3`
+recorded in the runner, so they are means over a declared sample of separations and not over every separation in the shell.
+
+The `-1/12` and the `4/pi^2` are properties of **this** hop: the nearest-neighbour `pi`-flux hopping with the KS signs and no other term. They are not
+properties of the framework, of any dynamical clause, or of any interacting theory. No coefficient, coupling, mass, rate or unit appears anywhere, and
+no clause quoted here selects the half-filled sea whose projector Theorem 5 uses; that filling is a declared object.
+
+The chirality assignment of Theorem 2 item 3 is stated in one intertwiner branch. The other branch exchanges the labels `T = +1` and `T = -1`; only
+the relative assignment -- that the two `T` eigenspaces carry opposite chirality with two Weyl components each -- is used, and only that is
+branch-independent. The relabelling corrects a **reading** of PR #7844, not any number in it: every multiplicity, spectrum and representation content
+of that note stands.
+
+Theorem 5's `1/4` requires an exactly half-filled projector; on the `8^3` periodic torus the eight zero modes prevent that, and the result there is
+reported as ambiguous, not used.
+
+## Review record
+
+An honest auditor should come away with: a corrected count of where the coarse staggered spectrum closes, two nodes and not one, with the same eight
+modes either way; a chirality census making those modes two tastes of one four-component Dirac field, vector-like, the four-dimensional factor of the
+landed spin-taste reading resolved into a chirality pair times a taste pair; an exact dispersion, isotropic at leading order with no free parameter and
+first anisotropic at `|p|^2/36`; an equal-time propagator with an exact selection identity and the coefficient `4/pi^2`; and a projector sum rule with
+negative association where half filling is exact. Deliberately not decided: whether any clause supplies a mass, what the fine lattice does to the
+isotropy, and whether interactions preserve any of it. The ambiguous torus is flagged not used, and the shells' stride subsampling is declared.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the three
+context notes in "Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache
+pair closing at `PASS=18 FAIL=0`, runtime under the declared `120` seconds, stdout under `5500` characters, a current zero-dependency citation-manifest
+entry, and passing pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.txt
+++ b/logs/runner-cache/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py
+runner_sha256: 69e98ed65db6467409067249a6521a4a319454a91edfe8ff334bc1e5a98e1a60
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 3.88
+status: ok
+----- stdout -----
+--- A  magnetic cell ---
+PASS A1 [exact, sympy] the 2x2x1 magnetic cell (4 coarse sites) has H4(Q)^2 = (6 + 2cosQ1 + 2cosQ2 + 2cos2Q3) I and tr H4 = 0: two doubly degenerate bands +-E4
+PASS A2 [exact] direction 3 has one site per cell, so its hop is diagonal and enters squared: 4cos^2 Q3 = 2 + 2cos 2Q3.  Q = (pi,pi,pi) is NOT a node: spectrum [-2.,-2., 2., 2.]
+PASS A3 [exact + exhaustive 60^3 scan] E4 = 0 iff cosQ1 = cosQ2 = cos2Q3 = -1: exactly TWO nodes, Q = (pi,pi,pi/2) and (pi,pi,3pi/2), each 4-fold (degeneracies [4, 4])
+PASS A4 [numerical, 1e-11] the 2x2x2 cell folds both onto q = (pi,pi,pi): its spectrum at (Q1,Q2,2Q3) is the union of the 2x2x1 spectra at Q3, Q3+pi (dev 3.6e-15), one 8-fold touching
+
+--- B  chirality census ---
+PASS B1 [exact, sympy] at q = (pi,pi,pi), M_a = dH/dp_a = -Gamma_a exactly, speeds all 1, X = -i m1 m2 m3 spectrum +1 x4, -1 x4: 2R + 2L Weyl (2 components each) = N_f = 2 four-component Dirac fields, net chirality 0 (Nielsen-Ninomiya)
+PASS B2 [numerical, 1e-12] each 2x2x1 node is a 4-component Dirac point, 1R + 1L, speeds (1,1,2) in that cell's coordinates; the two are 2R + 2L, the same vector-like N_f = 2
+  node (cell)              speeds                   chi+ chi-
+  (pi,pi,pi/2) 2x2x1       (1.0000,1.0000,2.0000)    2    2
+  (pi,pi,3pi/2) 2x2x1      (1.0000,1.0000,2.0000)    2    2
+  (pi,pi,pi) 2x2x2         (1.0000,1.0000,1.0000)    4    4
+PASS B3 [exact] in the branch U Gamma_a U^dag = -sigma_a x T the transported M_a are exactly sigma_a x T, so H(pi+p) = sum_a p_a (sigma_a x T) + O(p^2) (res/|p|^2 -> 0.49) and X = I x T EXACTLY: T = +1 is two RIGHT-handed Weyl (det v = +1), T = -1 two LEFT-handed (det v = -1), a branch swap only exchanging the labels
+  RELABELLING: the landed 'two-component spin x four-component taste' counts 8 = 2 x 4;
+  the census reads the same 8 as 2 (Weyl) x 2 (chiralities) x 2 (tastes), same multiplicities.
+PASS B4 [numerical, 1e-9] tori L = 4, 6, 8 carry 8, 0, 8 zero modes: the cell momenta q_a = 4 pi m / L hit pi iff 4 | L, and then all 8 modes of the touching are on the grid
+
+--- C  one velocity ---
+PASS C1 [exact, sympy] E(pi+p)^2 = sum_a (2 - 2 cos p_a) exactly (residual 0), expanding as |p|^2 - (1/12) sum_a p_a^4 + (1/360) sum_a p_a^6 + O(p^8): the O(p^2) term is exactly isotropic, the leading anisotropy the unique quartic cubic invariant with coefficient EXACTLY -1/12
+PASS C2 [exact, sympy] hence v = E/|p| = 1 - (|p|^2/24) sum_a nhat_a^4 + O(p^4): ONE velocity v -> 1 in every direction, every taste, both chiralities, no free parameter (unit-sphere residual to O(p^2): 0)
+  |p|     v[100]      v[110]      v[111]      spread      36 spread/|p|^2
+  0.8000  0.97354586  0.98671990  0.99113478  1.7589e-02  0.98938
+  0.4000  0.99334665  0.99667000  0.99777926  4.4326e-03  0.99734
+  0.1000  0.99958339  0.99979168  0.99986112  2.7773e-04  0.99983
+  0.0500  0.99989584  0.99994792  0.99996528  6.9442e-05  0.99996
+  0.0125  0.99999349  0.99999674  0.99999783  4.3403e-06  1.00000
+PASS C3 [numerical] the [100]/[111] spread is |p|^2/36 + O(p^4) (max rel dev 1.06e-02), log-log anisotropy exponent 1.9978 [exact 2]: isotropy fails only at relative order p^2
+PASS C4 [numerical, 4e-16] U H(pi+p) U^dag = sum_a sin p_a (sigma_a x T) + sum_a (1 - cos p_a)(I x B_a) to 4.1e-16; the taste-mixing term is O(p^2) (norm/|p|^2 -> 0.50) and commutes with every spin generator -- a singlet, so it does not touch the velocity
+
+--- D  propagator ---
+PASS D1 [exact] every entry of Xi_a, Gamma_a with popcount(s XOR s') != 1 vanishes, so P(q)_{ss'} = delta/2 - H(q)_{ss'}/(2E) is identically zero off the one-odd-component set and P_ss = 1/2: the selection rule is an identity of the projector, not asymptotics
+  |P_vu| |r|^3, 288^3 grid, stride-subsampled shells
+  shell |r|  measured   mean (4/pi^2)|nhat_a|  pairs
+  6-24       0.21145    0.21018                2994
+  30-50      0.20353    0.20340                2718
+  60-90      0.20213    0.20202                4137
+PASS D2 [numerical, 288^3 momentum grid] |P_vu| |r|^3 -> (4/pi^2)|nhat_a| = 0.405285 |nhat_a|: axis ratios 1.0049, 1.0024, 1.0019 at n = 41, 61, 81, approaching 1 with |r|
+PASS D3 [numerical] each shell mean tracks the mean of (4/pi^2)|nhat_a| over the same separations, both falling to the sphere average 2/pi^2 = 0.202642 (measured 0.21145 -> 0.20353 -> 0.20213): free massless Dirac in 3 spatial dimensions; the landed 0.21 is the finite-|r| value of that law
+
+--- E  sum rule ---
+  torus                    V zero P_vv       sum rule       max excess
+  8^3 antiperiodic x_3   512    0 0.5000000  0.2500000000   0.0e+00
+  6^3 periodic           216    0 0.5000000  0.2500000000   0.0e+00
+  8^3 periodic           512    8 0.4921875  0.2499389648   0.0e+00
+PASS E1 [numerical, 1e-15] on the 8^3 torus with one antiperiodic direction (zero modes lifted, an exact half-filled projector) P_vv = 1/2 at every site (dev 1.0e-15) and sum_{u != v} P_vu^2 = P_vv - P_vv^2 = 1/4 exactly (dev 6.7e-16): Var N = 0, perfect screening.  6^3 periodic gives the same 1/4
+PASS E2 [numerical] negative association det[[P_vv,P_vu],[P_uv,P_uu]] <= P_uu P_vv on all 262144 ordered pairs, max excess 0.0e+00: the record process is repulsive, Pauli
+PASS E3 [numerical, reported as ambiguous] on the 8^3 PERIODIC torus the zero modes make half filling ambiguous: proj(E < 0) has rank 252, P_vv = 252/512, and the sum rule closes at 0.2499390, not 1/4 (identity dev 4.4e-16).  Reported, not used
+
+TOTAL: PASS=18 FAIL=0   runtime 3.5 s
+
+----- stderr -----
+

--- a/scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py
+++ b/scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""Emergent Lorentz invariance at the Dirac point, and the taste census.
+
+Self-contained finite-cluster runner.  The object is the coarse-lattice
+staggered sector already on the table: the coarse lattice 2Z^3, one
+fermionic mode per coarse vertex, and the Kawamoto-Smit (KS) link sign
+field
+
+    eta_1 = 1,  eta_2(v) = (-1)^{v_1},  eta_3(v) = (-1)^{v_1+v_2}
+
+read on it.  The cell algebra of the landed pi-flux-sector note is
+redeclared here and recomputed: Gamma = (Y1, Z1 Y2, Z1 Z2 Y3),
+Xi = (X1, Z1 X2, Z1 Z2 X3), T = diag(1,1,-1,-1), B = (XX, XY, XZ), and
+the Clifford-averaging intertwiner U with U Gamma_a U^dag = -sigma_a (x) T,
+U Xi_a U^dag = I (x) B_a.  Nothing is imported from the repository.
+
+  A  THE MAGNETIC CELL AND THE NODES.  The minimal magnetic cell of the KS
+     sign field is 2x2x1 (four coarse sites), where H4(Q)^2 =
+     (6 + 2 cos Q1 + 2 cos Q2 + 2 cos 2Q3) I and tr H4 = 0.  Direction 3
+     carries one site per cell, so its hop is diagonal and enters squared:
+     Q = (pi,pi,pi) is NOT a node.  E4 = 0 at exactly two points of the
+     magnetic BZ; the 2x2x2 cell folds both onto q = (pi,pi,pi), 8-fold.
+  B  THE CHIRALITY CENSUS.  With m_a = M_a/v_a, M_a = dH/dp_a at the node,
+     X = -i m1 m2 m3 grades the zero modes.  Each 2x2x1 node carries
+     1R + 1L; the folded node carries 2R + 2L.  Net chirality 0, N_f = 2
+     four-component Dirac fields, vector-like.  M_a = -Gamma_a exactly and
+     X = I (x) T exactly in the intertwiner basis.
+  C  ONE VELOCITY.  E(pi+p)^2 = sum_a (2 - 2 cos p_a) exactly; the
+     expansion is |p|^2 - (1/12) sum p_a^4 + (1/360) sum p_a^6 + O(p^8), so
+     v = 1 - (|p|^2/24) sum nhat_a^4 + O(p^4): one velocity, no free
+     parameter, with the leading anisotropy at relative order p^2.
+  D  THE EQUAL-TIME PROPAGATOR.  P(q) = (1/2)(I - H(q)/E(q)) vanishes
+     identically off the one-odd-component set, an identity of the
+     projector; the surviving coefficient |P_vu| |r|^3 -> (4/pi^2)|nhat_a|,
+     the free massless Dirac value in three spatial dimensions.
+  E  SUM RULE AND PAULI REPULSION.  sum_{u!=v} P_vu^2 = P_vv - P_vv^2 = 1/4
+     on the half-filled tori, and det P_uv <= P_uu P_vv on every pair.
+
+Groups A-C are exact where tagged [exact]: sympy symbolic identities,
+integer and Z[i] matrix arithmetic at zero tolerance, exhaustive scan.  The
+items tagged [numerical] are floating-point evaluations at the stated
+tolerance.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import time
+
+import numpy as np
+import sympy as sp
+
+AUDIT_TIMEOUT_SEC = 120
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================================ KS sign field
+
+
+def eta_ks(v, a):
+    """KS link sign of the coarse bond (v, v + e_a); axes 0,1,2 = 1,2,3."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+# ======================================================== the cell algebra
+
+I2 = np.eye(2, dtype=complex)
+SX = np.array([[0, 1], [1, 0]], dtype=complex)
+SY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+SZ = np.diag([1, -1]).astype(complex)
+
+
+def kr(*ms):
+    o = np.array([[1.0 + 0j]])
+    for m in ms:
+        o = np.kron(o, m)
+    return o
+
+
+XI = [kr(SX, I2, I2), kr(SZ, SX, I2), kr(SZ, SZ, SX)]
+GAM = [kr(SY, I2, I2), kr(SZ, SY, I2), kr(SZ, SZ, SY)]
+SIX = GAM + XI
+TT = np.diag([1, 1, -1, -1]).astype(complex)
+BB = [kr(SX, SX), kr(SX, SY), kr(SX, SZ)]
+SIG = [SX, SY, SZ]
+
+
+def cell_sites(cell):
+    return list(itertools.product(*(range(c) for c in cell)))
+
+
+def bloch_cell(Q, cell, deriv=None):
+    """Bloch block of the KS hopping on a magnetic cell of the given extents."""
+    sites = cell_sites(cell)
+    idx = {v: i for i, v in enumerate(sites)}
+    H = np.zeros((len(sites), len(sites)), dtype=complex)
+    for v in sites:
+        for a in range(3):
+            w = list(v)
+            w[a] += 1
+            d = [0, 0, 0]
+            if w[a] >= cell[a]:
+                w[a] -= cell[a]
+                d[a] = 1
+            w = tuple(w)
+            ph = np.exp(-1j * sum(Q[b] * d[b] for b in range(3)))
+            f = (-1j * d[deriv]) if deriv is not None else 1.0
+            c = eta_ks(v, a) * ph * f
+            H[idx[w], idx[v]] += c
+            H[idx[v], idx[w]] += np.conj(c)
+    return H
+
+
+def bloch_cell_sym(Q, cell):
+    """Symbolic version of `bloch_cell`, exact in the cell momenta."""
+    sites = cell_sites(cell)
+    idx = {v: i for i, v in enumerate(sites)}
+    H = sp.zeros(len(sites), len(sites))
+    for v in sites:
+        for a in range(3):
+            w = list(v)
+            w[a] += 1
+            d = [0, 0, 0]
+            if w[a] >= cell[a]:
+                w[a] -= cell[a]
+                d[a] = 1
+            w = tuple(w)
+            ph = sp.exp(-sp.I * sum(Q[b] * d[b] for b in range(3)))
+            H[idx[w], idx[v]] += eta_ks(v, a) * ph
+            H[idx[v], idx[w]] += eta_ks(v, a) * sp.conjugate(ph)
+    return H
+
+
+def bloch8(q):
+    """The 2x2x2-cell Bloch block in closed Cl(6) form."""
+    return sum((1 + np.cos(q[a])) * XI[a] + np.sin(q[a]) * GAM[a] for a in range(3))
+
+
+print("--- A  magnetic cell ---")
+
+# ---- A1 the 2x2x1 magnetic cell, symbolically -----------------------------
+Qs = sp.symbols("Q1 Q2 Q3", real=True)
+H4s = bloch_cell_sym(Qs, (2, 2, 1))
+f4 = 6 + 2 * sp.cos(Qs[0]) + 2 * sp.cos(Qs[1]) + 2 * sp.cos(2 * Qs[2])
+sq4_ok = sp.simplify(sp.expand_trig(sp.expand(H4s * H4s)) - f4 * sp.eye(4)) == sp.zeros(4, 4)
+tr4_ok = sp.simplify(H4s.trace()) == 0
+check(
+    "A1 [exact, sympy] the 2x2x1 magnetic cell (4 coarse sites) has H4(Q)^2 = "
+    "(6 + 2cosQ1 + 2cosQ2 + 2cos2Q3) I and tr H4 = 0: two doubly degenerate bands +-E4",
+    sq4_ok and tr4_ok,
+)
+
+# ---- A2 direction 3 enters squared: (pi,pi,pi) is not a node --------------
+ev_ppp = np.linalg.eigvalsh(bloch_cell((np.pi,) * 3, (2, 2, 1)))
+diag3 = sp.simplify(sp.expand_trig(4 * sp.cos(Qs[2]) ** 2 - (2 + 2 * sp.cos(2 * Qs[2])))) == 0
+check(
+    "A2 [exact] direction 3 has one site per cell, so its hop is diagonal and enters "
+    "squared: 4cos^2 Q3 = 2 + 2cos 2Q3.  Q = (pi,pi,pi) is NOT a node: spectrum %s"
+    % np.array2string(np.round(ev_ppp.real, 12), separator=","),
+    diag3 and abs(abs(ev_ppp).min() - 2.0) < 1e-12,
+)
+
+# ---- A3 exhaustive scan: exactly two nodes --------------------------------
+NS = 60
+g = 2 * np.pi * np.arange(NS) / NS
+F = (
+    6
+    + 2 * np.cos(g)[:, None, None]
+    + 2 * np.cos(g)[None, :, None]
+    + 2 * np.cos(2 * g)[None, None, :]
+)
+hits = [(g[i], g[j], g[k]) for i, j, k in zip(*np.where(F < 1e-9))]
+nodes4 = [(np.pi, np.pi, np.pi / 2), (np.pi, np.pi, 3 * np.pi / 2)]
+scan_ok = len(hits) == 2 and all(
+    any(max(abs(np.array(h) - np.array(nd))) < 1e-9 for nd in nodes4) for h in hits
+)
+deg4 = [
+    int(np.sum(np.abs(np.linalg.eigvalsh(bloch_cell(nd, (2, 2, 1)))) < 1e-12))
+    for nd in nodes4
+]
+check(
+    "A3 [exact + exhaustive %d^3 scan] E4 = 0 iff cosQ1 = cosQ2 = cos2Q3 = -1: exactly "
+    "TWO nodes, Q = (pi,pi,pi/2) and (pi,pi,3pi/2), each 4-fold (degeneracies %s)"
+    % (NS, deg4),
+    scan_ok and deg4 == [4, 4],
+)
+
+# ---- A4 the 2x2x2 cell folds both nodes onto one point --------------------
+rng = np.random.default_rng(20260903)
+maxdev = 0.0
+for _ in range(60):
+    Q = rng.uniform(0, 2 * np.pi, 3)
+    q = (Q[0], Q[1], 2 * Q[2])
+    s8 = np.sort(np.linalg.eigvalsh(bloch_cell(q, (2, 2, 2))))
+    sA = np.linalg.eigvalsh(bloch_cell(Q, (2, 2, 1)))
+    sB = np.linalg.eigvalsh(bloch_cell((Q[0], Q[1], Q[2] + np.pi), (2, 2, 1)))
+    maxdev = max(maxdev, float(np.abs(s8 - np.sort(np.concatenate([sA, sB]))).max()))
+    maxdev = max(maxdev, float(np.abs(bloch_cell(q, (2, 2, 2)) - bloch8(q)).max()))
+z8 = int(np.sum(np.abs(np.linalg.eigvalsh(bloch8((np.pi,) * 3))) < 1e-12))
+check(
+    "A4 [numerical, 1e-11] the 2x2x2 cell folds both onto q = (pi,pi,pi): its spectrum at "
+    "(Q1,Q2,2Q3) is the union of the 2x2x1 spectra at Q3, Q3+pi (dev %.1e), one %d-fold "
+    "touching" % (maxdev, z8),
+    maxdev < 1e-11 and z8 == 8,
+)
+
+print()
+print("--- B  chirality census ---")
+
+
+def census(Mlist):
+    """(speeds, spectrum of X = -i m1 m2 m3) for velocity matrices M_a."""
+    v = [float(np.sqrt(np.real((M @ M)[0, 0]))) for M in Mlist]
+    m = [Mlist[a] / v[a] for a in range(3)]
+    return v, np.linalg.eigvalsh(-1j * m[0] @ m[1] @ m[2])
+
+
+# ---- B1 M_a = -Gamma_a exactly, and the 8-fold node is 2R + 2L ------------
+qs = sp.symbols("q1 q2 q3", real=True)
+H8s = bloch_cell_sym(qs, (2, 2, 2))
+GS = [sp.Matrix(8, 8, lambda i, j: sp.nsimplify(GAM[a][i, j])) for a in range(3)]
+exact_M = all(
+    sp.simplify(sp.diff(H8s, qs[a]).subs({qs[b]: sp.pi for b in range(3)}) + GS[a])
+    == sp.zeros(8, 8)
+    for a in range(3)
+)
+M8 = [-GAM[a] for a in range(3)]
+v8, x8 = census(M8)
+nR8 = int(np.sum(x8 > 0.5))
+nL8 = int(np.sum(x8 < -0.5))
+check(
+    "B1 [exact, sympy] at q = (pi,pi,pi), M_a = dH/dp_a = -Gamma_a exactly, speeds all 1, "
+    "X = -i m1 m2 m3 spectrum +1 x%d, -1 x%d: %dR + %dL Weyl (2 components each) = N_f = %d "
+    "four-component Dirac fields, net chirality %d (Nielsen-Ninomiya)"
+    % (nR8, nL8, nR8 // 2, nL8 // 2, (nR8 + nL8) // 4, (nR8 - nL8) // 2),
+    exact_M and nR8 == 4 and nL8 == 4 and max(abs(x - 1) for x in v8) < 1e-12,
+)
+
+# ---- B2 each 2x2x1 node is 1R + 1L, speeds (1,1,2) -----------------------
+rows4 = []
+for nd in nodes4:
+    M4 = [bloch_cell(nd, (2, 2, 1), deriv=a) for a in range(3)]
+    v4, x4 = census(M4)
+    rows4.append((nd, v4, int(np.sum(x4 > 0.5)), int(np.sum(x4 < -0.5))))
+check(
+    "B2 [numerical, 1e-12] each 2x2x1 node is a 4-component Dirac point, 1R + 1L, speeds "
+    "(1,1,2) in that cell's coordinates; the two are 2R + 2L, the same vector-like N_f = 2",
+    all(r[2] == 2 and r[3] == 2 for r in rows4)
+    and all(abs(r[1][0] - 1) < 1e-12 and abs(r[1][2] - 2) < 1e-12 for r in rows4),
+)
+print("  %-24s %-24s %4s %4s" % ("node (cell)", "speeds", "chi+", "chi-"))
+for nd, v4, nr, nl in rows4:
+    print("  %-24s (%.4f,%.4f,%.4f) %4d %4d"
+          % ("(pi,pi,%s) 2x2x1" % ("pi/2" if nd[2] < 3 else "3pi/2"),
+             v4[0], v4[1], v4[2], nr, nl))
+print("  %-24s (%.4f,%.4f,%.4f) %4d %4d"
+      % ("(pi,pi,pi) 2x2x2", v8[0], v8[1], v8[2], nR8, nL8))
+
+# ---- B3 X = I (x) T exactly, and the relabelling -------------------------
+def targets(sg):
+    return [sg * np.kron(SIG[a], TT) for a in range(3)] + [np.kron(I2, BB[a]) for a in range(3)]
+
+
+def averaging_intertwiner(N):
+    pg, pn = {}, {}
+    for m in range(64):
+        gg = np.eye(8, dtype=complex)
+        nn = np.eye(8, dtype=complex)
+        for k in range(6):
+            if (m >> k) & 1:
+                gg = gg @ SIX[k]
+                nn = nn @ N[k]
+        pg[m] = gg.conj().T
+        pn[m] = nn
+    for r in range(8):
+        for c in range(8):
+            M = np.zeros((8, 8), dtype=complex)
+            M[r, c] = 1
+            U = sum(pn[m] @ M @ pg[m] for m in range(64))
+            if abs(np.linalg.det(U)) > 1e-6:
+                return U
+    return None
+
+
+UEX = {}
+for sg in (1, -1):
+    U = averaging_intertwiner(targets(sg))
+    UEX[sg] = U / np.sqrt((U @ U.conj().T)[0, 0].real)
+Um = UEX[-1]
+tG = [np.kron(SIG[a], TT) for a in range(3)]
+tB = [np.kron(I2, BB[a]) for a in range(3)]
+Xu = -1j * tG[0] @ tG[1] @ tG[2]
+X_is_T = np.array_equal(np.round(Xu.real).astype(int), np.kron(I2, TT).real.astype(int)) and (
+    np.abs(Xu - np.kron(I2, TT)).max() < 1e-12
+)
+# transported velocity matrices on each branch, and det of the 2x2 Weyl block
+detrows = {}
+for sg in (1, -1):
+    UM = [UEX[sg] @ M8[a] @ UEX[sg].conj().T for a in range(3)]
+    per = []
+    for tsign, sel in ((+1, [0, 1]), (-1, [2, 3])):
+        pick = np.ix_([s * 4 + sel[0] for s in range(2)], [s * 4 + sel[0] for s in range(2)])
+        Ms = [UM[a][pick] for a in range(3)]
+        vmat = np.array(
+            [[np.real(np.trace(Ms[a] @ SIG[b])) / 2 for b in range(3)] for a in range(3)]
+        )
+        per.append((tsign, float(np.linalg.det(vmat))))
+    detrows[sg] = per
+branch_indep = detrows[1][0][1] * detrows[1][1][1] < 0 and detrows[-1][0][1] * detrows[-1][1][1] < 0
+inter_ok = all(
+    np.abs(UEX[sg] @ SIX[k] @ UEX[sg].conj().T - targets(sg)[k]).max() == 0.0
+    for sg in (1, -1)
+    for k in range(6)
+)
+trans_ok = all(
+    np.abs(UEX[-1] @ M8[a] @ UEX[-1].conj().T - tG[a]).max() == 0.0 for a in range(3)
+)
+lin = 0.0
+for _ in range(60):
+    n = rng.normal(size=3)
+    n /= np.linalg.norm(n)
+    p = 1e-4 * n
+    lin = max(
+        lin,
+        float(
+            np.abs(
+                Um @ bloch8(np.pi + p) @ Um.conj().T - sum(p[a] * tG[a] for a in range(3))
+            ).max()
+        )
+        / 1e-8,
+    )
+check(
+    "B3 [exact] in the branch U Gamma_a U^dag = -sigma_a x T the transported M_a are exactly "
+    "sigma_a x T, so H(pi+p) = sum_a p_a (sigma_a x T) + O(p^2) (res/|p|^2 -> %.2f) and "
+    "X = I x T EXACTLY: T = +1 is two RIGHT-handed Weyl (det v = %+.0f), T = -1 two LEFT-handed "
+    "(det v = %+.0f), a branch swap only exchanging the labels"
+    % (lin, detrows[-1][0][1], detrows[-1][1][1]),
+    inter_ok
+    and trans_ok
+    and X_is_T
+    and branch_indep
+    and detrows[-1][0][1] > 0
+    and detrows[-1][1][1] < 0
+    and lin < 10,
+)
+print("  RELABELLING: the landed 'two-component spin x four-component taste' counts 8 = 2 x 4;"
+      "\n  the census reads the same 8 as 2 (Weyl) x 2 (chiralities) x 2 (tastes), same multiplicities.")
+
+# ---- B4 torus zero-mode counts ------------------------------------------
+def ks_matrix(L, twist=None):
+    sites = list(itertools.product(range(L), repeat=3))
+    idx = {v: i for i, v in enumerate(sites)}
+    M = np.zeros((len(sites), len(sites)))
+    for v in sites:
+        for a in range(3):
+            w = list(v)
+            wrapped = (w[a] + 1 == L)
+            w[a] = (w[a] + 1) % L
+            w = tuple(w)
+            e = eta_ks(v, a) * (-1 if (wrapped and a == twist) else 1)
+            M[idx[w], idx[v]] += e
+            M[idx[v], idx[w]] += e
+    return M, sites, idx
+
+
+tor = []
+for L in (4, 6, 8):
+    M, _, _ = ks_matrix(L)
+    nz = int(np.sum(np.abs(np.linalg.eigvalsh(M)) < 1e-9))
+    tor.append((L, nz, 8 if L % 4 == 0 else 0))
+check(
+    "B4 [numerical, 1e-9] tori L = 4, 6, 8 carry %d, %d, %d zero modes: the cell momenta "
+    "q_a = 4 pi m / L hit pi iff 4 | L, and then all 8 modes of the touching are on the grid"
+    % tuple(t[1] for t in tor),
+    all(t[1] == t[2] for t in tor) and [t[1] for t in tor] == [8, 0, 8],
+)
+
+print()
+print("--- C  one velocity ---")
+
+ps = sp.symbols("p1 p2 p3", real=True)
+E2 = sum(2 - 2 * sp.cos(ps[a]) for a in range(3))
+E2res = sp.simplify(6 + 2 * sum(sp.cos(sp.pi + ps[a]) for a in range(3)) - E2)
+lam = sp.symbols("lam", positive=True)
+ns = sp.symbols("n1 n2 n3", real=True)
+ser = sp.expand(sp.series(E2.subs({ps[a]: lam * ns[a] for a in range(3)}), lam, 0, 8).removeO())
+quart = sum(n ** 4 for n in ns)
+c2_ok = sp.simplify(ser.coeff(lam, 2) - sum(n ** 2 for n in ns)) == 0
+c4_ok = sp.simplify(ser.coeff(lam, 4) + quart / 12) == 0
+c6_ok = sp.simplify(ser.coeff(lam, 6) - sum(n ** 6 for n in ns) / 360) == 0
+check(
+    "C1 [exact, sympy] E(pi+p)^2 = sum_a (2 - 2 cos p_a) exactly (residual %s), expanding as "
+    "|p|^2 - (1/12) sum_a p_a^4 + (1/360) sum_a p_a^6 + O(p^8): the O(p^2) term is exactly "
+    "isotropic, the leading anisotropy the unique quartic cubic invariant with coefficient "
+    "EXACTLY -1/12" % sp.simplify(E2res),
+    E2res == 0 and c2_ok and c4_ok and c6_ok,
+)
+
+sub = {ns[2]: sp.sqrt(1 - ns[0] ** 2 - ns[1] ** 2)}
+vsym = sp.simplify(
+    sp.series(sp.sqrt(sp.expand(ser.subs(sub))) / lam, lam, 0, 3).removeO()
+)
+vdiff = sp.simplify(sp.expand(vsym - (1 - lam ** 2 * quart.subs(sub) / 24)))
+check(
+    "C2 [exact, sympy] hence v = E/|p| = 1 - (|p|^2/24) sum_a nhat_a^4 + O(p^4): ONE velocity "
+    "v -> 1 in every direction, every taste, both chiralities, no free parameter (unit-sphere "
+    "residual to O(p^2): %s)" % vdiff,
+    vdiff == 0,
+)
+
+
+def vel(nhat, pm):
+    p = pm * np.asarray(nhat, dtype=float)
+    return float(np.sqrt(sum(2 - 2 * np.cos(p[a]) for a in range(3))) / pm)
+
+
+dirs = (
+    np.array([1.0, 0, 0]),
+    np.array([1.0, 1, 0]) / np.sqrt(2),
+    np.array([1.0, 1, 1]) / np.sqrt(3),
+)
+print("  %-7s %-11s %-11s %-11s %-11s %s"
+      % ("|p|", "v[100]", "v[110]", "v[111]", "spread", "36 spread/|p|^2"))
+tab = []
+for pm in (0.8, 0.4, 0.1, 0.05, 0.0125):
+    vs = [vel(d, pm) for d in dirs]
+    spread = max(vs) - min(vs)
+    tab.append((pm, spread))
+    print(
+        "  %-7.4f %-11.8f %-11.8f %-11.8f %-11.4e %.5f"
+        % (pm, vs[0], vs[1], vs[2], spread, spread * 36 / pm ** 2)
+    )
+expo = float(np.polyfit(np.log([t[0] for t in tab]), np.log([t[1] for t in tab]), 1)[0])
+rel = max(abs(t[1] - t[0] ** 2 / 36) / (t[0] ** 2 / 36) for t in tab)
+check(
+    "C3 [numerical] the [100]/[111] spread is |p|^2/36 + O(p^4) (max rel dev %.2e), log-log "
+    "anisotropy exponent %.4f [exact 2]: isotropy fails only at relative order p^2"
+    % (rel, expo),
+    abs(expo - 2.0) < 5e-3 and rel < 3e-2,
+)
+
+form_dev = 0.0
+mix = []
+for pm in (0.4, 0.1, 0.05):
+    mx = mm = 0.0
+    for _ in range(40):
+        n = rng.normal(size=3)
+        n /= np.linalg.norm(n)
+        p = pm * n
+        lhs = Um @ bloch8(np.pi + p) @ Um.conj().T
+        rhs = sum(np.sin(p[a]) * tG[a] + (1 - np.cos(p[a])) * tB[a] for a in range(3))
+        mx = max(mx, float(np.abs(lhs - rhs).max()))
+        mm = max(mm, float(np.abs(sum((1 - np.cos(p[a])) * tB[a] for a in range(3))).max()))
+    form_dev = max(form_dev, mx)
+    mix.append((pm, mm / pm ** 2))
+SPIN = [np.kron(SIG[b], np.eye(4)) for b in range(3)]
+singlet = all(
+    np.abs(tB[a] @ SPIN[b] - SPIN[b] @ tB[a]).max() == 0.0
+    for a in range(3)
+    for b in range(3)
+)
+check(
+    "C4 [numerical, 4e-16] U H(pi+p) U^dag = sum_a sin p_a (sigma_a x T) + sum_a "
+    "(1 - cos p_a)(I x B_a) to %.1e; the taste-mixing term is O(p^2) (norm/|p|^2 -> %.2f) and "
+    "commutes with every spin generator -- a singlet, so it does not touch the velocity"
+    % (form_dev, mix[-1][1]),
+    form_dev < 1e-13 and singlet and abs(mix[-1][1] - 0.5) < 0.02,
+)
+
+print()
+print("--- D  propagator ---")
+
+# ---- D1 the exact selection identity -------------------------------------
+sel_ok = True
+for s in range(8):
+    for t in range(8):
+        pc = bin(s ^ t).count("1")
+        if pc == 1:
+            continue
+        for a in range(3):
+            if XI[a][s, t] != 0 or GAM[a][s, t] != 0:
+                sel_ok = False
+check(
+    "D1 [exact] every entry of Xi_a, Gamma_a with popcount(s XOR s') != 1 vanishes, so "
+    "P(q)_{ss'} = delta/2 - H(q)_{ss'}/(2E) is identically zero off the one-odd-component set "
+    "and P_ss = 1/2: the selection rule is an identity of the projector, not asymptotics",
+    sel_ok,
+)
+
+
+def kernel_blocks(NC):
+    """|P_{s,0}(dR)| on an NC^3 half-shifted cell-momentum grid, per momentum."""
+    qa = 2 * np.pi * (np.arange(NC) + 0.5) / NC
+    q1 = qa[:, None, None]
+    q2 = qa[None, :, None]
+    q3 = qa[None, None, :]
+    E = np.sqrt(6 + 2 * (np.cos(q1) + np.cos(q2) + np.cos(q3)))
+    cq = (np.cos(q1), np.cos(q2), np.cos(q3))
+    sq = (np.sin(q1), np.sin(q2), np.sin(q3))
+    out = {}
+    for s, a in ((4, 0), (2, 1), (1, 2)):
+        coef = (1 + cq[a]) * XI[a][s, 0] + sq[a] * GAM[a][s, 0]
+        out[s] = np.abs(np.fft.ifftn(-coef / (2 * E)))
+        del coef
+    del E, cq, sq
+    return out
+
+
+def shells(blk):
+    """Per-shell (measured mean, predicted mean, count) and the axis ratios."""
+    means = []
+    for lo, hi, step in ((6, 24, 1), (30, 50, 2), (60, 90, 3)):
+        vals, pred = [], []
+        for s in (4, 2, 1):
+            a = {4: 0, 2: 1, 1: 2}[s]
+            for dR in itertools.product(range(0, hi // 2 + 1, step), repeat=3):
+                r = np.array([2 * dR[b] + ((s >> (2 - b)) & 1) for b in range(3)], dtype=float)
+                rn = float(np.linalg.norm(r))
+                if rn < lo or rn > hi:
+                    continue
+                vals.append(blk[s][dR] * rn ** 3)
+                pred.append((4 / np.pi ** 2) * abs(r[a]) / rn)
+        means.append((lo, hi, float(np.mean(vals)), float(np.mean(pred)), len(vals)))
+    ratios = [
+        (n, float(blk[4][((n - 1) // 2, 0, 0)] / ((4 / np.pi ** 2) / n ** 3)))
+        for n in (41, 61, 81)
+    ]
+    return means, ratios
+
+
+C0 = 4 / np.pi ** 2
+NC = 288
+blk = kernel_blocks(NC)
+means, ratios = shells(blk)
+del blk
+print("  |P_vu| |r|^3, %d^3 grid, stride-subsampled shells" % NC)
+print("  %-10s %-10s %-22s %s" % ("shell |r|", "measured", "mean (4/pi^2)|nhat_a|", "pairs"))
+for lo, hi, m, pr, n in means:
+    print("  %-10s %-10.5f %-22.5f %d" % ("%d-%d" % (lo, hi), m, pr, n))
+far = means[2][2]
+check(
+    "D2 [numerical, %d^3 momentum grid] |P_vu| |r|^3 -> (4/pi^2)|nhat_a| = %.6f |nhat_a|: "
+    "axis ratios %.4f, %.4f, %.4f at n = 41, 61, 81, approaching 1 with |r|"
+    % (NC, C0, ratios[0][1], ratios[1][1], ratios[2][1]),
+    all(abs(r - 1) < 0.01 for _, r in ratios),
+)
+check(
+    "D3 [numerical] each shell mean tracks the mean of (4/pi^2)|nhat_a| over the same "
+    "separations, both falling to the sphere average 2/pi^2 = %.6f (measured %.5f -> %.5f -> "
+    "%.5f): free massless Dirac in 3 spatial dimensions; the landed 0.21 is the "
+    "finite-|r| value of that law" % (2 / np.pi ** 2, means[0][2], means[1][2], far),
+    abs(far - 2 / np.pi ** 2) < 5e-3
+    and means[0][2] > means[1][2] > far
+    and all(abs(m - pr) < 3e-3 for _, _, m, pr, _ in means),
+)
+
+print()
+print("--- E  sum rule ---")
+
+
+def projector(L, twist=None):
+    M, sites, _ = ks_matrix(L, twist)
+    ev, W = np.linalg.eigh(M)
+    nz = int(np.sum(np.abs(ev) < 1e-9))
+    neg = W[:, ev < -1e-9]
+    return neg @ neg.T, nz
+
+
+print("  %-21s %4s %4s %-10s %-14s %s"
+      % ("torus", "V", "zero", "P_vv", "sum rule", "max excess"))
+res = {}
+for tag, L, tw in (
+    ("8^3 antiperiodic x_3", 8, 2),
+    ("6^3 periodic", 6, None),
+    ("8^3 periodic", 8, None),
+):
+    P, nz = projector(L, tw)
+    V = L ** 3
+    diag = np.diag(P)
+    lhs = (P ** 2).sum(axis=1) - diag ** 2
+    sr = float(np.abs(lhs - (diag - diag ** 2)).max())
+    outer = np.outer(diag, diag)
+    worst = float(((outer - P ** 2) - outer).max())
+    res[tag] = (V, nz, diag, lhs, sr, worst, int(round(float(np.trace(P)))))
+    print("  %-21s %4d %4d %-10.7f %-14.10f %.1e" % (tag, V, nz, diag[0], lhs[0], worst))
+
+V, nz, diag, lhs, sr, worst, rk = res["8^3 antiperiodic x_3"]
+check(
+    "E1 [numerical, 1e-15] on the 8^3 torus with one antiperiodic direction (zero modes "
+    "lifted, an exact half-filled projector) P_vv = 1/2 at every site (dev %.1e) and "
+    "sum_{u != v} P_vu^2 = P_vv - P_vv^2 = 1/4 exactly (dev %.1e): Var N = 0, perfect "
+    "screening.  6^3 periodic gives the same 1/4"
+    % (float(np.abs(diag - 0.5).max()), sr),
+    float(np.abs(diag - 0.5).max()) < 1e-13
+    and sr < 1e-13
+    and abs(lhs[0] - 0.25) < 1e-13
+    and res["6^3 periodic"][4] < 1e-13
+    and abs(res["6^3 periodic"][3][0] - 0.25) < 1e-13,
+)
+check(
+    "E2 [numerical] negative association det[[P_vv,P_vu],[P_uv,P_uu]] <= P_uu P_vv on all %d "
+    "ordered pairs, max excess %.1e: the record process is repulsive, Pauli" % (V * V, worst),
+    worst <= 1e-14,
+)
+Vp, nzp, diagp, lhsp, srp, worstp, rkp = res["8^3 periodic"]
+check(
+    "E3 [numerical, reported as ambiguous] on the 8^3 PERIODIC torus the zero modes make half "
+    "filling ambiguous: proj(E < 0) has rank %d, P_vv = %d/%d, and the sum rule closes at "
+    "%.7f, not 1/4 (identity dev %.1e).  Reported, not used" % (rkp, rkp, Vp, lhsp[0], srp),
+    srp < 1e-11 and rkp == 252 and abs(diagp[0] - 252 / 512) < 1e-12,
+)
+
+print()
+print("TOTAL: PASS=%d FAIL=%d   runtime %.1f s" % (PASS, FAIL, time.time() - T0))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache on the low-energy content of the coarse-lattice staggered sector: **two tastes of one four-component Dirac field, vector-like, with a single isotropic velocity and a free massless Dirac equal-time propagator.** It settles a reading question raised on PR #7844 during the vacuum panel: the 2x2x1 magnetic cell has band function `H4^2 = (6 + 2 cos Q1 + 2 cos Q2 + 2 cos 2Q3) I` with exactly two 4-fold nodes, which the 2x2x2 cell folds onto its single 8-fold point, so the landed count of eight is right and the four-dimensional factor of "spin(2) x taste(4)" is a chirality pair times a taste pair (`X = -i m1 m2 m3 = I x T` exactly): `8 = 2 (Weyl) x 2 (chiralities) x 2 (tastes)`, net chirality zero.

- `docs/EMERGENT_LORENTZ_INVARIANCE_AT_THE_DIRAC_POINT_AND_THE_TASTE_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (329 lines)
- `scripts/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.py` (`TOTAL: PASS=18 FAIL=0`, 3.7 s)
- `logs/runner-cache/emergent_lorentz_invariance_at_the_dirac_point_and_the_taste_census_check_2026_09_03.txt`

## Theorems

- **T1** the magnetic cell and its two nodes (exact band function; exhaustive scan; the folding identity).
- **T2** the chirality census: `2R + 2L` Weyl, `N_f = 2` four-component Dirac, vector-like (Nielsen-Ninomiya); the relabelling of PR #7844's factorisation (a correction of reading, not of any number); torus zero-mode counts 8, 0, 8 from `4 | L`.
- **T3** the exact dispersion `E(pi+p)^2 = |p|^2 - (1/12) sum p_a^4 + (1/360) sum p_a^6 + O(p^8)`: one velocity `v -> 1` in every direction, every taste, both chiralities, no free parameter; the leading anisotropy is the unique quartic cubic invariant, spread `|p|^2/36`; the taste-mixing term is `O(p^2)` and a spin singlet.
- **T4** the propagator: `P_vu = 0` exactly off the one-odd-component set (an identity of the projector), and `|P_vu| |r|^3 -> (4/pi^2)|nhat_a|`, the free massless Dirac equal-time kernel in three spatial dimensions, matched to `0.1 %` at `|r| = 60` to `90` on a `288^3` momentum grid.
- **T5** the sum rule `sum_{u != v} P_vu^2 = 1/4` (perfect screening) and negative association on all pairs (Pauli repulsion visible in the records), where half filling is exact; the `8^3` periodic torus's zero modes reported as ambiguous and not used.

## What this is not

- No chiral sector; no generations from tastes (`N_f = 2` identical copies); not a proof of Lorentz symmetry of correlators (isotropy of the one-particle dispersion and one equal-time kernel only); coarse lattice only (the fine `(4,2,2)` pattern's tetragonal anisotropy is not examined). The `-1/12` and `4/pi^2` are properties of the nearest-neighbour pi-flux hop.

## Context

- Parent: `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (PR #7844; a clarifying comment is posted there). The landed staggered-gate corner-structure clause is quoted verbatim.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03); ranked first by the vacuum panel's next-lanes list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
