### PR TITLE
feat(readout): when the odds are an energy, rank-one and cycle tests

### DIFF
--- a/docs/WHEN_THE_ODDS_ARE_AN_ENERGY_RANK_ONE_AND_DETAILED_BALANCE_TESTS_FOR_BREAKABLE_CONDITIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/WHEN_THE_ODDS_ARE_AN_ENERGY_RANK_ONE_AND_DETAILED_BALANCE_TESTS_FOR_BREAKABLE_CONDITIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,316 @@
+---
+claim_id: when_the_odds_are_an_energy_rank_one_detailed_balance_tests
+claim_type: bounded_theorem
+claim_scope: "On the coarse torus Z_L^3 at L = 8 with nearest-neighbour adjacency, 512 sites and coordination 6, carrying groups of n <= 3 records -- the dimer and the bent trimer {(0,0,0), (1,0,0), (1,1,0)} -- and on the classical record-pattern chains of PR #7899, under FOUR STIPULATED TABLES OF LOG-ODDS declared here in full and derived from nothing. A PROPOSAL is (which record shifts, one of the six unit directions d); the target is t = source + d; a target carrying a record makes the tick null; otherwise the shift is registered with odds (1/n) p_prop(d) min(1, e^{-w(c, D)}). D = dB = B(new) - B(old) = A(old) - A(new) is the configuration change, with A(S) the adjacent record pairs and B(S) = (n-1) - A(S), exact for n <= 3; writing A(others) for the bond the two records that do not shift already carry, A(old) = A(others) + m_s and A(new) = A(others) + m_t, so D = m_s - m_t exactly. The NEIGHBOURHOOD CONDITION c has four declared coordinates: m_t, records other than the mover adjacent to the target; m_s, records adjacent to the mover's source before the shift; s = +1 for d = +x, -1 for d = -x, 0 otherwise; and a = (x+y+z) mod 2 of the mover's source site, the declared two-sublattice ACTIVITY. THE FOUR TABLES, with g0 = 1, mu = 1/2, nu = 1/4 and g, h, kappa swept, all rational: A, separable, w = beta(c) D with beta(c) = g0 (1 + mu m_t)(1 + nu a) and a uniform proposal -- rank one by construction, the control; B, exactly PR #7899's BR(g, h, 1), w = g D with the field in the PROPOSAL, p_prop(d) = e^{h[d = +x]}/(5 + e^{h}); C, non-separable with the crowding switch on the TARGET, w = g D + kappa D^2 1[m_t >= 1] + h s, uniform proposal so the field sits in the odds; C', the same family with the switch on the MOVER's own neighbourhood, w = g D + kappa D^2 1[m_s >= 2] + h s, declared in response to a computed degeneracy of C on the bent trimer and not fitted to a target. The matrix under test is M_rel(c, D) = max(0, w(c, D)) - max(0, w(c, 0)), the extra log-odds of separating at the same neighbourhood; the raw -ln of the odds carries the additive ln p_prop, which makes it rank >= 2 for every table with no energy content, so the D = 0 column is subtracted throughout. (T1) [exact over Q] THE RANK-ONE TEST. Over the complete enumeration of the torus -- the dimer's 18 occurring (m_t, s, a, D) cells over 12240 unblocked proposals and the 3-record group's 36 cells over 4672620 proposals from all 130305 {0,x,y} representatives, with 9 conditions (m_s, s) for C' -- M_rel has EXACT RANK ONE over Q for table A on both groups at h = 0 and h = 1 (sigma_2/sigma_1 <= 1.302410e-16) with the exact temperature ladder T(c) = 1, 4/5, 2/3, 8/15, 1/2, 2/5, and for table B on both groups at both h (<= 4.602077e-17) with the same beta = g at all 18 conditions, so a single T = 1/g; table C is rank 1 on the dimer but EXACT RANK 2 on 3-record groups at h = 0 (sigma_2/sigma_1 = 3.411710e-02, rank-one residual 3.409726e-02) and rank 4 at h = 1 (1.426295e-01); table C' is EXACT RANK 2 (5.018675e-02 at kappa = 1/2, 1.304845e-01 at kappa = 1) and rank 4 at h = 1 (2.224582e-01). In all 9 rank-one cases the factorisation in the gauge E(D = +1) = 1 gives E(D) = max(0, D), a ONE-SIDED BARRIER and not the configuration energy. TWO TRAPS are measured: a dimer cannot run this test, since D in {-1, 0, +1} makes D^2 = |D| and table C comes out exactly rank one there (0.000000e+00) with a plausible T = 1, 2/3; and with ln p_prop left in even table C gives 4.032337e-02. (T2) [exact] KOLMOGOROV'S CYCLE CRITERION on four chains: all 56454 distinct 4-cycles of the 1022-state even-translation dimer chain, all 1524 of the 511-state relative chain, all 504 winding cycles of length L = 8, and a declared finite subgraph of 1620 trimer 4-cycles on absolute configurations. Table A fails by exactly nu = 1/4 on the dimer and trimer chains, its winding cycles clean, and its stationary law misses pi ~ e^{-g B} by 1.199957e-01; table B at h = 0 passes on all four chains to machine zero and is exactly Gibbs (1.5e-14); table B at h = 1 is still rank one and still exactly Gibbs (2.4e-14) yet fails by exactly 4h on the dimer chain and L h on the winding cycles -- a DRIVEN steady state with a Gibbs internal coordinate; table C at h = 0 passes every cycle and is exactly Gibbs (1.5e-14) while its odds matrix is rank 2, the symmetric kappa D^2 barrier cancelling in every ratio; table C' fails by exactly 4 kappa, independently of g. THE LUMPING TRAP: at h = 1 the translation-reduced relative chain and the declared trimer subgraph both PASS to 1e-16 while the unlumped chain fails by 4h, because lumping discards the parity label the witness cycle turns on. (T3) [exact] ARRHENIUS / VAN 'T HOFF on the bent trimer's 18 proposals, splitting 4 null, 2 at D = 0, 8 at D = +1 and 4 at D = +2: table B carries the common slope a(D)/D = g on both break channels at g = 1, 2, 4; table C' has a(1) = g on the end records (m_s = 1) and a(2) = 2g + 4 kappa on the centre record (m_s = 2), so a(2)/2 - a(1) = 2 kappa exactly at every coupling, a gap that cannot be absorbed into g, and the trimer's lifetime becomes 18/(8 e^{-g} + 4 e^{-2g - 4 kappa}) = 5.967579958344 against PR #7899's 5.165916817967 at g = 1, kappa = 1/2. The exact relation between the two discriminators is CYCLE DEFECT = 4 kappa = 2 x VAN 'T HOFF GAP. A NULL RESULT is recorded: table C keyed to the target is Arrhenius on the bent trimer at every kappa, because all 12 of its breaking proposals land on a site with no occupied neighbour (m_t = 0), so its rank-2 signature lives in the re-binding moves alone -- which is why C' was declared. (T4) [exact] CONSISTENCY: table B reproduces PR #7899's closed forms to 2.22e-16 relative for the dimer lifetimes 2 e^{g}(5 + e^{h})/(9 + e^{h}) and e^{g}(5 + e^{h})/(4 + e^{h}), to 1.94e-16 for the intact fraction 6/(6 + 505 e^{-g}) at every h, and to 1.78e-15 for the trimer's 18/(8 e^{-g} + 4 e^{-2g}), with the 1/n record-choice factor and the sign convention D = B(new) - B(old) both as declared. This note declares four tables of odds and computes with them; nothing is derived from any axiom, no axiom is amended, no status is set, no registry entry is created, and no claim is made about which of these tables, if any, the framework's own law resembles."
+upstream_dependencies: []
+runner: scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py
+---
+
+# When the odds are an energy: rank-one and detailed-balance tests for breakable conditions
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py`](../scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.txt`](../logs/runner-cache/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+`A_HIERARCHY_OF_NEIGHBOURHOOD_CONDITIONS_GLUED_BREAKABLE_AND_FREE_RECORD_GROUPS_UNDER_SHIFTING_TICKS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7899) answered its owner's question affirmatively at the **breakable** level: the
+cost **is** the odds, and what a suppression of `e^{-g}` per broken adjacency buys is a lifetime, `(6/5) e^{g}` for the dimer and `18/(8 e^{-g} + 4 e^{-2g})` for the bent trimer. This note takes the next step and asks what
+more a law has to satisfy before the word **energy** is earned. The answer, on the tables declared below, is that **two** conditions must hold and **neither implies the other**: the odds must factorise into a part reading
+only the neighbourhood and a part reading only the change, and every closed loop of changes must cost the same forwards as backwards. Both are exactly testable on a record history, and rules that pass one and fail the other
+are easy to write down.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-object theorems -- the ranks over Q of every odds matrix by Fraction row reduction, the derived energy E(D) = max(0, D) and the exact temperature ladders, the complete cell census over all 130305 3-record translation-class representatives, the complete 4-cycle censuses of the 1022-state and 511-state dimer chains and of the 504 winding cycles, and the exact channel activations a(1) = g and a(2) = 2g + 4 kappa with their gap 2 kappa -- together with deterministic double-precision evaluations of exactly specified quantities at the thresholds printed in their tags. There is no sampling, no seed and no random number anywhere in the runner."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Route to its owner the one question this note raises and does not decide: whether the framework's own law-level odds, read at whatever object plays the part of a neighbourhood condition, factorise in the rank-one sense and close around cycles -- and, under the Record axiom's permanence, whether the same two tests are to be read on which values FORM together given recorded neighbours rather than on which groups come apart across a tick."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the four statements below, exactly the runner's check groups `A`-`D`: `T1` (`A`) the rank-one test; `T2` (`B`) Kolmogorov's cycle criterion; `T3` (`C`) the Arrhenius / van 't Hoff census;
+`T4` (`D`) the reproduction of PR #7899's closed forms. Every group is **exact** -- integer or `Fraction` arithmetic, or a closed form checked against a complete enumeration at a printed threshold. Every chain is a
+classical record-pattern chain; the only floating point enters the singular values, the cycle products, the stationary solves and the closed-form comparisons, each tagged with its threshold. There is **no sampling, no seed
+and no random number anywhere in this runner**, and no line is a witness.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Metropolis acceptance rule, Kolmogorov's cycle criterion for reversibility, the singular value decomposition, the Arrhenius and van 't Hoff readings of an activation, and
+translation-class reduction are standard methodology; every object is redeclared here and the runner recomputes every statement, including the figures it compares against another lane. No observational value, no fitted
+number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no weight:
+`A_HIERARCHY_OF_NEIGHBOURHOOD_CONDITIONS_GLUED_BREAKABLE_AND_FREE_RECORD_GROUPS_UNDER_SHIFTING_TICKS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7899 -- the breakable level, the chains reused here, and the two closed forms
+`T4` reproduces), `SUPPORT_CONDITIONS_CONFINE_GROUPS_OF_SHIFTING_RECORDS_ENERGY_COSTS_DO_NOT_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7891 -- the cage and the rigid condition),
+`SHIFTING_POSITION_RECORDS_EXACT_DIFFUSION_LAW_AND_THE_UNIFORM_ATTRACTOR_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7889 -- the stipulated shifting tick and the axiom cost that note names and hands to its owner),
+`THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7893 -- a support condition as an emergent instance), and
+`MINIMAL_AXIOMS_2026-06-29.md`, from which the axiom text in "Setting" is quoted verbatim. This note cites no grade of any of these and consumes no ledger row.
+
+## Setting
+
+The framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations
+about each site." "No site is privileged." The lattice is physical. **Qubit / Site Possibility**: "Each site has a domain of local possibilities."
+
+**Admissibility / Local Constraint.** "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations." "For each site, the probability distribution over the
+possibilities is determined by, and varies with, the nearest-neighbor conditions." Reading note (3), interpretive and non-governing, quoted verbatim and in full:
+
+> The distribution is a probability measure on the local possibility domain; "available"/"admissible" denotes its support -- on finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may have zero singleton measure; Record locks a supported realization.
+
+That sentence fixes one piece of vocabulary used below. A **support condition** is a **zero of the law-level odds** at a site given its neighbourhood: a configuration the odds give `0` is not admissible, so no record ever
+locks it. It is a property of the **supplied law**, not an extra axiom and not a new primitive. Nothing in this note is a support condition: every table here is a **suppression**, finite at every argument.
+
+**Record / Fixed Reality.** "Records form." "When present, a record locks exactly one admissible local possibility. A site never carries more than one record; **records are permanent**." "Only records are readable."
+
+The owner's question, quoted on 2026-09-03, which PR #7899 answered at the level of the cost and this note takes one step further:
+
+> "couldn't the cost just be the odds of separating neighborhoods? Low under most conditions but raised under some?"
+
+and the two computations the panel ranked first and second in reply -- the **rank-one collapse** of the log-odds matrix, and **Kolmogorov's cycle criterion** on the tick graph -- which are exactly `T1` and `T2` below. The
+panel's type correction stands and is carried, not dismissed: the framework's Admissibility odds are over *which value a forming record locks*, and the tables here are over *whether a multi-site pattern changes across a
+tick*. These are **supplier tables**, and the note claims nothing about which of them, if any, the framework's law resembles.
+
+**The axiom cost of the tick, named.** The Record axiom makes records **permanent**. Everything below that speaks of a record *shifting* is inside a **stipulated tick model**, declared as such, of exactly the kind PR #7889
+declared and whose wording cost that note's corollary item 2 and its interfaces name and hand to its owner: at the physical sites a shift is a value change, so a shifting-record reading needs either a weakened
+value-permanence or records read at the coarse cells. This note takes no position on that call and supplies no formation clause. A record **registers** a value at a site; it does not report one the site already had.
+
+## The stipulated tables, declared in full
+
+Four tables, all declared here, none derived. A lane proposing different ones inherits the obligations of `T1`-`T4` and none of these choices.
+
+A **proposal** is (which record shifts, one of the six unit directions `d`); the target is `t = source + d`; a target carrying a record makes the tick **null**; otherwise the shift is **registered** with odds
+`(1/n) p_prop(d) Acc(c, D)`, `Acc(c, D) = min(1, e^{-w(c, D)})`. The **configuration change** is `D = dB = B(new) - B(old) = A(old) - A(new)`, adjacencies broken minus made. The **neighbourhood condition** `c` has four
+declared coordinates: `m_t`, the records other than the mover adjacent to the **target**; `m_s`, the records adjacent to the mover's **source** before the shift; `s = +1` for `d = +x`, `-1` for `d = -x`, `0` otherwise; and
+`a = (x+y+z) mod 2` of the mover's source site, the declared two-sublattice **activity**. Constants `g0 = 1`, `mu = 1/2`, `nu = 1/4`; `g`, `h`, `kappa` swept. All four are **rational**, so every odds matrix below has an
+**exact rank over Q**.
+
+| table | `w(c, D)` | proposal | what it is for |
+|---|---|---|---|
+| **A** separable | `beta(c) D`, `beta(c) = g0 (1 + mu m_t)(1 + nu a)` | uniform `1/6` | rank one **by construction** -- the control |
+| **B** breakable | `g D` | tilted, `p_prop(d) = e^{h[d = +x]}/(5 + e^{h})` | exactly PR #7899's `BR(g, h, 1)`; the field is in the **proposal** |
+| **C** target crowding | `g D + kappa D^2 1[m_t >= 1] + h s` | uniform `1/6` | deliberately non-separable; the field is in the **odds** |
+| **C'** mover crowding | `g D + kappa D^2 1[m_s >= 2] + h s` | uniform `1/6` | the same family, switch moved to the mover's own neighbourhood |
+
+`C'` was **declared in response to a computed degeneracy** of `C`, not fitted to a target: out of a bent trimer every breaking proposal has `m_t = 0`, so a target-keyed switch never fires on a break and `C` reproduces `B`
+there (`T3`). The **matrix under test** is `M_rel(c, D) = max(0, w(c, D)) - max(0, w(c, 0))`, the extra log-odds of separating at the same neighbourhood. The raw `-ln` of the odds carries the additive `ln p_prop`, which
+makes it rank `>= 2` for **every** table with no energy content; the `D = 0` column is subtracted throughout, and `T1` reports what leaving it in would have done.
+
+## Obligation graph
+
+The proof is acyclic; each node after `P0` is checked by the correspondingly lettered runner group, and the supported scope is precisely `P0`-`P4`.
+
+`P0` (declared here): the torus, the two groups, the four tables, the four coordinates of `c`, the gauge `M_rel`. `P1` (`A`): the rank-one test. `P2` (`B`): the cycle criterion. `P3` (`C`): the Arrhenius census. `P4` (`D`):
+the reproduction of PR #7899.
+
+## Definitions
+
+A **group of records** is a finite set of occupied sites of the torus `Z_L^3` at `L = 8`, one record each; `A(S)` counts its adjacent pairs and `B(S) = (n-1) - A(S)`, exact for `n <= 3`. The two groups are the **dimer** and
+the **bent trimer** `{(0,0,0), (1,0,0), (1,1,0)}`. Writing `A(others)` for the adjacency the two records that do not shift already carry, `A(old) = A(others) + m_s` and `A(new) = A(others) + m_t`, so **`D = m_s - m_t`
+exactly**; this is the direct computation of `D` and not a shortcut.
+
+The **chains**, all classical record-pattern chains, the largest object built anywhere being `1022 x 1022`: (1) the dimer **relative** chain, `511` states `r = v - u`, a valid reduction only for a fully translation-covariant
+table -- table `A` reads the declared sublattice, so it is not one for `A`; (2) the dimer **full** chain reduced by **even** translations, state `(p, r)` with `p` the parity of record 1's site, `2 x 511 = 1022` classes, even
+translations being an exact symmetry of every declared table, so every 4-cycle of the absolute chain is an even translate of one of these; (3) the **winding** cycles of length `L = 8` in chain (2), one record shifting `+x`
+around the torus; (4) the **trimer** chain on **absolute** configurations, no lumping, in the declared finite subgraph of 4-cycles based at the bent trimer and at each of its one-tick successors.
+
+The **cycle defect** of a chain is `max` over its cycles of `|ln(product of forward odds / product of backward odds)|`; `0` is detailed balance. The **activation** of a break channel is `a(D) = -ln` of the mean acceptance in
+that channel; **Arrhenius** holds exactly when `a(D)/D` is the same for every channel, and the **van 't Hoff gap** is `a(2)/2 - a(1)`.
+
+## Theorem 1 -- the rank-one test: which tables have an energy, and which energy
+
+**Conclusion.** `[exact over Q]` Over the complete enumeration of the `L = 8` torus -- the dimer's **18** occurring `(m_t, s, a, D)` cells over **12240** unblocked proposals, and the 3-record group's **36** cells over
+**4672620** proposals from all **130305** `{0,x,y}` representatives, with **9** conditions `(m_s, s)` for `C'` -- the gauge-fixed matrix `M_rel` has **exact rank one over Q** for **table A** on both groups at `h = 0` and
+`h = 1` alike (`sigma_2/sigma_1 <= 1.302410e-16`), with the exact temperature ladder `T(c) = 1/beta(c) = 1, 4/5, 2/3, 8/15, 1/2, 2/5`; and for **table B** on both groups at both `h` (`<= 4.602077e-17`), with the **same**
+`beta = g` at all `18` neighbourhood conditions, hence a single `T = 1/g`. A field in the **proposal** never enters the cost matrix at all. **Table C** is rank one on the dimer but **exact rank 2** on 3-record groups at
+`h = 0` (`sigma_2/sigma_1 = 3.411710e-02`, best rank-one relative residual `3.409726e-02`) and rank `4` at `h = 1` (`1.426295e-01`); **table C'** is **exact rank 2** (`5.018675e-02` at `kappa = 1/2`, `1.304845e-01` at
+`kappa = 1`) and rank `4` at `h = 1` (`2.224582e-01`). **Which energy.** In all `9` rank-one cases the factorisation in the gauge `E(D = +1) = 1` gives
+
+> **`E(D) = max(0, D)`** -- `E(-2) = E(-1) = E(0) = 0`, `E(+1) = 1`, `E(+2) = 2`.
+
+**Two traps, both measured.** (i) A **dimer cannot run this test**: `D` lies in `{-1, 0, +1}`, so `D^2 = |D|` and every even function of `D` is absorbed into the one-sided gauge -- table `C`, non-separable by construction,
+comes out **exactly rank one** on the dimer (`sigma_2/sigma_1 = 0.000000e+00`) and reports a perfectly plausible ladder `T = 1, 2/3`. (ii) With `ln p_prop` left in, even table `C` reports `4.032337e-02`, so the `D = 0`
+column must be subtracted before the singular values mean anything.
+
+**Proof.** The occurring cells are collected by complete enumeration over the torus, every representative, parity, mover and direction, with blocked targets dropped; `D` is computed as `m_s - m_t`, which is `A(old) - A(new)`
+because the two records that do not shift keep whatever bond they had. Every entry of `M_rel` is a `Fraction`, so the rank is obtained by exact row reduction over `Q` and the singular values are a float cross-check, not the
+statement. The factorisation is read off the `D = +1` column with the stated gauge and then compared entrywise against `max(0, D)`.
+
+**Reading, not theorem.** This is the first half of the answer. If the odds of a group coming apart split into a part that depends only on the surroundings and a part that depends only on the change, then the second part is
+an energy and the first is one over a temperature, and both can be read straight off a record history. Two things are worth saying about the energy that comes out. It is **not** the configuration energy: it is that energy's
+positive part, a one-sided barrier, because a rule that accepts every downhill change outright carries no information about the downhill half of the move set -- any `E` agreeing uphill fits equally well. And the test needs
+`D` to take at least three values, so it needs groups of at least **three** records; on two records it cannot fail, and it will hand back a plausible temperature for a rule that has none.
+
+## Theorem 2 -- the cycle criterion: which tables are reversible, and where the defect lives
+
+**Conclusion.** `[exact]` On all **56454** distinct 4-cycles of the `1022`-state even-translation dimer chain, all **1524** of the `511`-state relative chain, all **504** winding cycles of length `L = 8`, and the declared
+finite subgraph of **1620** trimer 4-cycles on absolute configurations. **Table A fails by exactly `nu = 1/4`** on the dimer chain (`2.500000000000001e-01`) and on the trimer chain (`2.500000000000001e-01`), its winding
+cycles being clean (`2.2e-16`), and its stationary law -- which exists, `|pi P - pi| = 1.0e-17` -- misses `pi ~ e^{-g B}` by `1.199957e-01`. **Table B at `h = 0` passes on all four chains** to machine zero and its stationary
+law is exactly `pi ~ e^{-g B}` (`1.5e-14`). **Table B at `h = 1`** is still rank one (`T1`) and still exactly Gibbs (`2.4e-14`), and **still fails by exactly `4h`** on the dimer chain and by `L h` on the winding cycles.
+**Table C at `h = 0`, `kappa = 1/2`, passes every cycle** on all four chains and is exactly Gibbs (`1.5e-14`) while its odds matrix is **rank 2**. **Table C' fails by exactly `4 kappa`** -- `0`, `1`, `2`, `4` at
+`kappa = 0, 1/4, 1/2, 1` -- and the defect is **independent of the coupling**, `2.000000000000` at `g = 2` as at `g = 1`. **The lumping trap:** at `h = 1` the translation-reduced relative chain **passes** (`2.2e-16`) and so
+does the declared trimer subgraph (`3.3e-16`), while the unlumped chain fails by `4.000000` and the winding cycles by `8.000000`.
+
+**Proof.** Each chain is built edge by edge from the declared table, with the `1/n` record-choice factor and the proposal odds in place, so every row is stochastic and the diagonal absorbs null ticks and unregistered
+proposals. The 4-cycle censuses are complete enumerations of the closed walks on four distinct states, deduplicated over the eight rotations and reflections of a 4-cycle. The winding cycles track the mover's source parity,
+so table `A` is read with its declared activity rather than with the activity discarded. The stationary law is a linear solve with the normalisation replacing one equation, refined three times so the small entries are solved
+rather than recovered by cancellation, and its residual is printed.
+
+**Reading, not theorem.** Rank one does **not** give a Gibbs state. Table `A` factorises to machine zero, hands back a clean temperature ladder, and has no Gibbs law at all -- and the reason is as simple as it is general: on
+a bipartite lattice a move and its reverse sit on **opposite** sublattices, so a condition keyed to which sublattice the mover started on takes a different value going and coming, and the inverse temperature that suppresses
+a move is not the one that suppresses its undoing, however cleanly the odds factorise. Detailed balance does **not** give rank one either: a symmetric `kappa D^2` term is a barrier, it costs the same both ways, it cancels
+in every ratio and changes the rate and not the resting law -- so table `C` at zero field sits in exactly the Gibbs law it would have had without the barrier while its odds refuse to factorise. And a Gibbs-looking resting
+law is **not sufficient**: with a field in the proposal, table `B` keeps its rank one and keeps its Boltzmann law and is nevertheless not reversible at all, because a current runs round the torus while the internal
+coordinate sits in its Boltzmann distribution. Finally, the test has to be run on the chain one actually has: lumping by translation closes the witness cycle, and on a torus part of the defect lives only on the cycles that
+wind.
+
+## Theorem 3 -- what a record history would show: Arrhenius, van 't Hoff, and a null result
+
+**Conclusion.** `[exact]` Out of the bent trimer the `18` proposals split **4 null**, **2 at `D = 0`**, **8 at `D = +1`** (an end record leaves) and **4 at `D = +2`** (the centre record leaves, both bonds go). **Table B**
+carries the **common slope** `a(D)/D = g` on both break channels at `g = 1, 2, 4`. **Table C'** does not: every `D = +1` break is an **end** record (`m_s = 1`, not crowded) so `a(1) = g`, and every `D = +2` break is the
+**centre** record (`m_s = 2`, crowded) so `a(2) = 2g + 4 kappa`, giving the **van 't Hoff gap**
+
+> **`a(2)/2 - a(1) = 2 kappa` exactly**, `1.000000000000` at `g = 1, 2, 4` for `kappa = 1/2` and `2.000000000000` for `kappa = 1`,
+
+the **same** gap at every coupling, so it cannot be absorbed into a redefinition of `g`. The trimer's lifetime becomes `18/(8 e^{-g} + 4 e^{-2g - 4 kappa})`, matched by the enumerated proposals to `0.0e+00`:
+`5.967579958344` against PR #7899's `5.165916817967` at `g = 1`, `16.474505674194` against `15.571677528219` at `g = 2` and `122.693773845084` against `121.731046628774` at `g = 4`. **The exact relation between the two
+discriminators:** for the same declared `kappa` the **cycle defect is `4 kappa`** and the **van 't Hoff gap is `2 kappa`**, so `defect = 2 x gap` -- `2.000000000000` against `2 x 1.000000000000` at `kappa = 1/2` and
+`4.000000000000` against `2 x 2.000000000000` at `kappa = 1`. **The null result.** Table `C`, keyed to the **target's** crowding, is Arrhenius on the bent trimer at **every** `kappa` (`a(1) = a(2)/2 = 1.000000000000` at
+`kappa = 0, 1/2, 1` alike), because all `12` of its breaking proposals land on a site with no occupied neighbour -- `m_t = 0` in every one of them -- so the crowding switch never fires on a break, and `C`'s rank-2 signature
+lives in the **re-binding** moves alone.
+
+**Proof.** The channel census enumerates the bent trimer's `18` proposals, records `(m_s, m_t)` for each breaking one, and reports the activation as `-ln` of the mean acceptance in the channel; the `(m_s, m_t)` sets are
+compared against `{(1, 0)}` for `D = +1` and `{(2, 0)}` for `D = +2`, which is the exact reason for `a(1) = g` and `a(2) = 2g + 4 kappa`. The lifetime is the reciprocal of the summed break odds over the same enumerated
+proposals and is compared with the closed form; the summation direction is the one in which the small weights are added rather than differenced.
+
+**Reading, not theorem.** The two tests are not just formal: each has a signature a record history would carry. A law whose odds do not factorise shows up as **break channels with different slopes** -- here the group's end
+records and its centre record part at activations that differ by a fixed amount, no matter how the coupling is tuned. A law that is not reversible shows up as a **loop that costs more one way round than the other**. On these
+tables the two are the same number up to a factor of two, which is a convenience and not a theorem. The null result is the practical warning: a non-separable law can be completely undetectable in the lifetimes of the very
+group whose separation it governs, and still be rank 2 in the odds. Which of the two tests sees it depends on which coordinate the condition is keyed to, so run both.
+
+## Theorem 4 -- consistency with the parent
+
+**Conclusion.** `[exact]` With the `1/n` record-choice factor and the sign convention `D = B(new) - B(old) = A(old) - A(new)` both as declared, **table B reproduces PR #7899's closed forms**: the dimer lifetimes
+`2 e^{g}(5 + e^{h})/(9 + e^{h})` aligned and `e^{g}(5 + e^{h})/(4 + e^{h})` transverse over six `(g, h)` cells to `2.22e-16` **relative** -- both `(6/5) e^{g}` at `h = 0` -- the intact fraction `6/(6 + 505 e^{-g})` to
+`1.94e-16` **at every `h`** (`|pi P - pi| <= 6.0e-17`), and the bent trimer's `18/(8 e^{-g} + 4 e^{-2g})` to `1.78e-15`, namely `5.165916817967`, `15.571677528219` and `121.731046628774` ticks at `g = 1, 2, 4`.
+
+**Proof.** The dimer figures come from the same `511`-state relative chain used in `T2`, the lifetime as the reciprocal of the summed break odds out of the intact vector and the intact fraction from the refined stationary
+solve; the trimer figure comes from the same `18`-proposal census used in `T3`. Both are compared against the closed forms as written in PR #7899.
+
+**Reading, not theorem.** This theorem carries no new content and is here for one reason: the three tables that are **not** PR #7899's are tested against a reproduction of PR #7899's own numbers on the same code path, so a
+difference reported in `T1`-`T3` is a difference between the declared tables and not between two implementations. Two conventions are load-bearing and were both fixed before any table was compared -- the `1/n` factor for
+choosing which record shifts, and the sign of `D` on the trimer.
+
+## Corollary -- when the odds are an energy
+
+Within the setting declared above, on the `L = 8` torus, for groups of `n <= 3` records and for the four stipulated tables alone:
+
+1. **The two tests are logically independent, and each fails without the other.** Rank one does not give a Gibbs state (table `A`: rank one to machine zero, a clean temperature ladder, cycle defect exactly `nu`, and a
+   stationary law `12 %` off Boltzmann). Detailed balance does not give rank one (table `C` at `h = 0`: every cycle product `1`, exactly Gibbs, odds matrix rank `2`). And a Gibbs stationary law is not sufficient for either
+   reading (table `B` with a field: rank one, exactly Gibbs, and not reversible). **Only both together license the sentence "these odds are an energy and a temperature".**
+2. **Where the odds are an energy, the energy is a one-sided barrier.** What comes out of Metropolis-type odds is `E(D) = max(0, D)`, the positive part of the configuration change, not the configuration energy itself; the
+   odds carry nothing about the downhill half of the move set.
+3. **A bipartite lattice puts a parity defect into any sublattice-dependent activity.** A move and its reverse start on opposite sublattices, so a law whose odds read which sublattice a record sits on is never in detailed
+   balance, however perfectly separable it is -- and the defect is exactly the activity coefficient `nu`.
+4. **A field is a driven steady state, not a hotter one.** With the tilt in the proposal the internal coordinate stays exactly Gibbs and the intact fraction is unmoved at every `h`, while the cycle products fail by exactly
+   `4h` on a 4-cycle and `L h` around the torus. A resting law that looks thermal is not evidence of reversibility.
+5. **The measurable discriminator on a record history is a pair.** Bin every registered change by `(c, D)`, subtract the `D = 0` column and take the singular values -- `sigma_2/sigma_1 = 0` is the energy; then take every
+   4-cycle of the **unlumped** history and every cycle that winds -- `0` is detailed balance. A third check comes free, the van 't Hoff gap between break channels, which here is exactly half the cycle defect.
+6. **Two traps for anyone repeating this.** A dimer cannot run the rank-one test, because `D^2 = |D|` when `D` has three values and a non-separable table comes out rank one with a plausible temperature. A
+   translation-reduced chain cannot run the cycle test, because the witness cycle is closed in the reduced chain and open in the real one. Both were walked into and measured here.
+
+## Reading, not theorem -- the whole thing in plain words
+
+When can the odds of a group coming apart be read as an energy divided by a temperature? Two things must both hold, and neither implies the other: the odds must split into a part that depends only on the surroundings and a
+part that depends only on the change, and going round any closed loop of changes must cost the same forwards as backwards. Rules that pass the first and fail the second, or the reverse, are easy to write down, and so is a
+rule that is perfectly thermal in its resting statistics yet not reversible at all because a steady push runs through it. So "the cost is the odds" is right, but "the odds are an energy" is an extra property that a law may
+or may not have, and there is an exact test for it on record histories.
+
+## Interfaces named for other lanes, not settled here
+
+- **The framework's actual law.** Every table here is supplied. Whether the framework's own odds, read at whatever object plays the part of a neighbourhood condition, factorise in the rank-one sense and close around cycles
+  is a question about the law and is asked, not answered, here.
+- **The form-together reading under permanence.** Records are permanent. Read that way, the two tests apply to which values are admissible to **form** at a site given its recorded neighbours, with `D` reading the change in
+  the neighbourhood pattern; the matrices and the cycle products are the same objects and the wording changes. Which reading the framework intends is the owner's call, the same call PR #7889's corollary item 2 hands over.
+- **Amplitude ticks.** Every chain here is classical. PR #7889's `M2` kernel -- a pre-record amplitude running for a time `tau`, the odds being its weights conditioned on the admissible set -- is a different object, and what
+  either test says about it is untouched here.
+- **Larger groups.** The censuses stop at `n <= 3`, where `B = (n-1) - A` is exact and `D` takes five values. At `n >= 4` a group can carry more than `n-1` adjacencies, `D` takes more values, and both tests get sharper; none
+  of that is computed.
+- **Non-Metropolis acceptance rules.** `Acc = min(1, e^{-w})` is a declared convention and it is what makes the derived energy one-sided. A smooth acceptance rule -- Glauber, or any strictly positive function of `w` --
+  would return an `E` determined on both halves of the move set, and what the two tests then measure is not computed here.
+
+## Remaining live routes
+
+1. Whether the exact factor of two between the cycle defect and the van 't Hoff gap survives beyond a single switched `D^2` term, or is an accident of this family.
+2. Whether a positive stationary law that passes the cycle test but fails the rank-one test admits a **local** energy at all -- the Hammersley-Clifford question, untouched here.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the four theorem conclusions.
+
+```text
+setting: the coarse torus Z_L^3 at L = 8, 512 sites, coordination 6, bipartite; groups of n <= 3 records, the dimer and the bent trimer {(0,0,0),(1,0,0),(1,1,0)}; A(S) adjacent record pairs, B(S) = (n-1) - A(S) exact for n <= 3. Axioms quoted from MINIMAL_AXIOMS_2026-06-29.md with Admissibility reading note (3) quoted in full
+tables: STIPULATED, derived from nothing. Proposal = (which record shifts, one of 6 unit directions); null tick on a blocked target; otherwise registered with odds (1/n) p_prop(d) min(1, e^{-w(c,D)}). D = B(new) - B(old) = A(old) - A(new) = m_s - m_t. c = (m_t, m_s, s, a) with a = (x+y+z) mod 2 of the mover's SOURCE. g0 = 1, mu = 1/2, nu = 1/4. A: w = g0 (1 + mu m_t)(1 + nu a) D, uniform proposal. B: w = g D, p_prop(d) = e^{h[d=+x]}/(5+e^{h}) -- PR #7899's BR(g,h,1). C: w = g D + kappa D^2 1[m_t >= 1] + h s, uniform. C': w = g D + kappa D^2 1[m_s >= 2] + h s, uniform. Gauge M_rel(c,D) = max(0,w(c,D)) - max(0,w(c,0)). Records are PERMANENT; every shifting statement is inside a stipulated tick model whose axiom cost PR #7889 names
+T1_rank_one [exact over Q]: cells by complete enumeration -- dimer 18 (m_t,s,a,D) over 12240 unblocked proposals, 3-record 36 over 4672620 from all 130305 {0,x,y} representatives, 9 conditions (m_s,s) for C'. A rank 1 on both groups at h = 0 and 1 (sigma_2/sigma_1 <= 1.302410e-16), ladder T(c) = 1, 4/5, 2/3, 8/15, 1/2, 2/5; B rank 1 on both groups at both h (<= 4.602077e-17), beta = g at all 18 conditions, T = 1/g; C rank 2 on 3-record at h = 0 (3.411710e-02, residual 3.409726e-02) and rank 4 at h = 1 (1.426295e-01); C' rank 2 (5.018675e-02 at kappa = 1/2, 1.304845e-01 at kappa = 1), rank 4 at h = 1 (2.224582e-01). In all 9 rank-one cases E(D) = max(0, D) EXACTLY in the gauge E(+1) = 1. TRAPS: C is rank one on the dimer (0.000000e+00, T = 1, 2/3) since D^2 = |D| there; with ln p_prop left in C gives 4.032337e-02
+T2_cycles [exact]: 56454 4-cycles of the 1022-state even-translation dimer chain, 1524 of the 511-state relative chain, 504 winding cycles of length 8, 1620 declared trimer 4-cycles on absolute configurations. A fails by exactly nu = 1/4 on the dimer and trimer chains, winding clean, stationary law off Gibbs by 1.199957e-01 (|pi P - pi| = 1.0e-17); B at h = 0 passes all four to machine zero, exactly Gibbs 1.5e-14; B at h = 1 rank one and exactly Gibbs 2.4e-14 yet fails by exactly 4h on the dimer chain and L h on the winding cycles; C at h = 0, kappa = 1/2 passes all four and is exactly Gibbs 1.5e-14 while rank 2; C' fails by exactly 4 kappa (0, 1, 2, 4 at kappa = 0, 1/4, 1/2, 1) and g-independently (2.000000000000 at g = 2). LUMPING TRAP: at h = 1 the relative chain (2.2e-16) and the trimer subgraph (3.3e-16) PASS while the unlumped chain fails by 4.000000 and winding by 8.000000
+T3_arrhenius [exact]: the bent trimer's 18 proposals split 4 null, 2 at D = 0, 8 at D = +1, 4 at D = +2. B: common slope a(D)/D = g at g = 1, 2, 4. C': a(1) = g on end records (m_s = 1), a(2) = 2g + 4 kappa on the centre record (m_s = 2), van 't Hoff gap a(2)/2 - a(1) = 2 kappa EXACTLY at every g; lifetime 18/(8 e^{-g} + 4 e^{-2g - 4 kappa}) matched to 0.0e+00, 5.967579958344 vs 5.165916817967 at g = 1 kappa = 1/2, 16.474505674194 vs 15.571677528219, 122.693773845084 vs 121.731046628774. RELATION: cycle defect 4 kappa = 2 x van 't Hoff gap 2 kappa. NULL RESULT: C is Arrhenius on the bent trimer at every kappa (a(1) = a(2)/2 = 1.000000000000) because all 12 breaking proposals have m_t = 0
+T4_consistency [exact]: table B reproduces PR #7899 -- dimer lifetimes 2 e^{g}(5+e^{h})/(9+e^{h}) and e^{g}(5+e^{h})/(4+e^{h}) to 2.22e-16 relative over six (g,h) cells, both (6/5) e^{g} at h = 0; intact fraction 6/(6 + 505 e^{-g}) to 1.94e-16 at EVERY h (|pi P - pi| <= 6.0e-17); trimer 18/(8 e^{-g} + 4 e^{-2g}) to 1.78e-15, i.e. 5.165916817967, 15.571677528219, 121.731046628774 at g = 1, 2, 4. The 1/n record-choice factor and the sign D = B(new) - B(old) are declared conventions fixed before any comparison
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=21 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **declared finite objects**: groups of `n <= 3` records on the `L = 8` torus, the `1022`-state and `511`-state dimer chains, the `504` winding cycles, and a declared finite subgraph of the
+trimer chain. Nothing is claimed for larger groups, for the thermodynamic limit, for other lattices, or for any table other than the four in "The stipulated tables".
+
+**The four tables are stipulated in full and derived from nothing.** Reading note (3) makes support a property of the **supplied odds**, so stipulating a table here is stipulating a law, not amending an axiom; reading note
+(2) is explicit that the axioms supply no formation site, probability or rate, and this note supplies none either. Table `C'` was declared in response to a computed degeneracy of `C` and is not fitted to any target. A lane
+proposing different tables inherits the obligations of `T1`-`T4` and none of these choices. **Records are permanent**; every sentence in which a record *shifts* is inside a stipulated tick model declared as such, and the
+axiom cost of that stipulation is the one PR #7889 names and hands to its owner.
+
+**Every chain is a classical record-pattern chain.** PR #7889's amplitude kernel is not used, so nothing here bears on any amplitude tick.
+
+**Complete enumeration where stated, bounded and declared where not.** Complete: the occurring `(c, D)` cells over all `130305` 3-record translation-class representatives and all `511` dimer relative vectors; all `56454`
+4-cycles of the `1022`-state chain; all `1524` of the `511`-state chain; all `504` winding cycles; the bent trimer's `18` proposals. **Bounded and declared:** the trimer's `1620` 4-cycles are those based at the bent trimer
+and at each of its one-tick successors, a finite declared subgraph and not the whole trimer chain -- so every trimer row is a **falsification** where it reports a defect and a **bounded** result where it reports none.
+
+**`[exact]` versus `[numerical]`.** Exact, with no floating point in the statement: every odds matrix, its rank over `Q` by `Fraction` row reduction, the derived `E(D) = max(0, D)`, every `beta(c)` and `T(c)`, the identity
+`D = m_s - m_t`, the channel activations `a(1) = g` and `a(2) = 2g + 4 kappa` and their gap `2 kappa`, and the cycle and proposal counts. Numerical: the singular values (a rank-one matrix returns `sigma_2/sigma_1` at or
+below `1.31e-16`), the cycle products (every violation lands on its exact rational -- `0.25`, `1`, `2`, `4`, `8` -- to fifteen digits), the stationary vectors and the closed-form comparisons, each at the threshold printed in
+its line. **There is no sampling, no seed and no random number anywhere in the runner**, and no line is a witness. The largest object built anywhere is `1022 x 1022`.
+
+**Nothing is derived from the axioms.** No axiom is used, amended or invoked; no status is set; no registry entry or ledger row is touched. The panel's type correction is carried: the framework's Admissibility odds are over
+which value a forming record locks, and these tables are over whether a multi-site pattern changes across a tick. **These are supplier tables, and the note claims nothing about which of them, if any, the framework's law
+resembles.** No claim is made that any table is unreachable, and none of the results below rules out any construction: a rule that fails one test on these tables is a rule with a named, measured defect, not a route that is
+closed.
+
+**Not computed:** groups of `n >= 4`; the complete trimer cycle census; cycles of length other than `4` and `L`; acceptance rules other than `min(1, e^{-w})`; anything about continuum limits, gaps, or the link sector; and
+whether a positive stationary law here admits a local energy.
+
+## Review record
+
+An honest auditor should come away with four declared tables of odds and two exact tests run on them, not a claim about what the framework's own law does; four exact finite-object theorems, three complete 4-cycle censuses,
+one complete cell census over `130305` representatives, and exact ranks over `Q` throughout, with the numerical lines deterministic, unsampled and threshold-tagged; no Monte Carlo anywhere; the stipulation declared as
+stipulated in the front matter, the setting, its own section, the claim block and the proof boundary alike; the axiom cost of the shifting tick named rather than absorbed; two methodological traps reported because this lane
+walked into both of them, and a null result reported because it is the reason table `C'` exists; and a corollary written as an answer to its owner's question, with the question it cannot settle -- what the framework's own
+odds do under these two tests -- handed back rather than settled.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions" and "The stipulated tables", no hypothesis is adopted, and the "Imports and authority" pointers are plain text carrying
+no grade and no weight. Hard landing conditions are a fresh runner and cache pair at `PASS=21 FAIL=0`, runtime under the declared `150` seconds, a current zero-dependency citation-manifest entry, and passing pipeline,
+strict-lint and changed-evidence gates; audit remains a separate lane.

