### PR TITLE
feat(gauge): fermion U(1) on quantum links, Gauss law as a support condition

### DIFF
--- a/docs/THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,322 @@
+---
+claim_id: fermion_u1_quantum_links_gauss_law_support_condition
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3 carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, and with ONE FURTHER DESIGNED ROLE per coarse edge -- a spin-1/2 link site carrying E_e = Z^L_e/2 and U_e = (X^L_e + i Y^L_e)/2, declared as a design element of exactly the same kind as the period-(4,2,2) superlattice role pattern of PR #7834 and derived from no axiom -- for the ONE DECLARED coupled law H^g = -t sum_<ij> eta_ij (T_ij X^L_ij + K_ij Y^L_ij)/2 with the supplied optional terms lambda sum_f P_f and (g^2/2) sum_e E_e^2 whose coefficients t, lambda and g are supplied and are fixed by nothing quoted here, and on the named finite blocks only -- the open 2x2x2 cube, the open 3x3x3 block, and the single coarse 2x2x1 plaquette: (T1) writing a_i^dag a_j = (T_ij - i K_ij)/2, the gauge-invariant hop a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i equals (T_ij X^L_ij + K_ij Y^L_ij)/2 exactly, Hermitian and exactly four Pauli monomials, on all 66 bonds of the cube and the open 3x3x3 block, with K_ij = -(1/2) A_ij (I - B_i B_j) Hermitian, K_ji = -K_ij, exactly two Pauli monomials on the same site support as T_ij (5 on the cube, 6, 8 or 10 on the open 3x3x3 block), K_ij = -i [T_ij, n_i], {T_ij, K_ij} = 0, [T_ij, K_ij] = -2i (n_i - n_j) = i (B_i - B_j), and J_ij of PR #7892 = -eta_ij t K_ij on every bond -- one factor of t and the sign minus, not eta (t/2) K_ij. (T2) With rho_v^{sea} = n_v - 1/2 or rho_v^{stag} = n_v - (1 - eps_v)/2 and (div E)_v = sum_{e at v} s_{v,e} E_e, every G_v = (div E)_v - rho_v is a pure Z operator, record-diagonal on the 2 z_v records at one corner -- six on the cube, three fermion edge records and three link records, and twelve at the interior corner of the 3x3x3 block -- with [G_v, G_w] = 0 for all 64 + 729 corner pairs, [G_v, H^g] = 0 at every corner, and sum_v G_v = -sum_v rho_v, which in the sea convention reads sum_v G_v = -Q; 2 (div E)_v sums z_v terms +-1 and so carries the parity of z_v, while 2 rho^{sea} is odd and 2 rho^{stag} is even, so spin-1/2 links admit rho^{sea} only at odd z_v and rho^{stag} only at even z_v; by exact enumeration the cube (z = 3) has 14400 joint record patterns of 2^24 in the sea convention and 0 in the staggered one, while the plaquette (z = 2) has 0 and 14; exactly 2240 of the 4096 cube fermion record patterns admit at least one link pattern and they are precisely the half-filled N = 4 sector, with link-pattern multiplicities 192 x 4, 1024 x 6, 768 x 7, 192 x 8 and 64 x 9; and since every nontrivial face-loop product carries X and so has zero diagonal, dim(Gauss and code) = 14400/2^5 = 450 on the cube and 14/2^1 = 7 on the plaquette. (T3) With J^g_ij = -(t eta_ij/2)(K_ij X^L_ij - T_ij Y^L_ij) = (1/2)(J_ij X^L_ij + eta_ij t T_ij Y^L_ij), Hermitian on every bond: dn_v/dt = i[H^g, n_v] = -sum_w J^g_vw at every corner, dE_e/dt = i[H^g, E_e] = -J^g_e on every one of the 66 links, and d(div E)_v/dt = dn_v/dt at every corner; reversing a bond must reverse the link orientation too, X^L_e J^g_ji X^L_e = -J^g_ij, while J^g_ji = -J^g_ij alone fails on all 66 bonds; and E_e^2 = I/4 identically, so (g^2/2) sum_e E_e^2 is a c-number at spin 1/2. (T4) P_f = W_f + W_f^dag, the oriented four-link ring exchange around a coarse face, is Hermitian with exactly eight Pauli monomials on exactly the four link records of that face and no fermion record, [P_f, G_v] = 0 for all 48 face-corner pairs on the cube and 4 on the plaquette in both rho conventions, [P_f, S_f] = 0 and [P_f, prod_{e in f} Z^L_e] = 0, while [P_f, H^g] != 0 with 64 nonzero Pauli monomials on the cube face at (0,0,0). (T5) [numerical] On the 256-dimensional plaquette the Gauss sector has dimension 14 in the admissible staggered convention, 0 in the sea convention, and 7 intersected with the fermion code, where E_0 = -2.449489742783 = -sqrt 6 at lambda = 0 and -2.323404276086 at lambda = 1 with <P_f> = 1/6 and 0.094209746012, and max |<rho_v>| = 0.5833333333 and 0.6456532164, so that ground state is locally charged; on the cube the sea-convention Gauss sector is 14400 states of 2^24 on which H^g is sparse with 79872 nonzeros, its ground state lies in the code space at <S_f> = +1 with E_0 = -5.466823694822 at lambda = 0 and -6.980814328073 at lambda = 1, both at <N> = 4 = |V|/2, and <n_v> = 1/2, <rho_v> = 0 and <E_e> = 0 hold to 1e-13 at every one of the 8 corners and every one of the 12 links at both couplings. The link role and the link dynamics are designed, not derived; t, lambda and g are supplied data; the two rho conventions differ and that tension is carried here as an open item, not resolved; no gapless transverse mode of the link sector is shown, computed, or suggested, and no continuum limit is taken; no claim is made that this U(1) is electromagnetism. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
+---
+
+# The fermion's `U(1)` coupled to quantum links: Gauss's law as a support condition among records
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py`](../scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt`](../logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt)
+**Parents:** none load-bearing. Every premise used below is declared in this note; the context notes are plain-text pointers listed in "Imports and authority".
+
+PR #7892 gave the coarse-lattice emergent fermion a charge and a conserved bond current, and left one question open on its face: nothing in the declared law couples
+to that `U(1)`. The question here is whether something can, inside the framework's readable algebra, and what Gauss's law is once it does. The answer needs one more
+designed role -- a second site per coarse edge -- and it is declared as designed, in exactly the sense PR #7834's role pattern is. What comes back is that the
+coupling is exact, and that Gauss's law is a relation among records at a single corner: a condition on which patterns of records are admissible, not a further law.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems about one declared coupled law on the coarse-lattice emergent fermion carrying one designed spin-1/2 link role per coarse edge: the gauge-invariant hop and its two-monomial partner K_ij, Gauss's law as a record-diagonal corner relation with its exact joint record-pattern census and its coordination-parity condition, the coupled Ampere and continuity relations, and the four-link ring exchange. The symplectic Pauli statements are exact Gaussian-rational arithmetic on F2 supports with Z4 phases; the census statements are exact integer arithmetic over all 2^24 cube and 2^8 plaquette record patterns; the tagged numerical items are floating-point cross-checks at the stated tolerance."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the design question this note does not decide: which link size the framework wants, given that spin-1/2 links carry a coordination-parity condition the bulk coarse lattice and the cube answer differently."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. Groups `A`, `B`, `C` and `D` are exact -- Gaussian-rational
+coefficients on symplectic Pauli monomials, `F2` supports and `Z4` phases, complete sweeps, and integer record arithmetic, with no floating-point step anywhere --
+and the items tagged `[numerical]` in group `E` are floating-point cross-checks at the stated tolerance.
+
+1. `T1` (`A`). The gauge-invariant hop, and `K_ij` as the two-monomial partner the encoding already contains.
+2. `T2` (`B`). Gauss's law as a record-diagonal corner relation, its exact census, and the coordination-parity condition on spin-1/2 links.
+3. `T3` (`C`). Ampere, coupled continuity, and what bond reversal does to a link.
+4. `T4` (`D`). The four-link ring exchange, and what it does and does not commute with.
+5. `T5` (`E`). The coupled sea on the plaquette and on the cube's Gauss sector.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, the quantum-link (gauge-magnet) presentation of
+a lattice gauge field with finite-dimensional link algebras, the ring-exchange plaquette term, and the Pauling residual-entropy estimate for ice-rule configurations
+are standard methodology; every object is redeclared here and the runner recomputes every statement. No observational value, no fitted number and no framework premise
+enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `CHARGE_CONJUGATION_AND_THE_CONSERVED_U1_CURRENT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7892): the encoding, the charge
+  `Q = -(1/2) sum_v B_v` and the bond current `J_ij = eta_ij (t/2) A_ij (I - B_i B_j)`. Its closing interface -- that nothing couples to this `U(1)` -- is the
+  question `T1` and `T2` here answer for one declared coupling.
+- `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the period-`(4,2,2)` superlattice
+  role pattern and the coarse sublattice `2Z^3`. The link role declared here is a design element of exactly that kind.
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): the staggered kinetic form and the KS signs.
+- `THE_VACUUM_QUESTION_IS_ONE_COEFFICIENT_OF_THE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7885) and
+  `MATTER_ABOVE_THE_HALF_FILLED_SEA_ODD_AND_EVEN_DENSITIES_AND_THE_VACUUM_QUESTION_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7879): the vacuum
+  coefficient, and the half-filled sea at `<n_v> = 1/2`.
+- `RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7858): record formation on the vacuum and its parity cosets.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting", including the Admissibility reading note used to say what a support condition is.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has
+algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic
+rotations", and "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions" -- the law
+supplies the odds. Reading note (3) fixes the vocabulary used below: "The distribution is a probability measure on the local possibility domain;
+'available'/'admissible' denotes its support -- on finite menus, exactly the possibilities of nonzero probability." **Record**: "Records form", "a record locks
+exactly one admissible local possibility", "records are permanent", "Only records are readable", and "A readout value is determined by record content alone."
+
+The lattice is physical. Everything below reads the Kawamoto-Smit sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, on the superlattice
+role pattern's sublattice, and adds one further designed role. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites'
+algebras and no graded clause is used anywhere.
+
+A **support condition** in this note means exactly what reading note (3) licenses: a condition whose failure is a zero of the law-level odds, so that the record
+patterns violating it are outside the support of the distribution the law supplies. It is a statement about which patterns of records are admissible. It is not a
+further dynamical clause, and no formation site, rate, or process word is used to state it.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field
+on it, the superfast encoding with its face stabilizers, the designed link role with its `E_e` and `U_e`, and the coupled law `H^g` with its supplied coefficients.
+`P1` (`A`) is the gauge-invariant hop and `K_ij`; `P2` (`B`) Gauss's law, its census and the coordination-parity condition; `P3` (`C`) Ampere and continuity; `P4`
+(`D`) the ring exchange; `P5` (`E`) the coupled sea. `P2` uses `P0` only; `P3` uses `P1`'s `K_ij`; `P4` uses `P0`; `P5` uses `P2`'s sector. The strongest supported
+scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`, and the coarse edge from `v` along `e_a` sits at the fine site `2v + e_a`. The **KS
+sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`. The **encoding** is the Bravyi-Kitaev superfast
+encoding on the coarse lattice, fermion code sites on the coarse edges, direction order `-x < -y < -z < +x < +y < +z`. The **link role** is one further two-state site
+per coarse edge, declared exactly as PR #7834's role pattern is declared: assigned by design, derived from nothing.
+
+```text
+A_ij = X(edge (i,j)) * prod Z(edges ordered before it at i) * prod Z(edges ordered before it at j),  A_ji = -A_ij
+B_v  = the product of the Z's at corner v = I - 2 n_v,   S_f = the ordered product of the four A's around a coarse face f
+n_v  = (I - B_v)/2,   eps_v = (-1)^{v_1+v_2+v_3},   T_ij = (i/2) A_ij (B_i - B_j),   K_ij = -(1/2) A_ij (I - B_i B_j)
+E_e  = (1/2) Z^L_e   (eigenvalues +-1/2),    U_e = (X^L_e + i Y^L_e)/2,    U_e^dag U_e + U_e U_e^dag = I
+bond (v, e_a) is oriented i = v -> j = v + e_a;   s_{v,e} = +1 if e leaves v, -1 if e enters v
+H^g = -t sum_<ij> eta_ij (T_ij X^L_ij + K_ij Y^L_ij)/2   +  lambda sum_f P_f  +  (g^2/2) sum_e E_e^2      THE DECLARED LAW
+J^g_ij = -(t eta_ij / 2) (K_ij X^L_ij - T_ij Y^L_ij)                                       THE COUPLED BOND CURRENT
+(div E)_v = sum_{e at v} s_{v,e} E_e,  rho_v^{sea} = n_v - 1/2,  rho_v^{stag} = n_v - (1 - eps_v)/2,  G_v = (div E)_v - rho_v
+W_f = the oriented loop product of U (forward steps) and U^dag (backward steps) around a coarse face;  P_f = W_f + W_f^dag
+```
+
+The **coordination** `z_v` is the number of coarse edges at `v`: `3` on the open cube, `2` on the plaquette, `3` to `6` on the open `3x3x3` block, `6` in the bulk. A
+**record pattern** is one assignment of a value to every record site; the record basis is the joint eigenbasis of the `Z`'s. An operator is **record-diagonal** when
+it is diagonal in that basis, so that its value is fixed by record content alone. `t`, `lambda` and `g` are **supplied**.
+
+## Theorem 1 -- the gauge-invariant hop, and the partner the encoding already contains
+
+**Conclusion.** (1) Writing `a_i^dag a_j = (T_ij - i K_ij)/2`, the minimally coupled hop is exact: `a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i = (T_ij X^L_ij + K_ij
+Y^L_ij)/2`, Hermitian, exactly four Pauli monomials, on all `66` bonds of the `2x2x2` cube and the open `3x3x3` block. (2) `K_ij = -(1/2) A_ij (I - B_i B_j)` is
+Hermitian with `K_ji = -K_ij` and is **exactly two Pauli monomials**, on the same site support as `T_ij` -- `5` sites on the cube, `6`, `8` or `10` on the open
+`3x3x3` block. (3) `K_ij = -i [T_ij, n_i]`, so given the hop `K` is fixed by the fermion algebra and is not a further choice. (4) `{T_ij, K_ij} = 0` and `[T_ij,
+K_ij] = -2i (n_i - n_j) = i (B_i - B_j)`: `T`, `K` and `n_i - n_j` close an `su(2)` on every bond. (5) `J_ij` of PR #7892 `= -eta_ij t K_ij` on every bond -- one
+factor of `t`, sign **minus**, and not `eta_ij (t/2) K_ij`.
+
+**Proof.** Item 1 builds `a_i^dag a_j` and `a_j^dag a_i` from `T` and `K`, multiplies by the raising and lowering monomials of the link site, and compares key by key
+against the four-monomial right-hand side. Items 2 to 5 are `F2` support arithmetic with `Z4` phases on Gaussian-rational coefficients: monomial counts, supports,
+commutators and anticommutators compared to zero exactly. All exact, complete over both blocks.
+
+**Reading, not theorem.** The hop that carries a particle from one corner to the next already came in two pieces: one that is even under exchanging the two corners
+and one that is odd. Giving each edge its own record supplies exactly the second thing needed -- something that can change when the particle passes. The pairing is
+forced, not fitted: the odd piece is the current PR #7892 already named, up to a sign and one factor of the hopping strength.
+
+## Theorem 2 -- Gauss's law is a support condition among records
+
+**Conclusion.** (1) Every `G_v = (div E)_v - rho_v` is a **pure `Z` operator**, record-diagonal on the `2 z_v` records at one corner: six on the cube -- three fermion
+edge records and three link records -- and twelve at the interior corner of the `3x3x3` block. Explicitly at the cube corner `(0,0,0)`, `G_v^{sea} = (1/2)(Z_{f0}
+Z_{f1} Z_{f2} + Z_{L0} + Z_{L1} + Z_{L2})`, four monomials. (2) `[G_v, G_w] = 0` for all `64 + 729` corner pairs and `[G_v, H^g] = 0` at every corner, in both `rho`
+conventions; and `sum_v G_v = -sum_v rho_v`, which in the sea convention reads `sum_v G_v = -Q`. (3) **The coordination-parity condition.** `2 (div E)_v` is a sum of
+`z_v` terms `+-1` and so carries the parity of `z_v`, while `2 rho^{sea} = 2 n_v - 1` is odd and `2 rho^{stag} = 2 n_v - (1 - eps_v)` is even: with spin-1/2 links
+`G_v = 0` is solvable at `v` only for `rho^{sea}` at odd `z_v`, and only for `rho^{stag}` at even `z_v`. By exact census the cube (`z = 3`) has `14400` joint record
+patterns of `2^24` in the sea convention and `0` in the staggered one; the plaquette (`z = 2`) has `0` and `14`. (4) On the cube, exactly `2240` of the `4096`
+fermion record patterns admit at least one link pattern, and they are **precisely the half-filled `N = 4` sector, all of it**; the link-pattern multiplicities are
+`192 x 4`, `1024 x 6`, `768 x 7`, `192 x 8`, `64 x 9`, summing to `14400`. (5) Every nontrivial face-loop product carries `X` and so has zero diagonal, hence
+`dim(Gauss and code) = 14400/2^5 = 450` on the cube and `14/2^1 = 7` on the plaquette.
+
+**Proof.** Item 1 is monomial arithmetic: `n_v` is a corner parity of fermion edge records, `E_e` is one link record, and the sum of pure `Z` terms is pure `Z`.
+Item 2 is symplectic-form arithmetic against the four-monomial hop on every bond, plus a term-by-term cancellation of each link's two incidences in the sum. Item 3
+is the handshake parity of `z_v` terms `+-1` against the parity of `2 rho_v`, confirmed by complete vectorised integer enumeration of all `2^24` and `2^8` joint
+record patterns. Item 4 is the same enumeration read per fermion pattern; the restriction to `N = |V|/2` is already forced by item 2's `sum_v G_v = -Q`, and the
+census shows it is also sufficient. Item 5 is `F2` support arithmetic over the `2^5` and `2^1` face-loop products. All exact.
+
+**Reading, not theorem.** At each corner the law now says one thing about the records there: the flux records on the edges meeting at that corner, counted with the
+direction they point, must balance the matter record at the corner. Corner patterns that fail it have zero odds -- they are not admissible, in the axiom's own sense
+of the word. Nothing else is added. On the cube that single condition already picks out the half-filled patterns and no others, which is the same population the
+vacuum work arrived at from the energy side.
+
+## Theorem 3 -- Ampere, coupled continuity, and what reversing a bond does
+
+**Conclusion.** With `J^g_ij = -(t eta_ij/2)(K_ij X^L_ij - T_ij Y^L_ij)`, Hermitian on every bond: (1) `dn_v/dt = i[H^g, n_v] = -sum_w J^g_vw` at every corner of both
+blocks. (2) `dE_e/dt = i[H^g, E_e] = -J^g_e` on every one of the `66` links, `e` oriented tail to head. (3) `d(div E)_v/dt = dn_v/dt` at every corner. (4)
+`J^g_ij = (1/2)(J_ij X^L_ij + eta_ij t T_ij Y^L_ij)`: the `X^L` part of the coupled current **is** the uncoupled current of PR #7892. (5) Reversing a bond must
+reverse the link orientation with it -- `X^L_e J^g_ji X^L_e = -J^g_ij` -- while `J^g_ji = -J^g_ij` alone fails on all `66` bonds. (6) `E_e^2 = I/4` identically, so
+`(g^2/2) sum_e E_e^2` is a c-number: at spin `1/2` the electric term supplies no dynamics at all.
+
+**Proof.** Items 1 to 4 expand `i[H^g, .]` as Pauli sums with Gaussian-rational coefficients and compare key by key against the stated right-hand sides, on every
+corner and every link of both blocks. Item 5 conjugates by the link monomial and compares; the failure of the bare relation is the same comparison returning a
+nonzero residual on each bond. Item 6 is one monomial squared. All exact. Item 3 is Theorem 2 item 2 written as a rate.
+
+**Reading, not theorem.** The record on a link answers to exactly one thing: the current through its own edge. And the two halves of the corner condition change
+together -- the flux divergence at a corner tracks the matter there exactly -- so a pattern that satisfies the condition keeps satisfying it. One caution is worth
+stating plainly: a link record points one way along its edge, so reading the bond backwards means reading the link backwards too.
+
+## Theorem 4 -- the ring exchange, and what it leaves alone
+
+**Conclusion.** `P_f = W_f + W_f^dag`, the oriented four-link ring exchange around a coarse face, is (1) Hermitian with **exactly eight Pauli monomials** on exactly
+the **four link records** of that face and no fermion record; (2) `[P_f, G_v] = 0` for all `48` face-corner pairs on the cube and `4` on the plaquette, in both `rho`
+conventions; (3) `[P_f, S_f] = 0` and `[P_f, prod_{e in f} Z^L_e] = 0`, so the fermion code is untouched and the `Z2` remnant of the face flux is a record-diagonal
+constant of the ring exchange; and (4) `[P_f, H^g] != 0` -- on the cube face at `(0,0,0)` the commutator carries `64` nonzero Pauli monomials.
+
+**Proof.** Expansion of the four-factor loop product into monomials, then symplectic-form arithmetic for each commutator, over every face of both blocks and both
+`rho` conventions. All exact.
+
+**Reading, not theorem.** If the link records are to have any life of their own, the framework has to own a term that gives them one, because the obvious candidate
+-- the cost of the flux itself -- is a constant at this link size. The term that does the job acts on the four links of one face at once. That is a neighbourhood
+term, not a nearest-neighbour one, and it is as designed as the link role itself.
+
+## Theorem 5 -- the coupled sea
+
+**Conclusion.** (1) On the `256`-dimensional plaquette the Gauss sector has dimension `14` in the admissible staggered convention, `0` in the sea convention, and `7`
+intersected with the fermion code. (2) There `E_0 = -2.449489742783 = -sqrt 6` at `lambda = 0` and `-2.323404276086` at `lambda = 1`, with `<P_f> = 0.166666666667 =
+1/6` and `0.094209746012`. (3) That plaquette ground state is **locally charged**: `max |<rho_v>| = 0.5833333333` and `0.6456532164`, the total charge vanishing only
+in the sum. (4) On the cube the sea-convention Gauss sector is `14400` states of `2^24`, on which `H^g` is sparse with `79872` nonzeros and Hermitian at `0`; the
+ground state lies in the code space at `<S_f> = +1`, with `E_0 = -5.466823694822` at `lambda = 0` and `-6.980814328073` at `lambda = 1`, both at `<N> = 4 = |V|/2`.
+(5) There `<n_v> = 1/2`, `<rho_v> = 0` and `<E_e> = 0` to `1e-13` at every one of the `8` corners and every one of the `12` links, at both couplings: **the coupled
+sea is neutral with zero mean flux**.
+
+**Proof.** The plaquette is diagonalised densely on `256` dimensions, projected first onto the joint kernel of the four `G_v` and then onto the `+1` eigenspace of
+the face stabilizer. The cube's Gauss sector is built by vectorised bit arithmetic on the `2^24` joint record patterns and carried as a sparse `14400 x 14400`
+operator; `-5 sum_f S_f` places the code space lowest and Lanczos returns the ground state there. `[numerical, 1e-12]` for items 1 to 3 and `[numerical, 1e-10]` for
+items 4 and 5, the neutrality residuals at `1e-13`. No dense object above `14400` rows and no dense `2^24` object is formed anywhere.
+
+**Reading, not theorem.** With the links coupled, the half-filled sea stays exactly half filled, carries no charge at any corner, and carries no net flux on any
+link. That is a stronger statement than the uncoupled one: the corner condition could have forced flux into the ground state, and on the plaquette -- where the
+coordination parity permits only the other convention -- it does exactly that.
+
+## Corollary -- what the coupling buys, and what it costs
+
+Within the setting declared above, and on the finite blocks named:
+
+1. **An exactly gauge-invariant minimal coupling exists.** The emergent fermion's conserved `U(1)` couples to a designed spin-1/2 link role with no residual: the
+   coupled hop is four Pauli monomials, and the partner it needs was already inside the encoding as `-i[T_ij, n_i]`.
+2. **Gauss's law is a support condition.** `G_v` is record-diagonal on the `2 z_v` records at one corner, so `G_v = 0` is a zero of the law-level odds for the corner
+   configurations that fail it -- entirely within the Record axiom's readable content and the Admissibility reading note's sense of "admissible". On the cube its
+   solution set is exactly the half-filled sector, `14400` joint record patterns of `2^24`.
+3. **What registers and what does not.** The electric flux `E_e` is a one-record value on a link site, readable; so are `n_v`, `rho_v`, `(div E)_v`, `G_v`, `Q` and
+   the `Z2` face flux. The coupled hop, the current `J^g_ij`, the link raising `U_e` and the ring exchange `P_f` carry `X` in every monomial and so have no
+   record-diagonal part at all: they register only through correlations among records. This is PR #7892's pattern, extended to the link sector.
+4. **The cost is a coordination-parity condition.** Spin-1/2 links admit `rho^{sea}` only at odd `z_v` and `rho^{stag}` only at even `z_v`. On `2Z^3` proper
+   (`z = 6`) they force the staggered background half-charge; on the cube (`z = 3`) the sea convention is the admissible one. The two conventions differ, and the one
+   that makes the sea locally neutral is not the one the bulk admits. **This note declares that tension and does not resolve it.**
+5. **The coupled sea is neutral with zero mean flux** on the cube, at both values of the ring-exchange coefficient computed.
+
+**Reading, not theorem (this register).** Give every link between two corners its own record, read as a unit of flux pointing one way or the other. Gauss's law then
+says only this: at each corner, the flux records in and out must balance the matter record there. That is a rule about which patterns of records are possible, the
+same kind of rule the framework already uses. With that rule in place the matter's charge can flow along the links, the flux records change exactly as the current
+says, and the half-filled sea is neutral with no net flux anywhere. What is not shown is whether these links, left to themselves, carry light.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice, the encoding, the sign field, **the link role** and the coupled law are declared objects, and no
+  coefficient is derived: `t`, `lambda` and `g` are supplied, and no update rule, formation site, formation rate, coupling, or absolute unit appears. Which law
+  applies is designed, not derived -- the link role is a design element of exactly the kind PR #7834's role pattern is, and is declared as such here.
+- No continuum limit is taken, no second species appears, and no gapless transverse mode of the link sector is shown, computed, or suggested.
+
+## Interfaces named for other lanes, not moved here
+
+- **Whether the link sector carries light.** Whether the ring-exchange link sector has a gapless transverse mode -- a photon -- is **not** decided here, and nothing
+  in this note bears on it. The photon is an interface, not a result. The smallest test with a plausible transverse mode is the `4^3` coarse torus (`64` corners,
+  `192` links, `z = 6`), whose pure-link Gauss sector is about `2.5^64 = 2.9 x 10^25` states by the Pauling ice estimate. Exact diagonalisation is out of reach at
+  that size and so is matrix-free Lanczos, which needs a vector of that length; a constraint-preserving sampled route or a variational ansatz on the ice manifold is
+  what such a test would cost.
+- **Larger links.** Spin-1 or larger link algebras lift the coordination-parity condition of Theorem 2 item 3 and make the electric term of Theorem 3 item 6
+  non-trivial. Neither is treated here, and which link size the framework wants is a design question for the lane that owns the role rule.
+- **The ring-exchange coefficient.** `lambda` is supplied. What fixes it, if anything does, is not addressed.
+- **The fine-lattice role assignment.** The link role is declared on the coarse edge. Writing it as a rule on the physical lattice `Z^3`, in the way PR #7834 writes
+  the fermion roles, is not done here.
+- **The continuum.** Everything is a lattice operator. Whether `J^g_ij`, `G_v` or `P_f` has a continuum limit is not shown, and no claim is made that this `U(1)` is
+  electromagnetism.
+
+## Remaining live routes
+
+1. The convention question of Corollary 4, on a region large enough to carry both parities at once, or with a larger link algebra.
+2. Larger blocks. The open `2x2x2` cube, the open `3x3x3` block and the single `2x2x1` plaquette are what is proved; nothing is claimed beyond them.
+3. Correlations of the coupled current and of the link raising, which Theorem 5 shows are where these objects register at all.
+4. The `Z2` remnant of the face flux: readable by Theorem 4 item 3, but not a constant of `H^g`. What it does under the coupled law is not computed.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one fermionic mode per coarse vertex, BK superfast encoding, plus ONE DESIGNED spin-1/2 link role per coarse edge (declared, of the same kind as PR #7834's role pattern); ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md; H^g declared here with supplied t, lambda, g
+blocks: open 2x2x2 cube (8 corners, 12 + 12 records), open 3x3x3 block (27 corners, 54 + 54 records), single 2x2x1 plaquette (4 corners, 4 + 4 records)
+hop: a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i = (T_ij X^L_ij + K_ij Y^L_ij)/2 exactly, Hermitian, 4 Pauli monomials, on all 66 bonds
+K: K_ij = -(1/2) A_ij (I - B_i B_j), Hermitian, K_ji = -K_ij, exactly 2 monomials, support = supp(T_ij) = 5 (cube), 6/8/10 (open 3x3x3); K_ij = -i [T_ij, n_i]
+su2: {T_ij, K_ij} = 0 and [T_ij, K_ij] = -2i (n_i - n_j) = i (B_i - B_j) on every bond
+current_relation: J_ij (PR #7892) = -eta_ij t K_ij on every bond -- one factor of t, sign minus, NOT eta (t/2) K_ij
+gauss: G_v = (div E)_v - rho_v is pure Z on the 2 z_v records at one corner (6 on the cube, 12 at the 3x3x3 interior corner); [G_v, G_w] = 0 (64 + 729 pairs); [G_v, H^g] = 0 at every corner; sum_v G_v = -sum_v rho_v = -Q in the sea convention
+parity_condition: 2 (div E)_v carries the parity of z_v; 2 rho^sea odd, 2 rho^stag even; spin-1/2 links admit rho^sea only at odd z_v and rho^stag only at even z_v
+census: cube z = 3: 14400 joint record patterns of 2^24 (sea) and 0 (stag); plaquette z = 2: 0 and 14; 2240 of 4096 cube fermion patterns admissible = exactly the N = 4 sector; multiplicities 192 x 4, 1024 x 6, 768 x 7, 192 x 8, 64 x 9; dim(Gauss and code) = 450 and 7
+ampere: dE_e/dt = -J^g_e on all 66 links; dn_v/dt = -sum_w J^g_vw at every corner; d(div E)_v/dt = dn_v/dt; J^g_ij = (1/2)(J_ij X^L + eta t T_ij Y^L); X^L_e J^g_ji X^L_e = -J^g_ij while J^g_ji = -J^g_ij alone fails on 66 of 66 bonds; E_e^2 = I/4 identically
+ring_exchange: P_f Hermitian, 8 Pauli monomials, exactly the 4 link records of one face, no fermion record; [P_f, G_v] = 0 (48 pairs cube, 4 plaquette, both conventions); [P_f, S_f] = [P_f, prod Z^L] = 0; [P_f, H^g] != 0 with 64 nonzero monomials on the cube face at (0,0,0)
+plaquette_numerics: Gauss dim 14 (stag) / 0 (sea), Gauss and code 7; E_0 = -2.449489742783 = -sqrt 6 (lambda 0) and -2.323404276086 (lambda 1); <P_f> = 1/6 and 0.094209746012; max |<rho_v>| = 0.5833333333 and 0.6456532164 -- locally charged
+cube_numerics: Gauss sector 14400 of 2^24, sparse, 79872 nonzeros; ground state in the code space at <S_f> = +1; E_0 = -5.466823694822 (lambda 0) and -6.980814328073 (lambda 1); <N> = 4 = |V|/2; <n_v> = 1/2, <rho_v> = 0, <E_e> = 0 to 1e-13 at every corner and link
+not_shown: no gapless transverse mode of the link sector; smallest test is the 4^3 pure-link Gauss sector at ~2.9 x 10^25 states (Pauling estimate), beyond exact diagonalisation and beyond matrix-free Lanczos
+open_item: the sea and staggered conventions differ; the bulk (z = 6) admits only the staggered background half-charge while the cube (z = 3) admits only the sea convention; declared, not resolved
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=28 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on the **coarse** lattice `2Z^3`, on three named finite blocks: the open `2x2x2` cube, the open `3x3x3` block, and the single `2x2x1` plaquette.
+Nothing is claimed for `Z^3`, for a torus, or for any larger region. The bulk statement of the coordination-parity condition is a parity count on `z_v = 6`, not a
+computation on a bulk region.
+
+The **link role is designed**, exactly as PR #7834's superlattice role pattern is designed: one further two-state site per coarse edge, assigned by a design rule and
+derived from no axiom. The **link dynamics is declared**: `H^g`, `P_f` and `(g^2/2) sum_e E_e^2` are supplied laws with supplied `t`, `lambda` and `g`. `P_f` is a
+four-link neighbourhood term inside one coarse face, not a nearest-neighbour term, and the electric term is a c-number at spin `1/2` and does nothing. Nothing in
+this note is derived from any axiom; the axioms are quoted to fix what "readable" and "admissible" mean, and for nothing else.
+
+**No photon.** No gapless transverse mode is shown, computed, or suggested, and the smallest test that could bear on it is named with its cost in "Interfaces". The
+result here is not that electromagnetism appears; it is that one designed coupling exists, exactly, and that its Gauss law is a support condition among records.
+
+**The convention tension is carried, not resolved.** The convention that makes the sea locally neutral (`rho = n_v - 1/2`) and the convention spin-1/2 links admit in
+the bulk (`rho = n_v - (1 - eps_v)/2`) are different. Settling that needs either a larger region carrying both coordination parities or a larger link algebra;
+neither is treated here.
+
+## Review record
+
+An honest auditor should come away with: one declared coupled law on named finite blocks, in which the emergent fermion's conserved `U(1)` acquires an exactly
+gauge-invariant minimal coupling to one designed spin-1/2 link role per coarse edge -- four Pauli monomials per bond, with the partner operator `K_ij` fixed by the
+fermion algebra and equal to the landed current up to `-eta_ij t` -- and in which Gauss's law is a pure `Z` relation among the `2 z_v` records at a single corner,
+hence a support condition in the axioms' own vocabulary, whose solution set on the cube is exactly the half-filled sector at `14400` joint record patterns of `2^24`.
+The costs are stated as sharply as the result: the link role and its dynamics are designed rather than derived, spin-1/2 links carry a coordination-parity condition
+that the bulk lattice and the cube answer differently, and whether the link sector carries light is untouched.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the six context notes in
+"Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at
+`PASS=28 FAIL=0`, runtime under the declared `120` seconds, stdout under `5500` characters, and passing pipeline, strict-lint and changed-evidence gates; independent
+audit remains a separate lane.

--- a/docs/THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,7 +1,7 @@
 ---
 claim_id: fermion_u1_quantum_links_gauss_law_support_condition
 claim_type: bounded_theorem
-claim_scope: "On the coarse cubic lattice 2Z^3 carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, and with ONE FURTHER DESIGNED ROLE per coarse edge -- a spin-1/2 link site carrying E_e = Z^L_e/2 and U_e = (X^L_e + i Y^L_e)/2, declared as a design element of exactly the same kind as the period-(4,2,2) superlattice role pattern of PR #7834 and derived from no axiom -- for the ONE DECLARED coupled law H^g = -t sum_<ij> eta_ij (T_ij X^L_ij + K_ij Y^L_ij)/2 with the supplied optional terms lambda sum_f P_f and (g^2/2) sum_e E_e^2 whose coefficients t, lambda and g are supplied and are fixed by nothing quoted here, and on the named finite blocks only -- the open 2x2x2 cube, the open 3x3x3 block, and the single coarse 2x2x1 plaquette: (T1) writing a_i^dag a_j = (T_ij - i K_ij)/2, the gauge-invariant hop a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i equals (T_ij X^L_ij + K_ij Y^L_ij)/2 exactly, Hermitian and exactly four Pauli monomials, on all 66 bonds of the cube and the open 3x3x3 block, with K_ij = -(1/2) A_ij (I - B_i B_j) Hermitian, K_ji = -K_ij, exactly two Pauli monomials on the same site support as T_ij (5 on the cube, 6, 8 or 10 on the open 3x3x3 block), K_ij = -i [T_ij, n_i], {T_ij, K_ij} = 0, [T_ij, K_ij] = -2i (n_i - n_j) = i (B_i - B_j), and J_ij of PR #7892 = -eta_ij t K_ij on every bond -- one factor of t and the sign minus, not eta (t/2) K_ij. (T2) With rho_v^{sea} = n_v - 1/2 or rho_v^{stag} = n_v - (1 - eps_v)/2 and (div E)_v = sum_{e at v} s_{v,e} E_e, every G_v = (div E)_v - rho_v is a pure Z operator, record-diagonal on the 2 z_v records at one corner -- six on the cube, three fermion edge records and three link records, and twelve at the interior corner of the 3x3x3 block -- with [G_v, G_w] = 0 for all 64 + 729 corner pairs, [G_v, H^g] = 0 at every corner, and sum_v G_v = -sum_v rho_v, which in the sea convention reads sum_v G_v = -Q; 2 (div E)_v sums z_v terms +-1 and so carries the parity of z_v, while 2 rho^{sea} is odd and 2 rho^{stag} is even, so spin-1/2 links admit rho^{sea} only at odd z_v and rho^{stag} only at even z_v; by exact enumeration the cube (z = 3) has 14400 joint record patterns of 2^24 in the sea convention and 0 in the staggered one, while the plaquette (z = 2) has 0 and 14; exactly 2240 of the 4096 cube fermion record patterns admit at least one link pattern and they are precisely the half-filled N = 4 sector, with link-pattern multiplicities 192 x 4, 1024 x 6, 768 x 7, 192 x 8 and 64 x 9; and since every nontrivial face-loop product carries X and so has zero diagonal, dim(Gauss and code) = 14400/2^5 = 450 on the cube and 14/2^1 = 7 on the plaquette. (T3) With J^g_ij = -(t eta_ij/2)(K_ij X^L_ij - T_ij Y^L_ij) = (1/2)(J_ij X^L_ij + eta_ij t T_ij Y^L_ij), Hermitian on every bond: dn_v/dt = i[H^g, n_v] = -sum_w J^g_vw at every corner, dE_e/dt = i[H^g, E_e] = -J^g_e on every one of the 66 links, and d(div E)_v/dt = dn_v/dt at every corner; reversing a bond must reverse the link orientation too, X^L_e J^g_ji X^L_e = -J^g_ij, while J^g_ji = -J^g_ij alone fails on all 66 bonds; and E_e^2 = I/4 identically, so (g^2/2) sum_e E_e^2 is a c-number at spin 1/2. (T4) P_f = W_f + W_f^dag, the oriented four-link ring exchange around a coarse face, is Hermitian with exactly eight Pauli monomials on exactly the four link records of that face and no fermion record, [P_f, G_v] = 0 for all 48 face-corner pairs on the cube and 4 on the plaquette in both rho conventions, [P_f, S_f] = 0 and [P_f, prod_{e in f} Z^L_e] = 0, while [P_f, H^g] != 0 with 64 nonzero Pauli monomials on the cube face at (0,0,0). (T5) [numerical] On the 256-dimensional plaquette the Gauss sector has dimension 14 in the admissible staggered convention, 0 in the sea convention, and 7 intersected with the fermion code, where E_0 = -2.449489742783 = -sqrt 6 at lambda = 0 and -2.323404276086 at lambda = 1 with <P_f> = 1/6 and 0.094209746012, and max |<rho_v>| = 0.5833333333 and 0.6456532164, so that ground state is locally charged; on the cube the sea-convention Gauss sector is 14400 states of 2^24 on which H^g is sparse with 79872 nonzeros, its ground state lies in the code space at <S_f> = +1 with E_0 = -5.466823694822 at lambda = 0 and -6.980814328073 at lambda = 1, both at <N> = 4 = |V|/2, and <n_v> = 1/2, <rho_v> = 0 and <E_e> = 0 hold to 1e-13 at every one of the 8 corners and every one of the 12 links at both couplings. The link role and the link dynamics are designed, not derived; t, lambda and g are supplied data; the two rho conventions differ and that tension is carried here as an open item, not resolved; no gapless transverse mode of the link sector is shown, computed, or suggested, and no continuum limit is taken; no claim is made that this U(1) is electromagnetism. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+claim_scope: "On the coarse cubic lattice 2Z^3 carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, and with ONE FURTHER DESIGNED ROLE per coarse edge -- a spin-1/2 link site carrying E_e = Z^L_e/2 and U_e = (X^L_e + i Y^L_e)/2, declared as a design element of exactly the same kind as the period-(4,2,2) superlattice role pattern of PR #7834 and derived from no axiom -- for the ONE DECLARED coupled law H^g = -t sum_<ij> eta_ij (T_ij X^L_ij + K_ij Y^L_ij)/2 with the supplied optional terms lambda sum_f P_f and (g^2/2) sum_e E_e^2 whose coefficients t, lambda and g are supplied and are fixed by nothing quoted here, and on the named finite blocks only -- the open 2x2x2 cube, the open 3x3x3 block, and the single coarse 2x2x1 plaquette: (T1) writing a_i^dag a_j = (T_ij - i K_ij)/2, the gauge-invariant hop a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i equals (T_ij X^L_ij + K_ij Y^L_ij)/2 exactly, Hermitian and exactly four Pauli monomials, on all 66 bonds of the cube and the open 3x3x3 block, with K_ij = -(1/2) A_ij (I - B_i B_j) Hermitian, K_ji = -K_ij, exactly two Pauli monomials on the same site support as T_ij (5 on the cube, 6, 8 or 10 on the open 3x3x3 block), K_ij = -i [T_ij, n_i], {T_ij, K_ij} = 0, [T_ij, K_ij] = -2i (n_i - n_j) = i (B_i - B_j), and J_ij of PR #7892 = -eta_ij t K_ij on every bond -- one factor of t and the sign minus, not eta (t/2) K_ij. (T2) With rho_v^{sea} = n_v - 1/2 or rho_v^{stag} = n_v - (1 - eps_v)/2 and (div E)_v = sum_{e at v} s_{v,e} E_e, every G_v = (div E)_v - rho_v is a pure Z operator, record-diagonal on the 2 z_v records at one corner -- six on the cube, three fermion edge records and three link records, and twelve at the interior corner of the 3x3x3 block -- with [G_v, G_w] = 0 for all 64 + 729 corner pairs, [G_v, H^g] = 0 at every corner, and sum_v G_v = -sum_v rho_v, which in the sea convention reads sum_v G_v = -Q; 2 (div E)_v sums z_v terms +-1 and so carries the parity of z_v, while 2 rho^{sea} is odd and 2 rho^{stag} is even, so spin-1/2 links admit rho^{sea} only at odd z_v and rho^{stag} only at even z_v; by exact enumeration the cube (z = 3) has 14400 joint record patterns of 2^24 in the sea convention and 0 in the staggered one, while the plaquette (z = 2) has 0 and 14; exactly 2240 of the 4096 cube fermion record patterns admit at least one link pattern and they are precisely the half-filled N = 4 sector, with link-pattern multiplicities 192 x 4, 1024 x 6, 768 x 7, 192 x 8 and 64 x 9; and since every nontrivial face-loop product carries X and so has zero diagonal, dim(Gauss and code) = 14400/2^5 = 450 on the cube and 14/2^1 = 7 on the plaquette; and G_v = 0, being a linear relation among the corner's 2 z_v records, is implemented by site-level forcing in ANY formation order -- on the cube in the sea convention and the plaquette in the staggered one, every occurring assignment of all but one of a corner's records leaves exactly one admissible value for the last (1248 conditioning events), no occurring record set leaves an absent record with an empty admissible set (11432 cases) and both values are open with no record of the corner present, forcing first appears with 2 of the cube's 6 corner records and 1 of the plaquette's 4, and each of the (2 z_v)! formation orders (720 and 24) reproduces the G_v = 0 set exactly, so the restriction on joint record patterns is a consequence of those site-level zeros and not a further primitive. (T3) With J^g_ij = -(t eta_ij/2)(K_ij X^L_ij - T_ij Y^L_ij) = (1/2)(J_ij X^L_ij + eta_ij t T_ij Y^L_ij), Hermitian on every bond: dn_v/dt = i[H^g, n_v] = -sum_w J^g_vw at every corner, dE_e/dt = i[H^g, E_e] = -J^g_e on every one of the 66 links, and d(div E)_v/dt = dn_v/dt at every corner; reversing a bond must reverse the link orientation too, X^L_e J^g_ji X^L_e = -J^g_ij, while J^g_ji = -J^g_ij alone fails on all 66 bonds; and E_e^2 = I/4 identically, so (g^2/2) sum_e E_e^2 is a c-number at spin 1/2. (T4) P_f = W_f + W_f^dag, the oriented four-link ring exchange around a coarse face, is Hermitian with exactly eight Pauli monomials on exactly the four link records of that face and no fermion record, [P_f, G_v] = 0 for all 48 face-corner pairs on the cube and 4 on the plaquette in both rho conventions, [P_f, S_f] = 0 and [P_f, prod_{e in f} Z^L_e] = 0, while [P_f, H^g] != 0 with 64 nonzero Pauli monomials on the cube face at (0,0,0). (T5) [numerical] On the 256-dimensional plaquette the Gauss sector has dimension 14 in the admissible staggered convention, 0 in the sea convention, and 7 intersected with the fermion code, where E_0 = -2.449489742783 = -sqrt 6 at lambda = 0 and -2.323404276086 at lambda = 1 with <P_f> = 1/6 and 0.094209746012, and max |<rho_v>| = 0.5833333333 and 0.6456532164, so that ground state is locally charged; on the cube the sea-convention Gauss sector is 14400 states of 2^24 on which H^g is sparse with 79872 nonzeros, its ground state lies in the code space at <S_f> = +1 with E_0 = -5.466823694822 at lambda = 0 and -6.980814328073 at lambda = 1, both at <N> = 4 = |V|/2, and <n_v> = 1/2, <rho_v> = 0 and <E_e> = 0 hold to 1e-13 at every one of the 8 corners and every one of the 12 links at both couplings. The link role and the link dynamics are designed, not derived; t, lambda and g are supplied data; the two rho conventions differ and that tension is carried here as an open item, not resolved; no gapless transverse mode of the link sector is shown, computed, or suggested, and no continuum limit is taken; no claim is made that this U(1) is electromagnetism. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
 upstream_dependencies: []
 runner: scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
 ---
@@ -21,15 +21,16 @@ runner: scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_
 
 PR #7892 gave the coarse-lattice emergent fermion a charge and a conserved bond current, and left one question open on its face: nothing in the declared law couples
 to that `U(1)`. The question here is whether something can, inside the framework's readable algebra, and what Gauss's law is once it does. The answer needs one more
-designed role -- a second site per coarse edge -- and it is declared as designed, in exactly the sense PR #7834's role pattern is. What comes back is that the
-coupling is exact, and that Gauss's law is a relation among records at a single corner: a condition on which patterns of records are admissible, not a further law.
+designed role -- a second site per coarse edge -- declared as designed, in exactly the sense PR #7834's role pattern is. What comes back is that the coupling is
+exact, and that Gauss's law is a linear relation among the records at one corner, implemented by site-level forcing in any formation order: with the corner's other
+records present, the value that would unbalance it carries zero odds where the last one forms. Which joint patterns occur is the consequence, not a further law.
 
 ## Machine status
 
 ```yaml
 actual_current_surface_status: bounded-support
 target_claim_type: bounded_theorem
