### PR TITLE
feat(matter): discrete symmetries P, T and CPT of the emergent fermion

### DIFF
--- a/docs/DISCRETE_SYMMETRIES_P_T_AND_CPT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/DISCRETE_SYMMETRIES_P_T_AND_CPT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,328 @@
+---
+claim_id: discrete_symmetries_p_t_cpt_emergent_fermion
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, for the ONE DECLARED Hamiltonian H(t,m) = -t sum_<ij> eta_ij T_ij - (m/2) sum_v eps_v B_v whose coefficients t and m are supplied and are fixed by nothing quoted here, and on the named finite geometries only -- the open 2x2x2 coarse cube and the 4^3 coarse torus: EVERY PARITY STATEMENT BELOW IS CONDITIONAL ON THE LAW CARRYING IMPROPER POINT ELEMENTS, which the Lattice axiom does not name; it names 'nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site'. Conditional on the improper map being applied: (T1) the direction order -x < -y < -z < +x < +y < +z is carried cyclically by three under inversion, so the bare site relabelling V_P does not send A_ij to +-A_{P(i)P(j)}; the exact discrepancy is a pure-Z factor depending only on the image edge -- the three positive-direction edges at its upper endpoint together with the three negative-direction edges at its lower endpoint, degree 6 on the torus -- and no product of Z's can supply it, since a Z-Pauli only signs A_e whose X-support is its own edge; that adjacency is symmetric and loop-free, so U_P = G_g D_CZ V_P with G_g a Z2 gauge factor, D_CZ a diagonal Clifford CZ network and V_P the relabelling, satisfies U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)} with sigma_ij = eta_ij eta_{P(i)P(j)}, U_P B_v U_P^-1 = +B_{P(v)} with no sign at any corner, U_P S_f U_P^-1 = +S_{P(f)} on every face so the pi-flux code space is preserved, and U_P J_ij U_P^-1 = o_ij J_{P(i)P(j)} with o the image-bond orientation, both inversions reversing all 192 torus bonds. (T2) For inversion about a corner sigma_ij = +1 on every one of the 192 bonds, the sign field eta is carried to itself bond by bond with 0 of 192 differing and 0 flipped corners in the one-particle gauge -- not merely gauge-equivalent -- and H(t,m) is exactly P-symmetric for every t and every m; inversion about a cube centre and the three mid-plane reflections send m -> -m, carrying -1 on 64 and 128 bonds respectively; the uniform rule is eps_{P(v)} = (-1)^{sum of the shift components} eps_v, depending on the shift parity alone and never on the rotation or reflection part, and U_P H_hop U_P^-1 = H_hop exactly for every map on both geometries. (T3) Time reversal is T = Z_E K with Z_E = prod_e Z_e = prod over the corners with eps_v = -1 of B_v, the unique pure-Z choice because A_ij has X-support exactly its own edge and the bond-to-edge map is onto; A_ij -> -A_ij, B_v -> +B_v, T_ij -> +T_ij, S_f -> +S_f, J_ij -> -J_ij, Q -> +Q, and H(t,m) is invariant for every t and every m with no m -> -m; T^2 = +1 exactly on the 4096-dimensional cube space, on its 128-dimensional pi-flux code space and on the Dirac point. (T4) [numerical, 1e-12] on the 4^3 torus the one-particle operator is real symmetric with 8 zero modes gapped to exactly 2m; the symmetry class is BDI with T^2 = +1 and C^2 = +1 and chiral S = CT = Eps; in the canonical cell basis inversion about a corner is represented by exactly the same 8x8 matrix as the staggered mass, eps = Z1 Z2 Z3, the emergent gamma^0, anticommuting with the chirality X = -(Y x X x Y); CPT built from corner inversion is +1 times the identity on the Dirac-point subspace; a Kramers sign appears only as (PT)^2 = -1 for cube-centre inversion and (CP)^2 = -1 for the x = 1/2 reflection, and only at m = 0. (T5) The exact transformation table on the 4^3 torus for the rows B_v, n_v, A_ij, S_f, T_ij, H_hop, H_m, H(t,m), J_ij, Q, eps_v against the columns C, P about a corner, P about a cube centre, the x = 1/2 mid-plane reflection, T, CP, CT, PT and CPT: every entry is a sign on the same operator at the image index, B_v, S_f, H_hop, H_m, Q and eps_v are uniform in every column, and in the odd-shift columns A_ij, T_ij and J_ij carry the bond-dependent pattern sigma_ij = eta_ij eta_{P(i)P(j)} rather than a uniform sign; B_v, Q and H_m are pure Z hence record-diagonal, while A_ij, S_f, T_ij and J_ij have identically zero record-basis diagonal on both geometries. The values of t and m are supplied data; no interaction, no chiral sector, no gauge field beyond the encoding's own Z2 structure and no continuum limit is treated. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created; whether an improper element belongs in the Lattice axiom's symmetry list remains an axiom-level question for the owner."
+upstream_dependencies: []
+runner: scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py
+---
+
+# Discrete symmetries `P`, `T` and `CPT` of the emergent fermion
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py`](../scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.txt`](../logs/runner-cache/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.txt)
+**Parents:** none load-bearing. Every premise used below is declared in this note; the context notes are plain-text pointers listed in "Imports and authority".
+
+**The conditional, stated first.** The Lattice axiom names *proper* cubic rotations and nothing improper. Every parity statement in this note is therefore of the form "if the improper point element is applied, the encoded algebra does *this*". Landing the note does not license adding an improper element to the axiom; it supplies exactly the evidence the owner would need to decide whether the law *could* carry one at no cost. Whether it should is an axiom-level question for the owner, and this note does not decide it.
+
+PR #7892 built charge conjugation `C` and named `T` and `CPT` as an interface it did not compute. This note computes them, and computes parity alongside: which of `P`, `T` and `CPT` the emergent matter carries exactly, at what mass, and which of the resulting signs the records register. `T` is exact at every mass with `T^2 = +1`; parity about a lattice corner is exact at every mass, costing the encoding a Clifford network but no obstruction; and on the low-energy doublet the parity operator and the mass term are literally the same matrix.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems about one declared Hamiltonian on the coarse-lattice emergent fermion: the Clifford correction that realises an improper point element on the superfast encoding, the shift-parity rule governing the mass sign, the time-reversal operator and its full table, the Dirac-point representations, and the complete C/P/T transformation table with its record reading. The symplectic Pauli statements are exact Gaussian-rational arithmetic on F2 supports with Z4 phases; the tagged numerical items are floating-point cross-checks at the stated tolerance. Every parity statement is conditional on the law carrying improper point elements, which the Lattice axiom does not name."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the axiom-level question this note does not decide: whether an improper point element belongs in the Lattice axiom's symmetry list."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. Groups `A`, `B`, `C` and `E` are exact -- Gaussian-rational coefficients on
+symplectic Pauli monomials, `F2` supports and `Z4` phases, complete sweeps over both geometries -- and the items tagged `[numerical]` are floating-point cross-checks at the stated
+tolerance.
+
+1. `T1` (`A`). Parity needs a Clifford network on the encoding, and what that network is.
+2. `T2` (`B`). Inversion about a corner is exact at every mass; the shift-parity rule for the mass sign.
+3. `T3` (`C`). Time reversal `T = Z_E K`, its full table, and `T^2 = +1`.
+4. `T4` (`D`). The Dirac point: the mass is the parity operator, and `CPT` is the identity there.
+5. `T5` (`E`). The full transformation table, and which of its rows the records register.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, the Altland-Zirnbauer class labels, and the `CZ`-network form of a
+diagonal Clifford are standard methodology; every object is redeclared here and the runner recomputes every statement. No fitted number and no framework premise enters any proof.
+Non-load-bearing pointers, carrying no grade and no weight:
+
+- `CHARGE_CONJUGATION_AND_THE_CONSERVED_U1_CURRENT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7892): `C = Z_E C_0`, the bond current `J_ij`, the charge `Q`,
+  and the table format used here. Its named interface "`T` and `CPT`" is what this note computes.
+- `A_RECORD_NATIVE_STAGGERED_MASS_GAP_2M_EXPONENTIAL_KERNEL_AND_WHAT_IT_BREAKS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7890): `H(t,m)`, the grading `eps_v`, and its `T2` on
+  translations and the 24 proper rotations, of which `T2` here is the improper analogue.
+- `LORENTZ_AT_THE_DIRAC_POINT_TASTE_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7888): the 8-fold Dirac point and the `2x2x2` cell basis reused in `T4`.
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844) and
+  `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the encoding, the sign field, the superlattice role
+  pattern, and the coarse sublattice `2Z^3`.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting". No grade of theirs is cited and no hypothesis is adopted.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and
+proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has algebraic presentation `M_2(C)`".
+**Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations", and "For each site, the probability
+distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions" -- the law supplies the odds. **Record**: "Records form", "a record locks exactly
+one admissible local possibility", "records are permanent", "Only records are readable", and "A readout value is determined by record content alone."
+
+That symmetry clause, and the identical clause in Admissibility, name **"proper cubic rotations"** and no improper element; grepping the axioms file for
+`reflect|inversion|improper|parity|O_h|octahedral|point group` returns nothing. So every `P` statement below is conditional, as stated at the top.
+
+The lattice is physical. Everything below reads the Kawamoto-Smit sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, on the superlattice role pattern's
+sublattice. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras and no graded clause is used anywhere.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the sign field on it, the superfast
+encoding with its face stabilizers, the encoded hop, the grading `eps_v`, and `H(t,m)` with its supplied coefficients. `P1` (`A`) is the Clifford correction `U_P` and its action; `P2`
+(`B`) the shift-parity rule; `P3` (`C`) time reversal; `P4` (`D`) the Dirac-point representations; `P5` (`E`) the full table and the record reading. `P2` uses `P1`; `P3` uses `P0` only;
+`P4` uses `P0` and the one-particle reduction; `P5` uses `P1`, `P2`, `P3` and `C`, rebuilt here. The strongest supported scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`, and the coarse edge from `v` along `e_a` sits at the fine site `2v + e_a`. The **sign field** of the
+coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`. The **encoding** is the Bravyi-Kitaev superfast encoding on the coarse lattice, code
+qubits on the coarse edges, direction order `-x < -y < -z < +x < +y < +z`.
+
+```text
+A_ij = X(edge (i,j)) * prod Z(edges ordered before it at i) * prod Z(edges ordered before it at j),  A_ji = -A_ij
+B_v  = the product of the six Z's at corner v = I - 2 n_v,   S_f = the ordered product of the four A's around a coarse face f
+n_v  = (I - B_v)/2,   T_ij = (i/2) A_ij (B_i - B_j),   eps_v = (-1)^{v_1+v_2+v_3},   Q = sum_v (n_v - 1/2) = -(1/2) sum_v B_v
+H(t,m) = -t sum_<ij> eta_ij T_ij - (m/2) sum_v eps_v B_v          THE DECLARED LAW; t and m are supplied
+J_ij = eta_ij (t/2) A_ij (I - B_i B_j)                            the bond current of PR #7892
+C    = Z_E C_0,  C_0 = prod over a perfect matching of A_ij,  Z_E = prod over all edges of Z_e     conjugation, from PR #7892
+P: v -> M v + c    a signed permutation M and an integer shift c; improper when det M = -1
+V_P  = the bare relabelling of the code qubits induced by P        D_CZ = prod_{{e,f} in N} CZ_ef
+G_g  = prod_{v in S} B_v, the Z2 gauge factor                      U_P  = G_g . D_CZ . V_P          THE PARITY OPERATOR
+T    = Z_E . K,  K complex conjugation in the record basis         THE TIME-REVERSAL OPERATOR
+```
+
+The **star** of a corner is the set of edge sites incident to it, six in the bulk. A **record pattern** is one assignment of a value to every edge record; the record basis is the joint
+eigenbasis of the `Z_e`. An operator is **record-diagonal** when it is diagonal in that basis; one whose every Pauli monomial carries `X`-support has identically zero record-basis
+diagonal and registers only through correlations. A **cut** is an edge set `XOR_{v in S} star(v)`. The two geometries are the **open `2x2x2` coarse cube** (8 corners, 12 code qubits,
+4096-dimensional, 6 faces, 128-dimensional code space) and the **`4^3` coarse torus** (64 corners, 192 code qubits, 192 bonds, 192 faces).
+
+## Theorem 1 -- parity needs a Clifford network on the encoding
+
+**Conclusion.** Conditional on the improper element being applied: (1) `4` of the `10` point maps tested are automorphisms of the open cube -- the corner-centred ones leave the block --
+and all `10` are automorphisms of the torus; each induces a permutation of the code qubits. (2) Inversion carries the direction order `-x < -y < -z < +x < +y < +z` cyclically by three,
+so the bare relabelling `V_P` does **not** send `A_ij` to `+-A_{P(i)P(j)}`: the exact discrepancy is a **pure `Z`** factor, nontrivial on all `192` torus bonds. (3) No product of `Z`'s
+can absorb it: a `Z`-Pauli only supplies a **sign** to `A_e`, whose `X`-support is its own edge. The factor depends only on the **image edge** and is exactly the three
+positive-direction edges at its upper endpoint together with the three negative-direction edges at its lower endpoint -- degree `6` on the torus, truncated at the open boundary. (4)
+That adjacency is symmetric and loop-free for every map and geometry, so it is realised by the diagonal Clifford `D_CZ = prod CZ_ef`. (5) Hence `U_P = G_g D_CZ V_P` satisfies
+`U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)}` with `sigma_ij = eta_ij eta_{P(i)P(j)}` on every bond, `G_g`'s `Z`-mask always solving as a cut -- `|S| = 32` for both torus inversions -- so
+`G_g` is a `Z2` gauge factor, diagonal in the record basis. (6) `U_P B_v U_P^-1 = +B_{P(v)}` with no sign at any corner, so `n_v -> n_{P(v)}` and `Q -> +Q`; and
+`U_P S_f U_P^-1 = +S_{P(f)}` on every face, zero sign flips, so `U_P` is legal in the `pi`-flux code space. (7) `U_P J_ij U_P^-1 = o_ij J_{P(i)P(j)}` with `o` the image-bond
+orientation: both inversions reverse all `192` bonds and the `x`-reflections only the `64` `x`-bonds, so the current is a polar vector.
+
+**Proof.** Items 1 and 2 are `F2` support arithmetic on the induced edge permutation, with the residual monomial's `X`-part and phase parity read off directly. Item 3's necessity is the
+fact that conjugation by a `Z`-Pauli changes no `Z`-tail; the neighbourhood claim is checked edge by edge against the closed form. Item 4 is a symmetry and loop test. Item 5 conjugates
+each `A_ij` by the assembled Clifford, compares monomials exactly, then solves the mask over `F2` against the corner stars. Items 6 and 7 are the same comparison on the corner
+operators, face loops and bond currents. All exact.
+
+**Reading, not theorem.** The encoding fixes an order on the six directions at each site, and that order is not itself symmetric under a mirror. Repairing the mismatch is not a matter
+of signs: it takes a fixed pattern of two-record couplings, one per pair of neighbouring edges. Once that pattern is in place, the mirror is a legal operation of the code -- no face
+constraint is disturbed, and no record is ever flipped, only relabelled.
+
+## Theorem 2 -- inversion about a corner, and the shift-parity rule
+
+**Conclusion.** Conditional as above: (1) For inversion about a **corner**, `sigma_ij = +1` on every one of the `192` torus bonds, while inversion about a **cube centre** carries `-1`
+on `64` and the `x = 1/2` reflection on `128` -- a bond-dependent pattern, not a uniform sign. (2) The sign field is carried to **itself** bond by bond by corner inversion, `0` of `192`
+differing, and with `0` flipped corners in the one-particle gauge: it is not merely gauge-equivalent to its image. The odd-shift maps differ on `64` and `128` bonds and need a genuine
+gauge factor, `32` of the `64` corners at `g_v = -1`. (3) `U_P H_hop U_P^-1 = H_hop` **exactly** for every map on both geometries. (4)
+`eps_{P(v)} = (-1)^{sum of the shift components} eps_v` at every corner: the rule depends only on the shift parity, never on the rotation or reflection part, because a signed
+permutation preserves `v_1 + v_2 + v_3 mod 2`. (5) Hence `U_P H_m U_P^-1 = (-1)^{sum c} H_m`: `H(t,m)` is **exactly** `P`-symmetric at every `t` and `m` under corner inversion and the
+corner-plane reflections, and `P`-symmetric only with `m -> -m` under cube-centre inversion and the mid-plane reflections.
+
+**Proof.** Item 1 reads the signs produced by Theorem 1's construction. Item 2 compares `eta` bond by bond under the induced edge map, and independently solves the one-particle gauge by
+propagation over the torus. Item 3 conjugates the kinetic sum, item 5 the mass term. Item 4 is the parity of a signed permutation on the coordinate sum. All exact.
+
+**Reading, not theorem.** There are two kinds of mirror on this lattice: those centred on a corner and those centred half a cell away. The first kind leaves the sign field alone, bond
+for bond, and leaves the whole law alone at any mass. The second kind reverses the mass and nothing else. Which kind a given mirror is depends on one bit -- the parity of its shift --
+and on nothing else about it, which is the same bit that governs the translations of PR #7890.
+
+## Theorem 3 -- time reversal, exactly, at every mass
+
+**Conclusion.** (1) Every `A_ij` is a **real** Pauli, so `K A_ij K = +A_ij`, `K T_ij K = -T_ij` and `K H_hop K = -H_hop`: bare conjugation is an *anti*-symmetry of the hop, not a
+symmetry. (2) `Z_E = prod_e Z_e = prod over the corners with eps_v = -1 of B_v` as Pauli operators, an exact identity because the lattice is bipartite and every edge is covered once;
+and it is the **unique** pure-`Z` repair, since `A_ij` has `X`-support exactly its own edge and the bond-to-edge map is onto. (3) `T = Z_E K` acts as `A_ij -> -A_ij`, `B_v -> +B_v` --
+the records are `T`-even -- `n_v -> n_v`, `T_ij -> +T_ij`, and `S_f -> +S_f` on every face, so the `pi`-flux code space is `T`-invariant. (4) `T H(t,m) T^-1 = H(t,m)` for **every** `t`
+and **every** `m`, with no `m -> -m`. (5) `T J_ij T^-1 = -J_ij` on every bond, so the conserved bond current is `T`-odd, while `T Q T^-1 = +Q`. (6) `T^2 = +1` exactly: `Z_E` is a real
+diagonal involution on the `4096`-dimensional cube space, so `T^2 = Z_E Z_E^* = +I`; the code projector is real of rank exactly `128` and commutes with `Z_E`, so `T` carries the code
+space onto itself; and `T H T^-1 = Z_E H^* Z_E = H` at residual `0` for `m = 0, 0.7`. `[numerical, 1e-12]` for item 6.
+
+**Proof.** Item 1 is the reality of each monomial's coefficient after the phase is folded in. Item 2 is `F2` support arithmetic; the `X`-support condition is one linear equation per
+edge. Items 3 to 5 conjugate Pauli sums by `Z_E` and conjugate coefficients, key by key. Item 6 builds the `4096`-dimensional sparse algebra, projects onto the joint `+1` eigenspace of
+the six face stabilizers, and compares `Z_E H^* Z_E` with `H`.
+
+**Reading, not theorem.** Running the law backwards is not simply conjugating the numbers: doing that alone reverses the hopping term. The repair is a single fixed pattern of signs over
+the records -- the same object that distinguishes the two sublattices -- and once it is included, the law reads the same backwards as forwards, at any mass. Doing it twice returns
+exactly what one started with, so nothing here forces the doubling that a spin-half particle would show.
+
+## Theorem 4 -- the Dirac point: the mass is the parity operator
+
+**Conclusion.** `[numerical, 1e-12]` on the `4^3` torus throughout. (1) The one-particle operator is real symmetric with `{h_0, Eps} = 0`, has exactly `8` zero modes, and the staggered
+mass gaps them to exactly `2m` at `m = 0.2, 0.5, 1.0`. (2) The cell basis `psi_s(v) = (-1)^{sum(v div 2)} delta_{v mod 2, s}` is an orthonormal real basis of the kernel and the
+`q = (pi,pi,pi)` cell block of PR #7888, with velocities `M_a = -Gamma_a`. (3) The chirality `X = -i m_1 m_2 m_3 = -(Y x X x Y)` is a hermitian involution of spectrum `{+1 x4, -1 x4}`
+-- two right- and two left-handed Weyl doublets -- and the mass restricts to exactly `eps = Z1 Z2 Z3`, anticommuting with it: a chirality-mixing Dirac mass. (4) `U h_0 U^T = h_0` and
+`U Eps U^T = (-1)^{sum c} Eps` at residual `0` for both inversions, both `x`-reflections and the proper `C4`, with `0` flipped corners at a corner and `32` at a cube centre. (5)
+**Inversion about a corner is represented on the Dirac point by exactly the same `8x8` matrix as the staggered mass**, `eps = Z1 Z2 Z3` -- the emergent `gamma^0`, with
+`H_m|_D = m gamma^0` -- and it anticommutes with the chirality, exchanging the two handednesses. (6) The class is `BDI`: `T = K` restricted is the identity times `K` with `T^2 = +1`,
+`C = Eps.K` is `eps` times `K` with `C^2 = +1`, chiral `S = CT = Eps`. (7) `CPT` built from corner inversion is `+1` times the **identity** on the Dirac-point subspace; no other
+improper choice tested gives a scalar. (8) A Kramers sign appears only in the half-cell-shifted combinations and only at `m = 0`: `(PT)^2 = -1` for cube-centre inversion and
+`(CP)^2 = -1` for the `x = 1/2` reflection, against `+1` for both at a corner -- and those products send `m -> -m`, so they are not symmetries at `m =/= 0`.
+
+**Proof.** Item 1 diagonalises the `64x64` real symmetric operator. Item 2 verifies the closed-form kernel vectors and evaluates the cell Bloch matrix at `q = (pi,pi,pi)`. Items 3 and 5
+restrict the relevant `64x64` operators to the kernel and compare with explicit Pauli words on the three cell qubits. Item 4 builds the one-particle representation by propagating the
+gauge over the torus. Items 6 to 8 use `(A K)(B K) = A B^*` and the phase-invariant squares.
+
+**Reading, not theorem.** At low energy the lattice carries two doublets, one of each handedness, and a mass term that exchanges them. The mirror through a corner turns out to be that
+same exchange -- the same matrix, with no fitting -- which is the lattice form of the textbook relation between the parity operator and the mass. Combining the three operations,
+exchange of matter with its absence, mirror and time reversal, leaves the doublet exactly as it was.
+
+## Theorem 5 -- the full table, and what the records register
+
+**Conclusion.** Exact on the `4^3` torus, for the rows `B_v, n_v, A_ij, S_f, T_ij, H_hop, H_m, H(t,m), J_ij, Q, eps_v` and the columns `C`, `P` about a corner, `P` about a cube centre,
+the `x = 1/2` mid-plane reflection, `T`, `CP`, `CT`, `PT` and `CPT` (the products using corner inversion):
+
+```text
+        C     Pcor  Pcen  Ref   T     CP    CT    PT    CPT
+B_v     -1    +1    +1    +1    +1    -1    -1    +1    -1
+n_v     1-nP  n_P   n_P   n_P   n_P   1-nP  1-nP  n_P   1-nP
+A_ij    -1    +1    e.e'  e.e'  -1    -1    +1    -1    +1
+S_f     +1    +1    +1    +1    +1    +1    +1    +1    +1
+T_ij    +1    +1    e.e'  e.e'  +1    +1    +1    +1    +1
+H_hop   +1    +1    +1    +1    +1    +1    +1    +1    +1
+H_m     -1    +1    -1    -1    +1    -1    -1    +1    -1
+H(t,m)  -m    inv   -m    -m    inv   -m    -m    inv   -m
+J_ij    -1    +1    e.e'  e.e'  -1    -1    +1    -1    +1
+Q       -1    +1    +1    +1    +1    -1    -1    +1    -1
+eps_v   +1    +1    -1    -1    +1    +1    +1    +1    +1
+```
+
+(1) Every entry is a sign on the **same** operator at the image index -- `B_v -> s B_{P(v)}`, `A_ij -> s A_{P(i)P(j)}`, `S_f -> s S_{P(f)}`, `T_ij -> s T_{P(i)P(j)}`,
+`J_ij -> s J_{P(i)P(j)}` at the ordered image bond -- and no entry is lost; `B_v`, `S_f`, `H_hop`, `H_m`, `Q` and `eps_v` are uniform in every column. (2) In the two **odd-shift**
+columns the rows `A_ij`, `T_ij` and `J_ij` are *not* a uniform sign but the bond-dependent pattern `sigma_ij = eta_ij eta_{P(i)P(j)}`, at `-1` on `64` of the `192` bonds for the
+cube-centre inversion and on `128` for the `x = 1/2` reflection; `e.e'` marks that pattern in the table. (3) `H(t,m)` is invariant under `P` about a corner, under `T` and under `PT`,
+and goes to `H(t,-m)` under `C`, the two odd-shift parities, `CP`, `CT` and `CPT`. (4) `S_f -> +S_f` in every column. (5) **What the records register**: `B_v`, `Q` and `H_m` are pure
+`Z`, hence record-diagonal, and carry the table's `P` and `T` signs; `A_ij`, `S_f`, `T_ij` and `J_ij` have identically zero record-basis diagonal on both geometries, so they are
+correlation-only. Since both inversions reverse every bond, the current *vector* is carried to its opposite even where the table reads `+1`.
+
+**Proof.** Every column is a conjugation of Pauli sums, exact and compared key by key against the image operator; the antiunitary columns compose by `(A K)(B K) = A B^*`. The record
+statements are the `X`-support test on each Pauli sum, swept over both geometries. All exact.
+
+**Reading, not theorem.** Under a mirror and under time reversal the records are only relabelled, never flipped: the corner parity that says whether matter is present at a place is
+carried to the corner parity at the image place, with no sign. Under the exchange of matter with its absence, and under every product containing it, the record content is inverted
+instead. The mass term is the one part of the law whose sign any of these operations can change, and it is record-readable; the hop, the current and the face constraints are not
+readable from any single pattern of records, and register only in how records at neighbouring places correlate.
+
+## Corollary -- a vector-like Dirac theory, if the law has mirrors
+
+Within the setting declared above, on the two finite geometries named, and **conditional on the law carrying improper point elements, which the Lattice axiom does not name**:
+
+1. If the law carries inversion, the emergent matter is exactly `P`-symmetric about a lattice corner at every mass, and exactly `T`-symmetric at every mass, with `T^2 = +1` and `CPT`
+   the identity on the Dirac point: the discrete symmetries of a vector-like Dirac theory, with none of them broken.
+2. The improper elements cost the encoding nothing: every face stabilizer and the sign field are carried to themselves, and the correction is a fixed Clifford network on the code qubits
+   with a `Z2` gauge factor. The encoding does not obstruct them; whether to add them is an axiom-level decision.
+3. The staggered mass and inversion about a corner are the **same matrix** on the Dirac point: the mass is the parity operator, and the chirality anticommutes with both -- the lattice
+   form of the standard `gamma^0` relation, with no fitting.
+4. The Kramers sign lives in the half-cell-shifted combinations, `PT` with cube-centre inversion and `CP` with the `x = 1/2` reflection, and only at `m = 0`. That is where the emergent
+   doublet's spin-half character shows; `T` alone never produces it.
+5. `B_v`, `Q` and `H_m` are record-diagonal and carry the table's `P` and `T` signs, while `A_ij`, `S_f`, `T_ij` and `J_ij` are correlation-only: a record history is `P`- and
+   `T`-covariant with no extra structure, and inverted under `C`.
+6. Owner-level, and not decided here: whether an improper element belongs in the Lattice axiom's symmetry list. This note reports only that the emergent matter would be parity-symmetric
+   if it did, and says nothing about the weak sector, which has no chiral counterpart anywhere in this construction.
+
+**Reading, not theorem.** Mirror the lattice through one of its corners, or run it backwards in time, and the emergent matter's law reads the same, whatever its mass. Mirror it through
+the centre of a cell instead and the mass changes sign, which is the lattice's way of saying that the mass and the mirror are the same operation on the low-energy doublet. All three
+operations together, matter-exchange, mirror and time reversal, act as nothing at all on that doublet. The lattice axiom lists turns but not mirrors; whether the law has mirrors is a
+decision, and this note says only that nothing in the emergent matter stands in their way.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted. In particular the Lattice axiom's symmetry clause is quoted as it stands, and no improper
+  element is added to it.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms; the coarse lattice, the encoding, the sign field and the Hamiltonian are declared objects, and no coefficient is derived: `t` and `m` are
+  supplied, and no update rule, formation site, formation rate, coupling, or absolute unit appears. Which Hamiltonian applies is designed, not derived -- see PR #7834.
+- No interaction term is added, no second species appears, no chiral sector is constructed, and no continuum limit is taken.
+
+## Interfaces named for other lanes, not moved here
+
+- **The weak sector.** Nothing here bears on it. The construction has no chiral sector at all: the emergent content is a vector-like pair of doublets, and a parity-symmetric vector-like
+  theory says nothing about a sector that is not.
+- **The continuum.** Everything is a lattice operator or a finite-matrix restriction. Whether `U_P`, `T` or the `CPT` product has a continuum limit, and what it is, is not shown here.
+- **The fine `(4,2,2)` pattern's own improper symmetries.** Not examined. Everything here is on the coarse lattice; what the fine superlattice role pattern does under an improper
+  element is a separate question.
+- **Whether the designed marker rule of PR #7834 is inversion-symmetric.** Not examined. This note treats the encoded algebra and the declared Hamiltonian only.
+
+## Remaining live routes
+
+1. Larger blocks and other geometries. The open `2x2x2` cube and the `4^3` torus are what is proved; nothing is claimed beyond them.
+2. The many-body statements at nonzero `m` beyond the cube. Theorems 1, 2, 3 and 5 are exact at every `t` and `m`; the dense confirmation of `T^2 = +1` is on the eight-corner cube only.
+3. The other improper elements of the full point group. Two inversions and six reflections are tested, with a proper rotation and a translation for contrast; the remaining improper
+   elements are not enumerated here.
+4. Correlation structure. That the hop, the current and the face constraints register only through correlations is shown; what those correlations are is not computed.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one fermionic mode per coarse vertex, BK superfast encoding on it; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md; H(t,m) declared here with supplied t and m
+conditional: the Lattice axiom names "nearest-neighbor adjacency, standard translations, and proper cubic rotations" -- no improper element; every P statement below holds only if the improper map is applied, and this note does not decide whether the law carries one
+geometries: open 2x2x2 coarse cube (8 corners, 12 code qubits, 4096-dim, 6 faces, 128-dim code space); 4^3 coarse torus (64 corners, 192 code qubits, 192 bonds, 192 faces)
+parity_operator: U_P = G_g . D_CZ . V_P; V_P alone leaves a pure-Z factor per bond (direction order carried by three), nontrivial on all 192 torus bonds; no Z product can supply it, since a Z-Pauli only signs A_e; the factor depends only on the image edge = 3 +direction edges at its upper endpoint + 3 -direction edges at its lower, degree 6; symmetric and loop-free, so D_CZ is legal
+parity_action: U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)}, sigma_ij = eta_ij eta_{P(i)P(j)}; U_P B_v U_P^-1 = +B_{P(v)} (no sign, ever); U_P S_f U_P^-1 = +S_{P(f)} (0 flips, code space preserved); U_P J_ij U_P^-1 = o_ij J_{P(i)P(j)}, both inversions reversing all 192 bonds; G_g's mask is a cut with |S| = 32
+corner_inversion: sigma = +1 on all 192 bonds; eta carried to itself bond by bond (0 of 192 differ, 0 flipped corners in the one-particle gauge); H(t,m) exactly P-symmetric for every t and m
+odd_shift_rule: eps_{P(v)} = (-1)^{sum c} eps_v, shift parity alone; cube-centre inversion and the mid-plane reflections send m -> -m, carrying -1 on 64 and 128 bonds; U_P H_hop U_P^-1 = H_hop exactly for every map
+time_reversal: T = Z_E K, Z_E = prod_e Z_e = prod_{v: eps_v = -1} B_v, the unique pure-Z choice; A -> -A, B_v -> +B_v, T_ij -> +T_ij, S_f -> +S_f, J -> -J, Q -> +Q; H(t,m) invariant for every t and m, no m -> -m; T^2 = +1 on the 4096-dim space, on the 128-dim code space and on the Dirac point
+dirac_point: 8 zero modes, gap exactly 2m; class BDI (T^2 = +1, C^2 = +1, chiral S = CT = Eps); chirality X = -(Y x X x Y); corner inversion|_D = eps = Z1 Z2 Z3 = the staggered mass = the emergent gamma^0, anticommuting with X; CPT from corner inversion = +1 . I; (PT)^2 = -1 for cube-centre inversion and (CP)^2 = -1 for the x=1/2 reflection, only at m = 0
+table_rows_columns: rows B_v, n_v, A_ij, S_f, T_ij, H_hop, H_m, H(t,m), J_ij, Q, eps_v; columns C, P_corner, P_centre, x=1/2 reflection, T, CP, CT, PT, CPT; every entry a sign on the SAME operator at the image index; B_v, S_f, H_hop, H_m, Q, eps_v uniform in every column; A_ij, T_ij, J_ij carry sigma_ij = eta_ij eta_{P(i)P(j)} in the odd-shift columns, not a uniform sign
+records: B_v, Q and H_m are pure Z, hence record-diagonal, and carry the table's P and T signs; A_ij, S_f, T_ij and J_ij have identically zero record-basis diagonal on both geometries and register only through correlations
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=33 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on the **coarse** lattice `2Z^3`, on exactly two finite geometries: the open `2x2x2` coarse cube and the `4^3` coarse torus. Nothing is claimed for `Z^3`, for the
+fine lattice, or for any larger region, and no thermodynamic limit is taken.
+
+**Every parity statement is conditional on the law carrying improper point elements.** The Lattice axiom names proper cubic rotations only. What is proved is what the encoded algebra
+does when an improper map is applied, together with the fact that applying it costs the encoding nothing: `H_hop` is invariant, every face stabilizer is carried to itself with no sign,
+and the correction is a fixed Clifford network. That is evidence the law *could* carry improper elements at no cost; it is not a licence to add them, and whether to add them is an
+axiom-level question for the owner. Time reversal carries no such condition: `T = Z_E K` is built from the encoding's own objects.
+
+The content is **free hopping plus one declared diagonal term**. No interaction appears, and the coefficients `t` and `m` are **supplied**: derived from no axiom and fixed by no clause
+quoted here. No sign statement anywhere depends on `t`. Which Hamiltonian applies is a designed choice, not an axiom consequence.
+
+Theorems 1, 2, 3 and 5 are many-body statements in the encoded algebra, exact at every `t` and `m`. Theorem 3's dense confirmation is one `4096`-dimensional cube computation; Theorem 4
+is a `64x64` one-particle computation and `8x8` restrictions of it, about the exact zero-mode subspace of a finite matrix and the `O(p)` term of the landed Bloch expansion. **No
+continuum limit is taken**, and nothing is claimed about Lorentz covariance beyond PR #7888's own bound, about an interacting theory, or about an anomaly. The `CZ` network is a
+construction on the encoding, not an axiom object. `C`'s existence still requires an even corner count, as PR #7892 established; both geometries satisfy it.
+
+## Review record
+
+An honest auditor should come away with: one declared Hamiltonian, on two named finite geometries, whose emergent matter carries time reversal exactly at every mass with `T^2 = +1` and
+no Kramers doubling, and -- conditional on the law carrying improper point elements, which the Lattice axiom does not name -- parity about a lattice corner exactly at every mass,
+realised as `U_P = G_g D_CZ V_P` because the encoding's direction order is not itself mirror-symmetric and no product of `Z`'s can repair it. On the Dirac point the corner parity
+operator is literally the staggered-mass matrix and `CPT` built from it is the identity. The full table is exact, its uniform and bond-dependent rows are distinguished explicitly, and
+the record reading is stated: `B_v`, `Q` and `H_m` register directly; the hop, the current and the face constraints register only through correlations.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the five context notes in "Imports and authority"
+are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=33 FAIL=0`, runtime under the declared `90` seconds,
+stdout under `5500` characters, and passing pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.
+

--- a/logs/runner-cache/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.txt
+++ b/logs/runner-cache/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.txt
@@ -1,0 +1,60 @@
+===== runner cache v1 =====
+runner: scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py
+runner_sha256: 64ddfd480304ffd0428d7d92bf2de18e511041519fbc4e408f0b6de565d44130
+timeout_sec: 90
+exit_code: 0
+elapsed_sec: 1.79
+status: ok
+----- stdout -----
+H(t,m) = -t sum eta_ij T_ij - (m/2) sum eps_v B_v, open 2x2x2 cube and 4^3 torus. The Lattice axiom names PROPER rotations only: every P-line is CONDITIONAL.
+PASS A1 [exact] 4 of the 10 point maps are automorphisms of the open cube and all 10 of the torus; each PERMUTES the code qubits
+PASS A2 [exact] inversion shifts the direction order -x<-y<-z<+x<+y<+z by three, so V_P leaves a PURE Z factor on all 192 torus bonds
+PASS A3 [exact] a Z-Pauli only SIGNS A_e, so no Z product repairs it; the factor is the 3 +edges above and the 3 -edges below the image edge (degree [6])
+PASS A4 [exact] that adjacency is SYMMETRIC and LOOP-FREE for every map, so the diagonal Clifford D_CZ = prod CZ_ef is legal
+PASS A5 [exact] U_P = G_g D_CZ V_P gives U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)} with sigma_ij = eta_ij eta_{P(i)P(j)} on every bond
+PASS A6 [exact] the Z-mask of G_g is a CUT, prod_{v in S} B_v with |S| = 32: a Z2 gauge factor, DIAGONAL in the record basis
+PASS A7 [exact] U_P B_v U_P^-1 = +B_{P(v)}, no sign ever (Q -> +Q), and U_P S_f U_P^-1 = +S_{P(f)}: legal in the pi-flux code space
+PASS A8 [exact] U_P J_ij U_P^-1 = o_ij J_{P(i)P(j)}: the inversions reverse all 192 bonds, the x-mirrors only 64 -- J is POLAR
+PASS B1 [exact] CORNER inversion: sigma = +1 on all 192 bonds; the cube centre -1 on 64 and the x=1/2 mirror on 128
+PASS B2 [exact] corner inversion carries eta to ITSELF bond by bond, 0 of 192 differing; the odd-shift maps differ on 64 and 128
+PASS B3 [exact] U_P H_hop U_P^-1 = H_hop EXACTLY for every map on both geometries
+PASS B4 [exact] eps_{P(v)} = (-1)^{sum c} eps_v at every corner: the rule depends only on the SHIFT parity
+PASS B5 [exact] so H(t,m) is EXACTLY P-symmetric at every t and m about a corner, and only with m -> -m about a cube centre
+PASS C1 [exact] every A_ij is REAL, so K A_ij K = +A_ij and K H_hop K = -H_hop: bare conjugation is an ANTI-symmetry of the hop
+PASS C2 [exact] Z_E = prod_e Z_e = prod over the corners with eps_v = -1 of B_v: bipartite, so every edge is covered once
+PASS C3 [exact] Z_E is the UNIQUE pure-Z choice: A_ij has X-support exactly its own edge and the bond-to-edge map is onto
+PASS C4 [exact] T = Z_E K: A_ij -> -A_ij, B_v -> +B_v (records T-EVEN), T_ij -> +T_ij, S_f -> +S_f -- the code space is T-invariant
+PASS C5 [exact] T H(t,m) T^-1 = H(t,m) for EVERY t and EVERY m: time reversal is exact at every mass, with no m -> -m
+PASS C6 [exact] T J_ij T^-1 = -J_ij on every bond (the current is T-ODD) and T Q T^-1 = +Q
+PASS C7 [1e-12] Z_E is a real diagonal involution (T^2 = +I); the 4096-dim space's code projector is real of rank 128 and commutes with it; T H T^-1 = H (0e+00)
+PASS D1 [1e-12] the 4^3 one-particle operator is real symmetric with {h_0, Eps} = 0 (0.0e+00) and EXACTLY 8 zero modes gapped to exactly 2m (6e-15)
+PASS D2 [1e-12] the cell basis psi_s(v) = (-1)^{sum(v div 2)} delta_{v mod 2, s} is an orthonormal REAL kernel basis and the q = (pi,pi,pi) block (1e-16)
+PASS D3 [1e-12] the chirality X = -(Y x X x Y) has spectrum {+1 x4, -1 x4}: 2 right- and 2 left-handed doublets; the mass eps = Z1 Z2 Z3 ANTIcommutes (1e-16)
+PASS D4 [1e-12] one-particle: U h_0 U^T = h_0 and U Eps U^T = (-1)^{sum c} Eps (0.0e+00); 0 flipped corners at a corner, 32 at a cube centre
+PASS D5 [1e-12] CORNER inversion IS the staggered-mass matrix eps = Z1 Z2 Z3 (1.1e-16): the emergent gamma^0, ANTIcommuting with the chirality
+PASS D6 [1e-12] class BDI: T = K with T^2 = +1, C = Eps.K with C^2 = +1, chiral S = CT = Eps; no Kramers sign from T alone
+PASS D7 [1e-10] CPT from corner inversion is +1 times the IDENTITY on the Dirac point (2.2e-16); no other improper choice gives a scalar
+PASS D8 [1e-10] a Kramers sign only in the half-cell-shifted products, only at m = 0: (PT)^2 = -1 (cube centre), (CP)^2 = -1 (x=1/2), +1/+1 at a corner
+TABLE, 4^3 torus. Pcor/Pcen = corner/cube-centre inversion, Ref = the x=1/2 mid-plane; CP, PT, CPT use Pcor; e.e' = sigma_ij = eta_ij eta_{P(i)P(j)}; -m = m -> -m.
+       C    Pcor Pcen Ref  T    CP   CT   PT   CPT
+B_v    -1   +1   +1   +1   +1   -1   -1   +1   -1
+n_v    1-nP n_P  n_P  n_P  n_P  1-nP 1-nP n_P  1-nP
+A_ij   -1   +1   e.e' e.e' -1   -1   +1   -1   +1
+S_f    +1   +1   +1   +1   +1   +1   +1   +1   +1
+T_ij   +1   +1   e.e' e.e' +1   +1   +1   +1   +1
+H_hop  +1   +1   +1   +1   +1   +1   +1   +1   +1
+H_m    -1   +1   -1   -1   +1   -1   -1   +1   -1
+H(t,m) -m   inv  -m   -m   inv  -m   -m   inv  -m
+J_ij   -1   +1   e.e' e.e' -1   -1   +1   -1   +1
+Q      -1   +1   +1   +1   +1   -1   -1   +1   -1
+eps_v  +1   +1   -1   -1   +1   +1   +1   +1   +1
+PASS E1 [exact] every entry is a sign on the SAME operator at the image index; B_v, S_f, H_hop, H_m, Q and eps_v are uniform in every column
+PASS E2 [exact] the odd-shift columns Pcen, Ref carry sigma_ij = eta_ij eta_{P(i)P(j)} on A_ij, T_ij and J_ij, at -1 on 64 of 192 bonds and on 128
+PASS E3 [exact] H(t,m) is INVARIANT under Pcor, T and PT and goes to H(t,-m) under C, Pcen, Ref, CP, CT and CPT: vector-like, none broken
+PASS E4 [exact] S_f -> +S_f in every column: each operation carries the code space to itself with no sign; the encoding obstructs none
+PASS E5 [exact] B_v, Q and H_m are pure Z, so record-diagonal, carrying the table's signs; A_ij, S_f, T_ij, J_ij have zero record diagonal: correlation-only
+SUMMARY: conditional on improper elements in the law, the emergent matter is exactly P-symmetric about a corner and T-symmetric at every mass, T^2 = +1, CPT the identity.
+TOTAL: PASS=33 FAIL=0
+
+----- stderr -----
+

--- a/scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py
+++ b/scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py
@@ -1,0 +1,1087 @@
+#!/usr/bin/env python3
+"""Discrete symmetries P, T and CPT of the emergent fermion.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3, one
+fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding
+written on it, with the Kawamoto-Smit link signs
+    eta_1 = 1,  eta_2(v) = (-1)^{v_1},  eta_3(v) = (-1)^{v_1+v_2}.
+The declared Hamiltonian is
+    H(t, m) = -t sum_<ij> eta_ij T_ij - (m/2) sum_v eps_v B_v,
+    A_ij = X(edge) x Z-tails, direction order -x < -y < -z < +x < +y < +z,
+    A_ji = -A_ij,  B_v = prod of the six Z's at a corner = I - 2 n_v,
+    S_f = the ordered four-A face loop,  T_ij = (i/2) A_ij (B_i - B_j),
+    n_v = (I - B_v)/2,  eps_v = (-1)^{v_1+v_2+v_3},
+    J_ij = eta_ij (t/2) A_ij (I - B_i B_j),  Q = -(1/2) sum_v B_v.
+
+CONDITIONAL ON IMPROPER ELEMENTS.  The Lattice axiom of
+docs/MINIMAL_AXIOMS_2026-06-29.md names "nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site" -- no improper
+element.  Every P-statement below is of the form "if the improper map is
+applied, the encoded algebra does this"; nothing here licenses adding an
+improper element to the axiom.  That is an axiom-level question for the owner.
+
+  A  T1  PARITY NEEDS A CZ NETWORK.  Inversion shifts the direction order by
+     three, so the bare relabelling V_P leaves a pure-Z discrepancy per bond
+     that no Z-Pauli can absorb; it defines a symmetric loop-free adjacency,
+     hence U_P = G_g D_CZ V_P with U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)},
+     sigma_ij = eta_ij eta_{P(i)P(j)}; face stabilizers carry no sign.
+  B  T2  THE SHIFT-PARITY RULE.  Inversion about a corner: sigma = +1 on every
+     bond, eta invariant bond by bond, H(t,m) exactly P-symmetric at every t
+     and m.  Cube-centre inversion and the mid-plane reflections send m -> -m.
+     eps_{P(v)} = (-1)^{sum c} eps_v depends only on the shift parity.
+  C  T3  TIME REVERSAL.  T = Z_E K with Z_E = prod_e Z_e = prod_{v: eps_v = -1}
+     B_v, the unique pure-Z choice; the full transformation table; H(t,m)
+     invariant for every t and m; T^2 = +1 exactly.
+  D  T4  THE DIRAC POINT.  Eight zero modes, gap exactly 2m, class BDI; corner
+     inversion is represented by exactly the staggered-mass matrix
+     eps = Z1 Z2 Z3, the emergent gamma^0, anticommuting with the chirality;
+     CPT from corner inversion is +1 times the identity; a Kramers sign appears
+     only as (PT)^2 = -1 for cube-centre inversion and (CP)^2 = -1 for the
+     x = 1/2 reflection, and only at m = 0.
+  E  T5  THE FULL TABLE, and what the records register.
+
+Groups A, B, C and E are exact: Gaussian-rational coefficients on symplectic
+Pauli monomials (F2 supports, Z4 phases), with no floating-point step.  Group D
+and the tagged items are floating-point at the stated tolerance.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import time
+from fractions import Fraction as Fr
+
+import numpy as np
+import scipy.sparse as sp
+
+AUDIT_TIMEOUT_SEC = 90
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+TOL = 1e-12
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ===================================================== coarse lattice, KS signs
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def wrap(v, dims):
+    return tuple(v[i] % dims[i] for i in range(3))
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+def bits(n):
+    out = []
+    i = 0
+    while n:
+        if n & 1:
+            out.append(i)
+        n >>= 1
+        i += 1
+    return out
+
+
+def eps_of(v):
+    return -1 if (sum(v) & 1) else 1
+
+
+# ============================================ symplectic Pauli monomials / sums
+
+class Q:
+    """i^k X^x Z^z on a register of qubits indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+    def isI(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+
+def qprod(seq):
+    o = Q(0, 0, 0)
+    for p in seq:
+        o = o * p
+    return o
+
+
+def cmul(a, b):
+    return (a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0])
+
+
+ONE = (Fr(1), Fr(0))
+IMU = (Fr(0), Fr(1))
+HALF = (Fr(1, 2), Fr(0))
+HALFI = (Fr(0), Fr(1, 2))
+PHASE = [(Fr(1), Fr(0)), (Fr(0), Fr(1)), (Fr(-1), Fr(0)), (Fr(0), Fr(-1))]
+
+
+class PS(dict):
+    """sum_j c_j X^{x_j} Z^{z_j} with c_j a pair of Fractions: exact."""
+
+    def __add__(a, b):
+        o = PS(a)
+        for k, v in b.items():
+            w = o.get(k)
+            if w is None:
+                o[k] = v
+            else:
+                s = (w[0] + v[0], w[1] + v[1])
+                if s[0] == 0 and s[1] == 0:
+                    del o[k]
+                else:
+                    o[k] = s
+        return o
+
+    def __sub__(a, b):
+        return a + b.smul((Fr(-1), Fr(0)))
+
+    def smul(a, s):
+        o = PS()
+        for k, v in a.items():
+            c = cmul(v, s)
+            if c[0] or c[1]:
+                o[k] = c
+        return o
+
+    def __mul__(a, b):
+        o = PS()
+        for (x1, z1), c1 in a.items():
+            for (x2, z2), c2 in b.items():
+                c = cmul(c1, c2)
+                if pcnt(z1 & x2) & 1:
+                    c = (-c[0], -c[1])
+                k = (x1 ^ x2, z1 ^ z2)
+                w = o.get(k)
+                if w is None:
+                    o[k] = c
+                else:
+                    s = (w[0] + c[0], w[1] + c[1])
+                    if s[0] == 0 and s[1] == 0:
+                        del o[k]
+                    else:
+                        o[k] = s
+        return o
+
+    def iszero(a):
+        return len(a) == 0
+
+    def xsupp(a):
+        s = 0
+        for (x, z) in a:
+            s |= x
+        return s
+
+    def has_diag(a):
+        return any(x == 0 for (x, z) in a)
+
+    def is_pure_z(a):
+        return all(x == 0 for (x, z) in a)
+
+
+def mono(q, c=ONE):
+    return PS({(q.x, q.z): cmul(c, PHASE[q.k & 3])})
+
+
+def zop(z, c=ONE):
+    return PS({(0, z): c})
+
+
+IDP = PS({(0, 0): ONE})
+
+
+def comm(a, b):
+    return a * b - b * a
+
+
+def conj_mono(c):
+    """O -> c O c^{-1} for a Pauli MONOMIAL c: a sign per key."""
+    def f(P):
+        o = PS()
+        for (x, z), co in P.items():
+            if (pcnt(c.x & z) + pcnt(c.z & x)) & 1:
+                o[(x, z)] = (-co[0], -co[1])
+            else:
+                o[(x, z)] = co
+        return o
+    return f
+
+
+def antiK(P):
+    """K P K for a Pauli sum: conjugate the coefficient of every (x, z) key."""
+    o = PS()
+    for k, c in P.items():
+        o[k] = (c[0], -c[1])
+    return o
+
+
+class Lat:
+    """Coarse cubic block or torus with the BK superfast encoding on its edges."""
+
+    def __init__(self, dims, periodic):
+        self.dims = tuple(dims)
+        self.per = periodic
+        self.V = [v for v in itertools.product(*(range(d) for d in dims))]
+        self.nv = len(self.V)
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+
+    def step(self, v, d):
+        w = va(v, d)
+        if self.per:
+            return wrap(w, self.dims)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+    def bonds(self):
+        return [(v, self.step(v, EX[a]), eta_ks(v, a), a) for (v, a) in self.E]
+
+
+def Bop(L, v):
+    return zop(L.star[v])
+
+
+def nop(L, v):
+    return (IDP - Bop(L, v)).smul(HALF)
+
+
+def Aop(L, i, j):
+    return mono(L.Aij(i, j))
+
+
+def Top(L, i, j):
+    return (Aop(L, i, j) * (Bop(L, i) - Bop(L, j))).smul(HALFI)
+
+
+def Jop(L, i, j, w):
+    return (Aop(L, i, j) * (IDP - Bop(L, i) * Bop(L, j))).smul((Fr(w) / 2, Fr(0)))
+
+
+def Hhop(L):
+    H = PS()
+    for (i, j, e, a) in L.bonds():
+        H = H + Top(L, i, j).smul((-Fr(e), Fr(0)))
+    return H
+
+
+def Hmass(L):
+    H = PS()
+    for v in L.V:
+        H = H + zop(L.star[v], (Fr(-eps_of(v), 2), Fr(0)))
+    return H
+
+
+def Qop(L):
+    o = PS()
+    for v in L.V:
+        o = o + (nop(L, v) - IDP.smul(HALF))
+    return o
+
+
+# ======================================== point maps and the induced relabelling
+
+class Map:
+    """v -> M v + c on the coarse lattice; (M v)_i = s_i v[j_i]."""
+
+    def __init__(self, name, M, c, det):
+        self.name = name
+        self.M = M
+        self.c = tuple(c)
+        self.det = det
+
+    def pt(self, L, v):
+        w = tuple(self.M[i][1] * v[self.M[i][0]] + self.c[i] for i in range(3))
+        if L.per:
+            return wrap(w, L.dims)
+        return w if all(0 <= w[i] < L.dims[i] for i in range(3)) else None
+
+    def dirimg(self, a):
+        for i in range(3):
+            if self.M[i][0] == a:
+                return i, self.M[i][1]
+        raise KeyError
+
+
+NEG = [(0, -1), (1, -1), (2, -1)]
+POS = [(0, 1), (1, 1), (2, 1)]
+IDMAP = Map("identity", POS, (0, 0, 0), +1)
+INV0 = Map("inversion about a corner", NEG, (0, 0, 0), -1)
+INVC = Map("inversion about a cube centre", NEG, (1, 1, 1), -1)
+REF0X = Map("reflection x=0", [(0, -1), (1, 1), (2, 1)], (0, 0, 0), -1)
+REFHX = Map("reflection x=1/2", [(0, -1), (1, 1), (2, 1)], (1, 0, 0), -1)
+REF0Y = Map("reflection y=0", [(0, 1), (1, -1), (2, 1)], (0, 0, 0), -1)
+REFHY = Map("reflection y=1/2", [(0, 1), (1, -1), (2, 1)], (0, 1, 0), -1)
+REF0Z = Map("reflection z=0", [(0, 1), (1, 1), (2, -1)], (0, 0, 0), -1)
+REFHZ = Map("reflection z=1/2", [(0, 1), (1, 1), (2, -1)], (0, 0, 1), -1)
+ROTZ = Map("C4 about z (proper)", [(1, -1), (0, 1), (2, 1)], (0, 0, 0), +1)
+TRX = Map("translation +x (proper)", POS, (1, 0, 0), +1)
+
+IMPROPER = [INV0, INVC, REF0X, REFHX, REF0Y, REFHY, REF0Z, REFHZ]
+MAPS = IMPROPER + [ROTZ, TRX]
+
+
+def edge_perm(L, mp):
+    """Induced permutation of the code qubits, or (None, None)."""
+    vm = {}
+    for v in L.V:
+        w = mp.pt(L, v)
+        if w is None:
+            return None, None
+        vm[v] = w
+    if len(set(vm.values())) != L.nv:
+        return None, None
+    ep = {}
+    for (v, a) in L.E:
+        b, s = mp.dirimg(a)
+        u = vm[v]
+        e2 = (u, b) if s > 0 else (L.step(u, tuple(-x for x in EX[b])), b)
+        if e2[0] is None or e2 not in L.ei:
+            return None, None
+        ep[L.ei[(v, a)]] = L.ei[e2]
+    if len(set(ep.values())) != L.nq:
+        return None, None
+    return vm, ep
+
+
+def permmask(ep, msk):
+    o = 0
+    for q in bits(msk):
+        o |= 1 << ep[q]
+    return o
+
+
+def vperm(ep, q):
+    return Q(q.k, permmask(ep, q.x), permmask(ep, q.z))
+
+
+def cz_conj(N, q):
+    """D Q D^-1 for D = prod_{{e,f}: f in N[e]} CZ_{ef}, N symmetric, loop-free."""
+    S = bits(q.x)
+    zn = 0
+    for e in S:
+        zn ^= N[e]
+    sg = 0
+    for a in range(len(S)):
+        for b in range(a + 1, len(S)):
+            if (N[S[a]] >> S[b]) & 1:
+                sg ^= 1
+    return Q(q.k + 2 * sg, q.x, q.z ^ zn)
+
+
+def zw_conj(W, q):
+    return Q(q.k + 2 * (pcnt(W & q.x) & 1), q.x, q.z)
+
+
+class Conj:
+    """U_P = G_g . D_CZ . V_P acting by conjugation on monomials and sums."""
+
+    def __init__(self, ep, N, W):
+        self.ep = ep
+        self.N = N
+        self.W = W
+
+    def q(self, p):
+        return zw_conj(self.W, cz_conj(self.N, vperm(self.ep, p)))
+
+    def ps(self, P):
+        o = PS()
+        for (x, z), c in P.items():
+            r = self.q(Q(0, x, z))
+            cc = cmul(c, PHASE[r.k & 3])
+            w = o.get((r.x, r.z))
+            if w is None:
+                o[(r.x, r.z)] = cc
+            else:
+                s = (w[0] + cc[0], w[1] + cc[1])
+                if s[0] == 0 and s[1] == 0:
+                    del o[(r.x, r.z)]
+                else:
+                    o[(r.x, r.z)] = s
+        return o
+
+
+class Act:
+    """A possibly antiunitary symmetry acting by conjugation on Pauli sums."""
+
+    def __init__(self, fn, anti):
+        self.fn = fn
+        self.anti = anti
+
+    def __call__(self, O):
+        return self.fn(O)
+
+
+def comp(a, b):
+    return Act(lambda O: a(b(O)), a.anti ^ b.anti)
+
+
+def analyze(L, mp):
+    """Build U_P = G_g D_CZ V_P and every derived sign, exactly."""
+    vm, ep = edge_perm(L, mp)
+    if vm is None:
+        return None
+    N = {q: 0 for q in range(L.nq)}
+    s0 = {}
+    orient = {}
+    badk = 0
+    for (v, a) in L.E:
+        i, j, e = v, L.step(v, EX[a]), L.ei[(v, a)]
+        R = vperm(ep, L.Aij(i, j)) * L.Aij(vm[i], vm[j])
+        if R.x != 0 or (R.k & 1):
+            badk += 1
+        N[ep[e]] = R.z
+        s0[e] = 1 if (R.k & 3) == 0 else -1
+        orient[e] = 1 if (vm[i] == L.E[ep[e]][0]) else -1
+    sym_ok = all(((N[e] >> f) & 1) == ((N[f] >> e) & 1)
+                 for e in range(L.nq) for f in bits(N[e]))
+    self_ok = all(not ((N[e] >> e) & 1) for e in range(L.nq))
+    W = 0
+    for (v, a) in L.E:
+        e = L.ei[(v, a)]
+        (u, c) = L.E[ep[e]]
+        if s0[e] * eta_ks(v, a) != eta_ks(u, c):
+            W |= 1 << ep[e]
+    sigma = {e: s0[e] * (-1 if (W >> ep[e]) & 1 else 1) for e in s0}
+    return dict(vm=vm, ep=ep, N=N, s0=s0, W=W, U=Conj(ep, N, W), sigma=sigma,
+                orient=orient, sym_ok=sym_ok, self_ok=self_ok, badk=badk,
+                nz=sum(1 for e in range(L.nq) if N[e] != 0))
+
+
+def gauge_corners(L, W):
+    """Solve XOR_{v in S} star[v] = W over F2; return S, or None."""
+    piv = {}
+    for idx, v in enumerate(L.V):
+        r, prov = L.star[v], 1 << idx
+        while r:
+            h = r.bit_length() - 1
+            if h in piv:
+                r ^= piv[h][0]
+                prov ^= piv[h][1]
+            else:
+                piv[h] = (r, prov)
+                break
+    w, prov = W, 0
+    while w:
+        h = w.bit_length() - 1
+        if h not in piv:
+            return None
+        w ^= piv[h][0]
+        prov ^= piv[h][1]
+    return [L.V[i] for i in range(L.nv) if (prov >> i) & 1]
+
+
+def cz_neighbourhood_of_inversion(L, q):
+    """The three +direction edges at the image edge's upper endpoint together
+    with the three -direction edges at its lower endpoint."""
+    (u, c) = L.E[q]
+    w = L.step(u, EX[c])
+    msk = 0
+    for a in range(3):
+        if (w, a) in L.ei:
+            msk |= 1 << L.ei[(w, a)]
+        p = L.step(u, tuple(-x for x in EX[a]))
+        if p is not None and (p, a) in L.ei:
+            msk |= 1 << L.ei[(p, a)]
+    return msk
+
+
+CUBE = Lat((2, 2, 2), False)
+TOR = Lat((4, 4, 4), True)
+
+print("H(t,m) = -t sum eta_ij T_ij - (m/2) sum eps_v B_v, open 2x2x2 cube and 4^3 torus. The"
+      " Lattice axiom names PROPER rotations only: every P-line is CONDITIONAL.")
+
+# ============================ A -- T1: parity needs a CZ network on the encoding
+
+perm_ok = pureZ_ok = sym_ok = img_ok = sigA_ok = etaeta_ok = True
+cut_ok = rec_ok = face_ok = polar_ok = True
+auto = {}
+zfail = 0
+degs = {}
+cuts = {}
+nrev = {}
+nsig = {}
+for L, tag in ((CUBE, "cube"), (TOR, "torus")):
+    faces = L.faces()
+    fidx = {frozenset(f): f for f in faces}
+    Sf = {f: mono(L.loop(f)) for f in faces}
+    Qch = Qop(L)
+    for mp in MAPS:
+        r = analyze(L, mp)
+        auto[(tag, mp.name)] = r is not None
+        if r is None:
+            continue
+        U, vm, ep = r["U"], r["vm"], r["ep"]
+        perm_ok = perm_ok and len(set(ep.values())) == L.nq
+        pureZ_ok = pureZ_ok and r["badk"] == 0
+        sym_ok = sym_ok and r["sym_ok"] and r["self_ok"]
+        if mp in (INV0, INVC) and tag == "torus" and r["nz"] != L.nq:
+            zfail += 1
+        degs[(tag, mp.name)] = sorted({pcnt(r["N"][e]) for e in range(L.nq)})
+        if mp in (INV0, INVC):
+            img_ok = img_ok and all(
+                r["N"][q] == cz_neighbourhood_of_inversion(L, q) for q in range(L.nq))
+        ns = 0
+        for (v, a) in L.E:
+            i, j, e = v, L.step(v, EX[a]), L.ei[(v, a)]
+            tgt = L.Aij(vm[i], vm[j])
+            s = r["sigma"][e]
+            if not U.q(L.Aij(i, j)) == (tgt if s > 0 else tgt.neg()):
+                sigA_ok = False
+            if s != eta_ks(v, a) * eta_ks(*L.E[ep[e]]):
+                etaeta_ok = False
+            ns += (s < 0)
+        nsig[(tag, mp.name)] = ns
+        g = gauge_corners(L, r["W"])
+        cut_ok = cut_ok and g is not None
+        cuts[(tag, mp.name)] = len(g) if g is not None else -1
+        rec_ok = rec_ok and all(U.ps(Bop(L, v)) == Bop(L, vm[v]) for v in L.V) \
+            and (U.ps(Qch) - Qch).iszero()
+        for f in faces:
+            if not U.q(L.loop(f)) == L.loop(fidx[frozenset(tuple(vm[x] for x in f))]):
+                face_ok = False
+        nr = 0
+        for (v, a) in L.E:
+            i, j, e = v, L.step(v, EX[a]), L.ei[(v, a)]
+            (u, c) = L.E[ep[e]]
+            w = L.step(u, EX[c])
+            tg = Jop(L, u, w, eta_ks(u, c)).smul((Fr(r["orient"][e]), Fr(0)))
+            if not (U.ps(Jop(L, i, j, eta_ks(v, a))) - tg).iszero():
+                polar_ok = False
+            nr += (r["orient"][e] < 0)
+        nrev[(tag, mp.name)] = nr
+
+nauto = sum(1 for k in auto if auto[k])
+check("A1 [exact] %d of the %d point maps are automorphisms of the open cube and all %d of the "
+      "torus; each PERMUTES the code qubits"
+      % (sum(1 for k in auto if k[0] == "cube" and auto[k]), len(MAPS), len(MAPS)),
+      perm_ok and nauto == 14)
+check("A2 [exact] inversion shifts the direction order -x<-y<-z<+x<+y<+z by three, so V_P leaves a "
+      "PURE Z factor on all %d torus bonds"
+      % TOR.nq, pureZ_ok and zfail == 0 and degs[("torus", INV0.name)] == [6])
+check("A3 [exact] a Z-Pauli only SIGNS A_e, so no Z product repairs it; the factor is the 3 +edges "
+      "above and the 3 -edges below the image edge (degree %s)"
+      % (degs[("torus", INV0.name)],), img_ok)
+check("A4 [exact] that adjacency is SYMMETRIC and LOOP-FREE for every map, so the diagonal "
+      "Clifford D_CZ = prod CZ_ef is legal", sym_ok)
+check("A5 [exact] U_P = G_g D_CZ V_P gives U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)} with "
+      "sigma_ij = eta_ij eta_{P(i)P(j)} on every bond", sigA_ok and etaeta_ok)
+check("A6 [exact] the Z-mask of G_g is a CUT, prod_{v in S} B_v with |S| = %d: a Z2 gauge factor, "
+      "DIAGONAL in the record basis" % cuts[("torus", INV0.name)],
+      cut_ok and cuts[("torus", INV0.name)] == 32 and cuts[("torus", INVC.name)] == 32)
+check("A7 [exact] U_P B_v U_P^-1 = +B_{P(v)}, no sign ever (Q -> +Q), and U_P S_f U_P^-1 = "
+      "+S_{P(f)}: legal in the pi-flux code space", rec_ok and face_ok)
+check("A8 [exact] U_P J_ij U_P^-1 = o_ij J_{P(i)P(j)}: the inversions reverse all %d bonds, the "
+      "x-mirrors only %d -- J is POLAR"
+      % (nrev[("torus", INV0.name)], nrev[("torus", REFHX.name)]),
+      polar_ok and nrev[("torus", INV0.name)] == 192 and nrev[("torus", INVC.name)] == 192
+      and nrev[("torus", REFHX.name)] == 64 and nrev[("torus", TRX.name)] == 0)
+
+# ================================ B -- T2: inversion about a corner, shift parity
+
+etainv = {}
+for mp in (INV0, INVC, REF0X, REFHX):
+    bad = 0
+    for (v, a) in TOR.E:
+        vm, ep = edge_perm(TOR, mp)
+        (u, c) = TOR.E[ep[TOR.ei[(v, a)]]]
+        bad += (eta_ks(v, a) != eta_ks(u, c))
+    etainv[mp.name] = bad
+
+eps_ok = hh_ok = hm_ok = True
+for L in (CUBE, TOR):
+    Hh, Hm = Hhop(L), Hmass(L)
+    for mp in MAPS:
+        r = analyze(L, mp)
+        if r is None:
+            continue
+        s = (-1) ** (sum(mp.c) & 1)
+        eps_ok = eps_ok and all(eps_of(r["vm"][v]) == s * eps_of(v) for v in L.V)
+        hh_ok = hh_ok and (r["U"].ps(Hh) - Hh).iszero()
+        hm_ok = hm_ok and (r["U"].ps(Hm) - Hm.smul((Fr(s), Fr(0)))).iszero()
+
+check("B1 [exact] CORNER inversion: sigma = +1 on all %d bonds; the cube centre -1 on %d and the "
+      "x=1/2 mirror on %d"
+      % (TOR.nq, nsig[("torus", INVC.name)], nsig[("torus", REFHX.name)]),
+      nsig[("torus", INV0.name)] == 0 and nsig[("torus", INVC.name)] == 64
+      and nsig[("torus", REFHX.name)] == 128)
+check("B2 [exact] corner inversion carries eta to ITSELF bond by bond, %d of %d differing; the "
+      "odd-shift maps differ on %d and %d"
+      % (etainv[INV0.name], TOR.nq, etainv[INVC.name], etainv[REFHX.name]),
+      etainv[INV0.name] == 0 and etainv[REF0X.name] == 0 and etainv[INVC.name] > 0
+      and etainv[REFHX.name] > 0)
+check("B3 [exact] U_P H_hop U_P^-1 = H_hop EXACTLY for every map on both geometries", hh_ok)
+check("B4 [exact] eps_{P(v)} = (-1)^{sum c} eps_v at every corner: the rule depends only on the "
+      "SHIFT parity", eps_ok)
+check("B5 [exact] so H(t,m) is EXACTLY P-symmetric at every t and m about a corner, and only with "
+      "m -> -m about a cube centre", hm_ok)
+
+# ==================================================== C -- T3: time reversal
+
+realA_ok = kanti_ok = ze_ok = uniq_ok = True
+ta_ok = tb_ok = tt_ok = ts_ok = th_ok = tj_ok = tq_ok = True
+for L in (CUBE, TOR):
+    FULL = (1 << L.nq) - 1
+    ZEc = Conj({q: q for q in range(L.nq)}, {q: 0 for q in range(L.nq)}, FULL)
+    Tact = Act(lambda O, Z=ZEc: Z.ps(antiK(O)), True)
+    Hh, Hm, Qch = Hhop(L), Hmass(L), Qop(L)
+    Hf = Hh + Hm
+    zm = 0
+    for v in L.V:
+        if eps_of(v) < 0:
+            zm ^= L.star[v]
+    ze_ok = ze_ok and zm == FULL
+    xs = set()
+    for (i, j, e, a) in L.bonds():
+        A, Tb, J = Aop(L, i, j), Top(L, i, j), Jop(L, i, j, e)
+        realA_ok = realA_ok and antiK(A) == A
+        kanti_ok = kanti_ok and (antiK(Tb) + Tb).iszero()
+        xs.add(A.xsupp())
+        ta_ok = ta_ok and (Tact(A) + A).iszero()
+        tt_ok = tt_ok and (Tact(Tb) - Tb).iszero()
+        tj_ok = tj_ok and (Tact(J) + J).iszero()
+    uniq_ok = uniq_ok and xs == {1 << q for q in range(L.nq)}
+    kanti_ok = kanti_ok and (antiK(Hh) + Hh).iszero()
+    tb_ok = tb_ok and all(Tact(Bop(L, v)) == Bop(L, v) for v in L.V)
+    ts_ok = ts_ok and all(Tact(mono(L.loop(f))) == mono(L.loop(f)) for f in L.faces())
+    th_ok = th_ok and (Tact(Hh) - Hh).iszero() and (Tact(Hm) - Hm).iszero() \
+        and (Tact(Hf) - Hf).iszero()
+    tq_ok = tq_ok and (Tact(Qch) - Qch).iszero()
+
+check("C1 [exact] every A_ij is REAL, so K A_ij K = +A_ij and K H_hop K = -H_hop: bare conjugation "
+      "is an ANTI-symmetry of the hop", realA_ok and kanti_ok)
+check("C2 [exact] Z_E = prod_e Z_e = prod over the corners with eps_v = -1 of B_v: bipartite, so "
+      "every edge is covered once", ze_ok)
+check("C3 [exact] Z_E is the UNIQUE pure-Z choice: A_ij has X-support exactly its own edge and the "
+      "bond-to-edge map is onto", uniq_ok)
+check("C4 [exact] T = Z_E K: A_ij -> -A_ij, B_v -> +B_v (records T-EVEN), T_ij -> +T_ij, "
+      "S_f -> +S_f -- the code space is T-invariant",
+      ta_ok and tb_ok and tt_ok and ts_ok)
+check("C5 [exact] T H(t,m) T^-1 = H(t,m) for EVERY t and EVERY m: time reversal is exact at every "
+      "mass, with no m -> -m", th_ok)
+check("C6 [exact] T J_ij T^-1 = -J_ij on every bond (the current is T-ODD) and T Q T^-1 = +Q",
+      tj_ok and tq_ok)
+
+# dense many-body confirmation on the 4096-dimensional cube space
+L = CUBE
+D = 1 << L.nq
+col = np.arange(D, dtype=np.int64)
+
+
+def popcount(a):
+    a = a.copy()
+    c = np.zeros_like(a)
+    while a.any():
+        c += a & 1
+        a >>= 1
+    return c
+
+
+def pmat(q, coef=1.0):
+    ph = [1, 1j, -1, -1j][q.k & 3]
+    dat = ((-1.0) ** (popcount(col & q.z) & 1)).astype(complex) * (ph * coef)
+    return sp.csr_matrix((dat, (col ^ q.x, col)), shape=(D, D))
+
+
+IM = sp.identity(D, format="csr", dtype=complex)
+ZEm = pmat(Q(0, 0, D - 1))
+ZEd = np.real(ZEm.diagonal())
+Pc = IM
+for f in L.faces():
+    Pc = Pc @ ((IM + pmat(L.loop(f))) * 0.5)
+rank = float(np.real(Pc.diagonal().sum()))
+imP = float(np.abs(Pc.data.imag).max())
+cmP = abs(ZEm @ Pc - Pc @ ZEm)
+dcm = float(cmP.data.max()) if cmP.nnz else 0.0
+DZ = sp.diags(ZEd).tocsr()
+
+
+def Ham(m):
+    H = sp.csr_matrix((D, D), dtype=complex)
+    for (i, j, e, a) in L.bonds():
+        H = H + (pmat(L.Aij(i, j)) @ (pmat(Q(0, 0, L.star[i])) - pmat(Q(0, 0, L.star[j])))) \
+            * (0.5j * (-1.0) * e)
+    for v in L.V:
+        H = H + pmat(Q(0, 0, L.star[v])) * (-0.5 * m * eps_of(v))
+    return H
+
+
+dh = 0.0
+for m in (0.0, 0.7):
+    Hs = Ham(m)
+    R = DZ @ Hs.conj() @ DZ - Hs
+    dh = max(dh, float(np.abs(R.data).max()) if R.nnz else 0.0)
+check("C7 [1e-12] Z_E is a real diagonal involution (T^2 = +I); the %d-dim space's code projector "
+      "is real of rank %d and commutes with it; T H T^-1 = H (%.0e)"
+      % (D, int(round(rank)), dh),
+      float(np.abs(ZEd * ZEd - 1).max()) == 0.0 and imP < TOL
+      and abs(rank - 128) < 1e-8 and dcm < TOL and dh < TOL)
+
+# ============================================= D -- T4: the Dirac point, 8 x 8
+
+I2 = np.eye(2)
+Xp = np.array([[0, 1], [1, 0]], complex)
+Yp = np.array([[0, -1j], [1j, 0]])
+Zp = np.diag([1, -1]).astype(complex)
+
+
+def kr(*a):
+    o = np.array([[1.0 + 0j]])
+    for m in a:
+        o = np.kron(o, m)
+    return o
+
+
+GAM = [kr(Yp, I2, I2), kr(Zp, Yp, I2), kr(Zp, Zp, Yp)]
+XI = [kr(Xp, I2, I2), kr(Zp, Xp, I2), kr(Zp, Zp, Xp)]
+EPSC = kr(Zp, Zp, Zp).real
+
+V = TOR.V
+iv = {v: k for k, v in enumerate(V)}
+n1 = TOR.nv
+h0 = np.zeros((n1, n1))
+for (v, a) in TOR.E:
+    w = TOR.step(v, EX[a])
+    e = eta_ks(v, a)
+    h0[iv[v], iv[w]] += -e
+    h0[iv[w], iv[v]] += -e
+Eps = np.diag([float(eps_of(v)) for v in V])
+acom = float(np.abs(h0 @ Eps + Eps @ h0).max())
+ev = np.linalg.eigvalsh(h0)
+nz = int((np.abs(ev) < 1e-9).sum())
+gaps = []
+for m in (0.2, 0.5, 1.0):
+    e2 = np.linalg.eigvalsh(h0 + m * Eps)
+    gaps.append(abs(e2[e2 > 0].min() - e2[e2 < 0].max() - 2 * m))
+check("D1 [1e-12] the 4^3 one-particle operator is real symmetric with {h_0, Eps} = 0 (%.1e) and "
+      "EXACTLY %d zero modes gapped to exactly 2m (%.0e)"
+      % (acom, nz, max(gaps)), acom < TOL and nz == 8 and max(gaps) < 1e-10)
+
+Vb = np.zeros((n1, 8))
+for v in V:
+    s = tuple(c % 2 for c in v)
+    Vb[iv[v], 4 * s[0] + 2 * s[1] + s[2]] = (-1.0) ** sum(c // 2 for c in v)
+Vb /= np.sqrt(8.0)
+dker = float(np.abs(h0 @ Vb).max())
+dorth = float(np.abs(Vb.T @ Vb - np.eye(8)).max())
+qD = (np.pi, np.pi, np.pi)
+dbl = float(np.abs(sum((1 + np.cos(qD[a])) * XI[a] + np.sin(qD[a]) * GAM[a]
+                       for a in range(3))).max())
+
+
+def red(O):
+    return Vb.T @ (O @ Vb)
+
+
+CHI = np.real(-1j * (-GAM[0]) @ (-GAM[1]) @ (-GAM[2]))
+Er = red(Eps)
+check("D2 [1e-12] the cell basis psi_s(v) = (-1)^{sum(v div 2)} delta_{v mod 2, s} is an orthonormal "
+      "REAL kernel basis and the q = (pi,pi,pi) block (%.0e)" % (dbl,),
+      dker < TOL and dorth < TOL and dbl < TOL)
+check("D3 [1e-12] the chirality X = -(Y x X x Y) has spectrum {+1 x4, -1 x4}: 2 right- and 2 "
+      "left-handed doublets; the mass eps = Z1 Z2 Z3 ANTIcommutes (%.0e)"
+      % float(np.abs(Er - EPSC).max()),
+      float(np.abs(CHI @ CHI - np.eye(8)).max()) < TOL
+      and sorted(np.round(np.linalg.eigvalsh(CHI), 9).tolist()) == [-1.0] * 4 + [1.0] * 4
+      and float(np.abs(Er - EPSC).max()) < TOL
+      and float(np.abs(Er @ CHI + CHI @ Er).max()) < TOL)
+
+
+def one_particle_U(mp):
+    vm = {v: mp.pt(TOR, v) for v in V}
+    inv = {w: v for v, w in vm.items()}
+    g = {V[0]: 1}
+    stack = [V[0]]
+    while stack:
+        v = stack.pop()
+        for r in range(6):
+            w = TOR.inc[v][r][0]
+            if w in g:
+                continue
+            rr = h0[iv[inv[v]], iv[inv[w]]] * h0[iv[v], iv[w]]
+            g[w] = int(np.sign(rr) * g[v])
+            stack.append(w)
+    U = np.zeros((n1, n1))
+    for w in V:
+        U[iv[vm[w]], iv[w]] = g[vm[w]]
+    return U, sum(1 for v in V if g[v] < 0)
+
+
+DMAPS = [("corner inversion", INV0), ("cube-centre inversion", INVC),
+         ("reflection x=0", REF0X), ("reflection x=1/2", REFHX), ("C4 about z", ROTZ)]
+reps = {}
+d1p = 0.0
+gcnt = {}
+for nm, mp in DMAPS:
+    U, ng = one_particle_U(mp)
+    s = (-1) ** (sum(mp.c) & 1)
+    d1p = max(d1p, float(np.abs(U @ h0 @ U.T - h0).max()),
+              float(np.abs(U @ Eps @ U.T - s * Eps).max()))
+    reps[nm] = red(U)
+    gcnt[nm] = ng
+check("D4 [1e-12] one-particle: U h_0 U^T = h_0 and U Eps U^T = (-1)^{sum c} Eps (%.1e); %d "
+      "flipped corners at a corner, %d at a cube centre"
+      % (d1p, gcnt["corner inversion"], gcnt["cube-centre inversion"]),
+      d1p < TOL and gcnt["corner inversion"] == 0 and gcnt["cube-centre inversion"] == 32)
+Pc0 = reps["corner inversion"]
+check("D5 [1e-12] CORNER inversion IS the staggered-mass matrix eps = Z1 Z2 Z3 (%.1e): the "
+      "emergent gamma^0, ANTIcommuting with the chirality"
+      % float(np.abs(Pc0 - EPSC).max()),
+      float(np.abs(Pc0 - EPSC).max()) < TOL
+      and float(np.abs(Pc0 @ CHI + CHI @ Pc0).max()) < TOL)
+
+Cm, Tm = Er.copy(), np.eye(8)
+
+
+def mulop(a, b):
+    (A, aa), (B, ab) = a, b
+    return (A @ (B.conj() if aa else B), aa ^ ab)
+
+
+def sq(op):
+    M, aa = op
+    return M @ (M.conj() if aa else M)
+
+
+sqs = {}
+for nm, _ in DMAPS:
+    o = {"C": (Cm, True), "P": (reps[nm], False), "T": (Tm, True)}
+    o["CP"] = mulop(o["C"], o["P"])
+    o["PT"] = mulop(o["P"], o["T"])
+    o["CPT"] = mulop(o["C"], o["PT"])
+    for k in ("C", "T", "P", "CP", "PT", "CPT"):
+        M = sq(o[k])
+        v = M[0, 0].real
+        v = round(v) if abs(v - round(v)) < 1e-9 else v
+        sqs[(nm, k)] = float(v) if np.abs(M - M[0, 0] * np.eye(8)).max() < 1e-10 else 0.0
+    if nm == "corner inversion":
+        cpt = o["CPT"]
+check("D6 [1e-12] class BDI: T = K with T^2 = +1, C = Eps.K with C^2 = +1, chiral S = CT = Eps; no "
+      "Kramers sign from T alone",
+      float(np.abs(Tm - np.eye(8)).max()) < TOL
+      and float(np.abs(Cm @ Cm.conj() - np.eye(8)).max()) < TOL
+      and sqs[("corner inversion", "T")] == 1.0 and sqs[("corner inversion", "C")] == 1.0)
+Mc, ac = cpt
+check("D7 [1e-10] CPT from corner inversion is +1 times the IDENTITY on the Dirac point (%.1e); "
+      "no other improper choice gives a scalar" % float(np.abs(Mc - np.eye(8)).max()),
+      not ac and float(np.abs(Mc - np.eye(8)).max()) < 1e-10)
+check("D8 [1e-10] a Kramers sign only in the half-cell-shifted products, only at m = 0: "
+      "(PT)^2 = %+.0f (cube centre), (CP)^2 = %+.0f (x=1/2), %+.0f/%+.0f at a corner"
+      % (sqs[("cube-centre inversion", "PT")], sqs[("reflection x=1/2", "CP")],
+         sqs[("corner inversion", "PT")], sqs[("corner inversion", "CP")]),
+      sqs[("cube-centre inversion", "PT")] == -1.0 and sqs[("reflection x=1/2", "CP")] == -1.0
+      and sqs[("corner inversion", "PT")] == 1.0 and sqs[("corner inversion", "CP")] == 1.0)
+
+# ================================================= E -- T5: the full table
+
+L = TOR
+FULL = (1 << L.nq) - 1
+ZEc = Conj({q: q for q in range(L.nq)}, {q: 0 for q in range(L.nq)}, FULL)
+Tact = Act(lambda O: ZEc.ps(antiK(O)), True)
+Mmatch = [(v, L.step(v, EX[0])) for v in L.V if v[0] % 2 == 0]
+Cq = Q(0, 0, FULL) * qprod([L.Aij(i, j) for (i, j) in Mmatch])
+Cact = Act(conj_mono(Cq), False)
+rA, rB, rR = analyze(L, INV0), analyze(L, INVC), analyze(L, REFHX)
+Pa, Pb, Pr = Act(rA["U"].ps, False), Act(rB["U"].ps, False), Act(rR["U"].ps, False)
+COLS = [("C", Cact, IDMAP), ("Pcor", Pa, INV0), ("Pcen", Pb, INVC), ("Ref", Pr, REFHX),
+        ("T", Tact, IDMAP), ("CP", comp(Cact, Pa), INV0), ("CT", comp(Cact, Tact), IDMAP),
+        ("PT", comp(Pa, Tact), INV0), ("CPT", comp(Cact, comp(Pa, Tact)), INV0)]
+Hh, Hm, Qch = Hhop(L), Hmass(L), Qop(L)
+faces = L.faces()
+fidx = {frozenset(f): f for f in faces}
+
+
+def sgn(A, B):
+    if (A - B).iszero():
+        return 1
+    if (A + B).iszero():
+        return -1
+    return 0
+
+
+def uniq(s):
+    return list(s)[0] if len(s) == 1 else 0
+
+
+tab = {}
+nozero_ok = True
+mix_ok = True
+for name, act, mp in COLS:
+    vm = {v: mp.pt(L, v) for v in L.V}
+    raw = {}
+    raw["B_v"] = {sgn(act(Bop(L, v)), Bop(L, vm[v])) for v in L.V}
+    raw["A_ij"] = {sgn(act(Aop(L, i, j)), Aop(L, vm[i], vm[j])) for (i, j, e, a) in L.bonds()}
+    raw["S_f"] = {sgn(act(mono(L.loop(f))),
+                      mono(L.loop(fidx[frozenset(tuple(vm[x] for x in f))]))) for f in faces}
+    raw["T_ij"] = {sgn(act(Top(L, i, j)), Top(L, vm[i], vm[j])) for (i, j, e, a) in L.bonds()}
+    raw["J_ij"] = {sgn(act(Jop(L, i, j, e)), Jop(L, vm[i], vm[j], e))
+                   for (i, j, e, a) in L.bonds()}
+    raw["eps_v"] = {eps_of(vm[v]) * eps_of(v) for v in L.V}
+    nozero_ok = nozero_ok and all(0 not in st for st in raw.values())
+    c = {k: uniq(st) for k, st in raw.items()}
+    c["H_hop"] = sgn(act(Hh), Hh)
+    c["H_m"] = sgn(act(Hm), Hm)
+    c["Q"] = sgn(act(Qch), Qch)
+    c["n_v"] = "n_P" if c["B_v"] == 1 else "1-nP"
+    c["H(t,m)"] = "inv" if (c["H_hop"] == 1 and c["H_m"] == 1) else (
+        "-m" if (c["H_hop"] == 1 and c["H_m"] == -1) else "??")
+    tab[name] = c
+for name in ("Pcen", "Ref"):
+    vm = {v: (INVC if name == "Pcen" else REFHX).pt(L, v) for v in L.V}
+    act = Pb if name == "Pcen" else Pr
+    r = rB if name == "Pcen" else rR
+    for (v, a) in L.E:
+        i, j, e = v, L.step(v, EX[a]), L.ei[(v, a)]
+        if sgn(act(Aop(L, i, j)), Aop(L, vm[i], vm[j])) != r["sigma"][e]:
+            mix_ok = False
+
+ORD = ["B_v", "n_v", "A_ij", "S_f", "T_ij", "H_hop", "H_m", "H(t,m)", "J_ij", "Q", "eps_v"]
+
+
+def fmt(v):
+    if isinstance(v, str):
+        return v
+    return "e.e'" if v == 0 else "%+d" % v
+
+
+print("TABLE, 4^3 torus. Pcor/Pcen = corner/cube-centre inversion, Ref = the x=1/2 mid-plane;"
+      " CP, PT, CPT use Pcor; e.e' = sigma_ij = eta_ij eta_{P(i)P(j)}; -m = m -> -m.")
+print(("%-7s" % "" + "".join("%-5s" % n for n, _, _ in COLS)).rstrip())
+for k in ORD:
+    print(("%-7s" % k + "".join("%-5s" % fmt(tab[n][k]) for n, _, _ in COLS)).rstrip())
+
+uni = all(isinstance(tab[n][k], int) and tab[n][k] != 0
+          for n, _, _ in COLS for k in ("B_v", "S_f", "H_hop", "H_m", "Q", "eps_v"))
+mixcols = [n for n, _, _ in COLS if tab[n]["A_ij"] == 0]
+check("E1 [exact] every entry is a sign on the SAME operator at the image index; B_v, S_f, H_hop, "
+      "H_m, Q and eps_v are uniform in every column", uni and nozero_ok)
+check("E2 [exact] the odd-shift columns %s carry sigma_ij = eta_ij eta_{P(i)P(j)} on A_ij, T_ij "
+      "and J_ij, at -1 on %d of %d bonds and on %d"
+      % (", ".join(mixcols), nsig[("torus", INVC.name)], TOR.nq, nsig[("torus", REFHX.name)]),
+      mixcols == ["Pcen", "Ref"] and mix_ok
+      and all(tab[n][k] == 0 for n in mixcols for k in ("A_ij", "T_ij", "J_ij")))
+check("E3 [exact] H(t,m) is INVARIANT under Pcor, T and PT and goes to H(t,-m) under C, Pcen, "
+      "Ref, CP, CT and CPT: vector-like, none broken",
+      [tab[n]["H(t,m)"] for n, _, _ in COLS]
+      == ["-m", "inv", "-m", "-m", "inv", "-m", "-m", "inv", "-m"])
+check("E4 [exact] S_f -> +S_f in every column: each operation carries the code space to itself "
+      "with no sign; the encoding obstructs none",
+      all(tab[n]["S_f"] == 1 for n, _, _ in COLS))
+
+recd_ok = corr_ok = True
+for Lx in (CUBE, TOR):
+    for O in (Qop(Lx), Hmass(Lx)) + tuple(Bop(Lx, v) for v in Lx.V):
+        recd_ok = recd_ok and O.is_pure_z()
+    for (i, j, e, a) in Lx.bonds():
+        for O in (Aop(Lx, i, j), Top(Lx, i, j), Jop(Lx, i, j, e)):
+            corr_ok = corr_ok and not O.has_diag()
+    for f in Lx.faces():
+        corr_ok = corr_ok and not mono(Lx.loop(f)).has_diag()
+check("E5 [exact] B_v, Q and H_m are pure Z, so record-diagonal, carrying the table's signs; "
+      "A_ij, S_f, T_ij, J_ij have zero record diagonal: correlation-only",
+      recd_ok and corr_ok)
+
+print("SUMMARY: conditional on improper elements in the law, the emergent matter is exactly "
+      "P-symmetric about a corner and T-symmetric at every mass, T^2 = +1, CPT the identity.")
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache completing PR #7892's named interface "T and CPT", with parity alongside: **the emergent fermion is exactly time-reversal symmetric at every mass (`T = Z_E K`, `T^2 = +1`), exactly parity-symmetric about a lattice corner at every mass if the law carries inversion, and CPT acts as the identity on the Dirac point.** Conditional stated first, in the corollary and in the boundary: the Lattice axiom names *proper* cubic rotations only, so every parity statement is of the form "if the improper element is applied, the encoded algebra does this"; the note supplies the evidence that the law *could* carry mirrors at no cost (every face stabilizer and the sign field are carried to themselves; the correction is a fixed Clifford network), not a licence to add them. Two structural facts fall out: the Bravyi-Kitaev tails need a CZ network under inversion (a product of Z's cannot do it), and on the Dirac point inversion about a corner is *the same matrix* as the staggered mass (`eps = Z1 Z2 Z3`, the emergent `gamma^0`), anticommuting with the chirality. Cube-centre inversion and mid-plane reflections send `m -> -m`; the Kramers sign appears only in the half-cell-shifted combinations (`(PT)^2 = -1` at `m = 0`).

- `docs/DISCRETE_SYMMETRIES_P_T_AND_CPT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (328 lines)
- `scripts/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.py` (`TOTAL: PASS=33 FAIL=0`, 1.8 s; A/B/C/E exact over Q[i] on the cube and the `4^3` torus; D at 1e-12)
- `logs/runner-cache/discrete_symmetries_p_t_cpt_emergent_fermion_check_2026_09_03.txt`

