### PR TITLE
feat(readout): joint formation on a corner's record set keeps the sea's zeros

### DIFF
--- a/docs/JOINT_FORMATION_ON_A_CORNERS_RECORD_SET_KEEPS_THE_SEAS_ZEROS_UNDER_THE_UNITARY_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/JOINT_FORMATION_ON_A_CORNERS_RECORD_SET_KEEPS_THE_SEAS_ZEROS_UNDER_THE_UNITARY_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,328 @@
+---
+claim_id: joint_formation_corner_record_set_keeps_sea_zeros_unitary_tick
+claim_type: bounded_theorem
+claim_scope: "On the 2x2x2 cube graph (8 corners, 12 edge sites, 6 faces) with qubits on the EDGE sites, ordinary composition, the superfast encoding and the corner parity dictionary n_v = (1 - B_v)/2, in the staggered (pi-flux) Kawamoto-Smit sector H = -sum_e eta_e T_e at half filling, whose 128-dimensional code space is the even-N space and whose non-degenerate ground state -- the sea -- has E = -4 sqrt 3, gap 2 sqrt 3 and sharp N = 4, with Born support 1984 and 2112 zeros = 1856 charge zeros + 256 cancellation zeros on the 8 closed corner stars: under FIVE STIPULATED UNITS OF RECORD FORMATION, declared here and derived from nothing -- U1 a single edge site, U2 the three edges at one corner (a corner's own record set star(v)), U3 the four edges of a face, U4 the closed corner star of v (the nine edges incident to {v} u N(v), = E \\ star(7-v)), U5 all twelve at once -- in which the not-yet-recorded sites of the next unit in a DECLARED order register JOINTLY with the odds of the current pre-record object, and between formation events one of three DECLARED rules runs: (a) M_R, relaxation to the restricted ground state with the Pi/deg tie-break (PR #7895's tick), (b) A, the unitary exp(-i tau H_R) at tau = 0.5 (PR #7876's Model A), (c) L, nothing. (T1) Rule (c) is order-independent and IS the sea for all 17 declared schedules -- support 1984, TV <= 7.4e-16, max pairwise TV <= 4e-16 -- and U1 reproduces PR #7895 exactly (2240 support, 1856 charge zeros, 0 of 256 cancellation zeros, TV 0.324925160534 under rule (b)); so every deviation below is caused by the between-event rule and not by the joint conditioning. (T2) Under rule (b) joint formation on a corner's record set keeps ALL 256 cancellation zeros at 3 of the 4 declared U2 orders and at 4 of the declared 40-permutation lexicographic sweep, U4 antipodal keeps all 256, and two schedules -- U2 evenfirst (the four disjoint corner record sets) and U4 antipodal -- reproduce the sea EXACTLY, TV 1.11e-15 and 7.02e-16, at every tau in {0.1, 0.5, 1.234567, 2.0}; site-wise formation and every face order keep 0 of the 256. (T3) The mechanism: after a corner's record set forms jointly the Born-conditioned sea lies in the restricted ground space (G = 1) and is an exact eigenvector of H_R at 8/8 outcomes with TV(|psi|^2, Pi/deg) = 0, and after a closed corner star at 448/448 with deg 2, while after a single edge (0/2, G = 0.962606706) and after a FACE (0/16, G = 0.890431430) it is not; along both exact-sea schedules the eigenvector property holds at every node a between-event step follows. (T4) Under rule (a) no unit short of U5 keeps more than 64 of the 256 cancellation zeros in any declared order or in the sweep; the 64 surviving under U4 are exactly the first-formed star's coset and its antipode's; under U2 evenfirst they are cosets 1 and 6, NOT the first-formed corner0's coset 0; P(Q = 0) never reaches 1 below U5 (best 0.841145833 at U3, U4 0.666666667 .. 0.750000000). (T5) Order dependence shrinks with unit size and never vanishes short of U5 (max pairwise TV U1 0.602777777778 (a) / 0.619386368116 (b), U4 0.250000000000 / 0.076616282355) and is not monotone -- the 4-site face is more order-dependent than the 3-site corner record set under both rules; formation events per unit type average 12, 6.00, 4.50, 2.75, 1. OPEN and not claimed: why U2 identity and reverse keep all 256 under rule (b) although the propagated state visits 192 cancellation-coset labels at intermediate nodes. No seeds anywhere: every distribution is the exact product over the whole formation tree and every order is written out in the runner. This note stipulates a unit of record formation and computes with it; nothing is derived from any axiom, no formation clause is supplied, no axiom is amended, no status is set, and no claim is made about what the framework's tick is."
+upstream_dependencies: []
+runner: scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py
+---
+
+# Joint formation on a corner's record set keeps the sea's zeros under the unitary tick
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py`](../scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.txt`](../logs/runner-cache/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+`A_RELAXATION_TICK_IS_WELL_POSED_AND_LOSES_THE_SEAS_RECORD_STATISTICS_..._2026-09-03.md` (open PR #7895) lets **one edge site at a time** register, and finds that the sea's own
+forbidden patterns do not survive. On 2026-09-03 the owner put a different reading of the same clause: **"the whole neighbourhood generally has to move together because it is its own
+shared condition"**. Records are permanent, so at the level of formation that sentence is a statement about the **unit** in which records form: a formation event registers a whole
+neighbourhood's worth of records **together**, as one event. This note takes that as a stipulation under test. It declares five units of formation on the same cube in the same sector, runs them against the same three between-event rules, and reports what follows. The answer turns on the **shape** of the unit, not its size.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite-sector statements on one named cluster -- the 4096-dimensional record space of the 2x2x2 cube in the staggered sector, whose 128-dimensional code space is the even-N space -- for five stipulated units of record formation and three stipulated between-event rules. The unit and order combinatorics of B1-B2 are exact integer and F2 statements; the sea's zero census is exact F2 combinatorics on a zero set identified from the Born diagonal at 1e-12. The formation trees are enumerated whole and nothing is sampled, but each node's relaxed state or evolution comes from a diagonalisation, so those lines are deterministic double-precision evaluations of exactly specified quantities and are tagged [numerical] with their thresholds. There is no seed anywhere in the runner and no Monte Carlo section."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-sector theorem, and route to the vacuum panel the sharpened question: the unit of record formation is a free choice the axioms do not supply, and on this cluster one shape of unit -- a corner's own record set -- keeps the sea's registration under a unitary between-event rule while relaxation does not, so what a formation rule owes is a unit and a between-event rule together, not either alone."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below plus the open item, exactly the runner's check groups `A`-`G`: the setting and the sea's zeros (`A`); the stipulated units and
+orders (`B`); `T1` (`C`) the control; `T2` (`D`) the unitary tick; `T3` (`E1`-`E3`) the mechanism, with the open item recorded at `E4`; `T4` (`F`) relaxation; `T5` (`G`) order
+dependence. Groups `A1`, `A2`, `B1` and `B2` are **exact**: symplectic Pauli algebra with phases mod `4`, and integer combinatorics on the cube's own adjacency. `A4` is exact `F2`
+combinatorics on a zero set identified from the Born diagonal at `1e-12`. The rest are **deterministic double-precision evaluations** of exactly specified quantities at the stated
+thresholds. Nothing is sampled: every distribution is the exact product over the whole formation tree, every order is written out in the runner, and there is **no seed anywhere** and no Monte Carlo section.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggered link signs, Lueders conditioning and the total-variation distance
+are standard methodology; every object is redeclared here and the runner recomputes every statement, the encoding's relations included. No observational value, no fitted number and no
+framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no weight: `A_RELAXATION_TICK_IS_WELL_POSED_..._2026-09-03.md` (open PR #7895 -- the site-wise
+result this note extends, and the source of the `M_R` rule, the `Pi/deg` tie-break, and the zero census reproduced at `A4`); `RECORD_TICKS_ADMIT_NO_INVARIANT_PRE_RECORD_STATE_..._2026-09-03.md`
+(open PR #7876 -- Model A and `H_R`); `DETERMINANTAL_RECORD_STATISTICS_ON_THE_HALF_FILLED_SEA_..._2026-09-02.md` (PR #7883 -- the sea's Born statistics, the same `eta_ks`);
+`EMERGENT_DICTIONARY_SELECTION_RULE_ZEROS_THREE_DIMENSIONS_..._2026-09-02.md` (PR #7842 -- the selection-rule zeros from the dictionary side);
+`SUPPORT_CONDITIONS_CONFINE_RECORD_GROUPS_..._2026-09-03.md` (PR #7891 -- the owner's neighbourhood mechanism);
+`RECORD_FORMATION_ON_THE_EMERGENT_VACUUM_PARITY_FORCED_ODDS_..._2026-09-02.md` (PR #7858 -- the same cube and encoding); and `MINIMAL_AXIOMS_2026-06-29.md`, from which the axioms in
+"Setting" are quoted verbatim. This note cites no grade of any and consumes no ledger row.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency,
+standard translations, and proper cubic rotations about each site." "No site is privileged." The lattice is physical; the cube below is a finite open subgraph of it, drawn as a graph,
+so "edge site" and "corner" have their graph meanings. **Qubit / Site Possibility**: "Each site has a domain of local possibilities." "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+
+**Admissibility / Local Constraint.** "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." "For each site, the
+probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." Two reading notes, interpretive and non-governing, are the hinge of
+this note and are quoted with it. (2): "Read with Record, the distribution concerns which possibility a forming record locks, conditional on formation at that site; **it does not
+supply the formation site, probability, or rate.**" (3): "The distribution is a probability measure on the local possibility domain; 'available'/'admissible' denotes its support -- on finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may have zero singleton measure; Record locks a supported realization."
+
+**Record / Fixed Reality.** "Records form." "When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are permanent."
+"Only records are readable. A readout value is determined by record content alone. A site with no record cannot be read."
+
+Composition here is **ordinary**: the algebra of a region is the tensor product of its sites' algebras, operators on disjoint regions commute, and no graded clause is used anywhere.
+The **record ontology** is used as declared: a record at an edge site **registers** a value there; it does not report one the site already carried. Reading note (2) is what makes this
+note's subject a free choice: the axioms supply no formation site and no rate, so **the unit in which records form is not given** -- this note stipulates five of them and reports what each does. Reading note (3) is what makes a lost zero a real cost: "admissible" is the *support* of the odds, so a rule giving a pattern nonzero odds has made that pattern admissible.
+
+**Reading, not theorem.** Records are permanent, so "the whole neighbourhood together" cannot be about anything happening to records already present. Read at the level of formation it
+says: the records of one neighbourhood **form together**, in one event, because the neighbourhood is one shared condition. That is the reading tested below, and it is a stipulation.
+
+## The stipulated formation model, declared in full
+
+Seven choices, all made here, none derived. A lane proposing a different unit or a different between-event rule inherits the obligations of `T1`-`T5` and none of these choices.
+
+1. **The object before any record** is the sea: the ground state of `H` in the code space (see "Definitions"). 2. **The unit of formation.** Five **unit types** are declared, each a set of edge sites whose records form together as one event:
+
+   | type | what it is | count | size |
+   |---|---|---|---|
+   | `U1` | a single edge site | `12` | `1` |
+   | `U2` | the three edges at one corner `v` -- **a corner's own record set** `star(v)` | `8` | `3` |
+   | `U3` | the four edges of one face | `6` | `4` |
+   | `U4` | the **closed corner star** of `v`: every edge incident to `{v} u N(v)`, which on this cube is `E \ star(7 - v)` | `8` | `9` |
+   | `U5` | all twelve edge sites | `1` | `12` |
+
+3. **Which unit forms next.** The next unit in a **declared order**, a permutation of that type's unit list. **Sixteen** are declared for `U1`-`U4`, four per type, written out in the
+   runner, plus `U5`'s single order; a further declared **lexicographic sweep** of the first `40` permutations of the unit list is run for `U2`, `U3` and `U4`. None is drawn at random.
+4. **What forms.** Only the **not-yet-recorded** sites of that unit, and they form **together**: one event registers all `m` of them, with the odds of the current pre-record object on
+   the `2^m` joint outcome patterns.
+5. **Between formation events**, one of three **declared rules** runs:
+   * **(a) `M_R`** -- the object is replaced by the ground state of `H` restricted to the record-consistent subspace, with the normalised projector `Pi/deg` where that ground space is
+     degenerate. This is PR #7895's tick, one way of making the vacuum panel's candidate wording -- "Between records, the lattice settles into its lowest-energy arrangement" --
+     definite. That wording is a candidate, not axiom text, and is not called wrong here; what is reported is what `M_R` does.
+   * **(b) `A`** -- the unitary `exp(-i tau H_R)`, `tau = 0.5`, PR #7876's Model A: the lattice's law simply runs on.
+   * **(c) `L`** -- nothing at all, pure sequential Born. This is the control.
+6. **Conventions.** A unit with no unrecorded sites is **skipped**: no formation event and no between-event rule. The between-event rule after the **last** event is not applied; it
+   cannot change the final odds.
+7. **Permanence.** Records never change; the run continues until all `12` sites carry records, so each run ends on one of the `4096` record patterns.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is `P0`-`P5`. `P0` (declared here): the cube, the edge-site
+qubits, the encoding, the staggered sector, the parity dictionary, and the seven stipulated choices above, together with the setting and zero census of `A` and the unit/order
+combinatorics of `B`. `P1` (`C`): the control. `P2` (`D`): the unitary tick. `P3` (`E`): the mechanism, and the open item. `P4` (`F`): relaxation. `P5` (`G`): order dependence.
+
+## Definitions
+
+The **cube** is the `2x2x2` cube graph, corner `s = 4a + 2b + c`, `8` corners, `12` edge sites, `6` faces. One qubit sits on each **edge site**, neighbours ordered by index:
+
+```text
+A_ij = X(edge ij) * prod Z(edges at i ordered before j) * prod Z(edges at j ordered before i),   A_ji = -A_ij,
+B_v  = prod of the Z's on the edges incident to v,     S_f = the ordered product of the A's around a face f,
+T_ij = (i/2) A_ij (B_i - B_j),     H = -t sum_e eta_e T_e,  t = 1,     star(v) = the edges incident to v.
+```
+
+`eta` are the **Kawamoto-Smit staggered link signs** `eta_x = 1`, `eta_y = (-1)^x`, `eta_z = (-1)^(x+y)`, the same `eta_ks` as PR #7883; their product round every one of the six faces
+is `-1`, the all-minus (**pi-flux**) sector. The **code space** is all six `S_f = +1`, of dimension `2^12/2^5 = 128`; because `prod_v B_v = I` it *is* the even-`N` space, and the
+**sea** is the ground state of `H` there. A **record** at an edge site registers a `Z`-value, so a finished set of records is a vector in `F2^12`, one of `4096` **patterns**; the
+**parity dictionary** is `n_v = (1 - B_v)/2 = |y intersect star(v)| mod 2`, `N = sum_v n_v` and the **readable charge** is `Q = N - 4`. `H_R` is `H` restricted to the subspace
+consistent with the records so far, which by PR #7895's restriction identity is the sum of the hop terms on the **unrecorded** sites. `TV` is total variation, `(1/2) L1`. A
+**cancellation coset** is one of the eight `32`-label sets of the sea's non-charge zeros, indexed by the closed corner star carrying it.
+
+## The setting and the sea's zeros, reproduced
+
+`[exact]` The superfast relations `R0`-`R4` hold pair by pair, the face group carries no `-I`, `k = 5`, the code dimension is `128`, the flux is `-1` on all six faces, and every hop
+term has Pauli `X`-part exactly one edge qubit, so `P_S H P_S` is the sum of the hops on unrecorded sites. `[numerical, 1e-11]` The code space is `H`-invariant to `2.8e-17`; the sea
+has `E = -6.928203230276 = -4 sqrt 3`, is non-degenerate, has gap `3.464101615138 = 2 sqrt 3` and is sharp `N = 4` (mass off `N = 4`: `2.0e-31`). `[exact, 1e-12 zero read]` The
+**target** every rule below is checked against is the sea's own registration: support `1984 = 62 x 32`, and `2112` zeros `= 1856` **charge zeros** (`N != 4`) `+ 256` **cancellation
+zeros**, whose eight corner-occupation patterns are **exactly** the eight closed corner stars `{v} u N(v)`, `32` labels each; the smallest nonzero sea probability is `2.17e-04`.
+`[exact]` The five unit types have counts `12, 8, 6, 8, 1` and sizes `1, 3, 4, 9, 12`, and `cstar(v) = E \ star(7 - v)`: **a closed corner star's complement is the antipode's own
+record set.** The sixteen declared orders plus `U5`'s cover all twelve sites, with formation events `U1 [12,12,12,12]`, `U2 [7,7,4,6]`, `U3 [4,4,5,5]`, `U4 [3,3,2,3]`, `U5 [1]` --
+means `12`, `6.00`, `4.50`, `2.75`, `1`. `[numerical, 1e-12]` What **one unit's own joint odds** already forbid: `0` charge and `0` cancellation zeros at **every** `U1`, `U2` and `U3`
+unit, while every `U4` closed star forbids `448` charge and `64` cancellation zeros, and `U5` forbids all `1856 + 256`.
+
+## Theorem 1 -- the control: with nothing between events, the unit and the order do not matter
+
+**Conclusion.** `[numerical, 1e-15]` Under rule (c) all `17` declared schedules give support `1984` and **are** the sea's registration: `TV` to the sea at most `7.4e-16`. Between the
+four declared orders of each proper unit type the maximal pairwise `TV` is `4e-16` (`U1`), `4e-16` (`U2`), `2e-16` (`U3`), `8e-17` (`U4`). `[numerical, 1e-12]` And `U1` reproduces PR
+#7895 exactly: under rule (b) at `tau = 0.5` its support is `2240`, all `1856` charge zeros are kept, `0` of the `256` cancellation zeros are, and `TV` to the sea is
+`0.324925160534` at the identity order, at all four declared orders alike.
+
+**Proof.** Seventeen whole trees under rule (c) and four more under rule (b), each the exact product over its own leaves with nothing sampled and no branch pruned above `1e-12`
+relative. Joint conditioning in the `Z` basis commutes with itself, so the control's order independence is expected and is checked rather than assumed.
+
+**Reading, not theorem.** This is the control the rest of the note needs: with the lattice's law switched off between events, forming records one at a time and forming them a whole
+neighbourhood at a time give the same odds, and give the sea's odds. So every difference below is caused by what runs **between** formation events, not by the joint formation itself.
+
+## Theorem 2 -- under the unitary tick, a corner's record set keeps the sea's forbidden patterns
+
+**Conclusion.** `[numerical, 1e-12]` Under rule (b) at `tau = 0.5`, cancellation zeros kept over the four declared orders are `U1 [0,0,0,0]`, `U2 [256,256,256,0]`, `U3 [0,0,0,0]`,
+`U4 [128,128,256,128]`, `U5 [256]`: **all `256` at three of the four corner orders, none at any face order**, with all `1856` charge zeros kept everywhere. In the declared
+lexicographic sweep of the first `40` permutations, `4` of `40` `U2` orders keep all `256`, `U3` keeps `0` throughout and `U4` `128` throughout. Two schedules reproduce the sea
+**exactly**: `U2 evenfirst` -- the four **disjoint** corner record sets `star(0), star(3), star(5), star(6)` -- at `TV = 1.11e-15`, and `U4 antipodal` -- `cstar(0)` then `star(7)` --
+at `TV = 7.02e-16`, both on the sea's own support `1984`. Both do it at every `tau` tested, `0.1`, `0.5`, `1.234567`, `2.0`, while `U1 identity` and `U3 identity` keep `0` of the `256`
+at every one of them.
+
+**Proof.** Whole formation trees as in `T1`, one per (unit type, order, rule) and four more per schedule for the `tau` sweep; the zero census of each final distribution is read at
+`1e-12` against the sea's zero set and split by cancellation coset. The `40`-permutation sweep is `itertools.permutations` on the sorted unit list, a literal enumeration with no seed.
+
+**Reading, not theorem.** Letting the three records at one corner form together, with the lattice's law simply running on in between, keeps every one of the forbidden patterns that
+site-wise formation loses -- and for the right sequence of corners the records come out exactly as the sea itself would register them, at any gap length. The four edges of a face are a
+**larger** unit and keep none of them.
+
+## Theorem 3 -- the mechanism: a jointly formed corner set leaves the sea at rest under what remains of the law
+
+**Conclusion.** `[numerical, 1e-9]` After a corner's record set forms jointly, the Born-conditioned sea already lies in the restricted ground space (`G = <psi|Pi_0|psi> =
+1.000000000`, `deg = 1`) and is an **exact eigenvector of `H_R`** at `8` of `8` outcomes, with `TV(|psi|^2, Pi/deg) = 0`: relaxation is the **identity** there and the unitary is a
+global phase. The closed corner star has the same property at `448` of `448` outcomes (`G = 1.000000000`), but its ground space is `2`-fold degenerate, so the `Pi/deg` tie-break gives
+a rank-`2` mixture (`F = 0.636894534`, `Fq = 0.500`). A single edge (`G = 0.962606706`, `0/2`) and a **face** (`G = 0.890431430`, `0/16`) are eigenvectors at no outcome at all, though
+the face is the larger unit. `[numerical, 1e-9]` Along both exact-sea schedules the conditioned state is an `H_R` eigenvector at **every** node a between-event step follows --
+eigen-weight `1.000/1.000/1.000` (`U2 evenfirst`) and `1.000` (`U4 antipodal`) -- against `0.000` at each of the first seven levels for `U1 identity` and `0.000/0.079/0.142` for
+`U3 identity`.
+
+**Proof.** For each first-unit outcome the conditioned sea is formed, `H_R psi` is computed directly from the block's real skew form `H = i M` without any diagonalisation, and
+`psi` is called an eigenvector when `max |H_R psi - lambda psi| < 1e-9` with `lambda = Re<psi|H_R|psi>`. `G` is `deg` times `<psi|Pi_0/deg|psi>` from the block ground projector, `F` is
+the classical fidelity `(sum sqrt(p q))^2` between `|psi|^2` and `diag(Pi_0)/deg`, and every figure is weighted by the outcome's own odds. The stagewise profile repeats the test at
+each node of the rule-(b) tree, weighted the same way.
+
+**Reading, not theorem.** This is why the corner works and the face does not. Once a corner's own records are all present, what is left of the law is a Hamiltonian for which the
+conditioned sea is already at rest: running it forward changes nothing, and settling it to the lowest arrangement changes nothing either, because it is already there. The face leaves
+the conditioned sea off its own ground state, and the lattice's law then carries odds into patterns the sea never registers. Shape, not size.
+
+## Theorem 4 -- under relaxation nothing short of the whole cluster keeps the zeros
+
+**Conclusion.** `[numerical, 1e-12]` Under rule (a) the cancellation zeros kept over the sixteen declared orders are `U1 [0,0,0,0]`, `U2 [0,0,64,0]`, `U3 [0,0,0,0]`, `U4 [64,64,64,64]`,
+and over the declared sweep at most `64`; only `U5` -- all twelve sites at once -- keeps all `2112` zeros. The `64` that do survive under `U4` are **exactly the first-formed star's
+coset and its antipode's**, at all four declared orders: `cstar(v)`'s nine edges fix the corner parities on `{v} u N(v)`, and in the sharp-`N = 4` sea both all-occupied and all-empty
+are forced to zero, so a `U4` unit's own joint odds already vanish there. Later stars' cosets go to the intervening relaxation. The same "formed first, therefore kept" reading does
+**not** transfer to the corner unit: under `U2 evenfirst`, whose first unit is `corner0`, the surviving cosets are `1` and `6`, **not** `0` -- consistent with a `3`-site unit's own
+joint odds vanishing on none of the sea's zeros. And the readable charge stays smeared: `P(Q = 0)` never reaches `1` below `U5` -- best `0.841145833` at `U3`, the four-site face,
+against `U4`'s `0.666666667 .. 0.750000000` -- while `U5` gives exactly `1.000000000`.
+
+**Proof.** Whole trees again, one per (unit type, order) under rule (a) plus the `40`-permutation sweep for `U2`, `U3`, `U4`; the surviving cancellation zeros are broken out per
+cancellation coset and compared, coset by coset, with the antipodal pair of the schedule's first unit. The charge law is read off each tree against the parity dictionary.
+
+**Reading, not theorem.** Settling to the lowest-energy arrangement between formation events does something definite, and what it does here is not repaired by forming records
+together: at every unit shorter than the whole cube it leaves at least three quarters of the sea's forbidden patterns admissible, and it leaves the readable charge spread out. The
+panel's candidate wording and the corner unit are two separate choices, and on this cluster they do not combine.
+
+## Theorem 5 -- order dependence shrinks with the unit but does not vanish, and is not monotone
+
+**Conclusion.** `[numerical, 1e-12]` Max pairwise `TV` over the four declared orders, rules (a)/(b): `U1 0.602777777778 / 0.619386368116`, `U2 0.461024273 / 0.286110110`,
+`U3 0.562500000 / 0.506673787`, `U4 0.250000000000 / 0.076616282355`, against exactly `0` for the control. Each is a **lower bound** on the spread over all orders of that unit list.
+The dependence shrinks with unit size but never vanishes short of `U5`, and it is **not monotone**: the four-site face `U3` is more order-dependent than the three-site corner record
+set `U2` under both rules. Formation events per unit type average `12`, `6.00`, `4.50`, `2.75`, `1`.
+
+**Proof.** Six pairwise `L1` sums per unit type and rule over the trees of `T2` and `T4`; the event counts are the schedule lengths, which are deterministic because which unit
+registers which sites does not depend on the outcomes.
+
+**Reading, not theorem.** The finished set is the same twelve records whichever sequence of neighbourhoods formed them, and how likely it was should not depend on that sequence. It
+still does, everywhere short of the whole cluster -- and a bigger unit is not automatically a better one.
+
+## Open, not claimed
+
+Under rule (b), `U2 identity` and `U2 reverse` finish with all `256` cancellation zeros although the propagated state **visits** `192` cancellation-coset labels at intermediate nodes
+(the union of the state's `Z`-support over every node of the tree is `2176`, against the sea's `1984`). The union never leaves the `N = 4` sector for any schedule, and for the two
+exact-sea schedules it never leaves the sea's `1984` labels at all. Why the visited amplitude never reaches a leaf with a matching record prefix is **not** explained here: the
+eigenvector mechanism of `T3` covers the two exact-sea schedules and no more. This is recorded as an observation, and anyone landing on it should either derive it or keep it stated.
+
+## Corollary -- what this says about the unit of record formation
+
+Within the setting declared above, on the cube in the staggered sector at half filling, and for the five stipulated units and three stipulated between-event rules alone:
+
+1. **The unit of record formation matters, and the unit that fits is a corner's own record set.** With the unitary tick, joint formation on `star(v)` keeps the sea's forbidden patterns
+   that site-wise formation loses (`T2`), and schedules of **disjoint** corner record sets reproduce the sea's registration exactly, at every `tau` tested.
+2. **The reason is exact, and it is about shape.** A jointly formed corner set leaves the conditioned sea an eigenvector of what remains of the law, so the evolution between events
+   cannot disturb it (`T3`). The face unit is larger and does not have this property; the closed corner star has it, and its complement is another corner's record set.
+3. **The panel's candidate and the corner unit do not combine.** Under relaxation nothing short of the whole cluster keeps more than `64` of the `256` cancellation zeros, at any
+   declared order or swept order, and the readable charge stays smeared (`T4`).
+4. **What remains open.** Order independence short of the whole cluster is not achieved by any unit here (`T5`), and the mechanism for the non-disjoint corner schedules that keep the
+   zeros is not derived ("Open, not claimed").
+5. **A candidate formation sentence this supports**, offered as a candidate wording and **not** as axiom text, on the same footing as the vacuum panel's own candidate: *"Records form
+   together on a corner's record set; between formations the law runs on."*
+
+## Reading, not theorem -- the whole thing in plain words
+
+Let the records at one corner form all at once, as one event, and let the lattice's law run on undisturbed in between. Then the sea's own forbidden patterns, the ones that matched the
+known selection rules, all survive, and for the right sequence of corners the records come out exactly as the sea itself would register them. Forming one record at a time loses all of
+that, and so does settling to the lowest energy in between. It is the corner, the shape of the shared condition, that does the work, not the number of records formed at once.
+
+## Interfaces named for other lanes, not settled here
+
+- **Larger clusters.** Whether a corner's record set keeps this property on the `3x3x3` cube, on periodic boundaries, or in the thermodynamic limit is outside this note; the sea's
+  degeneracy and the corner-star census both depend on the cluster.
+- **The fine lattice.** The cube here is an emergent cluster of the physical lattice; nothing is said about the unit of formation on the physical sites themselves.
+- **The formation rate.** How often a unit forms, and which one forms next, is stipulated here as an order and is not derived; reading note (2) says the axioms supply neither.
+- **The open mechanism.** The non-disjoint corner schedules of `T2` that keep all `256` zeros are not covered by `T3`.
+- **The exact-sea schedules on tori.** Whether a minimum vertex cover of the cluster graph plays the role `U2 evenfirst` plays here, on other graphs and on periodic boundaries, is
+  named and not computed.
+
+## Remaining live routes
+
+1. Whether some between-event rule other than the three declared here -- a partial relaxation, or a dissipative generator with the sea as its stationary object -- keeps the zeros at a
+   unit smaller than the whole cluster. Only the three ends are computed here.
+2. Whether the eigenvector property of `T3` characterises the units that work, on this cluster and on others: every unit that keeps all `256` zeros here has it, but the converse is
+   not established.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the five theorem conclusions and the open item.
+
+```text
+setting: qubits on the 12 EDGE sites of the 2x2x2 cube graph (8 corners, 6 faces); ordinary (commuting) composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md with Admissibility reading notes (2) and (3)
+encoding: A_ij = X(edge ij) * Z's ordered before it at both endpoints; A_ji = -A_ij; B_v the Z's incident to v; S_f the ordered four-A face loop; T_ij = (i/2) A_ij (B_i - B_j)
+law: eta = Kawamoto-Smit staggered signs, flux -1 on all six faces; H = -sum_e eta_e T_e, t = 1; code space all six S_f = +1, dim 128 = the even-N space; the sea = its ground state, E = -4 sqrt 3, non-degenerate, gap 2 sqrt 3, sharp N = 4, Born support 1984 and 2112 zeros = 1856 charge + 256 cancellation on the 8 closed corner stars x 32
+dictionary: n_v = (1 - B_v)/2 = |y intersect star(v)| mod 2; N = sum_v n_v; readable charge Q = N - 4
+formation_model: STIPULATED, seven declared choices -- (i) start from the sea; (ii) five UNITS U1 edge / U2 star(v) / U3 face / U4 closed corner star (9 edges, = E \ star(7-v)) / U5 all twelve; (iii) the next unit in a DECLARED order, 16 declared for U1-U4 plus U5's, plus a declared 40-permutation lexicographic sweep for U2, U3, U4; (iv) only the unrecorded sites of that unit register, and they register JOINTLY with the odds of the current pre-record object on the 2^m patterns; (v) between events one of three DECLARED rules -- (a) M_R relaxation with the Pi/deg tie-break, (b) A = exp(-i tau H_R) at tau = 0.5, (c) L nothing; (vi) a unit with no unrecorded sites is SKIPPED and the rule after the last event is not applied; (vii) records permanent, run to 12. No seed anywhere; every order written out in the runner
+setting_and_zeros [exact; 1e-12 zero read]: R0-R4 pair by pair, no -I in the face group, k = 5, code dim 128, flux -1 on all six faces, every hop term has X-part exactly one edge qubit; E_sea = -6.928203230276 = -4 sqrt 3, deg 1, gap 3.464101615138, mass off N = 4 is 2.0e-31; sea support 1984 = 62 x 32, 2112 zeros = 1856 charge + 256 cancellation = the 8 closed corner stars x 32; unit counts 12/8/6/8/1 and sizes 1/3/4/9/12; cstar(v) = E \ star(7-v); events per order U1 [12,12,12,12], U2 [7,7,4,6], U3 [4,4,5,5], U4 [3,3,2,3], U5 [1]; one unit's own joint odds forbid 0 + 0 at every U1, U2, U3 unit, 448 + 64 at every U4 star, 1856 + 256 at U5
+T1_control [numerical, 1e-15]: rule (c) gives support 1984 and TV <= 7.4e-16 to the sea at all 17 declared schedules, with max pairwise TV 4e-16 (U1), 4e-16 (U2), 2e-16 (U3), 8e-17 (U4); [numerical, 1e-12] U1 under rule (b) reproduces PR #7895 -- support 2240, 1856 charge zeros kept, 0 of 256 cancellation kept, TV 0.324925160534
+T2_unitary [numerical, 1e-12]: cancellation zeros kept, rule (b), four declared orders: U1 [0,0,0,0], U2 [256,256,256,0], U3 [0,0,0,0], U4 [128,128,256,128], U5 [256], all 1856 charge zeros kept everywhere; lexicographic-40 sweep 4/40 for U2, 0 for U3, 128 constant for U4; U2 evenfirst TV 1.11e-15 and U4 antipodal TV 7.02e-16, both on support 1984, at every tau in {0.1, 0.5, 1.234567, 2.0}, while U1 identity and U3 identity keep 0 of 256 at every tau
+T3_mechanism [numerical, 1e-9]: after star(0), G = 1.000000000, deg 1, exact H_R eigenvector at 8/8 outcomes, TV(|psi|^2, Pi/deg) = 0; after cstar(0), G = 1.000000000 at 448/448, deg 2, F = 0.636894534, Fq = 0.500; after one edge G = 0.962606706 at 0/2; after one FACE G = 0.890431430 at 0/16; eigen-weight 1.000 at every node a between-event step follows for U2 evenfirst and U4 antipodal, 0.000 at the first seven levels for U1 identity, 0.000/0.079/0.142 for U3 identity
+T4_relaxation [numerical, 1e-12]: cancellation zeros kept, rule (a): U1 [0,0,0,0], U2 [0,0,64,0], U3 [0,0,0,0], U4 [64,64,64,64], sweep at most 64, U5 all 2112 zeros; the 64 under U4 are exactly the first-formed star's coset and its antipode's at all four declared orders; under U2 evenfirst the survivors are cosets 1 and 6, NOT the first-formed corner0's coset 0; P(Q = 0) best 0.841145833 (U3), U4 0.666666667 .. 0.750000000, U5 exactly 1
+T5_order [numerical, 1e-12]: max pairwise TV over the four declared orders, rules (a)/(b): U1 0.602777777778/0.619386368116, U2 0.461024273/0.286110110, U3 0.562500000/0.506673787, U4 0.250000000000/0.076616282355, control exactly 0; a LOWER BOUND over all orders of each unit list; not monotone -- U3 > U2 under both rules; mean events 12, 6.00, 4.50, 2.75, 1
+OPEN_not_claimed [numerical, 1e-11]: under rule (b) the node-support union never leaves N = 4, and is 1984 for both exact-sea schedules, but U2 identity visits 192 cancellation-coset labels at intermediate nodes (union 2176) and still finishes with all 256 zeros; not explained here
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=24 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **one finite cluster**, the `2x2x2` cube graph, in **one flux sector** (all-minus, the Kawamoto-Smit staggered signs) at **one filling** (the
+half-filled sea, `N = 4`). Nothing is claimed for larger clusters, periodic boundaries, infinite lattices, other sectors, other fillings, or any law family other than the one in
+"Definitions". The law is **designed**, not derived: the encoding is chosen so that the Majorana relations `R0`-`R4` hold, the face constraints make that consistent, and the parity
+dictionary is one readout map among many, with no uniqueness claimed for either.
+
+**The formation model is stipulated in full and derived from nothing.** The five unit types, the sixteen declared orders and `U5`'s, the declared `40`-permutation lexicographic sweep,
+the three between-event rules, the `Pi/deg` tie-break, the skip-an-already-recorded-unit convention, `tau in {0.1, 0.5, 1.234567, 2.0}`, and the joint-odds formation step itself are
+all declared here, not taken from any axiom. Reading note (2) is explicit that the axioms supply no formation site, probability or rate; they supply no unit of formation either, and
+this note supplies none and declares five instead. The owner's statement is quoted as the **question** this note answers on one cluster, read at the level of formation because records
+are permanent; it is not treated as axiom text and nothing here settles it. The vacuum panel's candidate wording is likewise a candidate, is not called wrong anywhere above, and
+`M_R` is reported as one way of making it definite: what is stated is what each declared rule does.
+
+**Nothing here says what the framework's tick is**, and nothing here forecloses any unit, rule or rate. The order-dependence figures of `T5` and the `4/40` and `0/40` counts of `T2`
+and `T4` are maxima and counts over **declared finite sets** -- sixteen orders and forty permutations, all written out in the runner -- and are lower bounds on the spread over all
+orders of each unit list, labelled so everywhere they appear. Every line not tagged `[exact]` is a **deterministic double-precision evaluation** of an exactly specified quantity at
+the stated threshold: the formation trees are enumerated whole and nothing is sampled, but each node's relaxed object or evolution comes from a diagonalisation, against which no exact
+rational value stands. There is **no seed anywhere** in this note or its runner and no Monte Carlo section. No absolute unit appears anywhere, no axiom text is amended, extended,
+reworded or reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is created or edited.
+
+## Review record
+
+An honest auditor should come away with a stipulated unit of record formation and its consequences, not a claim about what the framework's tick is; a two-sided result -- the corner
+unit keeps the sea's zeros under the unitary rule and the face unit does not, and under relaxation no proper unit does -- on one named finite cluster, sector and filling; the
+stipulation declared as stipulated in the front matter, the setting, its own section, the claim block and the proof boundary alike; the owner's statement quoted as the question and
+read at the level of formation, with the reading stated; the vacuum panel's candidate sentence quoted as a candidate wording and nowhere called wrong; the order and sweep figures
+labelled as lower bounds over declared finite sets; the disagreements with the naive form of the prediction stated plainly in `T3`, `T4` and `T5` -- the larger face unit is worse than
+the smaller corner unit, relaxation is the identity at `U2` and worse at `U4`, and the "formed first, therefore kept" reading holds for `U4` only; and the corollary written as an
+obligation on a formation rule, not as a foreclosure.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the "Imports and authority" pointers are plain
+text carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair at `PASS=24 FAIL=0`, runtime under the declared `150` seconds, a current
+zero-dependency citation-manifest entry, and passing pipeline, strict-lint and changed-evidence gates; audit remains a separate lane.

--- a/logs/runner-cache/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.txt
+++ b/logs/runner-cache/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.txt
@@ -1,0 +1,37 @@
+===== runner cache v1 =====
+runner: scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py
+runner_sha256: 4b611dc3c9807f55335cdc55c962d7d3e38cd88b7a3199fa5e8ea8ddbd0fa48a
+timeout_sec: 150
+exit_code: 0
+elapsed_sec: 66.72
+status: ok
+----- stdout -----
+PASS A1 [exact] cube 2x2x2, 8 corners / 12 edge sites / 6 faces: R0-R4 pair by pair, no -I in the face group, k = 5, code dim 2^12/2^5 = 128; each hop term has X-part exactly one edge qubit, so P_S H P_S is the sum of the hops on UNRECORDED sites -- H_R
+PASS A2 [exact] the Kawamoto-Smit signs put flux {-1} on all six faces -- the pi-flux sector -- and H = -sum_e eta_e T_e is Hermitian on the 4096-dimensional record space
+PASS A3 [numerical, 1e-11] the code space (six S_f = +1, dim 128 = the even-N space) is H-invariant to 2.8e-17; the sea has E = -6.928203230276 = -4 sqrt 3, deg 1, gap 3.464101615138 = 2 sqrt 3, sharp N = 4 (mass off: 2.0e-31)
+PASS A4 [exact, 1e-12 zero read] the target, the sea's registration: support 1984 = 62 x 32, 2112 zeros = 1856 charge (N != 4) + 256 cancellation, whose 8 corner patterns are EXACTLY the 8 closed corner stars {v} u N(v), 32 each (min nonzero sea probability 2.17e-04)
+PASS B1 [exact] the five stipulated units: U1 12 edge sites (size 1), U2 8 corner record sets star(v) (3), U3 6 faces (4), U4 8 closed corner stars (9), U5 the one 12-site unit; cstar(v) = E \ star(7 - v)
+PASS B2 [exact] the 16 declared orders for U1-U4 (four per type, written out; no seed) plus U5's cover all 12 sites; events U1 [12, 12, 12, 12], U2 [7, 7, 4, 6], U3 [4, 4, 5, 5], U4 [3, 3, 2, 3], U5 [1] -- means 12.00, 6.00, 4.50, 2.75, 1.00
+PASS B3 [numerical, 1e-12] what ONE unit's own joint Born marginal forbids: 0 charge and 0 cancellation at every U1, U2 and U3 unit -- an edge, a corner record set and a face each see none of the sea's zeros -- while every U4 closed star forbids 448 + 64, and U5 all 1856 + 256
+PASS C1 [numerical, 1e-15] THE CONTROL: with no between-event rule, all 17 declared schedules give support 1984 and ARE the sea's registration -- TV to the sea at most 7.4e-16
+PASS C2 [numerical, 1e-15] and order-independent for every unit type -- max pairwise TV 4e-16 (U1), 4e-16 (U2), 2e-16 (U3), 8e-17 (U4): joint Z-basis conditioning commutes, so what follows is the between-event rule, not the conditioning
+PASS D1 [numerical, 1e-12] site-wise formation (U1) under the unitary tick: support 2240, all 1856 charge zeros kept, 0 of the 256 cancellation zeros kept, TV to the sea 0.324925160534 at the identity order
+PASS D2 [numerical, 1e-12] joint formation on a corner's record set flips it: cancellation zeros kept over the four declared orders are U1 [0, 0, 0, 0], U2 [256, 256, 256, 0], U3 [0, 0, 0, 0], U4 [128, 128, 256, 128], U5 [256] -- all 256 at 3 of 4 corner orders, none at any face order; charge zeros kept everywhere
+PASS D3 [numerical, 1e-12] and two schedules reproduce the sea EXACTLY: U2 evenfirst, the four disjoint corner sets star(0), star(3), star(5), star(6), at TV 1.11e-15; U4 antipodal, cstar(0) then star(7), at TV 7.02e-16; both on support 1984
+PASS D4 [numerical, 1e-12] at every tau tested, (0.1, 0.5, 1.234567, 2.0): both stay at TV < 1e-14 with all 256 cancellation zeros, while U1 and U3 identity keep 0 of the 256 at every one of them
+PASS D5 [numerical, 1e-12] a declared lexicographic sweep, the first 40 permutations of each unit list (no seed): under the unitary tick 4 of 40 U2 orders keep all 256, U3 keeps 0 .. 0, U4 128 .. 128; under relaxation none over 64
+PASS E1 [numerical, 1e-9] THE MECHANISM. After a corner's record set forms jointly the Born-conditioned sea lies in the restricted ground space (G = 1.000000000, deg 1), an exact H_R eigenvector at 8 of 8 outcomes, TV(|psi|^2, Pi/deg) = 0.000000000: relaxation is the IDENTITY there, the unitary a global phase
+PASS E2 [numerical, 1e-9] the closed corner star too, G = 1.000000000 at 448/448, but its ground space is 2-fold degenerate, so Pi/deg gives a rank-2 mixture (F = 0.636894534, Fq = 0.500); an edge (0.962606706, 0/2) and a FACE (0.890431430, 0/16) are not eigenvectors, though the face is larger
+PASS E3 [numerical, 1e-9] along both exact-sea schedules the conditioned state is an H_R eigenvector at EVERY node a between-event step follows: eigen-weight 1.000/1.000/1.000 and 1.000, against 0.000/0.000/0.000/0.000/0.000/0.000/0.000 (U1 identity, first seven) and 0.000/0.079/0.142 (U3 identity)
+PASS E4 [numerical, 1e-11] OPEN, not claimed: the rule-(b) node-support union never leaves N = 4 ({0} outside) and, for the two exact-sea schedules, never leaves the sea's 1984 labels (unions 1984, 1984); yet U2 identity visits 192 cancellation-coset labels en route and still finishes with all 256 zeros -- observed, not explained
+PASS F1 [numerical, 1e-12] under RELAXATION nothing short of the whole cluster keeps more than 64 of the 256: over the 16 declared orders U1 [0, 0, 0, 0], U2 [0, 0, 64, 0], U3 [0, 0, 0, 0], U4 [64, 64, 64, 64], over the sweep at most 64; U5 keeps all 2112 zeros
+PASS F2 [numerical, 1e-12] the 64 that survive under U4 are exactly the FIRST-formed star's coset and its antipode's at all four declared orders ([(0, 7)]): cstar(v)'s nine edges fix the parities on {v} u N(v), and in the sharp-N = 4 sea both all-occupied and all-empty are forced to zero; later stars go to the relaxation
+PASS F3 [numerical, 1e-12] the 'formed first, therefore kept' reading does NOT transfer to the corner unit: under U2 evenfirst, whose first unit is corner0, the surviving cosets are [1, 6], not 0 -- as B3 requires
+PASS F4 [numerical, 1e-12] and the readable charge stays smeared: P(Q = 0) never reaches 1 below U5 -- best 0.841145833 at U3, the 4-site face, against U4's 0.666666667 .. 0.750000000; U5 gives exactly 1.000000000. Bigger units do not sharpen Q monotonically
+PASS G1 [numerical, 1e-12] order dependence shrinks with unit size and never vanishes short of U5: max pairwise TV over the four declared orders, rules (a)/(b), is U1 0.602777777778/0.619386368116, U2 0.461024273/0.286110110, U3 0.562500000/0.506673787, U4 0.250000000000/0.076616282355 -- a LOWER BOUND
+PASS G2 [numerical, 1e-12] and not monotone in the unit size: the 4-site face U3 is MORE order-dependent than the 3-site corner set U2 under both rules (0.562500000 > 0.461024273, 0.506673787 > 0.286110110) -- shape, not size, governs
+SUMMARY: under the unitary tick, records forming together on a corner's record set keep all 256 cancellation zeros that site-wise formation loses, and disjoint corner schedules reproduce the sea exactly at every tau, because the jointly conditioned sea is an exact eigenvector of what remains of the law; under relaxation nothing short of the whole cluster keeps more than 64.
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py
+++ b/scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py
@@ -1,0 +1,1050 @@
+#!/usr/bin/env python3
+"""Joint formation on a corner's record set keeps the sea's zeros under the unitary tick.
+
+Class-A finite-cluster runner, self-contained. Qubits sit on the 12 EDGE sites of
+the 2x2x2 cube graph (8 corners, 6 faces); the sites compose ordinarily (tensor
+product, operators on disjoint regions commute, no graded clause anywhere). A
+record at an edge site registers a Z-value there, and the corner-parity
+dictionary n_v = (1 - B_v)/2 registers occupancy from those records. The full
+record space is 2^12 = 4096-dimensional; the code space (all six face
+stabilizers S_f = +1) is 128-dimensional and, because prod_v B_v = I, is the
+even-N space. No dense object above 4096 x 4096 is formed, and every matrix
+actually diagonalized is a record block of dimension at most 2048, split further
+by the conserved record number N.
+
+THE LAW. eta = the Kawamoto-Smit staggered link signs (eta_x = 1,
+eta_y = (-1)^x, eta_z = (-1)^(x+y)), whose product round every one of the six
+faces is -1: the all-minus (pi-flux) sector. H = -sum_e eta_e T_e with the
+encoded hop T_ij = (i/2) A_ij (B_i - B_j), t = 1. THE SEA is the ground state of
+H in the code space: E = -4 sqrt 3, non-degenerate, gap 2 sqrt 3, sharp N = 4.
+
+WHAT IS STIPULATED HERE, AND DERIVED FROM NOTHING. The site-wise parent note
+(PR #7895) lets one edge site at a time register. This runner stipulates a UNIT
+of record formation instead -- a set of edge sites whose records form together,
+as one event -- and computes what follows. Five unit types are declared:
+
+  U1  a single edge site                                   12 units, size 1
+  U2  the three edges at one corner v, star(v)              8 units, size 3
+      -- a corner's own record set
+  U3  the four edges of one face                            6 units, size 4
+  U4  the closed corner star of v: every edge incident to    8 units, size 9
+      {v} u N(v), which on this cube is E \\ star(7 - v)
+  U5  all twelve edge sites at once                          1 unit, size 12
+
+A tick is: (i) take the next unit in a DECLARED order; (ii) the not-yet-recorded
+sites of that unit register JOINTLY, as one event, with the Born odds of the
+current pre-record object on the 2^m joint outcome patterns of those m sites;
+(iii) between events apply one of three DECLARED rules --
+
+  (a) M_R  relax to the ground state of H restricted to the record-consistent
+           subspace, with the normalized projector Pi/deg where that ground
+           space is degenerate (PR #7895's tick);
+  (b) A    the unitary exp(-i tau H_R), tau = 0.5 (PR #7876's Model A);
+  (c) L    nothing at all -- pure sequential Born, the control.
+
+Declared conventions: a unit with no unrecorded sites is SKIPPED (no formation
+event and no between-event rule); the between-event rule after the LAST event is
+not applied, since it cannot change the final distribution; records are
+permanent, so "together" is read at the level of FORMATION -- a formation event
+registers a whole unit's worth of records at once. Sixteen orders are declared
+for U1-U4, four per type, written out in ORDERS_U, plus U5's single order; a
+further declared lexicographic sweep of the first LEX_N permutations of the unit
+list is run for U2, U3 and U4.
+
+The runner establishes:
+
+  A  THE SETTING AND THE SEA'S ZEROS.  The encoding, the pi-flux sector, the sea,
+     and PR #7895's census: support 1984 = 62 x 32 and 2112 zeros = 1856 charge
+     zeros (N != 4) + 256 cancellation zeros = the 8 closed corner stars x 32.
+  B  THE UNITS AND ORDERS, DECLARED IN FULL.  Their counts, sizes, schedules and
+     event counts, and what a single unit's own joint Born marginal already
+     forbids.
+  C  THE CONTROL.  Rule (c) is order-independent and IS the sea, for every unit
+     type: joint Z-basis conditioning commutes, so every deviation below is
+     caused by the between-event rule and not by the joint conditioning.
+  D  THE UNITARY TICK.  Joint formation on a corner's record set keeps all 256
+     cancellation zeros where site-wise formation keeps none, and two schedules
+     of disjoint corner sets reproduce the sea EXACTLY at every tau tested.
+  E  THE MECHANISM.  After a corner's record set forms jointly the Born-
+     conditioned sea is an exact eigenvector of H_R, so the evolution between
+     events cannot disturb it; after a single edge or a face it is not.
+  F  RELAXATION.  Under rule (a) nothing short of the whole cluster keeps more
+     than 64 of the 256, and the readable charge stays smeared.
+  G  ORDER DEPENDENCE.  It shrinks with unit size, never vanishes short of U5,
+     and is not monotone.
+
+NO SEEDS ANYWHERE. Nothing is sampled: every distribution is the exact product
+over the whole formation tree, and every order used is written out in this file.
+
+Line tags. `[exact]` = integer, F2 or symplectic Pauli arithmetic with no
+floating point in the statement. `[numerical, tol]` = a deterministic
+double-precision evaluation of an exactly specified quantity at the stated
+threshold, with no sampling and no seed.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+from __future__ import annotations
+
+import itertools
+import sys
+from functools import reduce
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 150
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# --------------------------------------------------------------------------
+# Pauli algebra in the symplectic representation, phases mod 4
+# --------------------------------------------------------------------------
+def pc(n):
+    return bin(n).count("1")
+
+
+PH = [1 + 0j, 1j, -1 + 0j, -1j]
+
+
+class Pauli:
+    """i^k * prod_q X_q^{x_q} Z_q^{z_q}, X before Z on every qubit."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k % 4
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Pauli(a.k + b.k + 2 * pc(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(self):
+        return Pauli(self.k + 2, self.x, self.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def is_herm(self):
+        return self.k % 2 == pc(self.x & self.z) % 2
+
+    def is_id(self):
+        return self.x == 0 and self.z == 0 and self.k == 0
+
+    def is_mid(self):
+        return self.x == 0 and self.z == 0 and self.k == 2
+
+
+IDP = Pauli(0, 0, 0)
+
+
+def comm(a, b):
+    return (pc(a.x & b.z) + pc(a.z & b.x)) % 2 == 0
+
+
+def pact(p, b):
+    """P|b> = amp |b ^ p.x>, amp a unit Gaussian integer."""
+    return b ^ p.x, PH[p.k] * ((-1) ** (pc(p.z & b) % 2))
+
+
+# --------------------------------------------------------------------------
+# the cube and the superfast encoding (route B: Z tail on edges ordered BEFORE)
+# --------------------------------------------------------------------------
+def cube_cluster():
+    return 8, sorted((min(s, s ^ bit), max(s, s ^ bit)) for s in range(8) for bit in (4, 2, 1) if s ^ bit > s)
+
+
+def cube_faces():
+    out = []
+    for ax in range(3):
+        bits = [4, 2, 1]
+        fb = bits[ax]
+        ob = [b for b in bits if b != fb]
+        for val in (0, fb):
+            out.append((val, val | ob[1], val | ob[0] | ob[1], val | ob[0]))
+    return out
+
+
+class Enc:
+    def __init__(self, V, EDGES, FACES):
+        self.V = V
+        self.EDGES = list(EDGES)
+        self.FACES = list(FACES)
+        self.NQ = len(self.EDGES)
+        self.DIM = 1 << self.NQ
+        self.EIDX = {}
+        for q, (i, j) in enumerate(self.EDGES):
+            self.EIDX[(i, j)] = q
+            self.EIDX[(j, i)] = q
+        self.NBR = {
+            i: sorted(j for (a, b) in self.EDGES for j in ((b,) if a == i else ((a,) if b == i else ())))
+            for i in range(V)
+        }
+        self.STAR = {i: [self.EIDX[(i, k)] for k in self.NBR[i]] for i in range(V)}
+        self.STARMASK = {i: reduce(lambda a, b: a | (1 << b), self.STAR[i], 0) for i in range(V)}
+
+    def A_unsigned(self, i, j):
+        x = 1 << self.EIDX[(i, j)]
+        z = 0
+        for k in self.NBR[i]:
+            if k != j and k < j:
+                z ^= 1 << self.EIDX[(i, k)]
+        for l in self.NBR[j]:
+            if l != i and l < i:
+                z ^= 1 << self.EIDX[(j, l)]
+        return Pauli(pc(x & z) % 2, x, z)
+
+    def A(self, i, j):
+        p = self.A_unsigned(i, j)
+        return p if i < j else p.neg()
+
+    def B(self, i):
+        return Pauli(0, 0, self.STARMASK[i])
+
+    def loop(self, cyc):
+        out = IDP
+        for a in range(len(cyc)):
+            out = out * self.A(cyc[a], cyc[(a + 1) % len(cyc)])
+        return out
+
+    def record(self, z):
+        return tuple(pc(z & self.STARMASK[i]) % 2 for i in range(self.V))
+
+    def hop_pauli(self, i, j):
+        A = self.A(i, j)
+        return A * self.B(i), A * self.B(j)
+
+    def hop_amp(self, P1, P2, y):
+        b1, a1 = pact(P1, y)
+        b2, a2 = pact(P2, y)
+        assert b1 == b2
+        v = 0.5j * (a1 - a2)
+        assert abs(v.real - round(v.real)) < 1e-12 and abs(v.imag - round(v.imag)) < 1e-12
+        return b1, complex(round(v.real), round(v.imag))
+
+
+def encoding_audit(E):
+    """R0-R4 pair by pair, the face group, k, and the code dimension. All exact."""
+    R = {}
+    A = {e: E.A(*e) for e in E.EDGES}
+    Bv = {i: E.B(i) for i in range(E.V)}
+    R["R0"] = all(E.A_unsigned(i, j) == E.A_unsigned(j, i) for (i, j) in E.EDGES) and all(
+        E.A(j, i) == E.A(i, j).neg() for (i, j) in E.EDGES
+    )
+    R["R1"] = all(A[e].is_herm() and (A[e] * A[e]).is_id() for e in E.EDGES) and all(
+        Bv[i].is_herm() and (Bv[i] * Bv[i]).is_id() for i in range(E.V)
+    )
+    r2 = all(comm(Bv[i], Bv[j]) for i, j in itertools.combinations(range(E.V), 2))
+    for e in E.EDGES:
+        for v in range(E.V):
+            r2 &= comm(A[e], Bv[v]) != (v in e)
+    R["R2"] = bool(r2)
+    R["R3"] = all(
+        comm(A[e], A[f]) != (len(set(e) & set(f)) == 1) for e, f in itertools.combinations(E.EDGES, 2)
+    )
+    S = [E.loop(f) for f in E.FACES]
+    r4 = True
+    for s in S:
+        r4 &= s.is_herm() and (s * s).is_id()
+        for e in E.EDGES:
+            r4 &= comm(s, A[e])
+        for v in range(E.V):
+            r4 &= comm(s, Bv[v])
+    for a, b in itertools.combinations(S, 2):
+        r4 &= comm(a, b)
+    R["R4"] = bool(r4)
+    R["S"] = S
+    gens, basis = [], []
+    for s in S:
+        v = s.x
+        for b in basis:
+            v = min(v, v ^ b)
+        if v != 0:
+            basis.append(v)
+            basis.sort(reverse=True)
+            gens.append(s)
+    R["k"] = len(gens)
+    grp = []
+    for m in range(1 << len(gens)):
+        p = IDP
+        for t in range(len(gens)):
+            if (m >> t) & 1:
+                p = p * gens[t]
+        grp.append(p)
+    R["grp"] = grp
+    R["grp_ok"] = (not any(g.is_mid() for g in grp)) and sum(1 for g in grp if g.x == 0) == 1
+    R["code_dim"] = E.DIM >> len(gens)
+    return R
+
+
+def code_space(E, R):
+    """Cosets of the face group; phi[z] is the unit coefficient of |z> in its coset."""
+    grp = R["grp"]
+    phi = np.zeros(E.DIM, dtype=complex)
+    cid = -np.ones(E.DIM, dtype=np.int64)
+    reps = []
+    for z0 in range(E.DIM):
+        if cid[z0] >= 0:
+            continue
+        c = len(reps)
+        reps.append(z0)
+        for g in grp:
+            b, a = pact(g, z0)
+            assert cid[b] < 0
+            cid[b] = c
+            phi[b] = a
+    assert (cid >= 0).all()
+    return cid, phi, reps
+
+
+VN, EDG = cube_cluster()
+FAC = cube_faces()
+EN = Enc(VN, EDG, FAC)
+AUD = encoding_audit(EN)
+CID, PHI, REPS = code_space(EN, AUD)
+D = EN.DIM
+NQ = EN.NQ
+
+# ------------------------------------------------------- staggered link signs
+def corner_xyz(s):
+    return ((s >> 2) & 1, (s >> 1) & 1, s & 1)
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+ETA = np.zeros(NQ, dtype=np.int64)
+EDIR = np.zeros(NQ, dtype=np.int64)
+for q, (i, j) in enumerate(EN.EDGES):
+    a = {4: 0, 2: 1, 1: 2}[min(i, j) ^ max(i, j)]
+    EDIR[q] = a
+    ETA[q] = eta_ks(corner_xyz(min(i, j)), a)
+
+FACE_FLUX = [
+    int(np.prod([ETA[EN.EIDX[(cyc[t], cyc[(t + 1) % 4])]] for t in range(4)])) for cyc in FAC
+]
+
+# --------------------------------------------- H on the full 4096 record space
+HOPX_OK = True
+MI = np.zeros((NQ, D), dtype=np.int64)  # H[z ^ (1<<q), z] = 1j * MI[q, z]
+for q, e in enumerate(EN.EDGES):
+    P1, P2 = EN.hop_pauli(*e)
+    HOPX_OK &= (P1.x == (1 << q)) and (P2.x == (1 << q))
+    for z in range(D):
+        zz, amp = EN.hop_amp(P1, P2, z)
+        if amp == 0:
+            continue
+        assert zz == z ^ (1 << q) and abs(amp.real) < 1e-12
+        MI[q, z] = -int(ETA[q]) * int(round(amp.imag))  # H = -sum_e eta_e T_e
+
+HAMP = 1j * MI.astype(np.float64)
+HERM_OK = True
+for q in range(NQ):
+    HERM_OK &= bool(np.all(MI[q, np.arange(D) ^ (1 << q)] == -MI[q]))
+
+RECZ = np.array([EN.record(z) for z in range(D)], dtype=np.int8)
+NVAL = RECZ.sum(1).astype(np.int64)
+QVAL = NVAL - 4  # Q = -(1/2) sum_v B_v = N - 4
+
+
+def Hmul(psi):
+    out = np.zeros(D, dtype=np.complex128)
+    idx = np.arange(D)
+    for q in range(NQ):
+        out[idx ^ (1 << q)] += HAMP[q] * psi
+    return out
+
+
+# ------------------------------------------------------------ code space + sea
+NCOSET = len(REPS)
+W = np.zeros((D, NCOSET), dtype=np.complex128)
+W[np.arange(D), CID] = PHI / np.sqrt(float(1 << AUD["k"]))
+WORTH = float(np.max(np.abs(W.conj().T @ W - np.eye(NCOSET))))
+HW = np.zeros((D, NCOSET), dtype=np.complex128)
+for c in range(NCOSET):
+    HW[:, c] = Hmul(W[:, c])
+HC = W.conj().T @ HW
+CODE_INV = float(np.max(np.abs(HW - W @ HC)))
+EVC, VCC = np.linalg.eigh(HC)
+SEA = W @ VCC[:, 0]
+E_SEA = float(EVC[0])
+SEA_GAP = float(EVC[1] - EVC[0])
+SEA_DEG = int(np.sum(EVC < EVC[0] + 1e-9))
+P_SEA = np.abs(SEA) ** 2
+SEA_OFF_N4 = float(P_SEA[NVAL != 4].sum())
+SQ3 = float(np.sqrt(3.0))
+
+# --------------------------------------------------------------- record blocks
+ARG = np.arange(D)
+LOC = -np.ones(D, dtype=np.int64)
+TOL = 1e-9
+
+
+def block_M(Rmask, w):
+    """H on the block S(R,w) = {z : z & Rmask == w}, split by the conserved N.
+
+    Every hop term flips exactly one edge qubit, so the terms surviving the
+    restriction are exactly the hops on UNRECORDED sites: this is the parent
+    note's H_R. Its matrix is purely imaginary, so H = i M with M real and
+    skew-symmetric; the spectrum of H on each N sector is therefore symmetric
+    about 0, its square is -M M^T, and the ground level is -sqrt(lambda_max)."""
+    I = ARG[(ARG & Rmask) == w]
+    free = [q for q in range(NQ) if not (Rmask >> q) & 1]
+    out = []
+    for n in np.unique(NVAL[I]):
+        J = I[NVAL[I] == n]
+        d = len(J)
+        LOC[J] = np.arange(d)
+        M = np.zeros((d, d))
+        cols = np.arange(d)
+        for q in free:
+            a = MI[q][J]
+            m = a != 0
+            if not m.any():
+                continue
+            assert np.all(NVAL[J[m] ^ (1 << q)] == n)
+            M[LOC[J[m] ^ (1 << q)], cols[m]] += a[m]
+        LOC[J] = -1
+        out.append((J, M))
+    return out
+
+
+def sector_ground(M):
+    """(E0, top eigenvectors of -M M^T, their count) for one N sector."""
+    if M.size == 0 or not M.any():
+        return 0.0, None, M.shape[0]
+    lam, V = np.linalg.eigh(M @ M.T)
+    lmax = float(lam[-1])
+    if lmax <= 1e-9:
+        return 0.0, None, M.shape[0]
+    sel = np.flatnonzero(lam > lmax - 1e-7 * max(1.0, lmax))
+    assert len(sel) % 2 == 0
+    return -float(np.sqrt(lmax)), V[:, sel], len(sel)
+
+
+def relax(Rmask, w, nfix=None):
+    """The relaxed state on block (R,w): the normalized projector Pi/deg onto the
+    ground space of H restricted to the block (to the N = nfix sector if given).
+    Returns (E0, deg, indices, diagonal), the diagonal summing to 1.
+
+    Because H = i M with M real skew, the ground projector inside a sector is
+    (1/2)(P - (i/mu) M P) with P the real spectral projector of -M M^T at
+    lambda_max; M P is skew, so the projector's DIAGONAL is exactly (1/2) diag P."""
+    secs = []
+    for J, M in block_M(Rmask, w):
+        if nfix is not None and NVAL[J[0]] != nfix:
+            continue
+        e, V, d = sector_ground(M)
+        secs.append((J, M, e, V, d))
+    if not secs:
+        return None, 0, None, None
+    E0 = min(s[2] for s in secs)
+    tot = 0
+    Js, vs = [], []
+    for J, M, e, V, d in secs:
+        if e > E0 + TOL:
+            continue
+        if V is None:
+            tot += d
+            Js.append(J)
+            vs.append(np.ones(len(J)))
+        else:
+            tot += d // 2
+            Js.append(J)
+            vs.append(0.5 * np.sum(V ** 2, axis=1))
+    return E0, tot, np.concatenate(Js), np.concatenate(vs) / tot
+
+
+def relax_full(Rmask, w):
+    """As relax, but also returns the per-sector data needed for fidelities."""
+    secs = []
+    for J, M in block_M(Rmask, w):
+        e, V, d = sector_ground(M)
+        secs.append((J, M, e, V, d))
+    E0 = min(s[2] for s in secs)
+    tot = sum((d if V is None else d // 2) for J, M, e, V, d in secs if e <= E0 + TOL)
+    return E0, tot, secs
+
+
+def fidelity(secs, E0, deg, psi):
+    """<psi| Pi/deg |psi> with Pi the ground projector of the block."""
+    f = 0.0
+    for J, M, e, V, d in secs:
+        if e > E0 + TOL:
+            continue
+        v = psi[J]
+        if V is None:
+            f += float(np.vdot(v, v).real)
+        else:
+            c = V.T @ v
+            f += 0.5 * float((np.vdot(c, c) - (1j / (-e)) * np.vdot(v, M @ (V @ c))).real)
+    return f / deg
+
+
+def expect_HR(Rmask, w, psi):
+    """<psi| H_R |psi> on the block, without any diagonalization."""
+    return sum(float((1j * np.vdot(psi[J], M @ psi[J])).real) for J, M in block_M(Rmask, w))
+
+
+def evolve_HR(Rmask, w, psi, tau):
+    """exp(-i tau H_R) psi = exp(tau M) psi, sector by sector."""
+    out = np.zeros(D, dtype=np.complex128)
+    for J, M in block_M(Rmask, w):
+        v = psi[J]
+        if not M.any():
+            out[J] = v
+            continue
+        lam, V = np.linalg.eigh(M @ M.T)
+        mu = np.sqrt(np.maximum(lam, 0.0))
+        c = V.T @ v
+        si = np.where(mu > 1e-9, np.sin(tau * mu) / np.where(mu > 1e-9, mu, 1.0), 0.0)
+        out[J] = V @ (np.cos(tau * mu) * c) + M @ (V @ (si * c))
+    return out
+
+
+def HR_apply(Rmask, w, psi):
+    """H_R psi on the block. H = i M with M real skew, sector by sector."""
+    out = np.zeros(D, dtype=np.complex128)
+    for J, M in block_M(Rmask, w):
+        out[J] = 1j * (M @ psi[J])
+    return out
+
+
+def tv(p, q):
+    return 0.5 * float(np.abs(np.asarray(p) - np.asarray(q)).sum())
+
+
+# ==========================================================================
+# the stipulated formation units, the declared orders, and the joint tree
+# ==========================================================================
+FULL = D - 1
+ZTOL = 1e-12
+PTOL = 1e-12
+LEX_N = 40  # the declared lexicographic sweep: first LEX_N permutations
+
+
+def mk(qs):
+    m = 0
+    for q in qs:
+        m |= 1 << q
+    return m
+
+
+def face_edges(cyc):
+    return [EN.EIDX[(cyc[t], cyc[(t + 1) % 4])] for t in range(4)]
+
+
+def cstar_edges(v):
+    """Every edge incident to {v} u N(v): the closed corner star of v."""
+    S = {v} | set(EN.NBR[v])
+    return sorted(q for q in range(NQ) if EN.EDGES[q][0] in S or EN.EDGES[q][1] in S)
+
+
+UNITS = {
+    "U1": [("e%d" % q, 1 << q) for q in range(NQ)],
+    "U2": [("corner%d" % v, mk(sorted(EN.STAR[v]))) for v in range(8)],
+    "U3": [("face%d" % i, mk(face_edges(FAC[i]))) for i in range(6)],
+    "U4": [("cstar%d" % v, mk(cstar_edges(v))) for v in range(8)],
+    "U5": [("all12", FULL)],
+}
+
+ORDERS_U = {
+    "U1": [
+        ("identity", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+        ("reverse", [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
+        ("byaxis", [2, 4, 6, 7, 0, 3, 8, 11, 1, 5, 9, 10]),
+        ("interleave", [0, 6, 1, 7, 2, 8, 3, 9, 4, 10, 5, 11]),
+    ],
+    "U2": [
+        ("identity", [0, 1, 2, 3, 4, 5, 6, 7]),
+        ("reverse", [7, 6, 5, 4, 3, 2, 1, 0]),
+        ("evenfirst", [0, 3, 5, 6, 1, 2, 4, 7]),
+        ("antipodal", [0, 7, 1, 6, 2, 5, 3, 4]),
+    ],
+    "U3": [
+        ("identity", [0, 1, 2, 3, 4, 5]),
+        ("reverse", [5, 4, 3, 2, 1, 0]),
+        ("oneperaxis", [0, 2, 4, 1, 3, 5]),
+        ("mixed", [3, 0, 5, 2, 1, 4]),
+    ],
+    "U4": [
+        ("identity", [0, 1, 2, 3, 4, 5, 6, 7]),
+        ("reverse", [7, 6, 5, 4, 3, 2, 1, 0]),
+        ("antipodal", [0, 7, 1, 6, 2, 5, 3, 4]),
+        ("gray", [0, 1, 3, 2, 6, 7, 5, 4]),
+    ],
+    "U5": [("identity", [0])],
+}
+UT4 = ("U1", "U2", "U3", "U4")
+ONAME = {ut: [nm for nm, _ in ORDERS_U[ut]] for ut in ORDERS_U}
+
+
+def schedule(ut, perm):
+    """(unit name, newly recorded bits) per actual formation event."""
+    sch, R = [], 0
+    for i in perm:
+        nm, m = UNITS[ut][i]
+        nb = m & ~R
+        if nb == 0:
+            continue
+        sch.append((nm, nb))
+        R |= nb
+        if R == FULL:
+            break
+    assert R == FULL, "declared order does not cover all 12 sites"
+    return sch
+
+
+SCHED = {(ut, nm): schedule(ut, p) for ut in ORDERS_U for nm, p in ORDERS_U[ut]}
+
+
+def run(sch, mode, tau=0.5, eig=None, visit=None):
+    """The exact formation tree for one schedule: every leaf, nothing sampled."""
+    ne = len(sch)
+    out = np.zeros(D)
+
+    def rec(k, Rmask, w, obj, prob):
+        nm, nb = sch[k]
+        dg = obj if mode == "MR" else np.abs(obj) ** 2
+        grp = np.bincount(ARG & nb, weights=dg, minlength=nb + 1)
+        tot = float(grp.sum())
+        for val in np.flatnonzero(grp > 0.0):
+            pb = float(grp[val]) / tot
+            if pb <= PTOL:
+                continue
+            R2 = Rmask | nb
+            w2 = w | int(val)
+            if k + 1 == ne:
+                out[w2] += prob * pb
+                continue
+            if mode == "MR":
+                E0, deg, J2, v2 = relax(R2, w2)
+                nx = np.zeros(D)
+                nx[J2] = v2
+            else:
+                nx = obj.copy()
+                nx[(ARG & nb) != val] = 0.0
+                nx /= np.linalg.norm(nx)
+                if visit is not None:
+                    visit[np.abs(nx) > 1e-11] = True
+                if eig is not None:
+                    r = HR_apply(R2, w2, nx)
+                    lam = float(np.vdot(nx, r).real)
+                    e = float(np.max(np.abs(r - lam * nx))) < 1e-9
+                    a = eig.setdefault(k + 1, [0.0, 0.0])
+                    a[0] += prob * pb * (1.0 if e else 0.0)
+                    a[1] += prob * pb
+                if mode == "A":
+                    nx = evolve_HR(R2, w2, nx, tau)
+                    if visit is not None:
+                        visit[np.abs(nx) > 1e-11] = True
+            rec(k + 1, R2, w2, nx, prob * pb)
+
+    st = P_SEA.copy() if mode == "MR" else SEA.copy()
+    if visit is not None:
+        visit[np.abs(st) > 1e-11] = True
+    rec(0, 0, 0, st, 1.0)
+    return out
+
+
+# ------------------------------------------------- the sea's zeros, by class
+SEAZ = P_SEA <= ZTOL
+CHG0 = SEAZ & (NVAL != 4)
+CAN0 = SEAZ & (NVAL == 4)
+SEASUP = ~SEAZ
+CSTAR_PAT = []
+for v in range(8):
+    p = [0] * 8
+    p[v] = 1
+    for u in EN.NBR[v]:
+        p[u] = 1
+    CSTAR_PAT.append(tuple(p))
+RECT = [tuple(int(x) for x in RECZ[z]) for z in range(D)]
+CANCEL_OF = -np.ones(D, dtype=np.int64)
+for z in range(D):
+    if CAN0[z]:
+        CANCEL_OF[z] = CSTAR_PAT.index(RECT[z])
+CANC_PATS = {RECT[z] for z in np.flatnonzero(CAN0)}
+SUPP_PATS = {RECT[z] for z in np.flatnonzero(SEASUP)}
+N_ZERO = int(SEAZ.sum())
+N_CHG = int(CHG0.sum())
+N_CAN = int(CAN0.sum())
+
+
+def kept(p):
+    """(cancellation zeros kept, charge zeros kept, support) of a distribution."""
+    z = p <= ZTOL
+    return int((z & CAN0).sum()), int((z & CHG0).sum()), int((p > ZTOL).sum())
+
+
+def per_star(p):
+    z = p <= ZTOL
+    return [int(((CANCEL_OF == v) & z).sum()) for v in range(8)]
+
+
+def pq0(p):
+    return float(p[QVAL == 0].sum())
+
+
+def varq(p):
+    m = float((p * QVAL).sum())
+    return float((p * QVAL ** 2).sum()) - m * m
+
+
+# ==========================================================================
+# A -- the setting and the sea's zeros (the census PR #7895 reports)
+# ==========================================================================
+check(
+    "A1 [exact] cube 2x2x2, 8 corners / 12 edge sites / 6 faces: R0-R4 pair by pair, no -I in the face group, k = %d, code dim "
+    "2^12/2^%d = %d; each hop term has X-part exactly one edge qubit, so P_S H P_S is the sum of the hops on UNRECORDED "
+    "sites -- H_R" % (AUD["k"], AUD["k"], AUD["code_dim"]),
+    AUD["R0"] and AUD["R1"] and AUD["R2"] and AUD["R3"] and AUD["R4"] and AUD["grp_ok"]
+    and AUD["k"] == 5 and AUD["code_dim"] == 128 and D == 4096 and NQ == 12 and HOPX_OK,
+)
+check(
+    "A2 [exact] the Kawamoto-Smit signs put flux %s on all six faces -- the pi-flux sector -- and H = -sum_e eta_e T_e is "
+    "Hermitian on the 4096-dimensional record space" % (set(FACE_FLUX),),
+    all(f == -1 for f in FACE_FLUX) and HERM_OK,
+)
+check(
+    "A3 [numerical, 1e-11] the code space (six S_f = +1, dim 128 = the even-N space) is H-invariant to %.1e; the sea has "
+    "E = %.12f = -4 sqrt 3, deg 1, gap %.12f = 2 sqrt 3, sharp N = 4 (mass off: %.1e)"
+    % (CODE_INV, E_SEA, SEA_GAP, SEA_OFF_N4),
+    WORTH < 1e-12 and CODE_INV < 1e-11 and abs(E_SEA + 4 * SQ3) < 1e-11
+    and SEA_DEG == 1 and abs(SEA_GAP - 2 * SQ3) < 1e-11 and SEA_OFF_N4 < 1e-25,
+)
+check(
+    "A4 [exact, 1e-12 zero read] the target, the sea's registration: support %d = 62 x 32, %d zeros = %d charge (N != 4) + %d "
+    "cancellation, whose 8 corner patterns are EXACTLY the 8 closed corner stars {v} u N(v), 32 each (min nonzero sea "
+    "probability %.2e)" % (D - N_ZERO, N_ZERO, N_CHG, N_CAN, float(P_SEA[SEASUP].min())),
+    (D - N_ZERO) == 1984 and len(SUPP_PATS) == 62 and N_ZERO == 2112 and N_CHG == 1856 and N_CAN == 256
+    and CANC_PATS == set(CSTAR_PAT) and len(CSTAR_PAT) == 8
+    and all(int((CANCEL_OF == v).sum()) == 32 for v in range(8)),
+)
+
+# ==========================================================================
+# B -- the units and the declared orders
+# ==========================================================================
+SIZES = {ut: sorted({bin(m).count("1") for _, m in UNITS[ut]}) for ut in UNITS}
+CSTAR_COMPL = all(
+    UNITS["U4"][v][1] == FULL ^ UNITS["U2"][7 - v][1] for v in range(8)
+)
+EV = {ut: [len(SCHED[(ut, nm)]) for nm in ONAME[ut]] for ut in UNITS}
+MEANEV = {ut: sum(EV[ut]) / len(EV[ut]) for ut in UNITS}
+NORD = sum(len(ORDERS_U[ut]) for ut in UT4)
+
+check(
+    "B1 [exact] the five stipulated units: U1 %d edge sites (size 1), U2 %d corner record sets star(v) (3), U3 %d faces (4), "
+    "U4 %d closed corner stars (9), U5 the one 12-site unit; cstar(v) = E \\ star(7 - v)" % (len(UNITS["U1"]), len(UNITS["U2"]), len(UNITS["U3"]), len(UNITS["U4"])),
+    [SIZES[u] for u in ("U1", "U2", "U3", "U4", "U5")] == [[1], [3], [4], [9], [12]]
+    and [len(UNITS[u]) for u in ("U1", "U2", "U3", "U4", "U5")] == [12, 8, 6, 8, 1]
+    and CSTAR_COMPL,
+)
+check(
+    "B2 [exact] the %d declared orders for U1-U4 (four per type, written out; no seed) plus U5's cover all 12 sites; events "
+    "U1 %s, U2 %s, U3 %s, U4 %s, U5 %s -- means %.2f, %.2f, %.2f, %.2f, %.2f"
+    % (NORD, EV["U1"], EV["U2"], EV["U3"], EV["U4"], EV["U5"],
+       MEANEV["U1"], MEANEV["U2"], MEANEV["U3"], MEANEV["U4"], MEANEV["U5"]),
+    NORD == 16
+    and all(sorted(p) == list(range(len(UNITS[ut]))) for ut in ORDERS_U for _, p in ORDERS_U[ut])
+    and EV["U1"] == [12, 12, 12, 12] and EV["U2"] == [7, 7, 4, 6]
+    and EV["U3"] == [4, 4, 5, 5] and EV["U4"] == [3, 3, 2, 3] and EV["U5"] == [1]
+    and abs(MEANEV["U2"] - 6.0) < 1e-12 and abs(MEANEV["U3"] - 4.5) < 1e-12
+    and abs(MEANEV["U4"] - 2.75) < 1e-12,
+)
+
+MARG = {}
+for ut in UNITS:
+    rows = []
+    for nm, m in UNITS[ut]:
+        g = np.bincount(ARG & m, weights=P_SEA, minlength=m + 1)
+        alive = g > 1e-14
+        blocked = ~alive[ARG & m]
+        rows.append((int((blocked & CHG0).sum()), int((blocked & CAN0).sum())))
+    MARG[ut] = rows
+
+check(
+    "B3 [numerical, 1e-12] what ONE unit's own joint Born marginal forbids: 0 charge and 0 cancellation at every U1, U2 and "
+    "U3 unit -- an edge, a corner record set and a face each see none of the sea's zeros -- while every U4 closed star "
+    "forbids %d + %d, and U5 all %d + %d"
+    % (MARG["U4"][0][0], MARG["U4"][0][1], MARG["U5"][0][0], MARG["U5"][0][1]),
+    all(r == (0, 0) for ut in ("U1", "U2", "U3") for r in MARG[ut])
+    and all(r == (448, 64) for r in MARG["U4"])
+    and MARG["U5"] == [(1856, 256)],
+)
+
+# ==========================================================================
+# C -- the control: rule (c), pure sequential Born
+# ==========================================================================
+P_L = {(ut, nm): run(SCHED[(ut, nm)], "L") for ut in UNITS for nm in ONAME[ut]}
+tvL = {k: tv(p, P_SEA) for k, p in P_L.items()}
+suppL = {k: int((p > ZTOL).sum()) for k, p in P_L.items()}
+ordL = {ut: max(tv(P_L[(ut, a)], P_L[(ut, b)]) for a in ONAME[ut] for b in ONAME[ut]) for ut in UT4}
+
+check(
+    "C1 [numerical, 1e-15] THE CONTROL: with no between-event rule, all %d declared schedules give support %d and ARE the "
+    "sea's registration -- TV to the sea at most %.1e" % (len(P_L), 1984, max(tvL.values())),
+    all(s == 1984 for s in suppL.values()) and max(tvL.values()) < 1e-15,
+)
+check(
+    "C2 [numerical, 1e-15] and order-independent for every unit type -- max pairwise TV %.0e (U1), %.0e (U2), %.0e (U3), "
+    "%.0e (U4): joint Z-basis conditioning commutes, so what follows is the between-event rule, not the conditioning" % (ordL["U1"], ordL["U2"], ordL["U3"], ordL["U4"]),
+    max(ordL.values()) < 1e-15,
+)
+
+# ==========================================================================
+# D -- the unitary tick (rule (b), Model A at tau = 0.5)
+# ==========================================================================
+TAU = 0.5
+P_A = {(ut, nm): run(SCHED[(ut, nm)], "A", TAU) for ut in UNITS for nm in ONAME[ut]}
+KA = {k: kept(p) for k, p in P_A.items()}
+tvA = {k: tv(p, P_SEA) for k, p in P_A.items()}
+
+check(
+    "D1 [numerical, 1e-12] site-wise formation (U1) under the unitary tick: support %d, all %d charge zeros kept, %d of the "
+    "256 cancellation zeros kept, TV to the sea %.12f at the identity order"
+    % (KA[("U1", "identity")][2], KA[("U1", "identity")][1], KA[("U1", "identity")][0], tvA[("U1", "identity")]),
+    KA[("U1", "identity")] == (0, 1856, 2240) and abs(tvA[("U1", "identity")] - 0.324925160534) < 1e-9
+    and all(KA[("U1", nm)] == (0, 1856, 2240) for nm in ONAME["U1"]),
+)
+canA = {ut: [KA[(ut, nm)][0] for nm in ONAME[ut]] for ut in UNITS}
+check(
+    "D2 [numerical, 1e-12] joint formation on a corner's record set flips it: cancellation zeros kept over the four declared "
+    "orders are U1 %s, U2 %s, U3 %s, U4 %s, U5 %s -- all 256 at 3 of 4 corner orders, none at any face order; charge "
+    "zeros kept everywhere" % (canA["U1"], canA["U2"], canA["U3"], canA["U4"], canA["U5"]),
+    canA["U1"] == [0, 0, 0, 0] and sorted(canA["U2"]) == [0, 256, 256, 256]
+    and canA["U3"] == [0, 0, 0, 0] and sorted(canA["U4"]) == [128, 128, 128, 256]
+    and canA["U5"] == [256] and all(v[1] == 1856 for v in KA.values()),
+)
+check(
+    "D3 [numerical, 1e-12] and two schedules reproduce the sea EXACTLY: U2 evenfirst, the four disjoint corner sets star(0), "
+    "star(3), star(5), star(6), at TV %.2e; U4 antipodal, cstar(0) then star(7), at TV %.2e; both on support %d" % (tvA[("U2", "evenfirst")], tvA[("U4", "antipodal")], KA[("U2", "evenfirst")][2]),
+    tvA[("U2", "evenfirst")] < 1e-14 and tvA[("U4", "antipodal")] < 1e-14
+    and KA[("U2", "evenfirst")] == (256, 1856, 1984) and KA[("U4", "antipodal")] == (256, 1856, 1984),
+)
+TAUS = (0.1, 0.5, 1.234567, 2.0)
+tau_rows = {}
+for ut, nm in (("U2", "evenfirst"), ("U4", "antipodal"), ("U1", "identity"), ("U3", "identity")):
+    tau_rows[(ut, nm)] = [
+        (tv(run(SCHED[(ut, nm)], "A", t), P_SEA), kept(run(SCHED[(ut, nm)], "A", t))[0]) for t in TAUS
+    ]
+check(
+    "D4 [numerical, 1e-12] at every tau tested, %s: both stay at TV < 1e-14 with all 256 cancellation zeros, while U1 and U3 "
+    "identity keep 0 of the 256 at every one of them" % (TAUS,),
+    all(r[0] < 1e-14 and r[1] == 256 for k in (("U2", "evenfirst"), ("U4", "antipodal")) for r in tau_rows[k])
+    and all(r[1] == 0 for k in (("U1", "identity"), ("U3", "identity")) for r in tau_rows[k]),
+)
+
+LEX = {ut: [list(p) for p in itertools.islice(itertools.permutations(range(len(UNITS[ut]))), LEX_N)]
+       for ut in ("U2", "U3", "U4")}
+lex_can = {}
+for ut in ("U2", "U3", "U4"):
+    for mode in ("A", "MR"):
+        lex_can[(ut, mode)] = [kept(run(schedule(ut, p), mode, TAU))[0] for p in LEX[ut]]
+lex_full = {k: sum(1 for c in v if c == 256) for k, v in lex_can.items()}
+
+check(
+    "D5 [numerical, 1e-12] a declared lexicographic sweep, the first %d permutations of each unit list (no seed): under the "
+    "unitary tick %d of %d U2 orders keep all 256, U3 keeps 0 .. %d, U4 %d .. %d; under relaxation none over 64" % (LEX_N, lex_full[("U2", "A")], LEX_N, max(lex_can[("U3", "A")]),
+       min(lex_can[("U4", "A")]), max(lex_can[("U4", "A")])),
+    lex_full[("U2", "A")] > 0 and lex_full[("U3", "A")] == 0
+    and max(lex_can[("U3", "A")]) == 0
+    and all(max(lex_can[(ut, "MR")]) <= 64 for ut in ("U2", "U3", "U4")),
+)
+
+# ==========================================================================
+# E -- the mechanism
+# ==========================================================================
+def first_unit_report(ut):
+    """G, F, Fq, TV(|psi|^2, Pi/deg) and the eigenvector count after the first unit."""
+    nm, nb = SCHED[(ut, "identity")][0]
+    g = np.bincount(ARG & nb, weights=P_SEA, minlength=nb + 1)
+    tot = float(g.sum())
+    G = F = Fq = TVd = 0.0
+    degs, ne, nt = [], 0, 0
+    for val in np.flatnonzero(g > 1e-14):
+        pb = float(g[val]) / tot
+        sel = (ARG & nb) == val
+        psi = SEA.copy()
+        psi[~sel] = 0.0
+        psi /= np.linalg.norm(psi)
+        nt += 1
+        if nb == FULL:
+            G += pb
+            F += pb
+            Fq += pb
+            degs.append(1)
+            ne += 1
+            continue
+        E0, deg, secs = relax_full(nb, int(val))
+        _, _, J2, v2 = relax(nb, int(val))
+        dg = np.zeros(D)
+        dg[J2] = v2
+        fq = fidelity(secs, E0, deg, psi)
+        degs.append(deg)
+        G += pb * fq * deg
+        Fq += pb * fq
+        qq = np.abs(psi) ** 2
+        F += pb * float(np.sum(np.sqrt(qq * dg))) ** 2
+        TVd += pb * 0.5 * float(np.abs(qq - dg).sum())
+        r = HR_apply(nb, int(val), psi)
+        lam = float(np.vdot(psi, r).real)
+        if float(np.max(np.abs(r - lam * psi))) < 1e-9:
+            ne += 1
+    return nm, G, F, Fq, TVd, (min(degs), max(degs)), ne, nt
+
+
+FU = {ut: first_unit_report(ut) for ut in ("U1", "U2", "U3", "U4")}
+
+check(
+    "E1 [numerical, 1e-9] THE MECHANISM. After a corner's record set forms jointly the Born-conditioned sea lies in the "
+    "restricted ground space (G = %.9f, deg %d), an exact H_R eigenvector at %d of %d outcomes, TV(|psi|^2, Pi/deg) = %.9f: "
+    "relaxation is the IDENTITY there, the unitary a global phase"
+    % (FU["U2"][1], FU["U2"][5][1], FU["U2"][6], FU["U2"][7], FU["U2"][4]),
+    abs(FU["U2"][1] - 1.0) < 1e-9 and FU["U2"][5] == (1, 1) and FU["U2"][6] == 8 and FU["U2"][7] == 8
+    and FU["U2"][4] < 1e-9,
+)
+check(
+    "E2 [numerical, 1e-9] the closed corner star too, G = %.9f at %d/%d, but its ground space is %d-fold degenerate, so "
+    "Pi/deg gives a rank-2 mixture (F = %.9f, Fq = %.3f); an edge (%.9f, %d/%d) and a FACE (%.9f, %d/%d) are not "
+    "eigenvectors, though the face is larger"
+    % (FU["U4"][1], FU["U4"][6], FU["U4"][7], FU["U4"][5][1], FU["U4"][2], FU["U4"][3],
+       FU["U1"][1], FU["U1"][6], FU["U1"][7], FU["U3"][1], FU["U3"][6], FU["U3"][7]),
+    abs(FU["U4"][1] - 1.0) < 1e-9 and FU["U4"][6] == 448 and FU["U4"][7] == 448 and FU["U4"][5] == (2, 2)
+    and abs(FU["U4"][2] - 0.636894534) < 1e-8 and abs(FU["U4"][3] - 0.5) < 1e-9
+    and FU["U1"][6] == 0 and FU["U1"][7] == 2 and abs(FU["U1"][1] - 0.962606705806) < 1e-8
+    and FU["U3"][6] == 0 and FU["U3"][7] == 16 and abs(FU["U3"][1] - 0.890431430) < 1e-8,
+)
+
+EIG = {}
+for ut, nm in (("U2", "evenfirst"), ("U4", "antipodal"), ("U1", "identity"), ("U3", "identity")):
+    d = {}
+    run(SCHED[(ut, nm)], "A", TAU, eig=d)
+    EIG[(ut, nm)] = [d[k][0] / d[k][1] for k in sorted(d)]
+
+check(
+    "E3 [numerical, 1e-9] along both exact-sea schedules the conditioned state is an H_R eigenvector at EVERY node a "
+    "between-event step follows: eigen-weight %s and %s, against %s (U1 identity, first seven) and %s (U3 identity)"
+    % ("/".join("%.3f" % x for x in EIG[("U2", "evenfirst")]), "/".join("%.3f" % x for x in EIG[("U4", "antipodal")]),
+       "/".join("%.3f" % x for x in EIG[("U1", "identity")][:7]),
+       "/".join("%.3f" % x for x in EIG[("U3", "identity")])),
+    all(abs(x - 1.0) < 1e-9 for x in EIG[("U2", "evenfirst")])
+    and all(abs(x - 1.0) < 1e-9 for x in EIG[("U4", "antipodal")])
+    and all(x < 1e-9 for x in EIG[("U1", "identity")][:7])
+    and EIG[("U3", "identity")][0] < 1e-9,
+)
+
+LEAK = {}
+for ut, nm in (("U1", "identity"), ("U2", "identity"), ("U2", "evenfirst"), ("U4", "antipodal")):
+    vis = np.zeros(D, dtype=bool)
+    run(SCHED[(ut, nm)], "A", TAU, visit=vis)
+    LEAK[(ut, nm)] = (int(vis.sum()), int((vis & ~SEASUP & (NVAL != 4)).sum()), int((vis & CAN0).sum()))
+
+check(
+    "E4 [numerical, 1e-11] OPEN, not claimed: the rule-(b) node-support union never leaves N = 4 (%s outside) and, for the "
+    "two exact-sea schedules, never leaves the sea's 1984 labels (unions %d, %d); yet U2 identity visits %d "
+    "cancellation-coset labels en route and still finishes with all 256 zeros -- observed, not explained"
+    % ({LEAK[k][1] for k in LEAK}, LEAK[("U2", "evenfirst")][0], LEAK[("U4", "antipodal")][0],
+       LEAK[("U2", "identity")][2]),
+    all(LEAK[k][1] == 0 for k in LEAK)
+    and LEAK[("U2", "evenfirst")][0] == 1984 and LEAK[("U4", "antipodal")][0] == 1984
+    and LEAK[("U2", "identity")][2] == 192 and LEAK[("U1", "identity")][2] == 256
+    and KA[("U2", "identity")][0] == 256,
+)
+
+# ==========================================================================
+# F -- relaxation (rule (a), M_R with the Pi/deg tie-break)
+# ==========================================================================
+P_M = {(ut, nm): run(SCHED[(ut, nm)], "MR") for ut in UNITS for nm in ONAME[ut]}
+KM = {k: kept(p) for k, p in P_M.items()}
+tvM = {k: tv(p, P_SEA) for k, p in P_M.items()}
+canM = {ut: [KM[(ut, nm)][0] for nm in ONAME[ut]] for ut in UNITS}
+best_prop = max(max(canM[ut]) for ut in UT4)
+best_lex = max(max(lex_can[(ut, "MR")]) for ut in ("U2", "U3", "U4"))
+
+check(
+    "F1 [numerical, 1e-12] under RELAXATION nothing short of the whole cluster keeps more than %d of the 256: over the 16 "
+    "declared orders U1 %s, U2 %s, U3 %s, U4 %s, over the sweep at most %d; U5 keeps all %d zeros"
+    % (best_prop, canM["U1"], canM["U2"], canM["U3"], canM["U4"], best_lex,
+       KM[("U5", "identity")][0] + KM[("U5", "identity")][1]),
+    best_prop == 64 and best_lex <= 64 and canM["U1"] == [0, 0, 0, 0] and canM["U3"] == [0, 0, 0, 0]
+    and canM["U4"] == [64, 64, 64, 64] and sorted(canM["U2"]) == [0, 0, 0, 64]
+    and KM[("U5", "identity")] == (256, 1856, 1984) and tvM[("U5", "identity")] < 1e-14,
+)
+u4_first = {nm: int(SCHED[("U4", nm)][0][0][5:]) for nm in ONAME["U4"]}
+u4_ok = all(
+    sorted(v for v, c in enumerate(per_star(P_M[("U4", nm)])) if c == 32) == sorted([u4_first[nm], 7 - u4_first[nm]])
+    for nm in ONAME["U4"]
+)
+check(
+    "F2 [numerical, 1e-12] the 64 that survive under U4 are exactly the FIRST-formed star's coset and its antipode's at all "
+    "four declared orders (%s): cstar(v)'s nine edges fix the parities on {v} u N(v), and in the sharp-N = 4 sea both "
+    "all-occupied and all-empty are forced to zero; later stars go to the relaxation"
+    % (sorted({tuple(sorted([u4_first[nm], 7 - u4_first[nm]])) for nm in ONAME["U4"]}),),
+    u4_ok and all(sum(per_star(P_M[("U4", nm)])) == 64 for nm in ONAME["U4"]),
+)
+u2ef = [v for v, c in enumerate(per_star(P_M[("U2", "evenfirst")])) if c == 32]
+check(
+    "F3 [numerical, 1e-12] the 'formed first, therefore kept' reading does NOT transfer to the corner unit: under U2 "
+    "evenfirst, whose first unit is corner0, the surviving cosets are %s, not 0 -- as B3 requires" % (u2ef,),
+    u2ef == [1, 6] and MARG["U2"][0] == (0, 0),
+)
+pq_prop = {ut: [pq0(P_M[(ut, nm)]) for nm in ONAME[ut]] for ut in UT4}
+best_pq = max(max(v) for v in pq_prop.values())
+check(
+    "F4 [numerical, 1e-12] and the readable charge stays smeared: P(Q = 0) never reaches 1 below U5 -- best %.9f at U3, the "
+    "4-site face, against U4's %.9f .. %.9f; U5 gives exactly %.9f. Bigger units do not sharpen Q monotonically"
+    % (best_pq, min(pq_prop["U4"]), max(pq_prop["U4"]), pq0(P_M[("U5", "identity")])),
+    abs(best_pq - 0.841145833333) < 1e-9 and best_pq < 1.0 - 1e-9
+    and abs(pq0(P_M[("U5", "identity")]) - 1.0) < 1e-12
+    and abs(varq(P_M[("U5", "identity")])) < 1e-12
+    and max(pq_prop["U4"]) < max(pq_prop["U3"]),
+)
+
+# ==========================================================================
+# G -- order dependence
+# ==========================================================================
+ordM = {ut: max(tv(P_M[(ut, a)], P_M[(ut, b)]) for a in ONAME[ut] for b in ONAME[ut]) for ut in UT4}
+ordA = {ut: max(tv(P_A[(ut, a)], P_A[(ut, b)]) for a in ONAME[ut] for b in ONAME[ut]) for ut in UT4}
+
+check(
+    "G1 [numerical, 1e-12] order dependence shrinks with unit size and never vanishes short of U5: max pairwise TV over the "
+    "four declared orders, rules (a)/(b), is U1 %.12f/%.12f, U2 %.9f/%.9f, U3 %.9f/%.9f, U4 %.12f/%.12f -- a LOWER BOUND"
+    % (ordM["U1"], ordA["U1"], ordM["U2"], ordA["U2"], ordM["U3"], ordA["U3"], ordM["U4"], ordA["U4"]),
+    abs(ordM["U1"] - 0.602777777778) < 1e-9 and abs(ordA["U1"] - 0.619386368116) < 1e-9
+    and abs(ordM["U4"] - 0.25) < 1e-9 and abs(ordA["U4"] - 0.076616282355) < 1e-9
+    and all(ordM[ut] > 0 and ordA[ut] > 0 for ut in UT4),
+)
+check(
+    "G2 [numerical, 1e-12] and not monotone in the unit size: the 4-site face U3 is MORE order-dependent than the 3-site "
+    "corner set U2 under both rules (%.9f > %.9f, %.9f > %.9f) -- shape, not size, governs"
+    % (ordM["U3"], ordM["U2"], ordA["U3"], ordA["U2"]),
+    ordM["U3"] > ordM["U2"] and ordA["U3"] > ordA["U2"],
+)
+
+print(
+    "SUMMARY: under the unitary tick, records forming together on a corner's record set keep all 256 cancellation zeros that "
+    "site-wise formation loses, and disjoint corner schedules reproduce the sea exactly at every tau, because the jointly "
+    "conditioned sea is an exact eigenvector of what remains of the law; under relaxation nothing short of the whole "
+    "cluster keeps more than 64."
+)
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + runner + cache extending PR #7895 from site-wise to neighbourhood-wise record formation, testing the owner's statement (2026-09-03) that "the whole neighbourhood has to move together because it is its own shared condition", read at the level of formation since records are permanent. **The unit of record formation matters, and the unit that fits is a corner's own record set.** With the unitary tick between events (PR #7876's Model A), joint formation on the three edges at one corner keeps every one of the sea's 256 cancellation zeros (3 of 4 declared orders; 4 of 40 in the lexicographic window), and schedules of **disjoint** corner sets reproduce the sea's record statistics **exactly** (`TV ~ 1e-15`) at every `tau` tested. The reason is exact and about shape: after a corner set forms jointly, the conditioned sea is an eigenvector of what remains of the law (8/8 outcomes; 448/448 for the closed corner star), so the evolution between events cannot disturb it; after a single edge (0/2) or a face's four edges (0/16) it is not, and the face unit is worse than the corner unit on every measure. Under relaxation between events (PR #7895's `M_R`) nothing short of the whole cluster keeps more than 64 of the 256 zeros, so the panel's candidate and the corner unit do not combine. Order independence short of the whole cluster is not achieved by any unit; the mechanism for the non-disjoint corner schedules that keep the zeros is stated as open. A candidate formation sentence, offered as a candidate wording and not as axiom text: *"Records form together on a corner's record set; between formations the law runs on."*

- `docs/JOINT_FORMATION_ON_A_CORNERS_RECORD_SET_KEEPS_THE_SEAS_ZEROS_UNDER_THE_UNITARY_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md` (328 lines)
- `scripts/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.py` (`TOTAL: PASS=24 FAIL=0`, 67 s; no seeds; 16 declared orders plus a 40-permutation sweep, all literals)
- `logs/runner-cache/joint_formation_corner_record_set_keeps_sea_zeros_check_2026_09_03.txt`

## Theorems

- **T1** the control: sequential Born equals the sea and is order-independent for every unit; U1 reproduces PR #7895.
- **T2** the unitary tick with corner units keeps all 256 cancellation zeros; disjoint-corner schedules reproduce the sea exactly at `tau = 0.1, 0.5, 1.234567, 2.0`.
- **T3** the eigenvector mechanism (corner 8/8, closed star 448/448; edge 0/2, face 0/16).
- **T4** relaxation keeps at most 64 zeros below the whole cluster (the first star's coset and its antipode's); `P(Q = 0)` at most `0.841`; relaxation is the identity at U2 and worse at U4.
- **T5** order dependence shrinks with unit size but never vanishes short of U5; event counts 12, 6, 4.5, 2.75, 1.

## Boundary

- One cluster, one sector, one filling; units, orders, rules, tie-break and `tau` values stipulated; the owner's statement quoted as the question, the panel's wording as a candidate; nothing derived from the axioms; no claim about what the framework's tick is. Executor refinements kept (`P(Q = 0)` at U4 is `0.667 .. 0.750`; last-digit TV differences from the real-skew propagator).

## Context

- Parents: PR #7895 (site-wise formation), PR #7876 (Model A), PR #7883 (the sea's Born statistics), PR #7842 (the zeros), PR #7891 and PR #7899 (the neighbourhood mechanism).
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03). A generality test on the `2x2x4` slab is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