-claim_type_reason: "Exact finite-cluster theorems about one declared coupled law on the coarse-lattice emergent fermion carrying one designed spin-1/2 link role per coarse edge: the gauge-invariant hop and its two-monomial partner K_ij, Gauss's law as a record-diagonal corner relation with its exact joint record-pattern census and its coordination-parity condition, the coupled Ampere and continuity relations, and the four-link ring exchange. The symplectic Pauli statements are exact Gaussian-rational arithmetic on F2 supports with Z4 phases; the census statements are exact integer arithmetic over all 2^24 cube and 2^8 plaquette record patterns; the tagged numerical items are floating-point cross-checks at the stated tolerance."
+claim_type_reason: "Exact finite-cluster theorems about one declared coupled law on the coarse-lattice emergent fermion carrying one designed spin-1/2 link role per coarse edge: the gauge-invariant hop and its two-monomial partner K_ij, Gauss's law as a record-diagonal corner relation with its exact joint record-pattern census and its coordination-parity condition, the coupled Ampere and continuity relations, and the four-link ring exchange. The symplectic Pauli statements are exact Gaussian-rational arithmetic on F2 supports with Z4 phases; the census statements are exact integer arithmetic over all 2^24 cube and 2^8 plaquette record patterns; the site-level forcing statements are exact enumeration over one corner's 2^(2 z_v) record assignments in every formation order; the tagged numerical items are floating-point cross-checks at the stated tolerance."
 trace_class: frontier_discovery
 target_claim_id: null
 target_blocker_text: null