## Theorems

- **T1** parity needs a CZ network: `U_P = G_g D_CZ V_P` with `U_P A_ij U_P^-1 = sigma_ij A_{P(i)P(j)}`; the residual Z factor is nontrivial on all 192 torus bonds for both inversions.
- **T2** inversion about a corner: `sigma = +1` on every bond, `eta` invariant bond by bond, `H(t,m)` exactly symmetric for every `t`, `m`; cube-centre inversion and reflections give `m -> -m` by the shift-parity rule `eps_{P(v)} = (-1)^{shift parity} eps_v`.
- **T3** `T = Z_E K` (unique pure-Z): `H(t,m)` invariant at every `m`, `J -> -J`, `Q -> Q`, `T^2 = +1` on the 4096-dim space, the code space and the Dirac point.
- **T4** the Dirac point (class BDI): corner inversion `= Z1 Z2 Z3 =` the mass matrix; `CPT = +I`; `(PT)^2 = -1` for cube-centre inversion and `(CP)^2 = -1` for the `x = 1/2` reflection, only at `m = 0`.
- **T5** the full table (`C`, corner inversion, centre inversion, reflection, `T`, `CP`, `CT`, `PT`, `CPT`) on `B_v`, `n_v`, `A_ij`, `S_f`, `T_ij`, `H_hop`, `H_m`, `H(t,m)`, `J_ij`, `Q`, `eps_v`.

## Boundary

- Coarse lattice; the open cube and the `4^3` torus; free hopping plus one declared diagonal term with supplied `t`, `m`; no continuum; parity conditional on the law; the CZ network is a construction on the encoding; nothing about the weak sector (no chiral counterpart exists in this construction).

## Context

- Parents: PR #7892 (C, J, Q), PR #7890 (the mass and its T2), PR #7888 (the Dirac point), PR #7844, PR #7834.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03). Owner-level item raised: whether improper elements belong in the Lattice axiom's symmetry list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
