### PR TITLE
feat(readout): support conditions confine groups of shifting records

### DIFF
--- a/docs/SUPPORT_CONDITIONS_CONFINE_GROUPS_OF_SHIFTING_RECORDS_ENERGY_COSTS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/SUPPORT_CONDITIONS_CONFINE_GROUPS_OF_SHIFTING_RECORDS_ENERGY_COSTS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,325 @@
+---
+claim_id: support_conditions_confine_shifting_record_groups
+claim_type: bounded_theorem
+claim_scope: "On three declared finite objects -- (a) the cubic lattice Z^3 with nearest-neighbour adjacency, exhaustively over every fixed polycube up to n = 6 records and the whole reachable set of each; (b) the 2x2x2 cube graph (8 corners, 12 edge sites, 6 faces) with qubits on the EDGE sites, ordinary composition, the superfast encoding and the corner parity dictionary n_v = (1 - B_v)/2, over all 4096 record patterns; and (c) the coarse L^3 torus carrying one-particle hopping with Kogut-Susskind staggered (pi-flux) link signs, unit amplitude, unit spacing and coordination 6, at L = 6 and L = 8 for two records -- under TWO STIPULATED SUPPORT CONDITIONS and THREE STIPULATED TICK MODELS declared here in full and derived from nothing: C_comp, every record has at least one adjacent record; C_rig, every pair of records adjacent now stays adjacent (with an isometry form); K1, one record shifts one site per tick, uniformly over the admissible shifts; KS, every member shifts at once, under a STRICT or a PERMISSIVE occupancy convention; KT, the pre-record amplitude runs for a time tau and the odds are its weights conditioned on the admissible set -- PR #7889's M2 registration with a support condition in place of that note's energy cost. (T1) [exact] Z^3 is bipartite, so two distinct neighbours of a site are never adjacent and for every shift x -> y the neighbour sets N(x), N(y) are disjoint (0 violations over the 1296 shifts of the L = 6 torus and 6480 ordered neighbour pairs): a record that shifts one step loses EVERY former companion at once. (T2) [exact] Under C_comp and K1 the exhaustive polycube census (fixed polycubes 1, 3, 15, 86, 534, 3481 at n = 1..6; reachable sets 3, 15, 86, 990, 11851 mod translation at n = 2..6 carrying 0, 24, 192, 3372, 52320 admissible shifts) gives: the dimer, the straight trimer, the straight-4 and the 2x2 square are FROZEN while the bent trimer carries 2 shifts and the tripod 6; no one-record group is admissible at all, so a record is never alone; record number is conserved exactly; a group of size <= 4 can never split, while at n = 5 there are 336 splitting shifts whose parts always hold >= 2 records, and merges are as many; and the CAGE theorem -- for n = 3, 4, 5, 6 an exact RATIONAL potential Phi of the SHAPE satisfies CoM(s') - CoM(s) = Phi(s') - Phi(s) at every admissible shift, 0 inconsistencies over 24/192/3372/52320 shifts and 6/13/34/40 components, with within-component spread 1/3, 1/2, 4/5, 4/3 lattice units -- so the lab centre of mass takes finitely many values and D_group = 0 EXACTLY: the group rattles in a cage and does not walk, the bent trimer occupying three corners of one FIXED unit square forever. (T3) [exact] Under C_rig a one-step shift is frozen outright (0 admissible over all 104 connected groups of size 2, 3, 4); under the SIMULTANEOUS tick KS with STRICT occupancy the only admissible whole-group moves are RIGID UNIT TRANSLATIONS (0 non-translations over 8 named groups), and the isometry form with PERMISSIVE occupancy adds exactly the rigid rotations and reflections (all 160 admissible assignments over 10 groups land on a congruent copy, 0 violations). The occupancy convention is load-bearing: PERMISSIVE admits all 6 unit translations so D_group = D_1 EXACTLY, while STRICT blocks the longitudinal directions -- dimer 4/6, bent trimer 2/6, 2x2x2 block 0/6. (T4) [exact] On the cube the 4096 record patterns split into 128 parity sectors of 32, each sector's membership being a support condition on record patterns. In the vacuum sector no single edge-record complement is admissible (0 of 12); the sector-preserving complement sets form a 5-dimensional subspace of 32 elements with weight census {0: 1, 4: 6, 6: 16, 8: 9} that is EXACTLY the span of the six face 4-cycles and EXACTLY the cube's cycle space, so admissible vacuum moves are CLOSED LOOPS only. In a one-pair sector the admissible single complements are exactly the edges incident to exactly one of the two odd corners (0 mismatches over 28 pairs; 4 hops plus 1 annihilation at distance 1, 6 hops at distances 2 and 3), each hop changing the VALUE of exactly one edge record and moving exactly one odd corner: the star does not translate, the odd corner does. All 24 adjacent two-edge complements leave the vacuum sector. (T5) [numerical, 1e-3] Under KT a pair held by a HARD ADJACENCY support condition on the L = 6 and L = 8 pi-flux tori -- 22572 and 129280 non-adjacent two-record configurations carrying odds 0, leaving 648 and 1536 admissible, the tick kernel translation covariant to 1.9e-16 -- stays adjacent at every tick with certainty and still moves: D_pair/D_1 = 0.5016 and 0.5075 at tau = 0.5, 0.1058 and 0.1453 at tau = 1, against the independent-record value 1/2; the odds on the admissible set before renormalising are 0.31 at tau = 0.5 and 0.28 at tau = 1; the orientation is a 3-state chain with stationary odds exactly (1/3, 1/3, 1/3) and P(the axis changes) 0.476 at tau = 0.5 and 0.072 at tau = 1; and the joint-move census at L = 8, tau = 0.5 reads one record shifts 0.540, rigid translation 0.239, same sites 0.218, non-rigid 0.002. The same torus under PR #7889's ENERGY COST g = 32 and no support condition carries P(adjacent) 0.978 -> 0.424 over 40 ticks toward the uniform 0.0279. This note declares support conditions and tick models and computes with them; nothing is derived from any axiom, no formation clause is supplied, no axiom is amended, no status is set, and no claim is made about what the framework's tick is or about which conditions the framework's law carries."
+upstream_dependencies: []
+runner: scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py
+---
+
+# Support conditions confine groups of shifting records; energy costs do not
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py`](../scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.txt`](../logs/runner-cache/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+`SHIFTING_POSITION_RECORDS_EXACT_DIFFUSION_LAW_AND_THE_UNIFORM_ATTRACTOR_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7889) showed that two records held together by an
+**energy cost** come apart at every cost, and named as an interface the mechanism it did not test: a **support condition** of the law, whose parting configurations carry
+odds `0` and are never registered. This note answers that interface. It writes two support conditions down, computes exhaustively what they do to a group of shifting
+records, and finds a sharper answer than either "they hold" or "they fail": the confinement is exact and absolute, and on this lattice it is a **cage** rather than a
+vehicle unless the tick reaches further than one site.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-object theorems -- the bipartite census on the L = 6 torus, the exhaustive polycube census and reachability closure to n = 6 records, the exact Fraction coboundary certificate over 55908 admissible shifts, the simultaneous-shift and isometry enumerations, and the 4096-pattern parity census on the cube -- together with deterministic double-precision evaluations of exactly specified quantities on the L = 6 and L = 8 pi-flux tori, tagged [numerical] at stated thresholds. There is no sampling, no seed and no random number anywhere in the runner."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Route to its owner the one question this note raises and does not decide: whether the framework's actual law carries a support condition that moves a composite rigidly, which on the results below requires either a tick whose amplitude reaches beyond one site or a condition stated on simultaneous whole-group moves."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`: `T1` (`A`) the bipartite lemma; `T2` (`B`) the companion condition;
+`T3` (`C`) the rigid condition; `T4` (`D`) the cube's parity sectors; `T5` (`E`) the hard-adjacency pair. Groups `A`-`D` are **exact**: integer, `F2` and `Fraction`
+arithmetic with no floating point in the statement. Group `E` is a **deterministic double-precision evaluation** of exactly specified quantities at the thresholds printed
+in its tags: the propagator `exp(-i tau H)` is transcendental, so no rational value exists to compare against, but there is **no sampling, no seed and no random number
+anywhere in this runner**. No line is a witness.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kogut-Susskind staggered link signs, polycube enumeration, reachability closure and the Markov-additive martingale decomposition of a functional's variance are standard methodology; every object is redeclared here and the runner recomputes every statement. No observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no weight: `SHIFTING_POSITION_RECORDS_EXACT_DIFFUSION_LAW_AND_THE_UNIFORM_ATTRACTOR_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7889 -- whose `M2` registration is the `KT`
+tick reused here, whose `T5` energetic pair is the contrast recomputed in `T5` below, and whose "support-conditioned shifts" interface this note answers),
+`RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7858 -- the same cube, encoding and parity cosets),
+`RECORD_TICKS_ADMIT_NO_INVARIANT_PRE_RECORD_STATE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7876 -- the frozen-record tick convention), and
+`MINIMAL_AXIOMS_2026-06-29.md`, from which the axiom text in "Setting" is quoted verbatim. This note cites no grade of any of these and consumes no ledger row.
+
+## Setting
+
+The framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site." "No site is privileged." **Qubit / Site Possibility**: "Each site has a domain of local
+possibilities."
+
+**Admissibility / Local Constraint.** "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." "For each
+site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." Reading note (3), interpretive and
+non-governing, quoted verbatim and in full:
+
+> The distribution is a probability measure on the local possibility domain; "available"/"admissible" denotes its support -- on finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may have zero singleton measure; Record locks a supported realization.
+
+That sentence is the whole hinge of this note. A **support condition** is a **zero of the law-level distribution** at a site given its neighbourhood: a configuration the distribution gives odds `0` is not admissible, so no record ever locks it. It is therefore a property of the **supplied law**, not an extra axiom and not a new primitive -- the axioms already permit a distribution with zeros, and this note stipulates two particular families of zeros to see what they do.
+
+**Record / Fixed Reality.** "Records form." "When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are
+permanent." "Only records are readable."
+
+The owner's point, quoted on 2026-09-03 as the question this note answers on declared conditions and does not settle for the framework: **"neighbourhood conditions keep
+records together through translation. Groups of records could be forced to translate together due to neighbourhood conditions"**.
+
+Composition here is **ordinary**: the algebra of a region is the tensor product of its sites' algebras, and no graded or signed clause is used anywhere. The **record
+ontology** is used as declared: a record at a site **registers** a value there; it does not report one the site already had. Reading note (2) says the axioms supply no
+formation site, probability or rate, and this note **stipulates** its conditions and ticks rather than deriving any.
+
+## The stipulated conditions and tick models, declared in full
+
+Two support conditions and three ticks, all declared here, none derived. A lane proposing a different condition or tick inherits the obligations of `T2`-`T5` and none of
+these choices.
+
+1. **`C_comp` the companion condition.** Every record has at least one adjacent record. Every configuration with a lone record carries odds `0`. This is the weakest
+   condition that makes "records stay together" mean anything at all.
+2. **`C_rig` the rigid condition.** Every pair of records adjacent now stays adjacent. Its **isometry form** strengthens this to: every pair keeps its exact separation.
+   This is the strongest reading of "forced to translate together".
+3. **`K1` the one-step tick.** Each tick exactly one record shifts to a nearest-neighbour site, with uniform odds over the admissible shifts. Uniformity is a choice of
+   convention and every `[exact]` statement below -- what is admissible, what is conserved, what is reachable, and the coboundary certificate -- is independent of it.
+4. **`KS` the simultaneous tick.** Each tick every member of the group shifts at once, by one site or not at all. Two occupancy conventions are computed separately:
+   **STRICT**, a target site must be vacant in the OLD configuration, and **PERMISSIVE**, a site vacated in the same tick counts as vacant.
+5. **`KT` the tau-tick.** The pre-record amplitude runs for a time `tau` and the odds are its weights **conditioned on the admissible set** and renormalised. This is
+   exactly PR #7889's `M2` registration with a **support condition** in place of that note's **energy cost**, so the two mechanisms are compared on one tick and one
+   torus.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is precisely `P0`-`P5`.
+
+`P0` (declared here): `Z^3`, the cube, the coarse torus, and the conditions and ticks above. `P1` (`A`): the bipartite lemma. `P2` (`B`): `C_comp` under `K1`. `P3` (`C`):
+`C_rig` under `K1` and `KS`. `P4` (`D`): the cube's sectors. `P5` (`E`): the hard-adjacency pair under `KT`.
+
+## Definitions
+
+A **group of records** is a finite set of occupied sites of `Z^3`. A **fixed polycube** of size `n` is a connected such set modulo translation; the **reachable set** of
+`n` is the closure of all of them under the admissible shifts of the condition in force, again modulo translation. `CoM(S)` is the arithmetic mean of the occupied sites,
+and `D_1` is the diffusion constant of one free record: `E|dx|^2 = 1` and `D_1 = 1/6` per `K1` tick.
+
+The **cube** is the `2x2x2` cube graph, corner `s = 4a + 2b + c`, `8` corners, `12` edge sites, `6` faces, one qubit per edge site, with `B_v` the product of the `Z`'s
+on the edges incident to `v` and `star(v)` the edges incident to `v`. A record at an edge site registers a `Z`-value there, so a **finished set of records** is a vector
+`y` in `F2^12`; the **parity dictionary** is `n_v(y) = (1 - B_v)/2 = |y intersect star(v)| mod 2`. A **sector** fixes every `B_v`, and sector membership is the support
+condition: the `4096` patterns fall into `128` sectors of `32`, indexed by the set of **odd corners**, whose size is always even because `prod_v B_v = I`.
+
+The **coarse torus** is `Z_L^3` with nearest-neighbour hopping of unit amplitude and unit spacing, coordination `6`, and Kogut-Susskind staggered (pi-flux) link signs
+`eta(v, 1) = 1`, `eta(v, 2) = (-1)^{v_x}`, `eta(v, 3) = (-1)^{v_x + v_y}`. The two-record generator is the corresponding hopping on the `C(L^3, 2)` configurations with
+the site-ordered exchange sign. `D_pair` is the asymptotic diffusion constant of the pair's centre of mass under `KT`, taken with the correlations of the orientation
+chain included.
+
+## Theorem 1 -- one step severs every companion
+
+**Conclusion.** `[exact]` `Z^3` is bipartite by coordinate-sum parity: on the `L = 6` torus every one of the `1296` bonds joins opposite classes (`0` violations), so no
+triangle closes and two distinct neighbours of a site are never adjacent (`0` violations over `6480` ordered pairs). Hence for every one of the `1296` shifts `x -> y` the
+neighbour sets `N(x)` and `N(y)` are **disjoint** (maximum overlap `0`), and no former companion of `x` survives as a companion at `y` (`0` survivors).
+
+**Proof.** Exhaustive integer enumeration over the sites, bonds and ordered neighbour pairs of the `L = 6` torus, whose girth `4` matches `Z^3`'s for this statement. No
+floating point.
+
+**Reading, not theorem.** This is the geometric fact everything below turns on. On this lattice a record cannot edge away from its neighbours: one step away from a site
+is one step away from **all** of that site's neighbours at once. Whatever a condition asks a group to preserve, a single one-site shift breaks every adjacency the moving
+record had.
+
+## Theorem 2 -- the companion condition confines absolutely, and the cage is small
+
+**Conclusion.** `[exact]` Under `C_comp` with the `K1` tick. **The census.** Fixed polycubes number `1, 3, 15, 86, 534, 3481` at `n = 1..6`; the reachable sets modulo
+translation number `3, 15, 86, 990, 11851` at `n = 2..6` and carry `0, 24, 192, 3372, 52320` admissible shifts. By shape: the dimer, the straight trimer, the straight-4
+and the `2x2` square are **frozen** (`0` shifts); the L tetracube carries `1`, the S and skew tetracubes and the bent trimer `2`, the T tetracube `4`, the tripod `6`.
+**The invariants.** No one-record group is admissible at all, so a record is never alone; the record number is conserved at every shift (`0` violations); every reachable
+group satisfies the condition (`0` violations). **Splitting.** A connected group of size `<= 4` can **never** split (`0` splitting shifts at `n = 2, 3, 4`); at `n = 5`
+there are `336`, the witness `[(0,0,0),(1,0,0),(2,0,0),(3,0,0),(3,1,0)]` splitting into parts of sizes `2` and `3`; no part of any split at `n <= 6` holds fewer than `2`
+records, and merges are exactly as many. **The cage.** For `n = 3, 4, 5, 6` an exact **rational** potential `Phi` of the **shape** satisfies
+`CoM(s') - CoM(s) = Phi(s') - Phi(s)` at every admissible shift -- `0` inconsistencies over `24/192/3372/52320` shifts and `6/13/34/40` connected components of the shift
+graph -- with within-component spread `1/3, 1/2, 4/5, 4/3` lattice units. Hence the lab centre of mass takes finitely many values and **`D_group = 0` exactly**. The bent
+trimer's lab orbit is exactly `4` configurations inside one **fixed** unit square: three of that square's four corners, forever.
+
+**Proof.** The censuses are exhaustive enumerations in integer arithmetic; the reachable sets are the closures of the polycube sets under the admissible shifts, taken
+modulo translation, and the shift graph is undirected because the reverse of an admissible shift restores a configuration already known to satisfy the condition. The
+potential is built by breadth-first assignment from one root per component with exact `Fraction` increments `(y - x)/n`, then **every** edge is re-checked against it, so
+the certificate is a proof of exactness and not a fit. `Phi` is determined up to one additive constant per component, which is why the spread is taken **within** a
+component; that spread bounds the whole lab excursion of the centre of mass, and a bounded centre of mass has diffusion constant `0` identically.
+
+**Reading, not theorem.** Forbid a record from ever being alone and the owner's mechanism appears in its strongest form: the group is held together not approximately but
+absolutely, because the shift that would break it carries odds `0` and is never registered. But by `T1` one step away is away from **all** companions at once, so the only
+shifts left are the ones that find a **new** companion, and those turn out to trace a closed loop. The centre of mass is a function of the shape alone; the shape has
+finitely many values; so the group never travels. It shuffles inside a box a little over one site wide. A bent trimer under this rule sits on three corners of one square
+for all time, permuting which corner is empty.
+
+## Theorem 3 -- the rigid condition freezes one-step shifts and makes simultaneous ones rigid
+
+**Conclusion.** `[exact]` Under `C_rig`. **One-step shifts.** Summed over **all** `104` connected groups of size `2, 3, 4`, the admissible `K1` shifts number `0`: a
+record with any companion cannot move alone. **Simultaneous shifts.** Under `KS` with **strict** occupancy the only admissible whole-group moves are **rigid unit
+translations** -- `0` non-translations over the `8` named groups -- with `4, 4, 2, 2, 4, 2, 2, 0` of the `6` unit directions free, in the runner's declared order: the
+dimer, the straight trimer, the bent trimer, the square, and the straight-4, L and T tetracubes, then the tripod. **The isometry form** with **permissive** occupancy adds exactly the rigid rotations and reflections: all `160` admissible
+assignments over the `10` named groups carry the group to a **congruent** copy (`0` violations), of which `70` are pure translations, `7` per group. **The convention is
+load-bearing.** Permissive occupancy admits all `6` unit translations from every group, so the centre of mass performs the free one-record walk and `D_group = D_1`
+**exactly**; strict occupancy blocks the longitudinal directions -- dimer `4/6`, bent trimer `2/6`, `2x2x2` block `0/6`, giving `D_group/D_1 = 0.667, 0.333, 0.000`.
+
+**Proof.** The one-step count enumerates every group, every record and every direction and tests the condition on every currently-adjacent pair. The simultaneous counts
+enumerate all `6^n` or `7^n` assignments of unit steps to members, reject those that collide or that violate the occupancy convention, and keep those preserving every
+current adjacency; the isometry count keeps those preserving every pairwise squared distance and then verifies the image against the `48`-element cubic point group
+modulo translation. Under permissive occupancy the group's own translations are always admissible and the shape is unchanged, so the walk of the centre of mass is
+literally the free single-record walk; under strict occupancy the admissible direction set is the same at every step, so the walk is i.i.d. on it and the ratio is the
+count over `6`.
+
+**Reading, not theorem.** Ask that nothing currently touching ever stops touching and a single record can no longer move at all. What is left is a group that steps as one
+piece -- and then it travels exactly as fast as a single free record would, no faster and no slower. Whether it can step at all in a given direction depends on a
+bookkeeping choice nobody has made yet: if a site being vacated this same tick counts as free, a dimer can move along its own axis; if it must have been free already, it
+cannot, and a solid `2x2x2` block cannot move in any direction whatsoever. That choice is not decoration; it is the difference between a mobile composite and a
+permanently pinned one.
+
+## Theorem 4 -- the cube's parity sectors are worked support conditions
+
+**Conclusion.** `[exact]` The cube's `4096` record patterns split into `128` parity sectors of `32`. **The vacuum.** In the sector with every `B_v = +1`, **no** single
+edge-record complement is admissible (`0` of `12`): complementing one edge flips the parity at **both** its corners. The sector-preserving complement sets form a linear
+subspace of `32` elements with weight census `{0: 1, 4: 6, 6: 16, 8: 9}`, and that subspace is **exactly** the span of the six face `4`-cycles and **exactly** the cycle
+space of the cube graph, of dimension `E - V + 1 = 5`. So admissible vacuum moves are **closed loops** of edge-record complements: no record changes alone. **One pair.**
+In a sector with `B_v = -1` at exactly two corners `u, w`, the admissible single complements are **exactly** the edges incident to exactly one of `u, w` (`0` mismatches
+over the `28` corner pairs): `4` hops plus `1` annihilation at corner distance `1`, `6` hops at distances `2` and `3`. At every such hop exactly **one** edge record
+changes its **value** and exactly **one** odd corner moves, to an adjacent corner. And all `24` adjacent two-edge complements -- the nearest thing to a rigid two-record
+shift -- leave the vacuum sector.
+
+**Proof.** Exhaustive enumeration in `F2` over the `4096` patterns, the `12` edge sites, the `128` sectors and the `28` corner pairs, with the dictionary evaluated by
+popcount. The subspace is computed as `{w : y XOR w` lies in the sector for every `y` in it`}`, the face span by closing the six face `4`-cycles under `XOR`, and the
+cycle space as the even-degree subsets; the three sets are compared as sets. No floating point.
+
+**Reading, not theorem.** The emergent model already carries support conditions of exactly this kind, and they behave the way `T2` and `T3` describe. In the vacuum no
+record can change on its own: changes come only as closed loops. Where a particle sits -- an odd corner -- a record can change alone, and when it does the particle steps
+to the next corner. What moves is not the group of records around the corner, which stays exactly where it is, but the **parity pattern**: one value flips and the odd
+corner is somewhere else. This is a worked instance of the general lesson, in a model nobody designed for the purpose.
+
+## Theorem 5 -- a hard-adjacency pair, against PR #7889's energetic pair
+
+**Conclusion.** `[numerical, 1e-9]` On the `L = 6` and `L = 8` pi-flux tori a support condition of **hard adjacency** gives odds `0` to all `22572` and `129280`
+non-adjacent two-record configurations, leaving `648` and `1536` admissible; the tick kernel is translation covariant to `1.9e-16`, so the reduction to relative classes
+is exact. `[numerical, 1e-3]` Under `KT` the pair stays adjacent at **every** tick with certainty -- the orientation chain's rows sum to `1` to `3.3e-16` -- and still
+moves: `D_pair/D_1 = 0.5016` and `0.5075` at `tau = 0.5`, `0.1058` and `0.1453` at `tau = 1`, against the independent-record value `1/2`. The odds the law puts on the
+admissible set before renormalising are `0.31` at `tau = 0.5` and `0.28` at `tau = 1`; the wrap mass on the centre-of-mass displacement is at most `1.5e-2` and the mean
+drift, zero by symmetry, at most `1.0e-2`. `[numerical, 1e-9]` The orientation is a `3`-state chain on the relative axis with stationary odds exactly `(1/3, 1/3, 1/3)`
+(deviation `7.8e-16`) and `P(the axis changes)` `0.475, 0.476` at `tau = 0.5` and `0.079, 0.072` at `tau = 1`. `[numerical, 1e-6]` The joint-move census at `L = 8`,
+`tau = 0.5` from an axis-`1` pair reads **one record shifts** `0.540`, **rigid translation** `0.239`, **same sites** `0.218`, **non-rigid** `0.002`. `[numerical, 1e-6]`
+The contrast: the same `6^3` torus under PR #7889's **energy cost** `g = 32` with no support condition carries `P(adjacent) = 0.978, 0.957, 0.896, 0.804, 0.648, 0.424` at
+ticks `1, 2, 5, 10, 20, 40`, running toward the uniform-over-configurations value `0.0279`.
+
+**Proof.** The two-record generator is built sparsely and never densified; one column is propagated per relative class by Krylov exponentiation, and translation
+covariance -- verified entrywise against explicit lattice translations -- makes the relative class a Markov chain, so the reduction is exact rather than an approximation.
+The centre-of-mass step variance is accumulated along that chain with the martingale correction that makes it the true asymptotic constant rather than a per-tick
+variance. The energetic row adds the diagonal cost to the same generator and propagates the `111`-class chain of PR #7889 for `40` ticks. Torus wrap mass is reported and
+is small wherever a row is tabulated.
+
+**Reading, not theorem.** Give the law a genuine zero -- the two records are never registered apart -- and the pair is bound with certainty at every tick, which no energy
+cost achieves at any strength. And it is not pinned: it diffuses at half the single-record rate, exactly as two independent records' centre of mass would. But look at how
+it moves. Nearly all the weight is on one record shifting while the other stays, or on nothing moving at all; genuine rigid translation is under a quarter of it. The pair
+travels the way a caterpillar does, by rearranging, not by stepping as one piece.
+
+## Corollary -- what this says about the owner's point
+
+Within the setting declared above, on the three named objects, and for the stipulated conditions and ticks alone:
+
+1. **The mechanism is real and exactly characterisable.** A translation-covariant support condition whose members' conditions reference each other confines a group
+   **absolutely**: the parting configuration carries odds `0`, is never registered, and no strength parameter can be turned down. `T2`'s coboundary certificate and `T5`'s
+   `P(adjacent) = 1` are two forms of the same statement, and PR #7889's energy cost achieves neither at any `g`. The owner's reading of neighbourhood conditions is
+   correct on the mechanism.
+2. **But confinement is not transport, and the tick's reach is what separates them.** By `T1` a one-step shift on the bipartite cubic lattice severs **every** companion at
+   once. So a companion-conditioned group under one-step ticks rattles in a cage -- `D_group = 0` exactly, a box `4/3` of a site wide at `n = 6` -- rather than walking.
+   Rigid translation needs a **simultaneous whole-group** tick (`T3`), or a tick whose amplitude reaches beyond one site (`T5`, where the group does move, though mostly
+   by rearranging). **The mobility of a bound group is set by how far a record can shift in one tick, not by the condition alone.**
+3. **The emergent model is a worked instance.** By `T4` no record changes alone in the cube's vacuum -- changes come as closed loops or, where a particle sits, as the
+   motion of an odd corner by one record changing value. The object that moves is the parity pattern, not the group of records that marks it. The general lesson is
+   already visible in a model built for other reasons.
+4. **Whether the framework's law carries such a condition is untested.** Nothing here derives a support condition from any axiom, and nothing here says which zeros the
+   supplied distribution actually has. What the results do say is what such a condition would have to be paired with to move a composite rigidly: a further condition
+   stated on simultaneous whole-group moves, or a gap scale large compared with the tick. That is a question for its owner and for the lane that fixes the tick.
+
+## Reading, not theorem -- the whole thing in plain words
+
+Forbid a record from ever being alone and it can never leave its companions; but on this lattice one step away is always away from all of them at once, so a small group
+under that rule does not travel, it shuffles inside a box the size of a few sites. Let the whole group step together and it travels as one, exactly as fast as a single
+record would. In the emergent picture the vacuum's records can only change in closed loops, and a particle moves by one record at a time changing value while the odd
+corner it marks steps to the next.
+
+## Interfaces named for other lanes, not settled here
+
+- **The tick's reach.** Every frozen result above is a statement about **one-site** shifts. A tick reaching two sites, or moving several records at once, is a different object; `T3` and `T5` show two ways it changes the answer. What the framework's tick is remains open and untouched here.
+- **The occupancy convention.** Whether a site vacated in the same tick counts as vacant decides whether a bound group can move along its own axis at all (`T3`). This is
+  a convention, not a theorem, and this note computes both branches rather than choosing one.
+- **Which conditions the actual law carries.** The two conditions here are stipulated. Reading note (3) makes support a property of the supplied distribution, so the
+  question "does the framework's law have these zeros?" is a question about the law and is not asked here.
+- **Larger groups and other conditions.** The exhaustive census stops at `n = 6` records, the cube has `8` corners, and the tori are `L = 6` and `L = 8` with two records.
+  Longer-range conditions, three-body conditions, and the thermodynamic limit are outside this note.
+- **The fine-lattice marker sites.** Only edge sites carry records in the cube model. The coarse corner, face and cube-centre marker sites of the **superlattice role
+  pattern** construction (open PR #7834) are pinned and are not part of these groups.
+
+## Remaining live routes
+
+1. Whether the `D_group = 0` cage of `T2` survives to arbitrary `n`, or whether some size admits a shape cycle whose centre-of-mass increments fail to close. The certificate is exact to `n = 6` and the component count is still growing.
+2. Whether the joint-move census of `T5` -- rigid translation under a quarter of the weight at `tau = 0.5` -- has a `tau` at which rigid motion dominates.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the five theorem conclusions.
+
+```text
+setting: (a) Z^3 with nearest-neighbour adjacency, exhaustively over fixed polycubes to n = 6 and the whole reachable set of each; (b) qubits on the 12 EDGE sites of the 2x2x2 cube graph, ordinary composition, superfast encoding, dictionary n_v = (1 - B_v)/2, all 4096 patterns; (c) the coarse L^3 torus, two-record hopping, KS staggered (pi-flux) signs, unit amplitude and spacing, coordination 6, L = 6 and L = 8; axioms quoted from MINIMAL_AXIOMS_2026-06-29.md with Admissibility reading note (3) quoted in full
+conditions_and_ticks: STIPULATED -- C_comp (every record has >= 1 adjacent record); C_rig (every currently adjacent pair stays adjacent; isometry form: every pair keeps its separation); K1 (one record shifts one site per tick, uniform over admissible shifts); KS (all members shift at once, STRICT or PERMISSIVE occupancy); KT (the pre-record amplitude runs for tau, odds = its weights conditioned on the admissible set) = PR #7889's M2 with a support condition in place of that note's energy cost. A support condition is a ZERO of the law-level distribution; none is derived, and no formation site, probability or rate is taken from any axiom
+T1_bipartite_lemma [exact]: Z^3 is bipartite by coordinate-sum parity (0 violations over the 1296 bonds of the L = 6 torus), so no triangle closes (0 over 6480 ordered neighbour pairs) and for every one of the 1296 shifts x -> y the sets N(x), N(y) are DISJOINT (max overlap 0, 0 surviving companions): one step severs every companion at once
+T2_companion_condition [exact]: fixed polycubes 1, 3, 15, 86, 534, 3481 at n = 1..6; reachable sets 3, 15, 86, 990, 11851 mod translation at n = 2..6 with 0, 24, 192, 3372, 52320 admissible shifts; dimer/straight trimer/straight-4/2x2 square FROZEN, L 1, S 2, skew 2, bent trimer 2, T 4, tripod 6; NO one-record group admissible; record number conserved (0 violations); no split at n <= 4 (0 shifts), 336 at n = 5 with every part >= 2 records, merges as many; CAGE: an exact rational Phi of the SHAPE with CoM(s') - CoM(s) = Phi(s') - Phi(s), 0 inconsistencies over 24/192/3372/52320 shifts and 6/13/34/40 components, within-component spread 1/3, 1/2, 4/5, 4/3 -> D_group = 0 EXACTLY; the bent trimer's lab orbit is 4 configurations in one fixed unit square
+T3_rigid_condition [exact]: 0 admissible one-step shifts over all 104 connected groups of size 2, 3, 4; under KS with STRICT occupancy 0 non-translations over 8 named groups (free directions 4, 4, 2, 2, 4, 2, 2, 0 of 6, for dimer, straight trimer, bent trimer, square, straight-4, L, T, tripod); the isometry form with PERMISSIVE occupancy gives 160 admissible assignments over 10 groups, all landing on a CONGRUENT copy (0 violations), 70 of them translations; PERMISSIVE gives D_group = D_1 EXACTLY, STRICT gives dimer 4/6, bent trimer 2/6, 2x2x2 block 0/6
+T4_cube_sectors [exact]: 4096 patterns in 128 parity sectors of 32; vacuum admits 0 of 12 single edge-record complements; the sector-preserving sets are a 5-dim subspace of 32 with weights {0: 1, 4: 6, 6: 16, 8: 9} = the span of the six face 4-cycles = the cube's cycle space, so vacuum moves are CLOSED LOOPS only; in a one-pair sector the admissible single complements are exactly the edges incident to exactly one odd corner (0 mismatches over 28 pairs; 4 hops + 1 annihilation at distance 1, 6 hops at distances 2 and 3), each changing exactly 1 edge-record VALUE and moving exactly 1 odd corner; all 24 adjacent two-edge complements leave the vacuum sector
+T5_hard_adjacency_pair [numerical, 1e-3]: on L = 6 and L = 8, 22572 and 129280 non-adjacent two-record configurations carry odds 0, leaving 648 and 1536; tick kernel translation covariant to 1.9e-16; P(adjacent) = 1 at every tick (rows sum to 1 to 3.3e-16); D_pair/D_1 = 0.5016, 0.5075 at tau = 0.5 and 0.1058, 0.1453 at tau = 1 against the independent 1/2; admissible-set odds 0.31 and 0.28; stationary orientation odds exactly (1/3, 1/3, 1/3) (7.8e-16), P(axis changes) 0.475, 0.476 at tau = 0.5 and 0.079, 0.072 at tau = 1; joint-move census at L = 8, tau = 0.5: one record shifts 0.540, rigid translation 0.239, same sites 0.218, non-rigid 0.002; CONTRAST, PR #7889's energy cost g = 32 with no support condition: P(adjacent) 0.978, 0.957, 0.896, 0.804, 0.648, 0.424 at ticks 1, 2, 5, 10, 20, 40 toward the uniform 0.0279
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=21 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **declared finite objects**: the fixed polycubes of `Z^3` up to `n = 6` records and their reachable closures, the `2x2x2` cube graph
+with its `4096` record patterns and `128` parity sectors, and the `L = 6` and `L = 8` pi-flux tori with two records and free hopping. Nothing is claimed for larger
+groups, for the thermodynamic limit, for other lattices or flux conventions, or for any condition or tick other than the ones in "The stipulated conditions and tick
+models". The coarse law is **designed**, not derived: the staggered sign convention is one pi-flux gauge among many and no minimality or uniqueness is claimed for it, and
+the parity dictionary is one readout map among many.
+
+**The two support conditions and the three ticks are stipulated in full and derived from nothing.** Reading note (3) makes support a property of the **supplied
+distribution**, so stipulating a condition here is stipulating a law, not amending an axiom; reading note (2) is explicit that the axioms supply no formation site,
+probability or rate, and this note supplies none either. **Nothing here says what the framework's tick is, and nothing forecloses any tick.** In particular `T2`'s
+`D_group = 0` is a statement about **one-step** shifts under `C_comp`, and says nothing about a tick that reaches further; `T3`'s rigid translations are a statement about
+**simultaneous** shifts under `C_rig`; and `T5` is a statement about one hard-adjacency condition under one registration convention. No no-go is asserted and none is
+implied: every frozen count above is a property of a declared condition-and-tick pair, and a different pair is a different object.
+
+The `[exact]` lines -- groups `A` through `D`, including the `Fraction` coboundary certificate -- carry no floating point. Group `E` is a **deterministic double-precision
+evaluation** of exactly specified quantities at the thresholds printed in its tags: the propagator is transcendental, so no exact rational value exists to compare
+against, but there is **no sampling, no seed and no random number anywhere in the runner**, and no line is a witness. The `K1` tick's uniform odds are a convention and no
+`[exact]` conclusion depends on them. Torus wrap mass is reported wherever it could matter. No absolute unit appears anywhere, no axiom text is amended, extended,
+reworded or reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is created or edited.
+
+## Review record
+
+An honest auditor should come away with two declared support conditions, three declared ticks and their consequences, not a claim about which conditions the framework's
+law carries or what its tick is; four exhaustive exact censuses and one exact rational coboundary certificate, with group `E` a deterministic unsampled double-precision
+evaluation on named finite objects; no Monte Carlo anywhere; the stipulation declared as stipulated in the front matter, the setting, its own section, the claim block and
+the proof boundary alike; an answer to PR #7889's named interface that **confirms** the mechanism it named -- absolute confinement, which no energy cost achieves -- and
+then separates it cleanly from transport, which the tick's reach and not the condition decides; and a corollary written as an answer to its owner's point, with the one
+open question handed back rather than settled.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the "Imports and authority"
+pointers are plain text carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair at `PASS=21 FAIL=0`, runtime under the declared `150`
+seconds, stdout under `5500` characters, a current zero-dependency citation-manifest entry, and passing pipeline, strict-lint and changed-evidence gates; audit remains a
+separate lane.

--- a/logs/runner-cache/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.txt
+++ b/logs/runner-cache/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py
+runner_sha256: e5fc2b6ff59a9887cce9fc54858726fa471d617c9c3f2fbd760b8dfaab13ba14
+timeout_sec: 150
+exit_code: 0
+elapsed_sec: 8.81
+status: ok
+----- stdout -----
+PASS A1 [exact] the L = 6 torus is bipartite by coordinate-sum parity: all 1296 bonds join opposite classes (0 violations), so no triangle closes -- two neighbours of a site are never adjacent (0 over 6480 pairs)
+PASS A2 [exact] so at each of the 1296 shifts x -> y there N(x), N(y) are DISJOINT (max overlap 0) and no companion of x survives at y (0): a record that shifts one step loses EVERY companion at once
+PASS B1 [exact] fixed polycubes of size 1..6 in Z^3: 1, 3, 15, 86, 534, 3481. Admissible ONE-STEP shifts under C_comp, by shape: dimer 0, straight trimer 0, bent trimer 2, square 0, straight-4 0, L 1, T 4, S 2, skew 2, tripod 6
+PASS B2 [exact] C_comp admits NO one-record group -- a record is never alone; over the 3/15/86/990/11851 groups reachable mod translation at n = 2..6 and their 0/24/192/3372/52320 shifts record number is conserved (0 violations, 0 off-condition)
+PASS B3 [exact] splitting shifts: 0, 0, 0 at n = 2, 3, 4 -- a group of size <= 4 can NEVER split. At n = 5 there are 336, witness [(0,0,0),(1,0,0),(2,0,0),(3,0,0),(3,1,0)] splitting into [2,3]; every part of a split at n <= 6 holds >= 2 records; merges are as many (336/4440 at n = 5/6)
+PASS B4 [exact] the CAGE: for n = 3, 4, 5, 6 an exact RATIONAL potential Phi of the SHAPE has CoM(s') - CoM(s) = Phi(s') - Phi(s) at every shift -- 0/0/0/0 inconsistencies over 24/192/3372/52320 shifts, 6/13/34/40 components -- so the lab centre of mass takes finitely many values: D_group = 0 EXACTLY
+PASS B5 [exact] the cage is SMALL: Phi is fixed up to a constant per component, so its within-component spread bounds the lab excursion -- 1/3, 1/2, 4/5, 4/3 lattice units at n = 3, 4, 5, 6. The BENT TRIMER's orbit is 4 configurations in one FIXED unit square: three of its corners, forever
+PASS C1 [exact] under C_rig a ONE-STEP shift is frozen: over ALL 104 connected groups of size 2, 3, 4 they number 0 -- by A1 the target is non-adjacent to x's other neighbours, so a record with a companion cannot move alone
+PASS C2 [exact] under C_rig with the SIMULTANEOUS tick and STRICT occupancy the only admissible whole-group moves are RIGID UNIT TRANSLATIONS: 0 non-translations over the 8 named groups; free directions 4/4/2/2/4/2/2/0
+PASS C3 [exact] the ISOMETRY form with PERMISSIVE occupancy adds exactly the rigid rotations and reflections: all 160 admissible assignments over 10 groups land on a CONGRUENT copy (0 violations), 70 of them translations, 7 per group
+PASS C4 [exact] the OCCUPANCY convention is load-bearing: PERMISSIVE admits all 6 unit translations, so D_group = D_1 EXACTLY; STRICT blocks the longitudinal ones -- dimer 4/6, bent trimer 2/6, 2x2x2 block 0/6, i.e. D_group/D_1 0.667, 0.333, 0.000
+PASS D1 [exact] the cube's 4096 patterns split into 128 parity sectors of 32. In the VACUUM no single edge-record complement is admissible (0 of 12): one complement flips BOTH its corners. The sector-preserving sets are a subspace of 32, weights {0: 1, 4: 6, 6: 16, 8: 9}
+PASS D2 [exact] that subspace is EXACTLY the span of the six face 4-cycles (32 elements, True) and EXACTLY the cube's cycle space, dim E - V + 1 = 5 (True): admissible vacuum moves are CLOSED LOOPS only -- no record changes alone
+PASS D3 [exact] in a ONE-PAIR sector (B_v = -1 at corners u, w) the admissible single complements are EXACTLY the edges incident to exactly one of u, w -- 0 mismatches over 28 pairs: 4 hops + 1 annihilation at distance 1 (12 pairs), 6 hops at distance 2 (12) and 3 (4)
+PASS D4 [exact] at every such hop exactly 1 edge record changes its VALUE and exactly 1 odd corner moves, to an adjacent corner: the star of edge records does NOT translate -- the odd corner does, and what moves is the parity pattern
+PASS D5 [exact] and all 24 adjacent TWO-edge complements -- the nearest thing to a rigid two-record shift -- LEAVE the vacuum sector: odd-corner counts {2: 24}
+PASS E1 [numerical, 1e-9] the HARD-ADJACENCY pair: on the L = 6 and L = 8 pi-flux tori the 22572 and 129280 non-adjacent two-record configurations carry odds 0, leaving 648 and 1536; the tick kernel is translation covariant to 1.9e-16, so the class chain is exact
+PASS E2 [numerical, 1e-3] a group confined by a SUPPORT condition still MOVES: D_pair/D_1 = 0.5016, 0.5075 at tau = 0.5 and 0.1058, 0.1453 at tau = 1 (L = 6, 8) against the independent-record 1/2; the odds on the admissible set before renormalising, 0.31 and 0.28 (wrap <= 1.5e-02, drift <= 1.0e-02)
+PASS E3 [numerical, 1e-9] P(adjacent) = 1 at EVERY tick by construction -- absolute, not statistical (rows sum to 1 to 3.3e-16); the orientation is a 3-state chain on the relative axis, stationary odds exactly (1/3, 1/3, 1/3) (7.8e-16), P(axis changes) 0.475, 0.476 at tau = 0.5 and 0.079, 0.072 at 1
+PASS E4 [numerical, 1e-6] it moves by SHUFFLING, not translating: the joint-move census at L = 8, tau = 0.5 from an axis-1 pair reads one record shifts 0.540, rigid translation 0.239, same sites 0.218, non-rigid 0.002 (sum 1.000000)
+PASS E5 [numerical, 1e-6] the CONTRAST, PR #7889's energetic pair on the same torus: with an ENERGY COST g = 32 and no support condition P(adjacent) at ticks 1, 2, 5, 10, 20, 40 runs 0.978, 0.957, 0.896, 0.804, 0.648, 0.424 toward uniform 0.0279 -- a cost only slows the parting
+SUMMARY: a support condition confines a group ABSOLUTELY where an energy cost does not; but on this bipartite lattice one step severs every companion, so the group rattles in an exact cage (D = 0): rigid travel needs a simultaneous tick.
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py
+++ b/scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python3
+"""Support conditions confine groups of shifting records; energy costs do not.
+
+Class-A finite-object runner, self-contained.  Three declared objects, none
+derived from any axiom.
+
+  * Z^3 AND ITS POLYCUBES.  The cubic lattice with nearest-neighbour
+    adjacency.  A GROUP OF RECORDS is a finite set of occupied sites; the
+    exhaustive censuses below run over every fixed polycube (translation
+    class) up to n = 6 and over the whole reachable set of each.
+  * THE CUBE.  Qubits on the 12 EDGE sites of the 2x2x2 cube graph (8 corners,
+    6 faces), ordinary composition, the superfast encoding, and the corner
+    parity dictionary n_v = (1 - B_v)/2.  A finished set of records is a
+    vector y in F2^12; a sector fixes every B_v, and "admissible" is
+    membership of the sector -- the support of the sector's odds.
+  * THE COARSE TORUS.  One-particle hopping on an L^3 torus with the
+    Kogut-Susskind staggered (pi-flux) link signs eta(v,1) = 1,
+    eta(v,2) = (-1)^{v_x}, eta(v,3) = (-1)^{v_x + v_y}, unit amplitude, unit
+    spacing, coordination 6.  L = 6 and L = 8 carry the two-record chains.
+
+The TWO SUPPORT CONDITIONS and the THREE TICK MODELS are STIPULATED here, in
+full, and derived from nothing.  A support condition is a zero of the
+law-level distribution at a site given its neighbourhood: a shift into a
+configuration it excludes carries odds 0 and is never registered.
+
+  C_comp  THE COMPANION CONDITION.  Every record has at least one adjacent
+          record.  Configurations with a lone record carry odds 0.
+  C_rig   THE RIGID CONDITION.  Every pair of records adjacent now stays
+          adjacent.  Its isometry form: every pair keeps its exact separation.
+  K1      ONE-STEP TICK.  Each tick exactly one record shifts to a
+          nearest-neighbour site, uniformly over the admissible shifts.
+  KS      SIMULTANEOUS TICK.  Each tick every member of the group shifts at
+          once, by one site or not at all.  Two occupancy conventions:
+          STRICT (a target must be vacant in the OLD configuration) and
+          PERMISSIVE (a site vacated in the same tick counts as vacant).
+  KT      TAU-TICK.  The pre-record amplitude runs for a time tau and the
+          odds are its weights CONDITIONED on the admissible set -- the M2
+          registration of PR #7889 with a support condition in place of a
+          cost.  Contrasted against that note's ENERGY cost g sum_bonds n n.
+
+The runner establishes:
+
+  A  THE BIPARTITE LEMMA.  On Z^3 two distinct neighbours of a site are never
+     adjacent, so a shifting record loses every former companion at once.
+  B  THE COMPANION CONDITION.  The exhaustive polycube census of admissible
+     one-step shifts, the invariants, the splitting threshold, and the CAGE
+     theorem: an exact rational potential of the shape, so D_group = 0.
+  C  THE RIGID CONDITION.  One-step shifts frozen; simultaneous shifts are
+     rigid translations; D_group = D_1; the occupancy convention is
+     load-bearing.
+  D  THE CUBE.  The vacuum admits closed loops only; a one-pair sector admits
+     exactly the edges incident to one odd corner, one record value per hop.
+  E  THE HARD-ADJACENCY PAIR.  Confined by construction under KT, mobile,
+     with D_pair/D_1 ~ 0.50, against PR #7889's energetic pair.
+
+Line tags.  `[exact]` = integer, F2 or `Fraction` arithmetic with no floating
+point in the statement.  `[numerical]` = a deterministic double-precision
+evaluation of an exactly specified quantity at a stated threshold: no
+sampling, no seed, no random number anywhere in this runner.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from fractions import Fraction
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+AUDIT_TIMEOUT_SEC = 150
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+def _tq(q, p=4):
+    return ", ".join(("%." + str(p) + "f") % x for x in q)
+
+
+# ======================================================== Z^3 and its groups
+
+NB = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+
+
+def add(p, d):
+    return (p[0] + d[0], p[1] + d[1], p[2] + d[2])
+
+
+def canon(S):
+    """Translation class of a finite set of sites."""
+    m = [min(p[a] for p in S) for a in range(3)]
+    return frozenset((p[0] - m[0], p[1] - m[1], p[2] - m[2]) for p in S)
+
+
+def ok_comp(S):
+    """C_comp: every record has at least one adjacent record."""
+    return all(any(add(p, d) in S for d in NB) for p in S)
+
+
+def shifts_comp(S):
+    """Every admissible one-step shift (x, y, S') of the group S under C_comp."""
+    out = []
+    S = set(S)
+    for x in S:
+        for d in NB:
+            y = add(x, d)
+            if y in S:
+                continue
+            S2 = (S - {x}) | {y}
+            if ok_comp(S2):
+                out.append((x, y, frozenset(S2)))
+    return out
+
+
+def components(S):
+    S = set(S)
+    out = []
+    while S:
+        s = S.pop()
+        c, st = {s}, [s]
+        while st:
+            u = st.pop()
+            for d in NB:
+                v = add(u, d)
+                if v in S:
+                    S.discard(v)
+                    c.add(v)
+                    st.append(v)
+        out.append(frozenset(c))
+    return out
+
+
+def polycubes(n):
+    """Fixed polycubes of size n in Z^3, as translation classes."""
+    cur = {canon(frozenset({(0, 0, 0)}))}
+    for _ in range(n - 1):
+        nxt = set()
+        for S in cur:
+            for p in S:
+                for d in NB:
+                    q = add(p, d)
+                    if q not in S:
+                        nxt.add(canon(S | {q}))
+        cur = nxt
+    return sorted(cur, key=lambda s: sorted(s))
+
+
+def shape48(S):
+    """Canonical form of a shape under the 48 cubic isometries and translation."""
+    best = None
+    for perm in itertools.permutations(range(3)):
+        for sg in itertools.product((1, -1), repeat=3):
+            T = canon(frozenset(tuple(sg[i] * p[perm[i]] for i in range(3)) for p in S))
+            k = tuple(sorted(T))
+            if best is None or k < best:
+                best = k
+    return best
+
+
+def reachable(n):
+    """The whole C_comp-reachable set of n-record groups mod translation, and
+    the list of admissible one-step shifts on it."""
+    seen = set(polycubes(n))
+    st = list(seen)
+    edges = []
+    while st:
+        S = st.pop()
+        for x, y, S2 in shifts_comp(S):
+            c = canon(S2)
+            edges.append((S, x, y, c))
+            if c not in seen:
+                seen.add(c)
+                st.append(c)
+    # a state discovered late still needs its own outgoing shifts recorded
+    done = {S for S, _, _, _ in edges}
+    for S in seen - done:
+        for x, y, S2 in shifts_comp(S):
+            edges.append((S, x, y, canon(S2)))
+    return seen, edges
+
+
+SHAPES = [
+    ("dimer", [(0, 0, 0), (1, 0, 0)]),
+    ("straight trimer", [(0, 0, 0), (1, 0, 0), (2, 0, 0)]),
+    ("bent trimer", [(0, 0, 0), (1, 0, 0), (1, 1, 0)]),
+    ("square", [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]),
+    ("straight-4", [(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0)]),
+    ("L", [(0, 0, 0), (1, 0, 0), (2, 0, 0), (2, 1, 0)]),
+    ("T", [(0, 0, 0), (1, 0, 0), (2, 0, 0), (1, 1, 0)]),
+    ("S", [(0, 0, 0), (1, 0, 0), (1, 1, 0), (2, 1, 0)]),
+    ("skew", [(0, 0, 0), (0, 0, 1), (0, 1, 0), (1, 0, 1)]),
+    ("tripod", [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)]),
+]
+
+
+# ===================================================================== group A
+
+def group_A():
+    """The bipartite lemma: a shift severs every companion at once."""
+    L = 6
+    sites = list(itertools.product(range(L), repeat=3))
+    col = {v: (v[0] + v[1] + v[2]) % 2 for v in sites}
+
+    def nb(v):
+        return [tuple((v[i] + d[i]) % L for i in range(3)) for d in NB]
+
+    bonds = [(v, w) for v in sites for w in nb(v)]
+    bad_col = sum(1 for v, w in bonds if col[v] == col[w])
+    tri = sum(1 for v in sites for w1 in nb(v) for w2 in nb(v)
+              if w1 != w2 and w2 in nb(w1))
+    check("A1 [exact] the L = %d torus is bipartite by coordinate-sum parity: all %d bonds join "
+          "opposite classes (%d violations), so no triangle closes -- two neighbours of a "
+          "site are never adjacent (%d over %d pairs)"
+          % (L, len(bonds), bad_col, tri, len(sites) * 6 * 5),
+          bad_col == 0 and tri == 0 and len(bonds) == 6 * L ** 3)
+
+    worst = -1
+    lone = 0
+    for v in sites:
+        Nv = set(nb(v))
+        for w in Nv:
+            Nw = set(nb(w))
+            worst = max(worst, len(Nv & Nw))
+            lone += sum(1 for z in Nv if z != w and z in Nw)
+    check("A2 [exact] so at each of the %d shifts x -> y there N(x), N(y) are DISJOINT (max overlap "
+          "%d) and no companion of x survives at y (%d): a record that shifts one step loses EVERY "
+          "companion at once"
+          % (len(sites) * 6, worst, lone),
+          worst == 0 and lone == 0)
+
+
+# ===================================================================== group B
+
+def group_B():
+    """C_comp: the census, the invariants, the splitting threshold, the cage."""
+    npoly = [len(polycubes(n)) for n in range(1, 7)]
+    named = {}
+    for nm, S in SHAPES:
+        named[nm] = len(shifts_comp(frozenset(S)))
+    check("B1 [exact] fixed polycubes of size 1..6 in Z^3: %s. Admissible ONE-STEP shifts under "
+          "C_comp, by shape: %s"
+          % (", ".join(str(x) for x in npoly),
+             ", ".join("%s %d" % (nm, named[nm]) for nm, _ in SHAPES)),
+          npoly == [1, 3, 15, 86, 534, 3481]
+          and named["dimer"] == 0 and named["straight trimer"] == 0
+          and named["bent trimer"] == 2 and named["straight-4"] == 0
+          and named["square"] == 0 and named["L"] == 1 and named["T"] == 4
+          and named["S"] == 2 and named["skew"] == 2 and named["tripod"] == 6)
+
+    REACH = {}
+    for n in (2, 3, 4, 5, 6):
+        REACH[n] = reachable(n)
+    ns = [len(REACH[n][0]) for n in (2, 3, 4, 5, 6)]
+    nsh = [len(REACH[n][1]) for n in (2, 3, 4, 5, 6)]
+    badn = sum(1 for n in REACH for S, x, y, c in REACH[n][1] if len(c) != n)
+    badc = sum(1 for n in REACH for S in REACH[n][0] if not ok_comp(S))
+    check("B2 [exact] C_comp admits NO one-record group -- a record is never alone; over the %s "
+          "groups reachable mod translation at n = 2..6 and their %s shifts record number is "
+          "conserved (%d violations, %d off-condition)"
+          % ("/".join(str(x) for x in ns), "/".join(str(x) for x in nsh), badn, badc),
+          ns == [3, 15, 86, 990, 11851] and nsh == [0, 24, 192, 3372, 52320]
+          and badn == 0 and badc == 0 and not ok_comp(frozenset({(0, 0, 0)})))
+
+    split = {}
+    merge = {}
+    minpart = 99
+    for n in (2, 3, 4, 5, 6):
+        sp_ = mg = 0
+        for S, x, y, c in REACH[n][1]:
+            a, b = len(components(S)), len(components(c))
+            if b > a:
+                sp_ += 1
+                minpart = min(minpart, min(len(p) for p in components(c)))
+            elif b < a:
+                mg += 1
+        split[n], merge[n] = sp_, mg
+    W = frozenset({(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0), (3, 1, 0)})
+    wit = [(x, y, sorted(len(p) for p in components(S2)))
+           for x, y, S2 in shifts_comp(W) if len(components(S2)) > 1]
+    check("B3 [exact] splitting shifts: %s at n = 2, 3, 4 -- a group of size <= 4 can NEVER split. At "
+          "n = 5 there are %d, witness %s splitting into %s; every part of a split at n <= 6 holds "
+          ">= %d records; merges are as many (%d/%d at n = 5/6)"
+          % (", ".join(str(split[n]) for n in (2, 3, 4)), split[5],
+             str(sorted(W)).replace(" ", ""), str(wit[0][2]).replace(" ", "") if wit else "none",
+             minpart, merge[5], merge[6]),
+          split[2] == 0 and split[3] == 0 and split[4] == 0 and split[5] > 0
+          and len(wit) > 0 and minpart >= 2 and merge[5] == split[5] and merge[6] == split[6])
+
+    # ---- the CAGE: an exact rational potential of the shape
+    ncomp, ninc, spreads, tot = {}, {}, {}, {}
+    for n in (3, 4, 5, 6):
+        states, edges = REACH[n]
+        adjm = {}
+        for S, x, y, c in edges:
+            adjm.setdefault(S, []).append((c, tuple(Fraction(y[a] - x[a], n) for a in range(3))))
+            adjm.setdefault(c, []).append((S, tuple(Fraction(x[a] - y[a], n) for a in range(3))))
+        Psi, nc, inc, spread = {}, 0, 0, Fraction(0)
+        for root in states:
+            if root in Psi:
+                continue
+            nc += 1
+            Psi[root] = (Fraction(0), Fraction(0), Fraction(0))
+            st = [root]
+            comp = [root]
+            while st:
+                u = st.pop()
+                for w, d in adjm.get(u, []):
+                    val = tuple(Psi[u][a] + d[a] for a in range(3))
+                    if w not in Psi:
+                        Psi[w] = val
+                        st.append(w)
+                        comp.append(w)
+                    elif Psi[w] != val:
+                        inc += 1
+            for a in range(3):
+                spread = max(spread, max(Psi[s][a] for s in comp) - min(Psi[s][a] for s in comp))
+        bad = 0
+        for S, x, y, c in edges:
+            d = tuple(Fraction(y[a] - x[a], n) for a in range(3))
+            if tuple(Psi[c][a] - Psi[S][a] for a in range(3)) != d:
+                bad += 1
+        ncomp[n], ninc[n], spreads[n], tot[n] = nc, inc + bad, spread, len(edges)
+    check("B4 [exact] the CAGE: for n = 3, 4, 5, 6 an exact RATIONAL potential Phi of the SHAPE has "
+          "CoM(s\') - CoM(s) = Phi(s\') - Phi(s) at every shift -- %s inconsistencies over "
+          "%s shifts, %s components -- so the lab centre of mass takes finitely many values: "
+          "D_group = 0 EXACTLY"
+          % ("/".join(str(ninc[n]) for n in (3, 4, 5, 6)),
+             "/".join(str(tot[n]) for n in (3, 4, 5, 6)),
+             "/".join(str(ncomp[n]) for n in (3, 4, 5, 6))),
+          all(ninc[n] == 0 for n in (3, 4, 5, 6))
+          and [tot[n] for n in (3, 4, 5, 6)] == [24, 192, 3372, 52320]
+          and [ncomp[n] for n in (3, 4, 5, 6)] == [6, 13, 34, 40])
+    check("B5 [exact] the cage is SMALL: Phi is fixed up to a constant per component, so its "
+          "within-component spread bounds the lab excursion -- %s lattice units at n = 3, 4, 5, 6. "
+          "The BENT TRIMER\'s orbit is %d configurations in one FIXED unit square: three of its "
+          "corners, forever"
+          % (", ".join(str(spreads[n]) for n in (3, 4, 5, 6)), _bent_orbit()[0]),
+          spreads[3] == Fraction(1, 3) and spreads[4] == Fraction(1, 2)
+          and spreads[5] == Fraction(4, 5) and spreads[6] == Fraction(4, 3)
+          and max(spreads.values()) <= Fraction(3, 2)
+          and _bent_orbit() == (4, (1, 1, 0)))
+
+
+def _bent_orbit():
+    """Lab-coordinate orbit of the bent trimer under C_comp one-step shifts."""
+    S0 = frozenset({(0, 0, 0), (1, 0, 0), (1, 1, 0)})
+    seen, st = {S0}, [S0]
+    while st:
+        S = st.pop()
+        for _, _, S2 in shifts_comp(S):
+            if S2 not in seen:
+                seen.add(S2)
+                st.append(S2)
+    pts = [p for S in seen for p in S]
+    box = tuple(max(p[a] for p in pts) - min(p[a] for p in pts) for a in range(3))
+    return len(seen), box
+
+
+# ===================================================================== group C
+
+def group_C():
+    """C_rig: one-step shifts frozen, simultaneous shifts rigid."""
+    tot = 0
+    for n in (2, 3, 4):
+        for S in polycubes(n):
+            Sl = sorted(S)
+            adj = [(p, q) for p in Sl for q in Sl if p < q
+                   and sum(abs(p[a] - q[a]) for a in range(3)) == 1]
+            for x in Sl:
+                for d in NB:
+                    y = add(x, d)
+                    if y in S:
+                        continue
+                    good = True
+                    for p, q in adj:
+                        p2 = y if p == x else p
+                        q2 = y if q == x else q
+                        if sum(abs(p2[a] - q2[a]) for a in range(3)) != 1:
+                            good = False
+                    if good:
+                        tot += 1
+    check("C1 [exact] under C_rig a ONE-STEP shift is frozen: over ALL %d connected groups of size "
+          "2, 3, 4 they number %d -- by A1 the target is non-adjacent to "
+          "x\'s other neighbours, so a record with a companion cannot move alone"
+          % (sum(len(polycubes(n)) for n in (2, 3, 4)), tot),
+          tot == 0)
+
+    def simul(S, strict, stay):
+        Sl = sorted(S)
+        n = len(Sl)
+        opts = list(NB) + ([(0, 0, 0)] if stay else [])
+        adj = [(i, j) for i in range(n) for j in range(i + 1, n)
+               if sum(abs(Sl[i][a] - Sl[j][a]) for a in range(3)) == 1]
+        res = []
+        for dd in itertools.product(opts, repeat=n):
+            NEW = [add(Sl[i], dd[i]) for i in range(n)]
+            if len(set(NEW)) != n:
+                continue
+            if strict and any(dd[i] != (0, 0, 0) and NEW[i] in set(Sl) for i in range(n)):
+                continue
+            if all(sum(abs(NEW[i][a] - NEW[j][a]) for a in range(3)) == 1 for i, j in adj):
+                res.append(dd)
+        return res
+
+    CL = [(nm, S) for nm, S in SHAPES if nm not in ("S", "skew")]
+    nontr = 0
+    counts = []
+    for nm, S in CL:
+        r = simul(frozenset(S), True, True)
+        t = [d for d in r if len(set(d)) == 1]
+        nontr += len(r) - len(t)
+        counts.append(len(t) - 1)
+    check("C2 [exact] under C_rig with the SIMULTANEOUS tick and STRICT occupancy the only admissible "
+          "whole-group moves are RIGID UNIT TRANSLATIONS: %d non-translations over the %d named "
+          "groups; free directions %s"
+          % (nontr, len(CL), "/".join(str(c) for c in counts)),
+          nontr == 0 and counts[0] == 4 and counts[2] == 2)
+
+    bad_iso = 0
+    iso = []
+    for nm, S in SHAPES:
+        Sl = sorted(S)
+        n = len(Sl)
+        D2 = [[sum((Sl[i][a] - Sl[j][a]) ** 2 for a in range(3)) for j in range(n)]
+              for i in range(n)]
+        res = []
+        for dd in itertools.product(NB + [(0, 0, 0)], repeat=n):
+            NEW = [add(Sl[i], dd[i]) for i in range(n)]
+            if len(set(NEW)) != n:
+                continue
+            if all(sum((NEW[i][a] - NEW[j][a]) ** 2 for a in range(3)) == D2[i][j]
+                   for i in range(n) for j in range(i + 1, n)):
+                res.append(NEW)
+        for NEW in res:
+            if shape48(frozenset(NEW)) != shape48(frozenset(Sl)):
+                bad_iso += 1
+        iso.append((nm, len(res), sum(1 for NEW in res
+                                      if len({tuple(NEW[i][a] - Sl[i][a] for a in range(3))
+                                              for i in range(n)}) == 1)))
+    check("C3 [exact] the ISOMETRY form with PERMISSIVE occupancy adds exactly the rigid rotations "
+          "and reflections: all %d admissible assignments over %d groups land on a CONGRUENT copy "
+          "(%d violations), %d of them translations, 7 per group"
+          % (sum(k for _, k, _ in iso), len(iso), bad_iso, sum(t for _, _, t in iso)),
+          bad_iso == 0 and all(t == 7 for _, _, t in iso))
+
+    BLK = [(i, j, k) for i in range(2) for j in range(2) for k in range(2)]
+    free = {}
+    for nm, S in SHAPES + [("2x2x2 block", BLK)]:
+        Ss = set(S)
+        free[nm] = len([t for t in NB if not (set(add(p, t) for p in S) & Ss)])
+    check("C4 [exact] the OCCUPANCY convention is load-bearing: PERMISSIVE admits all 6 unit "
+          "translations, so D_group = D_1 EXACTLY; STRICT blocks the longitudinal "
+          "ones -- dimer %d/6, bent trimer %d/6, 2x2x2 block %d/6, i.e. D_group/D_1 %.3f, %.3f, %.3f"
+          % (free["dimer"], free["bent trimer"], free["2x2x2 block"],
+             free["dimer"] / 6, free["bent trimer"] / 6, free["2x2x2 block"] / 6),
+          free["dimer"] == 4 and free["bent trimer"] == 2 and free["2x2x2 block"] == 0)
+
+
+# ===================================================================== group D
+
+def group_D():
+    """The cube: the parity sectors as support conditions on record patterns."""
+    V = 8
+    EDGES = [(i, j) for i in range(8) for j in range(i + 1, 8)
+             if bin(i ^ j).count("1") == 1]
+    NQ = len(EDGES)
+    DIM = 1 << NQ
+    SMASK = {v: sum(1 << q for q, (i, j) in enumerate(EDGES) if v in (i, j))
+             for v in range(V)}
+
+    def odd(z):
+        return tuple(v for v in range(V) if bin(z & SMASK[v]).count("1") & 1)
+
+    SEC = {}
+    for z in range(DIM):
+        SEC.setdefault(odd(z), []).append(z)
+    vac = set(SEC[()])
+    single = sum(1 for q in range(NQ) if any(odd(z ^ (1 << q)) == () for z in vac))
+    W = [w for w in range(DIM) if all((z ^ w) in vac for z in vac)]
+    wt = {}
+    for w in W:
+        wt[bin(w).count("1")] = wt.get(bin(w).count("1"), 0) + 1
+    check("D1 [exact] the cube\'s %d patterns split into %d parity sectors of %d. In the "
+          "VACUUM no single edge-record complement is admissible (%d of %d): one complement flips "
+          "BOTH its corners. The sector-preserving sets are a subspace of %d, weights %s"
+          % (DIM, len(SEC), len(vac), single, NQ, len(W), str({k: wt[k] for k in sorted(wt)})),
+          single == 0 and len(W) == 32 and wt == {0: 1, 4: 6, 6: 16, 8: 9}
+          and len(SEC) == 128 and len(vac) == 32)
+
+    FACES = []
+    for a in range(3):
+        bit = 1 << a
+        for val in (0, bit):
+            cs = [s for s in range(8) if (s & bit) == val]
+            cyc = [cs[0], cs[1], cs[3], cs[2]]
+            FACES.append(cyc)
+    EIX = {}
+    for q, (i, j) in enumerate(EDGES):
+        EIX[(i, j)] = q
+        EIX[(j, i)] = q
+    FSP = {0}
+    for f in FACES:
+        m = 0
+        for i in range(4):
+            m |= 1 << EIX[(f[i], f[(i + 1) % 4])]
+        FSP = {s ^ m for s in FSP} | FSP
+    CYC = {w for w in range(DIM) if all(bin(w & SMASK[v]).count("1") % 2 == 0 for v in range(V))}
+    check("D2 [exact] that subspace is EXACTLY the span of the six face 4-cycles (%d elements, %s) "
+          "and EXACTLY the cube\'s cycle space, dim E - V + 1 = %d (%s): admissible "
+          "vacuum moves are CLOSED LOOPS only -- no record changes alone"
+          % (len(FSP), set(FSP) == set(W), NQ - V + 1, CYC == set(W)),
+          set(FSP) == set(W) and CYC == set(W) and len(FSP) == 32)
+
+    bad = 0
+    rows = {}
+    for u in range(V):
+        for w in range(u + 1, V):
+            z = SEC[tuple(sorted((u, w)))][0]
+            hop = {q for q in range(NQ) if len(odd(z ^ (1 << q))) == 2}
+            ann = sum(1 for q in range(NQ) if len(odd(z ^ (1 << q))) == 0)
+            T = {q for q, (i, j) in enumerate(EDGES) if (u in (i, j)) ^ (w in (i, j))}
+            if hop != T:
+                bad += 1
+            d = bin(u ^ w).count("1")
+            rows.setdefault(d, [0, len(hop), ann])
+            rows[d][0] += 1
+    check("D3 [exact] in a ONE-PAIR sector (B_v = -1 at corners u, w) the admissible single "
+          "complements are EXACTLY the edges incident to exactly one of u, w -- %d mismatches over %d "
+          "pairs: %d hops + %d annihilation at distance 1 (%d pairs), %d hops at distance 2 (%d) "
+          "and 3 (%d)"
+          % (bad, V * (V - 1) // 2, rows[1][1], rows[1][2], rows[1][0],
+             rows[2][1], rows[2][0], rows[3][0]),
+          bad == 0 and rows[1][1] == 4 and rows[1][2] == 1
+          and rows[2][1] == 6 and rows[2][2] == 0 and rows[3][1] == 6 and rows[3][2] == 0)
+
+    chg = set()
+    star = set()
+    for u in range(V):
+        for w in range(u + 1, V):
+            z = SEC[tuple(sorted((u, w)))][0]
+            for q in range(NQ):
+                o = odd(z ^ (1 << q))
+                if len(o) == 2 and set(o) != {u, w}:
+                    chg.add(bin((z ^ (1 << q)) ^ z).count("1"))
+                    moved = ({u, w} | set(o)) - ({u, w} & set(o))
+                    star.add(len(moved))
+    check("D4 [exact] at every such hop exactly %d edge record changes its VALUE and exactly %d odd "
+          "corner moves, to an adjacent corner: the star of edge records does NOT "
+          "translate -- the odd corner does, and what moves is the parity pattern"
+          % (min(chg), min(k // 2 for k in star)),
+          chg == {1} and star == {2})
+
+    padj = [(q, r) for q in range(NQ) for r in range(q + 1, NQ)
+            if set(EDGES[q]) & set(EDGES[r])]
+    z0 = SEC[()][0]
+    outc = {}
+    for q, r in padj:
+        k = len(odd(z0 ^ (1 << q) ^ (1 << r)))
+        outc[k] = outc.get(k, 0) + 1
+    check("D5 [exact] and all %d adjacent TWO-edge complements -- the nearest thing to a rigid "
+          "two-record shift -- LEAVE the vacuum sector: odd-corner counts %s"
+          % (len(padj), str({k: outc[k] for k in sorted(outc)})),
+          len(padj) == 24 and outc == {2: 24})
+
+
+# ===================================================================== group E
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    """Kogut-Susskind staggered (pi-flux) link sign of the bond (v, v + e_a)."""
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def torus(L):
+    sites = list(itertools.product(range(L), repeat=3))
+    idx = {v: i for i, v in enumerate(sites)}
+    r, c, d = [], [], []
+    for v in sites:
+        for a in range(3):
+            w = tuple((v[i] + EX[a][i]) % L for i in range(3))
+            s = float(eta_ks(v, a))
+            r += [idx[w], idx[v]]
+            c += [idx[v], idx[w]]
+            d += [s, s]
+    return sp.csr_matrix((d, (r, c)), shape=(L ** 3, L ** 3)), sites, idx
+
+
+def minimal(x, L):
+    x %= L
+    return x - L if x > L // 2 else x
+
+
+def two_record(L):
+    """The two-record hopping generator H = -T on the L^3 torus, its
+    configuration index, and the adjacency data.  Sparse throughout."""
+    M1, sites, idx = torus(L)
+    V = L ** 3
+    M1d = M1.toarray()
+    nbr = [[idx[tuple((v[i] + e[i]) % L for i in range(3))] for e in NB] for v in sites]
+    pid = -np.ones((V, V), dtype=np.int64)
+    cfg = []
+    for a in range(V):
+        for b in range(a + 1, V):
+            pid[a, b] = pid[b, a] = len(cfg)
+            cfg.append((a, b))
+    nc = len(cfg)
+    cfg = np.array(cfg)
+    r2, c2, v2 = [], [], []
+    for ci, (a, b) in enumerate(cfg):
+        for (v, u) in ((a, b), (b, a)):
+            for w in nbr[v]:
+                if w == u:
+                    continue
+                amp = M1d[w, v]
+                if amp == 0:
+                    continue
+                sgn = -1.0 if (min(v, w) < u < max(v, w)) else 1.0
+                r2.append(pid[w, u])
+                c2.append(ci)
+                v2.append(-amp * sgn)
+    H2 = sp.csr_matrix((v2, (r2, c2)), shape=(nc, nc))
+    P0 = np.array([sites[a] for a in cfg[:, 0]])
+    P1 = np.array([sites[b] for b in cfg[:, 1]])
+    MIND = np.array([minimal(x, L) for x in range(L)])
+    REL = np.stack([MIND[(P1[:, a] - P0[:, a]) % L] for a in range(3)], 1)
+    DIST = np.abs(REL).sum(1)
+    ADJ = np.where(DIST == 1)[0]
+    AX = -np.ones(nc, dtype=np.int64)
+    AX[ADJ] = np.argmax(np.abs(REL[ADJ]), axis=1)
+    SUMC = (P0 + P1) % L
+    return dict(L=L, M1=M1, sites=sites, idx=idx, pid=pid, cfg=cfg, nc=nc, H2=H2,
+                ADJ=ADJ, AX=AX, SUMC=SUMC, MIND=MIND, DIST=DIST)
+
+
+def pair_chain(T, tau):
+    """One KT tick of the hard-adjacency pair, reduced to the 3 relative-axis
+    classes by translation covariance.  Returns the orientation chain, the
+    exact centre-of-mass diffusion constant, and the joint-move census."""
+    L, idx, pid, nc = T["L"], T["idx"], T["pid"], T["nc"]
+    ADJ, AX, SUMC, MIND = T["ADJ"], T["AX"], T["SUMC"], T["MIND"]
+    reps = [pid[idx[(0, 0, 0)], idx[tuple(EX[a])]] for a in range(3)]
+    B = np.zeros((nc, 3), dtype=complex)
+    for k in range(3):
+        B[reps[k], k] = 1.0
+    OUT = spla.expm_multiply(-1j * tau * T["H2"], B)
+    Pm = np.zeros((3, 3))
+    MU = np.zeros((3, 3))
+    adm = np.zeros(3)
+    wrap = 0.0
+    joint = []
+    for k in range(3):
+        p = np.abs(OUT[:, k]) ** 2
+        p /= p.sum()
+        adm[k] = p[ADJ].sum()
+        q = p[ADJ] / p[ADJ].sum()
+        s0 = SUMC[reps[k]]
+        dS = np.stack([MIND[(SUMC[ADJ, i] - s0[i]) % L] for i in range(3)], 1).astype(float) / 2.0
+        wrap = max(wrap, float(q[np.max(np.abs(dS), axis=1) >= L / 4.0].sum()))
+        kk = AX[ADJ]
+        for k2 in range(3):
+            Pm[k, k2] = q[kk == k2].sum()
+        MU[k] = q @ dS
+        joint.append((q, dS, kk))
+    w_, v_ = np.linalg.eig(Pm.T)
+    k0 = int(np.argmin(np.abs(w_ - 1)))
+    pi = np.real(v_[:, k0])
+    pi /= pi.sum()
+    m = pi @ MU
+    A = np.vstack([np.eye(3) - Pm, pi[None, :]])
+    bb = np.vstack([MU - m[None, :], np.zeros((1, 3))])
+    h, *_ = np.linalg.lstsq(A, bb, rcond=None)
+    sig = 0.0
+    for k in range(3):
+        q, dS, kk = joint[k]
+        M = dS + h[kk] - h[k] - m[None, :]
+        sig += pi[k] * float(q @ (M * M).sum(1))
+    # free single-record reference on the same torus
+    e0 = np.zeros(L ** 3, dtype=complex)
+    e0[idx[(0, 0, 0)]] = 1.0
+    ps = np.abs(spla.expm_multiply(-1j * tau * (-T["M1"]), e0)) ** 2
+    D = np.array([[minimal(s[i], L) for i in range(3)] for s in T["sites"]], float)
+    m1 = ps @ D
+    D1 = float((ps @ D ** 2).sum() - (m1 ** 2).sum()) / (6 * tau)
+    # joint-move census from an axis-1 pair
+    q, dS, kk = joint[0]
+    old = {idx[(0, 0, 0)], idx[tuple(EX[0])]}
+    cls = {}
+    sites = T["sites"]
+    for t, ci in enumerate(ADJ):
+        a, b = T["cfg"][ci]
+        new = {int(a), int(b)}
+        if new == old:
+            nm = "same sites"
+        elif len(new & old) == 1:
+            nm = "one record shifts"
+        else:
+            o = sorted(old)
+            n2 = sorted(new)
+            t1 = tuple((np.array(sites[n2[0]]) - np.array(sites[o[0]])) % L)
+            t2 = tuple((np.array(sites[n2[1]]) - np.array(sites[o[1]])) % L)
+            t3 = tuple((np.array(sites[n2[1]]) - np.array(sites[o[0]])) % L)
+            t4 = tuple((np.array(sites[n2[0]]) - np.array(sites[o[1]])) % L)
+            nm = "rigid translation" if (t1 == t2 or t3 == t4) else "non-rigid"
+        cls[nm] = cls.get(nm, 0.0) + float(q[t])
+    return dict(adm=adm, Pm=Pm, pi=pi, D=sig / (6 * tau), D1=D1, drift=float(np.abs(m).max()),
+                wrap=wrap, census=cls, rowerr=float(np.abs(Pm.sum(1) - 1).max()))
+
+
+def group_E():
+    """KT: the hard-adjacency pair, against PR #7889's energetic pair."""
+    T6 = two_record(6)
+    T8 = two_record(8)
+
+    # translation covariance of the tick kernel
+    L = 6
+    worst = 0.0
+    sites, idx, pid, cfg = T6["sites"], T6["idx"], T6["pid"], T6["cfg"]
+    o1, o2 = idx[(0, 0, 0)], idx[(1, 0, 0)]
+    for shift in [(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 1), (2, 3, 1)]:
+        s1 = idx[tuple(shift)]
+        s2 = idx[tuple((shift[i] + EX[0][i]) % L for i in range(3))]
+        B = np.zeros((T6["nc"], 2), dtype=complex)
+        B[pid[o1, o2], 0] = 1.0
+        B[pid[s1, s2], 1] = 1.0
+        O = spla.expm_multiply(-1j * 1.0 * T6["H2"], B)
+        p0 = np.abs(O[:, 0]) ** 2
+        p1 = np.abs(O[:, 1]) ** 2
+        perm = np.array([pid[idx[tuple((sites[a][i] + shift[i]) % L for i in range(3))],
+                             idx[tuple((sites[b][i] + shift[i]) % L for i in range(3))]]
+                         for a, b in cfg])
+        worst = max(worst, float(np.abs(p1[perm] - p0).max()))
+    check("E1 [numerical, 1e-9] the HARD-ADJACENCY pair: on the L = 6 and L = 8 pi-flux tori the %d "
+          "and %d non-adjacent two-record configurations carry odds 0, leaving %d and %d; the tick "
+          "kernel is translation covariant to %.1e, so the class chain is exact"
+          % (T6["nc"] - len(T6["ADJ"]), T8["nc"] - len(T8["ADJ"]),
+             len(T6["ADJ"]), len(T8["ADJ"]), worst),
+          T6["nc"] == 23220 and T8["nc"] == 130816 and len(T6["ADJ"]) == 648
+          and len(T8["ADJ"]) == 1536 and worst < 1e-9)
+
+    R = {}
+    for T in (T6, T8):
+        for tau in (0.5, 1.0):
+            R[(T["L"], tau)] = pair_chain(T, tau)
+    rat = [R[(k, t)]["D"] / R[(k, t)]["D1"] for t in (0.5, 1.0) for k in (6, 8)]
+    check("E2 [numerical, 1e-3] a group confined by a SUPPORT condition still MOVES: D_pair/D_1 = "
+          "%.4f, %.4f at tau = 0.5 and %.4f, %.4f at tau = 1 (L = 6, 8) against the "
+          "independent-record 1/2; the odds on the admissible set before renormalising, %.2f and "
+          "%.2f (wrap <= %.1e, drift <= %.1e)"
+          % (rat[0], rat[1], rat[2], rat[3],
+             R[(6, 0.5)]["adm"][0], R[(6, 1.0)]["adm"][0],
+             max(R[k]["wrap"] for k in R), max(R[k]["drift"] for k in R)),
+          abs(rat[0] - 0.5016) < 1e-3 and abs(rat[1] - 0.5075) < 1e-3
+          and abs(rat[2] - 0.1058) < 1e-3 and abs(rat[3] - 0.1453) < 1e-3
+          and abs(R[(6, 0.5)]["adm"][0] - 0.31) < 5e-3
+          and abs(R[(6, 1.0)]["adm"][0] - 0.28) < 5e-3
+          and max(R[k]["wrap"] for k in R) < 2e-2)
+
+    pierr = max(float(np.abs(R[k]["pi"] - 1.0 / 3).max()) for k in R)
+    chg = [1 - float(sum(R[(k, t)]["pi"][a] * R[(k, t)]["Pm"][a, a] for a in range(3)))
+           for t in (0.5, 1.0) for k in (6, 8)]
+    check("E3 [numerical, 1e-9] P(adjacent) = 1 at EVERY tick by construction -- absolute, not "
+          "statistical (rows sum to 1 to %.1e); the orientation is a 3-state chain on the relative "
+          "axis, stationary odds exactly (1/3, 1/3, 1/3) (%.1e), P(axis changes) %.3f, %.3f at "
+          "tau = 0.5 and %.3f, %.3f at 1"
+          % (max(R[k]["rowerr"] for k in R), pierr, chg[0], chg[1], chg[2], chg[3]),
+          pierr < 1e-9 and max(R[k]["rowerr"] for k in R) < 1e-9
+          and abs(chg[1] - 0.4760) < 1e-3 and abs(chg[3] - 0.0717) < 1e-3)
+
+    c = R[(8, 0.5)]["census"]
+    check("E4 [numerical, 1e-6] it moves by SHUFFLING, not translating: the joint-move census at "
+          "L = 8, tau = 0.5 from an axis-1 pair reads one record shifts %.3f, rigid translation %.3f, "
+          "same sites %.3f, non-rigid %.3f (sum %.6f)"
+          % (c["one record shifts"], c["rigid translation"], c["same sites"], c["non-rigid"],
+             sum(c.values())),
+          abs(c["one record shifts"] - 0.540) < 2e-3 and abs(c["rigid translation"] - 0.239) < 2e-3
+          and abs(c["same sites"] - 0.218) < 2e-3 and abs(c["non-rigid"] - 0.002) < 2e-3
+          and abs(sum(c.values()) - 1) < 1e-9)
+
+    seq, unif = _energetic_pair(T6, 0.5, 32.0)
+    check("E5 [numerical, 1e-6] the CONTRAST, PR #7889\'s energetic pair on the same torus: with "
+          "an ENERGY COST g = 32 and no support condition P(adjacent) at ticks 1, 2, 5, 10, 20, 40 "
+          "runs %s toward uniform %.4f -- a cost only slows the parting"
+          % (_tq(seq, 3), unif),
+          abs(seq[0] - 0.9783) < 1e-3 and abs(seq[-1] - 0.4235) < 1e-3
+          and all(a > b for a, b in zip(seq, seq[1:])))
+
+
+def _energetic_pair(T, tau, g):
+    """PR #7889's M4: two records under a bond ENERGY COST, on the exact
+    111-class relative chain of the 6^3 torus."""
+    L, nc, cfg, sites, idx = T["L"], T["nc"], T["cfg"], T["sites"], T["idx"]
+    pid, DIST = T["pid"], T["DIST"]
+    H2 = T["H2"] + sp.diags((DIST == 1).astype(float) * g)
+
+    def relkey(a, b):
+        va, vb = sites[a], sites[b]
+        r1 = tuple((vb[i] - va[i]) % L for i in range(3))
+        return min(r1, tuple((-x) % L for x in r1))
+
+    keys = sorted({relkey(int(a), int(b)) for a, b in cfg})
+    kid = {k: i for i, k in enumerate(keys)}
+    nk = len(keys)
+    ckey = np.array([kid[relkey(int(a), int(b))] for a, b in cfg], dtype=np.int64)
+    kdist = np.array([sum(min(x, L - x) for x in k) for k in keys])
+    rep = {kid[k]: pid[idx[(0, 0, 0)], idx[k]] for k in keys}
+    csize = np.bincount(ckey, minlength=nk).astype(float)
+    unif = float((csize / csize.sum())[kdist == 1].sum())
+    B = np.zeros((nc, nk), dtype=complex)
+    for k in range(nk):
+        B[rep[k], k] = 1.0
+    Q = np.zeros((nk, nk))
+    for s in range(0, nk, 24):
+        out = spla.expm_multiply(-1j * tau * H2, B[:, s:s + 24])
+        for k in range(out.shape[1]):
+            Q[s + k] = np.bincount(ckey, weights=np.abs(out[:, k]) ** 2, minlength=nk)
+    p = np.zeros(nk)
+    p[[k for k in range(nk) if kdist[k] == 1][0]] = 1.0
+    seq = []
+    for n in range(1, 41):
+        p = p @ Q
+        if n in (1, 2, 5, 10, 20, 40):
+            seq.append(float(p[kdist == 1].sum()))
+    return seq, unif
+
+
+def main():
+    group_A()
+    group_B()
+    group_C()
+    group_D()
+    group_E()
+    print("SUMMARY: a support condition confines a group ABSOLUTELY where an energy cost does not; "
+          "but on this bipartite lattice one step severs every companion, so the group rattles in "
+          "an exact cage (D = 0): rigid travel needs a simultaneous tick.")
+    print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache answering the owner's point (2026-09-03) that neighbourhood conditions can force groups of records to translate together. **A support condition of the law (zero odds for a configuration in which a record loses a needed neighbour; Admissibility reading note (3)) confines a group absolutely, where an energy cost only slows its parting.** A hard-adjacency pair on the pi-flux torus keeps `P(adjacent) = 1` at every tick by construction and still moves at about half the single-record diffusion rate, while PR #7889's energy-bound pair at `g = 32` drifts apart. But confinement is not transport: the cubic lattice is bipartite, so a one-step shift severs every companion at once; a companion-conditioned group under one-step ticks rattles in an exact cage (`D_group = 0`, the centre-of-mass displacement an exact coboundary for all groups up to six records), and rigid translation needs a simultaneous whole-group tick (then `D_group = D_1` exactly) or a tick whose amplitude reaches beyond one site. The emergent cube is a worked instance: in the vacuum no record changes alone (admissible moves are exactly the cycle space), and with a particle present the odd corner moves by one record changing value.

- `docs/SUPPORT_CONDITIONS_CONFINE_GROUPS_OF_SHIFTING_RECORDS_ENERGY_COSTS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-09-03.md` (325 lines)
- `scripts/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.py` (`TOTAL: PASS=21 FAIL=0`, 8.8 s; no sampling, no seed)
- `logs/runner-cache/support_conditions_confine_groups_of_shifting_records_check_2026_09_03.txt`

## Theorems

- **T1** the bipartite lemma: two neighbours of a site are never adjacent, so a shifting record loses every former companion.
- **T2** companion condition: no record is ever alone; groups of size <= 4 never split; for `n = 3..6` an exact rational potential of the shape gives the centre-of-mass displacement as a coboundary, so `D_group = 0` exactly and the cage is under `4/3` of a site wide.
- **T3** rigid condition: one-step shifts frozen; simultaneous whole-group shifts are exactly rigid unit translations (isometry form adds rotations/reflections); the occupancy convention is load-bearing (`D_group/D_1 = 1` permissive; `0.667, 0.333, 0` strict for dimer, bent trimer, `2x2x2` block).
- **T4** the emergent cube: vacuum moves are closed loops only (the cycle space, exactly); in a one-pair sector the admissible single complements are exactly the hops of an odd corner; the star of records does not translate.
- **T5** the hard-adjacency pair: `D_pair/D_1 = 0.50` at `tau = 0.5`, orientation stationary at `(1/3, 1/3, 1/3)`, moves mostly by rearranging (one record shifts 0.54, rigid translation 0.24); contrast with the energetic pair.

## Corollary and boundary

- The mechanism is real; the mobility of a bound group is set by how far a record can shift in one tick, not by the condition alone; whether the framework's law carries such a condition is untested and named as the owner's question. Stipulated conditions and ticks; polycubes to `n = 6`; the cube; tori `L = 6, 8` with free hopping; nothing derived from the axioms.

## Context

- Parent: `SHIFTING_POSITION_RECORDS_EXACT_DIFFUSION_LAW_AND_THE_UNIFORM_ATTRACTOR_BOUNDED_THEOREM_NOTE_2026-09-03.md` (PR #7889); pointers to PR #7858, #7876, #7834.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
