### PR TITLE
feat(readout): a relaxation tick is well-posed and loses the sea statistics

### DIFF
--- a/docs/A_RELAXATION_TICK_IS_WELL_POSED_AND_LOSES_THE_SEAS_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/A_RELAXATION_TICK_IS_WELL_POSED_AND_LOSES_THE_SEAS_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,328 @@
+---
+claim_id: relaxation_tick_well_posed_loses_sea_record_statistics
+claim_type: bounded_theorem
+claim_scope: "On the 2x2x2 cube graph (8 corners, 12 edge sites, 6 faces) with qubits on the EDGE sites, ordinary composition, the superfast encoding and the corner parity dictionary n_v = (1 - B_v)/2, in the staggered (pi-flux) sector H = -sum_e eta_e T_e with the Kawamoto-Smit link signs, whose 128-dimensional code space is the even-N space and whose ground state -- the sea -- has E = -4 sqrt 3, is non-degenerate with gap 2 sqrt 3 and is a sharp N = 4 state: under ONE STIPULATED tick model M_R, declared here and derived from nothing, in which (i) the next unrecorded edge site in a DECLARED order forms a record with the Born odds of the current pre-record state, (ii) the state is then replaced by the ground state of H restricted to the record-consistent subspace, (iii) with the normalised projector Pi/deg where that ground space is degenerate, and (iv) records are permanent, run to 12 records. (T1) Every hop term has Pauli X-part exactly one edge qubit, so P_S H P_S is the sum of the hop terms on the unrecorded sites: 'H restricted to the records' and the parent note's H_R are one operator, and M_R is memoryless -- its state is a function of the record set alone. (T2) The sea's own record odds are flat: every one of the 24 + 264 + 1760 = 2048 record blocks with k <= 3 carries sea weight 2^-k to 4e-15, so a forming record has odds 1/2 and nothing is forced up to three records; and at p = 1, where every site registers at once, the finished set is the sea's Born diagonal with support 1984 = 62 x 32 and 2112 zeros = 1856 charge zeros (N != 4) + 256 = 8 x 32 cancellation zeros whose 8 corner-occupation patterns are exactly the closed corner stars {v} u N(v). (T3) Under M_R the support is all 4096 patterns for every one of the 32 declared orders and none of the 2112 zeros survives; TV(M_R, sea) = 1283/2880 at the identity order, against 0.324925160534 for the parent note's Model A at tau = 0.5. (T4) TV(identity order, reverse order) = 1/3; over the 32 declared orders the maximal pairwise TV is 0.727031250000 and the minimal 0.113194444444, a lower bound on the spread over all 12! orders; pure Lueders conditioning is order-independent to 6e-15. (T5) <Q> = 0 and <N> = 4 at every declared order to 1e-14, but Q is not sharp: the identity-order law is (1/384, 1/8, 143/192, 1/8, 1/384) with var Q = 13/12, P(Q = 0) ranges 0.6146 .. 0.8813 over the declared orders, the 1456 tree nodes whose relaxed state is not N-sharp are exactly the 1456 carrying a degenerate ground space (ticks 5, 6, 8, 9, 11), and the declared variant M_R^N restores P(Q = 0) = 1 while still losing all 256 cancellation zeros, as Model A does. (T6) Relaxation is not conditioning: the relaxed state overlaps the Lueders-conditioned sea by 0.962606705806 at all 24 one-record blocks, by k = 3 the worst of 1760 blocks is at 0.448473881026 with mean 0.773546569701 and 64 blocks at 1; the conditioned column is exactly -(12 - k)/sqrt 3; E_0(R,w) <= <sea_S|H_R|sea_S> at all 2048 blocks with 0 violations, the tree-average drop peaking at k = 9 (0.401011505139) and vanishing at k = 0 and k = 12. (T7) Z_e commutes with all 8 corner parities at all 12 sites while X_e and Y_e each anticommute with exactly the two endpoint parities; Z_e anticommutes with exactly the two faces through its site; no one-site basis commutes with the corner and face dictionaries at once. No seeds anywhere: every distribution is the exact product over the whole 4096-leaf tick tree and every order is written out in the runner. This note declares a tick model and computes with it; nothing is derived from any axiom, no formation clause is supplied, no axiom is amended, no status is set, and no claim is made about what the framework's tick IS."
+upstream_dependencies: []
+runner: scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py
+---
+
+# A relaxation tick is well posed and loses the sea's record statistics
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py`](../scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.txt`](../logs/runner-cache/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+`RECORD_TICKS_ADMIT_NO_INVARIANT_PRE_RECORD_STATE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7876) writes a tick model down and finds its answer turning on two declared choices it
+cannot settle -- the gap length `tau` and the post-record generator `H_R` -- and names the interface it leaves open: something would have to re-supply, between one record and the
+next, a state at rest under the current generator. At the campaign's vacuum panel on 2026-09-03 a candidate wording was proposed that would close exactly that interface: **"Between
+records, the lattice settles into its lowest-energy arrangement."** That sentence is not axiom text. This note takes it as a **stipulation under test**, turns it into a tick on the
+same cube in the staggered sector, and computes what it does against the reference it has to reproduce -- the half-filled sea's own record statistics. The result is two-sided: the
+tick is well posed and memoryless, and it does not give back the sea's odds.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite-sector statements on one named cluster -- the 4096-dimensional record space of the 2x2x2 cube in the staggered sector, whose 128-dimensional code space is the even-N space -- for one stipulated tick model. T1 and T7 are exact symplectic-Pauli statements with no floating point, and T2's zero census is exact F2 combinatorics on a zero set identified from the Born diagonal at 1e-12. The tick trees of T3-T6 are enumerated whole, 4096 leaves and nothing sampled, but each node's relaxed state comes from a diagonalisation, so those lines are deterministic double-precision evaluations of exactly specified quantities and are tagged [numerical] with their thresholds. There is no seed anywhere in the runner and no Monte Carlo section."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-sector theorem, and route to the vacuum panel the science-level question it sharpens: a tick has to keep the sea's flat odds and its selection-rule zeros, and the record basis is already fixed by the corner parities, so what remains open is the formation rule -- the rate and the odds -- not the basis."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the seven statements below, exactly the runner's check groups `A`-`G`: `T1` (`A`) the restriction identity and the setting; `T2` (`B`) the sea's own
+record odds and its zeros; `T3` (`C`) support; `T4` (`D`) order dependence; `T5` (`E`) charge; `T6` (`F`) relaxation against conditioning; `T7` (`G`) the pointer-basis table. Groups
+`A1`-`A3` and `G` are **exact**: symplectic Pauli algebra with phases mod `4` and integer amplitudes. `B2` and `B3` are exact `F2` combinatorics on a zero set identified from the Born
+diagonal at `1e-12`, and are tagged so. The rest are **deterministic double-precision evaluations** of exactly specified quantities at the stated thresholds. Nothing is sampled: every
+distribution is the exact product over the whole `4096`-leaf tick tree, every order is written out in the runner, and there is **no seed anywhere** and no Monte Carlo section.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggered link signs, Lueders conditioning and the total-variation distance
+are standard methodology; every object is redeclared here and the runner recomputes every statement, the encoding's relations included. No observational value, no fitted number and no
+framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no weight: `RECORD_TICKS_ADMIT_NO_INVARIANT_PRE_RECORD_STATE_..._2026-09-03.md`
+(open PR #7876 -- the same cube and encoding, its Models A and B, its `T2` boundary at `p = 1`, and the `tau`/`H_R` interface this note's model closes by fiat);
+`DETERMINANTAL_RECORD_STATISTICS_ON_THE_HALF_FILLED_SEA_..._2026-09-02.md` (PR #7883 -- the sea's Born statistics, the same `eta_ks`);
+`EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_..._2026-09-02.md` (PR #7842 -- the selection-rule zeros from the dictionary side);
+`RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_..._2026-09-02.md` (PR #7858 -- forcing on the empty vacuum, whose `T2` this note's `T2` is the half-filled analogue of);
+and `MINIMAL_AXIOMS_2026-06-29.md`, from which the four axioms in "Setting" are quoted verbatim. This note cites no grade of any and consumes no ledger row.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency,
+standard translations, and proper cubic rotations about each site." "No site is privileged. Sites are distinguished by the supplied lattice structure alone." The lattice is physical;
+the cube below is a finite open subgraph of it, drawn as a graph, so "edge site" and "corner" have their graph meanings. **Qubit / Site Possibility**: "Each site has a domain of local
+possibilities." "The full one-site possibility domain has algebraic presentation `M_2(C)`." "No possibility is privileged. Possibilities are distinguished by the supplied algebraic
+structure alone."
+
+**Admissibility / Local Constraint.** "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." "For each site, the
+probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." Two reading notes, interpretive and non-governing, are the hinge
+of this note and are quoted with it. (2): "Read with Record, the distribution concerns which possibility a forming record locks, conditional on formation at that site; **it does not
+supply the formation site, probability, or rate.**" (3): "The distribution is a probability measure on the local possibility domain; 'available'/'admissible' denotes its support -- on
+finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may have zero singleton measure; Record locks a supported realization."
+
+**Record / Fixed Reality.** "Records form." "When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are permanent."
+"Only records are readable. A readout value is determined by record content alone. A site with no record cannot be read."
+
+Composition here is **ordinary**: the algebra of a region is the tensor product of its sites' algebras, operators on disjoint regions commute, and no graded clause is used anywhere.
+The **record ontology** is used as declared: a record at an edge site **registers** a value there; it does not report one the site already carried. Reading note (3) is what makes `T3`
+a real cost: "admissible" is the *support* of the distribution, so a tick giving every pattern nonzero odds has made every pattern admissible. **The stipulation under test** --
+"Between records, the lattice settles into its lowest-energy arrangement" -- is a candidate wording, not axiom text, and is not called wrong anywhere below; `M_R` is one way of making
+it definite, and what is reported is what `M_R` does and does not do.
+
+## The stipulated tick model `M_R`, declared in full
+
+Six choices, all made here, none derived. A lane proposing a different tick inherits the obligations of `T3`-`T6` and none of these choices.
+
+1. **The state before any record** is the sea: the ground state of `H` in the code space (see "Definitions").
+2. **Which site forms next.** The next unrecorded edge site in a **declared order**, a permutation of the `12` sites. Thirty-two are declared and written out in the runner -- the `12`
+   cyclic shifts of the identity order, their `12` reverses, and `8` further orders listed explicitly -- and none is drawn at random.
+3. **The value the forming record locks.** The Born odds of the current pre-record state in the `Z_e` record basis.
+4. **Relaxation -- the panel's clause.** The pre-record state is then **replaced** by the ground state of `H` restricted to the subspace consistent with all records so far. Unitarity
+   is given up at this step and the map is not linear in the state.
+5. **The tie-break.** Where that ground space is degenerate the state becomes the **normalised projector** `Pi/deg` onto it, and the next record's odds are its diagonal. Degeneracy is
+   not a corner case: it occurs at ticks `5`, `6`, `8`, `9` and `11` (`T5`).
+6. **Permanence.** Records never change; the run continues until all `12` sites carry records, so each run ends on one of the `4096` record patterns.
+
+**`M_R^N`**, the charge-superselected variant, is declared alongside: identical except that step 4 relaxes inside the conserved `N = 4` sector of the block. Two reference ticks are
+computed against `M_R`: **`L`**, pure Lueders conditioning with no dynamics at all, which is PR #7876's `p = 1` boundary; and **`A`**, PR #7876's Model A, identical to `M_R` except
+that step 4 is replaced by the unitary `exp(-i tau H_R)`, run at `tau = 0.5`.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is `P0`-`P7`. `P0` (declared here): the cube, the edge-site
+qubits, the encoding, the staggered sector, the parity dictionary, and the six stipulated choices above. `P1` (`A`): the restriction identity and the sea. `P2` (`B`): the sea's own
+record odds and its zeros. `P3` (`C`): support. `P4` (`D`): order dependence. `P5` (`E`): charge. `P6` (`F`): relaxation against conditioning. `P7` (`G`): the pointer-basis table.
+
+## Definitions
+
+The **cube** is the `2x2x2` cube graph, corner `s = 4a + 2b + c`, `8` corners, `12` edge sites, `6` faces. One qubit sits on each **edge site**, neighbours ordered by index:
+
+```text
+A_ij = X(edge ij) * prod Z(edges at i ordered before j) * prod Z(edges at j ordered before i),   A_ji = -A_ij,
+B_v  = prod of the Z's on the edges incident to v,     S_f = the ordered product of the A's around a face f,
+T_ij = (i/2) A_ij (B_i - B_j),     H = -t sum_e eta_e T_e,  t = 1,     star(v) = the edges incident to v.
+```
+
+`eta` are the **Kawamoto-Smit staggered link signs** `eta_x = 1`, `eta_y = (-1)^x`, `eta_z = (-1)^(x+y)`, the same `eta_ks` as PR #7883; their product round every one of the six faces
+is `-1`, the all-minus (**pi-flux**) sector. The **code space** is all six `S_f = +1`, of dimension `2^12/2^5 = 128`; because `prod_v B_v = I` it *is* the even-`N` space, and the
+**sea** is the ground state of `H` there. A **record** at an edge site registers a `Z`-value, so a finished set of records is a vector in `F2^12`, one of `4096` **patterns**; the
+**parity dictionary** is `n_v = (1 - B_v)/2 = |y intersect star(v)| mod 2`, `N = sum_v n_v` and the **readable charge** is `Q = N - 4`. A **record block** `S(R,w) = {z : z|_R = w}` is
+the subspace consistent with the records `w` on `R`; `H_R` is `H` restricted to it. The **odds at a site** are the probability that a record forming there locks `1`, given the records
+present. `TV` is total variation, `(1/2) L1`.
+
+## Theorem 1 -- the restriction identity, and why `M_R` is memoryless
+
+**Conclusion.** `[exact]` Every one of the `12` hop terms has Pauli `X`-part exactly one edge qubit. Hence for every record set `R`, `P_S H P_S` is the sum of the hop terms on the
+sites carrying **no** record: "`H` restricted to the records" and PR #7876's `H_R` are **the same operator**, not two conventions. So the relaxed state of step 4 depends on `(R, w)`
+and nothing else, and `M_R` is **memoryless**. `[numerical, 1e-11]` The setting: `R0`-`R4` hold pair by pair, the face group carries no `-I`, `k = 5`, the code dimension is `128`, the
+flux is `-1` on all six faces, the code space is `H`-invariant to `3e-17`, and the sea has `E = -6.928203230276 = -4 sqrt 3`, is non-degenerate, has gap `3.464101615138 = 2 sqrt 3`
+and is sharp `N = 4` (Born mass off `N = 4`: `2e-31`).
+
+**Proof.** `T_ij = (i/2) A_ij (B_i - B_j)` and `B_i`, `B_j` are pure `Z`, so both Pauli words `A_ij B_i` and `A_ij B_j` carry the `X`-part of `A_ij`, the single edge qubit `ij`; the
+runner asserts this pair by pair. A term whose `X`-part touches a recorded site carries `S(R,w)` off itself and is killed by `P_S ... P_S`; a term whose `X`-part is unrecorded
+preserves it. The relations, the group and the code dimension are the complete symplectic computation with `Z4` phases; the sea is one `128 x 128` diagonalisation.
+
+**Reading, not theorem.** This is the one thing the candidate wording buys outright, and it is worth having: with it, nothing at all is left to declare between one record and the
+next. The state is fixed by the records.
+
+## Theorem 2 -- the sea's own record odds are flat, and its zeros
+
+**Conclusion.** `[numerical, 1e-12]` On the sea, every one of the `24 + 264 + 1760 = 2048` record blocks with `k <= 3` carries weight exactly `2^-k` (to `4e-15`): the odds at a
+forming record are `1/2` and **nothing is forced up to three records** -- the half-filled-sea analogue of PR #7858's `T2`. `[exact, 1e-12 zero read]` At `p = 1`, where every site registers before
+anything else happens, the finished set is the sea's Born diagonal: support `1984 = 62 x 32`, and `2112` zeros splitting as `1856` **charge zeros** (every pattern with `N != 4`) plus
+`256 = 8 x 32` **cancellation zeros**. The `8` corner-occupation patterns carrying the cancellation zeros are **exactly the `8` closed corner stars** `{v} u N(v)`, one per corner --
+for example `{0,1,2,4}` and its complement `{3,5,6,7}`.
+
+**Proof.** The block weights are sums of `|sea|^2` over coordinate subsets. The zero census is read off the Born diagonal at `1e-12` and then handled combinatorially: the `N != 4`
+count is `4096 - 2240 = 1856` by the parity dictionary, the remaining zero labels group by corner-occupation pattern into `8` patterns of `32`, and those `8` are compared as sets
+against the `8` closed corner stars built from the cube's adjacency -- an equality of two `8`-element sets of `F2^8` vectors, with no tolerance in it.
+
+**Reading, not theorem.** This is the target any tick has to hit: before any record the lattice favours neither value at any site, and it never registers eight of the corner patterns
+at all -- the forbidden patterns PR #7842 and PR #7883 exhibit from the dictionary side.
+
+## Theorem 3 -- under `M_R` every pattern becomes admissible
+
+**Conclusion.** `[numerical, 1e-12]` Under `M_R` at the identity order all `4096` patterns carry strictly positive odds (smallest `1.6e-05`), so **not one of the sea's `2112` zeros
+survives**; the same holds at all `32` declared orders -- support `4096`, `0` zeros kept -- the charge zeros included, although `N` is conserved by `H` and commutes with every record
+projection. `TV(M_R, sea Born) = 0.445486111111 = 1283/2880` at the identity order. PR #7876's Model A at `tau = 0.5` sits **closer**, `TV = 0.324925160534`, on support `2240`,
+keeping all `1856` charge zeros and losing the same `256` cancellation zeros.
+
+**Proof.** Each order's distribution is the exact product over the whole `4096`-leaf tree: at every node the block ground space is diagonalised once, the branch odds are the masses of
+the relaxed diagonal on the two values, and the leaf weights are accumulated; nothing is sampled and no branch is pruned. The relaxed state uses the real skew form of `H_R`: the block
+matrix is purely imaginary, so its square is `-M M^T`, the ground level is `-sqrt(lambda_max)`, and the ground projector's diagonal is half that of the real spectral projector at
+`lambda_max`.
+
+**Reading, not theorem.** By reading note (3), "admissible" is the support of the distribution; under this tick the support is everything, so the patterns the sea never registered are
+now registered, with odds of one in sixty thousand or better.
+
+## Theorem 4 -- the odds depend on the order in which the sites record
+
+**Conclusion.** `[numerical, 1e-12]` `TV(identity order, reverse order) = 0.333333333333 = 1/3`, for the same twelve sites and tick. Over the `32` declared orders -- the `12` cyclic
+shifts, their `12` reverses, and `8` further orders written out in the runner, **no seed anywhere** -- the maximal pairwise `TV` is `0.727031250000` and the minimal `0.113194444444`,
+and `TV` to the sea ranges `0.445486111111` .. `0.569444444444`. The maximum is a **lower bound** on the spread over all `12!` orders, not the spread itself. `[numerical, 1e-14]` The
+sea's own Born rule, by contrast, is order-independent: pure Lueders conditioning reproduces its Born diagonal to `6e-15`, identity and reverse agreeing to `6e-15`.
+
+**Proof.** Thirty-two whole trees as in `T3`, then `496` pairwise `L1` sums; the Lueders tree is the same enumeration with the relaxation step removed. The declared order set is a
+literal in the runner, asserted to be `32` distinct permutations of the `12` sites.
+
+**Reading, not theorem.** The finished set is the same twelve records either way, and which order they formed in should not change how likely it was. Under this tick it does: by a
+third between one order and its reverse, and by more than seven tenths between the two furthest orders tried.
+
+## Theorem 5 -- half filling survives on average; the readable charge does not stay sharp
+
+**Conclusion.** `[numerical, 1e-12]` `<Q> = 0` and `<N> = 4` at every one of the `32` declared orders (`max |<Q>| = 2e-16`, `max |<N> - 4| = 1e-14`), so `M_R` keeps half filling on
+average. But `Q` is no longer sharp: at the identity order the law over `Q = -4, -2, 0, 2, 4` is `(1/384, 1/8, 143/192, 1/8, 1/384)` and `var Q = 1.083333333333 = 13/12`; over the
+declared orders `P(Q = 0)` ranges `0.614583333333` .. `0.881319444444` and `var Q` ranges `0.488888888889` .. `1.666666666667`, so the charge law is itself order-dependent. The spread
+sits on the tie-break: of the `8190` nodes of the identity-order tree, the `1456` whose relaxed state is **not** `N`-sharp are **exactly** the `1456` carrying a degenerate ground
+space, at ticks `5`, `6`, `8`, `9` and `11`; at every tick the weight-averaged `<N>` is still `4` to `7e-15`. The variant `M_R^N` restores `P(Q = 0) = 1` and all `1856` charge zeros
+on support `2240`, but still loses all `256` cancellation zeros, as Model A does.
+
+**Proof.** The charge law is read off the `T3` trees against the parity dictionary and compared with the stated rationals at `1e-12`. The node census records, at every node, the
+block's ground-space degeneracy and the `N` values its relaxed diagonal is supported on, and asserts the two coincide node by node. At tick `11` the degenerate blocks are exactly
+those where `H_R` vanishes -- the last free hop has zero amplitude, its two corner endpoints carrying equal occupancy -- and the block's two states then differ in `N` by `2`; at ticks
+`5`, `6`, `8` and `9` the degenerate ground space has `E_0 < 0` and still spans two `N` sectors.
+
+**Reading, not theorem.** The tie-break is doing real work, and it is a declared choice, not a technicality: where the lattice has more than one lowest-energy arrangement this tick
+shares the weight evenly among them, and there the arrangement carries no one definite charge. Superselecting charge fixes that and not the rest.
+
+## Theorem 6 -- relaxation is not the sea held to the records
+
+**Conclusion.** `[numerical, 1e-12]` Relaxation parts from conditioning at the **first** record: the relaxed state and the Lueders-conditioned sea overlap by `0.962606705806` at all
+`24` (site, value) blocks, identically (spread `7e-15`), so `P_S|sea>` is not a ground state of `H_R` even after one record. By `k = 3` the overlap has fallen to `0.448473881026` in
+the worst of the `1760` blocks, with mean `0.773546569701`, while in `64` of them the conditioned sea **is** the block ground state. The conditioned column has the closed form `<H_R>
+= -(12 - k) / sqrt 3` at `k = 0..12` (to `4e-14`): conditioning alone costs `sqrt 3 / 3` per record, whatever the record says. `[numerical, 1e-9]` Relaxation lowers the energy and
+never raises it: `E_0(R,w) <= <sea_S|H_R|sea_S>` at all `2048` blocks with `k <= 3`, `0` violations. But the gain is not where a settling picture would put it: the tree-average drop
+peaks at `k = 9` (`0.401011505139`), vanishes at `k = 0` and `k = 12` where the block is one-dimensional, and is `0` to `1e-14` at `k = 3`.
+
+**Proof.** Each of the `2048` blocks is diagonalised once; the overlap with the conditioned sea uses the same real skew form as `T3`, the ground projector being `(1/2)(P - (i/mu) M
+P)`. The conditioned column needs no diagonalisation -- `<H_R>` is one quadratic form per node -- and its closed form has an exact reason: each hop term is block-diagonal in the
+record bits of any `R` not containing its site, so averaging over the Lueders values leaves `<sea|T_e|sea>` unchanged, and the staggered sector's site symmetry gives `<sea|T_e|sea> =
+E_sea/12 = -sqrt 3 / 3` at every edge. The `0` violations are the variational principle, checked block by block.
+
+**Reading, not theorem.** "Settling to the lowest arrangement" and "the sea, held to the records so far" are not the same state, and they part company at the first record, by the same
+amount at every site and value. The energy bookkeeping is honest -- settling never costs energy -- but that is all it buys.
+
+## Theorem 7 -- which description a record can take is already settled
+
+**Conclusion.** `[exact]` `Z_e` commutes with all `8` corner parities `B_v` at all `12` edge sites, while `X_e` and `Y_e` each anticommute with exactly the two endpoint parities of
+their site. So the **corner-parity dictionary singles out the record basis**: `Z_e` is the unique one-site description it cannot disturb. The **face dictionary singles out none**:
+`Z_e` anticommutes with exactly the two faces through `e` at all `12` sites, and no one-site basis at any site commutes with the corner dictionary and the face dictionary at once.
+
+**Proof.** Three one-site Pauli words per site against `8 + 6` stabilizer words in the symplectic representation, the face incidences compared against the cube's own face list; all
+integer arithmetic. (The `X_e`/`Y_e` counts against the faces are not uniform across sites and are an artefact of the declared `Z`-tail ordering; they are not used, `X_e` and `Y_e`
+being already excluded by the corner column.)
+
+**Reading, not theorem.** Whatever the tick turns out to be, it does not have to choose which description a record locks: the corner parities have already chosen, and they choose the
+same one at every site.
+
+## Corollary -- what this says about a relaxation tick
+
+Within the setting declared above, on the cube in the staggered sector at half filling, and for the stipulated model `M_R` alone:
+
+1. **The candidate tick is well posed and memoryless.** By `T1` the relaxed state is a function of the records alone, so `M_R` does close PR #7876's `tau`/`H_R` interface -- by fiat,
+   since there is nothing left to declare between one record and the next except which site records next. It also has an honest variational content (`T6`): settling never raises the
+   energy, at any of the `2048` blocks checked.
+2. **It is not the sea's registration.** Every pattern becomes admissible (`T3`), the selection-rule zeros of `T2` are lost -- the `256` cancellation zeros and, through the tie-break,
+   even the `1856` charge zeros -- the odds depend on the order the sites record in (`T4`), and the readable charge is no longer sharp (`T5`), though `<Q> = 0` and half filling
+   survive on average.
+3. **Among the ticks examined so far, only registration of all sites at once reproduces the sea's odds.** That is `p = 1`, the `L` reference of `T2`, and it is a limit rather than a
+   tick: nothing happens between records because there is no between. `M_R` sits further from the sea than a plain unitary gap at `tau = 0.5` does (`T3`).
+4. **What any tick must satisfy is now sharper.** It has to keep the sea's flat odds (`T2`) and its zeros, and by `T7` the corner-parity dictionary already fixes the basis a record
+   forms in. So the open content of a tick is the **formation rule** -- the rate and the odds -- and not the basis.
+
+## Reading, not theorem -- the whole thing in plain words
+
+Suppose that between one record and the next the lattice always drops to its lowest-energy arrangement given the records so far. That rule is at least definite: the state is fixed by
+the records alone. But it does not give back the sea's own record statistics. Every pattern becomes possible, the forbidden patterns that matched known selection rules are lost, and
+the answer depends on the order in which sites record. Whatever the framework's tick is, it has to keep the sea's odds, and this one does not. Which values a record can take, on the
+other hand, is already settled by the corner parities: the record basis is the one they cannot disturb.
+
+## Interfaces named for other lanes, not settled here
+
+- **The formation rate.** How often a record forms, and where, is outside this note; reading note (2) says the axioms supply neither, and `M_R` stipulates an order rather than
+  deriving one. Corollary item 4 is the obligation a formation rule has to answer, and none is supplied here.
+- **A Lindbladian stationary state.** The panel's referee lens -- a tick written as a dissipative generator whose stationary state is the sea, rather than as a replacement map -- is
+  named and not computed; `M_R` is not linear in the state and is not of that form.
+- **Partial relaxation.** Ticks relaxing only partly, running a finite time towards the conditioned ground state rather than arriving, interpolate between PR #7876's Model A and
+  `M_R`; only the two ends are computed here.
+- **Larger regions.** The `3x3x3` cube, periodic boundaries, other fillings and other flux sectors are outside this note; the sea's degeneracy and the corner-star census both depend
+  on the cluster.
+
+## Remaining live routes
+
+1. Whether the order spread of `T4` grows or saturates on larger clusters. The `0.727031250000` here is a maximum over `32` declared orders, and the true maximum over all `12!` orders
+   is not computed.
+2. Whether any tie-break other than `Pi/deg` and the `N`-superselected one makes `T5`'s charge spread vanish without a superselection rule added by hand; `M_R^N` adds one, and nothing
+   here says whether something else does it.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the seven theorem conclusions.
+
+```text
+setting: qubits on the 12 EDGE sites of the 2x2x2 cube graph (8 corners, 6 faces); ordinary (commuting) composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md with Admissibility reading notes (2) and (3)
+encoding: A_ij = X(edge ij) * Z's ordered before it at both endpoints; A_ji = -A_ij; B_v the Z's incident to v; S_f the ordered four-A face loop; T_ij = (i/2) A_ij (B_i - B_j)
+law: eta = Kawamoto-Smit staggered signs (eta_x = 1, eta_y = (-1)^x, eta_z = (-1)^(x+y)), flux -1 on all six faces; H = -sum_e eta_e T_e, t = 1; code space all six S_f = +1, dim 128 = the even-N space; the sea = its ground state, E = -4 sqrt 3, non-degenerate, gap 2 sqrt 3, sharp N = 4
+dictionary: n_v = (1 - B_v)/2 = |y intersect star(v)| mod 2; N = sum_v n_v; readable charge Q = N - 4
+tick_model: STIPULATED, six declared choices -- (i) start from the sea; (ii) the next unrecorded site in a DECLARED order forms; (iii) it locks its value with the Born odds of the current pre-record state; (iv) the state is then REPLACED by the ground state of H restricted to the record-consistent subspace; (v) Pi/deg where that ground space is degenerate; (vi) records permanent, run to 12. Variant M_R^N relaxes inside N = 4. References: L = pure Lueders (the p = 1 boundary), A = PR #7876 Model A at tau = 0.5. No seed anywhere; every order written out in the runner
+T1_restriction [exact]: every hop term has Pauli X-part exactly one edge qubit, so P_S H P_S = sum over unrecorded e of T_e = PR #7876's H_R; hence M_R is memoryless, its state a function of the record set alone. R0-R4 pair by pair, no -I in the face group, k = 5, code dim 2^12/2^5 = 128, flux -1 on all six faces; [numerical, 1e-11] code space H-invariant to 3e-17, E_sea = -6.928203230276 = -4 sqrt 3, non-degenerate, gap 3.464101615138 = 2 sqrt 3, Born mass off N = 4 is 2e-31
+T2_sea_odds [numerical, 1e-12]: all 24 + 264 + 1760 = 2048 record blocks with k <= 3 carry sea weight 2^-k to 4e-15 -- odds 1/2, nothing forced up to three records; [exact, 1e-12 zero read] at p = 1 the support is 1984 = 62 x 32 and the 2112 zeros are 1856 charge zeros (N != 4) + 256 = 8 x 32 cancellation zeros whose 8 corner patterns are EXACTLY the 8 closed corner stars {v} u N(v)
+T3_support [numerical, 1e-12]: under M_R support 4096 and 0 of the 2112 zeros kept, at the identity order (smallest pattern probability 1.6e-05) and at all 32 declared orders; TV(M_R identity, sea Born) = 0.445486111111 = 1283/2880; Model A at tau = 0.5 is closer, TV = 0.324925160534, on support 2240, keeping 1856 charge zeros and 0 of the 256 cancellation zeros
+T4_order [numerical, 1e-12]: TV(identity, reverse) = 0.333333333333 = 1/3; over the 32 declared orders max pairwise TV = 0.727031250000, min 0.113194444444, TV to the sea 0.445486111111 .. 0.569444444444, the maximum a LOWER BOUND on the spread over all 12! orders; [numerical, 1e-14] pure Lueders reproduces the sea's Born diagonal to 6e-15 and is order-independent to 6e-15
+T5_charge [numerical, 1e-12]: max |<Q>| = 2e-16 and max |<N> - 4| = 1e-14 over the 32 orders; identity-order law over Q = -4,-2,0,2,4 is (1/384, 1/8, 143/192, 1/8, 1/384), var Q = 1.083333333333 = 13/12; over the orders P(Q = 0) in 0.614583333333 .. 0.881319444444 and var Q in 0.488888888889 .. 1.666666666667; of the 8190 identity-tree nodes the 1456 whose relaxed state is not N-sharp are EXACTLY the 1456 with a degenerate ground space, at ticks 5, 6, 8, 9, 11, and the weight-averaged <N> is 4 at every tick to 7e-15; M_R^N gives P(Q = 0) = 1, support 2240, all 1856 charge zeros, 0 of the 256 cancellation zeros
+T6_relaxation_vs_conditioning [numerical, 1e-12]: overlap with the Lueders-conditioned sea is 0.962606705806 at all 24 one-record blocks (spread 7e-15); at k = 3, min 0.448473881026, mean 0.773546569701, 64 of 1760 blocks at 1; <H_R> on the conditioned sea = -(12 - k)/sqrt 3 at k = 0..12 to 4e-14; [numerical, 1e-9] E_0(R,w) <= <sea_S|H_R|sea_S> at all 2048 blocks, 0 violations; tree-average drop peaks at k = 9 (0.401011505139), vanishes at k = 0 and k = 12, and is 0 to 1e-14 at k = 3
+T7_pointer [exact]: Z_e commutes with all 8 corner parities at all 12 sites; X_e and Y_e each anticommute with exactly the two endpoint parities; Z_e anticommutes with exactly the two faces through its site at all 12 sites; no one-site basis commutes with the corner and face dictionaries at once
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=26 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **one finite cluster**, the `2x2x2` cube graph, in **one flux sector** (all-minus, the Kawamoto-Smit staggered signs) at **one filling** (the
+half-filled sea, `N = 4`). Nothing is claimed for larger clusters, periodic boundaries, infinite lattices, other sectors, other fillings, or any law family other than the one in
+"Definitions". The law is **designed**, not derived: the encoding is chosen so that the Majorana relations `R0`-`R4` hold, the face constraints make that consistent, and the parity
+dictionary is one readout map among many, with no uniqueness claimed for either.
+
+**The tick model is stipulated in full and derived from nothing.** All six choices -- the starting state, the declared order, Born odds at formation, replacement by the restricted
+ground state, the `Pi/deg` tie-break, and permanence -- are declared here, not taken from any axiom. Reading note (2) is explicit that the axioms supply no formation site, probability
+or rate, and they supply no relaxation clause either; this note supplies none and declares one instead. **Nothing here says what the framework's tick is**, and nothing here forecloses
+any tick. This is an obstruction for **one stipulated tick model**: a different formation rule, a different tie-break, a partial relaxation, or a dissipative generator with the sea as
+its stationary state are all untouched above, and several are named as interfaces. The panel's candidate sentence is a candidate wording and is not called wrong here; what is reported
+is what `M_R`, one way of making it definite, does and does not do.
+
+The order-dependence figure of `T4` is a maximum over **`32` declared orders**, written out in the runner, and is a **lower bound** on the spread over all `12!` orders, labelled so
+everywhere it appears. The `Pi/deg` tie-break is a further declared choice, and `M_R^N` is reported alongside because it changes the charge conclusion. The `p`-variant of PR
+#7876 is touched only at its `p = 1` boundary. Every line not tagged `[exact]` is a **deterministic double-precision evaluation** of an exactly specified quantity at the stated
+threshold: the tick trees are enumerated whole, `4096` leaves and nothing sampled, but each node's relaxed state comes from a diagonalisation, against which no exact rational value
+stands. There is **no seed anywhere** in this note or its runner and no Monte Carlo section. No absolute unit appears anywhere, no axiom text is amended, extended, reworded or
+reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is created or edited.
+
+## Review record
+
+An honest auditor should come away with a declared tick model and its consequences, not a claim about what the framework's tick is; a two-sided result -- well posed and memoryless,
+and not the sea's record statistics -- on one named finite cluster, sector and filling; the stipulation declared as stipulated in the front matter, the setting, its own section, the
+claim block and the proof boundary alike; the panel's candidate sentence quoted as a candidate wording and nowhere called wrong; the order-dependence maximum labelled a lower bound
+over a declared finite set of orders; and the corollary written as an obligation, not a foreclosure.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the "Imports and authority" pointers are plain
+text carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair at `PASS=26 FAIL=0`, runtime under the declared `120` seconds, a current
+zero-dependency citation-manifest entry, and passing pipeline, strict-lint and changed-evidence gates; audit remains a separate lane.

--- a/logs/runner-cache/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.txt
+++ b/logs/runner-cache/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py
+runner_sha256: 473b1eda5b05807661f453bd04b0182dd8a9b5077fadbf05e20c151dc9f7c7a5
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 45.35
+status: ok
+----- stdout -----
+PASS A1 [exact] cube 2x2x2, 8 corners / 12 edge sites / 6 faces: the superfast relations R0-R4 hold pair by pair, the face group carries no -I, k = 5, code dimension 2^12/2^5 = 128
+PASS A2 [exact] the Kawamoto-Smit staggered signs put flux {-1} on all six faces -- the all-minus (pi-flux) sector -- and H = -sum_e eta_e T_e is Hermitian on the 4096-dimensional record space
+PASS A3 [exact] THE RESTRICTION IDENTITY: each of the 12 hop terms has Pauli X-part exactly one edge qubit, so P_S H P_S is the sum of the hops on UNRECORDED sites -- 'H restricted to the records' IS the parent note's H_R, and M_R is memoryless
+PASS A4 [numerical, 1e-11] the code space (six S_f = +1, dim 128 = the even-N space) is H-invariant to 2.8e-17; the sea, its ground state, has E = -6.928203230276 = -4 sqrt 3, non-degenerate, gap 3.464101615138 = 2 sqrt 3, sharp N = 4 (mass off N = 4: 2.0e-31)
+PASS B1 [numerical, 1e-12] the sea's own record odds are FLAT: each of the 24 + 264 + 1760 = 2048 record blocks with k <= 3 carries sea weight 2^-k to 3.7e-15 -- odds 1/2, nothing forced up to three records
+PASS B2 [exact, 1e-12 zero read] at p = 1, where the finished set is the sea's own Born diagonal, the support is 1984 = 62 x 32 and the 2112 zeros split as 1856 charge zeros (N != 4) + 256 cancellation zeros
+PASS B3 [exact, 1e-12 zero read] the 256 cancellation zeros are 8 corner-occupation patterns x 32, and those are EXACTLY the 8 corner stars {v} u N(v) -- the cube's selection-rule zeros
+PASS C1 [numerical, 1e-12] under M_R at the identity order all 4096 patterns carry positive odds (support 4096, smallest 1.628e-05): not one of the sea's 2112 zeros survives
+PASS C2 [numerical, 1e-12] the same for all 32 declared orders: support 4096 in all 32, 0 of the 2112 zeros kept -- the charge zeros included, though N is conserved by H and by every record projection
+PASS C3 [numerical, 1e-12] TV(M_R identity order, sea Born) = 0.445486111111 = 1283/2880: this tick is not the sea's registration
+PASS C4 [numerical, 1e-12] the parent note's Model A at tau = 0.5 sits CLOSER to the sea -- TV 0.324925160534 against 0.445486111111 -- on support 2240, keeping all 1856 charge zeros and losing the same 256 cancellation zeros
+PASS D1 [numerical, 1e-12] the odds depend on the order in which the sites record: TV(identity, reverse) = 0.333333333333 = 1/3, for the same twelve sites and the same tick
+PASS D2 [numerical, 1e-12] over the 32 declared orders (12 cyclic shifts, their reverses, 8 more written out; no seed) the maximal pairwise TV is 0.727031250000, the minimal 0.113194444444, TV to the sea 0.445486111 .. 0.569444444 -- a LOWER BOUND over all 12! orders
+PASS D3 [numerical, 1e-14] the sea's own Born rule is order-independent: pure Lueders conditioning reproduces its Born diagonal to 5.5e-15, identity and reverse agreeing to 5.8e-15
+PASS E1 [numerical, 1e-12] M_R keeps half filling on average at all 32 orders: max |<Q>| = 1.7e-16, max |<N> - 4| = 1.2e-14
+PASS E2 [numerical, 1e-12] but the readable charge is no longer sharp: at the identity order the law over Q = -4,-2,0,2,4 is 0.0026042, 0.1250000, 0.7447917, 0.1250000, 0.0026042 = (1/384, 1/8, 143/192, 1/8, 1/384), var Q = 1.083333333333 = 13/12
+PASS E3 [numerical, 1e-12] and the charge law depends on the order: over the 32 orders P(Q = 0) ranges 0.614583333333 .. 0.881319444444, var Q 0.488888888889 .. 1.666666666667
+PASS E4 [numerical, 1e-12] the spread sits on the Pi/deg tie-break: of the 8190 nodes of the identity tree the 1456 not N-sharp are EXACTLY the 1456 with a degenerate ground space, at ticks [5, 6, 8, 9, 11]; per tick the weight-averaged <N> stays 4 (to 7.1e-15)
+PASS E5 [numerical, 1e-12] the variant M_R^N -- relax inside the conserved N = 4 sector -- restores P(Q = 0) = 1.000000000000 and all 1856 charge zeros on support 2240, but still loses all 256 cancellation zeros, as Model A does
+PASS F1 [numerical, 1e-12] relaxation parts from conditioning at the FIRST record: the relaxed state and the conditioned sea overlap by 0.962606705806 at all 24 (site, value) blocks, identically (spread 6.9e-15)
+PASS F2 [numerical, 1e-12] by three records the overlap is 0.448473881026 in the worst of the 1760 blocks, mean 0.773546569701, while in 64 of them the conditioned sea IS the block ground state (overlap 1)
+PASS F3 [numerical, 1e-12] the conditioned column has the closed form <H_R> = -(12 - k)/sqrt 3 at k = 0..12 (to 3.5e-14): conditioning alone costs sqrt 3 / 3 per record, whatever the record says
+PASS F4 [numerical, 1e-9] relaxation lowers the energy and never raises it: E_0(R,w) <= <sea_S|H_R|sea_S> at all 2048 blocks with k <= 3, 0 violations
+PASS F5 [numerical, 1e-12] the tree-average drop peaks at k = 9 (0.401011505139), vanishes at k = 0 and k = 12 where the block is one-dimensional, and is 0 to 9.8e-15 at k = 3
+PASS G1 [exact] the corner-parity dictionary singles out the record basis: Z_e commutes with all 8 parities B_v at all 12 sites, while X_e and Y_e each anticommute with exactly the two endpoint parities of their site
+PASS G2 [exact] the face dictionary singles out none: Z_e anticommutes with exactly the two faces through e at all 12 sites, and no one-site basis commutes with the corner and face dictionaries at once
+SUMMARY: the stipulated relaxation tick is well posed and memoryless, its state a function of the records alone, and it does not give back the sea's odds: every pattern becomes admissible, the zeros go, the odds depend on the order.
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py
+++ b/scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py
@@ -1,0 +1,898 @@
+#!/usr/bin/env python3
+"""A relaxation tick is well posed and loses the sea's record statistics.
+
+Class-A finite-cluster runner, self-contained. Qubits sit on the 12 EDGE sites of
+the 2x2x2 cube graph (8 corners, 6 faces); the sites compose ordinarily (tensor
+product, operators on disjoint regions commute, no graded clause anywhere). A
+record at an edge site registers a Z-value there, and the corner-parity
+dictionary n_v = (1 - B_v)/2 registers occupancy from those records. The full
+record space is 2^12 = 4096-dimensional; the code space (all six face
+stabilizers S_f = +1) is 128-dimensional and, because prod_v B_v = I, is the
+even-N space. No dense object above 4096 x 4096 is formed, and every matrix
+actually diagonalized is a record block of dimension at most 2048, split further
+by the conserved record number N.
+
+THE LAW. eta = the Kawamoto-Smit staggered link signs (eta_x = 1,
+eta_y = (-1)^x, eta_z = (-1)^(x+y)), whose product round every one of the six
+faces is -1: the all-minus (pi-flux) sector. H = -sum_e eta_e T_e with the
+encoded hop T_ij = (i/2) A_ij (B_i - B_j), t = 1. THE SEA is the ground state of
+H in the code space: E = -4 sqrt 3, non-degenerate, gap 2 sqrt 3, sharp N = 4.
+
+THE TICK MODEL M_R IS STIPULATED HERE, NOT DERIVED. It is the vacuum panel's
+candidate sentence -- "Between records, the lattice settles into its
+lowest-energy arrangement" -- turned into a tick, with every free choice named:
+
+  (i)   the state before any record is the sea;
+  (ii)  each tick the next unrecorded edge site in a DECLARED order forms a
+        record, which locks its value with the Born odds of the current
+        pre-record state;
+  (iii) the state is then REPLACED by the ground state of H restricted to the
+        subspace consistent with all records so far. Unitarity is given up at
+        this step and the map is not linear in the state;
+  (iv)  where that ground space is degenerate the state becomes the normalized
+        projector Pi/deg onto it, and the next record's odds are its diagonal;
+  (v)   records are permanent; the run continues to 12 records.
+  The charge-superselected variant M_R^N, declared alongside, relaxes inside the
+  conserved N = 4 sector of the block instead of the whole block.
+
+Reference ticks computed against M_R: L, pure Lueders conditioning with no
+dynamics at all (the p = 1 boundary, where the finished set is the sea's own
+Born diagonal); and A, the tick of the parent note, identical to M_R except that
+step (iii) is replaced by the unitary exp(-i tau H_R), run at tau = 0.5.
+
+The runner establishes:
+
+  A  THE RESTRICTION IDENTITY AND THE SETTING.  Every hop term flips exactly one
+     edge qubit, so P_S H P_S = sum over UNRECORDED e of T_e: "H restricted to
+     the records" and the parent note's H_R are the same operator, and M_R is
+     memoryless -- its state is a function of the record set alone.
+  B  THE SEA'S OWN RECORD ODDS.  Flat 2^-k at every record block with k <= 3, and
+     at p = 1 the Born support 1984 = 62 x 32 with 2112 zeros = 1856 charge zeros
+     plus 256 cancellation zeros = the 8 closed corner stars x 32.
+  C  SUPPORT.  Under M_R every one of the 4096 patterns carries positive odds and
+     not one of the 2112 zeros survives, for every declared order.
+  D  ORDER DEPENDENCE.  TV(identity, reverse) = 1/3, and the spread over the 32
+     declared orders against exact order independence for pure Lueders.
+  E  CHARGE.  <Q> = 0 and <N> = 4, but Q is no longer sharp; the spread sits
+     exactly on the degenerate blocks; M_R^N restores sharp Q.
+  F  RELAXATION AGAINST CONDITIONING.  Fidelities to the Lueders-conditioned sea
+     at k = 1, 2, 3, the closed form -(12-k)/sqrt 3 for the conditioned column,
+     and the variational inequality at all 2048 blocks.
+  G  THE POINTER-BASIS TABLE.  The corner-parity dictionary singles out the
+     record basis Z_e; the face dictionary singles out none.
+
+NO SEEDS ANYWHERE. Nothing is sampled: every distribution is the exact product
+over the whole 4096-leaf tick tree, and every order used is written out in this
+file. The 32 declared orders are the 12 cyclic shifts of the identity order,
+their 12 reverses, and 8 further orders listed explicitly in ORDERS_EXTRA.
+
+Line tags. `[exact]` = integer, F2 or symplectic Pauli arithmetic with no
+floating point in the statement. `[numerical, tol]` = a deterministic
+double-precision evaluation of an exactly specified quantity at the stated
+threshold, with no sampling and no seed: the block ground spaces come from a
+diagonalization, so no rational value exists to compare against, and the tick
+trees, though enumerated whole, are built from those diagonalizations.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+from functools import reduce
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 120
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# --------------------------------------------------------------------------
+# Pauli algebra in the symplectic representation, phases mod 4
+# --------------------------------------------------------------------------
+def pc(n):
+    return bin(n).count("1")
+
+
+PH = [1 + 0j, 1j, -1 + 0j, -1j]
+
+
+class Pauli:
+    """i^k * prod_q X_q^{x_q} Z_q^{z_q}, X before Z on every qubit."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k % 4
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Pauli(a.k + b.k + 2 * pc(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(self):
+        return Pauli(self.k + 2, self.x, self.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def is_herm(self):
+        return self.k % 2 == pc(self.x & self.z) % 2
+
+    def is_id(self):
+        return self.x == 0 and self.z == 0 and self.k == 0
+
+    def is_mid(self):
+        return self.x == 0 and self.z == 0 and self.k == 2
+
+
+IDP = Pauli(0, 0, 0)
+
+
+def comm(a, b):
+    return (pc(a.x & b.z) + pc(a.z & b.x)) % 2 == 0
+
+
+def pact(p, b):
+    """P|b> = amp |b ^ p.x>, amp a unit Gaussian integer."""
+    return b ^ p.x, PH[p.k] * ((-1) ** (pc(p.z & b) % 2))
+
+
+# --------------------------------------------------------------------------
+# the cube and the superfast encoding (route B: Z tail on edges ordered BEFORE)
+# --------------------------------------------------------------------------
+def cube_cluster():
+    return 8, sorted((min(s, s ^ bit), max(s, s ^ bit)) for s in range(8) for bit in (4, 2, 1) if s ^ bit > s)
+
+
+def cube_faces():
+    out = []
+    for ax in range(3):
+        bits = [4, 2, 1]
+        fb = bits[ax]
+        ob = [b for b in bits if b != fb]
+        for val in (0, fb):
+            out.append((val, val | ob[1], val | ob[0] | ob[1], val | ob[0]))
+    return out
+
+
+class Enc:
+    def __init__(self, V, EDGES, FACES):
+        self.V = V
+        self.EDGES = list(EDGES)
+        self.FACES = list(FACES)
+        self.NQ = len(self.EDGES)
+        self.DIM = 1 << self.NQ
+        self.EIDX = {}
+        for q, (i, j) in enumerate(self.EDGES):
+            self.EIDX[(i, j)] = q
+            self.EIDX[(j, i)] = q
+        self.NBR = {
+            i: sorted(j for (a, b) in self.EDGES for j in ((b,) if a == i else ((a,) if b == i else ())))
+            for i in range(V)
+        }
+        self.STAR = {i: [self.EIDX[(i, k)] for k in self.NBR[i]] for i in range(V)}
+        self.STARMASK = {i: reduce(lambda a, b: a | (1 << b), self.STAR[i], 0) for i in range(V)}
+
+    def A_unsigned(self, i, j):
+        x = 1 << self.EIDX[(i, j)]
+        z = 0
+        for k in self.NBR[i]:
+            if k != j and k < j:
+                z ^= 1 << self.EIDX[(i, k)]
+        for l in self.NBR[j]:
+            if l != i and l < i:
+                z ^= 1 << self.EIDX[(j, l)]
+        return Pauli(pc(x & z) % 2, x, z)
+
+    def A(self, i, j):
+        p = self.A_unsigned(i, j)
+        return p if i < j else p.neg()
+
+    def B(self, i):
+        return Pauli(0, 0, self.STARMASK[i])
+
+    def loop(self, cyc):
+        out = IDP
+        for a in range(len(cyc)):
+            out = out * self.A(cyc[a], cyc[(a + 1) % len(cyc)])
+        return out
+
+    def record(self, z):
+        return tuple(pc(z & self.STARMASK[i]) % 2 for i in range(self.V))
+
+    def hop_pauli(self, i, j):
+        A = self.A(i, j)
+        return A * self.B(i), A * self.B(j)
+
+    def hop_amp(self, P1, P2, y):
+        b1, a1 = pact(P1, y)
+        b2, a2 = pact(P2, y)
+        assert b1 == b2
+        v = 0.5j * (a1 - a2)
+        assert abs(v.real - round(v.real)) < 1e-12 and abs(v.imag - round(v.imag)) < 1e-12
+        return b1, complex(round(v.real), round(v.imag))
+
+
+def encoding_audit(E):
+    """R0-R4 pair by pair, the face group, k, and the code dimension. All exact."""
+    R = {}
+    A = {e: E.A(*e) for e in E.EDGES}
+    Bv = {i: E.B(i) for i in range(E.V)}
+    R["R0"] = all(E.A_unsigned(i, j) == E.A_unsigned(j, i) for (i, j) in E.EDGES) and all(
+        E.A(j, i) == E.A(i, j).neg() for (i, j) in E.EDGES
+    )
+    R["R1"] = all(A[e].is_herm() and (A[e] * A[e]).is_id() for e in E.EDGES) and all(
+        Bv[i].is_herm() and (Bv[i] * Bv[i]).is_id() for i in range(E.V)
+    )
+    r2 = all(comm(Bv[i], Bv[j]) for i, j in itertools.combinations(range(E.V), 2))
+    for e in E.EDGES:
+        for v in range(E.V):
+            r2 &= comm(A[e], Bv[v]) != (v in e)
+    R["R2"] = bool(r2)
+    R["R3"] = all(
+        comm(A[e], A[f]) != (len(set(e) & set(f)) == 1) for e, f in itertools.combinations(E.EDGES, 2)
+    )
+    S = [E.loop(f) for f in E.FACES]
+    r4 = True
+    for s in S:
+        r4 &= s.is_herm() and (s * s).is_id()
+        for e in E.EDGES:
+            r4 &= comm(s, A[e])
+        for v in range(E.V):
+            r4 &= comm(s, Bv[v])
+    for a, b in itertools.combinations(S, 2):
+        r4 &= comm(a, b)
+    R["R4"] = bool(r4)
+    R["S"] = S
+    gens, basis = [], []
+    for s in S:
+        v = s.x
+        for b in basis:
+            v = min(v, v ^ b)
+        if v != 0:
+            basis.append(v)
+            basis.sort(reverse=True)
+            gens.append(s)
+    R["k"] = len(gens)
+    grp = []
+    for m in range(1 << len(gens)):
+        p = IDP
+        for t in range(len(gens)):
+            if (m >> t) & 1:
+                p = p * gens[t]
+        grp.append(p)
+    R["grp"] = grp
+    R["grp_ok"] = (not any(g.is_mid() for g in grp)) and sum(1 for g in grp if g.x == 0) == 1
+    R["code_dim"] = E.DIM >> len(gens)
+    return R
+
+
+def code_space(E, R):
+    """Cosets of the face group; phi[z] is the unit coefficient of |z> in its coset."""
+    grp = R["grp"]
+    phi = np.zeros(E.DIM, dtype=complex)
+    cid = -np.ones(E.DIM, dtype=np.int64)
+    reps = []
+    for z0 in range(E.DIM):
+        if cid[z0] >= 0:
+            continue
+        c = len(reps)
+        reps.append(z0)
+        for g in grp:
+            b, a = pact(g, z0)
+            assert cid[b] < 0
+            cid[b] = c
+            phi[b] = a
+    assert (cid >= 0).all()
+    return cid, phi, reps
+
+
+VN, EDG = cube_cluster()
+FAC = cube_faces()
+EN = Enc(VN, EDG, FAC)
+AUD = encoding_audit(EN)
+CID, PHI, REPS = code_space(EN, AUD)
+D = EN.DIM
+NQ = EN.NQ
+
+# ------------------------------------------------------- staggered link signs
+def corner_xyz(s):
+    return ((s >> 2) & 1, (s >> 1) & 1, s & 1)
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+ETA = np.zeros(NQ, dtype=np.int64)
+EDIR = np.zeros(NQ, dtype=np.int64)
+for q, (i, j) in enumerate(EN.EDGES):
+    a = {4: 0, 2: 1, 1: 2}[min(i, j) ^ max(i, j)]
+    EDIR[q] = a
+    ETA[q] = eta_ks(corner_xyz(min(i, j)), a)
+
+FACE_FLUX = [
+    int(np.prod([ETA[EN.EIDX[(cyc[t], cyc[(t + 1) % 4])]] for t in range(4)])) for cyc in FAC
+]
+
+# --------------------------------------------- H on the full 4096 record space
+HOPX_OK = True
+MI = np.zeros((NQ, D), dtype=np.int64)  # H[z ^ (1<<q), z] = 1j * MI[q, z]
+for q, e in enumerate(EN.EDGES):
+    P1, P2 = EN.hop_pauli(*e)
+    HOPX_OK &= (P1.x == (1 << q)) and (P2.x == (1 << q))
+    for z in range(D):
+        zz, amp = EN.hop_amp(P1, P2, z)
+        if amp == 0:
+            continue
+        assert zz == z ^ (1 << q) and abs(amp.real) < 1e-12
+        MI[q, z] = -int(ETA[q]) * int(round(amp.imag))  # H = -sum_e eta_e T_e
+
+HAMP = 1j * MI.astype(np.float64)
+HERM_OK = True
+for q in range(NQ):
+    HERM_OK &= bool(np.all(MI[q, np.arange(D) ^ (1 << q)] == -MI[q]))
+
+RECZ = np.array([EN.record(z) for z in range(D)], dtype=np.int8)
+NVAL = RECZ.sum(1).astype(np.int64)
+QVAL = NVAL - 4  # Q = -(1/2) sum_v B_v = N - 4
+
+
+def Hmul(psi):
+    out = np.zeros(D, dtype=np.complex128)
+    idx = np.arange(D)
+    for q in range(NQ):
+        out[idx ^ (1 << q)] += HAMP[q] * psi
+    return out
+
+
+# ------------------------------------------------------------ code space + sea
+NCOSET = len(REPS)
+W = np.zeros((D, NCOSET), dtype=np.complex128)
+W[np.arange(D), CID] = PHI / np.sqrt(float(1 << AUD["k"]))
+WORTH = float(np.max(np.abs(W.conj().T @ W - np.eye(NCOSET))))
+HW = np.zeros((D, NCOSET), dtype=np.complex128)
+for c in range(NCOSET):
+    HW[:, c] = Hmul(W[:, c])
+HC = W.conj().T @ HW
+CODE_INV = float(np.max(np.abs(HW - W @ HC)))
+EVC, VCC = np.linalg.eigh(HC)
+SEA = W @ VCC[:, 0]
+E_SEA = float(EVC[0])
+SEA_GAP = float(EVC[1] - EVC[0])
+SEA_DEG = int(np.sum(EVC < EVC[0] + 1e-9))
+P_SEA = np.abs(SEA) ** 2
+SEA_OFF_N4 = float(P_SEA[NVAL != 4].sum())
+SQ3 = float(np.sqrt(3.0))
+
+# --------------------------------------------------------------- record blocks
+ARG = np.arange(D)
+LOC = -np.ones(D, dtype=np.int64)
+TOL = 1e-9
+
+
+def block_M(Rmask, w):
+    """H on the block S(R,w) = {z : z & Rmask == w}, split by the conserved N.
+
+    Every hop term flips exactly one edge qubit, so the terms surviving the
+    restriction are exactly the hops on UNRECORDED sites: this is the parent
+    note's H_R. Its matrix is purely imaginary, so H = i M with M real and
+    skew-symmetric; the spectrum of H on each N sector is therefore symmetric
+    about 0, its square is -M M^T, and the ground level is -sqrt(lambda_max)."""
+    I = ARG[(ARG & Rmask) == w]
+    free = [q for q in range(NQ) if not (Rmask >> q) & 1]
+    out = []
+    for n in np.unique(NVAL[I]):
+        J = I[NVAL[I] == n]
+        d = len(J)
+        LOC[J] = np.arange(d)
+        M = np.zeros((d, d))
+        cols = np.arange(d)
+        for q in free:
+            a = MI[q][J]
+            m = a != 0
+            if not m.any():
+                continue
+            assert np.all(NVAL[J[m] ^ (1 << q)] == n)
+            M[LOC[J[m] ^ (1 << q)], cols[m]] += a[m]
+        LOC[J] = -1
+        out.append((J, M))
+    return out
+
+
+def sector_ground(M):
+    """(E0, top eigenvectors of -M M^T, their count) for one N sector."""
+    if M.size == 0 or not M.any():
+        return 0.0, None, M.shape[0]
+    lam, V = np.linalg.eigh(M @ M.T)
+    lmax = float(lam[-1])
+    if lmax <= 1e-9:
+        return 0.0, None, M.shape[0]
+    sel = np.flatnonzero(lam > lmax - 1e-7 * max(1.0, lmax))
+    assert len(sel) % 2 == 0
+    return -float(np.sqrt(lmax)), V[:, sel], len(sel)
+
+
+def relax(Rmask, w, nfix=None):
+    """The relaxed state on block (R,w): the normalized projector Pi/deg onto the
+    ground space of H restricted to the block (to the N = nfix sector if given).
+    Returns (E0, deg, indices, diagonal), the diagonal summing to 1.
+
+    Because H = i M with M real skew, the ground projector inside a sector is
+    (1/2)(P - (i/mu) M P) with P the real spectral projector of -M M^T at
+    lambda_max; M P is skew, so the projector's DIAGONAL is exactly (1/2) diag P."""
+    secs = []
+    for J, M in block_M(Rmask, w):
+        if nfix is not None and NVAL[J[0]] != nfix:
+            continue
+        e, V, d = sector_ground(M)
+        secs.append((J, M, e, V, d))
+    if not secs:
+        return None, 0, None, None
+    E0 = min(s[2] for s in secs)
+    tot = 0
+    Js, vs = [], []
+    for J, M, e, V, d in secs:
+        if e > E0 + TOL:
+            continue
+        if V is None:
+            tot += d
+            Js.append(J)
+            vs.append(np.ones(len(J)))
+        else:
+            tot += d // 2
+            Js.append(J)
+            vs.append(0.5 * np.sum(V ** 2, axis=1))
+    return E0, tot, np.concatenate(Js), np.concatenate(vs) / tot
+
+
+def relax_full(Rmask, w):
+    """As relax, but also returns the per-sector data needed for fidelities."""
+    secs = []
+    for J, M in block_M(Rmask, w):
+        e, V, d = sector_ground(M)
+        secs.append((J, M, e, V, d))
+    E0 = min(s[2] for s in secs)
+    tot = sum((d if V is None else d // 2) for J, M, e, V, d in secs if e <= E0 + TOL)
+    return E0, tot, secs
+
+
+def fidelity(secs, E0, deg, psi):
+    """<psi| Pi/deg |psi> with Pi the ground projector of the block."""
+    f = 0.0
+    for J, M, e, V, d in secs:
+        if e > E0 + TOL:
+            continue
+        v = psi[J]
+        if V is None:
+            f += float(np.vdot(v, v).real)
+        else:
+            c = V.T @ v
+            f += 0.5 * float((np.vdot(c, c) - (1j / (-e)) * np.vdot(v, M @ (V @ c))).real)
+    return f / deg
+
+
+def expect_HR(Rmask, w, psi):
+    """<psi| H_R |psi> on the block, without any diagonalization."""
+    return sum(float((1j * np.vdot(psi[J], M @ psi[J])).real) for J, M in block_M(Rmask, w))
+
+
+def evolve_HR(Rmask, w, psi, tau):
+    """exp(-i tau H_R) psi = exp(tau M) psi, sector by sector."""
+    out = np.zeros(D, dtype=np.complex128)
+    for J, M in block_M(Rmask, w):
+        v = psi[J]
+        if not M.any():
+            out[J] = v
+            continue
+        lam, V = np.linalg.eigh(M @ M.T)
+        mu = np.sqrt(np.maximum(lam, 0.0))
+        c = V.T @ v
+        si = np.where(mu > 1e-9, np.sin(tau * mu) / np.where(mu > 1e-9, mu, 1.0), 0.0)
+        out[J] = V @ (np.cos(tau * mu) * c) + M @ (V @ (si * c))
+    return out
+
+
+# --------------------------------------------------------------- the tick trees
+BLOCK_CACHE = {}
+
+
+def relaxed_node(Rmask, w):
+    r = BLOCK_CACHE.get((Rmask, w))
+    return r if r is not None else relax(Rmask, w)
+
+
+def tree_MR(order, nfix=None, stats=None):
+    """The exact M_R tree for one declared order: all 4096 leaves, nothing sampled."""
+    out = np.zeros(D)
+    order = list(order)
+
+    def rec(k, Rmask, w, J, v, prob):
+        if k == NQ:
+            out[w] += prob
+            return
+        q = order[k]
+        hi = ((J >> q) & 1).astype(bool)
+        for b in (0, 1):
+            m = hi if b else ~hi
+            pb = float(v[m].sum())
+            if pb <= 0.0:
+                continue
+            R2 = Rmask | (1 << q)
+            w2 = w | (b << q)
+            E0, deg, J2, v2 = relax(R2, w2, nfix) if nfix is not None else relaxed_node(R2, w2)
+            if J2 is None:
+                continue
+            if stats is not None:
+                stats.append((k + 1, prob * pb, E0, deg, float((v2 * NVAL[J2]).sum()), len(set(NVAL[J2].tolist()))))
+            rec(k + 1, R2, w2, J2, v2, prob * pb)
+
+    rec(0, 0, 0, ARG, P_SEA.copy(), 1.0)
+    return out
+
+
+def tree_unitary(order, tau, lueders=False, prof=None):
+    """The Lueders tree (tau ignored) and the parent note's Model A tree."""
+    out = np.zeros(D)
+    order = list(order)
+
+    def rec(k, Rmask, w, psi, prob):
+        if k == NQ:
+            out[w] += prob
+            return
+        q = order[k]
+        d = np.abs(psi) ** 2
+        for b in (0, 1):
+            sel = ((ARG >> q) & 1) == b
+            pb = float(d[sel].sum())
+            if pb <= 1e-15:
+                continue
+            R2 = Rmask | (1 << q)
+            w2 = w | (b << q)
+            p2 = psi.copy()
+            p2[~sel] = 0.0
+            p2 /= np.linalg.norm(p2)
+            if prof is not None:
+                prof.setdefault(k + 1, []).append((prob * pb, expect_HR(R2, w2, p2)))
+            if not lueders:
+                p2 = evolve_HR(R2, w2, p2, tau)
+            rec(k + 1, R2, w2, p2, prob * pb)
+
+    rec(0, 0, 0, SEA.copy(), 1.0)
+    return out
+
+
+def tv(p, q):
+    return 0.5 * float(np.abs(np.asarray(p) - np.asarray(q)).sum())
+
+
+# ------------------------------------------------------------ declared orders
+ORDER_ID = list(range(12))
+ORDERS_SHIFT = [[(j + i) % 12 for i in range(12)] for j in range(12)]
+ORDERS_REV = [list(reversed(o)) for o in ORDERS_SHIFT]
+ORDERS_EXTRA = [
+    [2, 4, 6, 7, 1, 3, 9, 10, 0, 5, 8, 11],   # x edges, then y, then z
+    [0, 5, 8, 11, 1, 3, 9, 10, 2, 4, 6, 7],   # z edges, then y, then x
+    [5, 8, 9, 10, 0, 1, 2, 3, 4, 6, 7, 11],   # the four eta = -1 sites first
+    [0, 1, 2, 7, 10, 11, 3, 4, 5, 6, 8, 9],   # star of corner 0, star of corner 7, rest
+    [0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11],   # even indices, then odd
+    [1, 3, 5, 7, 9, 11, 0, 2, 4, 6, 8, 10],   # odd indices, then even
+    [0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11],   # index bit-reversal
+    [5, 11, 0, 8, 2, 9, 7, 1, 10, 4, 3, 6],   # outward from site 5
+]
+ORDERS = ORDERS_SHIFT + ORDERS_REV + ORDERS_EXTRA
+assert len({tuple(o) for o in ORDERS}) == 32
+assert all(sorted(o) == ORDER_ID for o in ORDERS)
+
+# ==========================================================================
+# A -- the restriction identity and the setting
+# ==========================================================================
+check(
+    "A1 [exact] cube 2x2x2, 8 corners / 12 edge sites / 6 faces: the superfast relations R0-R4 hold pair by pair, the face "
+    "group carries no -I, k = %d, code dimension 2^12/2^%d = %d" % (AUD["k"], AUD["k"], AUD["code_dim"]),
+    AUD["R0"] and AUD["R1"] and AUD["R2"] and AUD["R3"] and AUD["R4"] and AUD["grp_ok"]
+    and AUD["k"] == 5 and AUD["code_dim"] == 128 and D == 4096 and NQ == 12,
+)
+check(
+    "A2 [exact] the Kawamoto-Smit staggered signs put flux %s on all six faces -- the all-minus (pi-flux) sector -- and "
+    "H = -sum_e eta_e T_e is Hermitian on the 4096-dimensional record space" % (set(FACE_FLUX),),
+    all(f == -1 for f in FACE_FLUX) and HERM_OK,
+)
+check(
+    "A3 [exact] THE RESTRICTION IDENTITY: each of the 12 hop terms has Pauli X-part exactly one edge qubit, so P_S H P_S is the "
+    "sum of the hops on UNRECORDED sites -- 'H restricted to the records' IS the parent note's H_R, and M_R is memoryless",
+    HOPX_OK,
+)
+check(
+    "A4 [numerical, 1e-11] the code space (six S_f = +1, dim 128 = the even-N space) is H-invariant to %.1e; the sea, its ground "
+    "state, has E = %.12f = -4 sqrt 3, non-degenerate, gap %.12f = 2 sqrt 3, sharp N = 4 (mass off N = 4: %.1e)"
+    % (CODE_INV, E_SEA, SEA_GAP, SEA_OFF_N4),
+    WORTH < 1e-12 and CODE_INV < 1e-11 and abs(E_SEA + 4 * SQ3) < 1e-11
+    and SEA_DEG == 1 and abs(SEA_GAP - 2 * SQ3) < 1e-11 and SEA_OFF_N4 < 1e-25,
+)
+
+# ==========================================================================
+# B -- the sea's own record odds
+# ==========================================================================
+flat_dev = 0.0
+fid = {}
+viol = 0
+nblocks = {}
+for k in (1, 2, 3):
+    F, EE, LL = [], [], []
+    for S in itertools.combinations(range(NQ), k):
+        Rmask = sum(1 << q for q in S)
+        for vals in itertools.product((0, 1), repeat=k):
+            w = sum(b << q for q, b in zip(S, vals))
+            E0, deg, secs = relax_full(Rmask, w)
+            BLOCK_CACHE[(Rmask, w)] = relax(Rmask, w)
+            sel = (ARG & Rmask) == w
+            psi = SEA.copy()
+            psi[~sel] = 0.0
+            wgt = float(np.vdot(psi, psi).real)
+            flat_dev = max(flat_dev, abs(wgt - 2.0 ** -k))
+            psi /= np.sqrt(wgt)
+            F.append(fidelity(secs, E0, deg, psi))
+            eL = expect_HR(Rmask, w, psi)
+            LL.append(eL)
+            EE.append(E0)
+            if E0 > eL + 1e-9:
+                viol += 1
+    fid[k] = (np.array(F), np.array(LL))
+    nblocks[k] = len(F)
+
+zero_idx = np.flatnonzero(P_SEA < 1e-12)
+n_zero = len(zero_idx)
+n_charge = int((NVAL[zero_idx] != 4).sum())
+canc = zero_idx[NVAL[zero_idx] == 4]
+canc_pats = {tuple(RECZ[z]) for z in canc}
+supp_pats = {tuple(RECZ[z]) for z in np.flatnonzero(P_SEA >= 1e-12)}
+stars = set()
+for v in range(8):
+    s = [0] * 8
+    s[v] = 1
+    for u in EN.NBR[v]:
+        s[u] = 1
+    stars.add(tuple(s))
+
+check(
+    "B1 [numerical, 1e-12] the sea's own record odds are FLAT: each of the %d + %d + %d = %d record blocks with k <= 3 carries "
+    "sea weight 2^-k to %.1e -- odds 1/2, nothing forced up to three records"
+    % (nblocks[1], nblocks[2], nblocks[3], sum(nblocks.values()), flat_dev),
+    flat_dev < 1e-12 and nblocks == {1: 24, 2: 264, 3: 1760},
+)
+check(
+    "B2 [exact, 1e-12 zero read] at p = 1, where the finished set is the sea's own Born diagonal, the support is %d = 62 x 32 and the %d zeros "
+    "split as %d charge zeros (N != 4) + %d cancellation zeros" % (4096 - n_zero, n_zero, n_charge, len(canc)),
+    (4096 - n_zero) == 1984 and len(supp_pats) == 62 and n_zero == 2112 and n_charge == 1856 and len(canc) == 256,
+)
+check(
+    "B3 [exact, 1e-12 zero read] the %d cancellation zeros are %d corner-occupation patterns x 32, and those are EXACTLY the 8 corner "
+    "stars {v} u N(v) -- the cube's selection-rule zeros" % (len(canc), len(canc_pats)),
+    canc_pats == stars and len(stars) == 8 and len(canc) == 8 * 32,
+)
+
+# ==========================================================================
+# C -- support: every pattern becomes admissible
+# ==========================================================================
+P_ORD = [tree_MR(o) for o in ORDERS]
+P_MR = P_ORD[0]
+P_A = tree_unitary(ORDER_ID, 0.5)
+supp_all = [int((p > 1e-13).sum()) for p in P_ORD]
+kept_all = [int((p[zero_idx] < 1e-13).sum()) for p in P_ORD]
+tv_mr = tv(P_MR, P_SEA)
+tv_A = tv(P_A, P_SEA)
+
+check(
+    "C1 [numerical, 1e-12] under M_R at the identity order all 4096 patterns carry positive odds (support %d, smallest "
+    "%.3e): not one of the sea's %d zeros survives" % (supp_all[0], float(P_MR.min()), n_zero),
+    supp_all[0] == 4096 and kept_all[0] == 0 and P_MR.min() > 0,
+)
+check(
+    "C2 [numerical, 1e-12] the same for all 32 declared orders: support 4096 in all 32, 0 of the 2112 zeros kept -- the charge "
+    "zeros included, though N is conserved by H and by every record projection",
+    all(s == 4096 for s in supp_all) and all(z == 0 for z in kept_all),
+)
+check(
+    "C3 [numerical, 1e-12] TV(M_R identity order, sea Born) = %.12f = 1283/2880: this tick is not the sea's registration" % tv_mr,
+    abs(tv_mr - 1283 / 2880) < 1e-12,
+)
+check(
+    "C4 [numerical, 1e-12] the parent note's Model A at tau = 0.5 sits CLOSER to the sea -- TV %.12f against %.12f -- on "
+    "support %d, keeping all %d charge zeros and losing the same 256 cancellation zeros"
+    % (tv_A, tv_mr, int((P_A > 1e-13).sum()), int((P_A[zero_idx] < 1e-13).sum())),
+    tv_A < tv_mr and abs(tv_A - 0.324925160534) < 1e-9 and int((P_A > 1e-13).sum()) == 2240
+    and int((P_A[zero_idx] < 1e-13).sum()) == 1856,
+)
+
+# ==========================================================================
+# D -- order dependence
+# ==========================================================================
+tv_rev = tv(P_ORD[0], P_ORD[12])
+pairs = [(a, b) for a in range(32) for b in range(a + 1, 32)]
+tvs = [tv(P_ORD[a], P_ORD[b]) for a, b in pairs]
+tv_max, tv_min = max(tvs), min(tvs)
+tv_sea = [tv(p, P_SEA) for p in P_ORD]
+P_L = tree_unitary(ORDER_ID, 0.0, lueders=True)
+P_LR = tree_unitary(list(reversed(ORDER_ID)), 0.0, lueders=True)
+
+check(
+    "D1 [numerical, 1e-12] the odds depend on the order in which the sites record: TV(identity, reverse) = %.12f = 1/3, for "
+    "the same twelve sites and the same tick" % tv_rev,
+    abs(tv_rev - 1.0 / 3.0) < 1e-12,
+)
+check(
+    "D2 [numerical, 1e-12] over the 32 declared orders (12 cyclic shifts, their reverses, 8 more written out; no seed) the "
+    "maximal pairwise TV is %.12f, the minimal %.12f, TV to the sea %.9f .. %.9f -- a LOWER BOUND over all 12! orders"
+    % (tv_max, tv_min, min(tv_sea), max(tv_sea)),
+    tv_max > 0.7 and tv_min > 0.1 and abs(min(tv_sea) - tv_mr) < 1e-12,
+)
+check(
+    "D3 [numerical, 1e-14] the sea's own Born rule is order-independent: pure Lueders conditioning reproduces its Born diagonal "
+    "to %.1e, identity and reverse agreeing to %.1e" % (tv(P_L, P_SEA), tv(P_L, P_LR)),
+    tv(P_L, P_SEA) < 1e-14 and tv(P_L, P_LR) < 1e-14 and int((P_L > 1e-13).sum()) == 1984,
+)
+
+# ==========================================================================
+# E -- charge
+# ==========================================================================
+stats = []
+tree_MR(ORDER_ID, stats=stats)
+law = np.array([float(P_MR[QVAL == v].sum()) for v in (-4, -2, 0, 2, 4)])
+law_exact = np.array([1 / 384, 1 / 8, 143 / 192, 1 / 8, 1 / 384])
+varQ = float((P_MR * QVAL ** 2).sum())
+meanQ = [abs(float((p * QVAL).sum())) for p in P_ORD]
+meanN = [abs(float((p * NVAL).sum()) - 4.0) for p in P_ORD]
+pq0 = [float(p[QVAL == 0].sum()) for p in P_ORD]
+vq = [float((p * QVAL ** 2).sum()) for p in P_ORD]
+mixed = [r for r in stats if r[5] > 1]
+degen = [r for r in stats if r[3] > 1]
+mixed_ticks = sorted({r[0] for r in mixed})
+nmean_tick = {k: sum(r[1] * r[4] for r in stats if r[0] == k) for k in range(1, 13)}
+P_MRN = tree_MR(ORDER_ID, nfix=4)
+
+check(
+    "E1 [numerical, 1e-12] M_R keeps half filling on average at all 32 orders: max |<Q>| = %.1e, max |<N> - 4| = %.1e"
+    % (max(meanQ), max(meanN)),
+    max(meanQ) < 1e-12 and max(meanN) < 1e-12,
+)
+check(
+    "E2 [numerical, 1e-12] but the readable charge is no longer sharp: at the identity order the law over Q = -4,-2,0,2,4 is "
+    "%s = (1/384, 1/8, 143/192, 1/8, 1/384), var Q = %.12f = 13/12"
+    % (", ".join("%.7f" % x for x in law), varQ),
+    float(np.max(np.abs(law - law_exact))) < 1e-12 and abs(varQ - 13 / 12) < 1e-12,
+)
+check(
+    "E3 [numerical, 1e-12] and the charge law depends on the order: over the 32 orders P(Q = 0) ranges %.12f .. %.12f, var Q "
+    "%.12f .. %.12f" % (min(pq0), max(pq0), min(vq), max(vq)),
+    max(pq0) - min(pq0) > 0.2 and max(vq) - min(vq) > 1.0,
+)
+check(
+    "E4 [numerical, 1e-12] the spread sits on the Pi/deg tie-break: of the 8190 nodes of the identity tree the %d not N-sharp "
+    "are EXACTLY the %d with a degenerate ground space, at ticks %s; per tick the weight-averaged <N> stays 4 (to %.1e)"
+    % (len(mixed), len(degen), mixed_ticks, max(abs(v - 4.0) for v in nmean_tick.values())),
+    len(mixed) == len(degen) and len(mixed) > 0
+    and all((r[5] > 1) == (r[3] > 1) for r in stats)
+    and mixed_ticks == [5, 6, 8, 9, 11]
+    and max(abs(v - 4.0) for v in nmean_tick.values()) < 1e-12,
+)
+check(
+    "E5 [numerical, 1e-12] the variant M_R^N -- relax inside the conserved N = 4 sector -- restores P(Q = 0) = %.12f and all %d "
+    "charge zeros on support %d, but still loses all 256 cancellation zeros, as Model A does"
+    % (float(P_MRN[QVAL == 0].sum()), int((P_MRN[zero_idx] < 1e-13).sum()), int((P_MRN > 1e-13).sum())),
+    abs(float(P_MRN[QVAL == 0].sum()) - 1.0) < 1e-12 and int((P_MRN > 1e-13).sum()) == 2240
+    and int((P_MRN[zero_idx] < 1e-13).sum()) == 1856,
+)
+
+# ==========================================================================
+# F -- relaxation against conditioning
+# ==========================================================================
+prof = {}
+tree_unitary(ORDER_ID, 0.0, lueders=True, prof=prof)
+lue_col = {k: sum(a * b for a, b in prof[k]) / sum(a for a, _ in prof[k]) for k in prof}
+lue_dev = max(abs(lue_col[k] + (12 - k) / SQ3) for k in lue_col)
+relaxed_col = {
+    k: sum(r[1] * r[2] for r in stats if r[0] == k) / sum(r[1] for r in stats if r[0] == k) for k in range(1, 13)
+}
+drops = {k: lue_col[k] - relaxed_col[k] for k in range(1, 13)}
+kpeak = max(drops, key=lambda k: drops[k])
+F1 = fid[1][0]
+F3 = fid[3][0]
+
+check(
+    "F1 [numerical, 1e-12] relaxation parts from conditioning at the FIRST record: the relaxed state and the conditioned sea "
+    "overlap by %.12f at all 24 (site, value) blocks, identically (spread %.1e)"
+    % (float(F1.mean()), float(F1.max() - F1.min())),
+    float(F1.max() - F1.min()) < 1e-12 and abs(float(F1.mean()) - 0.962606705806) < 1e-9,
+)
+check(
+    "F2 [numerical, 1e-12] by three records the overlap is %.12f in the worst of the 1760 blocks, mean %.12f, while in %d of "
+    "them the conditioned sea IS the block ground state (overlap 1)"
+    % (float(F3.min()), float(F3.mean()), int((F3 > 1 - 1e-9).sum())),
+    abs(float(F3.min()) - 0.448473881026) < 1e-9 and abs(float(F3.mean()) - 0.773546569701) < 1e-9
+    and int((F3 > 1 - 1e-9).sum()) == 64,
+)
+check(
+    "F3 [numerical, 1e-12] the conditioned column has the closed form <H_R> = -(12 - k)/sqrt 3 at k = 0..12 (to %.1e): "
+    "conditioning alone costs sqrt 3 / 3 per record, whatever the record says" % lue_dev,
+    lue_dev < 1e-12,
+)
+check(
+    "F4 [numerical, 1e-9] relaxation lowers the energy and never raises it: E_0(R,w) <= <sea_S|H_R|sea_S> at all %d blocks with "
+    "k <= 3, %d violations" % (sum(nblocks.values()), viol),
+    viol == 0,
+)
+check(
+    "F5 [numerical, 1e-12] the tree-average drop peaks at k = %d (%.12f), vanishes at k = 0 and k = 12 where the block is "
+    "one-dimensional, and is 0 to %.1e at k = 3" % (kpeak, drops[kpeak], abs(drops[3])),
+    kpeak == 9 and abs(drops[kpeak] - 0.401011505139) < 1e-9 and abs(drops[12]) < 1e-12 and drops[3] < 1e-12,
+)
+
+# ==========================================================================
+# G -- the pointer-basis table
+# ==========================================================================
+BV = [EN.B(i) for i in range(8)]
+SF = [EN.loop(f) for f in FAC]
+
+
+def one_site(q, kind):
+    return Pauli(1 if kind == "Y" else 0, (1 << q) if kind in "XY" else 0, (1 << q) if kind in "ZY" else 0)
+
+
+z_vs_B = [sum(1 for v in range(8) if not comm(one_site(q, "Z"), BV[v])) for q in range(12)]
+xy_endpoints = all(
+    sorted(v for v in range(8) if not comm(one_site(q, kind), BV[v])) == sorted(EN.EDGES[q])
+    for q in range(12)
+    for kind in ("X", "Y")
+)
+z_faces_ok = True
+for q in range(12):
+    anti = sorted(f for f in range(6) if not comm(one_site(q, "Z"), SF[f]))
+    thru = sorted(
+        f for f, cyc in enumerate(FAC) if q in [EN.EIDX[(cyc[t], cyc[(t + 1) % 4])] for t in range(4)]
+    )
+    z_faces_ok &= anti == thru and len(thru) == 2
+no_basis_both = all(
+    any(not comm(one_site(q, kind), BV[v]) for v in range(8))
+    or any(not comm(one_site(q, kind), SF[f]) for f in range(6))
+    for q in range(12)
+    for kind in ("X", "Y", "Z")
+)
+
+check(
+    "G1 [exact] the corner-parity dictionary singles out the record basis: Z_e commutes with all 8 parities B_v at all 12 sites, "
+    "while X_e and Y_e each anticommute with exactly the two endpoint parities of their site",
+    all(c == 0 for c in z_vs_B) and xy_endpoints,
+)
+check(
+    "G2 [exact] the face dictionary singles out none: Z_e anticommutes with exactly the two faces through e at all 12 sites, and "
+    "no one-site basis commutes with the corner and face dictionaries at once",
+    z_faces_ok and no_basis_both,
+)
+
+print(
+    "SUMMARY: the stipulated relaxation tick is well posed and memoryless, its state a function of the records alone, and it does "
+    "not give back the sea's odds: every pattern becomes admissible, the zeros go, the odds depend on the order."
+)
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache turning the vacuum panel's candidate tick wording ("Between records, the lattice settles into its lowest-energy arrangement") into a fully stipulated model `M_R` (Lueders formation in a declared order, then replacement by the ground state of `H` restricted to the records) and computing what it does on the emergent cube against the reference any tick has to reproduce, the half-filled sea's own record statistics. **`M_R` is well-posed and memoryless (the restricted Hamiltonian is exactly PR #7876's `H_R`, so the state is a function of the records alone), but it is not the sea's registration:** every one of the 4096 patterns becomes admissible (none of the sea's 2112 zeros survives: 1856 charge zeros and the 256 cancellation zeros on the eight closed corner stars), the odds depend on the order in which the sites record (`TV(identity, reverse) = 1/3` exactly; maximal pairwise `TV = 0.727` over 32 declared orders), and the readable charge is no longer sharp (`var Q = 13/12`), though `<Q> = 0` and `<N> = 4` survive on average. Bonus exact facts: the sea's own record odds are flat `2^-k` with nothing forced for `k <= 3`; at `p = 1` (all sites at once) the distribution is the sea's Born distribution; conditioning alone costs `sqrt 3 / 3` of energy per record (`<H_R> = -(12 - k)/sqrt 3`); and `Z_e` is the unique one-site operator commuting with every corner parity, so the record basis is already fixed and the open content of a tick is the formation rule (rate and odds), not the basis.

- `docs/A_RELAXATION_TICK_IS_WELL_POSED_AND_LOSES_THE_SEAS_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (328 lines)
- `scripts/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.py` (`TOTAL: PASS=26 FAIL=0`, 45 s; no seeds, every order a literal; trees enumerated whole)
- `logs/runner-cache/relaxation_tick_well_posed_loses_sea_record_statistics_check_2026_09_03.txt`

## Theorems

- **T1** the restriction identity `P_S H P_S = sum_{e not in R} T_e` (every hop flips exactly one edge qubit): `M_R` is memoryless.
- **T2** the sea's flat odds and its zeros (support `1984 = 62 x 32`; `2112` zeros; the eight closed corner stars).
- **T3** under `M_R` every pattern becomes admissible; `TV(M_R, sea) = 1283/2880`; PR #7876's Model A at `tau = 0.5` is closer.
- **T4** order dependence (`1/3` exactly; `0.727` maximal over the declared set, a lower bound on the spread over all `12!` orders).
- **T5** half filling survives on average, the charge does not stay sharp; the `N`-superselected variant restores it but still loses the 256 cancellation zeros (executor correction kept: the relaxed state is not `N`-sharp at the 1456 degenerate nodes, at ticks 5, 6, 8, 9, 11).
- **T6** relaxation is not the sea held to the records (`F = 0.9626` at every one-record block; energy lowered at every block, peak drop at `k = 9`).
- **T7** the pointer-basis table.

## Boundary

- One cluster, one sector, one filling; the tick model and its tie-break stipulated and derived from nothing; an obstruction for one stipulated model, not a no-go; the panel's sentence is quoted as a candidate wording and not called wrong; nothing here says what the framework's tick is.

## Context

- Parent: PR #7876 (record ticks admit no invariant pre-record state; its `tau`/`H_R` interface); pointers to PR #7883 (the sea's determinantal record statistics), PR #7842 (the selection-rule zeros), PR #7858, PR #7879.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03); the vacuum panel's tick question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