--- a/logs/runner-cache/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.txt
+++ b/logs/runner-cache/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.txt
@@ -1,0 +1,34 @@
+===== runner cache v1 =====
+runner: scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py
+runner_sha256: 232c52df250cd83901c84c06f625452cee8378db0e3f9e5f38ff41be5d42d863
+timeout_sec: 150
+exit_code: 0
+elapsed_sec: 2.82
+status: ok
+----- stdout -----
+PASS A1 [exact] occurring (c, D) cells, by complete enumeration over the L = 8 torus: DIMER 18 cells over 12240 unblocked proposals, D in [-1, 0, 1], m_t in [0, 1]; 3-record 36 cells over 4672620 proposals (all 130305 {0,x,y} representatives), D in [-2, -1, 0, 1, 2], m_t in [0, 1, 2]; 9 conditions (m_s, s) for table C'
+PASS A2 [exact] TABLE A, separable by construction: M_rel is EXACTLY RANK ONE over Q on the dimer (12x3) and on 3-record groups (18x5), at h = 0 and h = 1 alike, sigma_2/sigma_1 <= 1.302410e-16, with the exact temperature ladder T(c) = 1/beta(c) = 2/5, 1/2, 8/15, 2/3, 4/5, 1
+PASS A3 [exact] TABLE B, PR #7899's Metropolis rule: M_rel is EXACTLY RANK ONE on both groups at h = 0 and h = 1 (sigma_2/sigma_1 <= 4.602077e-17) with the SAME beta = g at all 18 conditions, so one temperature T = 1/g -- a field in the PROPOSAL never enters the cost matrix
+PASS A4 [exact] TABLE C, non-separable by construction: on 3-record groups M_rel has EXACT RANK 2 over Q at h = 0, sigma_2/sigma_1 = 3.411710e-02, rank-one residual 3.409726e-02, and rank 4 at h = 1 (1.426295e-01): no beta(c) x E(D) exists, so no energy and no temperature
+PASS A5 [exact] TABLE C', the same family keyed to the MOVER's own neighbourhood: M_rel is 9x5 of EXACT RANK 2, sigma_2/sigma_1 = 5.018675e-02 at kappa = 1/2 and 1.304845e-01 at kappa = 1, rank 4 at h = 1 (2.224582e-01) -- the departure grows with the declared kappa
+PASS A6 [exact] WHICH energy: in all 9 rank-one cases the factorisation in the gauge E(D = +1) = 1 gives E(D) = max(0, D) -- E(-2) = E(-1) = E(0) = 0, E(+1) = 1, E(+2) = 2 -- a ONE-SIDED BARRIER, not the configuration energy: the odds say nothing about the downhill half of the move set
+PASS A7 [exact] TWO TRAPS. (i) A DIMER CANNOT RUN THIS TEST: D in {-1, 0, +1} makes D^2 = |D|, so table C is EXACTLY RANK ONE there (sigma_2/sigma_1 = 0.000000e+00) with a plausible T = 2/3, 1; three records are needed. (ii) Leave ln p_prop in and even table C gives 4.032337e-02, so subtract the D = 0 column
+PASS B1 [exact] the CYCLE CENSUS, complete where stated: 56454 distinct 4-cycles of the 1022-state even-translation dimer chain, 1524 of the 511-state relative chain, 504 winding cycles of length L = 8, and the declared subgraph of 1620 trimer 4-cycles on absolute configurations
+PASS B2 [exact] TABLE A -- RANK ONE GIVES NO GIBBS STATE: cycle products fail by exactly nu = 1/4 on the dimer chain (2.500000000000001e-01) and the trimer chain (2.500000000000001e-01), winding clean (2.2e-16); the stationary law (|pi P - pi| = 1.0e-17) misses e^{-g B} by 1.199957e-01
+PASS B3 [exact] TABLE B at h = 0 -- BOTH tests pass: every cycle product is 1 to machine zero on all four chains (dimer 0.0e+00, relative 0.0e+00, winding 0.0e+00, trimer 2.2e-16) and the law is exactly pi ~ e^{-g B} (1.5e-14, |pi P - pi| = 3.2e-17). Here the odds ARE an energy
+PASS B4 [exact] TABLE B WITH A FIELD -- A GIBBS LAW IS NOT SUFFICIENT: at h = 1 the odds matrix is still rank one and the law still exactly Gibbs (2.4e-14), yet cycle products fail by exactly 4h = 4.000000000000000 on the dimer chain and L h = 8.000000000000000 on the winding cycles: a DRIVEN steady state
+PASS B5 [exact] TABLE C at h = 0 -- DETAILED BALANCE GIVES NO RANK ONE: at kappa = 1/2 every cycle product is 1 (dimer 0.0e+00, relative 0.0e+00, winding 0.0e+00, trimer 2.2e-16) and the law is exactly Gibbs (1.5e-14) while the odds matrix is rank 2: a symmetric kappa D^2 BARRIER cancels in every ratio
+PASS B6 [exact] TABLE C' -- a crowding barrier keyed to the MOVER does break detailed balance: over the 1620 declared trimer 4-cycles at h = 0 the defect is exactly 4 kappa -- 0.000000000000, 1.000000000000, 2.000000000000, 4.000000000000 at kappa = 0, 1/4, 1/2, 1 -- and 2.000000000000 at g = 2, coupling-independent
+PASS B7 [exact] THE LUMPING TRAP: at h = 1 the translation-reduced relative chain PASSES (2.2e-16) and so does the declared trimer subgraph (3.3e-16) while the unlumped chain fails by 4h (4.000000) and the winding cycles by L h (8.000000): a 4-cycle test on a reduced chain is not a detailed-balance test
+PASS C1 [exact] TABLE B on the bent trimer: its 18 proposals split 4 null, 2 at D = 0, 8 at D = +1, 4 at D = +2, and both break channels carry the COMMON SLOPE a(D)/D = g at g = 1, 2, 4 (1.000000000000, 2.000000000000, 4.000000000000): Arrhenius holds
+PASS C2 [exact] TABLE C' on the bent trimer: every D = +1 break is an END record (m_s = 1) so a(1) = g, every D = +2 break the CENTRE (m_s = 2) so a(2) = 2g + 4 kappa; the van 't Hoff gap a(2)/2 - a(1) = 2 kappa EXACTLY, 1.000000000000 at g = 1, 2, 4 for kappa = 1/2 and 2.000000000000 for kappa = 1
+PASS C3 [exact] the bent trimer's lifetime under C' is 18/(8 e^{-g} + 4 e^{-2g - 4 kappa}), matched by the enumerated proposals to 0.0e+00: 5.967579958344 ticks at g = 1, kappa = 1/2 against PR #7899's 5.165916817967, 16.474505674194 against 15.571677528219, 122.693773845084 against 121.731046628774 at g = 2 and 4
+PASS C4 [exact] THE NULL RESULT: table C, keyed to the TARGET's crowding, is Arrhenius on the bent trimer at EVERY kappa (a(1) = a(2)/2 = 1.000000000000 at kappa = 0, 1/2, 1) because all 12 of its breaking proposals land on a site with no occupied neighbour (m_t = 0), so C's rank-2 signature lives in the re-binding moves alone
+PASS C5 [exact] THE TWO DISCRIMINATORS, a factor of two apart: the Kolmogorov defect is 4 kappa and the van 't Hoff gap 2 kappa, so defect = 2 x gap exactly -- 2.000000000000 against 2 x 1.000000000000 at kappa = 1/2, 4.000000000000 against 2 x 2.000000000000 at kappa = 1; the rank-one departure 5.018675e-02 is the third
+PASS D1 [exact] CONSISTENCY with PR #7899, dimer: table B reproduces 2 e^{g}(5 + e^{h})/(9 + e^{h}) aligned and e^{g}(5 + e^{h})/(4 + e^{h}) transverse over six (g, h) cells to 2.22e-16 relative -- both (6/5) e^{g} at h = 0 -- and 6/(6 + 505 e^{-g}) to 1.94e-16 AT EVERY h (|pi P - pi| <= 6.0e-17)
+PASS D2 [exact] CONSISTENCY with PR #7899, bent trimer: with the 1/n record-choice factor and D = B(new) - B(old) = A(old) - A(new) both as declared, table B returns 18/(8 e^{-g} + 4 e^{-2g}) to 1.78e-15 -- 5.165916817967, 15.571677528219, 121.731046628774 ticks at g = 1, 2, 4
+SUMMARY: the odds are an energy only when the odds matrix is rank one AND every cycle product is 1; neither gives the other, and a Gibbs resting law gives neither.
+TOTAL: PASS=21 FAIL=0
+
+----- stderr -----
+