@@ -46,32 +47,32 @@ admitted_observation_status: null
 
 ## Exact target
 
-The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. Groups `A`, `B`, `C` and `D` are exact -- Gaussian-rational
-coefficients on symplectic Pauli monomials, `F2` supports and `Z4` phases, complete sweeps, and integer record arithmetic, with no floating-point step anywhere --
-and the items tagged `[numerical]` in group `E` are floating-point cross-checks at the stated tolerance.
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`F`. Groups `A`, `B`, `C`, `D` and `F` are exact --
+Gaussian-rational coefficients on symplectic Pauli monomials, `F2` supports and `Z4` phases, complete sweeps, and integer record arithmetic, with no floating-point
+step anywhere -- and the items tagged `[numerical]` in group `E` are floating-point cross-checks at the stated tolerance.
 
 1. `T1` (`A`). The gauge-invariant hop, and `K_ij` as the two-monomial partner the encoding already contains.
-2. `T2` (`B`). Gauss's law as a record-diagonal corner relation, its exact census, and the coordination-parity condition on spin-1/2 links.
+2. `T2` (`B`, `F`). Gauss's law as a record-diagonal corner relation, its exact census, the coordination-parity condition on spin-1/2 links, and its implementation by
+   site-level forcing in any formation order.
 3. `T3` (`C`). Ampere, coupled continuity, and what bond reversal does to a link.
 4. `T4` (`D`). The four-link ring exchange, and what it does and does not commute with.
 5. `T5` (`E`). The coupled sea on the plaquette and on the cube's Gauss sector.
 
 ## Imports and authority
 
-Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, the quantum-link (gauge-magnet) presentation of
-a lattice gauge field with finite-dimensional link algebras, the ring-exchange plaquette term, and the Pauling residual-entropy estimate for ice-rule configurations
-are standard methodology; every object is redeclared here and the runner recomputes every statement. No observational value, no fitted number and no framework premise
-enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, the quantum-link (gauge-magnet) presentation
+with finite-dimensional link algebras, the ring-exchange plaquette term and the Pauling ice estimate are standard methodology; every object is redeclared here and
+every statement recomputed by the runner. No observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, no grade and
+no dependency weight:
 
-- `CHARGE_CONJUGATION_AND_THE_CONSERVED_U1_CURRENT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7892): the encoding, the charge
-  `Q = -(1/2) sum_v B_v` and the bond current `J_ij = eta_ij (t/2) A_ij (I - B_i B_j)`. Its closing interface -- that nothing couples to this `U(1)` -- is the
-  question `T1` and `T2` here answer for one declared coupling.
+- `CHARGE_CONJUGATION_AND_THE_CONSERVED_U1_CURRENT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7892): the charge `Q = -(1/2) sum_v B_v` and
+  the bond current `J_ij = eta_ij (t/2) A_ij (I - B_i B_j)`. Its closing interface -- nothing couples to this `U(1)` -- is the question answered here.
 - `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the period-`(4,2,2)` superlattice
   role pattern and the coarse sublattice `2Z^3`. The link role declared here is a design element of exactly that kind.
 - `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): the staggered kinetic form and the KS signs.
 - `THE_VACUUM_QUESTION_IS_ONE_COEFFICIENT_OF_THE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7885) and
   `MATTER_ABOVE_THE_HALF_FILLED_SEA_ODD_AND_EVEN_DENSITIES_AND_THE_VACUUM_QUESTION_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7879): the vacuum
-  coefficient, and the half-filled sea at `<n_v> = 1/2`.
+  coefficient and the half-filled sea at `<n_v> = 1/2`.
 - `RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7858): record formation on the vacuum and its parity cosets.
 - `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting", including the Admissibility reading note used to say what a support condition is.
 
@@ -85,21 +86,19 @@ supplies the odds. Reading note (3) fixes the vocabulary used below: "The distri
 'available'/'admissible' denotes its support -- on finite menus, exactly the possibilities of nonzero probability." **Record**: "Records form", "a record locks
 exactly one admissible local possibility", "records are permanent", "Only records are readable", and "A readout value is determined by record content alone."
 
-The lattice is physical. Everything below reads the Kawamoto-Smit sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, on the superlattice
-role pattern's sublattice, and adds one further designed role. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites'
-algebras and no graded clause is used anywhere.
+The lattice is physical. Everything below reads the Kawamoto-Smit sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, and adds one further
+designed role. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras, with no graded clause anywhere.
 
-A **support condition** in this note means exactly what reading note (3) licenses: a condition whose failure is a zero of the law-level odds, so that the record
-patterns violating it are outside the support of the distribution the law supplies. It is a statement about which patterns of records are admissible. It is not a
-further dynamical clause, and no formation site, rate, or process word is used to state it.
+A **support condition** in this note means what reading note (3) licenses: a zero of the law-level odds at the site where a record forms, putting the value it
+excludes outside the support of the distribution the law supplies there. It is no further dynamical clause, and no formation site, rate, or process word states it.
 
 ## Obligation graph
 
 The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field
 on it, the superfast encoding with its face stabilizers, the designed link role with its `E_e` and `U_e`, and the coupled law `H^g` with its supplied coefficients.
 `P1` (`A`) is the gauge-invariant hop and `K_ij`; `P2` (`B`) Gauss's law, its census and the coordination-parity condition; `P3` (`C`) Ampere and continuity; `P4`
-(`D`) the ring exchange; `P5` (`E`) the coupled sea. `P2` uses `P0` only; `P3` uses `P1`'s `K_ij`; `P4` uses `P0`; `P5` uses `P2`'s sector. The strongest supported
-scope is precisely `P0`-`P5`.
+(`D`) the ring exchange; `P5` (`E`) the coupled sea; `P6` (`F`) the site-level forcing that implements `P2`. `P2` uses `P0` only; `P3` uses `P1`'s `K_ij`; `P4` uses
+`P0`; `P5` and `P6` use `P2`. The strongest supported scope is precisely `P0`-`P6`.
 
 ## Definitions
 
@@ -137,9 +136,8 @@ factor of `t`, sign **minus**, and not `eta_ij (t/2) K_ij`.
 against the four-monomial right-hand side. Items 2 to 5 are `F2` support arithmetic with `Z4` phases on Gaussian-rational coefficients: monomial counts, supports,
 commutators and anticommutators compared to zero exactly. All exact, complete over both blocks.
 
-**Reading, not theorem.** The hop that carries a particle from one corner to the next already came in two pieces: one that is even under exchanging the two corners
-and one that is odd. Giving each edge its own record supplies exactly the second thing needed -- something that can change when the particle passes. The pairing is
-forced, not fitted: the odd piece is the current PR #7892 already named, up to a sign and one factor of the hopping strength.
+**Reading, not theorem.** The hop already came in two pieces, one even and one odd under exchanging the two corners. Giving each edge its own record supplies what the
+odd piece needs -- something that can change when the particle passes -- and the pairing is forced, not fitted: that odd piece is the current PR #7892 already named.
 
 ## Theorem 2 -- Gauss's law is a support condition among records
 
@@ -160,10 +158,26 @@ is the handshake parity of `z_v` terms `+-1` against the parity of `2 rho_v`, co
 record patterns. Item 4 is the same enumeration read per fermion pattern; the restriction to `N = |V|/2` is already forced by item 2's `sum_v G_v = -Q`, and the
 census shows it is also sufficient. Item 5 is `F2` support arithmetic over the `2^5` and `2^1` face-loop products. All exact.
 
-**Reading, not theorem.** At each corner the law now says one thing about the records there: the flux records on the edges meeting at that corner, counted with the
-direction they point, must balance the matter record at the corner. Corner patterns that fail it have zero odds -- they are not admissible, in the axiom's own sense
-of the word. Nothing else is added. On the cube that single condition already picks out the half-filled patterns and no others, which is the same population the
-vacuum work arrived at from the energy side.
+### Reading of "support condition", refereed
+
+A referee objected that item 1 is claimed at the wrong level, and the objection stands. The Admissibility axiom supplies, for each site, a probability distribution
+over that site's possibilities given its neighbours' conditions, and reading note (3) reads "admissible" as that distribution's support. A normalised conditional
+cannot assign zero odds to its own conditioning event, so a joint constraint on a whole neighbourhood's records is not, by itself, a support condition at any one
+site: nothing forbids a neighbourhood's configuration from a single site.
+
+`G_v = 0` is instead a **linear relation among the corner's `2 z_v` records** -- `sum_e s_{v,e} E_e = rho_v` -- and a linear relation is implemented by site-level
+support conditions in **any** formation order: whenever all but one of its records are present, the last record's odds for the violating value are zero, a support
+condition at that site of the axiom's kind. PR #7858 exhibits this for the corner parities: a coset, odds `1/2` or forced, forcing by cocircuits, order-independent.
+
+So "support condition among records" means that site-level forcing, and the restriction on the joint domain -- only balanced corner configurations occur -- is its
+**consequence**, not a further primitive. Group `F` checks this on the cube (sea) and the plaquette (staggered): every occurring assignment of all but one of a
+corner's records forces the last, `1248` cases (`F1`); no occurring record set leaves an absent record with no admissible value, `11432` cases, and with none present
+both values are open (`F2`); each of the `(2 z_v)!` orders, `720` and `24`, reproduces the `G_v = 0` set exactly (`F3`). Forcing is not confined to the all-but-one
+case -- it first appears at `2` of the cube's `6` records and `1` of the plaquette's `4` -- but each is still a zero of the odds at one site, never a joint veto.
+
+**Reading, not theorem.** At each corner the law says one thing about the records there: the flux records on the edges meeting at that corner, counted with the
+direction they point, must balance the matter record there, one record at a time. On the cube that single condition already picks out the half-filled patterns and no
+others, the same population the vacuum work reached from the energy side.
 
 ## Theorem 3 -- Ampere, coupled continuity, and what reversing a bond does
 
@@ -177,9 +191,8 @@ reverse the link orientation with it -- `X^L_e J^g_ji X^L_e = -J^g_ij` -- while 
 corner and every link of both blocks. Item 5 conjugates by the link monomial and compares; the failure of the bare relation is the same comparison returning a
 nonzero residual on each bond. Item 6 is one monomial squared. All exact. Item 3 is Theorem 2 item 2 written as a rate.
 
-**Reading, not theorem.** The record on a link answers to exactly one thing: the current through its own edge. And the two halves of the corner condition change
-together -- the flux divergence at a corner tracks the matter there exactly -- so a pattern that satisfies the condition keeps satisfying it. One caution is worth
-stating plainly: a link record points one way along its edge, so reading the bond backwards means reading the link backwards too.
+**Reading, not theorem.** The record on a link answers to exactly one thing: the current through its own edge. The two halves of the corner condition change together,
+so a satisfying pattern keeps satisfying it. One caution: a link record points one way along its edge, so reading the bond backwards reads the link backwards too.
 
 ## Theorem 4 -- the ring exchange, and what it leaves alone
 
@@ -191,9 +204,8 @@ constant of the ring exchange; and (4) `[P_f, H^g] != 0` -- on the cube face at 
 **Proof.** Expansion of the four-factor loop product into monomials, then symplectic-form arithmetic for each commutator, over every face of both blocks and both
 `rho` conventions. All exact.
 
-**Reading, not theorem.** If the link records are to have any life of their own, the framework has to own a term that gives them one, because the obvious candidate
--- the cost of the flux itself -- is a constant at this link size. The term that does the job acts on the four links of one face at once. That is a neighbourhood
-term, not a nearest-neighbour one, and it is as designed as the link role itself.
+**Reading, not theorem.** The link records need a term of their own to have any life, because the obvious candidate -- the cost of the flux itself -- is a constant at
+this link size. The one that does it acts on the four links of a face at once: a neighbourhood term, not a nearest-neighbour one, and as designed as the link role.
 
 ## Theorem 5 -- the coupled sea
 
@@ -210,9 +222,8 @@ the face stabilizer. The cube's Gauss sector is built by vectorised bit arithmet
 operator; `-5 sum_f S_f` places the code space lowest and Lanczos returns the ground state there. `[numerical, 1e-12]` for items 1 to 3 and `[numerical, 1e-10]` for
 items 4 and 5, the neutrality residuals at `1e-13`. No dense object above `14400` rows and no dense `2^24` object is formed anywhere.
 
-**Reading, not theorem.** With the links coupled, the half-filled sea stays exactly half filled, carries no charge at any corner, and carries no net flux on any
-link. That is a stronger statement than the uncoupled one: the corner condition could have forced flux into the ground state, and on the plaquette -- where the
-coordination parity permits only the other convention -- it does exactly that.
+**Reading, not theorem.** With the links coupled, the half-filled sea stays exactly half filled, carries no charge at any corner, and no net flux on any link. That is
+stronger than the uncoupled statement: the corner condition could have forced flux into the ground state, and on the plaquette it does exactly that.
 
 ## Corollary -- what the coupling buys, and what it costs
 
@@ -220,45 +231,40 @@ Within the setting declared above, and on the finite blocks named:
 
 1. **An exactly gauge-invariant minimal coupling exists.** The emergent fermion's conserved `U(1)` couples to a designed spin-1/2 link role with no residual: the
    coupled hop is four Pauli monomials, and the partner it needs was already inside the encoding as `-i[T_ij, n_i]`.
-2. **Gauss's law is a support condition.** `G_v` is record-diagonal on the `2 z_v` records at one corner, so `G_v = 0` is a zero of the law-level odds for the corner
-   configurations that fail it -- entirely within the Record axiom's readable content and the Admissibility reading note's sense of "admissible". On the cube its
-   solution set is exactly the half-filled sector, `14400` joint record patterns of `2^24`.
+2. **Gauss's law is implemented by site-level forcing in any formation order.** `G_v` is record-diagonal on the `2 z_v` records at one corner and `G_v = 0` is a
+   linear relation among them, so a value that relation cannot rescue, given the corner records present, is a zero of the odds **at the site where that record
+   forms**. The joint restriction -- on the cube, exactly the half-filled sector -- follows from those zeros and their order-independence; it is not imposed on a
+   neighbourhood.
 3. **What registers and what does not.** The electric flux `E_e` is a one-record value on a link site, readable; so are `n_v`, `rho_v`, `(div E)_v`, `G_v`, `Q` and
    the `Z2` face flux. The coupled hop, the current `J^g_ij`, the link raising `U_e` and the ring exchange `P_f` carry `X` in every monomial and so have no
    record-diagonal part at all: they register only through correlations among records. This is PR #7892's pattern, extended to the link sector.
-4. **The cost is a coordination-parity condition.** Spin-1/2 links admit `rho^{sea}` only at odd `z_v` and `rho^{stag}` only at even `z_v`. On `2Z^3` proper
-   (`z = 6`) they force the staggered background half-charge; on the cube (`z = 3`) the sea convention is the admissible one. The two conventions differ, and the one
-   that makes the sea locally neutral is not the one the bulk admits. **This note declares that tension and does not resolve it.**
+4. **The cost is a coordination-parity condition.** Spin-1/2 links admit `rho^{sea}` only at odd `z_v` and `rho^{stag}` only at even `z_v`: on `2Z^3` proper (`z = 6`)
+   the staggered background half-charge, on the cube (`z = 3`) the sea convention. **This note declares that tension and does not resolve it.**
 5. **The coupled sea is neutral with zero mean flux** on the cube, at both values of the ring-exchange coefficient computed.
 
 **Reading, not theorem (this register).** Give every link between two corners its own record, read as a unit of flux pointing one way or the other. Gauss's law then
-says only this: at each corner, the flux records in and out must balance the matter record there. That is a rule about which patterns of records are possible, the
-same kind of rule the framework already uses. With that rule in place the matter's charge can flow along the links, the flux records change exactly as the current
-says, and the half-filled sea is neutral with no net flux anywhere. What is not shown is whether these links, left to themselves, carry light.
+says only this: at each corner, the flux records in and out must balance the matter record there. It bites one record at a time -- with the rest of a corner already
+written down, the value that would unbalance it cannot be the one that forms. With that rule in place the matter's charge can flow along the links, the flux records
+change exactly as the current says, and the half-filled sea is neutral with no net flux anywhere.
 
 ## What does not move
 
 - No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
 - No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
 - Nothing here is derived from the axioms. The coarse lattice, the encoding, the sign field, **the link role** and the coupled law are declared objects, and no
