### PR TITLE
feat(matter): interaction generates the staggered mass, its sign registered

### DIFF
--- a/docs/THE_INTERACTION_GENERATES_THE_STAGGERED_MASS_AT_HARTREE_LEVEL_AND_NO_TERM_IN_THE_LAW_FIXES_ITS_SIGN_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_INTERACTION_GENERATES_THE_STAGGERED_MASS_AT_HARTREE_LEVEL_AND_NO_TERM_IN_THE_LAW_FIXES_ITS_SIGN_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,329 @@
+---
+claim_id: interaction_generates_staggered_mass_hartree_sign_registered
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3, one fermionic mode per coarse vertex, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2} read on that lattice, for the ONE DECLARED record-conserving nearest-neighbour law H(t,V) = -t sum_bonds eta_ij (c_i^dag c_j + h.c.) + V sum_bonds n_i n_j at t = 1 and at half filling, whose coupling V is supplied and whose grading eps_v = (-1)^{v_1+v_2+v_3} is a supplied corner label, and on the named finite clusters and tori only: (T1) the Hartree decoupling of V sum_<ij> n_i n_j under the staggered ansatz <n_i> = 1/2 + eps_i O, O = (1/N) sum_v eps_v (<n_v> - 1/2), gives at residual 0.0e+00 sum_{j in nn(i)} <n_j> = z(1/2 - eps_i O) with z = 6 and hence exactly H_MF = H_0 + m* sum_v eps_v n_v + const with m* = -z V O, the generated one-body term being character for character the declared mass operator H_m of the record-native staggered mass note and the subtracted constant depending on O only through O^2; substituting that note's own T5 response O(m) = -(m/2) c(m), c(m) = [(M^2 + m^2)^{-1/2}]_vv, re-verified here on the antiperiodic 8^3 torus at m = 0.3 (-0.066175285) and m = 1.0 (-0.200251524) to 5.6e-17, closes the self-consistency into the gap equation 1 = (zV/2) c(m*) and V_c^MF = 2/(z c(0)); with c(m) evaluated in closed 1-D form from <e^{-s(6+2 sum_a cos q_a)}>_BZ = (e^{-2s} I_0(2s))^3 (checked against a 64^3 midpoint grid to 3.3e-16), c(0) = 0.455344052, so chi = c(0)/2 = 0.227672 against that note's 0.227671, and V_c^MF = 0.732047 t, approached from above by the antiperiodic tori L = 8, 12, 16 at 0.747072, 0.738124, 0.735366. (T2) The three-dimensional Dirac density of states vanishes quadratically, so c(0) - c(m) ~ A m^2 ln(1/m) + B m^2 -- the ratio (c0 - c(m))/(m^2 ln(1/m)) reads 0.0399, 0.0444, 0.0501 at m = 0.02, 0.05, 0.1 -- and the gap equation gives m* ~ sqrt((V - V_c)/|ln(V - V_c)|), i.e. beta = 1/2 with a logarithm and not 1: beta_eff = dln m*/dln(V - V_c) drifts monotonically 0.5991 -> 0.5378 as (V - V_c) goes 1e-1 -> 1e-5. At V = 2, 4, 6 t the Hartree state is the classical checkerboard, m*/3V = 0.915, 0.979, 0.991 and 2m* = 10.98, 23.50, 35.67 t against a free bandwidth 2 sqrt12 = 6.928 t, with xi = 0.58, 0.40, 0.35 coarse units, below one spacing; the window in which a generated Dirac mass has any meaning is 0.732 < V <~ 1.0 t, where m* = 0.365 to 1.877 t and xi = 5.51 down to 1.19 coarse units. Every statement in T1 and T2 about a threshold, an exponent or an ordered state is MEAN-FIELD and is not a proved transition. (T3) On the open 2x2x2 cube (uniform degree 3, 12 bonds, every face flux -1, half-filling dimension 70, exact) and the 2x2x4 slab periodic in z (uniform degree 4, 32 bonds, every face flux -1, dimension 12870, sparse Lanczos in each C sector), with C the charge conjugation of the conjugation note: C^2 = I, [C, H_0] = 0 and d(~b) - d(b) = 0 on every basis state, all at 0.0e+00, and the free ground energy of the cube is -6.928203 = -4 sqrt3, bridging that note's encoded value; at every V tested the ground state is C-even and the first excited state is its C-conjugate partner, gap = Delta_C to 1.2e-14, with Delta_C falling from 2 sqrt3 = 3.464102 (cube) and 2 sqrt2 = 2.828427 (slab) at V = 0 to 7.8163e-02 and 9.5445e-05 at V = 8 t; at V = 0 both clusters give S = <O^2> = 1/(2N) exactly and odds over O equal to Binomial(N/2, 1/2) exactly, so the free half-filled sea's staggered fluctuation is shot noise; the odds over O go bimodal, the cube at V = 8 t holding 0.472875 + 0.472875 on O = -1/2 and +1/2 against 0.004317 on O = 0 with the two staggered patterns carrying 0.945751 of the weight; chi = -d<O>/dh at h = 1e-4 t is size-flat at V = 0 (0.28868 -> 0.27884) and then explodes with size, 6.52 -> 717.3 at V = 4 t and 48.64 -> 4920.8 at V = 8 t from cube to slab; the S-doubling crossover falls with size, 2.03411 t (cube) -> 1.14065 t (slab); and the two-size crossing of S is V_x = 1.76598 t against V_c^MF = 0.732047 t, mean field low by a factor 2.41. Two cluster sizes, no error bar, no extrapolation. (T4) The sign is registered, not supplied: +-m* are exactly degenerate at Hartree level, E_MF(+m*) - E_MF(-m*) = 4.5e-13, 0.0e+00, 0.0e+00 at V = 2, 4, 6 t on the antiperiodic 8^3 with O(+m*) = -O(-m*), the Hartree functional holding O only through O^2; in every finite cluster <O> = 0 at h = 0 to 1e-9 while <O^2> = 0.1235 to 0.2439; a supplied field h sum_v eps_v n_v -- the parent note's own term -- selects the sign singularly, h = -+0.001 t already saturating <O> at +0.492970 / -0.492970 on the slab at V = 8 t; O is a signed version of the conjugation note's Q, the same six-bit corner-parity readout weighted by the supplied label eps_v, record-diagonal, taking 5 and 9 record-readable values on cube and slab and obeying C: O -> -O entry by entry at 0.0e+00, while Q itself is identically 0 in this sector; and C H(t,V) C^-1 = H(t,V) exactly at V = 1, 3 t on both clusters while C H_m C^-1 = -H_m exactly, so the law, holding only t and V and both of them eps-even, fixes |m*| through the gap equation and fixes its sign not at all. (T5) Two methodological facts are recorded: the OPEN 2x2x4 slab has degrees 3 and 4, so d(~b) - d(b) is not constant (9 values) and V itself breaks C there, C H C^-1 - H = 4.0 at V = 1 t, and no C-odd gap is definable on it, which is why periodic z is used throughout; and the PERIODIC 8^3 torus carries 8 exact zero modes, so c(0) diverges there and the gap equation returns V_c^MF = 0, a finite-size artefact, the antiperiodic sector with min|E| = 1.325654 at L = 8 carrying every mean-field number here and matching the parent note's own convention. The coupling V is supplied; the grading eps_v is a supplied corner label; the transition itself is a mean-field statement and no thermodynamic limit, no fluctuation correction, no Fock channel and no continuum is taken. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py
+---
+
+# The interaction generates the staggered mass at Hartree level, and no term in the law fixes its sign
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py`](../scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.txt`](../logs/runner-cache/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+A companion note writes a staggered mass for the coarse-lattice emergent fermion by hand: one alternating price at a coarse corner, `H_m = m sum_v eps_v n_v`, whose size and
+sign that note states plainly are supplied data. The matter already carries a record-conserving repulsion between neighbouring corners. Does that repulsion, acting on the
+half-filled sea, produce the very same operator -- and if it does, what then fixes the sign, given that the law holding `t` and `V` has no alternating term in it at all?
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact algebraic content plus exact finite-cluster diagonalisation about one declared two-parameter law: the Hartree identity that generates the companion note's mass operator character for character, the gap equation and its closed 1-D kernel, the exact C algebra and C-odd spectra of the 70- and 12870-dimensional half-filling sectors, the exact degeneracy of +-m*, and two recorded finite-size traps. Every threshold, exponent and ordered-state statement is MEAN-FIELD and is labelled as such; the two-size crossing is a two-point estimate. The tagged numerical items are floating-point cross-checks at the stated tolerance."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the science-level question it does not decide: whether the coupling V is itself supplied or registered, and what the true V_c is beyond Hartree."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. Groups `A1`, `C1`, `C3`, `D4`, `D5` and `E1` are exact -- zero-residual
+identities, sweeps over the whole half-filling basis, closed-form combinatorics -- and the items tagged `[numerical]` are floating-point cross-checks at the stated tolerance.
+Every statement about a threshold, a critical exponent or an ordered state is **mean-field**, labelled so wherever it appears; none is a proved transition.
+
+1. `T1` (`A`). The Hartree decoupling generates exactly the companion note's mass operator, with the gap equation and `V_c^MF = 0.732047 t`.
+2. `T2` (`B`). The mean-field exponent is `1/2` with a logarithm, and the window in which the generated object is a Dirac mass at all.
+3. `T3` (`C`). What the two exact clusters carry: the C-odd partner, the bimodal odds over `O`, the exploding susceptibility, and `V_x = 1.76598 t`.
+4. `T4` (`D`). The sign is registered, not supplied: `+-m*` exactly degenerate, `O` a signed `Q`, the law exactly C-even.
+5. `T5` (`E`). Two traps recorded: the open slab's non-uniform coordination, and the periodic torus's zero modes.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Kawamoto-Smit staggering, the Hartree decoupling of a nearest-neighbour repulsion, the Watson-type lattice integral and
+the Jordan-Wigner encoding of a spinless fermion on a finite cluster are standard methodology; every object is redeclared here and the runner recomputes every statement. No
+observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- `A_RECORD_NATIVE_STAGGERED_MASS_GAP_2M_EXPONENTIAL_KERNEL_AND_WHAT_IT_BREAKS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7890): the declared mass term `H_m = m sum_v eps_v
+  n_v`, its `T5` sea response `<n_v> = 1/2 - (m/2) eps_v c(m)` with `C(m) = -m c(m)/2` and slope `chi = c(0)/2 = 0.227671`, its `T6` length `xi = 2/arccosh(1 + m^2/2)`, its `T3`
+  statement that the periodic `8^3` torus carries 8 exact zero modes, and its statement that the size and the sign of `m` are supplied data. Every one of those objects is
+  redeclared below and recomputed by this runner.
+- `INTERACTION_KEEPS_THE_STAGGERED_SECTOR` (open PR #7878, branch `physics-loop/interaction-keeps-staggered-sector`): the record-conserving nearest-neighbour law, quoted here in
+  exactly its form, `H(t,V) = -t sum_bonds eta_ij (c_i^dag c_j + c_j^dag c_i) + V sum_bonds n_i n_j`, one term per bond and no double counting; the open `2x2x2` cube is its
+  group-A cluster.
+- `CHARGE_CONJUGATION_AND_THE_U1_CURRENT` (open PR #7892, branch `physics-loop/charge-conjugation-u1-current`): `C` with its table `n_v -> I - n_v`, `H_hop -> +H_hop`, `H_m ->
+  -H_m`, `Q -> -Q`, `C^2 = +I`; `Q = sum_v (n_v - 1/2)` read as a six-bit corner-parity count on all 4096 cube record patterns; and, verbatim, "the grading `eps_v` is a supplied
+  corner label and is unchanged".
+- `MATTER_ABOVE_THE_HALF_FILLED_SEA_..._NOTE_2026-09-03.md` (open PR #7879): the half-filled sea, `<n_v> = 1/2` at every site. `EMERGENT_FERMION_PI_FLUX_SECTOR_..._2026-09-02.md`
+  (PR #7844) and `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_..._2026-09-02.md` (PR #7834): the superlattice role pattern and the coarse sublattice `2Z^3`.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting". No grade of theirs is cited and no hypothesis is adopted.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has algebraic
+presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations", and "For
+each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." **Record**: "Records form", "a record locks
+exactly one admissible local possibility", "records are permanent", "Only records are readable."
+
+The lattice is physical. Everything below reads the Kawamoto-Smit sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, on the superlattice role
+pattern's sublattice. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras and no graded clause is used anywhere.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field on it, the
+two-parameter law `H(t,V)`, the grading `eps_v`, the order parameter `O`, the conjugation `C`, and the two finite clusters. `P1` (`A`) is the Hartree identity, the gap equation
+and its kernel; `P2` (`B`) the exponent and the window, both using `P1`; `P3` (`C`) the exact clusters, independent of `P1`; `P4` (`D`) the degeneracy and the readout, using
+`P1` and `P3`; `P5` (`E`) the two traps, on which `P1` and `P3` rely for their conventions. The strongest supported scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`. The **KS sign** of the coarse bond `(v, v + e_a)` is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`,
+`eta_3(v) = (-1)^{v_1 + v_2}`; every elementary face of both clusters used here carries flux `-1`.
+
+```text
+H(t,V) = -t sum_bonds eta_ij (c_i^dag c_j + c_j^dag c_i) + V sum_bonds n_i n_j     THE DECLARED LAW, read at t = 1
+eps_v  = (-1)^{v_1+v_2+v_3},   Eps = diag(eps_v),   M = the one-particle KS hopping matrix
+H_m    = m sum_v eps_v n_v        the companion note's declared mass term; its m is supplied
+O      = (1/N) sum_v eps_v (n_v - 1/2),   N = number of coarse vertices,   so H_m = m N O on every even block
+Q      = sum_v (n_v - 1/2)        the conjugation note's charge; identically 0 in the half-filling sector
+c(m)   = [(M^2 + m^2)^{-1/2}]_vv = (1/N) sum_k (E_k^2 + m^2)^{-1/2}
+m*     = -z V O,  z = 6           the SELF-CONSISTENT Hartree coefficient
+S      = <O^2>,   chi = -d<O>/dh at h = 1e-4 t, with the field term h sum_v eps_v n_v = h N O
+Delta_C = the gap to the lowest state of the opposite C sector
+```
+
+`C` is the charge conjugation of the conjugation note, `c_v -> eps_v c_v^dag`, realised here in the one-mode-per-vertex Fock space with Jordan-Wigner signs. `C` is exact on a
+cluster exactly when the conjugate interaction `V sum (1-n_i)(1-n_j)` differs from `V sum n_i n_j` by a constant at fixed particle number, which needs **uniform coordination**.
+The two clusters that satisfy it are the **cube** `2x2x2` open (`z_i = 3`, 12 bonds, `N = 4` particles, dimension `C(8,4) = 70`) and the **slab** `2x2x4`, open in `x, y` and
+**periodic in `z`** (`z_i = 4`, 32 bonds, `N = 8`, dimension `C(16,8) = 12870`).
+
+The **Bravyi-Kitaev superfast encoding is not carried here**; the probe works in the fermion language directly. That is legitimate for exactly the statements made, because the
+conjugation note already establishes `C H(t,m) C^-1 = H(t,-m)` on the encoded cube's code space with free ground energy `-4 sqrt3 = -6.928203`, which this runner reproduces at
+`V = 0`. That agreement is the bridge; nothing else is claimed about the encoding.
+
+## Theorem 1 -- the interaction generates exactly that mass operator
+
+**Conclusion.** (1) With `<n_i> = 1/2 + eps_i O` and uniform `z = 6`, every neighbour of a site lies on the opposite sublattice, so `sum_{j in nn(i)} <n_j> = z(1/2 - eps_i O)` at
+residual `0.0e+00`, and the decoupling `n_i n_j -> <n_i> n_j + n_i <n_j> - <n_i><n_j>` gives, exactly,
+
+```text
+V sum_<ij> n_i n_j  ->  (zV/2) Nhat  -  z V O sum_i eps_i n_i  +  const,     H_MF = H_0 + m* sum_v eps_v n_v + const,   m* = -z V O.
+```
+
+The generated one-body term, less its `eps`-even mean, is `m* eps_v` at residual `0.0e+00`: it is the companion note's `H_m` character for character, not a new operator. The
+subtracted constant is `(z N/2)(1/4 - O^2)` exactly, hence even in `O`. (2) The companion note's `T5` response `O(m) = -(m/2) c(m)` is re-verified on the antiperiodic `8^3`
+torus at `m = 0.3` and `m = 1.0`, giving `-0.066175285` and `-0.200251524` against the prediction to `5.6e-17`. (3) Substituting it into `m* = -zVO` closes the self-consistency:
+
+```text
+GAP EQUATION:   1 = (z V / 2) c(m*),   z = 6           V_c^MF = 2 / (z c(0))
+```
+
+(4) `c(m)` has the closed 1-D form `c(m) = (1/sqrt(pi)) int_0^inf ds s^{-1/2} e^{-s m^2} (e^{-2s} I_0(2s))^3`, whose kernel identity `<e^{-s(6 + 2 sum_a cos q_a)}>_BZ = (e^{-2s}
+I_0(2s))^3` agrees with a `64^3` midpoint grid to `3.3e-16`. It gives `c(0) = 0.455344052`, so `chi = c(0)/2 = 0.227672` against the companion note's `0.227671`, and
+
+```text
+V_c^MF = 2 / (6 * 0.455344052) = 0.732047 t          [MEAN FIELD]
+```
+
+approached from above by the antiperiodic tori: `0.747072` at `L = 8`, `0.738124` at `L = 12`, `0.735366` at `L = 16`.
+
+**Proof.** Item 1 is bond-by-bond arithmetic on the `4^3` coarse torus over every site and dyadic `O`, at residual `0.0e+00`; the bipartite structure is what reduces every
+neighbour sum to `z(1/2 - eps_i O)`. Item 2 diagonalises `M + m Eps` densely and reads the diagonal of the half-filled projector; item 3 is substitution; item 4 evaluates the
+proper-time representation of `(M^2 + m^2)^{-1/2}` and factorises the zone average over the three directions. Item 1 exact; 2 `[numerical, 1e-9]`; 4 `[numerical, 1e-12]`.
+
+**Reading, not theorem.** The mass need not be written into the law. Let the matter repel itself between neighbouring corners, and ask what the half-filled sea then does to
+itself: what comes back out of the arithmetic is not some new term but the alternating corner price the companion note wrote down by hand, with its coefficient no longer a
+number somebody chose but a number the self-consistency fixes.
+
+## Theorem 2 -- the exponent is `1/2` with a logarithm, and the window is narrow
+
+**Conclusion.** All of this theorem is **mean-field**; none of it is a proved transition. (1) The three-dimensional Dirac density of states vanishes **quadratically**, not
+linearly, so `c(0) - c(m) ~ A m^2 ln(1/m) + B m^2`: the ratio `(c(0) - c(m))/(m^2 ln(1/m))` reads `0.0399`, `0.0444`, `0.0501` at `m = 0.02, 0.05, 0.1`, drifting slowly upward
+exactly as a pure `m^2 ln(1/m)` law with a subleading `m^2` must. (2) Hence `m*^2 ln(1/m*) prop (V - V_c)` and `m* ~ sqrt((V - V_c)/|ln(V - V_c)|)`: `beta = 1/2` with a
+logarithmic correction. The effective exponent `beta_eff = dln m*/dln(V - V_c)` drifts monotonically `0.5991 -> 0.5378` as `(V - V_c)` goes `1e-1` down to `1e-5`, nowhere near
+`1`. (3) At `V = 2, 4, 6 t` the Hartree state is the **classical checkerboard**, not a massive Dirac fermion: `m*/3V = 0.915, 0.979, 0.991`, the gap `2m* = 10.98, 23.50, 35.67
+t` sits above the entire free bandwidth `2 sqrt12 = 6.928 t`, and `xi = 0.58, 0.40, 0.35` coarse units, below one lattice spacing. (4) The window where a generated **Dirac**
+mass has meaning is therefore `0.732 < V <~ 1.0 t`, where `m* = 0.365, 0.802, 1.397, 1.877 t` and `xi = 5.51, 2.56, 1.54, 1.19` coarse units at `V = 0.75, 0.8, 0.9, 1.0 t`.
+
+**Proof.** Item 1 evaluates the closed 1-D form at small `m` and takes the stated ratio. Item 2 solves the gap equation by bisection at nine values of `V - V_c` and reads the
+log-log slope between consecutive pairs. Items 3 and 4 read `m*`, `2m*` and the companion note's `xi = 2/arccosh(1 + m^2/2)` off the same solution and compare with the free
+bandwidth `2 sqrt(12)`. `[numerical]` throughout.
+
+**Reading, not theorem.** The threshold is real at this level of treatment, but the language of a light generated mass survives only just above it. Push the repulsion further
+and the sea stops being a sea: it settles onto one checkerboard outright, with a price larger than the whole range of energies the motion can supply and a length shorter than
+the distance between corners. Whatever that is, it is not a Dirac mass, and calling it one would be a misdescription.
+
+## Theorem 3 -- what the two exact clusters carry
+
+**Conclusion.** On the cube (uniform degree `3`, dimension `70`, exact) and the slab (uniform degree `4`, dimension `12870`, sparse Lanczos in each `C` sector), every
+elementary face carrying flux `-1`: (1) `C^2 = I`, `[C, H_0] = 0` and `d(~b) - d(b) = 0` on every basis state, all at `0.0e+00`, and the free cube energy is `-6.928203 = -4
+sqrt3`. (2) At every `V` tested the ground state is `C`-even and the **first excited state is its `C`-conjugate partner**: `gap = Delta_C` to `1.2e-14`, and `Delta_C` falls from
+`2 sqrt3 = 3.464102` (cube) and `2 sqrt2 = 2.828427` (slab) at `V = 0` to `7.8163e-02` and `9.5445e-05` at `V = 8 t`. (3) At `V = 0` both clusters give `S = 1/(2N)` exactly and
+the odds over `O` are `Binomial(N/2, 1/2)` exactly: the free half-filled sea's staggered fluctuation is shot noise. (4) The odds over `O` go bimodal: the cube at `V = 8 t` holds
+`0.472875 + 0.472875` on `O = -1/2` and `O = +1/2` against `0.004317` on `O = 0`, the two staggered patterns carrying `0.945751` of the weight. (5) `chi` is size-flat at `V = 0`, `0.28868 ->
+0.27884`, then explodes with size: `6.52 -> 717.3` at `V = 4 t` and `48.64 -> 4920.8` at `V = 8 t` from cube to slab; the `V = 8` slab value is saturation of the finite difference, not a
+slope. (6) The `S`-doubling crossover **falls** with size, `2.03411 t -> 1.14065 t`. (7) Since `S(V=0) = 1/(2N)` exactly, `S(slab) < S(cube)` while the state is disordered
+and `S(slab) > S(cube)` once the order grows with size; the crossing is `V_x = 1.76598 t`, against `V_c^MF = 0.732047 t` -- mean field low by a factor `2.41`.
+
+**Proof.** Both clusters are built over the whole half-filling occupation basis with Jordan-Wigner signs; `C` is a signed permutation of that basis, and item 1 is integer
+arithmetic over the whole basis. Item 2 projects `H` into the two `C` sectors and takes the two lowest levels of each. Items 3 to 7 read the ground vector: the odds over `O` are
+its weight in each `k`-block, `S` its second moment, `chi` a central difference at `h = 1e-4 t`, the crossings bisections. Item 1 exact; 3 `[numerical, 1e-12]`; 2, 4-7 `[numerical]`.
+
+**Reading, not theorem.** These are two very small boxes, and what a broken symmetry looks like from inside a small box is exactly this: a partner state that ought to be far
+away in energy comes down to meet the ground state and sits `10^-4` of a hop above it; the record patterns the state holds separate into two lumps with almost nothing between
+them; and the response to the faintest alternating price grows by two orders of magnitude when the box is doubled. None of that is the transition. It is the shadow the
+transition casts on a box of eight and a box of sixteen corners.
+
+## Theorem 4 -- the sign is registered, not supplied
+
+**Conclusion.** (1) `+-m*` are **exactly degenerate** at Hartree level: `E_MF(+m*) - E_MF(-m*) = 4.5e-13, 0.0e+00, 0.0e+00` at `V = 2, 4, 6 t` on the antiperiodic `8^3`, with
+`O(+m*) = -O(-m*)` to all digits. This is not numerical luck: the Hartree functional holds `O` only through `O^2` (Theorem 1), and `C` carries one solution onto the other. (2)
+In every finite cluster `<O> = 0` at `h = 0` to `1e-9`, while `<O^2>` runs `0.1235` to `0.2439`; `C` is exact, so the finite state is the even combination of the two staggered
+record patterns. (3) A **supplied** field `h sum_v eps_v n_v` -- the companion note's own term -- selects the sign, and singularly: on the slab at `V = 8 t`, `h = -+0.001 t`, a
+thousandth of a hop, already saturates `<O>` at `+0.492970 / -0.492970`, so `lim_{h->0^+} <O> = -1/2` while `<O>|_{h=0} = 0`. (4) `O` is a **signed** `Q`: the conjugation
+note's six-bit corner-parity readout weighted by the supplied corner label `eps_v`. It is record-diagonal, takes `5` and `9` record-readable values on cube and slab, and obeys
+`C: O -> -O` entry by entry at `0.0e+00`; `Q` itself is identically `0` in this sector, so it is `O` and not `Q` that carries the pattern. (5) The law holds only `t` and `V`,
+**both `eps`-even**: `C H(t,V) C^-1 = H(t,V)` exactly at `V = 1, 3 t` on both clusters, while `C H_m C^-1 = -H_m` exactly.
+
+**Proof.** Item 1 evaluates the Hartree energy at `+m*` and `-m*` on the `8^3` antiperiodic torus, sea term and `O^2` term separately. Item 2 is the ground-vector expectation.
+Item 3 adds `h N O` to the diagonal and re-solves. Items 4 and 5 are exact statements about signed permutations and diagonal operators on the whole half-filling basis, at
+residual `0.0e+00`. Items 1-3 `[numerical, 1e-9]`; items 4 and 5 exact.
+
+**Reading, not theorem.** What the law cannot do is choose which checkerboard. The two are exact mirror images under the exchange of matter and its absence, they cost precisely
+the same, and nothing written in `t` or in `V` distinguishes them, because neither of them changes sign when the two colours of corner are relabelled. So the choice is not
+delivered by the law; it is written in the records, and it is read off by the same six-bit count at each corner that already reads the charge. That is a registered pattern in
+guardrail G3's sense: the readout value is fixed by record content alone.
+
+## Theorem 5 -- two traps, recorded
+
+**Conclusion.** (1) The **open** `2x2x4` slab has degrees `3` and `4`. Its `d(~b) - d(b)` is therefore not constant -- it takes `9` values -- and `V` itself breaks `C` on it,
+`C H C^-1 - H = 4.0` at `V = 1 t`: no `C`-odd gap is definable there. Periodic `z` restores uniform degree `4`, keeps every face flux at `-1`, and is what Theorem 3 uses. The
+result of Theorem 3 is boundary-condition-dependent at this size. (2) The **periodic** `8^3` torus carries `8` exact zero modes -- the companion note's `T3` says so -- so `c(0)`
+diverges there and the gap equation returns `V_c^MF = 0`, a pure finite-size artefact. The **antiperiodic** sector, `min|E| = 1.325654` at `L = 8`, carries every mean-field
+number in this note, matching the companion note's own convention.
+
+**Proof.** Item 1 counts degrees, sweeps `d(~b) - d(b)` over the whole basis of the open cluster, and evaluates `C H C^-1 - H` directly. Item 2 diagonalises the periodic
+one-particle matrix and counts eigenvalues below `1e-10`. Item 1 exact; item 2 `[numerical, 1e-10]`.
+
+**Reading, not theorem.** Two ways of getting this wrong, written down so nobody repeats them. Leave the slab open and the repulsion is no longer blind to the exchange of
+matter and its absence, because the corners no longer all have the same number of neighbours, and the quantity being tracked stops existing; put the torus on the periodic grid
+and the massless energies include exact zeros, which make the threshold read as zero, an artefact of the grid and not a property of the lattice.
+
+## Corollary -- one supplied number traded for one supplied coupling and one registered bit
+
+Within the setting declared above, and on the finite clusters and tori named:
+
+1. **At Hartree level the interaction generates exactly the record-native mass operator**, with `V_c^MF = 0.732047 t`, `beta = 1/2` with a logarithm, and a two-size exact
+   crossing near `1.8 t`. The transition itself is a **mean-field statement**, not a proved one; the clusters show its finite-size signatures -- a `C`-odd quasi-degeneracy
+   collapsing with size, bimodal odds over `O`, a susceptibility exploding with size -- and finite-size signatures are not a proof.
+2. **The law contains no `eps`-odd term, so it fixes `|m*|` and cannot fix the sign.** Which checkerboard holds is read from the records: `O` is a signed `Q`, the same
+   corner-parity readout already landed, and its sign is a **registered** bit in guardrail G3's sense rather than a supplied datum.
+3. **The trade, stated exactly.** One supplied `m` -- a continuous magnitude and a sign -- is traded for one supplied `V` -- a magnitude and one sign -- plus one registered bit,
+   with `eps_v` still a supplied corner label. What becomes registered is the state's choice *relative to* that supplied labelling: one bit, not the whole of `m`.
+4. **The generated mass is a Dirac mass only in the window `0.732 < V <~ 1.0 t`.** Beyond it the Hartree state is the classical checkerboard, with `xi` below one coarse spacing
+   and a gap above the whole free bandwidth.
+
+**Reading, not theorem.** Let the matter repel itself between neighbouring corners. Above a threshold, the half-filled sea prefers to sit on one of the two checkerboards, and
+sitting on a checkerboard is exactly what the mass term of the earlier note describes. So the mass need not be written into the law; the matter can make it. What the law cannot
+do is choose which checkerboard: the two are exact mirror images under the exchange of matter and its absence, and the choice is written in the records, not in the law. That is
+the difference between a number the law supplies and a pattern the lattice registers.
+
+## What is not touched
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms; the coarse lattice, the sign field, the law `H(t,V)` and the grading are declared objects. `V`, `t` and `eps_v` are supplied, and no
+  update rule, formation site, formation rate, or absolute unit appears.
+- No thermodynamic limit is taken and no transition is proved; every threshold, exponent and ordered-state statement is mean-field. The taste classification of the generated
+  term is untouched, because that term is literally the companion note's `H_m` and not a new operator: nothing is added to or subtracted from that note's `T4`.
+
+## Interfaces named for other lanes, not moved here
+
+- **Fluctuations beyond Hartree, and the true `V_c`.** Hartree with a single staggered ansatz is what is done; the gap between `V_c^MF = 0.732 t` and the two-size estimate
+  `V_x = 1.766 t` is a factor `2.41`, and what narrows it belongs to whoever owns the many-body lane. **The Fock channel** -- the exchange decoupling of a spinless
+  nearest-neighbour `V`, which would shift `V_c^MF` -- is not carried here either.
+- **Larger clusters.** Two sizes, `8` and `16` coarse sites; a third would turn `V_x` from a two-point crossing into an extrapolation. **Whether `V` is registered or supplied**
+  is likewise open: this note trades a supplied `m` for a supplied `V`, and whether `V` is itself fixed by anything belongs to the lane that owns the dynamical clause.
+- **The sign's registration under a tick.** What is shown is that the law does not fix the sign and that the readout is record-diagonal. How the registered bit behaves under a
+  formation step is not shown here and is not claimed.
+
+## Remaining live routes
+
+1. Larger and differently shaped clusters, and a third size for the crossing.
+2. The Fock channel, and fluctuation corrections to the Hartree threshold.
+3. The encoded statement (everything here is in the fermion language, bridged only at `V = 0`) and other staggered orderings: only the `eps_v` ansatz is examined here.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one fermionic mode per coarse vertex, KS signs, half filling; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md; the law H(t,V) declared here with supplied t, V and supplied corner label eps_v
+hartree: sum_{j~i}<n_j> = z(1/2 - eps_i O) at 0.0e+00, z = 6; H_MF = H_0 + m* sum eps_v n_v + const with m* = -zVO, the companion note's H_m character for character; const = (zN/2)(1/4 - O^2), even in O
+response: O(m) = -(m/2)c(m) re-verified on antiperiodic 8^3 at m = 0.3 (-0.066175285) and 1.0 (-0.200251524) to 5.6e-17
+gap_equation: 1 = (zV/2) c(m*); c(m) = (1/sqrt pi) int ds s^-1/2 e^{-s m^2}(e^{-2s}I_0(2s))^3; kernel identity vs 64^3 grid 3.3e-16; c(0) = 0.455344052; chi = c(0)/2 = 0.227672 vs 0.227671; V_c^MF = 0.732047 t [MEAN FIELD]; L = 8, 12, 16 give 0.747072, 0.738124, 0.735366 from above
+exponent: (c0-c(m))/(m^2 ln(1/m)) = 0.0399, 0.0444, 0.0501 at m = 0.02, 0.05, 0.1; beta_eff drifts 0.5991 -> 0.5378 over (V-V_c) 1e-1 -> 1e-5; beta = 1/2 with a logarithm [MEAN FIELD]
+classical_regime: m*/3V = 0.915, 0.979, 0.991 and 2m* = 10.98, 23.50, 35.67 t at V = 2, 4, 6 t, above the bandwidth 2 sqrt12 = 6.928; xi = 0.58, 0.40, 0.35; Dirac window 0.732 < V <~ 1.0 t
+clusters: cube 2x2x2 open, degree 3, dim 70, exact; slab 2x2x4 periodic z, degree 4, dim 12870, Lanczos per C sector; all face fluxes -1; C^2 = I, [C,H_0] = 0, d(~b)-d(b) = 0 at 0.0e+00; free E_0(cube) = -6.928203 = -4 sqrt3
+c_odd_gap: gap = Delta_C to 1.2e-14 at every V on both clusters, ground state C-even; Delta_C 3.464102 -> 7.8163e-02 (cube), 2.828427 -> 9.5445e-05 (slab) by V = 8 t
+free_sea_and_bimodality: S(V=0) = 1/(2N) exactly and odds over O = Binomial(N/2, 1/2) exactly on both clusters (1.7e-16); cube at V = 8 t holds 0.472875 + 0.472875 on O = -+1/2 against 0.004317 on O = 0, staggered-pattern weight 0.945751
+susceptibility: chi 0.28868 -> 0.27884 (V = 0, size-flat), 6.52 -> 717.3 (V = 4), 48.64 -> 4920.8 (V = 8), cube -> slab, h = 1e-4 t
+crossings: S-doubling 2.03411 t (cube) -> 1.14065 t (slab); two-size S crossing V_x = 1.76598 t vs V_c^MF = 0.732047 t, factor 2.41; two sizes, no error bar
+degeneracy: E_MF(+m*) - E_MF(-m*) = 4.5e-13, 0.0e+00, 0.0e+00 at V = 2, 4, 6 t on antiperiodic 8^3, O(+m*) = -O(-m*); <O> = 0 at h = 0 to 1e-9 on both clusters while <O^2> = 0.1235 to 0.2439; h = -+0.001 t saturates <O> at +0.492970 / -0.492970 on the slab at V = 8 t
+readout: O is a signed Q, record-diagonal, 5 and 9 record-readable values, C: O -> -O entry by entry at 0.0e+00; Q identically 0 in this sector
+law_parity: C H(t,V) C^-1 = H(t,V) at 0.0e+00 (V = 1, 3 t, both clusters); C H_m C^-1 = -H_m at 0.0e+00; the law fixes |m*| and not the sign
+traps: open 2x2x4 degrees {3,4}, d(~b)-d(b) takes 9 values, C H C^-1 - H = 4.0 at V = 1 t; periodic 8^3 has 8 exact zero modes so V_c^MF = 0 is an artefact; antiperiodic min|E| = 1.325654 at L = 8 used throughout
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=23 FAIL=0
+```
+
+## Proof boundary
+
+**Mean field for the transition.** `V_c^MF`, `m*(V)`, `beta` and the ordered-state language of Theorems 1 and 2 are Hartree results within a single staggered ansatz. No
+fluctuation correction is applied, no Fierz ambiguity is discussed, and the exchange (Fock) channel of the spinless nearest-neighbour `V` is not decoupled and would shift
+`V_c^MF`. Nothing here proves a transition, and none of these numbers is offered as one.
+
+**Exact only on two clusters.** The cube of `8` coarse sites and the slab of `16`. The crossing `V_x = 1.76598 t` is a **two-point estimate** with no error bar and no
+extrapolation, and the finite-size signatures of Theorem 3 are signatures, not proofs.
+
+**The slab needs periodic `z`.** On the open `2x2x4` the coordination is non-uniform and `V` itself breaks `C`; no `C`-odd gap exists there. Theorem 3 is
+boundary-condition-dependent at this size, by Theorem 5.
+
+**Coarse lattice, fermion language.** Everything is on `2Z^3`, one mode per coarse vertex, with Jordan-Wigner signs; the Bravyi-Kitaev superfast encoding is not carried, only bridged at `V = 0` against the conjugation note's `-4 sqrt3`.
+
+**`V` is supplied.** The probe trades a supplied `m` (magnitude and sign) for a supplied `V` (magnitude, one sign) plus one registered bit; it derives neither `V` nor `t`. And
+**`eps_v` remains supplied** -- the conjugation note says so verbatim -- so the registered object is one bit relative to that label.
+
+**No continuum.** `xi` is quoted in coarse-lattice units and is below one lattice spacing at every `V` in the classical regime; no continuum Dirac limit is taken and none is
+claimed. **No axiom is touched:** nothing here is derived from an axiom, no status is set, no hypothesis is adopted.
+
+## Review record
+
+An honest auditor should come away with: one declared two-parameter law, decoupled at Hartree level on the named tori, shown at residual zero to generate the companion note's
+declared mass operator character for character with a self-consistent coefficient `m* = -zVO` fixed by `1 = (zV/2) c(m*)`; and shown, exactly, that the law holds nothing that
+is odd under the exchange of the two corner colours, so that it fixes `|m*|` and the sign not at all. What the sign then is, is a pattern the records carry, read by the same
+six-bit corner count that already reads the charge -- one registered bit, relative to a corner label that stays supplied.
+
+The auditor should also come away with the limits stated as plainly. The threshold `V_c^MF = 0.732047 t`, the exponent `beta = 1/2` with a logarithm, and every ordered-state
+statement are mean-field, and none of them is a transition proved. The exact evidence is two clusters, of `8` and `16` coarse sites, whose crossing `V_x = 1.76598 t` is a
+two-point estimate; mean field sits low by a factor `2.41`. The `16`-site result depends on periodic `z`, for the reason Theorem 5 records. And the generated object earns the
+name Dirac mass only in `0.732 < V <~ 1.0 t`; above that window it is the classical checkerboard, with a correlation length below one coarse spacing. This note is
+self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the pointers in "Imports and authority" carry no grade
+and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=23 FAIL=0`, runtime under the declared `120` seconds, stdout under `5500` characters,
+and passing pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.txt
+++ b/logs/runner-cache/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py
+runner_sha256: 7359039b174df5dd10026107a6b4c6a1ec3793e2da70f3f8451ff0907ca75cd0
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 12.32
+status: ok
+----- stdout -----
+PASS A1 [exact] torus 4^3, z = 6: sum_{j~i}<n_j> = z(1/2 - eps_i O), so Hartree gives exactly H_MF = H_0 + m* sum eps_v n_v + const, m* = -zVO: the parent note's mass operator, the const even in O (0.0e+00)
+PASS A2 [1e-9] antiperiodic 8^3: the parent note's T5 response O(m) = -(m/2)c(m), c(m) = [(M^2+m^2)^-1/2]_vv, holds at m = 0.3 (-0.066175285) and 1.0 (-0.200251524), residual 5.6e-17
+PASS A3 [1e-12] closed 1-D form: <e^{-s(6+2 sum cos q_a)}>_BZ = (e^{-2s}I_0(2s))^3 on a 64^3 grid at s = 0.1, 0.5, 2 (3.3e-16), so c(m) = (1/sqrt pi) int ds s^-1/2 e^{-s m^2}(e^{-2s}I_0(2s))^3
+PASS A4 [numerical] c(0) = 0.455344052, chi = c(0)/2 = 0.227672 vs the parent note's 0.227671, V_c^MF = 2/(z c(0)) = 0.732047 t [mean field]; L = 8, 12, 16 give 0.747072, 0.738124, 0.735366, from above
+PASS A5 [1e-9] the gap equation 1 = (zV/2)c(m*) and the self-consistency m* = -zVO(m*) close on one root at V = 0.8, 1, 2, 4 t (1.8e-15); below V_c^MF only m* = 0
+PASS B1 [numerical] the 3-D Dirac density of states vanishes QUADRATICALLY, so c(0)-c(m) ~ A m^2 ln(1/m) + B m^2: (c0-c(m))/(m^2 ln(1/m)) = 0.0399, 0.0444, 0.0501 at m = 0.02, 0.05, 0.1
+PASS B2 [numerical] hence m*^2 ln(1/m*) prop (V-V_c): beta_eff = dln m*/dln(V-V_c) drifts 0.5991 -> 0.5378 over (V-V_c) 1e-1 -> 1e-5 [mean field]: beta = 1/2 with a logarithm, not 1
+PASS B3 [numerical] at V = 2, 4, 6 t the Hartree state is the CLASSICAL checkerboard: m*/3V = 0.915, 0.979, 0.991; 2m* = 10.98, 23.50, 35.67 t above the bandwidth 6.928; xi = 0.58, 0.40, 0.35, below one spacing
+PASS B4 [numerical] so a generated DIRAC mass has meaning only in 0.732 < V <~ 1.0 t: m* = 0.365, 0.802, 1.397, 1.877 and xi = 5.51, 2.56, 1.54, 1.19 at V = 0.75, 0.8, 0.9, 1 t
+  Hartree mean field, antiperiodic tori (not a proved transition):
+     V    m*(inf)     2m*    O=-m*c/2    xi
+   0.732  0.000000  0.000000  0.000000      inf
+   0.800  0.802440  1.604881 -0.167175   2.5564
+   1.000  1.876516  3.753032 -0.312753   1.1947
+   2.000  5.488652 10.977303 -0.457388   0.5766
+PASS C1 [exact] cube 2x2x2 open (degree 3, dim 70) and slab 2x2x4 periodic z (degree 4, dim 12870), every face flux -1: C^2 = I, [C,H_0] = 0, d(~b)-d(b) = 0 on all basis states (0.0e+00); free E_0(cube) = -6.928203 = -4 sqrt3
+PASS C2 [1e-9] on BOTH clusters at every V the first excited state is the C-conjugate partner: gap = Delta_C to 1.2e-14, ground state C-even; Delta_C falls to 7.8163e-02 (cube) and 9.5445e-05 (slab) by V = 8 t
+  exact clusters, C-resolved; O = (1/N) sum eps_v (n_v - 1/2), S = <O^2>:
+     V  E0(cube) Delta_C(c)  S(cube)  E0(slab) Delta_C(s)  S(slab)
+    0.0 -6.928203 3.4641e+00 0.062500 -15.454813 2.8284e+00 0.031250
+    2.0 -3.538207 1.5382e+00 0.123521 -5.526154 4.3541e-01 0.138291
+    4.0 -1.776766 4.8526e-01 0.199939 -2.669957 9.7748e-03 0.225239
+    8.0 -0.795961 7.8163e-02 0.239558 -1.333152 9.5445e-05 0.243913
+PASS C3 [1e-12] the free half-filled sea's staggered fluctuation is shot noise: at V = 0 both clusters give S = 1/(2N) exactly (1/16, 1/32) and odds over O of Binomial(N/2, 1/2) exactly (1.7e-16)
+PASS C4 [numerical] the odds over O go bimodal: cube at V = 8 t, 0.4729 + 0.4729 on O = -1/2 and +1/2 against 0.0043 on O = 0; the two staggered patterns carry 0.945751 of the weight
+PASS C5 [numerical, h = 1e-4 t] chi = -d<O>/dh is size-flat at V = 0 (0.28868 -> 0.27884) and explodes with size once V grows: 6.52 -> 717.3 at V = 4, 48.64 -> 4920.8 at V = 8 t (cube -> slab), the last already saturation
+PASS C6 [numerical] the S-doubling crossover FALLS with size: V* = 2.03411 t (cube, N = 8) -> 1.14065 t (slab, N = 16)
+PASS C7 [numerical] S(V=0) = 1/(2N), so S(slab) < S(cube) while disordered and S(slab) > S(cube) once order grows with size: two-size crossing V_x = 1.76598 t against V_c^MF = 0.732047 t, 2.41x. Two sizes, no error bar
+PASS D1 [1e-9] +-m* are EXACTLY degenerate at Hartree level: E_MF(+m*) - E_MF(-m*) = 4.5e-13, 0.0e+00, 0.0e+00 at V = 2, 4, 6 t on the antiperiodic 8^3, O(+m*) = -O(-m*); the functional holds O only through O^2
+PASS D2 [1e-9] in every finite cluster <O> = 0 at h = 0 while <O^2> is large: <O> = -1.5e-16 / 5.3e-13 against <O^2> = 0.1999 / 0.2252 (cube / slab, V = 4 t); C is exact, so the state is the even combination
+PASS D3 [numerical] a SUPPLIED field h sum_v eps_v n_v selects the sign, singularly: slab at V = 8 t, h = -+0.001 t saturates <O> at +0.492970 / -0.492970, while <O>|_{h=0} = 0
+PASS D4 [exact] O is a SIGNED Q: the conjugation note's six-bit corner-parity readout weighted by the supplied label eps_v. Record-diagonal, 5 and 9 readable values, C: O -> -O entry by entry (0.0e+00); Q is identically 0 here
+PASS D5 [exact] the law holds only t and V, both eps-EVEN: C H(t,V) C^-1 = H(t,V) exactly at V = 1, 3 t on both clusters while C H_m C^-1 = -H_m (0.0e+00), so it fixes |m*| and not the sign: one registered bit relative to the supplied eps_v
+PASS E1 [exact] the OPEN 2x2x4 has degrees [3, 4], so d(~b)-d(b) is not constant (9 values) and V breaks C there (C H C^-1 - H = 4.0 at V = 1 t): no C-odd gap is definable, so periodic z is used
+PASS E2 [1e-10] the PERIODIC 8^3 torus carries 8 exact zero modes (parent note T3), so c(0) diverges and V_c^MF = 0, an artefact; the ANTIPERIODIC sector, min|E| = 1.325654 at L = 8, carries every mean-field number
+SUMMARY: Hartree on V sum n_i n_j generates exactly the parent note's staggered mass, 1 = (zV/2)c(m*) and V_c^MF = 0.732047 t [mean field]; the law is eps-even, so the sign is a registered bit.
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py
+++ b/scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""The record-conserving interaction generates the staggered mass at Hartree
+level, and no term in the law fixes its sign.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3, one
+fermionic mode per coarse vertex, with the Kawamoto-Smit link signs
+    eta_1 = 1,  eta_2(v) = (-1)^{v_1},  eta_3(v) = (-1)^{v_1+v_2},
+and the record-conserving nearest-neighbour law read at t = 1
+    H(t, V) = -t sum_bonds eta_ij (c_i^dag c_j + h.c.) + V sum_bonds n_i n_j.
+The declared staggered mass of the parent note is H_m = m sum_v eps_v n_v with
+eps_v = (-1)^{v_1+v_2+v_3}, whose size and sign that note states are supplied.
+The order parameter here is O = (1/N) sum_v eps_v (n_v - 1/2), so H_m = m N O.
+
+  A  HARTREE.  Decoupling V sum n_i n_j with <n_i> = 1/2 + eps_i O gives
+     exactly H_MF = H_0 + m* sum_v eps_v n_v + const, m* = -z V O, z = 6:
+     the generated term IS the parent note's mass operator.  Gap equation
+     1 = (zV/2) c(m*), c(m) = [(M^2+m^2)^{-1/2}]_vv, V_c^MF = 2/(z c(0)).
+  B  EXPONENT AND WINDOW.  The 3-D Dirac density of states vanishes
+     quadratically, so c(0) - c(m) ~ A m^2 ln(1/m) and beta = 1/2 with a
+     logarithm; beyond V ~ 1 t the Hartree state is the classical
+     checkerboard, xi below one coarse spacing.
+  C  EXACT CLUSTERS.  Cube 2x2x2 open (70-dim) and slab 2x2x4 periodic in z
+     (12870-dim): the first excited state is the C-conjugate partner at every
+     V, P(O) goes bimodal, chi explodes with size, and the two-size crossing
+     is V_x = 1.766 t.
+  D  THE REGISTERED SIGN.  +-m* exactly degenerate; <O> = 0 at h = 0 with
+     <O^2> large; a supplied field h = +-0.001 t saturates <O>; the law is
+     exactly C-even, so it fixes |m*| and not the sign.
+  E  METHOD.  The open 2x2x4 has degrees 3 and 4, so V itself breaks C there;
+     the periodic 8^3 torus carries 8 exact zero modes and its V_c^MF = 0 is
+     an artefact.  The antiperiodic sector is used throughout.
+
+Groups A, C1, C4, D2, D5, E1 carry exact algebraic content (zero-residual
+identities, exhaustive basis sweeps, closed-form combinatorics); the items
+tagged [numerical] are floating-point cross-checks at the stated tolerance.
+Every mean-field statement is labelled mean-field and is not a proved
+transition.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spl
+from scipy.integrate import quad
+from scipy.special import i0e
+
+AUDIT_TIMEOUT_SEC = 120
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+Z = 6.0
+RNG = np.random.default_rng(20260903)
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+# ================================================ finite clusters, exact sector
+
+def build_cluster(lx, ly, lz, pz):
+    """Half-filling sector of H(t,V) on an open lx x ly x lz block, z periodic
+    if pz.  Returns a dict of everything the checks below read."""
+    sites = [(x, y, z) for x in range(lx) for y in range(ly) for z in range(lz)]
+    idx = {v: i for i, v in enumerate(sites)}
+    ns = len(sites)
+    eps = np.array([(-1) ** sum(v) for v in sites], float)
+    bonds = []
+    for v in sites:
+        for a in range(3):
+            w = list(v)
+            w[a] += 1
+            if a == 2 and pz:
+                w[2] %= lz
+            w = tuple(w)
+            if w in idx and w != v:
+                bonds.append((idx[v], idx[w], eta_ks(v, a)))
+    deg = np.zeros(ns, int)
+    for i, j, _ in bonds:
+        deg[i] += 1
+        deg[j] += 1
+    # every elementary face carries flux -1
+    fluxes = set()
+    for v in sites:
+        for a, b in ((0, 1), (0, 2), (1, 2)):
+            ea = [0, 0, 0]
+            ea[a] = 1
+            eb = [0, 0, 0]
+            eb[b] = 1
+
+            def wr(u):
+                u = list(u)
+                if pz:
+                    u[2] %= lz
+                return tuple(u)
+
+            p2 = wr([v[k] + ea[k] for k in range(3)])
+            p4 = wr([v[k] + eb[k] for k in range(3)])
+            p3 = wr([v[k] + ea[k] + eb[k] for k in range(3)])
+            if p2 in idx and p4 in idx and p3 in idx and len({v, p2, p3, p4}) == 4:
+                fluxes.add(eta_ks(v, a) * eta_ks(p2, b) * eta_ks(p4, a) * eta_ks(v, b))
+    nf = ns // 2
+    bas = [b for b in range(1 << ns) if bin(b).count("1") == nf]
+    pos = {b: i for i, b in enumerate(bas)}
+    dim = len(bas)
+
+    def jw(b, p):
+        return -1 if (bin(b & ((1 << p) - 1)).count("1") & 1) else 1
+
+    rr, cc, dd = [], [], []
+    for n, b in enumerate(bas):
+        for (i, j, e) in bonds:
+            for (p, q) in ((i, j), (j, i)):
+                if (b >> q) & 1 and not (b >> p) & 1:
+                    b1 = b ^ (1 << q)
+                    s = jw(b, q)
+                    b2 = b1 | (1 << p)
+                    s *= jw(b1, p)
+                    rr.append(pos[b2])
+                    cc.append(n)
+                    dd.append(-1.0 * e * s)
+    hop = sp.csr_matrix((dd, (rr, cc)), shape=(dim, dim))
+    vdi = np.array([sum(1 for (i, j, _) in bonds
+                        if ((b >> i) & 1) and ((b >> j) & 1)) for b in bas], float)
+    kev = np.array([sum(1 for v in range(ns) if eps[v] > 0 and (b >> v) & 1) for b in bas])
+    oval = (2.0 * kev - ns / 2) / ns
+    # charge conjugation C: c_v -> eps_v c_v^dag on the half-filling sector
+    wv = np.array([0 if (eps[v] * (-1) ** v) == 1 else 1 for v in range(ns)])
+    full = (1 << ns) - 1
+    cr, cq, cd = [], [], []
+    for n, b in enumerate(bas):
+        ph = sum(wv[v] for v in range(ns) if not ((b >> v) & 1)) & 1
+        cr.append(pos[b ^ full])
+        cq.append(n)
+        cd.append(-1.0 if ph else 1.0)
+    cmat = sp.csr_matrix((cd, (cr, cq)), shape=(dim, dim))
+    vdc = np.array([vdi[pos[b ^ full]] for b in bas])
+    # C-sector isometries
+    ccsc = cmat.tocsc()
+    seen = np.zeros(dim, bool)
+    s2 = 1 / np.sqrt(2)
+    pr, pc, pd, mr, mc, md, npn, nmn = [], [], [], [], [], [], 0, 0
+    for n in range(dim):
+        if seen[n]:
+            continue
+        m = pos[bas[n] ^ full]
+        seen[n] = seen[m] = True
+        s = ccsc[:, [n]].data[0]
+        pr += [n, m]
+        pc += [npn, npn]
+        pd += [s2, s * s2]
+        npn += 1
+        mr += [n, m]
+        mc += [nmn, nmn]
+        md += [s2, -s * s2]
+        nmn += 1
+    pl = sp.csr_matrix((pd, (pr, pc)), shape=(dim, npn))
+    pm = sp.csr_matrix((md, (mr, mc)), shape=(dim, nmn))
+    msp = np.zeros((ns, ns))
+    for i, j, e in bonds:
+        msp[i, j] += -e
+        msp[j, i] += -e
+    return dict(ns=ns, nf=nf, dim=dim, bonds=bonds, deg=set(deg.tolist()),
+                fluxes=sorted(fluxes), eps=eps, hop=hop, vd=vdi, vdc=vdc,
+                oval=oval, kev=kev, cmat=cmat, pl=pl, pm=pm,
+                sp1=np.linalg.eigvalsh(msp),
+                ineel=(pos[sum(1 << v for v in range(ns) if eps[v] > 0)],
+                       pos[sum(1 << v for v in range(ns) if eps[v] < 0)]))
+
+
+def gstate(cl, V, h=0.0):
+    """Ground state of H(t,V) + h N O in the half-filling sector."""
+    H = (cl["hop"] + sp.diags(V * cl["vd"] + h * cl["ns"] * cl["oval"])).tocsr()
+    if cl["dim"] <= 400:
+        w, U = np.linalg.eigh(H.toarray())
+        return float(w[0]), U[:, 0]
+    v0 = RNG.standard_normal(cl["dim"])
+    w, U = spl.eigsh(H, k=1, which="SA", tol=1e-13, v0=v0, maxiter=50000)
+    return float(w[0]), U[:, 0]
+
+
+def sof(cl, V, h=0.0):
+    _, g = gstate(cl, V, h)
+    return float(np.sum(g ** 2 * cl["oval"] ** 2)), float(np.sum(g ** 2 * cl["oval"]))
+
+
+def sectors(cl, V):
+    """(E0, gap, Delta_C, C-parity of the ground state, ground vector)."""
+    H = (cl["hop"] + sp.diags(V * cl["vd"])).tocsr()
+    Hp = (cl["pl"].T @ H @ cl["pl"]).tocsr()
+    Hm = (cl["pm"].T @ H @ cl["pm"]).tocsr()
+    if Hp.shape[0] <= 400:
+        ep, vp = np.linalg.eigh(Hp.toarray())
+        em, vm = np.linalg.eigh(Hm.toarray())
+    else:
+        ep, vp = spl.eigsh(Hp, k=2, which="SA", tol=1e-13,
+                           v0=RNG.standard_normal(Hp.shape[0]), maxiter=50000)
+        em, vm = spl.eigsh(Hm, k=2, which="SA", tol=1e-13,
+                           v0=RNG.standard_normal(Hm.shape[0]), maxiter=50000)
+        o = np.argsort(ep)
+        ep, vp = ep[o], vp[:, o]
+        o = np.argsort(em)
+        em, vm = em[o], vm[:, o]
+    if ep[0] <= em[0]:
+        g = cl["pl"] @ vp[:, 0]
+        return float(ep[0]), float(min(ep[1], em[0]) - ep[0]), float(em[0] - ep[0]), +1, g / np.linalg.norm(g)
+    g = cl["pm"] @ vm[:, 0]
+    return float(em[0]), float(min(em[1], ep[0]) - em[0]), float(ep[0] - em[0]), -1, g / np.linalg.norm(g)
+
+
+CUBE = build_cluster(2, 2, 2, False)
+SLAB = build_cluster(2, 2, 4, True)
+OPEN4 = build_cluster(2, 2, 4, False)
+
+# ================================================ antiperiodic coarse tori
+
+
+def build_M(L, twist):
+    N = L ** 3
+
+    def ix(x, y, z):
+        return (x * L + y) * L + z
+
+    M = np.zeros((N, N))
+    for x in range(L):
+        for y in range(L):
+            for z in range(L):
+                i = ix(x, y, z)
+                for a, e in enumerate(((1, 0, 0), (0, 1, 0), (0, 0, 1))):
+                    w = [x + e[0], y + e[1], z + e[2]]
+                    ph = 1.0
+                    for k in range(3):
+                        if w[k] == L:
+                            w[k] = 0
+                            ph *= twist
+                    j = ix(*w)
+                    et = eta_ks((x, y, z), a)
+                    M[i, j] += -et * ph
+                    M[j, i] += -et * ph
+    return M
+
+
+def c_inf(m):
+    """c(m) = (1/sqrt pi) int_0^inf ds s^-1/2 e^{-s m^2} (e^{-2s} I_0(2s))^3,
+    integrated after s = u^2 so the endpoint singularity is removed."""
+    f = lambda u: 2.0 * np.exp(-u * u * m * m) * i0e(2 * u * u) ** 3
+    return quad(f, 0, np.inf, limit=600)[0] / np.sqrt(np.pi)
+
+
+def c_tor(ev, m):
+    return float(np.mean(1.0 / np.sqrt(ev ** 2 + m * m)))
+
+
+def solve_m(V, ev=None, nit=60):
+    """Largest root of 1 = (zV/2) c(m); 0 if V <= V_c."""
+    cf = (lambda m: c_tor(ev, m)) if ev is not None else c_inf
+    if (Z * V / 2) * cf(0.0) <= 1.0:
+        return 0.0
+    lo, hi = 0.0, 1.0
+    while (Z * V / 2) * cf(hi) > 1.0:
+        hi *= 2
+    for _ in range(nit):
+        mid = (lo + hi) / 2
+        if (Z * V / 2) * cf(mid) > 1.0:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+C0 = c_inf(0.0)
+VC = 2 / (Z * C0)
+EVA = {}
+for L in (8, 12, 16):
+    EVA[L] = np.linalg.eigvalsh(build_M(L, -1.0))
+
+# ================================================================ A -- Hartree
+
+resid = 0.0
+for V in (1.0, 2.0):
+    for Oq in (0.25, 0.5, -0.125):
+        nbar = 0.5 + CUBE["eps"] * 0.0  # placeholder, torus below
+        L = 4
+        sites = [(x, y, z) for x in range(L) for y in range(L) for z in range(L)]
+        idx = {v: i for i, v in enumerate(sites)}
+        e4 = np.array([(-1) ** sum(v) for v in sites], float)
+        nb = 0.5 + e4 * Oq
+        coef = np.zeros(L ** 3)
+        pairs = 0.0
+        for v in sites:
+            i = idx[v]
+            for a in range(3):
+                w = list(v)
+                w[a] = (w[a] + 1) % L
+                j = idx[tuple(w)]
+                coef[i] += V * nb[j]
+                coef[j] += V * nb[i]
+                pairs += nb[i] * nb[j]
+        # sum_{j~i} <n_j> = z(1/2 - eps_i O) exactly
+        resid = max(resid, float(np.max(np.abs(coef / V - Z * (0.5 - e4 * Oq)))))
+        # the generated one-body term, less its (eps-even) mean, is m* eps_v
+        mstar = -Z * V * Oq
+        resid = max(resid, float(np.max(np.abs(coef - coef.mean() - mstar * e4))))
+        resid = max(resid, abs(coef.mean() - Z * V / 2))
+        # the subtracted constant depends on O only through O^2
+        resid = max(resid, abs(pairs - (Z * L ** 3 / 2) * (0.25 - Oq * Oq)))
+check("A1 [exact] torus 4^3, z = 6: sum_{j~i}<n_j> = z(1/2 - eps_i O), so Hartree gives exactly "
+      "H_MF = H_0 + m* sum eps_v n_v + const, m* = -zVO: the parent note's mass operator, the const "
+      "even in O (%.1e)" % resid, resid == 0.0)
+
+M8 = build_M(8, -1.0)
+e8 = np.array([(-1) ** (x + y + z) for x in range(8) for y in range(8) for z in range(8)], float)
+d5 = 0.0
+mm = []
+for m in (0.3, 1.0):
+    w, U = np.linalg.eigh(M8 + m * np.diag(e8))
+    P = U[:, :256] @ U[:, :256].T
+    Oq = float(np.mean(e8 * (np.diag(P) - 0.5)))
+    pr = -(m / 2) * c_tor(EVA[8], m)
+    mm.append((Oq, pr))
+    d5 = max(d5, abs(Oq - pr))
+check("A2 [1e-9] antiperiodic 8^3: the parent note's T5 response O(m) = -(m/2)c(m), "
+      "c(m) = [(M^2+m^2)^-1/2]_vv, holds at m = 0.3 (%.9f) and 1.0 (%.9f), residual %.1e"
+      % (mm[0][0], mm[1][0], d5), d5 < 1e-9)
+
+dbz = 0.0
+for s in (0.1, 0.5, 2.0):
+    q = 2 * np.pi * (np.arange(64) + 0.5) / 64
+    ck = np.cos(q)
+    grid = np.exp(-s * (6 + 2 * (ck[:, None, None] + ck[None, :, None] + ck[None, None, :])))
+    dbz = max(dbz, abs(float(grid.mean()) - float(i0e(2 * s) ** 3)))
+check("A3 [1e-12] closed 1-D form: <e^{-s(6+2 sum cos q_a)}>_BZ = (e^{-2s}I_0(2s))^3 on a 64^3 grid "
+      "at s = 0.1, 0.5, 2 (%.1e), so c(m) = (1/sqrt pi) int ds s^-1/2 e^{-s m^2}(e^{-2s}I_0(2s))^3"
+      % dbz, dbz < 1e-12)
+
+cs = {L: c_tor(EVA[L], 0.0) for L in (8, 12, 16)}
+check("A4 [numerical] c(0) = %.9f, chi = c(0)/2 = %.6f vs the parent note's 0.227671, "
+      "V_c^MF = 2/(z c(0)) = %.6f t [mean field]; L = 8, 12, 16 give %.6f, %.6f, %.6f, from above"
+      % (C0, C0 / 2, VC, 2 / (Z * cs[8]), 2 / (Z * cs[12]), 2 / (Z * cs[16])),
+      abs(C0 - 0.455344052) < 1e-8 and abs(C0 / 2 - 0.227671) < 2e-6
+      and abs(VC - 0.732047) < 1e-6
+      and 2 / (Z * cs[8]) > 2 / (Z * cs[12]) > 2 / (Z * cs[16]) > VC)
+
+dgap = 0.0
+mstars = {}
+for V in (0.8, 1.0, 2.0, 4.0):
+    ms = solve_m(V)
+    mstars[V] = ms
+    dgap = max(dgap, abs(1.0 - (Z * V / 2) * c_inf(ms)))
+    dgap = max(dgap, abs(ms - (-Z * V * (-(ms / 2) * c_inf(ms)))))
+check("A5 [1e-9] the gap equation 1 = (zV/2)c(m*) and the self-consistency m* = -zVO(m*) close on "
+      "one root at V = 0.8, 1, 2, 4 t (%.1e); below V_c^MF only m* = 0" % dgap,
+      dgap < 1e-9 and solve_m(0.70) == 0.0 and solve_m(0.732) == 0.0)
+
+# ================================================== B -- exponent and window
+
+rat = [(m, (C0 - c_inf(m)) / (m * m * np.log(1 / m))) for m in (0.02, 0.05, 0.1)]
+check("B1 [numerical] the 3-D Dirac density of states vanishes QUADRATICALLY, so "
+      "c(0)-c(m) ~ A m^2 ln(1/m) + B m^2: (c0-c(m))/(m^2 ln(1/m)) = %.4f, %.4f, %.4f at "
+      "m = 0.02, 0.05, 0.1"
+      % (rat[0][1], rat[1][1], rat[2][1]),
+      all(0.03 < r < 0.06 for _, r in rat) and rat[0][1] < rat[1][1] < rat[2][1])
+
+ds = [1e-5, 3e-5, 1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2, 1e-1]
+ms = [solve_m(VC + d) for d in ds]
+be = [np.log(ms[i + 1] / ms[i]) / np.log(ds[i + 1] / ds[i]) for i in range(len(ds) - 1)]
+check("B2 [numerical] hence m*^2 ln(1/m*) prop (V-V_c): beta_eff = dln m*/dln(V-V_c) drifts "
+      "%.4f -> %.4f over (V-V_c) 1e-1 -> 1e-5 [mean field]: beta = 1/2 with a logarithm, not 1" % (be[-1], be[0]),
+      all(be[i] < be[i + 1] for i in range(len(be) - 1)) and 0.50 < be[0] < 0.55
+      and 0.55 < be[-1] < 0.62)
+
+cls = []
+for V in (2.0, 4.0, 6.0):
+    m = solve_m(V)
+    cls.append((V, m, m / (3 * V), 2 * m, 2 / np.arccosh(1 + m * m / 2)))
+BW = 2 * np.sqrt(12.0)
+check("B3 [numerical] at V = 2, 4, 6 t the Hartree state is the CLASSICAL checkerboard: "
+      "m*/3V = %.3f, %.3f, %.3f; 2m* = %.2f, %.2f, %.2f t above the bandwidth %.3f; xi = %.2f, %.2f, "
+      "%.2f, below one spacing"
+      % (cls[0][2], cls[1][2], cls[2][2], cls[0][3], cls[1][3], cls[2][3], BW,
+         cls[0][4], cls[1][4], cls[2][4]),
+      all(r[2] > 0.9 for r in cls) and all(r[3] > BW for r in cls) and all(r[4] < 1.0 for r in cls))
+
+win = [(V, solve_m(V), 2 / np.arccosh(1 + solve_m(V) ** 2 / 2)) for V in (0.75, 0.8, 0.9, 1.0)]
+check("B4 [numerical] so a generated DIRAC mass has meaning only in %.3f < V <~ 1.0 t: "
+      "m* = %.3f, %.3f, %.3f, %.3f and xi = %.2f, %.2f, %.2f, %.2f at V = 0.75, 0.8, 0.9, 1 t"
+      % (VC, win[0][1], win[1][1], win[2][1], win[3][1],
+         win[0][2], win[1][2], win[2][2], win[3][2]),
+      all(r[2] > 1.15 for r in win) and win[3][1] < 2.0)
+
+print("  Hartree mean field, antiperiodic tori (not a proved transition):")
+print("     V    m*(inf)     2m*    O=-m*c/2    xi")
+for V in (0.732, 0.8, 1.0, 2.0):
+    mi = solve_m(V)
+    o = -(mi / 2) * c_inf(mi) if mi > 0 else 0.0
+    xi = 2 / np.arccosh(1 + mi * mi / 2) if mi > 1e-9 else float("inf")
+    print("  %6.3f %9.6f %9.6f %9.6f %8.4f" % (V, mi, 2 * mi, o, xi))
+
+# ================================================== C -- the exact clusters
+
+dc1 = max(float(abs(CUBE["cmat"] @ CUBE["hop"] - CUBE["hop"] @ CUBE["cmat"]).max()),
+          float(abs(SLAB["cmat"] @ SLAB["hop"] - SLAB["hop"] @ SLAB["cmat"]).max()))
+dc2 = max(float(abs(CUBE["cmat"] @ CUBE["cmat"] - sp.identity(CUBE["dim"])).max()),
+          float(abs(SLAB["cmat"] @ SLAB["cmat"] - sp.identity(SLAB["dim"])).max()))
+dc3 = max(float(np.max(np.abs(CUBE["vdc"] - CUBE["vd"]))),
+          float(np.max(np.abs(SLAB["vdc"] - SLAB["vd"]))))
+E0c0, _ = gstate(CUBE, 0.0)
+check("C1 [exact] cube 2x2x2 open (degree 3, dim 70) and slab 2x2x4 periodic z (degree 4, dim 12870), "
+      "every face flux -1: C^2 = I, [C,H_0] = 0, d(~b)-d(b) = 0 on all basis states (%.1e); free "
+      "E_0(cube) = %.6f = -4 sqrt3"
+      % (max(dc1, dc2, dc3), E0c0),
+      CUBE["deg"] == {3} and SLAB["deg"] == {4} and CUBE["fluxes"] == [-1]
+      and SLAB["fluxes"] == [-1] and CUBE["dim"] == 70 and SLAB["dim"] == 12870
+      and dc1 == 0.0 and dc2 == 0.0 and dc3 == 0.0 and abs(E0c0 + 4 * np.sqrt(3)) < 1e-9)
+
+VG = (0.0, 1.0, 2.0, 4.0, 8.0)
+CT, ST = {}, {}
+for V in VG:
+    CT[V] = sectors(CUBE, V)
+    ST[V] = sectors(SLAB, V)
+gapeq = max(max(abs(CT[V][1] - CT[V][2]) for V in VG), max(abs(ST[V][1] - ST[V][2]) for V in VG))
+check("C2 [1e-9] on BOTH clusters at every V the first excited state is the C-conjugate partner: "
+      "gap = Delta_C to %.1e, ground state C-even; Delta_C falls to %.4e (cube) and %.4e (slab) by "
+      "V = 8 t"
+      % (gapeq, CT[8.0][2], ST[8.0][2]),
+      gapeq < 1e-9 and all(CT[V][3] == 1 and ST[V][3] == 1 for V in VG)
+      and abs(CT[0.0][2] - 2 * np.sqrt(3)) < 1e-9 and abs(ST[0.0][2] - 2 * np.sqrt(2)) < 1e-9
+      and abs(CT[8.0][2] - 7.8163e-2) < 1e-5 and abs(ST[8.0][2] - 9.5445e-5) < 1e-8)
+
+print("  exact clusters, C-resolved; O = (1/N) sum eps_v (n_v - 1/2), S = <O^2>:")
+print("     V  E0(cube) Delta_C(c)  S(cube)  E0(slab) Delta_C(s)  S(slab)")
+for V in (0.0, 2.0, 4.0, 8.0):
+    gc = CT[V][4]
+    gs = ST[V][4]
+    print("  %5.1f %9.6f %10.4e %8.6f %9.6f %10.4e %8.6f"
+          % (V, CT[V][0], CT[V][2], float(np.sum(gc ** 2 * CUBE["oval"] ** 2)),
+             ST[V][0], ST[V][2], float(np.sum(gs ** 2 * SLAB["oval"] ** 2))))
+
+
+def binom(n):
+    from math import comb
+    return np.array([comb(n, k) for k in range(n + 1)], float) / 2.0 ** n
+
+
+d0 = 0.0
+for cl, tab in ((CUBE, CT), (SLAB, ST)):
+    g = tab[0.0][4]
+    P = np.array([float(np.sum(g[cl["kev"] == k] ** 2)) for k in range(cl["ns"] // 2 + 1)])
+    d0 = max(d0, float(np.max(np.abs(P - binom(cl["ns"] // 2)))))
+    d0 = max(d0, abs(float(np.sum(g ** 2 * cl["oval"] ** 2)) - 1.0 / (2 * cl["ns"])))
+check("C3 [1e-12] the free half-filled sea's staggered fluctuation is shot noise: at V = 0 both "
+      "clusters give S = 1/(2N) exactly (1/16, 1/32) and odds over O of Binomial(N/2, 1/2) exactly "
+      "(%.1e)" % d0, d0 < 1e-12)
+
+gcu8 = CT[8.0][4]
+P8 = np.array([float(np.sum(gcu8[CUBE["kev"] == k] ** 2)) for k in range(5)])
+check("C4 [numerical] the odds over O go bimodal: cube at V = 8 t, %.4f + %.4f on O = -1/2 and +1/2 "
+      "against %.4f on O = 0; the two staggered patterns carry %.6f of the weight"
+      % (P8[0], P8[4], P8[2],
+         float(gcu8[CUBE["ineel"][0]] ** 2 + gcu8[CUBE["ineel"][1]] ** 2)),
+      abs(P8[0] - 0.472875) < 1e-5 and abs(P8[4] - 0.472875) < 1e-5 and abs(P8[2] - 0.004317) < 1e-5)
+
+HFD = 1e-4
+chis = {}
+for V in (0.0, 4.0, 8.0):
+    chis[V] = (-(sof(CUBE, V, HFD)[1] - sof(CUBE, V, -HFD)[1]) / (2 * HFD),
+               -(sof(SLAB, V, HFD)[1] - sof(SLAB, V, -HFD)[1]) / (2 * HFD))
+check("C5 [numerical, h = 1e-4 t] chi = -d<O>/dh is size-flat at V = 0 (%.5f -> %.5f) and explodes "
+      "with size once V grows: %.2f -> %.1f at V = 4, %.2f -> %.1f at V = 8 t (cube -> slab), the "
+      "last already saturation"
+      % (chis[0.0][0], chis[0.0][1], chis[4.0][0], chis[4.0][1], chis[8.0][0], chis[8.0][1]),
+      abs(chis[4.0][0] - 6.52) < 0.02 and abs(chis[4.0][1] - 717.3) < 1.0
+      and abs(chis[8.0][0] - 48.64) < 0.05 and abs(chis[8.0][1] - 4920.8) < 5.0)
+
+
+def crossover(cl):
+    s0 = 1.0 / (2 * cl["ns"])
+    lo, hi = 0.0, 8.0
+    for _ in range(45):
+        mid = (lo + hi) / 2
+        if sof(cl, mid)[0] > 2 * s0:
+            hi = mid
+        else:
+            lo = mid
+    return (lo + hi) / 2
+
+
+vsc, vss = crossover(CUBE), crossover(SLAB)
+check("C6 [numerical] the S-doubling crossover FALLS with size: V* = %.5f t (cube, N = 8) -> "
+      "%.5f t (slab, N = 16)" % (vsc, vss),
+      abs(vsc - 2.034113) < 1e-4 and abs(vss - 1.14065) < 1e-4 and vss < vsc)
+
+lo, hi = 1.0, 2.5
+for _ in range(40):
+    mid = (lo + hi) / 2
+    if sof(SLAB, mid)[0] > sof(CUBE, mid)[0]:
+        hi = mid
+    else:
+        lo = mid
+VX = (lo + hi) / 2
+check("C7 [numerical] S(V=0) = 1/(2N), so S(slab) < S(cube) while disordered and S(slab) > S(cube) "
+      "once order grows with size: two-size crossing V_x = %.5f t against V_c^MF = %.6f t, %.2fx. "
+      "Two sizes, no error bar" % (VX, VC, VX / VC),
+      abs(VX - 1.76598) < 1e-4 and 2.3 < VX / VC < 2.5)
+
+# ================================================== D -- the registered sign
+
+deg = []
+for V in (2.0, 4.0, 6.0):
+    m = solve_m(V, EVA[8])
+
+    def emf(mu):
+        w = np.linalg.eigvalsh(M8 + mu * np.diag(e8))
+        oq = -(mu / 2) * c_tor(EVA[8], mu)
+        return float(np.sum(w[:256])) + (Z * V / 2) * 512 * oq * oq
+
+    deg.append((V, m, emf(m) - emf(-m),
+                -(m / 2) * c_tor(EVA[8], m), +(m / 2) * c_tor(EVA[8], m)))
+check("D1 [1e-9] +-m* are EXACTLY degenerate at Hartree level: E_MF(+m*) - E_MF(-m*) = %.1e, %.1e, "
+      "%.1e at V = 2, 4, 6 t on the antiperiodic 8^3, O(+m*) = -O(-m*); the functional holds O only "
+      "through O^2" % (deg[0][2], deg[1][2], deg[2][2]),
+      all(abs(r[2]) < 1e-9 for r in deg) and all(abs(r[3] + r[4]) < 1e-12 for r in deg))
+
+zz = []
+for cl, nm in ((CUBE, "cube"), (SLAB, "slab")):
+    for V in (2.0, 4.0, 8.0):
+        s2v, o1 = sof(cl, V)
+        zz.append((nm, V, o1, s2v))
+check("D2 [1e-9] in every finite cluster <O> = 0 at h = 0 while <O^2> is large: <O> = %.1e / %.1e "
+      "against <O^2> = %.4f / %.4f (cube / slab, V = 4 t); C is exact, so the state is the even "
+      "combination" % (zz[1][2], zz[4][2], zz[1][3], zz[4][3]),
+      all(abs(r[2]) < 1e-9 for r in zz) and all(0.12 <= r[3] <= 0.245 for r in zz))
+
+hs = [(h, sof(SLAB, 8.0, h)[1]) for h in (-0.005, -0.001, 0.001, 0.005)]
+check("D3 [numerical] a SUPPLIED field h sum_v eps_v n_v selects the sign, singularly: slab at "
+      "V = 8 t, h = -+0.001 t saturates <O> at %+.6f / %+.6f, while <O>|_{h=0} = 0" % (hs[1][1], hs[2][1]),
+      abs(hs[1][1] - 0.492970) < 1e-5 and abs(hs[2][1] + 0.492970) < 1e-5
+      and abs(hs[0][1] - 0.492983) < 1e-5 and abs(hs[3][1] + 0.492983) < 1e-5)
+
+dq = 0.0
+nval = []
+for cl in (CUBE, SLAB):
+    # Q = sum_v (n_v - 1/2) is identically 0 on the half-filling sector
+    dq = max(dq, abs(cl["nf"] - cl["ns"] / 2))
+    # C: O -> -O, checked entry by entry through the permutation C carries
+    perm = np.asarray((cl["cmat"] != 0).argmax(axis=0)).ravel()
+    dq = max(dq, float(np.max(np.abs(cl["oval"][perm] + cl["oval"]))))
+    nval.append(len(set(np.round(cl["oval"], 12))))
+check("D4 [exact] O is a SIGNED Q: the conjugation note's six-bit corner-parity readout weighted by "
+      "the supplied label eps_v. Record-diagonal, %d and %d readable values, C: O -> -O entry by "
+      "entry (%.1e); Q is identically 0 here"
+      % (nval[0], nval[1], dq), dq == 0.0 and nval == [5, 9])
+
+dl = 0.0
+for cl in (CUBE, SLAB):
+    for V in (1.0, 3.0):
+        H = (cl["hop"] + sp.diags(V * cl["vd"])).tocsr()
+        dl = max(dl, float(abs(cl["cmat"] @ H @ cl["cmat"] - H).max()))
+    Hm = sp.diags(cl["ns"] * cl["oval"]).tocsr()
+    dl = max(dl, float(abs(cl["cmat"] @ Hm @ cl["cmat"] + Hm).max()))
+check("D5 [exact] the law holds only t and V, both eps-EVEN: C H(t,V) C^-1 = H(t,V) exactly at "
+      "V = 1, 3 t on both clusters while C H_m C^-1 = -H_m (%.1e), so it fixes |m*| and not the "
+      "sign: one registered bit relative to the supplied eps_v" % dl, dl == 0.0)
+
+# ================================================================ E -- method
+
+dop = set(np.round(OPEN4["vdc"] - OPEN4["vd"], 9).tolist())
+Ho = (OPEN4["hop"] + sp.diags(1.0 * OPEN4["vd"])).tocsr()
+dbr = float(abs(OPEN4["cmat"] @ Ho @ OPEN4["cmat"] - Ho).max())
+check("E1 [exact] the OPEN 2x2x4 has degrees %s, so d(~b)-d(b) is not constant (%d values) and V "
+      "breaks C there (C H C^-1 - H = %.1f at V = 1 t): no C-odd gap is definable, so periodic z is "
+      "used" % (sorted(OPEN4["deg"]), len(dop), dbr),
+      OPEN4["deg"] == {3, 4} and len(dop) > 1 and dbr > 0.5)
+
+evp = np.linalg.eigvalsh(build_M(8, 1.0))
+nz = int(np.sum(np.abs(evp) < 1e-10))
+check("E2 [1e-10] the PERIODIC 8^3 torus carries %d exact zero modes (parent note T3), so c(0) "
+      "diverges and V_c^MF = 0, an artefact; the ANTIPERIODIC sector, min|E| = %.6f at L = 8, "
+      "carries every mean-field number"
+      % (nz, float(np.abs(EVA[8]).min())),
+      nz == 8 and float(np.abs(EVA[8]).min()) > 1.3)
+
+print("SUMMARY: Hartree on V sum n_i n_j generates exactly the parent note's staggered mass, "
+      "1 = (zV/2)c(m*) and V_c^MF = 0.732047 t [mean field]; the law is eps-even, so the sign is a "
+      "registered bit.")
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache on mass generation: **the record-conserving nearest-neighbour interaction generates, at Hartree level, exactly the record-native staggered mass operator of PR #7890, and no term in the law fixes its sign.** The Hartree decoupling of `V sum n_i n_j` with `<n_i> = 1/2 + eps_i O` gives `H_MF = H_0 + m* sum_v eps_v n_v`, `m* = -6 V O`, with the gap equation `1 = 3 V c(m*)`, `c(0) = 0.455344` (a closed one-dimensional integral reproducing PR #7890's susceptibility), `V_c^MF = 0.732 t`, exponent `1/2` with a logarithm (the three-dimensional Dirac density of states vanishes quadratically), and a two-size exact crossing `V_x = 1.77 t`. Exact diagonalisation of the cube (70-dim) and the periodic-`z` `2x2x4` slab (12870-dim) shows the finite-size signatures: the first excited state is always the `C`-conjugate partner, with the `C`-odd gap collapsing from `2 sqrt 3` to `7.8e-2` (cube) and from `2 sqrt 2` to `9.5e-5` (slab) at `V = 8 t`; bimodal odds over `O`; a susceptibility size-flat at `V = 0` and exploding with `V`. Two exact bonus facts: `S(V = 0) = 1/(2N)` and the odds over `O` are `Binomial(N/2, 1/2)` exactly (the free sea's staggered fluctuation is shot noise). **The registered sign:** the law holds only `t` and `V`, both `eps`-even, so it fixes `|m*|` and cannot fix the sign; which checkerboard holds is read from the records (`O` is a signed version of PR #7892's charge readout), a registered bit in the sense of guardrail G3. The trade, stated exactly: one supplied `m` (size and sign) for one supplied `V` plus one registered bit, with `eps_v` still a supplied corner label.

- `docs/THE_INTERACTION_GENERATES_THE_STAGGERED_MASS_AT_HARTREE_LEVEL_AND_NO_TERM_IN_THE_LAW_FIXES_ITS_SIGN_BOUNDED_THEOREM_NOTE_2026-09-03.md` (329 lines)
- `scripts/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.py` (`TOTAL: PASS=23 FAIL=0`, 12 s)
- `logs/runner-cache/interaction_generates_staggered_mass_hartree_sign_registered_check_2026_09_03.txt`

## Theorems

- **T1** the Hartree identity and gap equation; `V_c^MF = 0.732047 t`; PR #7890's `O(m) = -(m/2) c(m)` re-verified to `5.6e-17`.
- **T2** the mean-field exponent (`beta_eff` drifting `0.599 -> 0.538`); the classical regime at `V = 2, 4, 6 t` (`m*/3V -> 1`, `xi` below one spacing); the Dirac-mass window `0.73 < V <~ 1.0 t`.
- **T3** exact clusters: `C`-odd quasi-degeneracy, bimodal `P(O)`, susceptibility, crossover moving down with size, `V_x = 1.766 t` (mean field low by `2.4x`); shot-noise facts.
- **T4** the registered sign: `+-m*` exactly degenerate; `<O> = 0` at `h = 0`; a supplied `h = +-0.001 t` saturates `<O>` at `-+0.493` on the slab at `V = 8`.
- **T5** the methodological facts: the open slab's non-uniform coordination breaks `C` through `V` itself; the periodic `8^3` torus's exact zero modes make `c(0)` divergent (antiperiodic sector used, matching PR #7890).

## Boundary

- Mean field for the transition (single staggered ansatz; no Fock channel; no fluctuations); exact only on 8- and 16-site clusters with a two-point crossing and no error bar; slab periodic-`z` dependent; coarse lattice in the fermion language; `V` and `eps_v` supplied; no continuum. Executor refinements kept: `chi` is size-flat at `V = 0`; the `V = 8` slab `chi` is a saturation value; PR #7890's `0.227671` versus the recomputed `0.227672` printed side by side.

## Context

- Parents: PR #7890 (the mass with supplied size and sign), PR #7878 (the interaction keeps the staggered sector), PR #7892 (`C`, the charge readout), PR #7879 (the sea), PR #7844, PR #7834.
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03); the mass-generation lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
