### PR TITLE
feat(matter): record walls carry localized 2+1D Dirac matter, vector-like

### DIFF
--- a/docs/RECORD_WALLS_IN_THE_STAGGERED_MASS_CARRY_LOCALIZED_2P1D_DIRAC_MATTER_VECTOR_LIKE_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/RECORD_WALLS_IN_THE_STAGGERED_MASS_CARRY_LOCALIZED_2P1D_DIRAC_MATTER_VECTOR_LIKE_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,319 @@
+---
+claim_id: record_walls_staggered_mass_localized_2p1d_matter_vector_like
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, carrying one fermionic mode per coarse vertex, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2} of the landed staggered kinetic-form clause read on that lattice and the one-particle hopping matrix H_{wv} = eta_a(v) on each coarse bond (the declared t = -1 convention), plus the declared staggered mass H_m = m sum_v eps_v |v><v| with eps_v = (-1)^{v_1+v_2+v_3}, whose value, whose sign field and whose profile m(x) are all supplied and are fixed by nothing quoted here, in the ONE-PARTICLE sector only and on the named finite slabs only: (T1) a record wall -- a plane across which the supplied sign of m changes -- is a stacking fault of the alternating pattern: eps_{v+e_x} = -eps_v at residual 0.0, so on the half-space beyond the wall the supplied mass diagonal equals the uniform-m diagonal translated by one coarse site in x at residual 0.0, min_x |m(x)| = m on every plane, and no plane carries a vanishing mass; in the 2x2x2 cell algebra {Gamma_a, Gamma_b} = {Gamma_a, Eps} = 0, X = i Gamma_1 Gamma_2 Gamma_3 = -(Y x X x Y), [X, Gamma_a] = 0, {X, Eps} = 0, and the wall-chirality operator W = i Gamma_1 Eps = -(X x Z x Z) is hermitian with W^2 = I, anticommutes with Gamma_1 and with Eps, commutes with Gamma_2 and Gamma_3, and ANTICOMMUTES WITH X, all at residual 0.0; the 1x2x2 transverse Bloch cell reproduces the direct real-space coarse torus at L = 4, 6 and m = 0, 0.5, 1 to 1.6e-14 and the bulk E(q)^2 = 6 + 2 sum_a cos q_a + m^2 on the magnetic-cell momenta, each +-E fourfold, at L = 4, 6, 8 and m = 0, 0.5, 2 to 2.8e-14, with {M, Eps} = 0 at residual 0.0 and the periodic 8^3 Dirac point gapping to exactly 2m to 9.4e-15; and the commutant of {Gamma_1, Gamma_2, Gamma_3, Eps} in the cell algebra is 4-dimensional, spanned by I and the three traceless Pauli words I x Y x X, Y x X x I, Y x Z x X, each commuting with W at residual 0.0. (T2) The wall carries localized matter: an 8x8 scan of the transverse Brillouin zone at L_x = 32, m = 1 puts the wall slab's min|E| lowest at (k_Y, k_Z) = (pi, pi), 0.414214 against 0.870264 elsewhere; at that node the two-wall x-torus carries exactly 8 states inside the bulk gap, splitting 4 + 4 by the wall indicator at L_x = 32 and 64 and m = 0.5, 1, 2, and the single wall of the open slab carries exactly 4, two at +E_w and two at -E_w, the open ends carrying separate states at |E| ~ m, at L_x = 32 and 64; the fitted decay length of the resolved wall is 4.1632, 2.1353, 1.1602 against xi(m) = 2/arccosh(1 + m^2/2) = 4.0410, 2.0781, 1.1346 at m = 0.5, 1, 2, i.e. +3.03, +2.75, +2.26 per cent; 99.1 / 96.9 per cent of the density (sharp / resolved) lies within 4.5 coarse sites of the wall at m = 1 and 100.0 / 99.8 at m = 2, against 91.9 / 85.2 at m = 0.5 where xi is already 4.0 coarse sites, the sharp profile being pair-flat about the seam at m = 1 with n(30)/n(29) = 1.0000 and a step n(31)/n(30) = 5.828 per pair against 1.629 and 1.304 resolved; and the wall band disperses as a 2+1D cone at (pi, pi) of the wall's own zone with fitted velocity 0.9997 along q_y, along q_z and along the diagonal, at m = 0.5, 1, 2 and for both profiles, isotropic and independent of m. (T3) The sharp wall's band is gapped: E_w = 0.030776, 0.118034, 0.414214, 1.236068 at m = 0.25, 0.5, 1, 2, matching the FITTED closed form sqrt(1 + m^2) - 1 to six decimals and identical at L_x = 32 and 64, so the gap 2(sqrt(1+m^2) - 1) is not a hybridisation of the two walls of the torus; it lies inside the bulk gap 2m and is not zero. A supplied m(x) passing through zero over w coarse sites drives it down: 2.7e-08, 5.2e-07, 2.1e-05, 1.2e-03 at w = 4 and 4.2e-10, 6.5e-12, 5.0e-10, 1.0e-06 at w = 8, at the same four m. (T4) None of the wall's matter is chiral: <X> = 0 on every one of the four modes of every wall at m = 0.5, 1, 2 and for both profiles, worst 1.4e-15, forced by {W, X} = 0; <W> is constant across each wall's four modes and exactly opposite on the two walls, +-0.894427, +-0.707107, +-0.447214 for the sharp wall (the FITTED 1/sqrt(1 + m^2)) and +-0.989451, +-0.974387, +-0.939317 for the resolved one; H|wall = (Gamma_1 X) (x) (n . F) exactly, residual <= 3.1e-15, with the taste-singlet coefficient <= 5.1e-20 on every wall at every m, |n| = E_w to six decimals, and n reversed componentwise between the two walls; and each taste generator F_b is traceless on each wall's four-dimensional subspace to 1e-9, so the tastes localize identically and are split only, and oppositely, in parity: the net parity-odd mass is zero wall by wall and zero on the pair. (T5) With m(x, y) = m sgn(x - x_0) sgn(y - y_0) at m = 1, x and y explicit on an L x L torus and z Bloch-blocked, the intersection line binds an eightfold band at |E| = 0.317837 identically at L = 24 and L = 32 (2.2e-16), under the single-wall gap 0.414214 and the bulk gap 1; the band is even in k_z about the node, 0.317837, 0.327745, 0.355761 at dk = 0, 0.08, 0.16 with |E|(pi - dk) = |E|(pi + dk) to 1e-9, so there are no left or right movers on the line; with the mass resolved through zero at w = 3 the same crossing carries only the massless wall-plane cones, |E| = 6.5e-05 at the node and 0.099958 at k_z - pi = 0.1; and the band density is enhanced 11.2-fold within 1.5 coarse sites of the four intersection lines at L = 32. Three orthogonal walls, interactions on the wall, the fine lattice, and any continuum limit are not treated; the closed forms E_w = sqrt(1 + m^2) - 1 and <W> = 1/sqrt(1 + m^2), the decay lengths and the velocities are fits, labelled as such. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py
+---
+
+# Record walls in the staggered mass carry localized 2+1D Dirac matter, vector-like
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py`](../scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.txt`](../logs/runner-cache/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+The coarse-lattice emergent fermion has a mass that records register: an alternating price at a coarse corner, its size and its sign supplied. If the sign is supplied as a
+field rather than a constant, the lattice acquires a new kind of object -- a **record wall**, a plane across which the supplied sign of the mass changes. The question here is
+what such a wall carries. Domain walls in a mass are the standard place lower-dimensional matter gathers, and they are the standard route to matter with a hand. This note
+computes, in the one-particle sector and on named finite slabs, what a record wall in this mass does carry and what it does not.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact and numerical finite-slab theorems about one declared object: a plane across which the supplied sign of the staggered mass changes. The stacking-fault identity, the cell algebra and the wall-chirality operator W = i Gamma_1 Eps are zero-residual operator statements; the mode counts, the induced-mass decomposition and the vanishing chirality are floating-point cross-checks at the stated tolerance; the closed forms E_w = sqrt(1+m^2)-1 and <W> = 1/sqrt(1+m^2), the decay lengths and the cone velocity are fits, labelled as such."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-slab theorem, and route to its owner the science-level question this note does not decide: whether the law can supply a mass profile that passes through zero, and where matter with a hand would come from instead."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. The zero-residual items of `T1` are exact -- integer identities on the
+supplied mass diagonal and Pauli identities in the eight-dimensional cell algebra -- and the items tagged `[numerical]` are floating-point cross-checks at the stated tolerance.
+The closed forms of `T3` and `T4`, the decay lengths and the cone velocity of `T2` are **fits**, labelled as such wherever they appear.
+
+1. `T1` (`A`). A sharp record wall is a stacking fault; the cell algebra and `W = i Gamma_1 Eps`; the transverse cell.
+2. `T2` (`B`). The wall carries localized 2+1D Dirac matter: the count, the decay length, the cone.
+3. `T3` (`C`). The sharp wall's band is gapped; a supplied mass passing through zero carries zero modes.
+4. `T4` (`D`). None of the wall's matter is chiral, and the net parity-odd mass is zero.
+5. `T5` (`E`). Two orthogonal record walls bind a massive band on their line.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Kawamoto-Smit staggering, the Jackiw-Rebbi mechanism of a domain wall in a fermion mass, the Dirac-Kahler spin-taste
+split and the Nielsen-Ninomiya counting are standard methodology; every object is redeclared here and the runner recomputes every statement. No observational value, no fitted
+number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `A_RECORD_NATIVE_STAGGERED_MASS_GAP_2M_EXPONENTIAL_KERNEL_AND_WHAT_IT_BREAKS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7890): `H(t, m)`, the gap `2m`, the kernel length
+  `xi(m) = 2/arccosh(1 + m^2/2)`, and its `T2` -- odd coarse translations send `m -> -m` -- which is the exact reason a sharp record wall is a stacking fault.
+- `EMERGENT_LORENTZ_INVARIANCE_AT_THE_DIRAC_POINT_AND_THE_TASTE_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7888): the Dirac point, the `2x2x2` cell algebra, and the
+  chirality `X = -(Y x X x Y)`.
+- `DISCRETE_SYMMETRIES_P_T_AND_CPT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7894): the mass as the parity matrix.
+- `CHARGE_CONJUGATION_AND_THE_CONSERVED_U1_CURRENT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7892): `C` on this fermion.
+- `EMERGENT_FERMION_PI_FLUX_SECTOR_IS_THE_STAGGERED_KINETIC_FORM_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7844): the cell algebra and `eps = Z_1 Z_2 Z_3`.
+- `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the superlattice role pattern and the coarse
+  sublattice `2Z^3`.
+- `STAGGERED_DIRAC_REALIZATION_GATE_NOTE_2026-05-03.md`: the kinetic-form clause quoted below.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the framework axioms quoted in "Setting". No grade of theirs is cited and no hypothesis is adopted.
+
+## Setting
+
+The framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency,
+standard translations, and proper cubic rotations about each site." **Record / Fixed Reality**: "Records form."; "When present, a record locks exactly one admissible local
+possibility. A site never carries more than one record; records are permanent."; "Only records are readable. A readout value is determined by record content alone. A site with
+no record cannot be read." **Qubit / Site Possibility**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has algebraic presentation
+`M_2(C)`". **Admissibility / Local Constraint**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations", and
+"For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions" -- the law supplies the odds.
+
+The landed kinetic clause under test reads, verbatim:
+
+> **Kinetic-form clause.** Within the declared kinetic class (the naive-Dirac kinetic form on nearest-neighbor `Z^3` links, made
+> compatible with the matter-statistics clause by site-local spin diagonalization), the kinetic operator is the staggered operator
+> `D = (1/2) Σ_{x,μ} η_μ(x) (χ̄_{x+μ̂} χ_x − χ̄_x χ_{x+μ̂})` with the Kawamoto-Smit phases `η_1 = 1, η_2(x) = (−1)^{x_1},
+> η_3(x) = (−1)^{x_1+x_2}`, unique as a local Z2 gauge class.
+
+Everything below reads that sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, on the superlattice role pattern's sublattice. Composition is
+**ordinary** throughout. The lattice is physical; the wall is a pattern in the supplied mass sign written on it, and nothing here says what would supply such a pattern.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field on it, the
+one-particle hopping matrix, the staggered mass with its supplied coefficient, the supplied sign field `m(x)`, and the transverse `1x2x2` Bloch cell. `P1` (`A`) is the
+stacking-fault identity, the cell algebra, the operator `W`, and the validation of the transverse cell against the direct torus; `P2` (`B`) the mode count, the decay length and
+the cone; `P3` (`C`) the wall gap and its removal by a resolved profile; `P4` (`D`) the chirality content and the induced mass; `P5` (`E`) the two-wall line. `P2`-`P5` all use
+`P1`'s validation of the transverse cell, and `P4` uses `P1`'s `{W, X} = 0` and the taste commutant. The strongest supported scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`. The **KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`,
+`eta_3(v) = (-1)^{v_1 + v_2}`.
+
+```text
+H(t, m)  = H_kin + H_m,   H_kin[w, v] = eta_a(v) on each coarse bond (w = v + e_a) and h.c.
+                          -- the prompt's H = -t sum eta_ij (|i><j| + h.c.) at t = -1, a stated convention
+H_m      = sum_v m(v_1) eps_v |v><v|,   eps_v = (-1)^{v_1+v_2+v_3}    THE SUPPLIED MASS
+record wall   m(x) = +m for x < x_0 and -m for x >= x_0               THE SUPPLIED SIGN FIELD
+resolved wall m(x) = m tanh((x_0 - x)/w) x (the torus factors)        w coarse sites wide
+transverse cell   1 x 2 x 2: x explicit, 2 coarse sites in y and 2 in z; (k_Y, k_Z) exact, block 4 L_x x 4 L_x
+cell algebra  Gamma = (Y_1, Z_1 Y_2, Z_1 Z_2 Y_3),  Eps = Z_1 Z_2 Z_3,  X = -(Y x X x Y) = i Gamma_1 Gamma_2 Gamma_3
+wall chirality    W = i Gamma_1 Eps = -(X x Z x Z)          2+1D mass operator  Gamma_1 X = i Gamma_2 Gamma_3
+taste             F_b = I x Y x X, Y x X x I, Y x Z x X     the traceless commutant of {Gamma_a, Eps}
+xi(m) = 2/arccosh(1 + m^2/2)                                the bulk kernel length
+```
+
+The `1 x 2 x 2` cell is the minimal one on which **both** the sign field (`eta_3` has period `2` in `y`) **and** the mass grading (`eps_v` has period `2` in `y` and in `z`) are
+cell-periodic, so `(k_Y, k_Z)` are exact quantum numbers; they are the same momenta as the bulk `q_2, q_3`, and lengths conjugate to them are in coarse-site units.
+
+## Theorem 1 -- a sharp record wall is a stacking fault, and `W` anticommutes with the chirality
+
+**Conclusion.** (1) `eps_{v + e_x} = -eps_v` at residual `0.0`, so on the half-space `x >= x_0` the supplied mass diagonal of the wall slab is **identical** to the uniform-`m`
+diagonal translated by one coarse site in `x`, at residual `0.0`; and `min_x |m(x)| = m` on every plane. A record wall in this mass is a **stacking fault** of the alternating
+pattern, not a plane on which the mass vanishes. (2) In the cell algebra `{Gamma_a, Gamma_b} = {Gamma_a, Eps} = 0`, `X = i Gamma_1 Gamma_2 Gamma_3 = -(Y x X x Y)`,
+`[X, Gamma_a] = 0`, `{X, Eps} = 0`, all at residual `0.0`. (3) `W = i Gamma_1 Eps = -(X x Z x Z)` is hermitian with `W^2 = I`, anticommutes with `Gamma_1` and with `Eps`,
+commutes with `Gamma_2` and `Gamma_3`, and **anticommutes with the chirality `X`** -- residual `0.0` on every item. (4) The `1x2x2` transverse cell reproduces the direct
+real-space coarse torus at `L = 4, 6` and `m = 0, 0.5, 1` to `1.6e-14`, and `E(q)^2 = 6 + 2 sum_a cos q_a + m^2` on the magnetic-cell momenta, each `+-E` fourfold, at
+`L = 4, 6, 8` and `m = 0, 0.5, 2` to `2.8e-14`, with `{M, Eps} = 0` at `0.0` and the periodic `8^3` Dirac point gapping to exactly `2m` to `9.4e-15`. (5) The commutant of
+`{Gamma_1, Gamma_2, Gamma_3, Eps}` is 4-dimensional, spanned by `I` and three traceless Pauli words, each commuting with `W` at residual `0.0`.
+
+**Proof.** Item 1 is `(-1)^{x+1+a+b} = -(-1)^{x+a+b}` compared entry by entry against the constructed diagonal. Items 2, 3 and 5 are `8x8` Pauli identities, item 5 by enumerating
+the `64` words of the cell algebra. Item 4 diagonalizes both constructions and compares the sorted spectra. Items 1, 2, 3 and 5 exact at residual `0.0`; item 4
+`[numerical, 1e-13]`.
+
+**Reading, not theorem.** The price alternates from one corner to the next, so reversing its sign across half the lattice is the same thing as sliding the whole alternating
+pattern one corner along on that side. A record wall is the seam between two copies of the same pattern out of step by one, and nowhere along the seam does the price fall to
+nothing. The operator that says which side of the seam a state sits on trades the two sides of the slab for each other whenever it is asked about handedness.
+
+## Theorem 2 -- the wall carries localized 2+1D Dirac matter
+
+**Conclusion.** (1) An `8x8` scan of the transverse Brillouin zone at `L_x = 32`, `m = 1` puts the wall slab's `min|E|` lowest at `(k_Y, k_Z) = (pi, pi)`, the transverse
+projection of the `(pi, pi, pi)` Dirac point: `0.414214` there against `0.870264` everywhere else. (2) At that node the two-wall `x`-torus carries exactly `8` states inside the
+bulk gap, splitting `4 + 4` by the wall indicator, at `L_x = 32` and `64` and `m = 0.5, 1, 2`; the worst separation is `0.0208 / 0.9792` (`L_x = 32`, `m = 0.5`) and the best
+`9.3e-11 / 1.0000`. (3) The **single** wall of the **open** slab carries exactly four states too, two at `+E_w` and two at `-E_w`, the open ends carrying separate states at
+`|E| ~ m`, at `L_x = 32` and `64` and `m = 0.5, 1, 2`: the count is not an artefact of the two-wall torus. (4) The fitted decay length of the mode density is `4.1632, 2.1353,
+1.1602` for the resolved wall and `4.1562, 2.2692, 1.3854` for the sharp one, against `xi(m) = 4.0410, 2.0781, 1.1346` at `m = 0.5, 1, 2`: the resolved wall's fits are `+3.03`,
+`+2.75` and `+2.26` per cent. (5) `99.1 / 96.9` per cent of the density (sharp / resolved) lies within `4.5` coarse sites of the wall at `m = 1` and `100.0 / 99.8` at `m = 2`,
+against `91.9 / 85.2` at `m = 0.5`, where `xi` is already `4.0` coarse sites; and at `m = 1` the sharp profile is **pair-flat** about the seam,
+`n(30)/n(29) = 1.0000` with a step `n(31)/n(30) = 5.828` per pair, against `1.629` and `1.304` for the resolved one. (6) The wall band disperses as a `2+1D` cone at `(pi, pi)` of the wall's own zone with fitted
+velocity `0.9997` along `q_y`, along `q_z` and along the diagonal, at `m = 0.5, 1, 2` and for both profiles: isotropic, independent of `m`, and the bulk Dirac velocity `1`.
+
+**Proof.** Exact diagonalization of the `4 L_x x 4 L_x` transverse-Bloch blocks at the stated momenta; the wall subspaces are the eigenspaces of the half-slab indicator on the
+eight in-gap states. The decay lengths are least-squares fits of `log n(x)` against `|x - x_wall|` over `4.5 <= d <= 14.5`, and the velocity is a least-squares fit of
+`E^2 - E_0^2` against `p^2` over `p <= 0.08` -- both **fits**, and the `0.9997` is that fit's `O(p^2)` truncation. Items 1 to 3 and 5 `[numerical]`; items 4 and 6 `[fits]`.
+
+**Reading, not theorem.** Matter gathers on the wall: four kinds of it per wall, at the one place in the wall's own zone where it can be cheap. It fades out into the bulk over
+the same few corners the sea's own correlations do -- the bound thing is bound on the sea's own length, not on a length of the wall's. In the plane of the wall it carries the
+same speed the lattice gives everywhere else, the same in every direction, and unchanged by the size of the price.
+
+## Theorem 3 -- the sharp wall's band is gapped, and a mass through zero carries zero modes
+
+**Conclusion.** (1) `E_w = 0.030776, 0.118034, 0.414214, 1.236068` at `m = 0.25, 0.5, 1, 2`, matching the **fitted** closed form `sqrt(1 + m^2) - 1` to six decimals and
+**identical at `L_x = 32` and `L_x = 64`**: the wall band of a sharp wall is gapped by `2(sqrt(1 + m^2) - 1)`, which is `~ m^2` at small `m`, deep inside the bulk gap `2m`, and
+not a hybridisation of the two walls of the torus. It is not zero. (2) Replacing the step by a supplied `m(x)` that **passes through zero** over `w` coarse sites drives the gap
+down by three to five orders of magnitude: `2.7e-08, 5.2e-07, 2.1e-05, 1.2e-03` at `w = 4` and `4.2e-10, 6.5e-12, 5.0e-10, 1.0e-06` at `w = 8`, at the same four `m`.
+
+**Proof.** The same diagonalizations at the node, at `L_x = 32` and `64` for item 1 and `L_x = 64` for item 2. The `L_x`-independence to six decimals is what separates an
+intrinsic gap from a two-wall splitting, which would fall exponentially in `L_x`. The closed form is a **fit** matched at four values of `m`, not a proof. `[numerical, 1e-6]`.
+
+**Reading, not theorem.** A sharp reversal of the price is a seam, not a place where the price runs out, and the seam charges what gathers on it a small price of its own --
+small beside the sea's, and it shrinks quickly as the sea's price shrinks, but it is not nothing. A supplied price that fades through zero over a few corners charges nothing,
+and then what gathers there is free of any price at all. Which of the two the law can supply is not settled here.
+
+## Theorem 4 -- none of it is chiral, and the parity-odd mass cancels
+
+**Conclusion.** (1) `<X> = 0` on every one of the four modes of every wall, at `m = 0.5, 1, 2` and for both profiles, worst `1.4e-15` -- forced by the exact identity
+`{W, X} = 0` of Theorem 1, which carries one wall's subspace onto the other's, so no single wall is a chirality eigenspace. (2) `<W>` is constant across each wall's four modes
+and **exactly opposite on the two walls**: `+-0.894427, +-0.707107, +-0.447214` for the sharp wall -- the **fitted** `1/sqrt(1 + m^2)` -- and `+-0.989451, +-0.974387,
++-0.939317` for the resolved one, running to `1` as the wall resolves. That opposition is the index count. (3) `H|wall = (Gamma_1 X) (x) (n . F)` exactly, residual `<= 3.1e-15`,
+with the **taste-singlet** coefficient `<= 5.1e-20` on every wall at every `m`, `|n| = E_w` to six decimals, and `n` **reversed componentwise** between the two walls: the
+parity-odd part of the induced 2+1D mass is zero wall by wall and zero on the pair. (4) Each `F_b` is traceless on each wall's four-dimensional subspace to `1e-9`.
+
+**Proof.** The wall subspaces of Theorem 2; every operator is the matrix of a cell-local operator in that subspace, symmetrized and diagonalized. Item 3 projects `H|wall` on the
+four operators `Gamma_1 X` and `(Gamma_1 X) F_b` and reports the reconstruction residual. `[numerical, 1e-12]` throughout; the closed form for `<W>` is a **fit**.
+
+**Reading, not theorem.** What the wall carries comes in mirror pairs. The label that would tell left from right averages to nothing on every mode of every wall, because the
+operator carrying it trades one wall of the slab for the other. What each wall does carry is a sign of its own, exactly opposite to the other wall's -- and a small parity price
+that arrives in equal and opposite amounts on the two tastes, so that nothing is left over on one wall, and nothing on the pair. Both tastes gather on the wall alike; only their
+parity price tells them apart.
+
+## Theorem 5 -- two orthogonal record walls bind a massive band on their line
+
+**Conclusion.** With `m(x, y) = m sgn(x - x_0) sgn(y - y_0)` at `m = 1`, `x` and `y` explicit on an `L x L` torus and `z` Bloch-blocked: (1) at `k_z = pi` the intersection line
+binds an eightfold band at `|E| = 0.317837`, **identical at `L = 24` and `L = 32`** (`2.2e-16`), under the single-wall gap `0.414214` and the bulk gap `1` -- so the gap is
+intrinsic, not finite-size. (2) The band is **even** in `k_z` about the node: `0.317837, 0.327745, 0.355761` at `dk = 0, 0.08, 0.16`, with `|E|(pi - dk) = |E|(pi + dk)` to
+`1e-9`, so `dE/dk_z = 0` at the node and there are no left or right movers on the line. (3) With the mass resolved through zero at `w = 3` the same crossing carries only the
+massless wall-plane cones: `|E| = 6.5e-05` at the node and `0.099958` at `k_z - pi = 0.1`, i.e. `|k_z - pi|`. (4) The band density is enhanced `11.2`-fold within `1.5` coarse
+sites of the four intersection lines at `L = 32`, `17.5` per cent of it on `16` of the `1024` cells.
+
+**Proof.** Exact diagonalization of the `2 L^2 x 2 L^2` blocks at the stated `k_z`. The size-independence between `L = 24` and `L = 32` to `1e-6` is what makes the gap
+intrinsic. `[numerical]`.
+
+**Reading, not theorem.** Where two walls cross, something does gather on the line -- about eleven times the density there -- but it sits at a fixed price with no slope, so
+nothing runs one way along it. Resolve the price through zero and the line carries nothing extra at all; what is left is the matter on the two planes.
+
+## Corollary -- what record walls carry, on the geometries computed
+
+Within the setting declared above, in the one-particle sector, and on the finite slabs named:
+
+1. **Record walls carry localized 2+1D Dirac matter.** Four modes per wall per node -- two two-component 2+1D Dirac fermions, one per taste -- with the cone at `(pi, pi)` of
+   the wall's own zone, the bulk Dirac velocity `1`, isotropic and independent of `m`, and bound on the sea's own decay length `xi(m)`, on both walls of the periodic slab and
+   on the single wall of the open one.
+2. **A sharp wall is a stacking fault, gapped by a computed amount.** Reversing the supplied sign is a one-site translation of the alternating pattern, so no plane carries a
+   vanishing mass, and the fault feeds the wall band a gap `2(sqrt(1 + m^2) - 1)` -- an `L_x`-independent number matched by a fit at four values of `m`. Only a supplied mass
+   profile passing through zero carries exact zero modes. Whether the law can supply a graded mass is an interface, named below and not decided here.
+3. **None of it is chiral.** The chirality vanishes on every wall mode at every `m` and for both profiles, forced by the exact `{W, X} = 0`; the two walls of a slab carry
+   opposite wall-chirality and opposite taste-non-singlet parity masses, and the taste-singlet part is zero on each wall separately. The total is vector-like, as a lattice
+   construction in three dimensions has to be. Two orthogonal walls bind a massive band on their line and no chiral wire.
+4. **What the records register.** The wall is a pattern of mass signs on the coarse lattice, and the localized mode's density is a record-readable modulation across it: at
+   `m = 1` the sharp wall's profile is pair-flat about the seam -- `n(30)/n(29) = 1.0000`, with a step of `5.828` to the next pair -- the duplicated phase of the fault reading
+   itself out, while the resolved wall's profile has no such plateau (`1.629` and `1.304`).
+
+Stated plainly: **a chiral sector is not supplied by record walls in this mass, on the geometries computed here.** A two-dimensional wall in a three-dimensional lattice reduces
+`3+1` to `2+1`, and in `2+1` there is no handedness -- only a parity sign, whose taste-singlet part is zero here. The standard route to matter with a hand in four dimensions is
+a wall in a fifth dimension, which this lattice does not have. That is named below as an interface; other constructions are not examined here and nothing about them follows
+from this note.
+
+**Reading, not theorem (this register).** Draw a wall of records across the lattice with the mass sign reversed on one side. Matter gathers on that wall: four kinds per wall,
+moving in the wall plane at the same speed as everywhere else, fading out into the bulk over the same few sites the sea's own correlations do. But a sharp wall in a staggered
+mass is a stacking fault, not a place where the mass vanishes, so what gathers there has a small gap; a mass that fades through zero across the wall would carry gapless matter
+instead. What no wall supplies is handedness: each wall's matter comes in a left-and-right pair, the two walls of a slab are each other's mirror, and where two walls cross
+nothing runs one way along the line. Whatever gives matter a hand, it is not this.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms: the coarse lattice, the sign field, the mass term, the supplied profile `m(x)` and the wall geometries are declared objects, and no
+  coefficient is derived.
+- No interaction term is added, no second species appears, and no corner of the taste cube is identified with any named species.
+
+## Interfaces named for other lanes, not moved here
+
+- **A graded mass profile from the law.** The zero modes of Theorem 3 require a supplied `m(x)` that passes through zero, an additional supplied datum beyond a sign. Whether
+  the dynamical clause can supply one is a question for the lane that owns it.
+- **Matter with a hand.** The route computed here does not supply it. Where a chiral sector would come from instead -- and whether any construction on this lattice supplies one
+  -- is a live question for another lane; nothing here examines any other construction.
+- **Three orthogonal walls.** A point defect. **Not computed**; the line result of Theorem 5 suggests nothing about it that is established here.
+- **Interactions on the wall.** Only free hopping plus the declared diagonal term is treated. A four-fermion term on the wall could change the wall band and is not touched.
+- **The fine lattice.** Everything is on the coarse lattice `2Z^3`. How a wall in the mass sign reads on the fine lattice `Z^3`, and whether the superlattice role pattern can
+  carry one, is not shown here.
+
+## Remaining live routes
+
+1. Other wall orientations. The wall normal is `e_x` throughout; the other two axes and the diagonal planes are not computed.
+2. Larger slabs and other transverse cells. `L_x = 32, 64`, `L = 24, 32` and the `1x2x2` transverse cell are what is computed; nothing is claimed beyond them.
+3. The many-body statements. Everything here is one-particle; the many-body sea in the presence of a wall is untouched.
+4. Small `m`. The wall indicator already separates only `0.0208 / 0.9792` at `L_x = 32`, `m = 0.5`, the two walls of the torus overlapping as `xi(m)` grows; smaller `m` needs
+   longer slabs than are used here.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one fermionic mode per coarse vertex; KS signs; H_{wv} = eta_a(v) (t = -1, a stated convention); H_m = sum_v m(v_1) eps_v |v><v|; m, its sign field and its profile all supplied; one-particle sector; transverse 1x2x2 Bloch cell; axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+stacking_fault: eps_{v+e_x} = -eps_v at 0.0; the wall diagonal equals the uniform-m diagonal translated one coarse site in x at 0.0; min_x |m(x)| = m; no plane carries a vanishing mass
+cell_algebra: {Gamma_a,Gamma_b} = {Gamma_a,Eps} = 0; X = i G1G2G3 = -(YxXxY); [X,Gamma_a] = 0; {X,Eps} = 0; W = i Gamma_1 Eps = -(XxZxZ) hermitian, W^2 = I, {W,Gamma_1} = {W,Eps} = {W,X} = 0, [W,Gamma_2] = [W,Gamma_3] = 0 -- all residual 0.0
+validation: 1x2x2 cell vs direct real-space coarse torus L = 4, 6 at m = 0, 0.5, 1 to 1.6e-14; E(q)^2 = 6 + 2 sum cos q_a + m^2 fourfold, L = 4, 6, 8, m = 0, 0.5, 2 to 2.8e-14; {M,Eps} = 0 at 0.0; 8^3 Dirac point gaps to 2m to 9.4e-15
+taste: commutant of {Gamma_1,Gamma_2,Gamma_3,Eps} is 4-dimensional, I plus IxYxX, YxXxI, YxZxX, each commuting with W at 0.0
+count: node at (pi,pi) (0.414214 vs 0.870264 elsewhere, 8x8 scan); 8 in-gap states splitting 4 + 4 by wall indicator at L_x = 32, 64 and m = 0.5, 1, 2; open slab, one wall: exactly 4 wall states, 2 at +E_w and 2 at -E_w, ends at |E| ~ m, L_x = 32 and 64
+decay_length [fits]: resolved 4.1632 / 2.1353 / 1.1602 and sharp 4.1562 / 2.2692 / 1.3854 vs xi(m) = 4.0410 / 2.0781 / 1.1346 at m = 0.5 / 1 / 2 (resolved +3.03, +2.75, +2.26 per cent); density within 4.5 coarse sites 99.1 / 96.9 per cent at m = 1, 100.0 / 99.8 at m = 2, 91.9 / 85.2 at m = 0.5; sharp profile pair-flat at m = 1, n(30)/n(29) = 1.0000, step n(31)/n(30) = 5.828, against 1.629 and 1.304 resolved
+cone [fit]: velocity 0.9997 along q_y, q_z and the diagonal, m = 0.5, 1, 2, both profiles; isotropic, m-independent, the bulk Dirac velocity 1
+wall_gap [fit]: E_w = 0.030776 / 0.118034 / 0.414214 / 1.236068 at m = 0.25 / 0.5 / 1 / 2, matching sqrt(1+m^2) - 1 to six decimals, identical at L_x = 32 and 64; resolved w = 4 gives 2.7e-08 / 5.2e-07 / 2.1e-05 / 1.2e-03 and w = 8 gives 4.2e-10 / 6.5e-12 / 5.0e-10 / 1.0e-06
+chirality: <X> = 0 on every wall mode at every m and both profiles, worst 1.4e-15, forced by {W,X} = 0; <W> = +-0.894427 / +-0.707107 / +-0.447214 sharp (fitted 1/sqrt(1+m^2)) and +-0.989451 / +-0.974387 / +-0.939317 resolved, opposite on the two walls
+induced_mass: H|wall = (Gamma_1 X) (x) (n . F) at residual <= 3.1e-15; taste-singlet coefficient <= 5.1e-20; |n| = E_w to six decimals; n reversed componentwise between the walls; each F_b traceless on each wall subspace to 1e-9; net parity-odd mass zero
+line_defect: eightfold band at |E| = 0.317837 identical at L = 24 and 32 (2.2e-16); even in k_z, 0.317837 / 0.327745 / 0.355761 at dk = 0 / 0.08 / 0.16, |E|(pi-dk) = |E|(pi+dk) to 1e-9; resolved w = 3 gives 6.5e-05 at the node and 0.099958 at dk = 0.1; density enhanced 11.2-fold within 1.5 coarse sites of the four lines at L = 32
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=22 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved in the **one-particle sector** on the **coarse** lattice `2Z^3`, with free hopping plus one declared diagonal term. No interaction appears, no many-body sea
+is treated, and no continuum limit is taken. Nothing is claimed for `Z^3`.
+
+The geometries are the named finite slabs and nothing else: the two-wall `x`-torus at `L_x = 32` and `64`, the open slab with one wall at `L_x = 32` and `64`, and the
+intersecting-wall geometry at `L = 24` and `32`, all with the transverse directions treated by exact `1x2x2`-cell Bloch blocking, so `L_y` and `L_z` are infinite in that
+treatment. Three orthogonal walls -- a point defect -- were **not computed**, and nothing here bears on them.
+
+`t = -1` is a **stated convention**, chosen so that the cell gammas, `X` and the handedness labels carry the landed signs; its equivalence to `t = +1` up to the sublattice
+relabelling that also sends `m -> -m` is noted, not derived. The value, the **sign field** and the **profile** of `m` are all **supplied data**. Nothing here says what supplies
+a wall, why one would form, or whether a record pattern can contain one; the "resolved wall" that carries zero modes needs a supplied `m(x)` passing through zero, an additional
+supplied datum beyond a sign.
+
+`E_w = sqrt(1 + m^2) - 1`, `<W> = 1/sqrt(1 + m^2)` and `|n| = E_w` are **fits**, matched to six decimals at `m = 0.25, 0.5, 1, 2`, not proofs. The decay lengths and the cone
+velocity are **fits** at the windows stated; the `0.9997` is the fit's `O(p^2)` truncation and carries no claim beyond that. What is exact is the residual-`0.0` operator and
+integer content of Theorem 1 and the `<= 3.1e-15` decomposition of Theorem 4.
+
+Three numbers deserve their own line, because a reader could over-read them. The `97`-`99` per cent concentration of Theorem 2 holds at `m = 1` and `m = 2`; at `m = 0.5`, where
+`xi` is already `4.0` coarse sites, it is `91.9` per cent sharp and `85.2` per cent resolved. The resolved wall's decay-length fit at `m = 0.5` is `+3.03` per cent from `xi`,
+marginally outside three per cent. And a `w = 4` profile drives the wall gap below `1e-6` only for `m <= 0.5`; at `m = 1` and `m = 2` it is `2.1e-05` and `1.2e-03`, reaching
+`1.0e-06` or less at `w = 8`.
+
+## Review record
+
+An honest auditor should come away with: one declared object -- a plane across which the supplied sign of the staggered mass changes -- shown on named finite slabs to carry
+localized `2+1D` Dirac matter, four modes per wall per node, bound on the sea's own length `xi(m)`, with a cone at the corner of the wall's own zone at the bulk velocity, and
+shown to carry no handedness at all. The chirality vanishes on every wall mode because `W` anticommutes with it, an exact eight-dimensional identity; the two walls of a slab
+carry opposite `W` and exactly opposite taste-non-singlet parity masses, with the taste-singlet part zero on each; and two orthogonal walls bind a massive, non-dispersing band
+on their line. The auditor should also come away with the caveat that a **sharp** wall is a stacking fault rather than a zero of the mass, so its band is gapped by a fitted
+`2(sqrt(1 + m^2) - 1)`, and only a supplied profile passing through zero carries exact zero modes.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the eight context notes in "Imports and
+authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=22 FAIL=0`, runtime under the
+declared `120` seconds, and passing pipeline and strict-lint gates; independent audit remains a separate lane.

--- a/logs/runner-cache/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.txt
+++ b/logs/runner-cache/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.txt
@@ -1,0 +1,55 @@
+===== runner cache v1 =====
+runner: scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py
+runner_sha256: 19e0368581226ad2fdafbd392874b9d0e6a86cf363f12641a2b88c884e6df8f4
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 8.35
+status: ok
+----- stdout -----
+PASS A1 [exact] eps_{v+e_x} = -eps_v (0.0e+00), so a half-space sign flip IS a one-site translation of the mass pattern (0.0e+00): the wall is a STACKING FAULT, and min|m(x)| = 1.000 -- no plane's mass vanishes
+PASS A2 [exact] cell algebra: {G_a, G_b} = 0.0e+00, {G_a, Eps} = 0.0e+00, X = i G1G2G3 = -(YxXxY) (0.0e+00), [X, G_a] = 0.0e+00, {X, Eps} = 0.0e+00
+PASS A3 [exact] W = i G1 Eps = -(XxZxZ) (0.0e+00), hermitian (0.0e+00), W^2 = I (0.0e+00); {W,G1} = {W,Eps} = 0.0e+00, [W,G2] = [W,G3] = 0.0e+00, {W, X} = 0.0e+00: W ANTICOMMUTES WITH X
+PASS A4 [1e-13] the 1x2x2 transverse Bloch cell reproduces the DIRECT real-space coarse torus, L = 4, 6, m = 0, 0.5, 1 (1.6e-14)
+PASS A5 [exact/1e-13] {M, Eps} = 0.0e+00; bulk E(q)^2 = 6 + 2 sum_a cos q_a + m^2, each +-E fourfold, L = 4, 6, 8, m = 0, 0.5, 2 (2.8e-14); the 8^3 Dirac point gaps to 2m (9.4e-15)
+PASS A6 [exact] the commutant of {G_1, G_2, G_3, Eps} is 4-dimensional -- I and traceless taste generators F_b = IYX, YXI, YZX -- each commuting with W at 0.0e+00: taste is not split by a wall
+PASS B1 [numerical] 8x8 transverse-BZ scan, L_x = 32, m = 1: the wall slab's min|E| is lowest at (pi, pi), the projection of the (pi,pi,pi) Dirac point (0.414214 against 0.870264)
+PASS B2 [1e-10] FOUR MODES PER WALL PER NODE: 8 states inside the bulk gap at (pi,pi), splitting 4 + 4 by the wall indicator (worst 0.0208 / 0.9792), L_x = 32, 64, m = 0.5, 1, 2
+PASS B3 [1e-9] the SINGLE wall of the open slab carries four states too, 2 at +E_w and 2 at -E_w, ends separate at |E| ~ m; L_x = 32, 64, m = 0.5, 1, 2 (L=64, m=1: E_w = +0.414214 (x2), ends at 1.004258)
+   decay length [fits]:  m | sharp | w=4 | xi = 2/arccosh(1+m^2/2)
+     m=0.5  4.1562  4.1632  4.0410  (+3.03 per cent)
+     m=1.0  2.2692  2.1353  2.0781  (+2.75 per cent)
+     m=2.0  1.3854  1.1602  1.1346  (+2.26 per cent)
+PASS B4 [fits] the mode is bound on the SEA'S OWN length: the resolved wall's fitted length matches xi(m) to 3.1 per cent at m = 0.5, 1, 2
+PASS B5 [numerical] within 4.5 coarse sites lie 99.1 / 96.9 per cent of the density (sharp / resolved) at m = 1, 100.0 / 99.8 at m = 2, 91.9 / 85.2 at m = 0.5; and at m = 1 the sharp profile is PAIR-FLAT about the seam, n(30)/n(29) = 1.0000 with a step n(31)/n(30) = 5.828 per pair, against 1.629 and 1.304 resolved
+PASS B6 [fits] a 2+1D CONE at (pi,pi) of the wall's own zone: fitted velocity 0.9997 to 0.9997 along q_y, q_z and the diagonal, m = 0.5, 1, 2, both profiles -- isotropic, m-independent, the bulk velocity 1 (the shortfall is the fit's O(p^2) truncation)
+   m | E_w(L=32) | E_w(L=64) | sqrt(1+m^2)-1 | w=4 | w=8 | bulk
+     0.25  0.030776 0.030776 0.030776  2.7e-08 4.2e-10  0.25
+     0.50  0.118034 0.118034 0.118034  5.2e-07 6.5e-12  0.50
+     1.00  0.414214 0.414214 0.414214  2.1e-05 5.0e-10  1.00
+     2.00  1.236068 1.236068 1.236068  1.2e-03 1.0e-06  2.00
+PASS C1 [fit, 1e-6] E_w = sqrt(1 + m^2) - 1 to six decimals at m = 0.25, 0.5, 1, 2, IDENTICAL at L_x = 32 and 64: the sharp band is gapped by 2(sqrt(1+m^2) - 1), inside the bulk gap 2m but not zero, not a hybridisation
+PASS C2 [numerical] a supplied mass PASSING THROUGH ZERO restores zero modes: at w = 4 the gap falls three to five orders (under 1e-6 for m <= 0.5), at w = 8 to 1.0e-6 or less at every m: the gap is the fault's
+   L=64:  m | <W> sharp A / B | <W> w=4 A / B | 1/sqrt(1+m^2)
+     0.5  +0.894427 / -0.894427  +0.989451 / -0.989451  0.894427
+     1.0  +0.707107 / -0.707107  +0.974387 / -0.974387  0.707107
+     2.0  +0.447214 / -0.447214  +0.939317 / -0.939317  0.447214
+PASS D1 [1e-12] NO CHIRALITY ON THE WALL: <X> = 0 on all four modes of every wall, m = 0.5, 1, 2, both profiles, worst 1.4e-15 -- forced by {W, X} = 0
+PASS D2 [fit, 1e-7] <W> = +-1 IN SIGN, opposite on the two walls, constant across each wall's four modes -- the index count; magnitude 1/sqrt(1 + m^2) sharp (a fit, to 1e-6)
+   H|wall = (G_1 X)(x)(n.F):  m | singlet | |n| | E_w | residual
+     0.5  1.1e-24  0.118034  0.118034  1.7e-16
+     1.0  5.8e-24  0.414214  0.414214  1.6e-15
+     2.0  5.1e-20  1.236068  1.236068  3.1e-15
+PASS D3 [1e-12] the induced 2+1D mass is H|wall = (G_1 X) (x) (n . F) exactly, its TASTE-SINGLET coefficient exactly zero on every wall at every m, |n| = E_w, n reversed between the walls: NET PARITY ANOMALY ZERO
+PASS D4 [1e-9] the tastes LOCALIZE IDENTICALLY -- each F_b is traceless on each wall subspace -- while the 2+1D mass splits them oppositely in parity
+PASS E1 [1e-6] L = 24 and 32, m = 1, k_z = pi: the line binds an eightfold band at |E| = 0.317837, IDENTICAL at both sizes (2.2e-16), under the single-wall gap 0.414214: intrinsic
+   k_z dispersion:  dk | |E|(pi-dk) | |E|(pi+dk)
+     0.08  0.327745  0.327745
+     0.16  0.355761  0.355761
+PASS E2 [1e-9] the band is EVEN in k_z about the node, rising from 0.317837: dE/dk_z = 0 there, so NO LEFT OR RIGHT MOVERS on the line -- two orthogonal walls bind a massive band, not a chiral wire
+PASS E3 [numerical] with the mass RESOLVED (w = 3) the crossing carries only the massless wall-plane cones -- |E| = 6.5e-05 at the node, 0.099958 at k_z - pi = 0.1
+PASS E4 [numerical] the line does bind: the band density is enhanced 11.2-fold within 1.5 coarse sites of the four intersection lines (L = 32), 17.5 per cent on 16 of 1024 cells
+SUMMARY: four localized 2+1D Dirac modes per wall per node, on xi(m) at velocity 1; a sharp wall is a stacking fault, gapping them by 2(sqrt(1+m^2)-1); none of it is chiral; two walls bind a massive band.
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py
+++ b/scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Record walls in the staggered mass: what they carry.
+
+Self-contained one-particle runner.  The coarse lattice is 2Z^3, one fermionic
+mode per coarse vertex, with the Kawamoto-Smit link signs
+    eta_1 = 1,  eta_2(v) = (-1)^{v_1},  eta_3(v) = (-1)^{v_1+v_2},
+the hopping matrix H_{wv} = eta_a(v) on each coarse bond (the declared t = -1
+convention), and the staggered mass H_m = m sum_v eps_v |v><v| with
+eps_v = (-1)^{v_1+v_2+v_3}.  A RECORD WALL is a plane across which the SUPPLIED
+sign of m changes: m(x) = +m for x < x_0 and -m for x >= x_0.  The value, the
+sign and the profile of m are supplied data.
+
+  A  THE WALL IS A STACKING FAULT.  eps_{v+e_x} = -eps_v, so flipping the sign
+     of the mass on a half-space equals a one-site translation of the mass
+     pattern there and no plane carries a vanishing mass; the cell algebra and
+     the wall-chirality operator W = i Gamma_1 Eps = -(X x Z x Z), which
+     anticommutes with the chirality X = -(Y x X x Y); the 1 x 2 x 2 transverse
+     Bloch cell reproduces the direct real-space coarse torus and the bulk
+     E(q)^2 = 6 + 2 sum_a cos q_a + m^2.
+  B  LOCALIZED MATTER.  Four modes per wall per node, on both walls of the
+     periodic slab and on the single wall of the open slab; decay length
+     xi(m) = 2/arccosh(1 + m^2/2); a 2+1D cone at (pi, pi) of the wall zone
+     with velocity 1, isotropic and independent of m.
+  C  THE WALL BAND IS GAPPED.  E_w = sqrt(1 + m^2) - 1 (a fit), identical at
+     L_x = 32 and 64, so not a hybridisation of the two walls; a mass profile
+     passing through zero over w = 4 coarse sites restores zero modes.
+  D  NO CHIRALITY ON THE WALL.  <X> = 0 on every wall mode; <W> = +-1 in sign,
+     opposite on the two walls; H|wall = (Gamma_1 X) (x) (n . F) with the
+     taste-singlet coefficient exactly zero and n reversed between the walls.
+  E  TWO ORTHOGONAL WALLS.  A line binding a massive band, even in k_z: no
+     left or right movers.
+
+Group A carries exact integer and operator identities at residual 0.0; the
+items tagged [numerical] are floating-point cross-checks at the stated
+tolerance; the closed forms E_w = sqrt(1 + m^2) - 1 and <W> = 1/sqrt(1 + m^2),
+the decay lengths and the velocities are FITS, labelled as such everywhere.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import time
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 120
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================ the 2x2x2 cell algebra, verbatim
+
+I2 = np.eye(2, dtype=complex)
+X2 = np.array([[0, 1], [1, 0]], dtype=complex)
+Y2 = np.array([[0, -1j], [1j, 0]], dtype=complex)
+Z2 = np.array([[1, 0], [0, -1]], dtype=complex)
+PAULI = {"I": I2, "X": X2, "Y": Y2, "Z": Z2}
+
+
+def kr(*a):
+    out = np.array([[1.0 + 0j]])
+    for mat in a:
+        out = np.kron(out, mat)
+    return out
+
+
+GAM = [kr(Y2, I2, I2), kr(Z2, Y2, I2), kr(Z2, Z2, Y2)]   # Gamma_1, Gamma_2, Gamma_3
+EPSC = kr(Z2, Z2, Z2)                                    # Eps = Z1 Z2 Z3, the mass
+XCHI = -kr(Y2, X2, Y2)                                   # X = -(Y x X x Y), the chirality
+WWALL = 1j * GAM[0] @ EPSC                               # W = i Gamma_1 Eps
+MASS2D = GAM[0] @ XCHI                                   # Gamma_1 X = i Gamma_2 Gamma_3
+
+
+def acom(a, b):
+    return float(np.abs(a @ b + b @ a).max())
+
+
+def com(a, b):
+    return float(np.abs(a @ b - b @ a).max())
+
+
+# ====================================================== lattice / slab builders
+
+
+def idx(x, a, b):
+    return (x * 2 + a) * 2 + b
+
+
+def build_slab(Lx, kY, kZ, mvec, periodic_x=True):
+    """4 L_x x 4 L_x transverse-Bloch block at cell momenta (kY, kZ).
+
+    x is explicit; the Bloch cell is 2 coarse sites in y and 2 in z -- the
+    minimal cell on which both the KS sign field and the mass grading are
+    cell-periodic.  mvec[x] is the supplied m(x) on the x-th coarse plane.
+    """
+    n = 4 * Lx
+    A = np.zeros((n, n), dtype=complex)
+    d = np.zeros(n)
+    eY, eZ = np.exp(-1j * kY), np.exp(-1j * kZ)
+    for x in range(Lx):
+        sy = 1.0 if x % 2 == 0 else -1.0            # eta_2 = (-1)^{v_1}
+        for a in (0, 1):
+            sz = sy if a == 0 else -sy              # eta_3 = (-1)^{v_1+v_2}
+            for b in (0, 1):
+                if x + 1 < Lx:
+                    A[idx(x + 1, a, b), idx(x, a, b)] += 1.0
+                elif periodic_x:
+                    A[idx(0, a, b), idx(x, a, b)] += 1.0
+                if a == 0:
+                    A[idx(x, 1, b), idx(x, 0, b)] += sy
+                else:
+                    A[idx(x, 0, b), idx(x, 1, b)] += sy * eY
+                if b == 0:
+                    A[idx(x, a, 1), idx(x, a, 0)] += sz
+                else:
+                    A[idx(x, a, 0), idx(x, a, 1)] += sz * eZ
+                d[idx(x, a, b)] = mvec[x] * (-1.0) ** (x + a + b)
+    return A + A.conj().T + np.diag(d.astype(complex))
+
+
+def slab_diag(Lx, mvec):
+    """The supplied mass diagonal of the slab, indexed as build_slab."""
+    d = np.zeros(4 * Lx)
+    for x in range(Lx):
+        for a in (0, 1):
+            for b in (0, 1):
+                d[idx(x, a, b)] = mvec[x] * (-1.0) ** (x + a + b)
+    return d
+
+
+def build_torus_real(L, m):
+    """Direct real-space L^3 coarse torus at uniform mass m."""
+    n = L ** 3
+
+    def s(x, y, z):
+        return (x % L) * L * L + (y % L) * L + (z % L)
+
+    A = np.zeros((n, n))
+    d = np.zeros(n)
+    for x in range(L):
+        for y in range(L):
+            for z in range(L):
+                v = s(x, y, z)
+                A[s(x + 1, y, z), v] += 1.0
+                A[s(x, y + 1, z), v] += (-1.0) ** x
+                A[s(x, y, z + 1), v] += (-1.0) ** (x + y)
+                d[v] = m * (-1.0) ** (x + y + z)
+    return A + A.T + np.diag(d)
+
+
+def build_line(L, kZ, mgrid):
+    """x and y explicit on an L x L torus, 2-site Bloch cell in z; dim 2 L^2."""
+    n = 2 * L * L
+
+    def s(x, y, b):
+        return ((x % L) * L + (y % L)) * 2 + b
+
+    A = np.zeros((n, n), dtype=complex)
+    d = np.zeros(n)
+    eZ = np.exp(-1j * kZ)
+    for x in range(L):
+        for y in range(L):
+            sy, sz = (-1.0) ** x, (-1.0) ** (x + y)
+            for b in (0, 1):
+                A[s(x + 1, y, b), s(x, y, b)] += 1.0
+                A[s(x, y + 1, b), s(x, y, b)] += sy
+                if b == 0:
+                    A[s(x, y, 1), s(x, y, 0)] += sz
+                else:
+                    A[s(x, y, 0), s(x, y, 1)] += sz * eZ
+                d[s(x, y, b)] = mgrid[x, y] * (-1.0) ** (x + y + b)
+    return A + A.conj().T + np.diag(d.astype(complex))
+
+
+# ------------------------------------------------- supplied mass sign profiles
+
+
+def sharp(Lx, m):
+    """Two walls on the x-torus: +m for x < Lx/2, -m for x >= Lx/2."""
+    v = np.full(Lx, -float(m))
+    v[: Lx // 2] = float(m)
+    return v
+
+
+def resolved(Lx, m, w):
+    """The same two walls with m(x) ramped through zero over w coarse sites."""
+    x = np.arange(Lx)
+    return m * (np.tanh((Lx / 2.0 - 0.5 - x) / w) * np.tanh((x + 0.5) / w)
+                * np.tanh((Lx - 0.5 - x) / w))
+
+
+def sharp_open(Lx, m):
+    """One wall at x = Lx/2 with open x ends."""
+    v = np.full(Lx, -float(m))
+    v[: Lx // 2] = float(m)
+    return v
+
+
+def lowest(Lx, mvec, nlow=8, kY=np.pi, kZ=np.pi, periodic_x=True):
+    H = build_slab(Lx, kY, kZ, mvec, periodic_x)
+    w, V = np.linalg.eigh(H)
+    o = np.argsort(np.abs(w))[:nlow]
+    o = o[np.argsort(w[o])]
+    return H, w[o], V[:, o]
+
+
+def wall_indicator(V, Lx, lo, hi):
+    """Matrix of the indicator on lo <= x < hi in the span of the columns."""
+    mask = np.zeros(Lx)
+    mask[lo:hi] = 1.0
+    A = V.reshape(Lx, 4, V.shape[1])
+    return np.einsum("xan,x,xam->nm", A.conj(), mask, A)
+
+
+def cell_matrix(V, Lx, Op8):
+    """Matrix of a 2x2x2-cell-local operator in the span of the columns."""
+    W = V.reshape(Lx, 2, 2, V.shape[1]).reshape(Lx // 2, 8, V.shape[1])
+    return np.einsum("cin,ij,cjm->nm", W.conj(), Op8, W)
+
+
+def herm_eigs(A):
+    return np.linalg.eigvalsh((A + A.conj().T) / 2)
+
+
+def split_walls(Lx, mvec, periodic_x=True):
+    """The 8 in-gap states at the node, split into the two wall subspaces."""
+    H, e, V = lowest(Lx, mvec, 8, periodic_x=periodic_x)
+    ind = np.linalg.eigh(wall_indicator(V, Lx, Lx // 4, 3 * Lx // 4))
+    ev, U = ind
+    return H, e, V @ U[:, ev < 0.5], V @ U[:, ev >= 0.5], ev
+
+
+# ======================== A -- the sharp record wall is a stacking fault [exact]
+
+LX = 32
+M0 = 1.0
+r_eps = max(abs((-1.0) ** (x + 1 + a + b) + (-1.0) ** (x + a + b))
+            for x in range(4) for a in (0, 1) for b in (0, 1))
+d_wall = slab_diag(LX, sharp(LX, M0))
+d_shift = np.zeros(4 * LX)
+for x in range(LX):
+    sgn = (x + 1) if x >= LX // 2 else x           # a one-site translation of the pattern
+    for a in (0, 1):
+        for b in (0, 1):
+            d_shift[idx(x, a, b)] = M0 * (-1.0) ** (sgn + a + b)
+r_fault = float(np.abs(d_wall - d_shift).max())
+check("A1 [exact] eps_{v+e_x} = -eps_v (%.1e), so a half-space sign flip IS a one-site "
+      "translation of the mass pattern (%.1e): the wall is a STACKING FAULT, and min|m(x)| = %.3f "
+      "-- no plane's mass vanishes"
+      % (r_eps, r_fault, np.abs(d_wall).min()),
+      r_eps == 0.0 and r_fault == 0.0 and np.abs(d_wall).min() == M0)
+
+rg = max(acom(GAM[a], GAM[b]) for a in range(3) for b in range(3) if a != b)
+re = max(acom(GAM[a], EPSC) for a in range(3))
+rx = float(np.abs(XCHI - 1j * GAM[0] @ GAM[1] @ GAM[2]).max())
+rxg = max(com(XCHI, GAM[a]) for a in range(3))
+check("A2 [exact] cell algebra: {G_a, G_b} = %.1e, {G_a, Eps} = %.1e, X = i G1G2G3 = -(YxXxY) "
+      "(%.1e), [X, G_a] = %.1e, {X, Eps} = %.1e"
+      % (rg, re, rx, rxg, acom(XCHI, EPSC)),
+      rg == 0.0 and re == 0.0 and rx == 0.0 and rxg == 0.0 and acom(XCHI, EPSC) == 0.0)
+
+rw = float(np.abs(WWALL + kr(X2, Z2, Z2)).max())
+rh = float(np.abs(WWALL - WWALL.conj().T).max())
+r2 = float(np.abs(WWALL @ WWALL - np.eye(8)).max())
+check("A3 [exact] W = i G1 Eps = -(XxZxZ) (%.1e), hermitian (%.1e), W^2 = I (%.1e); "
+      "{W,G1} = {W,Eps} = %.1e, [W,G2] = [W,G3] = %.1e, {W, X} = %.1e: W ANTICOMMUTES WITH X"
+      % (rw, rh, r2, max(acom(WWALL, GAM[0]), acom(WWALL, EPSC)),
+         max(com(WWALL, GAM[1]), com(WWALL, GAM[2])), acom(WWALL, XCHI)),
+      rw == 0.0 and rh == 0.0 and r2 == 0.0 and acom(WWALL, GAM[0]) == 0.0
+      and acom(WWALL, EPSC) == 0.0 and com(WWALL, GAM[1]) == 0.0
+      and com(WWALL, GAM[2]) == 0.0 and acom(WWALL, XCHI) == 0.0)
+
+d_cell = 0.0
+for L in (4, 6):
+    for m in (0.0, 0.5, 1.0):
+        er = np.sort(np.linalg.eigvalsh(build_torus_real(L, m)))
+        nc = L // 2
+        eb = np.sort(np.concatenate([
+            np.linalg.eigvalsh(build_slab(L, 2 * np.pi * nY / nc, 2 * np.pi * nZ / nc,
+                                          np.full(L, m)))
+            for nY in range(nc) for nZ in range(nc)]))
+        d_cell = max(d_cell, float(np.abs(er - eb).max()))
+check("A4 [1e-13] the 1x2x2 transverse Bloch cell reproduces the DIRECT real-space coarse torus, "
+      "L = 4, 6, m = 0, 0.5, 1 (%.1e)" % d_cell, d_cell < 1e-13)
+
+d_disp = 0.0
+for L in (4, 6, 8):
+    for m in (0.0, 0.5, 2.0):
+        er = np.sort(np.linalg.eigvalsh(build_torus_real(L, m)))
+        pr = []
+        for n in itertools.product(range(L // 2), repeat=3):
+            q = 4 * np.pi * np.array(n) / L
+            E = np.sqrt(max(6 + 2 * np.cos(q).sum() + m * m, 0.0))
+            pr += [-E] * 4 + [E] * 4
+        d_disp = max(d_disp, float(np.abs(er - np.sort(np.array(pr))).max()))
+M8 = build_torus_real(8, 0.0)
+e8 = np.array([(-1.0) ** ((v // 64) + (v // 8) % 8 + v % 8) for v in range(512)])
+r_me = float(np.abs(M8 * e8[None, :] + e8[:, None] * M8).max())
+d_gap = max(abs(2 * np.abs(np.linalg.eigvalsh(build_torus_real(8, m))).min() - 2 * m)
+            for m in (0.2, 0.5, 1.0))
+check("A5 [exact/1e-13] {M, Eps} = %.1e; bulk E(q)^2 = 6 + 2 sum_a cos q_a + m^2, each +-E "
+      "fourfold, L = 4, 6, 8, m = 0, 0.5, 2 (%.1e); the 8^3 Dirac point gaps to 2m (%.1e)"
+      % (r_me, d_disp, d_gap),
+      r_me == 0.0 and d_disp < 1e-13 and d_gap < 1e-12)
+
+FB = []
+for word in itertools.product("IXYZ", repeat=3):
+    O = kr(*[PAULI[c] for c in word])
+    if all(com(O, g) == 0.0 for g in GAM + [EPSC]) and abs(np.trace(O)) < 1e-12:
+        FB.append(("".join(word), O))
+check("A6 [exact] the commutant of {G_1, G_2, G_3, Eps} is 4-dimensional -- I and traceless taste "
+      "generators F_b = %s -- each commuting with W at %.1e: taste is not split by a wall"
+      % (", ".join(f[0] for f in FB), max(com(F, WWALL) for _, F in FB)),
+      len(FB) == 3 and max(com(F, WWALL) for _, F in FB) == 0.0)
+
+# ============================================ B -- localized matter on the wall
+
+best, node = None, None
+for i in range(8):
+    for j in range(8):
+        kY, kZ = 2 * np.pi * i / 8, 2 * np.pi * j / 8
+        g = float(np.abs(np.linalg.eigvalsh(build_slab(LX, kY, kZ, sharp(LX, M0)))).min())
+        if i == j == 4:
+            node = g
+        elif best is None or g < best:
+            best = g
+check("B1 [numerical] 8x8 transverse-BZ scan, L_x = 32, m = 1: the wall slab's min|E| is lowest "
+      "at (pi, pi), the projection of the (pi,pi,pi) Dirac point (%.6f against %.6f)"
+      % (node, best), node < best)
+
+ok_b2 = True
+worst_ind = 0.0
+for Lx in (32, 64):
+    for m in (0.5, 1.0, 2.0):
+        H, e, VB, VA, ev = split_walls(Lx, sharp(Lx, m))
+        nin = int((np.abs(np.linalg.eigvalsh(H)) < 0.9 * m).sum())
+        ok_b2 = ok_b2 and nin == 8 and VA.shape[1] == 4 and VB.shape[1] == 4 \
+            and ev[3] < 0.05 and ev[4] > 0.95
+        worst_ind = max(worst_ind, float(ev[3]))
+check("B2 [1e-10] FOUR MODES PER WALL PER NODE: 8 states inside the bulk gap at (pi,pi), splitting "
+      "4 + 4 by the wall indicator (worst %.4f / %.4f), L_x = 32, 64, m = 0.5, 1, 2"
+      % (worst_ind, 1 - worst_ind), ok_b2)
+
+ok_b3 = True
+b3row = ""
+for Lx in (32, 64):
+    for m in (0.5, 1.0, 2.0):
+        H = build_slab(Lx, np.pi, np.pi, sharp_open(Lx, m), periodic_x=False)
+        w, V = np.linalg.eigh(H)
+        o = np.argsort(np.abs(w))[:10]
+        o = o[np.argsort(w[o])]
+        lab = []
+        for i in o:
+            p = (np.abs(V[:, i].reshape(Lx, 4)) ** 2).sum(1)
+            lab.append("W" if p[Lx // 2 - 4:Lx // 2 + 4].sum() > 0.5 else "E")
+        Ew = np.array([w[i] for i, l in zip(o, lab) if l == "W"])
+        Ee = np.array([abs(w[i]) for i, l in zip(o, lab) if l == "E"])
+        ok_b3 = ok_b3 and len(Ew) == 4 and abs(Ew[0] + Ew[3]) < 1e-9 \
+            and abs(Ew[0] - Ew[1]) < 1e-9 and abs(Ew[1]) < 0.9 * m \
+            and Ee.min() > 0.9 * m and abs(Ee.min() / m - 1) < 0.1
+        if m == 1.0 and Lx == 64:
+            b3row = "E_w = %+.6f (x2), ends at %.6f" % (Ew[3], Ee.min())
+check("B3 [1e-9] the SINGLE wall of the open slab carries four states too, 2 at +E_w and 2 at "
+      "-E_w, ends separate at |E| ~ m; L_x = 32, 64, m = 0.5, 1, 2 (L=64, m=1: %s)"
+      % b3row, ok_b3)
+
+print("   decay length [fits]:  m | sharp | w=4 | xi = 2/arccosh(1+m^2/2)")
+ok_b4 = True
+dens = {}
+for m in (0.5, 1.0, 2.0):
+    row = []
+    for tag, mv in (("sharp", sharp(64, m)), ("res", resolved(64, m, 4))):
+        _, _, _, VA, _ = split_walls(64, mv)
+        n = (np.abs(VA.reshape(64, 4, 4)) ** 2).sum(axis=(1, 2)) / 4.0
+        dens[(tag, m)] = n
+        d = np.abs(np.arange(64) - 31.5)
+        sel = (d >= 4.5) & (d <= 14.5) & (n > 1e-14)
+        row.append(-2.0 / np.polyfit(d[sel], np.log(n[sel]), 1)[0])
+    xi = 2.0 / np.arccosh(1 + m * m / 2)
+    print("     m=%.1f  %.4f  %.4f  %.4f  (%+.2f per cent)"
+          % (m, row[0], row[1], xi, 100 * (row[1] / xi - 1)))
+    ok_b4 = ok_b4 and abs(row[1] / xi - 1) < 0.031 and abs(row[0] / xi - 1) < 0.25
+check("B4 [fits] the mode is bound on the SEA'S OWN length: the resolved wall's fitted length "
+      "matches xi(m) to 3.1 per cent at m = 0.5, 1, 2", ok_b4)
+
+fr = {k: float(v[27:37].sum()) for k, v in dens.items()}
+fl = {k: (float(v[30] / v[29]), float(v[31] / v[30])) for k, v in dens.items()}
+check("B5 [numerical] within 4.5 coarse sites lie %.1f / %.1f per cent of the density (sharp / "
+      "resolved) at m = 1, %.1f / %.1f at m = 2, %.1f / %.1f at m = 0.5; and at m = 1 the sharp "
+      "profile is PAIR-FLAT about the seam, n(30)/n(29) = %.4f with a step n(31)/n(30) = %.3f per "
+      "pair, against %.3f and %.3f resolved"
+      % (100 * fr[("sharp", 1.0)], 100 * fr[("res", 1.0)], 100 * fr[("sharp", 2.0)],
+         100 * fr[("res", 2.0)], 100 * fr[("sharp", 0.5)], 100 * fr[("res", 0.5)],
+         fl[("sharp", 1.0)][0], fl[("sharp", 1.0)][1], fl[("res", 1.0)][0], fl[("res", 1.0)][1]),
+      fr[("sharp", 1.0)] > 0.97 and fr[("res", 1.0)] > 0.96 and fr[("sharp", 2.0)] > 0.99
+      and abs(fl[("sharp", 1.0)][0] - 1) < 1e-6 and fl[("sharp", 1.0)][1] > 5.0
+      and fl[("res", 1.0)][1] < 1.5)
+
+vs = []
+ok_b6 = True
+for tag, mk in (("sharp", lambda m: sharp(64, m)), ("res", lambda m: resolved(64, m, 4))):
+    for m in (0.5, 1.0, 2.0):
+        mv = mk(m)
+        E0 = float(np.abs(np.linalg.eigvalsh(build_slab(64, np.pi, np.pi, mv))).min())
+        for dv in ((1, 0), (0, 1), (1, 1)):
+            ps = np.array([0.02, 0.04, 0.06, 0.08])
+            Es = np.array([np.abs(np.linalg.eigvalsh(
+                build_slab(64, np.pi + p * dv[0], np.pi + p * dv[1], mv))).min() for p in ps])
+            pn = ps * np.sqrt(dv[0] ** 2 + dv[1] ** 2)
+            v = np.sqrt(max(np.polyfit(pn ** 2, Es ** 2 - E0 ** 2, 1)[0], 0.0))
+            vs.append(v)
+            ok_b6 = ok_b6 and abs(v - 1.0) < 3e-3
+check("B6 [fits] a 2+1D CONE at (pi,pi) of the wall's own zone: fitted velocity %.4f to %.4f "
+      "along q_y, q_z and the diagonal, m = 0.5, 1, 2, both profiles -- isotropic, m-independent, "
+      "the bulk velocity 1 (the shortfall is the fit's O(p^2) truncation)"
+      % (min(vs), max(vs)), ok_b6)
+
+# ================================================ C -- the wall band is gapped
+
+print("   m | E_w(L=32) | E_w(L=64) | sqrt(1+m^2)-1 | w=4 | w=8 | bulk")
+ok_c1 = ok_c2 = True
+for m in (0.25, 0.5, 1.0, 2.0):
+    e32 = float(np.abs(np.linalg.eigvalsh(build_slab(32, np.pi, np.pi, sharp(32, m)))).min())
+    e64 = float(np.abs(np.linalg.eigvalsh(build_slab(64, np.pi, np.pi, sharp(64, m)))).min())
+    r4 = float(np.abs(np.linalg.eigvalsh(build_slab(64, np.pi, np.pi, resolved(64, m, 4)))).min())
+    r8 = float(np.abs(np.linalg.eigvalsh(build_slab(64, np.pi, np.pi, resolved(64, m, 8)))).min())
+    cf = np.sqrt(1 + m * m) - 1
+    print("     %.2f  %.6f %.6f %.6f  %.1e %.1e  %.2f" % (m, e32, e64, cf, r4, r8, m))
+    ok_c1 = ok_c1 and abs(e32 - cf) < 1e-6 and abs(e64 - cf) < 1e-6 and cf < m
+    ok_c2 = ok_c2 and r4 < 2e-3 * cf and r8 < 1.1e-6
+check("C1 [fit, 1e-6] E_w = sqrt(1 + m^2) - 1 to six decimals at m = 0.25, 0.5, 1, 2, IDENTICAL "
+      "at L_x = 32 and 64: the sharp band is gapped by 2(sqrt(1+m^2) - 1), inside the bulk gap 2m "
+      "but not zero, not a hybridisation", ok_c1)
+check("C2 [numerical] a supplied mass PASSING THROUGH ZERO restores zero modes: at w = 4 the gap "
+      "falls three to five orders (under 1e-6 for m <= 0.5), at w = 8 to 1.0e-6 or less at every "
+      "m: the gap is the fault's", ok_c2)
+
+# =========================================== D -- no chirality on the record wall
+
+print("   L=64:  m | <W> sharp A / B | <W> w=4 A / B | 1/sqrt(1+m^2)")
+mx = 0.0
+ok_d2 = True
+for m in (0.5, 1.0, 2.0):
+    got = {}
+    for tag, mv in (("sharp", sharp(64, m)), ("res", resolved(64, m, 4))):
+        _, _, VB, VA, _ = split_walls(64, mv)
+        wA = herm_eigs(cell_matrix(VA, 64, WWALL))
+        wB = herm_eigs(cell_matrix(VB, 64, WWALL))
+        mx = max(mx, float(np.abs(herm_eigs(cell_matrix(VA, 64, XCHI))).max()),
+                 float(np.abs(herm_eigs(cell_matrix(VB, 64, XCHI))).max()))
+        ok_d2 = ok_d2 and np.ptp(wA) < 1e-9 and np.ptp(wB) < 1e-9 \
+            and abs(wA[0] + wB[0]) < 1e-7 and wA[0] > 0.4
+        got[tag] = (float(wA[0]), float(wB[0]))
+    ok_d2 = ok_d2 and abs(got["sharp"][0] - 1 / np.sqrt(1 + m * m)) < 1e-6
+    print("     %.1f  %+.6f / %+.6f  %+.6f / %+.6f  %.6f"
+          % (m, got["sharp"][0], got["sharp"][1], got["res"][0], got["res"][1],
+             1 / np.sqrt(1 + m * m)))
+check("D1 [1e-12] NO CHIRALITY ON THE WALL: <X> = 0 on all four modes of every wall, m = 0.5, 1, "
+      "2, both profiles, worst %.1e -- forced by {W, X} = 0"
+      % mx, mx < 1e-12)
+check("D2 [fit, 1e-7] <W> = +-1 IN SIGN, opposite on the two walls, constant across each wall's "
+      "four modes -- the index count; magnitude 1/sqrt(1 + m^2) sharp (a fit, to 1e-6)", ok_d2)
+
+print("   H|wall = (G_1 X)(x)(n.F):  m | singlet | |n| | E_w | residual")
+ok_d3 = ok_d4 = True
+for m in (0.5, 1.0, 2.0):
+    Hs, _, VB, VA, _ = split_walls(64, sharp(64, m))
+    coeff, resid = [], []
+    for Vw in (VA, VB):
+        Hw = Vw.conj().T @ Hs @ Vw
+        ops = [MASS2D] + [MASS2D @ F for _, F in FB]
+        cs = np.array([float(np.real(np.trace(Hw @ cell_matrix(Vw, 64, O)))) / 4 for O in ops])
+        rec = sum(c * cell_matrix(Vw, 64, O) for c, O in zip(cs, ops))
+        coeff.append(cs)
+        resid.append(float(np.abs(Hw - rec).max()))
+        ok_d4 = ok_d4 and all(abs(herm_eigs(cell_matrix(Vw, 64, F)).sum()) < 1e-9 for _, F in FB)
+    nA, nB = coeff[0][1:], coeff[1][1:]
+    sing = max(abs(coeff[0][0]), abs(coeff[1][0]))
+    ok_d3 = ok_d3 and sing < 1e-12 and float(np.abs(nA + nB).max()) < 1e-12 \
+        and abs(np.linalg.norm(nA) - (np.sqrt(1 + m * m) - 1)) < 1e-6 and max(resid) < 1e-12
+    print("     %.1f  %.1e  %.6f  %.6f  %.1e"
+          % (m, sing, np.linalg.norm(nA), np.sqrt(1 + m * m) - 1, max(resid)))
+check("D3 [1e-12] the induced 2+1D mass is H|wall = (G_1 X) (x) (n . F) exactly, its "
+      "TASTE-SINGLET coefficient exactly zero on every wall at every m, |n| = E_w, n reversed "
+      "between the walls: NET PARITY ANOMALY ZERO", ok_d3)
+check("D4 [1e-9] the tastes LOCALIZE IDENTICALLY -- each F_b is traceless on each wall subspace "
+      "-- while the 2+1D mass splits them oppositely in parity", ok_d4)
+
+# ================================= E -- two orthogonal walls: a line, not a wire
+
+MG = {}
+for L in (24, 32):
+    g = np.zeros((L, L))
+    for x in range(L):
+        for y in range(L):
+            g[x, y] = (1.0 if x < L // 2 else -1.0) * (1.0 if y < L // 2 else -1.0)
+    MG[L] = g
+
+e24 = np.sort(np.abs(np.linalg.eigvalsh(build_line(24, np.pi, MG[24]))))[:10]
+w32, V32 = np.linalg.eigh(build_line(32, np.pi, MG[32]))
+e32 = np.sort(np.abs(w32))[:10]
+check("E1 [1e-6] L = 24 and 32, m = 1, k_z = pi: the line binds an eightfold band at |E| = %.6f, "
+      "IDENTICAL at both sizes (%.1e), under the single-wall gap %.6f: intrinsic"
+      % (e32[0], abs(e24[0] - e32[0]), np.sqrt(2.0) - 1),
+      abs(e24[0] - e32[0]) < 1e-6 and float(np.ptp(e32[:8])) < 1e-6 and e32[0] < np.sqrt(2.0) - 1)
+
+print("   k_z dispersion:  dk | |E|(pi-dk) | |E|(pi+dk)")
+ok_e2 = True
+for dk in (0.08, 0.16):
+    a = float(np.abs(np.linalg.eigvalsh(build_line(24, np.pi - dk, MG[24]))).min())
+    b = float(np.abs(np.linalg.eigvalsh(build_line(24, np.pi + dk, MG[24]))).min())
+    print("     %.2f  %.6f  %.6f" % (dk, a, b))
+    ok_e2 = ok_e2 and abs(a - b) < 1e-9 and a > e24[0]
+check("E2 [1e-9] the band is EVEN in k_z about the node, rising from %.6f: dE/dk_z = 0 there, so "
+      "NO LEFT OR RIGHT MOVERS on the line -- two orthogonal walls bind a massive band, not a "
+      "chiral wire" % e24[0], ok_e2)
+
+gr = np.zeros((24, 24))
+for x in range(24):
+    for y in range(24):
+        gr[x, y] = (np.tanh((11.5 - x) / 3.0) * np.tanh((x + 0.5) / 3.0) * np.tanh((23.5 - x) / 3.0)
+                    * np.tanh((11.5 - y) / 3.0) * np.tanh((y + 0.5) / 3.0) * np.tanh((23.5 - y) / 3.0))
+z0 = float(np.abs(np.linalg.eigvalsh(build_line(24, np.pi, gr))).min())
+z1 = float(np.abs(np.linalg.eigvalsh(build_line(24, np.pi + 0.1, gr))).min())
+check("E3 [numerical] with the mass RESOLVED (w = 3) the crossing carries only the massless "
+      "wall-plane cones -- |E| = %.1e at the node, %.6f at k_z - pi = 0.1" % (z0, z1),
+      z0 < 1e-4 and abs(z1 - 0.1) < 2e-3)
+
+o32 = np.argsort(np.abs(w32))[:8]
+p = (np.abs(V32[:, o32].reshape(32, 32, 2, 8)) ** 2).sum(axis=(2, 3)) / 8.0
+
+
+def dline(c):
+    d = np.abs(np.arange(32) - c)
+    return np.minimum(d, 32 - d)
+
+
+dx = np.minimum(np.minimum(dline(-0.5), dline(31.5)), dline(15.5))
+msk = np.outer(dx < 1.5, dx < 1.5)
+enh = float(p[msk].sum()) / (msk.sum() / 32.0 ** 2)
+check("E4 [numerical] the line does bind: the band density is enhanced %.1f-fold within 1.5 "
+      "coarse sites of the four intersection lines (L = 32), %.1f per cent on %d of 1024 cells" % (enh, 100 * p[msk].sum(), msk.sum()), enh > 10.0)
+
+print("SUMMARY: four localized 2+1D Dirac modes per wall per node, on xi(m) at velocity 1; a "
+      "sharp wall is a stacking fault, gapping them by 2(sqrt(1+m^2)-1); none of it is chiral; "
+      "two walls bind a massive band.")
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache on the first weak-sector probe: **does a record wall in the sign of the record-native staggered mass carry localized matter, and is any of it chiral?** It carries localized 2+1D Dirac matter: four modes per wall per node (two two-component Dirac fermions, one per taste), a cone at `(pi, pi)` of the wall's zone with the bulk velocity, bound on the sea's own decay length `xi(m)`. But a sharp wall in a staggered mass is a **stacking fault** (reversing the sign is a one-site translation of the alternating pattern, `eps_{v+e_x} = -eps_v`), so no plane carries a vanishing mass and the wall band is gapped by `2(sqrt(1 + m^2) - 1)` (a fit to six decimals at four masses, `L_x`-independent); only a supplied profile passing through zero carries exact zero modes. **None of it is chiral:** `<X> = 0` on every wall mode (forced by the exact `{W, X} = 0`), the two walls carry opposite wall-chirality and opposite taste-non-singlet parity masses with the taste-singlet part exactly zero, and two orthogonal walls bind a massive band on their line with no chiral wire. Stated plainly in the note: record walls in this mass supply no handedness on the geometries computed; the four-dimensional chiral route is a wall in a fifth dimension the lattice does not have, named as an interface.

- `docs/RECORD_WALLS_IN_THE_STAGGERED_MASS_CARRY_LOCALIZED_2P1D_DIRAC_MATTER_VECTOR_LIKE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (319 lines)
- `scripts/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.py` (`TOTAL: PASS=22 FAIL=0`, 8.4 s; exact cell-algebra identities at residual 0; slabs by exact `1x2x2` Bloch blocking)
- `logs/runner-cache/record_walls_staggered_mass_localized_2p1d_matter_check_2026_09_03.txt`