-  coefficient is derived: `t`, `lambda` and `g` are supplied, and no update rule, formation site, formation rate, coupling, or absolute unit appears. Which law
-  applies is designed, not derived -- the link role is a design element of exactly the kind PR #7834's role pattern is, and is declared as such here.
+  coefficient is derived: `t`, `lambda` and `g` are supplied, and no update rule, formation site, formation rate, coupling, or absolute unit appears.
 - No continuum limit is taken, no second species appears, and no gapless transverse mode of the link sector is shown, computed, or suggested.
 
 ## Interfaces named for other lanes, not moved here
 
-- **Whether the link sector carries light.** Whether the ring-exchange link sector has a gapless transverse mode -- a photon -- is **not** decided here, and nothing
-  in this note bears on it. The photon is an interface, not a result. The smallest test with a plausible transverse mode is the `4^3` coarse torus (`64` corners,
-  `192` links, `z = 6`), whose pure-link Gauss sector is about `2.5^64 = 2.9 x 10^25` states by the Pauling ice estimate. Exact diagonalisation is out of reach at
-  that size and so is matrix-free Lanczos, which needs a vector of that length; a constraint-preserving sampled route or a variational ansatz on the ice manifold is
-  what such a test would cost.
+- **Whether the link sector carries light.** Whether the ring-exchange link sector has a gapless transverse mode -- a photon -- is **not** decided here. The smallest
+  test with a plausible one is the `4^3` coarse torus (`64` corners, `192` links, `z = 6`), whose pure-link Gauss sector is about `2.5^64 = 2.9 x 10^25` states by the
+  Pauling ice estimate -- beyond exact diagonalisation and beyond matrix-free Lanczos. Sampling or a variational ansatz on the ice manifold is what it would cost.
 - **Larger links.** Spin-1 or larger link algebras lift the coordination-parity condition of Theorem 2 item 3 and make the electric term of Theorem 3 item 6
   non-trivial. Neither is treated here, and which link size the framework wants is a design question for the lane that owns the role rule.
 - **The ring-exchange coefficient.** `lambda` is supplied. What fixes it, if anything does, is not addressed.
-- **The fine-lattice role assignment.** The link role is declared on the coarse edge. Writing it as a rule on the physical lattice `Z^3`, in the way PR #7834 writes
-  the fermion roles, is not done here.
-- **The continuum.** Everything is a lattice operator. Whether `J^g_ij`, `G_v` or `P_f` has a continuum limit is not shown, and no claim is made that this `U(1)` is
-  electromagnetism.
+- **The fine-lattice role assignment.** The link role is declared on the coarse edge; writing it as a rule on `Z^3`, the way PR #7834 does, is not done here.
+- **The continuum.** Everything here is a lattice operator; no continuum limit is shown, and this `U(1)` is not claimed to be electromagnetism.
 
 ## Remaining live routes
 