--- a/scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py
+++ b/scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+"""When the odds are an energy: rank-one and detailed-balance tests for
+breakable neighbourhood conditions.
+
+Class-A finite-object runner, self-contained.  Nothing is derived from any
+axiom; every object below is DECLARED here and derived from nothing.
+
+  THE COARSE TORUS.  Z_L^3 at L = 8: 512 sites, nearest-neighbour adjacency,
+  coordination 6, bipartite.  A GROUP OF RECORDS is a finite set of occupied
+  sites, one record each.  A(S) counts adjacent record pairs and
+  B(S) = (n-1) - A(S), exact for n <= 3.  Groups: the dimer (n = 2) and the
+  bent trimer {(0,0,0), (1,0,0), (1,1,0)} (n = 3).
+
+  A PROPOSAL is (which record shifts, one of the 6 unit directions d).  The
+  target is t = source + d.  A target carrying a record makes the tick NULL.
+  Otherwise the shift is registered with odds
+
+      P(shift registered | proposal) = (1/n) p_prop(d) Acc(c, D),
+      Acc(c, D) = min(1, e^{-w(c, D)}).
+
+  D = dB = B(new) - B(old) = adjacencies broken minus made -- the
+  CONFIGURATION CHANGE.  Writing A(others) for the adjacency the two records
+  that do not shift already carry, A(old) = A(others) + m_s and
+  A(new) = A(others) + m_t, so D = m_s - m_t exactly.
+
+  THE NEIGHBOURHOOD CONDITION c has four declared coordinates:
+      m_t  records other than the mover adjacent to the TARGET   (0, 1, 2)
+      m_s  records adjacent to the mover's SOURCE before the shift (0, 1, 2)
+      s    +1 for d = +x, -1 for d = -x, 0 otherwise
+      a    (x+y+z) mod 2 of the mover's SOURCE site -- the declared
+           two-sublattice ACTIVITY.
+
+  FOUR DECLARED TABLES of log-odds w(c, D).  Constants g0 = 1, mu = 1/2,
+  nu = 1/4; g, h, kappa swept.  All rational, so every odds matrix has an
+  EXACT RANK OVER Q by Fraction row reduction.
+
+      A   separable, the control:  w = beta(c) D,
+          beta(c) = g0 (1 + mu m_t)(1 + nu a);  uniform proposal 1/6.
+      B   PR #7899's Metropolis rule BR(g, h, 1):  w = g D; the field is in
+          the PROPOSAL, p_prop(d) = e^{h[d = +x]}/(5 + e^{h}).
+      C   non-separable, TARGET crowding:  w = g D + kappa D^2 1[m_t >= 1]
+          + h s;  uniform proposal, so the field is in the ODDS.
+      C'  non-separable, MOVER crowding:  w = g D + kappa D^2 1[m_s >= 2]
+          + h s;  uniform proposal.  Declared in response to a computed
+          degeneracy of C on the bent trimer, not fitted to a target.
+
+  THE MATRIX UNDER TEST, in the gauge that fixes the constant:
+      M_acc(c, D) = -ln Acc(c, D) = max(0, w(c, D))
+      M_rel(c, D) = M_acc(c, D) - M_acc(c, 0)
+  M_rel is the extra log-odds of separating at the same neighbourhood.  The
+  raw -ln of the odds carries the additive ln 6 or ln p_prop, which makes it
+  rank >= 2 for EVERY table with no energy content; the D = 0 column is
+  subtracted throughout.
+
+  THE CHAINS, all classical record-pattern chains, largest 1022 x 1022:
+   (1) the dimer RELATIVE chain, 511 states r = v - u.  Valid only for a
+       fully translation-covariant table (B, C, C'); table A reads the
+       declared sublattice, so this lumping is not a reduction for it.
+   (2) the dimer FULL chain reduced by EVEN translations, state (p, r) with
+       p the parity of record 1's site: 2 x 511 = 1022 classes.  Even
+       translations are an exact symmetry of every declared table, so every
+       4-cycle of the absolute chain is an even translate of one of these.
+   (3) the WINDING cycles of length L = 8 in chain (2).
+   (4) the TRIMER chain on ABSOLUTE configurations, no lumping: the declared
+       finite subgraph of 4-cycles based at the bent trimer and at each of
+       its one-tick successors.
+
+Records are PERMANENT.  Every sentence below in which a record SHIFTS sits
+inside a STIPULATED tick model, declared as such, whose axiom cost is the one
+PR #7889 names and hands to its owner.  A record REGISTERS a value at a site;
+it does not report one the site already had.
+
+Check groups:
+  A  T1  the rank-one test on M_rel: exact ranks over Q, the derived energy
+         E(D) = max(0, D) and the temperatures, and the dimer trap.
+  B  T2  Kolmogorov's cycle criterion on all four chains, the exact scaling
+         of every violation, the stationary laws, and the lumping trap.
+  C  T3  Arrhenius / van 't Hoff on the bent trimer's two break channels.
+  D  T4  reproduction of PR #7899's closed forms by table B.
+
+Line tags.  `[exact]` = integer or `Fraction` arithmetic with no floating
+point in the statement.  `[numerical]` = a deterministic double-precision
+evaluation of an exactly specified quantity at a stated threshold.  There is
+no sampling, no seed and no random number anywhere in this runner, and no
+line is a witness.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from fractions import Fraction as Fr
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 150
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ============================================================== the L^3 torus
+
+L = 8
+NSITE = L ** 3
+DIRS = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+NEGK = [1, 0, 3, 2, 5, 4]
+SGNK = [1, -1, 0, 0, 0, 0]
+
+
+def pack(v):
+    return (v[0] % L) * L * L + (v[1] % L) * L + (v[2] % L)
+
+
+def unpack(i):
+    return (i // (L * L), (i // L) % L, i % L)
+
+
+SITE = [unpack(i) for i in range(NSITE)]
+PAR = [sum(SITE[i]) % 2 for i in range(NSITE)]
+NBR = [[pack((SITE[i][0] + d[0], SITE[i][1] + d[1], SITE[i][2] + d[2]))
+        for d in DIRS] for i in range(NSITE)]
+ADJ = [bytearray(NSITE) for _ in range(NSITE)]
+for _i in range(NSITE):
+    for _j in NBR[_i]:
+        ADJ[_i][_j] = 1
+ADJ0 = ADJ[0]                       # ADJ0[r] = 1 iff the relative vector r is a unit step
+REL = list(range(1, NSITE))         # the 511 nonzero relative vectors
+BENT = (pack((0, 0, 0)), pack((1, 0, 0)), pack((1, 1, 0)))
+
+# ------------------------------------------- the four declared tables of odds
+
+G0, MU, NU = Fr(1), Fr(1, 2), Fr(1, 4)
+
+
+def wA(mt, s, a, D, g=Fr(1), h=Fr(0), kap=Fr(1, 2)):
+    return G0 * (1 + MU * mt) * (1 + NU * a) * D
+
+
+def wB(mt, s, a, D, g=Fr(1), h=Fr(0), kap=Fr(1, 2)):
+    return g * D
+
+
+def wC(mt, s, a, D, g=Fr(1), h=Fr(0), kap=Fr(1, 2)):
+    return g * D + kap * D * D * (1 if mt >= 1 else 0) + h * s
+
+
+def wCp(ms, s, D, g=Fr(1), h=Fr(0), kap=Fr(1, 2)):
+    return g * D + kap * D * D * (1 if ms >= 2 else 0) + h * s
+
+
+def pprop(table, s, h):
+    """The declared proposal odds for one direction."""
+    if table != "B":
+        return 1.0 / 6.0
+    eh = math.exp(float(h))
+    return (eh if s == 1 else 1.0) / (5.0 + eh)
+
+
+def acc_f(w):
+    return 1.0 if w <= 0.0 else math.exp(-w)
+
+
+# ============================================ the occurring (c, D) cells
+
+def dimer_cells():
+    """Every (m_t, s, a, D) and (m_s, s, D) that occurs for the dimer over the
+    whole L = 8 torus: all 511 relative vectors x 2 parities x 2 movers x 6
+    directions, blocked targets dropped."""
+    ct, cs, npr = set(), set(), 0
+    for r in REL:
+        ms = ADJ0[r]
+        for k in range(6):
+            s = SGNK[k]
+            r1 = NBR[r][NEGK[k]]        # record 1 shifts by d: r -> r - d
+            r2 = NBR[r][k]              # record 2 shifts by d: r -> r + d
+            for (rn, moved_first) in ((r1, True), (r2, False)):
+                if rn == 0:
+                    continue            # the target carries the other record
+                mt = ADJ0[rn]
+                D = ms - mt
+                for p in (0, 1):
+                    a = p if moved_first else (p + PAR[r]) % 2
+                    ct.add((mt, s, a, D))
+                cs.add((ms, s, D))
+                npr += 2
+    return ct, cs, npr
+
+
+def trimer_cells():
+    """Every (m_t, s, a, D) and (m_s, s, D) that occurs for 3-record groups
+    over the whole torus.  One pass over all C(511,2) = 130305 translation
+    class representatives {0, x, y} x 2 parities x 3 movers x 6 directions."""
+    ct, cs, npr = set(), set(), 0
+    for i in range(1, NSITE):
+        Ai = ADJ[i]
+        pi = PAR[i]
+        for j in range(i + 1, NSITE):
+            cfg = (0, i, j)
+            pcfg = (0, pi, PAR[j])
+            for wi in range(3):
+                src = cfg[wi]
+                o1, o2 = [cfg[k] for k in range(3) if k != wi]
+                As = ADJ[src]
+                ms = As[o1] + As[o2]
+                asrc = pcfg[wi]
+                nb = NBR[src]
+                for k in range(6):
+                    t = nb[k]
+                    if t == o1 or t == o2:
+                        continue
+                    At = ADJ[t]
+                    mt = At[o1] + At[o2]
+                    D = ms - mt         # = A(old) - A(new), the two others' bond cancels
+                    s = SGNK[k]
+                    for p in (0, 1):
+                        ct.add((mt, s, (p + asrc) % 2, D))
+                    cs.add((ms, s, D))
+                    npr += 2
+    return ct, cs, npr
+
+
+# ================================================== exact rank over Q and SVD
+
+def exact_rank(rows):
+    """Rank over Q of a matrix of Fractions, by exact row reduction."""
+    M = [list(r) for r in rows]
+    R = len(M)
+    C = len(M[0]) if R else 0
+    rk = 0
+    for col in range(C):
+        piv = None
+        for i in range(rk, R):
+            if M[i][col] != 0:
+                piv = i
+                break
+        if piv is None:
+            continue
+        M[rk], M[piv] = M[piv], M[rk]
+        pv = M[rk][col]
+        for i in range(R):
+            if i != rk and M[i][col] != 0:
+                f = M[i][col] / pv
+                for k in range(col, C):
+                    M[i][k] -= f * M[rk][k]
+        rk += 1
+        if rk == R:
+            break
+    return rk
+
+
+def sv_ratio(rows):
+    """(sigma_2/sigma_1, best rank-one relative residual) of a Fraction matrix."""
+    Mf = np.array([[float(v) for v in r] for r in rows], dtype=float)
+    sv = np.linalg.svd(Mf, compute_uv=False)
+    s1 = float(sv[0])
+    s2 = float(sv[1]) if len(sv) > 1 else 0.0
+    tail = math.sqrt(max(0.0, float((sv[1:] ** 2).sum())))
+    fro = math.sqrt(float((sv ** 2).sum()))
+    return (s2 / s1 if s1 > 0 else 0.0), (tail / fro if fro > 0 else 0.0)
+
+
+def odds_matrix(cells, table, g, h, kap):
+    """(conditions, D values, M_acc, M_rel) for one declared table."""
+    if table == "Cp":
+        cond = sorted({(c[0], c[1]) for c in cells})
+        Ds = sorted({c[2] for c in cells})
+
+        def w(c, D):
+            return wCp(c[0], c[1], D, g, h, kap)
+    else:
+        cond = sorted({(c[0], c[1], c[2]) for c in cells})
+        Ds = sorted({c[3] for c in cells})
+        base = {"A": wA, "B": wB, "C": wC}[table]
+
+        def w(c, D):
+            return base(c[0], c[1], c[2], D, g, h, kap)
+
+    Macc = [[max(Fr(0), w(c, D)) for D in Ds] for c in cond]
+    Mrel = [[max(Fr(0), w(c, D)) - max(Fr(0), w(c, 0)) for D in Ds]
+            for c in cond]
+    return cond, Ds, Macc, Mrel
+
+
+def energy_and_temperatures(cond, Ds, M):
+    """Where M is rank one, the factorisation M = beta(c) x E(D) in the gauge
+    E(D = +1) = 1.  Returns (E, {c: beta}) or None."""
+    if exact_rank(M) != 1:
+        return None
+    j1 = Ds.index(1)
+    col = [M[i][j1] for i in range(len(cond))]
+    i0 = max(range(len(cond)), key=lambda i: col[i])
+    E = [M[i0][j] / M[i0][j1] for j in range(len(Ds))]
+    return E, {cond[i]: col[i] for i in range(len(cond))}
+
+
+# ======================================================== the classical chains
+
+def dimer_full_edges(table, g, h, kap):
+    """Out-edges of chain (2), the 1022 even-translation classes (p, r)."""
+    n = len(REL)
+    E = [dict() for _ in range(2 * n)]
+    base = {"A": wA, "B": wB, "C": wC}.get(table)
+    for r in REL:
+        ms = ADJ0[r]
+        for p in (0, 1):
+            i = p * n + (r - 1)
+            for k in range(6):
+                s = SGNK[k]
+                pp = pprop(table, s, h)
+                for moved_first in (True, False):
+                    rn = NBR[r][NEGK[k]] if moved_first else NBR[r][k]
+                    if rn == 0:
+                        continue
+                    mt = ADJ0[rn]
+                    D = ms - mt
+                    a = p if moved_first else (p + PAR[r]) % 2
+                    pn = 1 - p if moved_first else p
+                    if table == "Cp":
+                        w = float(wCp(ms, s, D, g, h, kap))
+                    else:
+                        w = float(base(mt, s, a, D, g, h, kap))
+                    j = pn * n + (rn - 1)
+                    E[i][j] = E[i].get(j, 0.0) + 0.5 * pp * acc_f(w)
+    return E
+
+
+def dimer_rel_edges(table, g, h, kap):
+    """Out-edges of chain (1), the 511 relative classes.  A valid reduction
+    only for a translation-covariant table."""
+    n = len(REL)
+    E = [dict() for _ in range(n)]
+    base = {"A": wA, "B": wB, "C": wC}.get(table)
+    for r in REL:
+        ms = ADJ0[r]
+        i = r - 1
+        for k in range(6):
+            s = SGNK[k]
+            pp = pprop(table, s, h)
+            for moved_first in (True, False):
+                rn = NBR[r][NEGK[k]] if moved_first else NBR[r][k]
+                if rn == 0:
+                    continue
+                mt = ADJ0[rn]
+                D = ms - mt
+                if table == "Cp":
+                    w = float(wCp(ms, s, D, g, h, kap))
+                else:
+                    w = float(base(mt, s, 0, D, g, h, kap))
+                E[i][rn - 1] = E[i].get(rn - 1, 0.0) + 0.5 * pp * acc_f(w)
+    return E
+
+
+def cycles4(E, label=""):
+    """Every distinct 4-cycle x0 -> x1 -> x2 -> x3 -> x0 of distinct states;
+    returns (count, max |ln(product forward / product backward)|)."""
+    best = 0.0
+    ncyc = 0
+    seen = set()
+    for x0 in range(len(E)):
+        e0 = E[x0]
+        for x1 in e0:
+            if x1 == x0:
+                continue
+            e1 = E[x1]
+            for x2 in e1:
+                if x2 == x0 or x2 == x1:
+                    continue
+                e2 = E[x2]
+                for x3 in e2:
+                    if x3 == x0 or x3 == x1 or x3 == x2:
+                        continue
+                    e3 = E[x3]
+                    if x0 not in e3:
+                        continue
+                    key = min((x0, x1, x2, x3), (x1, x2, x3, x0),
+                              (x2, x3, x0, x1), (x3, x0, x1, x2),
+                              (x0, x3, x2, x1), (x3, x2, x1, x0),
+                              (x2, x1, x0, x3), (x1, x0, x3, x2))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    ncyc += 1
+                    f = e0[x1] * e1[x2] * e2[x3] * e3[x0]
+                    b = e0.get(x3, 0.0) * e3.get(x2, 0.0) * \
+                        e2.get(x1, 0.0) * e1.get(x0, 0.0)
+                    if f <= 0.0 or b <= 0.0:
+                        continue
+                    v = abs(math.log(f / b))
+                    if v > best:
+                        best = v
+    return ncyc, best
+
+
+def winding(table, g, h, kap):
+    """The length-L cycles of chain (2): record 2 shifts +x L times and
+    returns.  The mover's source parity is tracked, so table A is read with
+    its declared activity."""
+    base = {"A": wA, "B": wB, "C": wC}.get(table)
+    best = 0.0
+    n = 0
+    for r0 in REL:
+        seq = []
+        rr = r0
+        ok = True
+        for _ in range(L):
+            rn = NBR[rr][0]
+            if rn == 0:
+                ok = False
+                break
+            seq.append((rr, rn))
+            rr = rn
+        if not ok or rr != r0:
+            continue
+        n += 1
+        for p in (0, 1):
+            f = b = 1.0
+            for (ra, rb) in seq:
+                a = (p + PAR[ra]) % 2
+                D = ADJ0[ra] - ADJ0[rb]
+                w = float(wCp(ADJ0[ra], 1, D, g, h, kap)) if table == "Cp" \
+                    else float(base(ADJ0[rb], 1, a, D, g, h, kap))
+                f *= pprop(table, 1, h) * acc_f(w)
+            for (ra, rb) in reversed(seq):
+                a = (p + PAR[rb]) % 2
+                D = ADJ0[rb] - ADJ0[ra]
+                w = float(wCp(ADJ0[rb], -1, D, g, h, kap)) if table == "Cp" \
+                    else float(base(ADJ0[ra], -1, a, D, g, h, kap))
+                b *= pprop(table, -1, h) * acc_f(w)
+            best = max(best, abs(math.log(f / b)))
+    return n, best
+
+
+def trimer_out(cfg, table, g, h, kap):
+    """The one-tick successors of an absolute 3-record configuration, with the
+    odds of registering each."""
+    base = {"A": wA, "B": wB, "C": wC}.get(table)
+    res = {}
+    for wi in range(3):
+        src = cfg[wi]
+        o1, o2 = [cfg[k] for k in range(3) if k != wi]
+        ms = ADJ[src][o1] + ADJ[src][o2]
+        a = PAR[src]
+        for k in range(6):
+            t = NBR[src][k]
+            if t == o1 or t == o2:
+                continue
+            mt = ADJ[t][o1] + ADJ[t][o2]
+            D = ms - mt
+            s = SGNK[k]
+            w = float(wCp(ms, s, D, g, h, kap)) if table == "Cp" \
+                else float(base(mt, s, a, D, g, h, kap))
+            new = tuple(sorted((t, o1, o2)))
+            res[new] = res.get(new, 0.0) + \
+                (1.0 / 3.0) * pprop(table, s, h) * acc_f(w)
+    return res
+
+
+def trimer_cycles(table, g, h, kap):
+    """The declared finite subgraph: 4-cycles based at the bent trimer and at
+    each of its one-tick successors, on absolute configurations."""
+    cache = {}
+
+    def out(c):
+        if c not in cache:
+            cache[c] = trimer_out(c, table, g, h, kap)
+        return cache[c]
+
+    starts = [BENT] + sorted(out(BENT).keys())
+    best = 0.0
+    ncyc = 0
+    seen = set()
+    for x0 in starts:
+        for x1 in out(x0):
+            if x1 == x0:
+                continue
+            for x2 in out(x1):
+                if x2 in (x0, x1):
+                    continue
+                for x3 in out(x2):
+                    if x3 in (x0, x1, x2):
+                        continue
+                    if x0 not in out(x3):
+                        continue
+                    key = min((x0, x1, x2, x3), (x1, x2, x3, x0),
+                              (x2, x3, x0, x1), (x3, x0, x1, x2),
+                              (x0, x3, x2, x1), (x3, x2, x1, x0),
+                              (x2, x1, x0, x3), (x1, x0, x3, x2))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    ncyc += 1
+                    f = out(x0)[x1] * out(x1)[x2] * out(x2)[x3] * out(x3)[x0]
+                    b = out(x0)[x3] * out(x3)[x2] * out(x2)[x1] * out(x1)[x0]
+                    best = max(best, abs(math.log(f / b)))
+    return ncyc, best
+
+
+def stationary(E, nstates):
+    """The stationary law of the row-stochastic chain built from E, by a
+    linear solve with the normalisation replacing one equation."""
+    P = np.zeros((nstates, nstates))
+    for i in range(nstates):
+        tot = 0.0
+        for j, v in E[i].items():
+            P[i, j] += v
+            tot += v
+        P[i, i] += 1.0 - tot            # null ticks and unregistered proposals
+    Amat = (P.T - np.eye(nstates))
+    Amat[-1, :] = 1.0
+    rhs = np.zeros(nstates)
+    rhs[-1] = 1.0
+    pi = np.linalg.solve(Amat, rhs)
+    for _ in range(3):                  # iterative refinement, so the small
+        pi = pi + np.linalg.solve(Amat, rhs - Amat @ pi)   # entries are solved
+    return P, pi, float(np.abs(pi @ P - pi).max())
+
+
+def gibbs_gap(pi, gval, nstates):
+    """max_i |pi_i - pi^Gibbs_i| / max pi^Gibbs for pi^Gibbs ~ e^{-g B}."""
+    n = len(REL)
+    Bv = np.array([0.0 if ADJ0[REL[i % n]] else 1.0 for i in range(nstates)])
+    wg = np.exp(-gval * Bv)
+    pg = wg / wg.sum()
+    return float(np.abs(pi - pg).max() / pg.max())
+
+
+def bent_channels(table, g, h, kap):
+    """Out of the bent trimer: the acceptance of every unblocked proposal,
+    grouped by D, with the (m_s, m_t) census of the breaking proposals."""
+    base = {"A": wA, "B": wB, "C": wC}.get(table)
+    ch, cen, nblock = {}, {}, 0
+    for wi in range(3):
+        src = BENT[wi]
+        o1, o2 = [BENT[k] for k in range(3) if k != wi]
+        ms = ADJ[src][o1] + ADJ[src][o2]
+        a = PAR[src]
+        for k in range(6):
+            t = NBR[src][k]
+            if t == o1 or t == o2:
+                nblock += 1
+                continue
+            mt = ADJ[t][o1] + ADJ[t][o2]
+            D = ms - mt
+            s = SGNK[k]
+            w = float(wCp(ms, s, D, g, h, kap)) if table == "Cp" \
+                else float(base(mt, s, a, D, g, h, kap))
+            ch.setdefault(D, []).append(acc_f(w))
+            if D > 0:
+                cen.setdefault(D, set()).add((ms, mt))
+    return ch, cen, nblock
+
+
+def activations(ch):
+    """a(D) = -ln(mean acceptance in channel D), for the breaking channels."""
+    return {D: -math.log(sum(v) / len(v)) for D, v in ch.items() if D > 0}
+
+
+# ==================================================== group A -- T1, rank one
+
+STORE = {}
+
+
+def group_A():
+    dct, dcs, dnp = dimer_cells()
+    tct, tcs, tnp = trimer_cells()
+    STORE["cells"] = (dct, dcs, tct, tcs)
+    dD = sorted({c[3] for c in dct})
+    tD = sorted({c[3] for c in tct})
+    ncp = len({(c[0], c[1]) for c in tcs})
+    check("A1 [exact] occurring (c, D) cells, by complete enumeration over the L = 8 torus: DIMER "
+          "%d cells over %d unblocked proposals, D in %s, m_t in %s; 3-record %d cells over %d "
+          "proposals (all %d {0,x,y} representatives), D in %s, m_t in %s; %d conditions (m_s, s) "
+          "for table C'"
+          % (len(dct), dnp, dD, sorted({c[0] for c in dct}), len(tct), tnp,
+             len(REL) * (len(REL) - 1) // 2, tD, sorted({c[0] for c in tct}), ncp),
+          len(dct) == 18 and dnp == 12240 and dD == [-1, 0, 1] and len(tct) == 36
+          and tnp == 4672620 and tD == [-2, -1, 0, 1, 2] and ncp == 9)
+
+    res = {}
+    for tab in ("A", "B", "C"):
+        for grp, cells in (("dimer", dct), ("3-record", tct)):
+            for hv in (Fr(0), Fr(1)):
+                cond, Ds, Macc, Mrel = odds_matrix(cells, tab, Fr(1), hv, Fr(1, 2))
+                r2r1, resid = sv_ratio(Mrel)
+                res[(tab, grp, hv)] = (exact_rank(Mrel), r2r1, resid,
+                                       energy_and_temperatures(cond, Ds, Mrel),
+                                       len(cond), len(Ds), Ds)
+    for kv in (Fr(1, 2), Fr(1)):
+        cond, Ds, Macc, Mrel = odds_matrix(tcs, "Cp", Fr(1), Fr(0), kv)
+        r2r1, resid = sv_ratio(Mrel)
+        res[("Cp", "3-record", kv)] = (exact_rank(Mrel), r2r1, resid, None,
+                                       len(cond), len(Ds), Ds)
+    cond, Ds, _, Mrel = odds_matrix(tcs, "Cp", Fr(1), Fr(1), Fr(1, 2))
+    res[("Cp", "3-record", "h1")] = (exact_rank(Mrel), sv_ratio(Mrel)[0], 0.0,
+                                     None, len(cond), len(Ds), Ds)
+    STORE["res"] = res
+
+    Ta = res[("A", "3-record", Fr(0))]
+    ladder = sorted({Fr(1) / b for b in Ta[3][1].values()})
+    check("A2 [exact] TABLE A, separable by construction: M_rel is EXACTLY RANK ONE over Q on the "
+          "dimer (%dx%d) and on 3-record groups (%dx%d), at h = 0 and h = 1 alike, "
+          "sigma_2/sigma_1 <= %.6e, with the exact temperature ladder T(c) = 1/beta(c) = %s"
+          % (res[("A", "dimer", Fr(0))][4], res[("A", "dimer", Fr(0))][5], Ta[4], Ta[5],
+             max(res[("A", g, hv)][1] for g in ("dimer", "3-record") for hv in (Fr(0), Fr(1))),
+             ", ".join(str(t) for t in ladder)),
+          all(res[("A", g, hv)][0] == 1 for g in ("dimer", "3-record")
+              for hv in (Fr(0), Fr(1)))
+          and max(res[("A", g, hv)][1] for g in ("dimer", "3-record")
+                  for hv in (Fr(0), Fr(1))) < 1e-15
+          and ladder == [Fr(2, 5), Fr(1, 2), Fr(8, 15), Fr(2, 3), Fr(4, 5), Fr(1)])
+
+    Tb = res[("B", "3-record", Fr(0))]
+    check("A3 [exact] TABLE B, PR #7899's Metropolis rule: M_rel is EXACTLY RANK ONE on both groups "
+          "at h = 0 and h = 1 (sigma_2/sigma_1 <= %.6e) with the SAME beta = g at all %d "
+          "conditions, so one temperature T = 1/g -- a field in the PROPOSAL never enters the cost "
+          "matrix"
+          % (max(res[("B", g, hv)][1] for g in ("dimer", "3-record") for hv in (Fr(0), Fr(1))),
+             Tb[4]),
+          all(res[("B", g, hv)][0] == 1 for g in ("dimer", "3-record")
+              for hv in (Fr(0), Fr(1))) and set(Tb[3][1].values()) == {Fr(1)})
+
+    Tc0, Tc1 = res[("C", "3-record", Fr(0))], res[("C", "3-record", Fr(1))]
+    check("A4 [exact] TABLE C, non-separable by construction: on 3-record groups M_rel has EXACT "
+          "RANK %d over Q at h = 0, sigma_2/sigma_1 = %.6e, rank-one residual %.6e, and rank %d at "
+          "h = 1 (%.6e): no beta(c) x E(D) exists, so no energy and no temperature"
+          % (Tc0[0], Tc0[1], Tc0[2], Tc1[0], Tc1[1]),
+          Tc0[0] == 2 and abs(Tc0[1] - 3.411710e-02) < 1e-8 and Tc1[0] == 4)
+
+    Cp2, Cp1 = res[("Cp", "3-record", Fr(1, 2))], res[("Cp", "3-record", Fr(1))]
+    check("A5 [exact] TABLE C', the same family keyed to the MOVER's own neighbourhood: M_rel is "
+          "%dx%d of EXACT RANK %d, sigma_2/sigma_1 = %.6e at kappa = 1/2 and %.6e at kappa = 1, "
+          "rank %d at h = 1 (%.6e) -- the departure grows with the declared kappa"
+          % (Cp2[4], Cp2[5], Cp2[0], Cp2[1], Cp1[1], res[("Cp", "3-record", "h1")][0],
+             res[("Cp", "3-record", "h1")][1]),
+          Cp2[0] == 2 and Cp1[0] == 2
+          and abs(Cp2[1] / 5.018675e-02 - 1.0) < 1e-6
+          and abs(Cp1[1] / 1.304845e-01 - 1.0) < 1e-6)
+
+    one = [k for k in res if res[k][3] is not None]
+    good = all(res[k][3][0] == [Fr(max(0, D)) for D in res[k][6]] for k in one)
+    check("A6 [exact] WHICH energy: in all %d rank-one cases the factorisation in the gauge "
+          "E(D = +1) = 1 gives E(D) = max(0, D) -- E(-2) = E(-1) = E(0) = 0, E(+1) = 1, E(+2) = 2 "
+          "-- a ONE-SIDED BARRIER, not the configuration energy: the odds say nothing about the "
+          "downhill half of the move set" % len(one),
+          good and len(one) == 9)
+
+    condC, DsC, MaccC, MrelC = odds_matrix(dct, "C", Fr(1), Fr(0), Fr(1, 2))
+    et = energy_and_temperatures(condC, DsC, MrelC)
+    tl = sorted({Fr(1) / b for b in et[1].values()}) if et else []
+    lp = -math.log(1.0 / 6.0)
+    Mtot = np.array([[float(MaccC[i][j]) + lp for j in range(len(DsC))]
+                     for i in range(len(condC))])
+    svt = np.linalg.svd(Mtot, compute_uv=False)
+    check("A7 [exact] TWO TRAPS. (i) A DIMER CANNOT RUN THIS TEST: D in {-1, 0, +1} makes "
+          "D^2 = |D|, so table C is EXACTLY RANK ONE there (sigma_2/sigma_1 = %.6e) with a "
+          "plausible T = %s; three records are needed. (ii) Leave ln p_prop in and even table C "
+          "gives %.6e, so subtract the D = 0 column"
+          % (sv_ratio(MrelC)[0], ", ".join(str(t) for t in tl), svt[1] / svt[0]),
+          exact_rank(MrelC) == 1 and sv_ratio(MrelC)[0] == 0.0
+          and tl == [Fr(2, 3), Fr(1)] and svt[1] / svt[0] > 1e-3)
+
+
+# ============================================= group B -- T2, cycle criterion
+
+def group_B():
+    n2 = 2 * len(REL)
+    out = {}
+    for (tab, gv, hv, kv) in (("A", 1.0, 0.0, 0.5), ("B", 1.0, 0.0, 0.5),
+                              ("B", 1.0, 1.0, 0.5), ("C", 1.0, 0.0, 0.5)):
+        Ef = dimer_full_edges(tab, gv, hv, kv)
+        nf, bf = cycles4(Ef)
+        P, pi, resid = stationary(Ef, n2)
+        gap = gibbs_gap(pi, gv, n2)
+        nw, bw = winding(tab, gv, hv, kv)
+        nt, bt = trimer_cycles(tab, gv, hv, kv)
+        rel = (None, None)
+        if tab != "A":
+            rel = cycles4(dimer_rel_edges(tab, gv, hv, kv))
+        out[(tab, hv)] = (nf, bf, resid, gap, nw, bw, nt, bt, rel)
+    STORE["cyc"] = out
+    A0, B0, B1, C0 = out[("A", 0.0)], out[("B", 0.0)], out[("B", 1.0)], out[("C", 0.0)]
+
+    check("B1 [exact] the CYCLE CENSUS, complete where stated: %d distinct 4-cycles of the "
+          "%d-state even-translation dimer chain, %d of the %d-state relative chain, %d winding "
+          "cycles of length L = %d, and the declared subgraph of %d trimer 4-cycles on absolute "
+          "configurations" % (A0[0], n2, B0[8][0], len(REL), A0[4], L, A0[6]),
+          A0[0] == 56454 and B0[8][0] == 1524 and A0[4] == 504 and A0[6] == 1620)
+
+    check("B2 [exact] TABLE A -- RANK ONE GIVES NO GIBBS STATE: cycle products fail by exactly "
+          "nu = 1/4 on the dimer chain (%.15e) and the trimer chain (%.15e), winding clean (%.1e); "
+          "the stationary law (|pi P - pi| = %.1e) misses e^{-g B} by %.6e"
+          % (A0[1], A0[7], A0[5], A0[2], A0[3]),
+          abs(A0[1] - 0.25) < 1e-12 and abs(A0[7] - 0.25) < 1e-12 and A0[5] < 1e-12
+          and A0[2] < 1e-14 and abs(A0[3] - 1.199957e-01) < 1e-6)
+
+    check("B3 [exact] TABLE B at h = 0 -- BOTH tests pass: every cycle product is 1 to machine zero "
+          "on all four chains (dimer %.1e, relative %.1e, winding %.1e, trimer %.1e) and the law is "
+          "exactly pi ~ e^{-g B} (%.1e, |pi P - pi| = %.1e). Here the odds ARE an energy"
+          % (B0[1], B0[8][1], B0[5], B0[7], B0[3], B0[2]),
+          max(B0[1], B0[8][1], B0[5], B0[7]) < 1e-12 and B0[3] < 1e-12)
+
+    check("B4 [exact] TABLE B WITH A FIELD -- A GIBBS LAW IS NOT SUFFICIENT: at h = 1 the odds "
+          "matrix is still rank one and the law still exactly Gibbs (%.1e), yet cycle products fail "
+          "by exactly 4h = %.15f on the dimer chain and L h = %.15f on the winding cycles: a DRIVEN "
+          "steady state" % (B1[3], B1[1], B1[5]),
+          B1[3] < 1e-12 and abs(B1[1] - 4.0) < 1e-12 and abs(B1[5] - 8.0) < 1e-12)
+
+    check("B5 [exact] TABLE C at h = 0 -- DETAILED BALANCE GIVES NO RANK ONE: at kappa = 1/2 every "
+          "cycle product is 1 (dimer %.1e, relative %.1e, winding %.1e, trimer %.1e) and the law is "
+          "exactly Gibbs (%.1e) while the odds matrix is rank 2: a symmetric kappa D^2 BARRIER "
+          "cancels in every ratio" % (C0[1], C0[8][1], C0[5], C0[7], C0[3]),
+          max(C0[1], C0[8][1], C0[5], C0[7]) < 1e-12 and C0[3] < 1e-12)
+
+    cp = {}
+    for (gv, kv) in ((1.0, 0.0), (1.0, 0.25), (1.0, 0.5), (1.0, 1.0), (2.0, 0.5)):
+        cp[(gv, kv)] = trimer_cycles("Cp", gv, 0.0, kv)
+    STORE["cp"] = cp
+    check("B6 [exact] TABLE C' -- a crowding barrier keyed to the MOVER does break detailed "
+          "balance: over the %d declared trimer 4-cycles at h = 0 the defect is exactly 4 kappa -- "
+          "%.12f, %.12f, %.12f, %.12f at kappa = 0, 1/4, 1/2, 1 -- and %.12f at g = 2, "
+          "coupling-independent"
+          % (cp[(1.0, 0.5)][0], cp[(1.0, 0.0)][1], cp[(1.0, 0.25)][1], cp[(1.0, 0.5)][1],
+             cp[(1.0, 1.0)][1], cp[(2.0, 0.5)][1]),
+          cp[(1.0, 0.0)][1] < 1e-12
+          and all(abs(cp[(1.0, kv)][1] - 4 * kv) < 1e-12 for kv in (0.25, 0.5, 1.0))
+          and abs(cp[(2.0, 0.5)][1] - cp[(1.0, 0.5)][1]) < 1e-12)
+
+    check("B7 [exact] THE LUMPING TRAP: at h = 1 the translation-reduced relative chain PASSES "
+          "(%.1e) and so does the declared trimer subgraph (%.1e) while the unlumped chain fails by "
+          "4h (%.6f) and the winding cycles by L h (%.6f): a 4-cycle test on a reduced chain is not "
+          "a detailed-balance test" % (B1[8][1], B1[7], B1[1], B1[5]),
+          B1[8][1] < 1e-12 and B1[7] < 1e-12 and abs(B1[1] - 4.0) < 1e-12)
+
+
+# ============================================ group C -- T3, Arrhenius census
+
+def group_C():
+    slopesB = {}
+    for gv in (1.0, 2.0, 4.0):
+        ch, cen, nb = bent_channels("B", gv, 0.0, 0.5)
+        slopesB[gv] = {D: v / D for D, v in activations(ch).items()}
+    check("C1 [exact] TABLE B on the bent trimer: its %d proposals split %d null, %d at D = 0, %d "
+          "at D = +1, %d at D = +2, and both break channels carry the COMMON SLOPE a(D)/D = g at "
+          "g = 1, 2, 4 (%s): Arrhenius holds"
+          % (nb + sum(len(v) for v in ch.values()), nb, len(ch[0]), len(ch[1]), len(ch[2]),
+             ", ".join("%.12f" % slopesB[gv][1] for gv in (1.0, 2.0, 4.0))),
+          nb == 4 and len(ch[0]) == 2 and len(ch[1]) == 8 and len(ch[2]) == 4
+          and all(abs(slopesB[gv][1] - gv) < 1e-12 and abs(slopesB[gv][2] - gv) < 1e-12
+                  for gv in (1.0, 2.0, 4.0)))
+
+    gaps, aa, cenP = {}, {}, None
+    for gv in (1.0, 2.0, 4.0):
+        for kv in (0.5, 1.0):
+            ch, cenP, _ = bent_channels("Cp", gv, 0.0, kv)
+            a = activations(ch)
+            aa[(gv, kv)] = a
+            gaps[(gv, kv)] = a[2] / 2 - a[1]
+    STORE["gaps"] = gaps
+    check("C2 [exact] TABLE C' on the bent trimer: every D = +1 break is an END record (m_s = 1) so "
+          "a(1) = g, every D = +2 break the CENTRE (m_s = 2) so a(2) = 2g + 4 kappa; the van 't "
+          "Hoff gap a(2)/2 - a(1) = 2 kappa EXACTLY, %.12f at g = 1, 2, 4 for kappa = 1/2 and %.12f "
+          "for kappa = 1" % (gaps[(1.0, 0.5)], gaps[(1.0, 1.0)]),
+          all(abs(aa[(gv, kv)][1] - gv) < 1e-12
+              and abs(aa[(gv, kv)][2] - (2 * gv + 4 * kv)) < 1e-12
+              and abs(gaps[(gv, kv)] - 2 * kv) < 1e-12
+              for gv in (1.0, 2.0, 4.0) for kv in (0.5, 1.0))
+          and cenP[1] == {(1, 0)} and cenP[2] == {(2, 0)})
+
+    def tau(gv, kv):
+        return 18.0 / (8.0 * math.exp(-gv) + 4.0 * math.exp(-2 * gv - 4 * kv))
+    lf = []
+    for gv in (1.0, 2.0, 4.0):
+        ch, _, _ = bent_channels("Cp", gv, 0.0, 0.5)
+        rate = sum(sum(ch[D]) for D in ch if D > 0) / 18.0
+        lf.append((1.0 / rate, tau(gv, 0.5), tau(gv, 0.0)))
+    check("C3 [exact] the bent trimer's lifetime under C' is 18/(8 e^{-g} + 4 e^{-2g - 4 kappa}), "
+          "matched by the enumerated proposals to %.1e: %.12f ticks at g = 1, kappa = 1/2 against "
+          "PR #7899's %.12f, %.12f against %.12f, %.12f against %.12f at g = 2 and 4"
+          % (max(abs(a - b) for a, b, _c in lf), lf[0][0], lf[0][2], lf[1][0], lf[1][2],
+             lf[2][0], lf[2][2]),
+          max(abs(a - b) for a, b, _c in lf) < 1e-11
+          and abs(lf[0][0] - 5.967579958344) < 1e-9
+          and abs(lf[0][2] - 5.165916817967) < 1e-9)
+
+    slopesC, cenC, nbrk = {}, None, 0
+    for kv in (0.0, 0.5, 1.0):
+        ch, cenC, _ = bent_channels("C", 1.0, 0.0, kv)
+        a = activations(ch)
+        slopesC[kv] = (a[1], a[2] / 2)
+        nbrk = sum(len(v) for D, v in ch.items() if D > 0)
+    check("C4 [exact] THE NULL RESULT: table C, keyed to the TARGET's crowding, is Arrhenius on the "
+          "bent trimer at EVERY kappa (a(1) = a(2)/2 = %.12f at kappa = 0, 1/2, 1) because all %d "
+          "of its breaking proposals land on a site with no occupied neighbour (m_t = 0), so C's "
+          "rank-2 signature lives in the re-binding moves alone" % (slopesC[0.5][0], nbrk),
+          all(abs(slopesC[kv][0] - 1.0) < 1e-12 and abs(slopesC[kv][1] - 1.0) < 1e-12
+              for kv in (0.0, 0.5, 1.0))
+          and {m for st in cenC.values() for (_ms, m) in st} == {0})
+
+    cp = STORE["cp"]
+    check("C5 [exact] THE TWO DISCRIMINATORS, a factor of two apart: the Kolmogorov defect is "
+          "4 kappa and the van 't Hoff gap 2 kappa, so defect = 2 x gap exactly -- %.12f against "
+          "2 x %.12f at kappa = 1/2, %.12f against 2 x %.12f at kappa = 1; the rank-one departure "
+          "%.6e is the third"
+          % (cp[(1.0, 0.5)][1], gaps[(1.0, 0.5)], cp[(1.0, 1.0)][1], gaps[(1.0, 1.0)],
+             STORE["res"][("Cp", "3-record", Fr(1, 2))][1]),
+          all(abs(cp[(1.0, kv)][1] - 2 * gaps[(1.0, kv)]) < 1e-12 for kv in (0.5, 1.0)))
+
+
+# ====================================== group D -- T4, PR #7899's closed forms
+
+def group_D():
+    n = len(REL)
+    rows = []
+    for gv in (1.0, 2.0, 4.0):
+        for hv in (0.0, 1.0):
+            E = dimer_rel_edges("B", gv, hv, 0.0)
+            P, pi, resid = stationary(E, n)
+            intact = float(sum(pi[r - 1] for r in REL if ADJ0[r]))
+            eh = math.exp(hv)
+            t = [1.0 / sum(v for j, v in E[r0 - 1].items() if not ADJ0[REL[j]])
+                 for r0 in (pack((1, 0, 0)), pack((0, 1, 0)))]
+            cf = (2 * math.exp(gv) * (5 + eh) / (9 + eh),
+                  math.exp(gv) * (5 + eh) / (4 + eh))
+            rows.append((t, cf, intact, 6.0 / (6.0 + 505.0 * math.exp(-gv)), resid))
+    dtau = max(max(abs(t[0] / c[0] - 1.0), abs(t[1] / c[1] - 1.0))
+               for t, c, _i, _c, _r in rows)
+    dint = max(abs(i - c) for _t, _cf, i, c, _r in rows)
+    check("D1 [exact] CONSISTENCY with PR #7899, dimer: table B reproduces 2 e^{g}(5 + e^{h})/"
+          "(9 + e^{h}) aligned and e^{g}(5 + e^{h})/(4 + e^{h}) transverse over six (g, h) cells to "
+          "%.2e relative -- both (6/5) e^{g} at h = 0 -- and 6/(6 + 505 e^{-g}) to %.2e AT EVERY h "
+          "(|pi P - pi| <= %.1e)" % (dtau, dint, max(r[4] for r in rows)),
+          dtau < 1e-14 and dint < 1e-14)
+
+    ch, _cen, nb = bent_channels("B", 1.0, 0.0, 0.0)
+    tri = []
+    for gv in (1.0, 2.0, 4.0):
+        chg, _c, _n = bent_channels("B", gv, 0.0, 0.0)
+        rate = sum(sum(chg[D]) for D in chg if D > 0) / 18.0
+        tri.append((1.0 / rate, 18.0 / (8 * math.exp(-gv) + 4 * math.exp(-2 * gv))))
+    dtri = max(abs(a - b) for a, b in tri)
+    check("D2 [exact] CONSISTENCY with PR #7899, bent trimer: with the 1/n record-choice factor and "
+          "D = B(new) - B(old) = A(old) - A(new) both as declared, table B returns "
+          "18/(8 e^{-g} + 4 e^{-2g}) to %.2e -- %.12f, %.12f, %.12f ticks at g = 1, 2, 4"
+          % (dtri, tri[0][0], tri[1][0], tri[2][0]),
+          dtri < 1e-11 and abs(tri[0][0] - 5.165916817967) < 1e-9)
+
+
+def main():
+    group_A()
+    group_B()
+    group_C()
+    group_D()
+    print("SUMMARY: the odds are an energy only when the odds matrix is rank one AND every cycle "
+          "product is 1; neither gives the other, and a Gibbs resting law gives neither.")
+    print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache answering the breakable-level panel's two ranked tests on PR #7899's chains: **when are the odds of a group coming apart an energy divided by a temperature?** Two tests, and they are logically independent: (i) the rank-one collapse of the relative log-odds matrix `M_rel(c, D) = -ln[P(change | c, D)/P(change | c, 0)]`, computed by exact `Fraction` row reduction over four stipulated tables, and (ii) Kolmogorov's cycle criterion over all 56454 4-cycles of the 1022-state dimer chain, all 1524 of the relative chain, all 504 winding cycles and 1620 declared trimer cycles. Rank one does not give a Gibbs state (a separable table with a sublattice activity fails every cycle by exactly `nu`, since a move and its reverse start on opposite sublattices); detailed balance does not give rank one (a symmetric `kappa D^2` barrier cancels in every ratio, rank 2 yet exactly Gibbs); and a Gibbs stationary law is not sufficient (a field leaves the internal coordinate exactly Boltzmann while cycles fail by exactly `4h` and `Lh`: a driven steady state). Where the odds are an energy, the recovered energy is the one-sided barrier `E(D) = max(0, D)`, and the van 't Hoff gap between break channels is exactly half the cycle defect. Two traps measured: a dimer cannot run the rank-one test (`D^2 = |D|`), and a translation-reduced chain cannot run the cycle test (lumping closes the witness cycle).

- `docs/WHEN_THE_ODDS_ARE_AN_ENERGY_RANK_ONE_AND_DETAILED_BALANCE_TESTS_FOR_BREAKABLE_CONDITIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (316 lines)
- `scripts/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.py` (`TOTAL: PASS=21 FAIL=0`, 2.8 s; exact ranks; no seed)
- `logs/runner-cache/when_the_odds_are_an_energy_rank_one_detailed_balance_check_2026_09_03.txt`

## Theorems

- **T1** rank-one collapse: tables A and B rank 1 (temperature `1/g`, or an exact ladder), C and C' rank 2 on three records; `E(D) = max(0, D)`; the dimer trap.
- **T2** Kolmogorov: exact rational defects `nu`, `4h`, `Lh`, `4 kappa`; the lumping trap.
- **T3** Arrhenius / van 't Hoff: common slope `g` for table B; gap `2 kappa` for C' (`a(2)/2 - a(1)`), exactly half the cycle defect; the null result that forced C'.
- **T4** consistency: table B reproduces PR #7899's closed forms to `2e-16` relative.

## Boundary

- Stipulated tables derived from nothing (a lane proposing others inherits nothing); classical chains only; `n <= 3`; complete enumeration for the dimer chains and winding cycles, bounded and declared for the trimer; no sampling, no seed; nothing derived from the axioms; no claim about which table the framework's law resembles. Executor refinements kept (parity tracked on winding cycles; refined stationary solves; relative rather than absolute agreement bounds).

## Context

- Parents: PR #7899 (the hierarchy and its chains), PR #7891, PR #7889. Answers the breakable-level panel of 2026-09-03 (nuclear and statistical-mechanics lenses).
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