## Theorems

- **T1** the stacking-fault identity and the exact algebra: `W = i Gamma_1 Eps = -(X x Z x Z)`, `{W, X} = 0`; the transverse cell reproduces the torus and PR #7890's dispersion.
- **T2** localized matter: four modes per wall per node on periodic and open slabs (`L_x = 32, 64`), decay length within `3.1 %` of `xi(m)`, cone velocity `0.9997`.
- **T3** the wall gap `2(sqrt(1 + m^2) - 1)` (fit), restored zero modes for a profile through zero (`w = 8` at every mass tested).
- **T4** no chirality: `<X> = 0`; `<W> = +-1/sqrt(1 + m^2)`, opposite on the two walls; `H|wall = (Gamma_1 X) x (n . F)` with taste-singlet coefficient `<= 5e-20` and `n` reversed between walls (taste commutant enumerated exactly).
- **T5** two orthogonal walls: a massive line band (`0.317837` at `L = 24, 32`, even in `k_z`), `11.2x` density enhancement, no left or right movers.

## Boundary

- One-particle; coarse lattice; named finite slabs; `t = -1` a stated convention; the mass value, sign field and profile supplied; closed forms are fits; three orthogonal walls not computed; executor corrections kept (concentration and decay-length numbers at `m = 0.5`; `w = 4` versus `w = 8`; open-slab convergence at `L_x = 32`).

## Context

- Parents: PR #7890 (the mass; its T2 is the reason a sharp wall is a stacking fault), PR #7888 (the Dirac point and cell algebra), PR #7894 (the mass as the parity matrix), PR #7892, PR #7844, PR #7834.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03); the weak-sector lane's first computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