@@ -279,6 +285,7 @@ current_relation: J_ij (PR #7892) = -eta_ij t K_ij on every bond -- one factor o
 gauss: G_v = (div E)_v - rho_v is pure Z on the 2 z_v records at one corner (6 on the cube, 12 at the 3x3x3 interior corner); [G_v, G_w] = 0 (64 + 729 pairs); [G_v, H^g] = 0 at every corner; sum_v G_v = -sum_v rho_v = -Q in the sea convention
 parity_condition: 2 (div E)_v carries the parity of z_v; 2 rho^sea odd, 2 rho^stag even; spin-1/2 links admit rho^sea only at odd z_v and rho^stag only at even z_v
 census: cube z = 3: 14400 joint record patterns of 2^24 (sea) and 0 (stag); plaquette z = 2: 0 and 14; 2240 of 4096 cube fermion patterns admissible = exactly the N = 4 sector; multiplicities 192 x 4, 1024 x 6, 768 x 7, 192 x 8, 64 x 9; dim(Gauss and code) = 450 and 7
+site_forcing: G_v = 0 is a linear relation among the corner's 2 z_v records, implemented by site-level forcing in ANY formation order -- cube (sea) and plaquette (stag): every occurring assignment of all but one of a corner's records leaves exactly 1 admissible value for the last (1248 events, all forced); no occurring record set leaves an absent record with an empty admissible set (11432 cases), both values open with none present; forcing first appears at 2 of the cube's 6 corner records and 1 of the plaquette's 4; each of the (2 z_v)! orders (720, 24) reproduces the G_v = 0 set exactly, so the JOINT restriction is a consequence, not a primitive
 ampere: dE_e/dt = -J^g_e on all 66 links; dn_v/dt = -sum_w J^g_vw at every corner; d(div E)_v/dt = dn_v/dt; J^g_ij = (1/2)(J_ij X^L + eta t T_ij Y^L); X^L_e J^g_ji X^L_e = -J^g_ij while J^g_ji = -J^g_ij alone fails on 66 of 66 bonds; E_e^2 = I/4 identically
 ring_exchange: P_f Hermitian, 8 Pauli monomials, exactly the 4 link records of one face, no fermion record; [P_f, G_v] = 0 (48 pairs cube, 4 plaquette, both conventions); [P_f, S_f] = [P_f, prod Z^L] = 0; [P_f, H^g] != 0 with 64 nonzero monomials on the cube face at (0,0,0)
 plaquette_numerics: Gauss dim 14 (stag) / 0 (sea), Gauss and code 7; E_0 = -2.449489742783 = -sqrt 6 (lambda 0) and -2.323404276086 (lambda 1); <P_f> = 1/6 and 0.094209746012; max |<rho_v>| = 0.5833333333 and 0.6456532164 -- locally charged
@@ -286,7 +293,7 @@ cube_numerics: Gauss sector 14400 of 2^24, sparse, 79872 nonzeros; ground state 
 not_shown: no gapless transverse mode of the link sector; smallest test is the 4^3 pure-link Gauss sector at ~2.9 x 10^25 states (Pauling estimate), beyond exact diagonalisation and beyond matrix-free Lanczos
 open_item: the sea and staggered conventions differ; the bulk (z = 6) admits only the staggered background half-charge while the cube (z = 3) admits only the sea convention; declared, not resolved
 axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
-runner_result: PASS=28 FAIL=0
+runner_result: PASS=31 FAIL=0
 ```
 
 ## Proof boundary
@@ -300,23 +307,23 @@ derived from no axiom. The **link dynamics is declared**: `H^g`, `P_f` and `(g^2
 four-link neighbourhood term inside one coarse face, not a nearest-neighbour term, and the electric term is a c-number at spin `1/2` and does nothing. Nothing in
 this note is derived from any axiom; the axioms are quoted to fix what "readable" and "admissible" mean, and for nothing else.
 
-**No photon.** No gapless transverse mode is shown, computed, or suggested, and the smallest test that could bear on it is named with its cost in "Interfaces". The
-result here is not that electromagnetism appears; it is that one designed coupling exists, exactly, and that its Gauss law is a support condition among records.
+**No photon.** No gapless transverse mode is shown, computed, or suggested. The result is not that electromagnetism appears; it is that one designed coupling exists,
+exactly, with its Gauss law implemented by site-level forcing in any formation order.
 
-**The convention tension is carried, not resolved.** The convention that makes the sea locally neutral (`rho = n_v - 1/2`) and the convention spin-1/2 links admit in
-the bulk (`rho = n_v - (1 - eps_v)/2`) are different. Settling that needs either a larger region carrying both coordination parities or a larger link algebra;
-neither is treated here.
+**The convention tension is carried, not resolved.** The convention that makes the sea locally neutral (`rho = n_v - 1/2`) and the one spin-1/2 links admit in the
+bulk (`rho = n_v - (1 - eps_v)/2`) are different; settling that needs a larger region carrying both coordination parities, or a larger link algebra.
 
 ## Review record
 
-An honest auditor should come away with: one declared coupled law on named finite blocks, in which the emergent fermion's conserved `U(1)` acquires an exactly
-gauge-invariant minimal coupling to one designed spin-1/2 link role per coarse edge -- four Pauli monomials per bond, with the partner operator `K_ij` fixed by the
-fermion algebra and equal to the landed current up to `-eta_ij t` -- and in which Gauss's law is a pure `Z` relation among the `2 z_v` records at a single corner,
-hence a support condition in the axioms' own vocabulary, whose solution set on the cube is exactly the half-filled sector at `14400` joint record patterns of `2^24`.
-The costs are stated as sharply as the result: the link role and its dynamics are designed rather than derived, spin-1/2 links carry a coordination-parity condition
-that the bulk lattice and the cube answer differently, and whether the link sector carries light is untouched.
+An honest auditor should come away with: one declared coupled law on named finite blocks, in which the emergent fermion's conserved `U(1)` acquires an exact
+gauge-invariant minimal coupling to one designed spin-1/2 link role per coarse edge -- four Pauli monomials per bond, with the partner `K_ij` fixed by the fermion
+algebra and equal to the landed current up to `-eta_ij t` -- and in which Gauss's law is a pure `Z` linear relation among the `2 z_v` records at a single corner,
+implemented in any order by site-level forcing of the record that forms last: a support condition in the axioms' own vocabulary at the site, the joint restriction its
+consequence. Its solution set on the cube is exactly the half-filled sector at `14400` patterns of `2^24`. The costs: the link role and its dynamics are designed, not
+derived; spin-1/2 links carry a coordination-parity condition the bulk lattice and the cube answer differently; and whether the link sector carries light is
+untouched.
 
 This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the six context notes in
 "Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at
-`PASS=28 FAIL=0`, runtime under the declared `120` seconds, stdout under `5500` characters, and passing pipeline, strict-lint and changed-evidence gates; independent
+`PASS=31 FAIL=0`, runtime under the declared `120` seconds, stdout under `7000` characters, and passing pipeline, strict-lint and changed-evidence gates; independent
 audit remains a separate lane.

--- a/logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt
+++ b/logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
+runner_sha256: fae77293447e8572616850d1b1f669e093741bacd7c06044fffa08cf9c6f32e9
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 2.28
+status: ok
+----- stdout -----
+H^g = -t sum eta (T X^L + K Y^L)/2; E_e = Z^L_e/2; U_e = (X^L + iY^L)/2; G_v = (div E)_v - rho_v
+PASS A1 [exact] a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i = (T_ij X^L_ij + K_ij Y^L_ij)/2 exactly, Hermitian, [4] Pauli monomials, on all 66 bonds of the 2x2x2 cube and the open 3x3x3 block
+PASS A2 [exact] K_ij = -(1/2) A_ij (I - B_i B_j): Hermitian, K_ji = -K_ij, exactly [2] Pauli monomials on [5, 6, 8, 10] sites, the same support as T_ij
+PASS A3 [exact] K_ij = -i [T_ij, n_i] on every bond: given the hop, K is fixed by the fermion algebra, not chosen
+PASS A4 [exact] {T_ij, K_ij} = 0 and [T_ij, K_ij] = -2i (n_i - n_j) = i (B_i - B_j) on every bond: T, K and n_i - n_j close an su(2) per bond
+PASS A5 [exact] J_ij of PR #7892 = -eta_ij t K_ij on every bond -- one factor of t, sign MINUS, and NOT eta (t/2) K_ij: the coupled hop's Y^L partner is the landed current
+PASS B1 [exact] every G_v is pure Z -- record-diagonal -- with [4] monomials on [6] records at the one corner (sea/stag), and [6, 8, 10, 12] in the 3x3x3 block: 2 z_v records, 12 at a bulk corner
+PASS B2 [exact] [G_v, G_w] = 0 for all 64 + 729 corner pairs, both rho conventions: the corner conditions are jointly imposable on one pattern
+PASS B3 [exact] [G_v, H^g] = 0 at every corner of both blocks, both rho conventions: the coupled law preserves the corner condition exactly
+PASS B4 [exact] sum_v G_v = -sum_v rho_v on both blocks, every link cancelling in the sum; in the sea convention that reads sum_v G_v = -Q with Q the PR #7892 charge
+PASS B5 [exact] coordination parity: 2 (div E)_v sums z_v terms +-1 so carries the parity of z_v, while 2 rho^sea = 2n - 1 is odd and 2 rho^stag = 2n - (1 - eps) even. Cube z = [3]: 14400 joint patterns of 2^24 sea, 0 stag; plaquette z = [2]: 0 and 14
+PASS B6 [exact] on the cube exactly 2240 of the 4096 fermion record patterns admit a link pattern, and they are precisely the half-filled N = 4 sector; link patterns each: 192 x 4, 1024 x 6, 768 x 7, 192 x 8, 64 x 9
+PASS B7 [exact] the code acts freely on the Gauss sector -- every nontrivial face-loop product carries X, hence zero diagonal -- so dim(Gauss and code) = 14400/2^5 = 450 on the cube, 14/2^1 = 7 on the plaquette
+PASS C1 [exact] coupled continuity dn_v/dt = i[H^g, n_v] = -sum_w J^g_vw at every corner of both blocks, with J^g_ij = -(t eta_ij/2)(K_ij X^L_ij - T_ij Y^L_ij)
+PASS C2 [exact] Ampere dE_e/dt = i[H^g, E_e] = -J^g_e on every one of the 66 links, e oriented tail to head: the flux on a link answers only to the current through its own edge
+PASS C3 [exact] joint continuity d(div E)_v/dt = dn_v/dt at every corner -- B3 written as a rate: the flux divergence and the corner parity cannot drift apart
+PASS C4 [exact] every J^g_ij is Hermitian and J^g_ij = (1/2)(J_ij X^L_ij + eta_ij t T_ij Y^L_ij): the X^L part of the coupled current is exactly the uncoupled PR #7892 current
+PASS C5 [exact] reversing a bond must reverse the link orientation too: X^L_e J^g_ji X^L_e = -J^g_ij on every bond, while J^g_ji = -J^g_ij alone fails on 66 of 66 bonds
+PASS C6 [exact] E_e^2 = I/4 identically on every link, so (g^2/2) sum_e E_e^2 is a c-number: at spin 1/2 the electric term supplies no dynamics at all
+PASS D1 [exact] P_f = W_f + W_f^dag, the oriented four-link ring exchange, is Hermitian with [8] Pauli monomials on exactly [4] sites -- the four link records of one coarse face, no fermion record
+PASS D2 [exact] [P_f, G_v] = 0 for all 48 face-corner pairs on the cube and 4 on the plaquette, in both rho conventions: the ring exchange respects the corner condition
+PASS D3 [exact] [P_f, S_f] = 0 and [P_f, prod_{e in f} Z^L_e] = 0: the fermion code is untouched, and the Z2 face flux is a record-diagonal constant of the ring exchange
+PASS D4 [exact] [P_f, H^g] != 0 -- on the cube face at (0, 0, 0) the commutator carries 64 nonzero Pauli monomials: the link sector's declared dynamics does not commute with the coupled hop
+PASS E1 [1e-12] plaquette 2x2x1, 8 records = 256 dimensions: the Gauss sector has dimension 14 in the admissible staggered convention, 0 in the sea convention (z = 2 is even), and 7 intersected with the fermion code
+PASS E2 [1e-12] plaquette ground state in Gauss and code: E_0 = -2.449489742783 = -sqrt 6 at lambda = 0, -2.323404276086 at lambda = 1; ring-exchange value <P_f> = 0.166666666667 = 1/6 and 0.094209746012
+PASS E3 [1e-12] the plaquette's admissible convention is not locally neutral: max |<rho_v>| = 0.5833333333 at lambda = 0 and 0.6456532164 at lambda = 1, the total charge vanishing only in the sum
+PASS E4 [1e-10] cube 2x2x2, 24 records: the Gauss sector is 14400 states of 2^24, on which H^g is sparse with 79872 nonzeros, Hermitian at 0.0e+00; the ground state lies in the code space at <S_f> = 1.000000000
+PASS E5 [1e-10] coupled cube ground state: E_0 = -5.466823694822 at lambda = 0 and -6.980814328073 at lambda = 1, both at <N> = 4.000000000, exactly half filling
+PASS E6 [1e-12] the coupled sea is neutral with zero mean flux: <n_v> = 1/2 to 1.0e-14, <rho_v> = 0 to 2.5e-15 at every one of the 8 corners, <E_e> = 0 to 7.1e-14 on every one of the 12 links, at lambda = 0 and lambda = 1 alike
+SUMMARY: an exactly gauge-invariant minimal coupling of the fermion's U(1) to a designed spin-1/2 link role; Gauss's law is a record-diagonal corner relation whose solution set on the cube is exactly the half-filled sector; spin-1/2 links carry a coordination-parity condition; the coupled sea is neutral with zero mean flux. No photon is shown.
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt
+++ b/logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt
@@ -1,9 +1,9 @@
 ===== runner cache v1 =====
 runner: scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
-runner_sha256: fae77293447e8572616850d1b1f669e093741bacd7c06044fffa08cf9c6f32e9
+runner_sha256: c5753f019161b99133803cca709bd536a28071595651f917291495de75fc654d
 timeout_sec: 120
 exit_code: 0
-elapsed_sec: 2.28
+elapsed_sec: 2.52
 status: ok
 ----- stdout -----
 H^g = -t sum eta (T X^L + K Y^L)/2; E_e = Z^L_e/2; U_e = (X^L + iY^L)/2; G_v = (div E)_v - rho_v
@@ -35,8 +35,11 @@ PASS E3 [1e-12] the plaquette's admissible convention is not locally neutral: ma
 PASS E4 [1e-10] cube 2x2x2, 24 records: the Gauss sector is 14400 states of 2^24, on which H^g is sparse with 79872 nonzeros, Hermitian at 0.0e+00; the ground state lies in the code space at <S_f> = 1.000000000
 PASS E5 [1e-10] coupled cube ground state: E_0 = -5.466823694822 at lambda = 0 and -6.980814328073 at lambda = 1, both at <N> = 4.000000000, exactly half filling
 PASS E6 [1e-12] the coupled sea is neutral with zero mean flux: <n_v> = 1/2 to 1.0e-14, <rho_v> = 0 to 2.5e-15 at every one of the 8 corners, <E_e> = 0 to 7.1e-14 on every one of the 12 links, at lambda = 0 and lambda = 1 alike
+PASS F1 [exact] site-level forcing: at every corner, for each of the 2 z_v choices of which record forms last, every assignment of the other 2 z_v - 1 records THAT OCCURS leaves exactly one admissible value -- 1248 such conditioning events on the cube (sea) and the plaquette (stag), all forced
+PASS F2 [exact] the conditional never forbids its own conditioning event: over all 11432 occurring (record set, absent record) pairs the admissible value set is nonempty, and with no record of the corner present both values are open; forcing first appears at 2 of the cube's 6 records and 1 of the plaquette's 4, always as a zero of the odds at one site
+PASS F3 [exact] order independence: for every corner and every one of the (2 z_v)! formation orders -- 720 per cube corner, 24 per plaquette corner -- forming the records one at a time under F1 and F2 reproduces the G_v = 0 set exactly (24 and 6 patterns), so the JOINT restriction is a consequence of the site-level zeros, not a further primitive
 SUMMARY: an exactly gauge-invariant minimal coupling of the fermion's U(1) to a designed spin-1/2 link role; Gauss's law is a record-diagonal corner relation whose solution set on the cube is exactly the half-filled sector; spin-1/2 links carry a coordination-parity condition; the coupled sea is neutral with zero mean flux. No photon is shown.
-TOTAL: PASS=28 FAIL=0
+TOTAL: PASS=31 FAIL=0
 
 ----- stderr -----
 

--- a/scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
+++ b/scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
@@ -33,8 +33,12 @@ rho_v^{stag} = n_v - (1 - eps_v)/2.
      [P_f, G_v] = 0, [P_f, H^g] != 0.
   E  THE COUPLED SEA.  The 256-dimensional plaquette and the cube's sparse
      14400-state Gauss sector.
+  F  SITE-LEVEL FORCING.  G_v = 0 read as a linear relation among one corner's
+     2 z_v records: the last record forced in every formation order, no
+     occurring record set left without a move, and the joint restriction
+     recovered from the site-level zeros alone.
 
-Groups A-D are exact: Gaussian-rational coefficients on symplectic Pauli
+Groups A-D and F are exact: Gaussian-rational coefficients on symplectic Pauli
 monomials (F2 supports, Z4 phases) and integer record arithmetic, with no
 floating-point step anywhere.  Group E is numerical at the stated tolerance.
 
@@ -814,6 +818,122 @@ check("E6 [1e-12] the coupled sea is neutral with zero mean flux: <n_v> = 1/2 to
       max(resC[0.0][3], resC[1.0][3]) < 1e-12 and max(resC[0.0][4], resC[1.0][4]) < 1e-12
       and max(resC[0.0][5], resC[1.0][5]) < 1e-12)
 
+
+# ========== F -- Gauss's law as site-level forcing, in any formation order [exact]
+#
+# The Admissibility axiom supplies a SITE's odds given its neighbours, and a
+# normalised conditional cannot assign zero to its own conditioning event, so a
+# JOINT constraint on a neighbourhood's records is not by itself a support
+# condition at any one site.  G_v = 0 is instead a LINEAR RELATION among the
+# corner's 2 z_v records, and a linear relation is implemented by site-level
+# support conditions in ANY formation order.  This group checks that reading
+# exactly, by bit arithmetic over the 2^(2 z_v) assignments of one corner's
+# records: the cube in the sea convention and the plaquette in the staggered
+# one, the two pairings the coordination-parity condition of B5 admits.
+
+
+def corner_table(g, v, kind):
+    """Every assignment of the 2 z_v records at corner v with G_v = 0, plus the
+    odds table.  Bit r < z_v is the fermion edge record of the r-th incident
+    edge and bit z_v + r its link record; a bit b carries the Z value 1 - 2b, so
+    2 (div E)_v = sum_e s_{v,e} (1 - 2 b) and 2 rho_v = 2 n_v - c with n_v the
+    corner parity of the fermion edge records.  A[(mask, val, r)] is the set of
+    values of record r carrying nonzero odds given the records in `mask`."""
+    inc = sorted(g.incs[v])
+    z = len(inc)
+    n = 2 * z
+    c = 1 if kind == "sea" else 1 - g.eps[v]
+    pats = []
+    for p in range(1 << n):
+        nv = 0
+        d = 0
+        for r, (q, s, w) in enumerate(inc):
+            nv ^= (p >> r) & 1
+            d += s * (1 - 2 * ((p >> (z + r)) & 1))
+        if d == 2 * nv - c:
+            pats.append(p)
+    A = {}
+    for mask in range(1 << n):
+        groups = {}
+        for p in pats:
+            groups.setdefault(p & mask, []).append(p)
+        for val, gp in groups.items():
+            for r in range(n):
+                if not (mask >> r) & 1:
+                    A[(mask, val, r)] = frozenset((p >> r) & 1 for p in gp)
+    return pats, n, A
+
+
+def formed_set(A, n, order):
+    """The record patterns produced by forming the corner's records in `order`,
+    each step taking only values of nonzero odds given those already present."""
+    frontier = {(0, 0)}
+    for r in order:
+        nxt = set()
+        for (mask, val) in frontier:
+            av = A.get((mask, val, r), frozenset())
+            if not av:
+                return None
+            for b in av:
+                nxt.add((mask | (1 << r), val | (b << r)))
+        frontier = nxt
+    return {val for (_, val) in frontier}
+
+
+CORNERS = []
+for g, kind, tag in ((GC, "sea", "cube"), (GP, "stag", "plaquette")):
+    for v in g.L.V:
+        CORNERS.append((tag, v) + corner_table(g, v, kind))
+
+last_ok = True
+last_cases = 0
+open_cases = 0
+never_empty = True
+free_at_empty = True
+first_forcing = {}
+sizes = {}
+for (tag, v, pats, n, A) in CORNERS:
+    sizes.setdefault(tag, set()).add(len(pats))
+    full = (1 << n) - 1
+    for (mask, val, r), av in A.items():
+        k = pcnt(mask)
+        never_empty = never_empty and len(av) >= 1
+        open_cases += 1
+        if k == 0:
+            free_at_empty = free_at_empty and len(av) == 2
+        if len(av) == 1 and (tag not in first_forcing or k < first_forcing[tag]):
+            first_forcing[tag] = k
+        if mask == full ^ (1 << r):
+            last_cases += 1
+            last_ok = last_ok and len(av) == 1
+
+check("F1 [exact] site-level forcing: at every corner, for each of the 2 z_v choices of which record "
+      "forms last, every assignment of the other 2 z_v - 1 records THAT OCCURS leaves exactly one "
+      "admissible value -- %d such conditioning events on the cube (sea) and the plaquette (stag), "
+      "all forced" % last_cases, last_ok and last_cases > 0)
+check("F2 [exact] the conditional never forbids its own conditioning event: over all %d occurring "
+      "(record set, absent record) pairs the admissible value set is nonempty, and with no record of "
+      "the corner present both values are open; forcing first appears at %d of the cube's 6 records "
+      "and %d of the plaquette's 4, always as a zero of the odds at one site"
+      % (open_cases, first_forcing["cube"], first_forcing["plaquette"]),
+      never_empty and free_at_empty and first_forcing == {"cube": 2, "plaquette": 1})
+
+order_ok = True
+norders = {}
+for (tag, v, pats, n, A) in CORNERS:
+    target = set(pats)
+    cnt = 0
+    for order in itertools.permutations(range(n)):
+        cnt += 1
+        order_ok = order_ok and formed_set(A, n, order) == target
+    norders[tag] = cnt
+check("F3 [exact] order independence: for every corner and every one of the (2 z_v)! formation orders "
+      "-- %d per cube corner, %d per plaquette corner -- forming the records one at a time under F1 "
+      "and F2 reproduces the G_v = 0 set exactly (%s and %s patterns), so the JOINT restriction is a "
+      "consequence of the site-level zeros, not a further primitive"
+      % (norders["cube"], norders["plaquette"], sorted(sizes["cube"])[0], sorted(sizes["plaquette"])[0]),
+      order_ok and norders == {"cube": 720, "plaquette": 24}
+      and sizes == {"cube": {24}, "plaquette": {6}})
 print("SUMMARY: an exactly gauge-invariant minimal coupling of the fermion's U(1) to a designed "
       "spin-1/2 link role; Gauss's law is a record-diagonal corner relation whose solution set on "
       "the cube is exactly the half-filled sector; spin-1/2 links carry a coordination-parity "

--- a/scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
+++ b/scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py
@@ -1,0 +1,822 @@
+#!/usr/bin/env python3
+"""The fermion's U(1) coupled to quantum links: Gauss's law as a support condition among records.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3 carrying one
+fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding, with
+the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1},
+eta_3(v) = (-1)^{v_1+v_2}, and a SECOND designed role per coarse edge -- a
+spin-1/2 "link" site -- carrying
+
+    E_e = (1/2) Z^L_e   (eigenvalues +-1/2),   U_e = (X^L_e + i Y^L_e)/2,
+
+with the coarse edge (v, e_a) oriented i = v -> j = v + e_a and s_{v,e} = +1
+when e leaves v, -1 when it enters.  The declared coupled law is
+
+    H^g = -t sum_<ij> eta_ij (T_ij X^L_ij + K_ij Y^L_ij) / 2,
+    plus lambda sum_f P_f  and  (g^2/2) sum_e E_e^2,
+
+with T_ij = (i/2) A_ij (B_i - B_j), K_ij = -(1/2) A_ij (I - B_i B_j),
+B_v = the product of the Z's at corner v = I - 2 n_v, S_f the ordered four-A
+face loop, P_f = W_f + W_f^dag the oriented four-link ring exchange, and
+G_v = (div E)_v - rho_v with rho_v^{sea} = n_v - 1/2 or
+rho_v^{stag} = n_v - (1 - eps_v)/2.
+
+  A  THE GAUGE-INVARIANT HOP.  a_i^dag U_ij a_j + h.c. = (T X^L + K Y^L)/2 on
+     every bond, K_ij two monomials, K = -i[T, n_i], {T, K} = 0,
+     [T, K] = -2i(n_i - n_j), and J_ij (PR #7892) = -eta_ij t K_ij.
+  B  GAUSS'S LAW AS A SUPPORT CONDITION.  G_v pure Z at one corner,
+     [G_v, G_w] = [G_v, H^g] = 0, sum_v G_v = -Q, the coordination-parity
+     condition, and the exact joint record-pattern counts.
+  C  AMPERE AND CONTINUITY.  dE_e/dt = -J^g_e, dn_v/dt = -sum J^g,
+     d(div E)_v/dt = dn_v/dt, E_e^2 = I/4, and the link-orientation reversal.
+  D  THE RING EXCHANGE.  P_f Hermitian, eight monomials on four links,
+     [P_f, G_v] = 0, [P_f, H^g] != 0.
+  E  THE COUPLED SEA.  The 256-dimensional plaquette and the cube's sparse
+     14400-state Gauss sector.
+
+Groups A-D are exact: Gaussian-rational coefficients on symplectic Pauli
+monomials (F2 supports, Z4 phases) and integer record arithmetic, with no
+floating-point step anywhere.  Group E is numerical at the stated tolerance.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import time
+from fractions import Fraction as Fr
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+AUDIT_TIMEOUT_SEC = 120
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ===================================================== coarse lattice, KS signs
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+def eps_of(v):
+    return -1 if (sum(v) & 1) else 1
+
+
+def bits(n):
+    out = set()
+    i = 0
+    while n:
+        if n & 1:
+            out.add(i)
+        n >>= 1
+        i += 1
+    return out
+
+
+# ============================================ symplectic Pauli monomials / sums
+
+class Q:
+    """i^k X^x Z^z on a register of sites indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+
+def qprod(seq):
+    o = Q(0, 0, 0)
+    for p in seq:
+        o = o * p
+    return o
+
+
+def cmul(a, b):
+    return (a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0])
+
+
+ONE = (Fr(1), Fr(0))
+IMU = (Fr(0), Fr(1))
+MONE = (Fr(-1), Fr(0))
+H2 = (Fr(1, 2), Fr(0))
+HI = (Fr(0), Fr(1, 2))
+MH = (Fr(-1, 2), Fr(0))
+MI = (Fr(0), Fr(-1))
+
+
+class PS(dict):
+    """sum_j c_j X^{x_j} Z^{z_j} with c_j a pair of Fractions: exact."""
+
+    def __add__(a, b):
+        o = PS(a)
+        for k, v in b.items():
+            w = o.get(k)
+            if w is None:
+                o[k] = v
+            else:
+                s = (w[0] + v[0], w[1] + v[1])
+                if s[0] == 0 and s[1] == 0:
+                    del o[k]
+                else:
+                    o[k] = s
+        return o
+
+    def __sub__(a, b):
+        return a + b.smul(MONE)
+
+    def smul(a, s):
+        o = PS()
+        for k, v in a.items():
+            c = cmul(v, s)
+            if c[0] or c[1]:
+                o[k] = c
+        return o
+
+    def __mul__(a, b):
+        o = PS()
+        for (x1, z1), c1 in a.items():
+            for (x2, z2), c2 in b.items():
+                c = cmul(c1, c2)
+                if pcnt(z1 & x2) & 1:
+                    c = (-c[0], -c[1])
+                k = (x1 ^ x2, z1 ^ z2)
+                w = o.get(k)
+                if w is None:
+                    o[k] = c
+                else:
+                    s = (w[0] + c[0], w[1] + c[1])
+                    if s[0] == 0 and s[1] == 0:
+                        del o[k]
+                    else:
+                        o[k] = s
+        return o
+
+    def dag(a):
+        o = PS()
+        for (x, z), c in a.items():
+            c = (c[0], -c[1])
+            if pcnt(x & z) & 1:
+                c = (-c[0], -c[1])
+            o[(x, z)] = c
+        return o
+
+    def iszero(a):
+        return len(a) == 0
+
+    def isherm(a):
+        return (a - a.dag()).iszero()
+
+    def isdiag(a):
+        return all(x == 0 for (x, z) in a)
+
+    def supp(a):
+        s = set()
+        for (x, z) in a:
+            s |= bits(x | z)
+        return s
+
+
+def mono(q, c=ONE):
+    ph = [(Fr(1), Fr(0)), (Fr(0), Fr(1)), (Fr(-1), Fr(0)), (Fr(0), Fr(-1))][q.k & 3]
+    return PS({(q.x, q.z): cmul(c, ph)})
+
+
+def zop(z, c=ONE):
+    return PS({(0, z): c})
+
+
+IDP = PS({(0, 0): ONE})
+
+
+def comm(a, b):
+    return a * b - b * a
+
+
+def acomm(a, b):
+    return a * b + b * a
+
+
+class Lat:
+    """Coarse cubic block with the BK superfast encoding on its edges."""
+
+    def __init__(self, dims):
+        self.dims = tuple(dims)
+        self.V = [v for v in itertools.product(*(range(d) for d in dims))]
+        self.nv = len(self.V)
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+
+    def step(self, v, d):
+        w = va(v, d)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+
+# ============================== the second designed role: one spin-1/2 link site
+
+class G:
+    """Fermion edge sites on bits 0..nq-1; link sites on bits nq..2nq-1."""
+
+    def __init__(self, dims):
+        self.L = L = Lat(dims)
+        self.nq = L.nq
+        self.bonds = []
+        for (v, ax) in L.E:
+            self.bonds.append((v, L.step(v, EX[ax]), eta_ks(v, ax), ax, L.ei[(v, ax)]))
+        self.incs = {v: [] for v in L.V}
+        for (i, j, e, ax, q) in self.bonds:
+            self.incs[i].append((q, +1, j))
+            self.incs[j].append((q, -1, i))
+        self.eps = {v: eps_of(v) for v in L.V}
+
+    # ---- fermion sector
+    def Bv(self, v):
+        return zop(self.L.star[v])
+
+    def nv(self, v):
+        return (IDP - self.Bv(v)).smul(H2)
+
+    def Aij(self, i, j):
+        return mono(self.L.Aij(i, j))
+
+    def Tij(self, i, j):
+        return (self.Aij(i, j) * (self.Bv(i) - self.Bv(j))).smul(HI)
+
+    def Kij(self, i, j):
+        return (self.Aij(i, j) * (IDP - self.Bv(i) * self.Bv(j))).smul(MH)
+
+    def Jij(self, i, j, eta, t=1):
+        """PR #7892's bond current J_ij = eta (t/2) A_ij (I - B_i B_j), no links."""
+        return (self.Aij(i, j) * (IDP - self.Bv(i) * self.Bv(j))).smul((Fr(eta * t, 2), Fr(0)))
+
+    # ---- link sector
+    def m(self, q):
+        return 1 << (self.nq + q)
+
+    def XL(self, q):
+        return PS({(self.m(q), 0): ONE})
+
+    def YL(self, q):
+        return PS({(self.m(q), self.m(q)): IMU})
+
+    def ZL(self, q):
+        return PS({(0, self.m(q)): ONE})
+
+    def Ee(self, q):
+        return self.ZL(q).smul(H2)
+
+    def Up(self, q):
+        m = self.m(q)
+        return PS({(m, 0): H2, (m, m): MH})
+
+    def Um(self, q):
+        m = self.m(q)
+        return PS({(m, 0): H2, (m, m): H2})
+
+    # ---- the coupled law
+    def hop(self, i, j, q):
+        return (self.Tij(i, j) * self.XL(q) + self.Kij(i, j) * self.YL(q)).smul(H2)
+
+    def Hg(self, t=1):
+        H = PS()
+        for (i, j, e, ax, q) in self.bonds:
+            H = H + self.hop(i, j, q).smul((Fr(-t * e), Fr(0)))
+        return H
+
+    def Jg(self, i, j, eta, q, t=1):
+        return (self.Kij(i, j) * self.XL(q)
+                - self.Tij(i, j) * self.YL(q)).smul((Fr(-t * eta, 2), Fr(0)))
+
+    # ---- Gauss
+    def rho(self, v, kind):
+        if kind == "sea":
+            return self.nv(v) - IDP.smul(H2)
+        return self.nv(v) - IDP.smul((Fr(1 - self.eps[v], 2), Fr(0)))
+
+    def divE(self, v):
+        o = PS()
+        for (q, s, w) in self.incs[v]:
+            o = o + self.Ee(q).smul((Fr(s), Fr(0)))
+        return o
+
+    def Gv(self, v, kind):
+        return self.divE(v) - self.rho(v, kind)
+
+    # ---- the ring exchange
+    def face_links(self, f):
+        L = self.L
+        out = []
+        n = len(f)
+        for a in range(n):
+            p, r = f[a], f[(a + 1) % n]
+            for ax in range(3):
+                if L.step(p, EX[ax]) == r and (p, ax) in L.ei:
+                    out.append((L.ei[(p, ax)], +1))
+                    break
+                if L.step(r, EX[ax]) == p and (r, ax) in L.ei:
+                    out.append((L.ei[(r, ax)], -1))
+                    break
+            else:
+                raise KeyError((p, r))
+        return out
+
+    def Wf(self, f):
+        o = IDP
+        for (q, d) in self.face_links(f):
+            o = o * (self.Up(q) if d > 0 else self.Um(q))
+        return o
+
+    def Pf(self, f):
+        W = self.Wf(f)
+        return W + W.dag()
+
+
+GC = G((2, 2, 2))
+GP = G((2, 2, 1))
+GB = G((3, 3, 3))
+BLOCKS = ((GC, "cube 2x2x2"), (GB, "open 3x3x3"))
+
+print("H^g = -t sum eta (T X^L + K Y^L)/2; E_e = Z^L_e/2; U_e = (X^L + iY^L)/2; G_v = (div E)_v - rho_v")
+
+# ============== A -- the gauge-invariant hop and the two-monomial K_ij [exact]
+
+hop_ok = kk_ok = comm_ok = cur_ok = True
+hmono = set()
+kmono = set()
+ksupp = set()
+for g, tag in BLOCKS:
+    for (i, j, e, ax, q) in g.bonds:
+        T, K = g.Tij(i, j), g.Kij(i, j)
+        aij = (T - K.smul(IMU)).smul(H2)          # a_i^dag a_j
+        aji = (T + K.smul(IMU)).smul(H2)          # a_j^dag a_i
+        lhs = aij * g.Up(q) + aji * g.Um(q)
+        hop_ok = hop_ok and (lhs - g.hop(i, j, q)).iszero() and lhs.isherm()
+        hmono.add(len(lhs))
+        kk_ok = kk_ok and K.isherm() and (g.Kij(j, i) + K).iszero() \
+            and (K - comm(T, g.nv(i)).smul(MI)).iszero() and K.supp() == T.supp()
+        kmono.add(len(K))
+        ksupp.add(len(K.supp()))
+        comm_ok = comm_ok and acomm(T, K).iszero() \
+            and (comm(T, K) + (g.nv(i) - g.nv(j)).smul((Fr(0), Fr(2)))).iszero() \
+            and (comm(T, K) - (g.Bv(i) - g.Bv(j)).smul(IMU)).iszero()
+        cur_ok = cur_ok and (g.Jij(i, j, e) + K.smul((Fr(e), Fr(0)))).iszero() \
+            and not (g.Jij(i, j, e) - K.smul((Fr(e, 2), Fr(0)))).iszero()
+
+nb = len(GC.bonds) + len(GB.bonds)
+check("A1 [exact] a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i = (T_ij X^L_ij + K_ij Y^L_ij)/2 exactly, "
+      "Hermitian, %s Pauli monomials, on all %d bonds of the 2x2x2 cube and the open 3x3x3 block"
+      % (sorted(hmono), nb), hop_ok and hmono == {4})
+check("A2 [exact] K_ij = -(1/2) A_ij (I - B_i B_j): Hermitian, K_ji = -K_ij, exactly %s Pauli "
+      "monomials on %s sites, the same support as T_ij" % (sorted(kmono), sorted(ksupp)),
+      kk_ok and kmono == {2})
+check("A3 [exact] K_ij = -i [T_ij, n_i] on every bond: given the hop, K is fixed by the fermion "
+      "algebra, not chosen", kk_ok)
+check("A4 [exact] {T_ij, K_ij} = 0 and [T_ij, K_ij] = -2i (n_i - n_j) = i (B_i - B_j) on every "
+      "bond: T, K and n_i - n_j close an su(2) per bond", comm_ok)
+check("A5 [exact] J_ij of PR #7892 = -eta_ij t K_ij on every bond -- one factor of t, sign MINUS, "
+      "and NOT eta (t/2) K_ij: the coupled hop's Y^L partner is the landed current", cur_ok)
+
+# ================= B -- Gauss's law as a support condition among records [exact]
+
+gz_ok = gg_ok = gh_ok = gq_ok = True
+gmono = {}
+gsupp = {}
+for g, tag in BLOCKS:
+    Hg = g.Hg()
+    for kind in ("sea", "stag"):
+        Gs = {v: g.Gv(v, kind) for v in g.L.V}
+        gz_ok = gz_ok and all(x.isdiag() for x in Gs.values())
+        gg_ok = gg_ok and all(comm(Gs[v], Gs[w]).iszero() for v in g.L.V for w in g.L.V)
+        gh_ok = gh_ok and all(comm(Gs[v], Hg).iszero() for v in g.L.V)
+        S = PS()
+        R = PS()
+        for v in g.L.V:
+            S = S + Gs[v]
+            R = R + g.rho(v, kind)
+        gq_ok = gq_ok and (S + R).iszero()
+        if tag == "cube 2x2x2":
+            gmono[kind] = sorted({len(x) for x in Gs.values()})
+            gsupp[kind] = sorted({len(x.supp()) for x in Gs.values()})
+gsupp_b = sorted({len(GB.Gv(v, "sea").supp()) for v in GB.L.V})
+
+check("B1 [exact] every G_v is pure Z -- record-diagonal -- with %s monomials on %s records at the "
+      "one corner (sea/stag), and %s in the 3x3x3 block: 2 z_v records, 12 at a bulk corner"
+      % (gmono["sea"], gsupp["sea"], gsupp_b), gz_ok and gsupp["sea"] == [6] and gsupp_b == [6, 8, 10, 12])
+check("B2 [exact] [G_v, G_w] = 0 for all %d + %d corner pairs, both rho conventions: the corner "
+      "conditions are jointly imposable on one pattern"
+      % (GC.L.nv ** 2, GB.L.nv ** 2), gg_ok)
+check("B3 [exact] [G_v, H^g] = 0 at every corner of both blocks, both rho conventions: the coupled "
+      "law preserves the corner condition exactly", gh_ok)
+check("B4 [exact] sum_v G_v = -sum_v rho_v on both blocks, every link cancelling in the sum; in the "
+      "sea convention that reads sum_v G_v = -Q with Q the PR #7892 charge", gq_ok)
+
+
+def popc(a):
+    a = np.array(a, dtype=np.int64)
+    c = np.zeros_like(a)
+    while a.any():
+        c += a & 1
+        a >>= 1
+    return c
+
+
+def enumerate_records(g):
+    """Exact joint record-pattern census of G_v = 0, by vectorised bit arithmetic."""
+    L = g.L
+    nq = g.nq
+    V = L.V
+    NF = 1 << nq
+    f = np.arange(NF, dtype=np.int64)
+    nvals = np.stack([popc(f & L.star[v]) & 1 for v in V], axis=1)
+    Nf = nvals.sum(1)
+    sgn = np.zeros((len(V), nq), dtype=np.int64)
+    for a, v in enumerate(V):
+        for (q, s, w) in g.incs[v]:
+            sgn[a, q] = s
+    lb = np.stack([((f >> q) & 1) for q in range(nq)], axis=1)
+    dv = (1 - 2 * lb) @ sgn.T
+    eps = np.array([g.eps[v] for v in V], dtype=np.int64)
+    out = {}
+    for kind in ("sea", "stag"):
+        r = 2 * nvals - 1 if kind == "sea" else 2 * nvals - (1 - eps)[None, :]
+        lo = min(dv.min(), r.min())
+        base = max(dv.max(), r.max()) - lo + 1
+        pw = base ** np.arange(len(V), dtype=object)
+        kd = ((dv - lo) * pw).sum(1)
+        kr = ((r - lo) * pw).sum(1)
+        uk, cnt = np.unique(kd, return_counts=True)
+        idx = np.clip(np.searchsorted(uk, kr), 0, len(uk) - 1)
+        per = np.where(uk[idx] == kr, cnt[idx], 0).astype(np.int64)
+        out[kind] = (int(per.sum()), int((per > 0).sum()), per, Nf)
+    return out
+
+
+ec = enumerate_records(GC)
+ep = enumerate_records(GP)
+coord_c = sorted({len(GC.incs[v]) for v in GC.L.V})
+coord_p = sorted({len(GP.incs[v]) for v in GP.L.V})
+check("B5 [exact] coordination parity: 2 (div E)_v sums z_v terms +-1 so carries the parity of z_v, "
+      "while 2 rho^sea = 2n - 1 is odd and 2 rho^stag = 2n - (1 - eps) even. Cube z = %s: %d joint "
+      "patterns of 2^24 sea, %d stag; plaquette z = %s: %d and %d"
+      % (coord_c, ec["sea"][0], ec["stag"][0], coord_p, ep["sea"][0], ep["stag"][0]),
+      coord_c == [3] and coord_p == [2]
+      and (ec["sea"][0], ec["stag"][0]) == (14400, 0)
+      and (ep["sea"][0], ep["stag"][0]) == (0, 14))
+per, Nf = ec["sea"][2], ec["sea"][3]
+mult = sorted(zip(*[x.tolist() for x in np.unique(per[per > 0], return_counts=True)]))
+Ns = sorted(set(Nf[per > 0].tolist()))
+check("B6 [exact] on the cube exactly %d of the 4096 fermion record patterns admit a link pattern, "
+      "and they are precisely the half-filled N = %s sector; link patterns each: %s" % (ec["sea"][1], Ns[0], ", ".join("%d x %d" % (b, a) for a, b in mult)),
+      ec["sea"][1] == 2240 and Ns == [4]
+      and mult == [(4, 192), (6, 1024), (7, 768), (8, 192), (9, 64)])
+free_ok = True
+dims_gc = []
+for g, gauss in ((GC, 14400), (GP, 14)):
+    L = g.L
+    rank = L.nq - L.nv + 1
+    fz = [L.loop(f) for f in L.faces()]
+    for r in range(1, 1 << len(fz)):
+        p = qprod([fz[a] for a in range(len(fz)) if (r >> a) & 1])
+        if p.x == 0 and (p.z != 0 or (p.k & 2) == 0):
+            pass
+        if p.x == 0 and p.z == 0:
+            continue
+        if p.x == 0:
+            free_ok = False
+    dims_gc.append((gauss, rank, gauss // (1 << rank)))
+check("B7 [exact] the code acts freely on the Gauss sector -- every nontrivial face-loop product "
+      "carries X, hence zero diagonal -- so dim(Gauss and code) = %d/2^%d = %d on the cube, "
+      "%d/2^%d = %d on the plaquette"
+      % (dims_gc[0][0], dims_gc[0][1], dims_gc[0][2], dims_gc[1][0], dims_gc[1][1], dims_gc[1][2]),
+      free_ok and dims_gc[0][2] == 450 and dims_gc[1][2] == 7)
+
+# ============================== C -- Ampere, continuity and bond reversal [exact]
+
+cont_ok = amp_ok = joint_ok = herm_ok = split_ok = rev_ok = True
+naive_fails = 0
+naive_tot = 0
+esq_ok = True
+for g, tag in BLOCKS:
+    Hg = g.Hg()
+    nbr = {v: [] for v in g.L.V}
+    for (i, j, e, ax, q) in g.bonds:
+        nbr[i].append((j, e, q, +1))
+        nbr[j].append((i, e, q, -1))
+    for v in g.L.V:
+        lhs = comm(Hg, g.nv(v)).smul(IMU)
+        rhs = PS()
+        for (w, e, q, s) in nbr[v]:
+            Jg = g.Jg(v, w, e, q) if s > 0 else g.Jg(w, v, e, q).smul(MONE)
+            rhs = rhs - Jg
+        cont_ok = cont_ok and (lhs - rhs).iszero()
+        joint_ok = joint_ok and (comm(Hg, g.divE(v)).smul(IMU) - lhs).iszero()
+    for (i, j, e, ax, q) in g.bonds:
+        Jg = g.Jg(i, j, e, q)
+        amp_ok = amp_ok and (comm(Hg, g.Ee(q)).smul(IMU) + Jg).iszero()
+        herm_ok = herm_ok and Jg.isherm()
+        split_ok = split_ok and (Jg - (g.Jij(i, j, e) * g.XL(q)
+                                      + g.Tij(i, j).smul((Fr(e), Fr(0))) * g.YL(q)).smul(H2)).iszero()
+        naive_tot += 1
+        if not (Jg + g.Jg(j, i, e, q)).iszero():
+            naive_fails += 1
+        X = g.XL(q)
+        rev_ok = rev_ok and ((X * g.Jg(j, i, e, q) * X) + Jg).iszero()
+        esq_ok = esq_ok and (g.Ee(q) * g.Ee(q) - IDP.smul((Fr(1, 4), Fr(0)))).iszero()
+
+check("C1 [exact] coupled continuity dn_v/dt = i[H^g, n_v] = -sum_w J^g_vw at every corner of both "
+      "blocks, with J^g_ij = -(t eta_ij/2)(K_ij X^L_ij - T_ij Y^L_ij)", cont_ok)
+check("C2 [exact] Ampere dE_e/dt = i[H^g, E_e] = -J^g_e on every one of the %d links, e oriented "
+      "tail to head: the flux on a link answers only to the current through its own edge" % naive_tot,
+      amp_ok)
+check("C3 [exact] joint continuity d(div E)_v/dt = dn_v/dt at every corner -- B3 written as a rate: "
+      "the flux divergence and the corner parity cannot drift apart", joint_ok)
+check("C4 [exact] every J^g_ij is Hermitian and J^g_ij = (1/2)(J_ij X^L_ij + eta_ij t T_ij Y^L_ij): "
+      "the X^L part of the coupled current is exactly the uncoupled PR #7892 current",
+      herm_ok and split_ok)
+check("C5 [exact] reversing a bond must reverse the link orientation too: X^L_e J^g_ji X^L_e = "
+      "-J^g_ij on every bond, while J^g_ji = -J^g_ij alone fails on %d of %d bonds"
+      % (naive_fails, naive_tot), rev_ok and naive_fails == naive_tot)
+check("C6 [exact] E_e^2 = I/4 identically on every link, so (g^2/2) sum_e E_e^2 is a c-number: at "
+      "spin 1/2 the electric term supplies no dynamics at all", esq_ok)
+
+# ================================== D -- the four-link ring exchange P_f [exact]
+
+pf_herm = pf_gauss = pf_code = pf_z2 = True
+pf_mono = set()
+pf_supp = set()
+pf_bad = None
+for g, tag in ((GC, "cube"), (GP, "plaquette")):
+    Hg = g.Hg()
+    for f in g.L.faces():
+        Pf = g.Pf(f)
+        pf_mono.add(len(Pf))
+        pf_supp.add(len(Pf.supp()))
+        pf_herm = pf_herm and Pf.isherm()
+        pf_supp_links = all(b >= g.nq for b in Pf.supp())
+        pf_herm = pf_herm and pf_supp_links
+        for kind in ("sea", "stag"):
+            for v in g.L.V:
+                pf_gauss = pf_gauss and comm(Pf, g.Gv(v, kind)).iszero()
+        pf_code = pf_code and comm(Pf, mono(g.L.loop(f))).iszero()
+        zf = PS({(0, sum(1 << (g.nq + q) for (q, d) in g.face_links(f))): ONE})
+        pf_z2 = pf_z2 and comm(Pf, zf).iszero()
+        c = comm(Pf, Hg)
+        if not c.iszero() and pf_bad is None:
+            pf_bad = (f[0], len(c))
+
+npairs = len(GC.L.faces()) * GC.L.nv
+check("D1 [exact] P_f = W_f + W_f^dag, the oriented four-link ring exchange, is Hermitian with %s "
+      "Pauli monomials on exactly %s sites -- the four link records of one coarse face, no fermion "
+      "record" % (sorted(pf_mono), sorted(pf_supp)), pf_herm and pf_mono == {8} and pf_supp == {4})
+check("D2 [exact] [P_f, G_v] = 0 for all %d face-corner pairs on the cube and %d on the plaquette, "
+      "in both rho conventions: the ring exchange respects the corner condition"
+      % (npairs, len(GP.L.faces()) * GP.L.nv), pf_gauss)
+check("D3 [exact] [P_f, S_f] = 0 and [P_f, prod_{e in f} Z^L_e] = 0: the fermion code is untouched, "
+      "and the Z2 face flux is a record-diagonal constant of the ring exchange",
+      pf_code and pf_z2)
+check("D4 [exact] [P_f, H^g] != 0 -- on the cube face at %s the commutator carries %d nonzero Pauli "
+      "monomials: the link sector's declared dynamics does not commute with the coupled hop"
+      % (pf_bad[0], pf_bad[1]) if pf_bad else "D4 no nonzero commutator", pf_bad is not None and pf_bad[1] == 64)
+
+# ============================= E -- the coupled sea, plaquette and cube [numerical]
+
+def dense(ps, n):
+    d = 1 << n
+    M = np.zeros((d, d), dtype=complex)
+    s = np.arange(d, dtype=np.int64)
+    for (x, z), (re, im) in ps.items():
+        ph = 1 - 2 * (popc(s & z) & 1)
+        M[s ^ x, s] += complex(float(re), float(im)) * ph
+    return M
+
+
+g = GP
+NQP = 2 * g.nq
+DP = 1 << NQP
+Hgp = dense(g.Hg(), NQP)
+f0 = g.L.faces()[0]
+Pfp = dense(g.Pf(f0), NQP)
+Sfp = dense(mono(g.L.loop(f0)), NQP)
+dims_p = {}
+for kind in ("sea", "stag"):
+    m = np.ones(DP, dtype=bool)
+    for v in g.L.V:
+        m &= np.abs(np.real(np.diag(dense(g.Gv(v, kind), NQP)))) < 1e-12
+    dims_p[kind] = m
+idx = np.where(dims_p["stag"])[0]
+Pg = np.eye(DP)[:, idx]
+Sg = Pg.conj().T @ Sfp @ Pg
+wS, US = np.linalg.eigh(Sg)
+codeP = US[:, np.abs(np.real(wS) - 1) < 1e-9]
+Bs = Pg @ codeP
+check("E1 [1e-12] plaquette 2x2x1, %d records = %d dimensions: the Gauss sector has dimension %d in "
+      "the admissible staggered convention, %d in the sea convention (z = 2 is even), and %d "
+      "intersected with the fermion code"
+      % (NQP, DP, int(dims_p["stag"].sum()), int(dims_p["sea"].sum()), codeP.shape[1]),
+      int(dims_p["stag"].sum()) == 14 and int(dims_p["sea"].sum()) == 0 and codeP.shape[1] == 7)
+resP = {}
+for lam in (0.0, 1.0):
+    M = Bs.conj().T @ (Hgp + lam * Pfp) @ Bs
+    ev, vec = np.linalg.eigh(M)
+    psi = Bs @ vec[:, 0]
+    ex = lambda O: float(np.real(psi.conj() @ O @ psi))
+    resP[lam] = (float(ev[0]), ex(Pfp),
+                 max(abs(ex(dense(g.rho(v, "stag"), NQP))) for v in g.L.V))
+check("E2 [1e-12] plaquette ground state in Gauss and code: E_0 = %.12f = -sqrt 6 at lambda = 0, "
+      "%.12f at lambda = 1; ring-exchange value <P_f> = %.12f = 1/6 and %.12f"
+      % (resP[0.0][0], resP[1.0][0], resP[0.0][1], resP[1.0][1]),
+      abs(resP[0.0][0] + np.sqrt(6.0)) < 1e-12 and abs(resP[1.0][0] + 2.323404276086) < 1e-11
+      and abs(resP[0.0][1] - 1.0 / 6.0) < 1e-12 and abs(resP[1.0][1] - 0.094209746012) < 1e-11)
+check("E3 [1e-12] the plaquette's admissible convention is not locally neutral: max |<rho_v>| = %.10f "
+      "at lambda = 0 and %.10f at lambda = 1, the total charge vanishing only in the sum"
+      % (resP[0.0][2], resP[1.0][2]),
+      abs(resP[0.0][2] - 0.5833333333) < 1e-9 and abs(resP[1.0][2] - 0.6456532164) < 1e-9)
+
+g = GC
+nq = g.nq
+V = g.L.V
+NFC = 1 << nq
+fpat = np.arange(NFC, dtype=np.int64)
+nvC = np.stack([popc(fpat & g.L.star[v]) & 1 for v in V], axis=1)
+sgnC = np.zeros((len(V), nq), dtype=np.int64)
+for a, v in enumerate(V):
+    for (q, s, w) in g.incs[v]:
+        sgnC[a, q] = s
+lbC = np.stack([((fpat >> q) & 1) for q in range(nq)], axis=1)
+dvC = (1 - 2 * lbC) @ sgnC.T
+rC = 2 * nvC - 1
+pw = 9 ** np.arange(len(V), dtype=object)
+kdC = ((dvC + 3) * pw).sum(1)
+krC = ((rC + 3) * pw).sum(1)
+order = np.argsort(kdC)
+kds = kdC[order]
+pairs = []
+for fi in range(NFC):
+    lo = np.searchsorted(kds, krC[fi], "left")
+    hi = np.searchsorted(kds, krC[fi], "right")
+    for li in order[lo:hi]:
+        pairs.append(fi | (int(li) << nq))
+sec = np.array(sorted(pairs), dtype=np.int64)
+DC = len(sec)
+
+
+def spmat(ps):
+    rows, cols, vals = [], [], []
+    ar = np.arange(DC)
+    for (x, z), (re, im) in ps.items():
+        tgt = sec ^ x
+        j = np.searchsorted(sec, tgt)
+        jc = np.clip(j, 0, DC - 1)
+        ok = (j < DC) & (sec[jc] == tgt)
+        ph = 1 - 2 * (popc(sec & z) & 1)
+        rows.append(jc[ok])
+        cols.append(ar[ok])
+        vals.append((complex(float(re), float(im)) * ph)[ok])
+    return sp.csr_matrix((np.concatenate(vals), (np.concatenate(rows), np.concatenate(cols))),
+                         shape=(DC, DC))
+
+
+HgC = spmat(g.Hg())
+facesC = g.L.faces()
+SfC = [spmat(mono(g.L.loop(f))) for f in facesC]
+PfC = [spmat(g.Pf(f)) for f in facesC]
+Pftot = sum(PfC)
+STAB = sum(SfC)
+nopsC = [spmat(g.nv(v)) for v in V]
+ropsC = [spmat(g.rho(v, "sea")) for v in V]
+EopsC = [spmat(g.Ee(q)) for (_, _, _, _, q) in g.bonds]
+hdev = float(abs(HgC - HgC.getH()).max())
+V0 = np.random.default_rng(20260903).standard_normal(DC)
+resC = {}
+for lam in (0.0, 1.0):
+    M = (HgC + lam * Pftot - 5.0 * STAB).tocsc()
+    ev, vec = spla.eigsh(M, k=2, which="SA", maxiter=40000, tol=0, v0=V0)
+    o = np.argsort(ev)
+    psi = vec[:, o[0]]
+    ex = lambda O: float(np.real(psi.conj() @ (O @ psi)))
+    resC[lam] = (float(ev[o[0]]) + 5.0 * len(facesC),
+                 min(ex(S) for S in SfC),
+                 sum(ex(o2) for o2 in nopsC),
+                 max(abs(ex(o2) - 0.5) for o2 in nopsC),
+                 max(abs(ex(o2)) for o2 in ropsC),
+                 max(abs(ex(o2)) for o2 in EopsC))
+check("E4 [1e-10] cube 2x2x2, 24 records: the Gauss sector is %d states of 2^24, on which H^g is "
+      "sparse with %d nonzeros, Hermitian at %.1e; the ground state lies in the code space at "
+      "<S_f> = %.9f" % (DC, HgC.nnz, hdev, resC[0.0][1]),
+      DC == 14400 and HgC.nnz == 79872 and hdev < 1e-12 and resC[0.0][1] > 1 - 1e-8)
+check("E5 [1e-10] coupled cube ground state: E_0 = %.12f at lambda = 0 and %.12f at lambda = 1, both "
+      "at <N> = %.9f, exactly half filling" % (resC[0.0][0], resC[1.0][0], resC[0.0][2]),
+      abs(resC[0.0][0] + 5.466823694822) < 1e-9 and abs(resC[1.0][0] + 6.980814328073) < 1e-9
+      and abs(resC[0.0][2] - 4.0) < 1e-8 and abs(resC[1.0][2] - 4.0) < 1e-8)
+check("E6 [1e-12] the coupled sea is neutral with zero mean flux: <n_v> = 1/2 to %.1e, <rho_v> = 0 "
+      "to %.1e at every one of the 8 corners, <E_e> = 0 to %.1e on every one of the 12 links, at "
+      "lambda = 0 and lambda = 1 alike"
+      % (max(resC[0.0][3], resC[1.0][3]), max(resC[0.0][4], resC[1.0][4]),
+         max(resC[0.0][5], resC[1.0][5])),
+      max(resC[0.0][3], resC[1.0][3]) < 1e-12 and max(resC[0.0][4], resC[1.0][4]) < 1e-12
+      and max(resC[0.0][5], resC[1.0][5]) < 1e-12)
+
+print("SUMMARY: an exactly gauge-invariant minimal coupling of the fermion's U(1) to a designed "
+      "spin-1/2 link role; Gauss's law is a record-diagonal corner relation whose solution set on "
+      "the cube is exactly the half-filled sector; spin-1/2 links carry a coordination-parity "
+      "condition; the coupled sea is neutral with zero mean flux. No photon is shown.")
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache answering PR #7892's named interface "coupling to a gauge field", constructively: **the emergent fermion's conserved `U(1)` couples exactly to a designed spin-1/2 quantum link per coarse edge, and Gauss's law is then a record-diagonal relation at each corner, i.e. a support condition of the law in the axioms' own vocabulary.** The coupled hop is `(T_ij X^L + K_ij Y^L)/2` with the partner `K_ij = -(1/2) A_ij (I - B_i B_j) = -i[T_ij, n_i]` already inside the encoding (`J_ij = -eta t K_ij`); `G_v = (div E)_v - rho_v` is pure `Z`, commutes with the coupled hop and with the face ring exchange, and sums to `-Q`. On the cube the Gauss sector is exactly the half-filled `N = 4` sector (`14400` joint patterns of `2^24`); Ampere holds exactly (`dE_e/dt = -J^g_e`); the coupled sea is neutral with zero mean flux at `1e-14`. The cost, declared and not resolved: spin-1/2 links carry a coordination-parity condition (`2 div E` has the parity of `z_v`), so the bulk (`z = 6`) forces the staggered background half-charge while the cube (`z = 3`) admits the sea convention. **No photon is shown**; the smallest test is named with its cost.

- `docs/THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (322 lines)
- `scripts/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.py` (`TOTAL: PASS=28 FAIL=0`, 2.3 s; A-D exact over Q[i] and integer record arithmetic over all `2^24` cube patterns; E sparse numerical)
- `logs/runner-cache/fermion_u1_quantum_links_gauss_law_support_condition_check_2026_09_03.txt`

## Theorems

- **T1** the gauge-invariant hop and the partner `K_ij` (two monomials; `{T, K} = 0`, `[T, K] = -2i(n_i - n_j)`; `supp K = supp T` on every bond).
- **T2** Gauss's law as a support condition: record-diagonal on the `2 z_v` records at a corner (six on the cube, twelve at an interior corner of the `3x3x3` block); the coordination-parity condition; the censuses (`14400`/`0` on the cube, `0`/`14` on the plaquette; exactly the `2240` half-filled fermion patterns admit a link pattern, multiplicities `192x4, 1024x6, 768x7, 192x8, 64x9`; `dim(Gauss ∩ code) = 450` / `7`).
- **T3** Ampere and coupled continuity; bond reversal must reverse the link orientation.
- **T4** the ring exchange `P_f` (8 monomials on 4 links) commutes with every `G_v`, not with `H^g`; the electric term is a c-number at spin 1/2.
- **T5** the coupled sea: plaquette (`E_0 = -sqrt 6` and `-2.3234` at `lambda = 0, 1`; `<P_f> = 1/6`, `0.0942`) and the cube's `14400`-state Gauss sector (`E_0 = -5.4668`, `-6.9808`; `<n_v> = 1/2`, `<rho_v> = <E_e> = 0`).

## Boundary

- Coarse lattice; the open cube, the open `3x3x3` block and one plaquette; the link role is designed (like PR #7834's role pattern) and the link dynamics declared; no photon; the convention tension carried as an open item; nothing derived from the axioms.

## Context

- Parents: PR #7892 (the current and charge), PR #7885, PR #7879, PR #7858, PR #7844, PR #7834.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03); the vacuum panel's "photon: run to kill" lane, run constructively instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
