### PR TITLE
feat(gauge): fermion on compact U(1) links, staggered Gauss law, Maxwell join

### DIFF
--- a/docs/THE_FERMION_ON_COMPACT_U1_LINKS_THE_INTEGER_FLUX_SELECTS_THE_STAGGERED_GAUSS_LAW_AND_JOINS_THE_MAXWELL_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_FERMION_ON_COMPACT_U1_LINKS_THE_INTEGER_FLUX_SELECTS_THE_STAGGERED_GAUSS_LAW_AND_JOINS_THE_MAXWELL_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,329 @@
+---
+claim_id: fermion_compact_u1_links_staggered_gauss_law_maxwell_germ_join
+claim_type: bounded_theorem
+claim_scope: "On the coarse cubic lattice 2Z^3 carrying one fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding written on it, with the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1}, eta_3(v) = (-1)^{v_1+v_2}, and with ONE FURTHER DESIGNED ROLE per coarse edge -- a COMPACT U(1) link role carrying E_e |m> = m |m> with m integer, U_e |m> = |m + 1>, [E_e, U_e] = U_e, truncated to |m| <= S with S = 1 and S = 2, declared as a design element of exactly the same kind as the period-(4,2,2) superlattice role pattern of PR #7834 and derived from no axiom -- for the ONE DECLARED law H^g = -t sum_<ij> eta_ij (T_ij C_e + K_ij S_e)/2 with C_e = U_e + U_e^dag and S_e = -i(U_e - U_e^dag), plus H_E = (g^2/2) sum_e E_e^2 and H_B = -(1/g^2) sum_f cos_f with cos_f = (W_f + W_f^dag)/2, whose coefficients t and g are supplied and are fixed by nothing quoted here, and on the named finite blocks only -- the single coarse 2x2x1 plaquette, the open 2x2x2 cube, the open 3x3x3 block, the 2x2x3 block, and the periodic rings of L = 4 and L = 8 corners: (T1) writing a_i^dag a_j = (T_ij - i K_ij)/2, the minimally coupled hop a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i equals (T_ij C_e + K_ij S_e)/2 exactly, Hermitian, with 16 Pauli-monomial entries at S = 1 and 32 at S = 2, on all 140 bond checks -- every bond of the plaquette, the cube and the open 3x3x3 block at S = 1 and S = 2 -- while the opposite-sign partner +i(U_e - U_e^dag) fails on every one of them and is a_i^dag U_ij^dag a_j + h.c.; at spin 1/2 this reduces to PR #7893's landed (T_ij X^L_ij + K_ij Y^L_ij)/2 since U = (X^L + i Y^L)/2 gives C = X^L and S = Y^L; the partner relations [n_i, T] = -iK, [n_i, K] = +iT, [n_j, T] = +iK, [n_j, K] = -iT and [n_w, T] = [n_w, K] = 0 off the bond hold on all 12 cube bonds and all 96 off-bond corner-bond pairs; truncation is exact for [E_e, U_e] = U_e and [E_e, U_e^dag] = -U_e^dag and breaks exactly two things, U_e^dag U_e = I - P_{+S} with U_e U_e^dag = I - P_{-S} and [C_e, S_e] = 2i (P_{+S} - P_{-S}) != 0; and [G_v, H^g] = 0 with G_v = (div E)_v - rho_v at every corner of every coordination z_v = 2, 3, 4, 5, 6 -- 1570 corner-bond pairs over the three blocks -- in both rho conventions and at S = 1 and S = 2. (T2) With integer-valued E_e, 2 (div E)_v is EVEN at every corner of every coordination, while 2 rho^{sea}_v = 2 n_v - 1 is odd and 2 rho^{stag}_v = 2 n_v - (1 - eps_v) is even, so G_v = 0 is unsolvable for rho^{sea} and solvable for rho^{stag} independently of z_v: the coordination-parity condition PR #7893 declared is absent and what replaces it is a coordination-independent selection of the staggered background half-charge. By exact census, computed by dynamic programming and cross-checked by complete enumeration, the Gauss sector is 0 and 26 at S = 1 and 0 and 50 at S = 2 on the plaquette, 0 and 102304 at S = 1 and 0 and 1477920 at S = 2 on the cube, and 0 and 234 on the L = 8 ring; exactly 2240 of the 4096 cube fermion record patterns admit a link configuration and they are precisely the half-filled N = 4 sector, all of it, in eight multiplicity classes of sizes 128, 192, 416, 768, 128, 192, 384, 32 identical at S = 1 and S = 2; dim(Gauss and code) = 13 and 25 on the plaquette; the same census run on PR #7893's spin-1/2 link returns 14400 in the SEA convention and 0 in the staggered one on the cube and 0 and 14 on the plaquette; and rho^{sea} = rho^{stag} - eps_v/2, so the two conventions are one law in shifted variables exactly when a fixed background link field c_e with (div c)_v = -eps_v/2 exists, which it does with c_e in {-1/2, 0, +1/2} on the balanced plaquette, cube and 2x2x3 block and does not on the open 3x3x3 block, whose 14 and 13 corners give sum_v (-eps_v) = -1 while any divergence sums to zero. (T3) E_e^2 has spectrum {0, 1} at S = 1 and {0, 1, 4} at S = 2, so H_E is a genuine operator and not the c-number it is at spin 1/2 where E_e^2 = I/4; [P_f, G_v] = 0 on all 52 face-corner pairs -- 48 on the cube and 4 on the plaquette -- at S = 1 and S = 2, with nnz(P_f) = 32 and 512; the assembled H^g + H_E + H_B applied to every Gauss basis state of the plaquette with destinations computed in the full space produces 0 out-of-sector amplitudes and maximum leaked amplitude 0.0e+00 at both S; and H_B is, up to an additive constant, the one-plaquette Wilson potential V(theta) = (1/g^2)(1 - cos theta), even, 2 pi-periodic, C^infinity, with V(0) = V'(0) = 0 and V''(0) = 1/g^2 > 0, the positive isotropic quadratic germ the open PR #7884 states for its quadratic basin. (T4) [numerical] On the plaquette in the staggered convention, the only admissible one, at Gauss dimensions 26 and 50: E_0 at g^2 = 1, 2, 4 without and with H_B is -2.152012, -2.491848, -1.807851, -1.889263, -1.352280, -1.364473 at S = 1 and -2.153357, -2.573395, -1.807956, -1.899006, -1.352283, -1.365185 at S = 2 to 1e-9; without H_B the gap and <cos_f> vanish at every g^2 and both S, and with H_B the gaps are 0.395359, 0.110635, 0.017047 and 0.411731, 0.114075, 0.017220 with <cos_f> = 0.418515, 0.210243, 0.063343 and 0.541713, 0.244706, 0.068693; <E_e^2> at S = 1 is 0.205293, 0.145868, 0.089108 without H_B and 0.289139, 0.168525, 0.091811 with it to 1e-6; and <rho_v> = +0.180762247, -0.180762247, -0.180762247, +0.180762247 at g^2 = 4 with H_B at S = 2, so the coupled sea is NOT locally neutral -- the block's C_4 symmetry fixes the pattern +a, -a, -a, +a and hence the vanishing total, not the value a, whose maximum is 0.426, 0.305, 0.181 at g^2 = 1, 2, 4 at S = 1 -- with <N> = 2 at half filling and Hermiticity residual 0.0e+00. (T5) The superfast ring encoding realises only even total fermion number at L = 4, 6 and 8 while half filling needs N = L/2, so L = 0 mod 4 is required and L = 6 has an empty Gauss sector. [exact] With static charges +1 and -1 at separation d and no fermion, V(d) = (g^2/2) d exactly in rational arithmetic for d = 0..4 at g^2 = 1 and g^2 = 4 on the L = 8 ring at S = 1. [numerical] With the fermion hop at t = 1 and half filling the string breaks: at g^2 = 4 the potential is 2.271563, 2.383425, 4.295402, 2.819090 against the unbroken 2, 4, 6, 8 and is not monotone, at Gauss dimensions 234, 150, 160, 132, 150 and <N> = 4 at every separation; at d = 4 and g^2 = 4 the flux localises on the sources with sum_e |<E_e>| = 1.603 against 4 for an unbroken string, dying to 0.0094 three links away, and the screening charge shows as a hole <n> = 0.181 at the +1 source and a fermion <n> = 0.981 at the -1 source; the L = 4 ring gives V = 0.762517, 0.594051 at g^2 = 1 and 2.271118, 2.169659 at g^2 = 4, saturated there too. The link role and the link dynamics are designed, not derived; an integer flux record needs log2(2S+1) bits and so needs a collective role of several physical sites, which this note does not settle; t and g are supplied data; every numerical item is at S = 1 or S = 2 and is not the untruncated theory; no gapless transverse mode of the link sector is shown, computed, or suggested, and no photon appears anywhere in this note; no continuum limit is taken; no claim is made that this U(1) is electromagnetism. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py
+---
+
+# The fermion on compact `U(1)` links: the integer flux selects the staggered Gauss law, and joins the Maxwell germ
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py`](../scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.txt`](../logs/runner-cache/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.txt)
+**Parents:** none load-bearing. Every premise used below is declared in this note; the context notes are plain-text pointers listed in "Imports and authority".
+
+PR #7893 coupled the coarse-lattice emergent fermion's `U(1)` to one designed spin-1/2 link role per coarse edge, and left two things on its face: an electric term that was a c-number at that link size, and a
+coordination-parity condition that made the charge convention depend on how many neighbours a corner has, declared as an open tension. Its own interface named the way out -- a larger link algebra. A sister
+lane, open at PR #7884, was already carrying the compact `U(1)` connection the other half of the picture needs, with charged sources explicitly outside its claim. The question here is the join: does the
+fermion's charge couple to a compact `U(1)` link exactly, what is Gauss's law once it does, and what does putting the two halves together give. The answer is that the coupling is exact at every coordination,
+that the integer flux removes the parity condition and selects the staggered background half-charge everywhere instead, and that the resulting magnetic term sits at the centre of the sister lane's quadratic
+basin. No photon is shown here.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite-cluster theorems about one declared law on the coarse-lattice emergent fermion carrying one designed COMPACT U(1) link role per coarse edge: the gauge-invariant minimal coupling and what truncation preserves and breaks, the parity statement that makes the staggered convention the admissible one at every coordination, the exact Gauss-sector census by two independent methods, the electric and magnetic terms with the Wilson germ, and the ring's static potential. The symplectic Pauli statements are exact Gaussian-rational arithmetic on F2 supports with Z4 phases tensored with exact integer link matrices; the census statements are exact integer arithmetic by dynamic programming cross-checked by complete enumeration; the tagged numerical items are floating-point at the stated tolerance."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-cluster theorem, and route to its owner the design question this note does not decide: an integer flux record needs a collective role of several physical sites per coarse edge, and whether the staggered background half-charge is a registered pattern or supplied data is not settled here."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. Groups `A`, `B`, `C` and item `E2` are exact -- Gaussian-rational coefficients on symplectic Pauli
+monomials (`F2` supports, `Z4` phases) tensored with exact integer link matrices, and exact integer record arithmetic, with no floating-point step anywhere -- and the items tagged `[numerical]` are
+floating-point cross-checks at the stated tolerance.
+
+1. `T1` (`A`). The minimally coupled hop on a compact `U(1)` link, what truncation costs, and gauge invariance at every coordination. `T2` (`B`). The integer flux selects the staggered convention everywhere,
+   with the exact census and the background field that relates the two conventions on balanced blocks. `T3` (`C`). The electric term is dynamical, the Wilson term respects Gauss's law, and its germ is the
+   sister lane's. `T4` (`D`). The plaquette in its Gauss sector. `T5` (`E`). The ring: exact linear confinement, and string breaking when the fermion is present.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggering, the compact `U(1)` rotor with truncated integer flux, the Wilson plaquette term and the
+Kogut-Susskind Hamiltonian presentation are standard methodology; every object is redeclared here and every statement recomputed by the runner. No observational value, no fitted number and no framework
+premise enters any proof. Non-load-bearing pointers, no grade and no dependency weight:
+
+- `THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7893): the spin-1/2 link role, the coupled hop `(T_ij X^L_ij + K_ij
+  Y^L_ij)/2`, the coordination-parity condition declared as an open tension, and the refereed reading of "support condition" used below. Its named interface -- a larger link algebra -- is what this note takes
+  up.
+- `COMPACT_U1_QUADRATIC_BASIN_SOURCE_FREE_MAXWELL_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7884): the compact `U(1)` carrier and its quadratic-basin statement, quoted in Theorem 3. An open
+  sister-lane pointer, carrying no authority and no grade here.
+- `A_HIERARCHY_OF_NEIGHBOURHOOD_CONDITIONS_GLUED_BREAKABLE_AND_FREE_RECORD_GROUPS_UNDER_SHIFTING_TICKS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7899): the glued, breakable and free levels of a
+  neighbourhood condition; Theorem 5 exhibits the breakable level on a ring.
+- `EMERGENT_3D_FERMION_ONE_QUBIT_PER_SITE_SUPERLATTICE_ROLE_PATTERN_EXISTENCE_BOUNDED_THEOREM_NOTE_2026-09-02.md` (open PR #7834): the period-`(4,2,2)` superlattice role pattern and the coarse sublattice
+  `2Z^3`; the link role declared here is a design element of exactly that kind.
+- `CHARGE_CONJUGATION_AND_THE_CONSERVED_U1_CURRENT_OF_THE_EMERGENT_FERMION_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7892): the charge and the bond current the link couples to, and
+  `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms quoted in "Setting", with the Admissibility reading note used to say what a support condition is.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations
+about each site." **Qubit**: "Each site has a domain of local possibilities", whose "full one-site possibility domain has algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed
+nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations", and "For each site, the probability distribution over the possibilities is determined by, and varies
+with, the nearest-neighbor conditions" -- the law supplies the odds. Reading note (3) fixes the vocabulary used below: "The distribution is a probability measure on the local possibility domain;
+'available'/'admissible' denotes its support -- on finite menus, exactly the possibilities of nonzero probability." **Record**: "Records form", "a record locks exactly one admissible local possibility",
+"records are permanent", "Only records are readable", and "A readout value is determined by record content alone."
+
+The lattice is physical. Everything below reads the Kawamoto-Smit sign field on the coarse lattice `2Z^3`, one fermionic mode per coarse vertex, and replaces PR #7893's spin-1/2 link role by a compact `U(1)`
+one. Composition is **ordinary** throughout: the algebra of a region is the tensor product of its sites' algebras, with no graded clause anywhere.
+
+A **support condition** in this note means what reading note (3) licenses and what PR #7893's refereed reading fixes: a zero of the law-level odds at the site where a record forms, putting the value it
+excludes outside the support of the distribution the law supplies there. `G_v = 0` is a linear relation among the records at one corner, and a linear relation is implemented by site-level forcing in **any**
+formation order -- whenever all but one of its records are present, the last record's odds for the violating value are zero. The restriction on joint record patterns counted in Theorem 2 is the
+**consequence** of those site-level zeros, not a further primitive, and no formation site, rate, or process word states it.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the coarse lattice, the KS sign field on it, the superfast encoding, the designed
+compact `U(1)` link role with its `E_e` and `U_e`, and the declared `H^g`, `H_E` and `H_B` with their supplied coefficients. `P1` (`A`) is the coupling and its gauge invariance, `P2` (`B`) the parity
+statement and the census, `P3` (`C`) the electric and magnetic terms, `P4` (`D`) the plaquette Gauss sector and `P5` (`E`) the ring; `P1` and `P2` use `P0`, `P3` uses `P1`, and `P4` and `P5` use `P2` and
+`P3`. The strongest supported scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **coarse lattice** is `2Z^3`; a coarse vertex `v` sits at the fine site `2v`, and the coarse edge from `v` along `e_a` sits at the fine site `2v + e_a`. The **KS sign** of the coarse bond `(v, v + e_a)`
+is `eta_1 = 1`, `eta_2(v) = (-1)^{v_1}`, `eta_3(v) = (-1)^{v_1 + v_2}`. The **encoding** is the Bravyi-Kitaev superfast encoding on the coarse lattice, fermion code sites on the coarse edges, direction order
+`-x < -y < -z < +x < +y < +z`. The **link role** is one further role per coarse edge, declared exactly as PR #7834's superlattice role pattern is declared: assigned by design, derived from nothing.
+
+```text
+A_ij = X(edge (i,j)) * prod Z(edges ordered before it at i) * prod Z(edges ordered before it at j),  A_ji = -A_ij
+B_v  = the product of the Z's at corner v = I - 2 n_v,   S_f = the ordered product of the four A's around a coarse face
+n_v  = (I - B_v)/2,   eps_v = (-1)^{v_1+v_2+v_3},   T_ij = (i/2) A_ij (B_i - B_j),   K_ij = -(1/2) A_ij (I - B_i B_j)
+E_e |m> = m |m>, m integer, truncated to |m| <= S ;  U_e |m> = |m+1>  (U_e |S> = 0) ;   [E_e, U_e] = U_e   EXACTLY
+C_e = U_e + U_e^dag        S_e = -i (U_e - U_e^dag)        both Hermitian        W_f = the oriented four-link loop product
+bond (v, e_a) is oriented i = v -> j = v + e_a ;   s_{v,e} = +1 if e leaves v, -1 if e enters v
+H^g = -t sum_<ij> eta_ij (T_ij C_e + K_ij S_e)/2      H_E = (g^2/2) sum_e E_e^2      H_B = -(1/g^2) sum_f cos_f
+cos_f = (W_f + W_f^dag)/2 = P_f/2                     THE DECLARED LAW, with t and g SUPPLIED
+(div E)_v = sum_{e at v} s_{v,e} E_e,  rho_v^{sea} = n_v - 1/2,  rho_v^{stag} = n_v - (1 - eps_v)/2,  G_v = (div E)_v - rho_v
+```
+
+The **coordination** `z_v` is the number of coarse edges at `v`: `2` on the plaquette and the ring, `3` on the open cube, `3` to `6` on the open `3x3x3` block, `6` in the bulk. A **record pattern** is one
+assignment of a value to every record site. `t` and `g` are **supplied**. Untruncated, every Gauss sector counted below is infinite; the finite window is what makes any of these numbers a number.
+
+## Theorem 1 -- the coupling is exact, at every coordination
+
+**Conclusion.** (1) Writing `a_i^dag a_j = (T_ij - i K_ij)/2`, the minimally coupled hop is exact: `a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i = (T_ij C_e + K_ij S_e)/2`, Hermitian, with `16` Pauli-monomial
+entries at `S = 1` and `32` at `S = 2`, on all `140` bond checks -- every bond of the plaquette, the cube and the open `3x3x3` block at both truncations. (2) The opposite-sign partner `+i(U_e - U_e^dag)` is
+that hop on none of them: it is `a_i^dag U_ij^dag a_j + h.c.`, which carries flux the other way along the bond. (3) At spin `1/2` the same identity is PR #7893's landed form, since `U = (X^L + i Y^L)/2` gives
+`C = X^L` and `S = Y^L`. (4) The partner relations `[n_i, T] = -iK`, `[n_i, K] = +iT`, `[n_j, T] = +iK`, `[n_j, K] = -iT` hold on all `12` cube bonds, and `[n_w, T] = [n_w, K] = 0` at every corner `w` off the
+bond (`96` pairs). (5) Truncation is **exact** for `[E_e, U_e] = U_e` and `[E_e, U_e^dag] = -U_e^dag`, and breaks **exactly two** things: `U_e^dag U_e = I - P_{+S}` with `U_e U_e^dag = I - P_{-S}`, and `[C_e,
+S_e] = 2i (P_{+S} - P_{-S}) != 0`. (6) Hence `[G_v, H^g] = 0` at **every corner of every coordination `z_v = 2, 3, 4, 5, 6`** -- `1570` corner-bond pairs over the three blocks -- in both `rho` conventions and
+at both `S`.
+
+**Proof.** Item 1 builds `a_i^dag a_j` and `a_j^dag a_i` from `T` and `K`, multiplies by the exact integer link matrices, and compares key by key in the hybrid algebra: a `(2S+1) x (2S+1)` matrix of exact
+Gaussian-rational Pauli sums. Item 2 is the same comparison returning a nonzero residual. Items 3 to 5 are matrix identities on the link factor. Item 6 follows from items 4 and 5 with `[E_e, C_e] = i S_e` and
+`[E_e, S_e] = -i C_e`, and is then checked outright on all `1570` pairs. All exact, complete over the three blocks.
+
+**Reading, not theorem.** Giving each edge a record that counts whole units of flux rather than a half changes nothing about whether the charge couples to it: the coupled hop is the same two pieces the
+encoding already contains, one paired with the cosine of the link and one with its sine. The window on the count costs exactly two things, and neither is used here.
+
+## Theorem 2 -- the integer flux selects the staggered convention, everywhere
+
+**Conclusion.** (1) With integer-valued `E_e`, `2 (div E)_v = 2 sum_e s_{v,e} m_e` is **even at every corner of every coordination**, while `2 rho^{sea} = 2 n_v - 1` is odd and `2 rho^{stag} = 2 n_v - (1 -
+eps_v)` is even. So `G_v = 0` is unsolvable for `rho^{sea}` and solvable for `rho^{stag}`, and `z_v` has dropped out of the statement entirely. (2) The exact census, by dynamic programming and cross-checked
+by complete enumeration -- the whole link space on the plaquette and the ring, the whole `3^12` space and the cycle space on the cube -- is `0` and `26` at `S = 1` and `0` and `50` at `S = 2` on the
+plaquette, `0` and `102304` at `S = 1` and `0` and `1477920` at `S = 2` on the cube, and `0` and `234` on the `L = 8` ring. (3) Exactly `2240` of the `4096` cube fermion record patterns admit a link
+configuration, and they are **precisely the half-filled `N = 4` sector, all of it**, at both `S`, in eight multiplicity classes of sizes `128, 192, 416, 768, 128, 192, 384, 32` **identical at both
+truncations**: raising `S` re-weights the charge sectors and does not re-partition them. `dim(Gauss and code) = 13` and `25` on the plaquette. (4) The same census run on PR #7893's spin-1/2 link returns
+`14400` in the **sea** convention and `0` in the staggered one on the cube, and `0` and `14` on the plaquette. (5) `rho^{sea} = rho^{stag} - eps_v/2`, so the two conventions are one law in shifted variables
+exactly when a fixed background link field `c_e` with `(div c)_v = -eps_v/2` exists. It does on every **balanced** block, with `c_e in {-1/2, 0, +1/2}` -- the plaquette (`2/2` corners), the cube (`4/4`), the
+`2x2x3` block (`6/6`) -- and it does **not** on the open `3x3x3` block, whose `14` and `13` corners give `sum_v (-eps_v) = -1` while any divergence sums to zero.
+
+**Proof.** Item 1 is a parity count. Item 2 is exact integer arithmetic by two independent algorithms agreeing on every entry: a link-by-link dynamic program over prescribed divergences, and complete
+enumeration -- of the whole link space where that is small, and of the cycle space on the cube, where the spanning tree's values are determined by the divergence and only the five chords are free, so the cube
+is **counted** and never diagonalised. Item 3 reads the same counts per fermion record pattern, `sum_v rho^{stag}_v = N - 4` forcing `N = 4` and the census showing it sufficient. Item 4 is the same dynamic
+program at `2E = +-1`; item 5 is an integer spanning-tree solve. All exact.
+
+**Reading, not theorem.** With whole units of flux the balance at a corner no longer notices how many neighbours the corner has -- the cube, the plaquette and the bulk stop contradicting each other about the
+charge convention. The price is fixed and it is not the one this lane expected: the convention that survives is the one with a background half-charge alternating from corner to corner, and the convention that
+made the sea neutral at each corner separately is no longer available anywhere. On a block with equal numbers of the two kinds of corner the difference between the two is one fixed half-unit of background
+flux on the links; on a block without that balance it is not even that.
+
+## Theorem 3 -- the electric term is dynamical, and the magnetic term is the sister lane's germ
+
+**Conclusion.** (1) `E_e^2` has spectrum `{0, 1}` at `S = 1` and `{0, 1, 4}` at `S = 2`, so `H_E = (g^2/2) sum_e E_e^2` is a genuine operator -- contrast spin `1/2`, where `E_e^2 = I/4` identically and the
+electric term supplies no dynamics. (2) `[P_f, G_v] = 0` on all `52` face-corner pairs -- `48` on the cube and `4` on the plaquette -- at both `S`, with `nnz(P_f) = 32` and `512`; `rho_v` is fermion-only, so
+`[P_f, rho_v] = 0` outright and the content is `[P_f, (div E)_v] = 0`. (3) The **assembled** `H^g + H_E + H_B`, applied to every Gauss basis state of the plaquette with destinations computed in the full
+space, produces `0` out-of-sector amplitudes and maximum leaked amplitude `0.0e+00` at both `S`; the individual `T C` and `K S` terms do leave the sector and cancel exactly. (4) `H_B = -(1/g^2) sum_f cos_f`
+is, up to an additive constant, the one-plaquette Wilson potential `V(theta) = (1/g^2)(1 - cos theta)`: even, `2 pi`-periodic, `C^infinity`, with `V(0) = V'(0) = 0` and `V''(0) = 1/g^2 > 0`.
+
+**Proof.** Items 1 and 2 are exact integer and complex matrix arithmetic on the `(2S+1)^4` face-link space, over every face of both blocks and every corner of each face; item 3 applies the assembled operator
+state by state and looks up every destination; item 4 is the exact Maclaurin coefficients of `(1 - cos theta)/g^2`. All exact.
+
+The open sister-lane note PR #7884 supplies, verbatim, an isotropic one-plaquette action `S_V[ell] = sum_(x,mu<nu) V(bar_theta_mu_nu(x))` with `V` even, `2 pi`-periodic, `C^4` near the flat point, normalised
+by "`V(0)=0, V''(0)=kappa>0`", and concludes that "every smooth principal-branch refinement family has the same leading continuum physics", including "exactly two local transverse spatial modes after Gauss
+reduction". Its declared boundary, quoted: *"This is a supplied-action theorem. It does not establish that the framework's Admissibility law realizes a compact connection, an action in this basin, or a
+physical electromagnetic dictionary. Charged sources, coupling normalization, Record readout, interacting quantum electrodynamics, nonsmooth sectors, and general multi-plaquette actions are outside the
+claim."* Item 4 says only that the magnetic term written here is a member of that class, with `kappa = 1/g^2` -- a plain-text pointer carrying no authority. Three things it does not do, and this note says all
+three. PR #7884 is a Euclidean four-dimensional supplied-action statement about a classical limit; this is a `3+1` Hamiltonian with a truncated quantum link. Its two transverse modes are a flat-background
+Hessian count, and **nothing here computes a photon at the quantum level**. And it excludes charged sources, which is exactly what this note supplies -- the complement of its boundary, not a crossing of it.
+
+The object assembled here -- one fermionic mode per corner of a bipartite lattice with the staggered background charge, a compact `U(1)` rotor per link with integer flux, the coupled hop, the electric term,
+the plaquette term, and `div E = rho` as a commuting constraint -- is the Kogut-Susskind Hamiltonian lattice gauge theory of compact `U(1)` with staggered fermions. That is said plainly as an identification
+of the algebra, cited as nothing and used as no authority: every object is redeclared here and every statement recomputed. **The "designed" status is unchanged by it** -- the link role, the coupling, `H_E`,
+`H_B`, `t`, `g` and the staggered convention are all designed and derived from no axiom.
+
+**Reading, not theorem.** At the smaller link size the cost of the flux was the same number whatever the flux was, so it did nothing. With whole units it is a real energy, and it is what holds a string
+together. The plaquette energy is the one whose small-angle behaviour the sister lane's open note takes as its condition; the two lanes now touch, and where they touch is one number.
+
+## Theorem 4 -- the plaquette in its Gauss sector
+
+**Conclusion.** `[numerical]` In the staggered convention -- the only admissible one, `rho^{sea}` having Gauss dimension `0` -- at dimensions `26` and `50`: (1) `E_0` at `g^2 = 1, 2, 4` without and with `H_B`
+is `-2.152012, -2.491848, -1.807851, -1.889263, -1.352280, -1.364473` at `S = 1` and `-2.153357, -2.573395, -1.807956, -1.899006, -1.352283, -1.365185` at `S = 2`, to `1e-9`. (2) Without `H_B` the gap and
+`<cos_f>` vanish at every `g^2` and both `S`; with `H_B` the gaps are `0.395359, 0.110635, 0.017047` and `0.411731, 0.114075, 0.017220` and `<cos_f> = 0.418515, 0.210243, 0.063343` and `0.541713, 0.244706,
+0.068693` -- the magnetic term is what lifts the degeneracy and puts flux on the face. (3) `<E_e^2>` at `S = 1` is `0.205293, 0.145868, 0.089108` without `H_B` and `0.289139, 0.168525, 0.091811` with it, to
+`1e-6`: the flux window is barely used, and the `S = 1` to `S = 2` shift in `E_0` is `3.27%` at `g^2 = 1` with `H_B`, so **no `g^2 = 1` number with `H_B` is converged in `S`**. (4) `<rho_v> = +0.180762247,
+-0.180762247, -0.180762247, +0.180762247` at `g^2 = 4` with `H_B` at `S = 2`: the coupled sea is **not** locally neutral. The block's `C_4` symmetry fixes the pattern `+a, -a, -a, +a` and hence the vanishing
+**total**, not the value `a`, whose maximum is `0.426, 0.305, 0.181` at `g^2 = 1, 2, 4` at `S = 1` and falls to zero only in the strong-coupling limit. `<N> = 2` at half filling and the Hermiticity residual
+is `0.0e+00`. (5) The single face stabilizer splits the sector exactly in half, `26 = 13 + 13` and `50 = 25 + 25`, so `dim(Gauss and code) = 13` and `25`.
+
+**Proof.** The Gauss sector is built explicitly by exact integer arithmetic and diagonalised densely at dimensions `26` and `50`. The full plaquette space at `S = 2` is `16 x 625 = 10 000` and is never
+formed. `[numerical, 1e-9]` for items 1, 2, 4 and 5 and `[numerical, 1e-6]` for item 3.
+
+**Reading, not theorem.** The corner condition pins a nonzero flux on a corner with two neighbours, and the background half-charge is what it is pinned to, so the charge at a corner is not zero even though
+the charges of the four corners cancel. Which of those two facts a symmetry argument gives is exactly the pattern, not the size.
+
+## Theorem 5 -- the ring: an exact string, and a broken one
+
+**Conclusion.** (1) `[exact]` The superfast ring encoding realises **only even** total fermion number at `L = 4, 6, 8`, while half filling needs `N = L/2`, so `L = 0 mod 4` is required and `L = 6` has an
+empty Gauss sector. (2) `[exact]` With static charges `+1` and `-1` at separation `d` and no fermion, `V(d) = (g^2/2) d` **exactly** in rational arithmetic for `d = 0..4` at `g^2 = 1` and `g^2 = 4` on the `L
+= 8` ring at `S = 1`; `S = 1` already suffices, the minimiser using only `E in {0, 1}`. (3) `[numerical]` With the fermion hop at `t = 1` and half filling the string **breaks**: at `g^2 = 4` the potential is
+`2.271563, 2.383425, 4.295402, 2.819090` against the unbroken `2, 4, 6, 8`, and it is not monotone -- `V(4) < V(3)` at `g^2 = 1` too. Gauss dimensions `234, 150, 160, 132, 150` and `<N> = 4` exactly at every
+separation: the screening happens inside the half-filled sea. (4) `[numerical]` At `d = 4` and `g^2 = 4` the flux does not span the separation but localises on the sources, `sum_e |<E_e>| = 1.603` against `4`
+for an unbroken string, dying to `0.0094` three links away, and the screening charge shows as a **hole** `<n> = 0.181` at the `+1` source and a **fermion** `<n> = 0.981` at the `-1` source. (5) `[numerical]`
+The `L = 4` ring gives `V = 0.762517, 0.594051` at `g^2 = 1` and `2.271118, 2.169659` at `g^2 = 4` -- saturated there too, so the breaking is not an `L = 8` artefact, though the values are finite-size
+numbers.
+
+**Proof.** The ring carries a hand-rolled superfast encoding verified against the same relations as Theorem 1 item 4. Item 1 counts the encoded total over all `2^L` fermion record patterns; item 2 minimises
+`(g^2/2) sum_e E_e^2` over the rational solutions of the corner condition with sources; items 3 to 5 build the Gauss sector explicitly and diagonalise it densely at dimension at most `234`. `[numerical,
+1e-9]` for items 3 and 5, `[numerical, 1e-4]` for item 4's profiles.
+
+**Reading, not theorem.** Two fixed opposite charges on a ring with no matter between them are held by a string whose energy grows exactly in step with the distance. Put the matter back and the string does
+not hold: past a short separation it is cheaper to make a pair out of the sea, and what the ground state then shows is flux clinging to the two charges, a hole at one and a fermion at the other. This is PR
+#7899's breakable level, reached from a glued corner condition plus matter, on a finite ring.
+
+## Corollary -- what the join gives, and what it costs
+
+Within the setting declared above, and on the finite blocks named:
+1. **The full lattice-gauge structure exists at the supplied-carrier level.** The coupling is exact and gauge-invariant at every coordination from `2` to `6`, the electric term is dynamical rather than a
+   constant, and the Wilson plaquette term commutes with Gauss's law. Charge, Gauss's law, an electric energy and a magnetic energy are all present at once, and the magnetic term is a member of the class the
+   sister lane's open note (PR #7884) states its quadratic-basin conclusion for, with `V''(0) = 1/g^2 > 0`. That is a pointer to where the two lanes touch, nothing more.
+2. **The convention tension of PR #7893 is resolved in one direction, and it is not the direction this lane expected.** The premise carried into this computation was that the integer flux would make the
+   neutral-sea convention and the bulk convention coincide. **That premise was wrong.** The coordination-parity *condition* is genuinely absent -- `z_v` has dropped out -- but what replaces it is a
+   coordination-independent selection of the **staggered** background half-charge, and `rho^{sea} = n_v - 1/2` has a Gauss sector of dimension exactly zero on every block tested, at every coordination and
+   every `S`. On balanced blocks the two conventions differ by an explicit fixed `+-1/2` background link field; on the open `3x3x3` block no such field exists. The conventions do **not** coincide.
+3. **Static charges confine, and the string breaks when the matter is there.** The exact `(g^2/2) d` of Theorem 5 item 2 is the glued behaviour; Theorem 5 items 3 to 5 are PR #7899's breakable level derived
+   from that constraint plus matter, on a finite ring, with the screening charge visible corner by corner.
+4. **What it still lacks.** No photon is shown at the quantum level -- no gapless transverse mode is computed or suggested here, and the sister lane's two transverse modes are a classical flat-background
+   count in a supplied Euclidean action. The link record is **multi-valued**: it needs `log2(2S+1)` bits, `1.585` at `S = 1` and `2.322` at `S = 2`, unbounded untruncated. One physical site cannot carry it,
+   since `M_2(C)` per site is fixed, so the link role must be a **collective role of several physical sites** -- a role over a small block of sites, of exactly the kind PR #7834's superlattice role pattern
+   already uses. This note declares that and settles none of it. And nothing here is derived from any axiom: the link role, the coupling, both energy terms, the staggered background charge, `t` and `g` are
+   all supplied.
+
+**Reading, not theorem (this register).** Give each link a whole number of flux units instead of a half, and the charge couples to it exactly, at every corner, however many neighbours the corner has. The
+price is fixed: with whole units the balance at each corner must include a background half-charge that alternates from corner to corner, and the alternative that made the vacuum locally neutral is no longer
+available anywhere. With that settled, the electric energy is real, the plaquette energy is the one whose small-angle limit the sister lane showed gives Maxwell's equations, and two fixed charges on a ring
+are held by a string whose energy grows with distance until the matter breaks it by making a pair. What is still not shown is light itself.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The coarse lattice, the encoding, the sign field, **the link role**, the coupled law and both energy terms are declared objects, and no coefficient is derived: `t`
+  and `g` are supplied, and no update rule, formation site, formation rate, or absolute unit appears.
+- No continuum limit is taken, no second species appears, and **no photon** and no gapless transverse mode of the link sector is shown, computed, or suggested. PR #7884 is cited as an open sister-lane pointer
+  with no grade and no dependency weight: nothing in its claim is used as a premise here, and nothing here is claimed for it.
+
+## Interfaces named for other lanes, not moved here
+
+- **The photon at the quantum level.** Whether this link sector carries a gapless transverse mode is not decided here; PR #7893's estimate of the smallest plausible test -- a `4^3` coarse torus, whose
+  pure-link Gauss sector is about `10^25` states -- is unchanged by the larger link, which only enlarges it.
+- **The collective link role.** An integer flux record needs several physical sites per coarse edge, and writing that role -- how many sites, which pattern, which classes -- is a design question for the lane
+  that owns the role rule. **Larger blocks**: the plaquette, the cube, the open `3x3x3` block, the `2x2x3` block and the rings of `4` and `8` corners are what is treated. **The fine lattice**: the link role
+  is declared on the coarse edge, and writing it as a rule on `Z^3`, the way PR #7834 does, is not done here.
+- **The staggered background.** Whether the alternating background half-charge is a registered pattern of the framework or supplied data is not settled here. It is supplied in this note.
+
+## Remaining live routes
+
+1. The collective link role and its size, which decides whether the truncation `S` is itself a design parameter or a consequence.
+2. Larger blocks, and a region carrying more than one coordination at once with the magnetic term present.
+3. The string tension and the breaking scale as functions of `L` and `g^2`, which the two ring lengths here cannot separate from finite-size wobble, and the correlations of the coupled current and of the link raising, which have no record-diagonal part.
+
+## Executable claim block
+
+```text
+setting: coarse lattice 2Z^3, one fermionic mode per coarse vertex, BK superfast encoding, plus ONE DESIGNED COMPACT U(1) link role per coarse edge (declared, of the same kind as PR #7834's superlattice role pattern); ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md; H^g, H_E, H_B declared here with supplied t and g
+blocks: plaquette 2x2x1, open cube 2x2x2, open 3x3x3, block 2x2x3, periodic rings L = 4 and L = 8; truncations S = 1 and S = 2
+link: E_e |m> = m |m> integer, U_e |m> = |m+1>, [E_e, U_e] = U_e exact under truncation; C_e = U + U^dag, S_e = -i(U - U^dag)
+hop: a_i^dag U_ij a_j + a_j^dag U_ij^dag a_i = (T_ij C_e + K_ij S_e)/2 exactly, Hermitian, 16 and 32 monomial entries, on all 140 bond checks; the +i(U - U^dag) partner fails on every one and is a_i^dag U^dag a_j + h.c.; at spin 1/2 the identity is PR #7893's (T X^L + K Y^L)/2
+partner_relations: [n_i,T] = -iK, [n_i,K] = +iT, [n_j,T] = +iK, [n_j,K] = -iT on all 12 cube bonds; [n_w,T] = [n_w,K] = 0 on all 96 off-bond pairs
+truncation: exact for [E,U] = U and [E,U^dag] = -U^dag; breaks exactly two things, U^dag U = I - P_{+S} with U U^dag = I - P_{-S}, and [C,S] = 2i(P_{+S} - P_{-S}) != 0
+gauge: [G_v, H^g] = 0 at every corner of every coordination z = 2,3,4,5,6 -- 1570 corner-bond pairs -- both rho conventions, S = 1 and 2
+parity: 2 (div E)_v is EVEN at every corner when E is integer; 2 rho^sea odd, 2 rho^stag even; G_v = 0 unsolvable for rho^sea and solvable for rho^stag INDEPENDENTLY of z_v
+census: plaquette 0 / 26 (S=1) and 0 / 50 (S=2); cube 0 / 102304 (S=1) and 0 / 1477920 (S=2); ring L=8 0 / 234; DP cross-checked by complete enumeration (whole link space on plaquette and ring, whole 3^12 space and the cycle space on the cube); the cube is COUNTED, never diagonalised
+cube_structure: 2240 of 4096 fermion patterns admit, exactly the half-filled N = 4 sector, all of it, at both S; eight multiplicity classes of sizes 128, 192, 416, 768, 128, 192, 384, 32 identical at S = 1 (38,39,42,44,48,50,54,69) and S = 2 (616,626,642,652,672,682,702,767); dim(Gauss and code) = 13 and 25 on the plaquette
+spin_half_comparison: the same census on 2E = +-1 gives cube 14400 SEA / 0 staggered and plaquette 0 sea / 14 staggered -- PR #7893's 14400 is the SEA convention
+background_field: rho^sea = rho^stag - eps_v/2; c_e with (div c)_v = -eps_v/2 EXISTS with c_e in {-1/2,0,+1/2} on the balanced plaquette (2/2), cube (4/4) and 2x2x3 (6/6), and does NOT exist on the open 3x3x3 (14/13, sum_v -eps_v = -1)
+electric: E_e^2 spectrum {0,1} and {0,1,4}, so H_E is not a c-number -- contrast E_e^2 = I/4 at spin 1/2
+magnetic: [P_f, G_v] = 0 on all 52 face-corner pairs at both S, nnz(P_f) = 32 and 512; the assembled H^g + H_E + H_B leaves the plaquette Gauss sector with 0 out-of-sector amplitudes, max leaked 0.0e+00; H_B is the Wilson potential V = (1/g^2)(1 - cos theta), even, 2 pi-periodic, V(0) = V'(0) = 0, V''(0) = 1/g^2 > 0, a member of the class the open PR #7884 states its conclusion for
+plaquette_numerics: Gauss dims 26 and 50; E_0 (g^2 = 1,2,4, without/with H_B) = -2.152012, -2.491848, -1.807851, -1.889263, -1.352280, -1.364473 at S=1 and -2.153357, -2.573395, -1.807956, -1.899006, -1.352283, -1.365185 at S=2; gaps and <cos_f> vanish without H_B; with H_B gaps 0.395359, 0.110635, 0.017047 / 0.411731, 0.114075, 0.017220 and <cos_f> 0.418515, 0.210243, 0.063343 / 0.541713, 0.244706, 0.068693; <E_e^2> at S=1 0.205293, 0.145868, 0.089108 / 0.289139, 0.168525, 0.091811; <rho_v> = +-0.180762247 at g^2 = 4 with H_B, S = 2, total 0, max |<rho_v>| = 0.426, 0.305, 0.181 at S = 1; <N> = 2; NOT locally neutral, and not zero by symmetry
+ring: superfast encoding realises only even N, so L = 0 mod 4 and L = 6 is empty; V(d) = (g^2/2) d EXACTLY for d = 0..4 at g^2 = 1 and 4 with no fermion; with the hop at half filling V = 2.271563, 2.383425, 4.295402, 2.819090 at g^2 = 4 against 2,4,6,8, non-monotone, Gauss dims 234, 150, 160, 132, 150, <N> = 4; at d = 4, g^2 = 4: sum |<E_e>| = 1.603 vs 4, 0.0094 three links away, hole <n> = 0.181 at the +1 source and fermion <n> = 0.981 at the -1 source; L = 4 gives 0.762517, 0.594051 and 2.271118, 2.169659
+not_shown: no photon and no gapless transverse mode at the quantum level; no continuum limit; no claim that this U(1) is electromagnetism
+design_debt: the link record needs log2(2S+1) bits and so needs a COLLECTIVE ROLE of several physical sites per coarse edge; not settled here
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=28 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on the **coarse** lattice `2Z^3`, on named finite blocks: the `2x2x1` plaquette (algebra, census and numerics), the open `2x2x2` cube (algebra and census only -- it is **counted**, never
+diagonalised), the open `3x3x3` block (algebra and the background-field non-existence only), the `2x2x3` block (background field only), and the periodic rings of `L = 4` and `L = 8` corners. Nothing is
+claimed for `Z^3`, for a torus, or for any larger region.
+
+The **link role is designed**, exactly as PR #7834's superlattice role pattern is designed, and derived from no axiom. The **link dynamics is declared**: `H^g`, `H_E` and `H_B` are supplied laws with supplied
+`t` and `g`. `H_B` is a four-link term inside one coarse face, not a nearest-neighbour term. The link record is multi-valued and needs a collective role of several physical sites; that role is named as an
+interface and written nowhere here.
+
+**Truncation.** Every algebraic statement -- the coupling, `[G_v, H^g] = 0`, `[P_f, G_v] = 0`, the census parity -- uses only `[E_e, U_e] = U_e` and is exact at any `S`. Every **numerical** statement is at `S
+= 1` or `S = 2` and is not the untruncated theory: `E_0` shifts by `3.27%` between the two at `g^2 = 1` with `H_B`. Untruncated, every Gauss sector counted here is infinite.
+
+**The staggered convention is the one that survives.** `rho^{sea} = n_v - 1/2` has a Gauss sector of dimension exactly zero on every block tested, at every coordination and every `S`. The two conventions are
+not claimed to coincide, and on unbalanced blocks no background field relates them.
+
+**No photon.** No gapless transverse mode is shown, computed, or suggested. PR #7884's two transverse modes are a classical, Euclidean, supplied-action, flat-background Hessian count; this note's Hamiltonian
+is quantum, truncated, and on blocks of at most eight corners, and its germ statement is a pointer to an open PR, not a step of any proof here. **String breaking is a finite-size observation**: `L = 4` and `L
+= 8`, `S = 1`, no mass term, the plateau not claimed to equal twice any mass gap and no infinite-volume statement made. Nothing in this note is derived from any axiom; the axioms are quoted to fix what
+"readable" and "admissible" mean, and for nothing else.
+
+## Review record
+
+An honest auditor should come away with: one declared law on named finite blocks in which PR #7893's spin-1/2 link role is replaced by a compact `U(1)` link role, and in which the minimally coupled hop is
+exact and gauge-invariant at every coordination from `2` to `6`, the electric term is dynamical, the Wilson plaquette term commutes with Gauss's law, and the assembled Hamiltonian preserves the Gauss sector
+with zero leaked amplitude. The load-bearing new fact is a parity count with a complete census behind it: with integer flux the coordination drops out of Gauss's law and the staggered background half-charge
+is selected everywhere, so the tension PR #7893 declared is settled in that direction and **not** by the two conventions coinciding -- the premise this lane carried in was the opposite one and it was wrong.
+On a ring, static charges feel exactly `(g^2/2) d` and the string breaks once the fermion is present. The costs: the link role and both energy terms are designed, not derived; the link record needs a
+collective role of several physical sites that this note does not write; every numerical item is truncated; and no photon appears anywhere -- the sister lane's quadratic basin is cited as an open pointer and
+used as no premise.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the context notes in "Imports and authority" are plain-text pointers
+carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=28 FAIL=0`, runtime under the declared `150` seconds, and passing pipeline, strict-lint and
+changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.txt
+++ b/logs/runner-cache/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py
+runner_sha256: 1018fcee391ff5918f77ae79e26df44c851fbe802492f26883fa1bdc9b702f4a
+timeout_sec: 150
+exit_code: 0
+elapsed_sec: 2.42
+status: ok
+----- stdout -----
+H^g = -t sum eta (T C + K S)/2, C = U + U^dag, S = -i(U - U^dag); E|m> = m|m>, U|m> = |m+1>, |m| <= S; G_v = (div E)_v - rho_v
+PASS A1 [exact] a_i^dag U a_j + a_j^dag U^dag a_i = (T C + K S)/2, C = U + U^dag, S = -i(U - U^dag), Hermitian, 16 and 32 monomial entries: all 140 bond checks -- every bond of the plaquette, the cube and the open 3x3x3 at S = 1 and 2
+PASS A2 [exact] the opposite-sign partner +i(U - U^dag) is not this hop on any of the 140: it is a_i^dag U^dag a_j + h.c., carrying flux the other way along the bond
+PASS A3 [exact] at spin 1/2 this is PR #7893's landed form: U = (X^L + i Y^L)/2 gives C = X^L and S = Y^L, so (T C + K S)/2 = (T X^L + K Y^L)/2
+PASS A4 [exact] the relations behind gauge invariance, all 12 cube bonds: [n_i, T] = -iK, [n_i, K] = +iT, [n_j, T] = +iK, [n_j, K] = -iT, and [n_w, T] = [n_w, K] = 0 off the bond (96 pairs)
+PASS A5 [exact] truncation to |E| <= S is exact for the link algebra: [E, U] = U and [E, U^dag] = -U^dag hold identically at S = 1 and 2, C and S Hermitian, so every algebraic item here is truncation-independent
+PASS A6 [exact] truncation breaks exactly two things: U^dag U = I - P_{+S} and U U^dag = I - P_{-S} (the link is not unitary), and [C, S] = 2i (P_{+S} - P_{-S}) != 0 (cos and sin stop commuting)
+PASS A7 [exact] [G_v, H^g] = 0 at every corner of every coordination z = [2, 3, 4, 5, 6] -- 1570 corner-bond pairs on the plaquette, the cube and the open 3x3x3, both rho conventions, S = 1 and 2
+PASS B1 [exact] integer flux makes 2 (div E)_v EVEN at every corner of every coordination, while 2 rho^sea = 2n - 1 is ODD and 2 rho^stag = 2n - (1 - eps_v) is EVEN: z_v drops out of the condition, and the integer link selects the staggered convention everywhere
+PASS B2 [exact] plaquette census, DP and complete enumeration agreeing: rho^sea 0 of 16 x 81 and 0 of 16 x 625; rho^stag 26 (S = 1) and 50 (S = 2)
+PASS B3 [exact] cube census by DP and two complete enumerations (the whole 3^12 space at S = 1, the cycle space at both S), agreeing: rho^sea 0 and 0; rho^stag 102304 and 1477920. The cube is counted, never diagonalised
+PASS B4 [exact] 2240 of the 4096 cube fermion patterns admit a link configuration -- exactly the half-filled N = 4 sector, all of it, at both S -- in EIGHT multiplicity classes of sizes [128, 192, 416, 768, 128, 192, 384, 32], identical at S = 1 (counts [38, 39, 42, 44, 48, 50, 54, 69]) and S = 2 ([616, 626, 642, 652, 672, 682, 702, 767]): raising S re-weights the charge sectors, it does not re-partition them
+PASS B5 [exact] the same census on PR #7893's spin-1/2 link (2E = +-1) fixes which convention its landed numbers belong to: the cube's 14400 is the SEA convention (staggered gives 0), the plaquette 0 sea and 14 staggered
+PASS B6 [exact] periodic ring L = 8, S = 1, DP and complete enumeration agreeing: rho^sea 0 of 256 x 3^8, rho^stag 234 -- the same selection at coordination z = 2 with no face at all
+PASS B7 [exact] rho^sea = rho^stag - eps_v/2, so the conventions are one law in shifted variables exactly when a background field c_e with (div c)_v = -eps_v/2 exists: it does on balanced blocks, c_e in {-1/2, 0, +1/2} (plaquette 2/2, cube 4/4, 2x2x3 6/6), and not on the open 3x3x3 (14/13, sum_v -eps_v = -1 while any divergence sums to 0)
+PASS C1 [exact] E_e^2 has spectrum [0, 1] at S = 1 and [0, 1, 4] at S = 2, so H_E = (g^2/2) sum_e E_e^2 is a genuine operator -- contrast spin 1/2, where E_e^2 = I/4 and the electric term is a c-number that does nothing
+PASS C2 [exact] the Wilson term commutes with Gauss's law: [P_f, (div E)_v] = 0 on all 52 face-corner pairs (48 cube, 4 plaquette) at S = 1 and 2, nnz(P_f) = 32 and 512; rho_v is fermion-only, so [P_f, rho_v] = 0 outright
+PASS C3 [exact] the assembled H^g + H_E + H_B maps the plaquette Gauss sector into itself: on all 26 states at S = 1 and 50 at S = 2, destinations taken in the FULL space, 0 out-of-sector amplitudes, max leaked 0.0e+00 -- the T C and K S terms leave the sector separately and cancel
+PASS C4 [exact] H_B = -(1/g^2) sum_f cos_f is, up to a constant, the one-plaquette Wilson potential V = (1/g^2)(1 - cos theta): even, 2 pi-periodic, C^infinity, V(0) = V'(0) = 0, V''(0) = 1/g^2 > 0 -- the positive quadratic germ the open PR #7884 states for its basin
+PASS D1 [numerical 1e-9] plaquette Gauss dimensions 26 and 50 (rho^sea is empty, so there is nothing else to diagonalise); E_0 at g^2 = 1, 2, 4 without/with H_B: S = 1 -2.152012 -2.491848 -1.807851 -1.889263 -1.352280 -1.364473; S = 2 -2.153357 -2.573395 -1.807956 -1.899006 -1.352283 -1.365185
+PASS D2 [numerical 1e-9] the magnetic term lifts the degeneracy and puts flux on the face: without H_B the gap and <cos_f> are 0 at every g^2 and both S; with H_B the gaps are 0.395359 0.110635 0.017047 0.411731 0.114075 0.017220 and <cos_f> = 0.418515 0.210243 0.063343 0.541713 0.244706 0.068693, falling with the coupling
+PASS D3 [numerical 1e-6] <E_e^2> at S = 1 is 0.205293 0.145868 0.089108 without H_B and 0.289139 0.168525 0.091811 with it: the flux window is barely used, and the S = 1 to S = 2 shift in E_0 is 3.27% at g^2 = 1 with H_B, so no g^2 = 1 number with H_B is converged in S
+PASS D4 [numerical 1e-9] the coupled sea is NOT locally neutral: <rho_v> = +0.180762247 -0.180762247 -0.180762247 +0.180762247 at g^2 = 4 with H_B, S = 2. C_4 fixes the pattern +a -a -a +a and hence the vanishing TOTAL, not the value a, which falls with the coupling (max |<rho_v>| = 0.426 0.305 0.181 at g^2 = 1, 2, 4, S = 1); <N> = 2 and Hermiticity residual 0.0e+00
+PASS D5 [numerical 1e-9] the face stabiliser splits the plaquette Gauss sector in half, 26 = 13 + 13 and 50 = 25 + 25, so dim(Gauss and code) = 13 and 25 (spin 1/2 gave 14 = 7 + 7)
+PASS E1 [exact] the ring's hand-rolled superfast encoding satisfies the same relations ({A, B_i} = 0, A^2 = I, [n_i, T] = -iK, [n_i, K] = +iT, [n_w, T] = 0 off the bond) and realises ONLY EVEN total fermion number at L = 4, 6, 8; half filling needs N = L/2, so L = 0 mod 4 and L = 6 has an empty Gauss sector
+PASS E2 [exact] pure electric, no fermion, static +1 and -1 charges on the L = 8 ring at S = 1: V(d) = (g^2/2) d EXACTLY in rational arithmetic for d = 0..4 at g^2 = 1 and 4 -- a string whose energy grows linearly with the separation; S = 1 is already exact, the minimiser using only E in {0, 1}
+PASS E3 [numerical 1e-9] with the fermion hop at half filling (t = 1) the STRING BREAKS: at g^2 = 4 the potential is 2.271563 2.383425 4.295402 2.819090 against the unbroken 2, 4, 6, 8, and it is not monotone -- V(4) < V(3) at g^2 = 1 too (0.796888 0.796906 1.277804 1.026768 against 0.5, 1.0, 1.5, 2.0); Gauss dimensions [234, 150, 160, 132, 150], <N> = 4 exactly at every separation
+PASS E4 [numerical 1e-4] the mechanism, off the d = 4 ground state at g^2 = 4: the flux does not span the separation but localises on the sources, sum_e |<E_e>| = 1.603 against 4 unbroken, dying to 0.0094 three links away; the screening charge shows as a HOLE <n> = 0.181 at the +1 source and a fermion <n> = 0.981 at the -1 source
+PASS E5 [numerical 1e-6] finite-size cross-check on the L = 4 ring: V = 0.762517 0.594051 at g^2 = 1 and 2.271118 2.169659 at g^2 = 4, against the pure-electric 0.5, 1.0 and 2.0, 4.0 -- saturated there too, so the breaking is not an L = 8 artefact; the values are finite-size numbers and carry no infinite-volume statement
+TOTAL: PASS=28 FAIL=0
+
+----- stderr -----
+

--- a/scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py
+++ b/scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py
@@ -1,0 +1,1379 @@
+#!/usr/bin/env python3
+"""The fermion on compact U(1) links: the integer flux selects the staggered
+Gauss law and joins the Maxwell germ.
+
+Self-contained finite-cluster runner.  The coarse lattice is 2Z^3 carrying one
+fermionic mode per coarse vertex in the Bravyi-Kitaev superfast encoding, with
+the Kawamoto-Smit link signs eta_1 = 1, eta_2(v) = (-1)^{v_1},
+eta_3(v) = (-1)^{v_1+v_2}.  The ONE change from the spin-1/2 link role of
+PR #7893 is that each coarse edge carries a COMPACT U(1) link role instead:
+
+    E_e |m> = m |m>,  m integer, truncated to m in {-S, ..., S};
+    U_e |m> = |m+1>   (U|S> = 0),   so   [E_e, U_e] = U_e exactly;
+    C_e = U_e + U_e^dag,   S_e = -i(U_e - U_e^dag),   both Hermitian.
+
+The link role is a DESIGN element of exactly the kind PR #7834's period-(4,2,2)
+superlattice role pattern is; it is derived from no axiom.  The declared law is
+
+    H^g = -t sum_<ij> eta_ij (T_ij C_e + K_ij S_e) / 2      the coupled hop
+    H_E = (g^2/2) sum_e E_e^2                                the electric term
+    H_B = -(1/g^2) sum_f cos_f,  cos_f = (W_f + W_f^dag)/2   the magnetic term
+
+with T_ij = (i/2) A_ij (B_i - B_j), K_ij = -(1/2) A_ij (I - B_i B_j),
+B_v = the product of the Z's at corner v = I - 2 n_v, W_f the oriented four-link
+loop product, and G_v = (div E)_v - rho_v with rho^sea_v = n_v - 1/2 or
+rho^stag_v = n_v - (1 - eps_v)/2.  t and g are supplied.
+
+  A  THE COUPLING.  a_i^dag U_ij a_j + h.c. = (T C + K S)/2 on every bond,
+     what truncation preserves and what it breaks, and [G_v, H^g] = 0 at every
+     corner of every coordination z = 2..6.
+  B  THE INTEGER FLUX SELECTS THE STAGGERED CONVENTION.  2 (div E)_v is even at
+     every corner, so rho^sea is inadmissible everywhere and rho^stag is
+     admissible everywhere; the exact Gauss-sector census; the background field
+     that relates the two conventions on balanced blocks only.
+  C  THE ELECTRIC AND MAGNETIC TERMS.  E_e^2 is not a c-number, [P_f, G_v] = 0,
+     the assembled H preserves the Gauss sector, and H_B is the Wilson potential
+     with V''(0) = 1/g^2 > 0.
+  D  THE PLAQUETTE IN ITS GAUSS SECTOR.  Dimensions 26 and 50 only.
+  E  THE RING.  Exact linear confinement of static charges, and string breaking
+     when the fermion is dynamical.
+
+Groups A, B, C and E2 are exact -- Gaussian-rational Pauli monomials (F2
+supports, Z4 phases) tensored with exact integer link matrices, and exact
+integer record arithmetic, with no floating-point step anywhere.  The items
+tagged [numerical] are floating-point at the stated tolerance.  No dense object
+above 4096 x 4096 is formed anywhere; the cube is counted, never diagonalised.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import time
+from fractions import Fraction as Fr
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 150
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ===================================================== coarse lattice, KS signs
+
+EX = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+DIRS = [(-1, 0, 0), (0, -1, 0), (0, 0, -1), (1, 0, 0), (0, 1, 0), (0, 0, 1)]
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+def va(a, b):
+    return tuple(a[i] + b[i] for i in range(3))
+
+
+def pcnt(n):
+    return bin(n).count("1")
+
+
+def eps_of(v):
+    return -1 if (sum(v) & 1) else 1
+
+
+def bits(n):
+    out = set()
+    i = 0
+    while n:
+        if n & 1:
+            out.add(i)
+        n >>= 1
+        i += 1
+    return out
+
+
+# ============================================ symplectic Pauli monomials / sums
+
+class Q:
+    """i^k X^x Z^z on a register of sites indexed by bit position."""
+
+    __slots__ = ("k", "x", "z")
+
+    def __init__(self, k, x, z):
+        self.k = k & 3
+        self.x = x
+        self.z = z
+
+    def __mul__(a, b):
+        return Q(a.k + b.k + 2 * pcnt(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(s):
+        return Q(s.k + 2, s.x, s.z)
+
+    def scal(s, t):
+        return Q(s.k + t, s.x, s.z)
+
+
+def qprod(seq):
+    o = Q(0, 0, 0)
+    for p in seq:
+        o = o * p
+    return o
+
+
+def cmul(a, b):
+    return (a[0] * b[0] - a[1] * b[1], a[0] * b[1] + a[1] * b[0])
+
+
+ONE = (Fr(1), Fr(0))
+IMU = (Fr(0), Fr(1))
+MONE = (Fr(-1), Fr(0))
+H2 = (Fr(1, 2), Fr(0))
+HI = (Fr(0), Fr(1, 2))
+MH = (Fr(-1, 2), Fr(0))
+MI = (Fr(0), Fr(-1))
+
+
+class PS(dict):
+    """sum_j c_j X^{x_j} Z^{z_j} with c_j a pair of Fractions: exact."""
+
+    def __add__(a, b):
+        o = PS(a)
+        for k, v in b.items():
+            w = o.get(k)
+            if w is None:
+                o[k] = v
+            else:
+                s = (w[0] + v[0], w[1] + v[1])
+                if s[0] == 0 and s[1] == 0:
+                    del o[k]
+                else:
+                    o[k] = s
+        return o
+
+    def __sub__(a, b):
+        return a + b.smul(MONE)
+
+    def smul(a, s):
+        o = PS()
+        for k, v in a.items():
+            c = cmul(v, s)
+            if c[0] or c[1]:
+                o[k] = c
+        return o
+
+    def __mul__(a, b):
+        o = PS()
+        for (x1, z1), c1 in a.items():
+            for (x2, z2), c2 in b.items():
+                c = cmul(c1, c2)
+                if pcnt(z1 & x2) & 1:
+                    c = (-c[0], -c[1])
+                k = (x1 ^ x2, z1 ^ z2)
+                w = o.get(k)
+                if w is None:
+                    o[k] = c
+                else:
+                    s = (w[0] + c[0], w[1] + c[1])
+                    if s[0] == 0 and s[1] == 0:
+                        del o[k]
+                    else:
+                        o[k] = s
+        return o
+
+    def dag(a):
+        o = PS()
+        for (x, z), c in a.items():
+            c = (c[0], -c[1])
+            if pcnt(x & z) & 1:
+                c = (-c[0], -c[1])
+            o[(x, z)] = c
+        return o
+
+    def iszero(a):
+        return len(a) == 0
+
+    def supp(a):
+        s = set()
+        for (x, z) in a:
+            s |= bits(x | z)
+        return s
+
+
+def mono(q, c=ONE):
+    ph = [(Fr(1), Fr(0)), (Fr(0), Fr(1)), (Fr(-1), Fr(0)), (Fr(0), Fr(-1))][q.k & 3]
+    return PS({(q.x, q.z): cmul(c, ph)})
+
+
+def zop(z, c=ONE):
+    return PS({(0, z): c})
+
+
+IDP = PS({(0, 0): ONE})
+
+
+def comm(a, b):
+    return a * b - b * a
+
+
+def acomm(a, b):
+    return a * b + b * a
+
+
+def psmat(P, nq):
+    """dense complex matrix of a PS on nq fermion record qubits."""
+    N = 1 << nq
+    M = np.zeros((N, N), dtype=np.complex128)
+    b = np.arange(N)
+    for (x, z), (re, im) in P.items():
+        sgn = np.array([(-1) ** pcnt(int(k) & z) for k in b], dtype=np.float64)
+        M[b ^ x, b] += complex(float(re), float(im)) * sgn
+    return M
+
+
+# ================================== the compact U(1) link role: exact integers
+
+def linkops(S):
+    """E, U, U^dag, C = U + U^dag, Sm = -i(U - U^dag) on E in {-S..S}."""
+    d = 2 * S + 1
+    Em = np.diag(np.arange(-S, S + 1)).astype(np.int64)
+    U = np.zeros((d, d), dtype=np.int64)
+    for a in range(d - 1):
+        U[a + 1, a] = 1                       # U|m> = |m+1>
+    Ud = U.T.copy()
+    C = (U + Ud).astype(np.complex128)
+    Sm = (-1j) * (U - Ud).astype(np.complex128)
+    return d, Em, U, Ud, C, Sm
+
+
+class PM:
+    """d x d matrix of exact PS entries: the hybrid fermion x link algebra."""
+
+    __slots__ = ("d", "e")
+
+    def __init__(self, d, e=None):
+        self.d = d
+        self.e = dict(e or {})
+
+    @staticmethod
+    def eye(d, P=None):
+        P = IDP if P is None else P
+        return PM(d, {(a, a): P for a in range(d)})
+
+    @staticmethod
+    def kron(P, M):
+        d = M.shape[0]
+        e = {}
+        for a in range(d):
+            for b in range(d):
+                z = complex(M[a, b])
+                if z == 0:
+                    continue
+                t = P.smul((Fr(z.real).limit_denominator(10 ** 9),
+                            Fr(z.imag).limit_denominator(10 ** 9)))
+                if t:
+                    e[(a, b)] = t
+        return PM(d, e)
+
+    def __add__(a, b):
+        o = PM(a.d, a.e)
+        for k, v in b.e.items():
+            w = o.e.get(k)
+            s = v if w is None else (w + v)
+            if s:
+                o.e[k] = s
+            elif k in o.e:
+                del o.e[k]
+        return o
+
+    def __sub__(a, b):
+        return a + b.smul(MONE)
+
+    def smul(a, s):
+        o = PM(a.d)
+        for k, v in a.e.items():
+            t = v.smul(s)
+            if t:
+                o.e[k] = t
+        return o
+
+    def __mul__(a, b):
+        o = PM(a.d)
+        for (r, m), P in a.e.items():
+            for (m2, c), R in b.e.items():
+                if m2 != m:
+                    continue
+                t = P * R
+                if not t:
+                    continue
+                w = o.e.get((r, c))
+                s = t if w is None else (w + t)
+                if s:
+                    o.e[(r, c)] = s
+                elif (r, c) in o.e:
+                    del o.e[(r, c)]
+        return o
+
+    def dag(a):
+        return PM(a.d, {(b, r): P.dag() for (r, b), P in a.e.items()})
+
+    def iszero(a):
+        return all(not v for v in a.e.values())
+
+    def nterms(a):
+        return sum(len(v) for v in a.e.values())
+
+
+def pmcomm(a, b):
+    return a * b - b * a
+
+
+# ==================================== the coarse block and its superfast code
+
+class Lat:
+    def __init__(self, dims):
+        self.dims = tuple(dims)
+        self.V = [v for v in itertools.product(*(range(d) for d in dims))]
+        self.E = []
+        for v in self.V:
+            for ax in range(3):
+                if self.step(v, EX[ax]) is not None:
+                    self.E.append((v, ax))
+        self.ei = {e: i for i, e in enumerate(self.E)}
+        self.nq = len(self.E)
+        self.inc = {}
+        for v in self.V:
+            d = {}
+            for r in range(6):
+                w = self.step(v, DIRS[r])
+                if w is None:
+                    continue
+                d[r] = (w, self.ei[(v, r - 3) if r >= 3 else (w, r)])
+            self.inc[v] = d
+        self.star = {v: sum(1 << q for (_, q) in self.inc[v].values()) for v in self.V}
+
+    def step(self, v, d):
+        w = va(v, d)
+        return w if all(0 <= w[i] < self.dims[i] for i in range(3)) else None
+
+    def A(self, v, r):
+        w, q = self.inc[v][r]
+        x, z = 1 << q, 0
+        for r2, (_, q2) in self.inc[v].items():
+            if r2 < r:
+                z ^= 1 << q2
+        rb = (r + 3) % 6
+        for r2, (_, q2) in self.inc[w].items():
+            if r2 < rb:
+                z ^= 1 << q2
+        p = Q(pcnt(x & z) & 1, x, z)
+        return p if r >= 3 else p.neg()
+
+    def Aij(self, i, j):
+        for r in range(6):
+            if r in self.inc[i] and self.inc[i][r][0] == j:
+                return self.A(i, r)
+        raise KeyError("not adjacent")
+
+    def faces(self):
+        out = []
+        for v in self.V:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a = self.step(v, EX[d1])
+                    b = self.step(v, EX[d2])
+                    if a is None or b is None:
+                        continue
+                    c = self.step(a, EX[d2])
+                    if c is None:
+                        continue
+                    out.append((v, a, c, b))
+        return out
+
+    def loop(self, cyc):
+        n = len(cyc)
+        return qprod([self.Aij(cyc[a], cyc[(a + 1) % n]) for a in range(n)]).scal(n)
+
+
+class Geo:
+    """A coarse block: BK fermion edge records plus one compact link per edge."""
+
+    def __init__(self, dims):
+        self.L = L = Lat(dims)
+        self.nq = L.nq
+        self.V = L.V
+        self.bonds = [(v, L.step(v, EX[ax]), eta_ks(v, ax), ax, L.ei[(v, ax)])
+                      for (v, ax) in L.E]
+        self.incs = {v: [] for v in L.V}
+        for (i, j, e, ax, q) in self.bonds:
+            self.incs[i].append((q, +1, j))
+            self.incs[j].append((q, -1, i))
+        self.eps = {v: eps_of(v) for v in L.V}
+        self.star = L.star
+
+    def Bv(self, v):
+        return zop(self.star[v])
+
+    def nv(self, v):
+        return (IDP - self.Bv(v)).smul(H2)
+
+    def Aij(self, i, j):
+        return mono(self.L.Aij(i, j))
+
+    def Tij(self, i, j):
+        return (self.Aij(i, j) * (self.Bv(i) - self.Bv(j))).smul(HI)
+
+    def Kij(self, i, j):
+        return (self.Aij(i, j) * (IDP - self.Bv(i) * self.Bv(j))).smul(MH)
+
+    def rho(self, v, kind):
+        if kind == "sea":
+            return self.nv(v) - IDP.smul(H2)
+        return self.nv(v) - IDP.smul((Fr(1 - self.eps[v], 2), Fr(0)))
+
+    def faces(self):
+        return self.L.faces()
+
+    def face_links(self, f):
+        L = self.L
+        out = []
+        for a in range(len(f)):
+            p, r = f[a], f[(a + 1) % len(f)]
+            for ax in range(3):
+                if L.step(p, EX[ax]) == r and (p, ax) in L.ei:
+                    out.append((L.ei[(p, ax)], +1))
+                    break
+                if L.step(r, EX[ax]) == p and (r, ax) in L.ei:
+                    out.append((L.ei[(r, ax)], -1))
+                    break
+            else:
+                raise KeyError((p, r))
+        return out
+
+
+class Ring:
+    """Periodic 1D chain, Lv corners and Lv links, superfast encoding by hand:
+       A_{v,v+1} = X_{q_v} Z_{q_{v-1}}, B_v = Z_{q_{v-1}} Z_{q_v}, eta = 1."""
+
+    def __init__(self, Lv):
+        self.Lv = Lv
+        self.nq = Lv
+        self.V = list(range(Lv))
+        self.star = {v: (1 << ((v - 1) % Lv)) | (1 << v) for v in range(Lv)}
+        self.bonds = [(v, (v + 1) % Lv, 1, 0, v) for v in range(Lv)]
+        self.incs = {v: [] for v in range(Lv)}
+        for (i, j, e, ax, q) in self.bonds:
+            self.incs[i].append((q, +1, j))
+            self.incs[j].append((q, -1, i))
+        self.eps = {v: (1 if v % 2 == 0 else -1) for v in range(Lv)}
+
+    def Bv(self, v):
+        return zop(self.star[v])
+
+    def nv(self, v):
+        return (IDP - self.Bv(v)).smul(H2)
+
+    def Aij(self, i, j):
+        Lv = self.Lv
+        if (i + 1) % Lv == j:
+            return PS({((1 << i), (1 << ((i - 1) % Lv))): ONE})
+        if (j + 1) % Lv == i:
+            return PS({((1 << j), (1 << ((j - 1) % Lv))): MONE})
+        raise KeyError((i, j))
+
+    def Tij(self, i, j):
+        return (self.Aij(i, j) * (self.Bv(i) - self.Bv(j))).smul(HI)
+
+    def Kij(self, i, j):
+        return (self.Aij(i, j) * (IDP - self.Bv(i) * self.Bv(j))).smul(MH)
+
+
+GP = Geo((2, 2, 1))
+GC = Geo((2, 2, 2))
+GB = Geo((3, 3, 3))
+
+print("H^g = -t sum eta (T C + K S)/2, C = U + U^dag, S = -i(U - U^dag); E|m> = m|m>, "
+      "U|m> = |m+1>, |m| <= S; G_v = (div E)_v - rho_v")
+
+# ============================ A -- the coupling on a compact U(1) link [exact]
+
+LK = {S: linkops(S) for S in (1, 2)}
+
+hop_ok = sign_ok = herm_ok = True
+nmon = {}
+nbond = 0
+for g in (GP, GC, GB):
+    for (i, j, e, ax, q) in g.bonds:
+        T, K = g.Tij(i, j), g.Kij(i, j)
+        aij = (T - K.smul(IMU)).smul(H2)              # a_i^dag a_j = (T - iK)/2
+        aji = (T + K.smul(IMU)).smul(H2)              # a_j^dag a_i = (T + iK)/2
+        for S in (1, 2):
+            d, Em, U, Ud, C, Sm = LK[S]
+            lhs = PM.kron(aij, U) + PM.kron(aji, Ud)  # a^dag U a + a^dag U^dag a
+            rhs = (PM.kron(T, C) + PM.kron(K, Sm)).smul(H2)
+            hop_ok = hop_ok and (lhs - rhs).iszero()
+            herm_ok = herm_ok and (rhs - rhs.dag()).iszero()
+            bad = (PM.kron(T, C)
+                   + PM.kron(K, (1j * (U - Ud)).astype(np.complex128))).smul(H2)
+            sign_ok = sign_ok and not (lhs - bad).iszero()
+            nmon.setdefault(S, set()).add(rhs.nterms())
+            nbond += 1
+
+check("A1 [exact] a_i^dag U a_j + a_j^dag U^dag a_i = (T C + K S)/2, C = U + U^dag, "
+      "S = -i(U - U^dag), Hermitian, %d and %d monomial entries: all %d bond checks -- every "
+      "bond of the plaquette, the cube and the open 3x3x3 at S = 1 and 2"
+      % (min(nmon[1]), min(nmon[2]), nbond),
+      hop_ok and herm_ok and nmon[1] == {16} and nmon[2] == {32})
+
+check("A2 [exact] the opposite-sign partner +i(U - U^dag) is not this hop on any of the %d: "
+      "it is a_i^dag U^dag a_j + h.c., carrying flux the other way along the bond"
+      % nbond, sign_ok)
+
+# reduction to the landed spin-1/2 form: U = sigma^+ = (X + iY)/2
+sx = np.array([[0, 1], [1, 0]], dtype=np.complex128)
+sy = np.array([[0, -1j], [1j, 0]], dtype=np.complex128)
+Up2 = (sx + 1j * sy) / 2
+red = np.allclose(Up2 + Up2.conj().T, sx) and np.allclose(-1j * (Up2 - Up2.conj().T), sy)
+check("A3 [exact] at spin 1/2 this is PR #7893's landed form: U = (X^L + i Y^L)/2 gives "
+      "C = X^L and S = Y^L, so (T C + K S)/2 = (T X^L + K Y^L)/2", red)
+
+o1 = o2 = o3 = True
+for (i, j, e, ax, q) in GC.bonds:
+    T, K, ni, nj = GC.Tij(i, j), GC.Kij(i, j), GC.nv(i), GC.nv(j)
+    o1 = o1 and (comm(ni, T) - K.smul(MI)).iszero() and (comm(ni, K) - T.smul(IMU)).iszero()
+    o2 = o2 and (comm(nj, T) - K.smul(IMU)).iszero() and (comm(nj, K) - T.smul(MI)).iszero()
+    for w in GC.V:
+        if w in (i, j):
+            continue
+        o3 = o3 and comm(GC.nv(w), T).iszero() and comm(GC.nv(w), K).iszero()
+check("A4 [exact] the relations behind gauge invariance, all 12 cube bonds: [n_i, T] = -iK, "
+      "[n_i, K] = +iT, [n_j, T] = +iK, [n_j, K] = -iT, and [n_w, T] = [n_w, K] = 0 off the "
+      "bond (96 pairs)", o1 and o2 and o3)
+
+alg_ok = brk_ok = True
+for S in (1, 2):
+    d, Em, U, Ud, C, Sm = LK[S]
+    I = np.eye(d, dtype=np.int64)
+    Pp = np.diag([0] * (d - 1) + [1])
+    Pm = np.diag([1] + [0] * (d - 1))
+    alg_ok = alg_ok and np.array_equal(Em @ U - U @ Em, U) \
+        and np.array_equal(Em @ Ud - Ud @ Em, -Ud) \
+        and np.allclose(C, C.conj().T) and np.allclose(Sm, Sm.conj().T)
+    brk_ok = brk_ok and np.array_equal(Ud @ U, I - Pp) and np.array_equal(U @ Ud, I - Pm) \
+        and np.allclose(C @ Sm - Sm @ C, 2j * (Pp - Pm))
+check("A5 [exact] truncation to |E| <= S is exact for the link algebra: [E, U] = U and "
+      "[E, U^dag] = -U^dag hold identically at S = 1 and 2, C and S Hermitian, so every "
+      "algebraic item here is truncation-independent", alg_ok)
+check("A6 [exact] truncation breaks exactly two things: U^dag U = I - P_{+S} and U U^dag = "
+      "I - P_{-S} (the link is not unitary), and [C, S] = 2i (P_{+S} - P_{-S}) != 0 (cos and "
+      "sin stop commuting)", brk_ok)
+
+gauge_ok = True
+npair = 0
+zs = set()
+for g, Ss in ((GP, (1, 2)), (GC, (1, 2)), (GB, (1, 2))):
+    for v in g.V:
+        zs.add(len(g.incs[v]))
+    pre = {}
+    for (i, j, e, ax, q) in g.bonds:
+        pre[q] = (g.Tij(i, j), g.Kij(i, j), e)
+    for S in Ss:
+        d, Em, U, Ud, C, Sm = LK[S]
+        hops = {q: (PM.kron(T, C) + PM.kron(K, Sm)).smul((Fr(-e, 2), Fr(0)))
+                for q, (T, K, e) in pre.items()}
+        for kind in ("sea", "stag"):
+            for v in g.V:
+                inc = {q: s for (q, s, w) in g.incs[v]}
+                base = PM.eye(d, g.rho(v, kind)).smul(MONE)
+                for q, hop in hops.items():
+                    Gv = base
+                    if q in inc:
+                        Gv = Gv + PM.kron(IDP, (inc[q] * Em).astype(np.complex128))
+                    gauge_ok = gauge_ok and pmcomm(Gv, hop).iszero()
+                    if S == Ss[0] and kind == "sea":
+                        npair += 1
+check("A7 [exact] [G_v, H^g] = 0 at every corner of every coordination z = %s -- %d "
+      "corner-bond pairs on the plaquette, the cube and the open 3x3x3, both rho conventions, "
+      "S = 1 and 2" % (sorted(zs), npair), gauge_ok and sorted(zs) == [2, 3, 4, 5, 6] and npair == 1570)
+
+# ================== B -- the integer flux selects the staggered convention
+
+def nvec_table(g, nq, star, V):
+    """n_v for every fermion record pattern, as an exact integer table."""
+    N = 1 << nq
+    f = np.arange(N, dtype=np.int64)
+    out = np.zeros((N, len(V)), dtype=np.int64)
+    for a, v in enumerate(V):
+        m = star[v]
+        p = np.zeros(N, dtype=np.int64)
+        for k in range(nq):
+            if m >> k & 1:
+                p ^= ((f >> k) & 1)
+        out[:, a] = p
+    return out
+
+
+def dp_census(nv, ends, vals, targets):
+    """DP over links: count assignments of `vals` (DOUBLED link variables 2E_e)
+       with prescribed doubled divergence.  Exact integer arithmetic."""
+    rem = [0] * nv
+    for (a, b) in ends:
+        rem[a] += 1
+        rem[b] += 1
+    lo = [min(t[a] for t in targets) for a in range(nv)]
+    hi = [max(t[a] for t in targets) for a in range(nv)]
+    mx = max(abs(x) for x in vals)
+    st = {tuple([0] * nv): 1}
+    for (a, b) in ends:
+        rem[a] -= 1
+        rem[b] -= 1
+        ns = {}
+        for key, cnt in st.items():
+            for m in vals:
+                pa, pb = key[a] + m, key[b] - m
+                if pa < lo[a] - rem[a] * mx or pa > hi[a] + rem[a] * mx:
+                    continue
+                if pb < lo[b] - rem[b] * mx or pb > hi[b] + rem[b] * mx:
+                    continue
+                nk = list(key)
+                nk[a] = pa
+                nk[b] = pb
+                nk = tuple(nk)
+                ns[nk] = ns.get(nk, 0) + cnt
+        st = ns
+    return {t: st.get(t, 0) for t in targets}
+
+
+def full_census(nv, ends, vals, targets):
+    """Complete vectorised enumeration of the whole link space."""
+    nE = len(ends)
+    d = len(vals)
+    M = d ** nE
+    conf = np.empty((M, nE), dtype=np.int64)
+    t = np.arange(M, dtype=np.int64)
+    va_ = np.array(vals, dtype=np.int64)
+    for k in range(nE):
+        conf[:, k] = va_[t % d]
+        t //= d
+    DIV = np.zeros((M, nv), dtype=np.int64)
+    for k, (a, b) in enumerate(ends):
+        DIV[:, a] += conf[:, k]
+        DIV[:, b] -= conf[:, k]
+    out = {}
+    for tg in targets:
+        out[tg] = int((DIV == np.array(tg)).all(axis=1).sum())
+    return out
+
+
+def keyed_census(nv, ends, vals, targets, half):
+    """Complete vectorised enumeration of the whole link space, by histogram."""
+    nE = len(ends)
+    d = len(vals)
+    M = d ** nE
+    t = np.arange(M, dtype=np.int64)
+    va_ = np.array(vals, dtype=np.int64)
+    DIV = np.zeros((M, nv), dtype=np.int64)
+    for k, (a, b) in enumerate(ends):
+        col = va_[t % d]
+        t //= d
+        DIV[:, a] += col
+        DIV[:, b] -= col
+    W = 2 * half + 1
+    key = np.zeros(M, dtype=np.int64)
+    for a in range(nv):
+        key = key * W + (DIV[:, a] + half)
+    uq, ct = np.unique(key, return_counts=True)
+    hist = dict(zip(uq.tolist(), ct.tolist()))
+    out = {}
+    for tg in targets:
+        k = 0
+        bad = False
+        for x in tg:
+            if abs(x) > half:
+                bad = True
+            k = k * W + (x + half)
+        out[tg] = 0 if bad else int(hist.get(k, 0))
+    return out
+
+
+def cycle_census(nv, ends, vals, targets):
+    """Complete enumeration over the cycle space: the spanning tree's link values
+       are determined by the divergence, so only the nE - nv + 1 chords are free."""
+    nE = len(ends)
+    A = np.zeros((nv, nE), dtype=np.int64)
+    for k, (a, b) in enumerate(ends):
+        A[a, k] += 1
+        A[b, k] -= 1
+    adj = {a: [] for a in range(nv)}
+    for k, (a, b) in enumerate(ends):
+        adj[a].append((b, k))
+        adj[b].append((a, k))
+    seen = {0}
+    tre = []
+    stk = [0]
+    while stk:
+        a = stk.pop()
+        for (b, k) in adj[a]:
+            if b not in seen:
+                seen.add(b)
+                tre.append(k)
+                stk.append(b)
+    chords = [k for k in range(nE) if k not in set(tre)]
+    # leaf-strip the tree to express x_tree = Mtree @ r exactly
+    Mt = np.zeros((len(tre), nv), dtype=np.int64)
+    R = np.eye(nv, dtype=np.int64)
+    deg = {a: 0 for a in range(nv)}
+    for k in tre:
+        a, b = ends[k]
+        deg[a] += 1
+        deg[b] += 1
+    live = set(tre)
+    tix = {k: i for i, k in enumerate(tre)}
+    while live:
+        leaf = None
+        for u in range(nv):
+            if deg[u] == 1:
+                leaf = u
+                break
+        k = next(k for k in live if leaf in ends[k])
+        a, b = ends[k]
+        w = b if a == leaf else a
+        s = A[leaf, k]
+        Mt[tix[k]] = s * R[leaf]
+        R[w] = R[w] - A[w, k] * Mt[tix[k]]
+        deg[leaf] -= 1
+        deg[w] -= 1
+        live.discard(k)
+    Y = np.array(list(itertools.product(vals, repeat=len(chords))), dtype=np.int64)
+    Ac = A[:, chords]
+    Xy = Mt @ (Ac @ Y.T)                                  # (ntree, nY)
+    B = np.array(targets, dtype=np.int64)
+    Xb = Mt @ B.T                                         # (ntree, ntg)
+    mx = max(abs(x) for x in vals)
+    out = {}
+    st = sorted(set(vals))
+    for i, tg in enumerate(targets):
+        if sum(tg) != 0:                       # any divergence sums to zero
+            out[tg] = 0
+            continue
+        X = Xb[:, i][:, None] - Xy
+        ok = (np.abs(X) <= mx)
+        if len(st) != 2 * mx + 1:
+            ok &= np.isin(X, st)
+        out[tg] = int(ok.all(axis=0).sum())
+    return out
+
+
+def targets_of(g, kind, S=None):
+    """doubled rho targets, one per fermion record pattern class."""
+    V = list(g.V)
+    NT = nvec_table(g, g.nq, g.star, V)
+    if kind == "sea":
+        RH = 2 * NT - 1
+    else:
+        RH = 2 * NT - np.array([1 - g.eps[v] for v in V])
+    uq, inv, cts = np.unique(RH, axis=0, return_inverse=True, return_counts=True)
+    return NT, [tuple(int(x) for x in r) for r in uq], inv, cts
+
+
+def ends_of(g):
+    vix = {v: a for a, v in enumerate(g.V)}
+    return [(vix[i], vix[j]) for (i, j, e, ax, q) in g.bonds]
+
+
+def sector(g, kind, S, method):
+    NT, tg, inv, cts = targets_of(g, kind)
+    vals = list(range(-2 * S, 2 * S + 1, 2))          # 2E for a compact link
+    cnt = method(len(g.V), ends_of(g), vals, tg)
+    per = np.array([cnt[t] for t in tg], dtype=np.int64)
+    return NT, tg, inv, cts, per, int((per * cts).sum())
+
+_, _, _, _, _, pl1 = sector(GP, "stag", 1, dp_census)
+_, _, _, _, _, pl2 = sector(GP, "stag", 2, dp_census)
+_, _, _, _, _, ps1 = sector(GP, "sea", 1, dp_census)
+_, _, _, _, _, ps2 = sector(GP, "sea", 2, dp_census)
+_, _, _, _, _, xl1 = sector(GP, "stag", 1, full_census)
+_, _, _, _, _, xl2 = sector(GP, "stag", 2, full_census)
+_, _, _, _, _, xs1 = sector(GP, "sea", 1, full_census)
+
+check("B1 [exact] integer flux makes 2 (div E)_v EVEN at every corner of every coordination, "
+      "while 2 rho^sea = 2n - 1 is ODD and 2 rho^stag = 2n - (1 - eps_v) is EVEN: z_v drops out "
+      "of the condition, and the integer link selects the staggered convention everywhere",
+      ps1 == 0 and ps2 == 0 and xs1 == 0 and pl1 > 0 and pl2 > 0)
+
+check("B2 [exact] plaquette census, DP and complete enumeration agreeing: rho^sea 0 of "
+      "16 x 81 and 0 of 16 x 625; rho^stag %d (S = 1) and %d (S = 2)" % (pl1, pl2),
+      (pl1, pl2, xl1, xl2, ps1, xs1) == (26, 50, 26, 50, 0, 0))
+
+NTc, tgc, invc, ctsc, perc1, cu1 = sector(GC, "stag", 1, dp_census)
+_, _, _, _, perc2, cu2 = sector(GC, "stag", 2, dp_census)
+_, _, _, _, _, cs1 = sector(GC, "sea", 1, dp_census)
+_, _, _, _, _, cs2 = sector(GC, "sea", 2, dp_census)
+_, _, _, _, _, yc1 = sector(GC, "stag", 1, cycle_census)
+_, _, _, _, _, zc1 = sector(GC, "stag", 1,
+                            lambda n, e, v, t: keyed_census(n, e, v, t, 6))
+_, _, _, _, _, yc2 = sector(GC, "stag", 2, cycle_census)
+_, _, _, _, _, ys1 = sector(GC, "sea", 1, cycle_census)
+
+check("B3 [exact] cube census by DP and two complete enumerations (the whole 3^12 space at "
+      "S = 1, the cycle space at both S), agreeing: rho^sea 0 and 0; rho^stag %d and %d. The "
+      "cube is counted, never diagonalised" % (cu1, cu2),
+      (cu1, cu2, yc1, yc2, zc1, cs1, cs2, ys1)
+      == (102304, 1477920, 102304, 1477920, 102304, 0, 0, 0))
+
+Ns = NTc.sum(axis=1)
+adm1 = perc1[invc] > 0
+adm2 = perc2[invc] > 0
+h1, h2 = {}, {}
+for a in range(len(tgc)):
+    if perc1[a] > 0:
+        h1[int(perc1[a])] = h1.get(int(perc1[a]), 0) + int(ctsc[a])
+    if perc2[a] > 0:
+        h2[int(perc2[a])] = h2.get(int(perc2[a]), 0) + int(ctsc[a])
+cls1 = [h1[k] for k in sorted(h1)]
+cls2 = [h2[k] for k in sorted(h2)]
+check("B4 [exact] %d of the 4096 cube fermion patterns admit a link configuration -- exactly "
+      "the half-filled N = 4 sector, all of it, at both S -- in EIGHT multiplicity classes of "
+      "sizes %s, identical at S = 1 (counts %s) and S = 2 (%s): raising S re-weights the charge "
+      "sectors, it does not re-partition them"
+      % (int(adm1.sum()), cls1, sorted(h1), sorted(h2)),
+      int(adm1.sum()) == 2240 and np.array_equal(adm1, adm2)
+      and set(Ns[adm1]) == {4} and cls1 == cls2 == [128, 192, 416, 768, 128, 192, 384, 32]
+      and sorted(h1) == [38, 39, 42, 44, 48, 50, 54, 69]
+      and sorted(h2) == [616, 626, 642, 652, 672, 682, 702, 767])
+
+# spin-1/2 links, by the same DP: 2E = +-1
+def half_census(g, kind):
+    NT, tg, inv, cts = targets_of(g, kind)
+    cnt = dp_census(len(g.V), ends_of(g), [-1, 1], tg)
+    per = np.array([cnt[t] for t in tg], dtype=np.int64)
+    return int((per * cts).sum())
+
+hcs, hcg = half_census(GC, "sea"), half_census(GC, "stag")
+hps, hpg = half_census(GP, "sea"), half_census(GP, "stag")
+check("B5 [exact] the same census on PR #7893's spin-1/2 link (2E = +-1) fixes which "
+      "convention its landed numbers belong to: the cube's %d is the SEA convention (staggered "
+      "gives %d), the plaquette %d sea and %d staggered" % (hcs, hcg, hps, hpg), (hcs, hcg, hps, hpg) == (14400, 0, 0, 14))
+
+def ring_census(Lv, S, kind):
+    g = Ring(Lv)
+    V = list(range(Lv))
+    NT = nvec_table(g, Lv, g.star, V)
+    RH = 2 * NT - (1 if kind == "sea" else np.array([1 - g.eps[v] for v in V]))
+    uq, inv, cts = np.unique(RH, axis=0, return_inverse=True, return_counts=True)
+    tg = [tuple(int(x) for x in r) for r in uq]
+    ends = [(v, (v + 1) % Lv) for v in range(Lv)]
+    a = dp_census(Lv, ends, list(range(-2 * S, 2 * S + 1, 2)), tg)
+    b = full_census(Lv, ends, list(range(-2 * S, 2 * S + 1, 2)), tg)
+    pa = np.array([a[t] for t in tg])
+    pb = np.array([b[t] for t in tg])
+    return int((pa * cts).sum()), int((pb * cts).sum())
+
+rg8, rf8 = ring_census(8, 1, "stag")
+rs8, _ = ring_census(8, 1, "sea")
+check("B6 [exact] periodic ring L = 8, S = 1, DP and complete enumeration agreeing: rho^sea 0 "
+      "of 256 x 3^8, rho^stag %d -- the same selection at coordination z = 2 with no face at "
+      "all" % rg8, (rg8, rf8, rs8) == (234, 234, 0))
+
+# the background link field that relates the two conventions
+def bgfield(g):
+    V = list(g.V)
+    vix = {v: a for a, v in enumerate(V)}
+    nv, nE = len(V), len(g.bonds)
+    tgt = np.array([-g.eps[v] for v in V], dtype=np.int64)     # = 2 (div c)_v
+    if tgt.sum() != 0:
+        return None
+    A = np.zeros((nv, nE), dtype=np.int64)
+    for k, (i, j, e, ax, q) in enumerate(g.bonds):
+        A[vix[i], k] = 1
+        A[vix[j], k] = -1
+    adj = {a: [] for a in range(nv)}
+    for k in range(nE):
+        a = int(np.nonzero(A[:, k] == 1)[0][0])
+        b = int(np.nonzero(A[:, k] == -1)[0][0])
+        adj[a].append((b, k))
+        adj[b].append((a, k))
+    seen = {0}
+    order = [0]
+    par = {}
+    stk = [0]
+    while stk:
+        a = stk.pop()
+        for (b, k) in adj[a]:
+            if b not in seen:
+                seen.add(b)
+                par[b] = (a, k)
+                order.append(b)
+                stk.append(b)
+    dvec = np.zeros(nE, dtype=np.int64)
+    acc = tgt.copy()
+    for b in reversed(order[1:]):
+        a, k = par[b]
+        val = acc[b] * A[b, k]
+        dvec[k] = val
+        acc[b] -= A[b, k] * val
+        acc[a] -= A[a, k] * val
+    return dvec if np.array_equal(A @ dvec, tgt) else None
+
+bg = {}
+for dims, nm in (((2, 2, 1), "plaquette"), ((2, 2, 2), "cube"),
+                 ((2, 2, 3), "2x2x3"), ((3, 3, 3), "open 3x3x3")):
+    g = Geo(dims)
+    nev = sum(1 for v in g.V if g.eps[v] == 1)
+    bg[nm] = (bgfield(g), nev, len(g.V) - nev)
+mx = {nm: (None if d is None else int(np.abs(d).max())) for nm, (d, a, b) in bg.items()}
+check("B7 [exact] rho^sea = rho^stag - eps_v/2, so the conventions are one law in shifted "
+      "variables exactly when a background field c_e with (div c)_v = -eps_v/2 exists: it does "
+      "on balanced blocks, c_e in {-1/2, 0, +1/2} (plaquette 2/2, cube 4/4, 2x2x3 6/6), and not "
+      "on the open 3x3x3 (14/13, sum_v -eps_v = -1 while any divergence sums to 0)",
+      mx["plaquette"] == mx["cube"] == mx["2x2x3"] == 1 and bg["open 3x3x3"][0] is None
+      and bg["open 3x3x3"][1:] == (14, 13))
+
+# ==================================== C -- the electric and magnetic terms
+
+def gauss_basis(g, S, kind, qext=None):
+    V = list(g.V)
+    vix = {v: a for a, v in enumerate(V)}
+    nv, nE = len(V), len(g.bonds)
+    off = [(1 - g.eps[v]) // 2 for v in V]
+    q0 = qext if qext is not None else [0] * nv
+    bas = []
+    for f in range(1 << g.nq):
+        n = [pcnt(f & g.star[v]) & 1 for v in V]
+        if kind == "sea":
+            rr, sc = [2 * n[a] - 1 for a in range(nv)], 2
+        else:
+            rr, sc = [n[a] - off[a] + q0[a] for a in range(nv)], 1
+        for m in itertools.product(range(-S, S + 1), repeat=nE):
+            dv = [0] * nv
+            for k, (i, j, e, ax, qq) in enumerate(g.bonds):
+                dv[vix[i]] += m[k]
+                dv[vix[j]] -= m[k]
+            if all(sc * dv[a] == rr[a] for a in range(nv)):
+                bas.append((f, m))
+    return bas, {b: a for a, b in enumerate(bas)}
+
+
+SPEC = {S: sorted(set(int(x) for x in np.diag(LK[S][1] @ LK[S][1]))) for S in (1, 2)}
+check("C1 [exact] E_e^2 has spectrum %s at S = 1 and %s at S = 2, so H_E = (g^2/2) sum_e E_e^2 "
+      "is a genuine operator -- contrast spin 1/2, where E_e^2 = I/4 and the electric term is a "
+      "c-number that does nothing" % (SPEC[1], SPEC[2]), SPEC[1] == [0, 1] and SPEC[2] == [0, 1, 4])
+
+pf_ok = True
+npf = 0
+nnz = {}
+for g, nm in ((GP, "plaquette"), (GC, "cube")):
+    for S in (1, 2):
+        d = 2 * S + 1
+        D = d ** 4
+        for f in g.faces():
+            fl = g.face_links(f)
+            qs = [q for (q, s) in fl]
+            ds = [s for (q, s) in fl]
+            dec = np.empty((D, 4), dtype=np.int64)
+            t = np.arange(D, dtype=np.int64)
+            for k in range(4):
+                dec[:, k] = (t % d) - S
+                t //= d
+            W = np.zeros((D, D), dtype=np.complex128)
+            for a in range(D):
+                nn = dec[a] + np.array(ds)
+                if np.all(np.abs(nn) <= S):
+                    b = 0
+                    for k in range(3, -1, -1):
+                        b = b * d + int(nn[k]) + S
+                    W[b, a] = 1
+            Pf = W + W.conj().T
+            nnz.setdefault(S, set()).add(int((np.abs(Pf) > 0).sum()))
+            for v in g.V:
+                inc = {q: s for (q, s, w) in g.incs[v]}
+                dg = dec @ np.array([inc.get(q, 0) for q in qs], dtype=np.int64)
+                pf_ok = pf_ok and np.array_equal(Pf * dg[None, :], Pf * dg[:, None])
+                if S == 1:
+                    npf += 1
+check("C2 [exact] the Wilson term commutes with Gauss's law: [P_f, (div E)_v] = 0 on all %d "
+      "face-corner pairs (48 cube, 4 plaquette) at S = 1 and 2, nnz(P_f) = %d and %d; rho_v is "
+      "fermion-only, so [P_f, rho_v] = 0 outright" % (npf, min(nnz[1]), min(nnz[2])),
+      pf_ok and npf == 52 and nnz[1] == {32} and nnz[2] == {512})
+
+
+def apply_H(g, S, f, m, t=1.0, g2=1.0, mag=True, elec=True):
+    """H^g + H_E + H_B on one Gauss state, with destinations in the FULL space."""
+    out = {}
+
+    def add(k, c):
+        out[k] = out.get(k, 0j) + c
+    if elec:
+        add((f, tuple(m)), (g2 / 2) * sum(x * x for x in m))
+    for (i, j, e, ax, q) in g.bonds:
+        for (Pop, sh) in ((g.Tij(i, j), {+1: 1.0 + 0j, -1: 1.0 + 0j}),
+                          (g.Kij(i, j), {+1: -1j, -1: +1j})):
+            for (x, z), (re, im) in Pop.items():
+                c = complex(float(re), float(im)) * ((-1) ** pcnt(f & z))
+                f2 = f ^ x
+                for sgn, lc in sh.items():
+                    m2 = list(m)
+                    m2[q] += sgn
+                    if -S <= m2[q] <= S:
+                        add((f2, tuple(m2)), (-t * e / 2.0) * c * lc)
+    if mag:
+        for fc in g.faces():
+            fl = g.face_links(fc)
+            for dr in (+1, -1):
+                m2 = list(m)
+                ok = True
+                for (q, s) in fl:
+                    m2[q] += dr * s
+                    if not (-S <= m2[q] <= S):
+                        ok = False
+                if ok:
+                    add((f, tuple(m2)), -(1.0 / g2) * 0.5)
+    return {k: v for k, v in out.items() if abs(v) > 1e-14}
+
+
+leak_ok = True
+leaks = 0
+mxleak = 0.0
+BAS = {}
+for S in (1, 2):
+    bas, ix = gauss_basis(GP, S, "stag")
+    BAS[S] = (bas, ix)
+    for (f, m) in bas:
+        for k, v in apply_H(GP, S, f, m).items():
+            if k not in ix:
+                leaks += 1
+                mxleak = max(mxleak, abs(v))
+check("C3 [exact] the assembled H^g + H_E + H_B maps the plaquette Gauss sector into itself: "
+      "on all %d states at S = 1 and %d at S = 2, destinations taken in the FULL space, %d "
+      "out-of-sector amplitudes, max leaked %.1e -- the T C and K S terms leave the sector "
+      "separately and cancel" % (len(BAS[1][0]), len(BAS[2][0]), leaks, mxleak), leaks == 0 and mxleak == 0.0)
+
+# the Wilson potential's germ, exact Maclaurin coefficients of (1 - cos)/g^2
+fact = [1]
+for k in range(1, 12):
+    fact.append(fact[-1] * k)
+cos_c = [Fr((-1) ** (k // 2), fact[k]) if k % 2 == 0 else Fr(0) for k in range(9)]
+Vc = [-c for c in cos_c]
+Vc[0] = Fr(0)
+germ_ok = (Vc[0] == 0 and Vc[1] == 0 and 2 * Vc[2] == 1
+           and all(Vc[k] == 0 for k in (1, 3, 5, 7)))
+check("C4 [exact] H_B = -(1/g^2) sum_f cos_f is, up to a constant, the one-plaquette Wilson "
+      "potential V = (1/g^2)(1 - cos theta): even, 2 pi-periodic, C^infinity, V(0) = V'(0) = 0, "
+      "V''(0) = 1/g^2 > 0 -- the positive quadratic germ the open PR #7884 states for its "
+      "basin",
+      germ_ok)
+
+# ============================= D -- the plaquette in its Gauss sector [numerical]
+
+def build(g, S, bas, ix, t=1.0, g2=1.0, mag=True, elec=True):
+    D = len(bas)
+    H = np.zeros((D, D), dtype=np.complex128)
+    for a, (f, m) in enumerate(bas):
+        for k, v in apply_H(g, S, f, m, t=t, g2=g2, mag=mag, elec=elec).items():
+            H[ix[k], a] += v
+    return H
+
+
+Vp = list(GP.V)
+offp = [(1 - GP.eps[v]) // 2 for v in Vp]
+rows = {}
+herm = 0.0
+for S in (1, 2):
+    bas, ix = BAS[S]
+    for g2 in (1.0, 2.0, 4.0):
+        for mag in (False, True):
+            H = build(GP, S, bas, ix, g2=g2, mag=mag)
+            herm = max(herm, float(np.abs(H - H.conj().T).max()))
+            w, vv = np.linalg.eigh(H)
+            psi = vv[:, 0]
+            pr = np.abs(psi) ** 2
+            E2 = float(np.mean([sum(pr[a] * bas[a][1][q] ** 2 for a in range(len(bas)))
+                                for q in range(len(GP.bonds))]))
+            rv = np.array([sum(pr[a] * ((pcnt(bas[a][0] & GP.star[v]) & 1) - offp[b])
+                               for a in range(len(bas))) for b, v in enumerate(Vp)])
+            Ee = np.array([sum(pr[a] * bas[a][1][q] for a in range(len(bas)))
+                           for q in range(len(GP.bonds))])
+            Nv = sum(pr[a] * sum((pcnt(bas[a][0] & GP.star[v]) & 1) for v in Vp)
+                     for a in range(len(bas)))
+            Hb = build(GP, S, bas, ix, t=0.0, g2=1.0, mag=True, elec=False)
+            cf = float(np.real(psi.conj() @ (-Hb) @ psi)) / len(GP.faces())
+            rows[(S, g2, mag)] = (float(w[0]), float(w[1] - w[0]), E2, cf,
+                                  rv, Ee, float(Nv))
+
+TOL = 1e-9
+
+
+def close(a, b, tol=TOL):
+    return abs(a - b) < tol
+
+
+e1 = [rows[(1, g2, m)][0] for g2 in (1.0, 2.0, 4.0) for m in (False, True)]
+e2 = [rows[(2, g2, m)][0] for g2 in (1.0, 2.0, 4.0) for m in (False, True)]
+tgt1 = [-2.152011641, -2.491847562, -1.807850741, -1.889262585,
+        -1.352280241, -1.364473432]
+tgt2 = [-2.153356887, -2.573395352, -1.807956223, -1.899005796,
+        -1.352283081, -1.365185023]
+check("D1 [numerical 1e-9] plaquette Gauss dimensions %d and %d (rho^sea is empty, so there is "
+      "nothing else to diagonalise); E_0 at g^2 = 1, 2, 4 without/with H_B: S = 1 %s; S = 2 %s"
+      % (len(BAS[1][0]), len(BAS[2][0]),
+         " ".join("%.6f" % x for x in e1), " ".join("%.6f" % x for x in e2)),
+      len(BAS[1][0]) == 26 and len(BAS[2][0]) == 50
+      and all(close(a, b) for a, b in zip(e1, tgt1))
+      and all(close(a, b) for a, b in zip(e2, tgt2)))
+
+gapsF = [rows[(S, g2, False)][1] for S in (1, 2) for g2 in (1.0, 2.0, 4.0)]
+cosF = [rows[(S, g2, False)][3] for S in (1, 2) for g2 in (1.0, 2.0, 4.0)]
+gapsT = [rows[(S, g2, True)][1] for S in (1, 2) for g2 in (1.0, 2.0, 4.0)]
+cosT = [rows[(S, g2, True)][3] for S in (1, 2) for g2 in (1.0, 2.0, 4.0)]
+check("D2 [numerical 1e-9] the magnetic term lifts the degeneracy and puts flux on the face: "
+      "without H_B the gap and <cos_f> are 0 at every g^2 and both S; with H_B the gaps are %s "
+      "and <cos_f> = %s, falling with the coupling"
+      % (" ".join("%.6f" % x for x in gapsT), " ".join("%.6f" % x for x in cosT)),
+      all(abs(x) < TOL for x in gapsF) and all(abs(x) < TOL for x in cosF)
+      and all(close(a, b) for a, b in zip(
+          gapsT, [0.395359309, 0.110635103, 0.017047410,
+                  0.411730513, 0.114075109, 0.017219995]))
+      and all(close(a, b) for a, b in zip(
+          cosT, [0.418514989, 0.210242684, 0.063343275,
+                 0.541713235, 0.244706153, 0.068692838])))
+
+E2T = [rows[(S, g2, True)][2] for S in (1, 2) for g2 in (1.0, 2.0, 4.0)]
+E2F = [rows[(S, g2, False)][2] for S in (1, 2) for g2 in (1.0, 2.0, 4.0)]
+sh = abs(rows[(2, 1.0, True)][0] - rows[(1, 1.0, True)][0]) / abs(rows[(1, 1.0, True)][0])
+check("D3 [numerical 1e-6] <E_e^2> at S = 1 is %s without H_B and %s with it: the flux window "
+      "is barely used, and the S = 1 to S = 2 shift in E_0 is %.2f%% at g^2 = 1 with H_B, so no "
+      "g^2 = 1 number with H_B is converged in S"
+      % (" ".join("%.6f" % x for x in E2F[:3]), " ".join("%.6f" % x for x in E2T[:3]),
+         100 * sh),
+      all(close(a, b, 1e-6) for a, b in zip(E2F, [0.205293, 0.145868, 0.089108,
+                                                  0.207299, 0.145984, 0.089111]))
+      and all(close(a, b, 1e-6) for a, b in zip(E2T, [0.289139, 0.168525, 0.091811,
+                                                      0.332564, 0.172734, 0.092001])))
+
+rv4 = rows[(2, 4.0, True)][4]
+mxr = [float(np.abs(rows[(1, g2, True)][4]).max()) for g2 in (1.0, 2.0, 4.0)]
+epsp = np.array([GP.eps[v] for v in Vp], dtype=float)
+check("D4 [numerical 1e-9] the coupled sea is NOT locally neutral: <rho_v> = %s at g^2 = 4 with "
+      "H_B, S = 2. C_4 fixes the pattern +a -a -a +a and hence the vanishing TOTAL, not the "
+      "value a, which falls with the coupling (max |<rho_v>| = %s at g^2 = 1, 2, 4, S = 1); "
+      "<N> = 2 and Hermiticity residual %.1e"
+      % (" ".join("%+.9f" % x for x in rv4), " ".join("%.3f" % x for x in mxr), herm),
+      close(abs(rv4[0]), 0.180762247) and abs(rv4.sum()) < TOL
+      and np.allclose(rv4, abs(rv4[0]) * epsp, atol=TOL)
+      and all(close(a, b, 1e-3) for a, b in zip(mxr, [0.426, 0.305, 0.181]))
+      and close(rows[(2, 4.0, True)][6], 2.0) and herm == 0.0)
+
+Sf = mono(GP.L.loop([Vp[0], GP.L.step(Vp[0], EX[0]),
+                     GP.L.step(GP.L.step(Vp[0], EX[0]), EX[1]),
+                     GP.L.step(Vp[0], EX[1])]))
+Msf = psmat(Sf, GP.nq)
+dcode = []
+for S in (1, 2):
+    bas, ix = BAS[S]
+    Pr = np.zeros((len(bas), len(bas)), dtype=np.complex128)
+    for a, (f, m) in enumerate(bas):
+        col = Msf[:, f]
+        for f2 in np.nonzero(np.abs(col) > 1e-12)[0]:
+            k = ix.get((int(f2), m))
+            if k is not None:
+                Pr[k, a] += col[f2]
+    w = np.linalg.eigvalsh((Pr + Pr.conj().T) / 2)
+    dcode.append(int(round(sum(1 for x in w if x > 0.5))))
+check("D5 [numerical 1e-9] the face stabiliser splits the plaquette Gauss sector in half, "
+      "26 = 13 + 13 and 50 = 25 + 25, so dim(Gauss and code) = %d and %d (spin 1/2 gave "
+      "14 = 7 + 7)" % (dcode[0], dcode[1]),
+      dcode == [13, 25])
+
+# ============================================== E -- the ring [exact + numerical]
+
+def ring_parity(Lv):
+    """which total fermion numbers the superfast ring encoding realises."""
+    g = Ring(Lv)
+    N = 1 << Lv
+    f = np.arange(N, dtype=np.int64)
+    tot = np.zeros(N, dtype=np.int64)
+    for v in range(Lv):
+        m = g.star[v]
+        p = np.zeros(N, dtype=np.int64)
+        for k in range(Lv):
+            if m >> k & 1:
+                p ^= ((f >> k) & 1)
+        tot += p
+    return sorted(set(int(x) % 2 for x in tot))
+
+
+ring_alg = True
+gr = Ring(8)
+for (i, j, e, ax, q) in gr.bonds:
+    A, T, K = gr.Aij(i, j), gr.Tij(i, j), gr.Kij(i, j)
+    ring_alg = ring_alg and acomm(A, gr.Bv(i)).iszero() and acomm(A, gr.Bv(j)).iszero() \
+        and (A * A - IDP).iszero() \
+        and (comm(gr.nv(i), T) - K.smul(MI)).iszero() \
+        and (comm(gr.nv(i), K) - T.smul(IMU)).iszero()
+    for w in gr.V:
+        if w in (i, j):
+            continue
+        ring_alg = ring_alg and comm(gr.nv(w), T).iszero() and comm(gr.nv(w), K).iszero()
+par = {Lv: ring_parity(Lv) for Lv in (4, 6, 8)}
+check("E1 [exact] the ring's hand-rolled superfast encoding satisfies the same relations "
+      "({A, B_i} = 0, A^2 = I, [n_i, T] = -iK, [n_i, K] = +iT, [n_w, T] = 0 off the bond) and "
+      "realises ONLY EVEN total fermion number at L = 4, 6, 8; half filling needs N = L/2, so "
+      "L = 0 mod 4 and L = 6 has an empty Gauss sector",
+      ring_alg and par[4] == par[6] == par[8] == [0])
+
+
+def pure_electric(Lv, d, g2, S=1):
+    best = None
+    q = [0] * Lv
+    if d > 0:
+        q[0], q[d] = +1, -1
+    for m in itertools.product(range(-S, S + 1), repeat=Lv):
+        if [m[v] - m[(v - 1) % Lv] for v in range(Lv)] != q:
+            continue
+        E = Fr(g2, 2) * sum(x * x for x in m)
+        best = E if best is None else min(best, E)
+    return best
+
+
+pe_ok = True
+pev = {}
+for g2 in (1, 4):
+    b0 = pure_electric(8, 0, g2)
+    for d in range(5):
+        V = pure_electric(8, d, g2) - b0
+        pev[(g2, d)] = V
+        pe_ok = pe_ok and V == Fr(g2, 2) * d
+check("E2 [exact] pure electric, no fermion, static +1 and -1 charges on the L = 8 ring at "
+      "S = 1: V(d) = (g^2/2) d EXACTLY in rational arithmetic for d = 0..4 at g^2 = 1 and 4 -- "
+      "a string whose energy grows linearly with the separation; S = 1 is already exact, the "
+      "minimiser using only E in {0, 1}", pe_ok)
+
+
+def ring_basis(g, S, qext):
+    Lv = g.Lv
+    off = [(1 - g.eps[v]) // 2 for v in range(Lv)]
+    bas = []
+    for f in range(1 << Lv):
+        n = [pcnt(f & g.star[v]) & 1 for v in range(Lv)]
+        rho = [n[v] - off[v] + qext[v] for v in range(Lv)]
+        if sum(rho) != 0:
+            continue
+        ps_, acc = [0] * Lv, 0
+        for v in range(Lv):
+            acc += rho[v]
+            ps_[v] = acc
+        lo = max(-S - x for x in ps_)
+        hi = min(S - x for x in ps_)
+        for c in range(int(np.ceil(lo)), int(np.floor(hi)) + 1):
+            bas.append((f, tuple(c + x for x in ps_)))
+    return bas, {b: a for a, b in enumerate(bas)}
+
+
+def ring_H(g, S, bas, ix, t, g2):
+    D = len(bas)
+    H = np.zeros((D, D), dtype=np.complex128)
+    for a, (f, m) in enumerate(bas):
+        H[a, a] += (g2 / 2) * sum(x * x for x in m)
+    if t:
+        for (i, j, e, ax, q) in g.bonds:
+            for (Pop, sh) in ((g.Tij(i, j), {+1: 1.0 + 0j, -1: 1.0 + 0j}),
+                              (g.Kij(i, j), {+1: -1j, -1: +1j})):
+                for (x, z), (re, im) in Pop.items():
+                    cc = complex(float(re), float(im))
+                    for a, (f, m) in enumerate(bas):
+                        c = cc * ((-1) ** pcnt(f & z))
+                        f2 = f ^ x
+                        for sgn, lc in sh.items():
+                            m2 = list(m)
+                            m2[q] += sgn
+                            if not (-S <= m2[q] <= S):
+                                continue
+                            k = ix.get((f2, tuple(m2)))
+                            if k is not None:
+                                H[k, a] += (-t * e / 2.0) * c * lc
+    return H
+
+
+def ring_run(Lv, g2, ds, want=None):
+    g = Ring(Lv)
+    out = {}
+    for d in ds:
+        q = [0] * Lv
+        if d > 0:
+            q[0], q[d] = +1, -1
+        bas, ix = ring_basis(g, 1, q)
+        H = ring_H(g, 1, bas, ix, 1.0, g2)
+        w, vv = np.linalg.eigh(H)
+        psi = vv[:, 0]
+        pr = np.abs(psi) ** 2
+        Ee = np.array([sum(pr[a] * bas[a][1][q2] for a in range(len(bas)))
+                       for q2 in range(Lv)])
+        nvv = np.array([sum(pr[a] * (pcnt(bas[a][0] & g.star[v]) & 1)
+                            for a in range(len(bas))) for v in range(Lv)])
+        out[d] = (float(w[0]), len(bas), Ee, nvv, float(nvv.sum()),
+                  float(np.abs(H - H.conj().T).max()))
+    return out
+
+
+r1 = ring_run(8, 1.0, range(5))
+r4 = ring_run(8, 4.0, range(5))
+V4 = [r4[d][0] - r4[0][0] for d in range(1, 5)]
+V1 = [r1[d][0] - r1[0][0] for d in range(1, 5)]
+dims8 = [r4[d][1] for d in range(5)]
+check("E3 [numerical 1e-9] with the fermion hop at half filling (t = 1) the STRING BREAKS: at "
+      "g^2 = 4 the potential is %s against the unbroken 2, 4, 6, 8, and it is not monotone -- "
+      "V(4) < V(3) at g^2 = 1 too (%s against 0.5, 1.0, 1.5, 2.0); Gauss dimensions %s, <N> = 4 "
+      "exactly at every separation" % (" ".join("%.6f" % x for x in V4),
+                                       " ".join("%.6f" % x for x in V1), dims8),
+      all(close(a, b) for a, b in zip(V4, [2.271563007, 2.383425096,
+                                           4.295401559, 2.819090192]))
+      and all(close(a, b) for a, b in zip(V1, [0.796888158, 0.796906164,
+                                               1.277804351, 1.026768433]))
+      and dims8 == [234, 150, 160, 132, 150]
+      and all(close(r4[d][4], 4.0) for d in range(5)))
+
+Ee4 = r4[4][2]
+nv4 = r4[4][3]
+check("E4 [numerical 1e-4] the mechanism, off the d = 4 ground state at g^2 = 4: the flux does "
+      "not span the separation but localises on the sources, sum_e |<E_e>| = %.3f against 4 "
+      "unbroken, dying to %.4f three links away; the screening charge shows as a HOLE "
+      "<n> = %.3f at the +1 source and a fermion <n> = %.3f at the -1 source"
+      % (float(np.abs(Ee4).sum()), abs(float(Ee4[3])), float(nv4[0]), float(nv4[4])),
+      close(float(np.abs(Ee4).sum()), 1.6032, 1e-4)
+      and close(float(nv4[0]), 0.1805, 1e-4) and close(float(nv4[4]), 0.9811, 1e-4)
+      and abs(float(Ee4[3])) < 0.01)
+
+s1 = ring_run(4, 1.0, range(3))
+s4 = ring_run(4, 4.0, range(3))
+W1 = [s1[d][0] - s1[0][0] for d in (1, 2)]
+W4 = [s4[d][0] - s4[0][0] for d in (1, 2)]
+check("E5 [numerical 1e-6] finite-size cross-check on the L = 4 ring: V = %s at g^2 = 1 and %s "
+      "at g^2 = 4, against the pure-electric 0.5, 1.0 and 2.0, 4.0 -- saturated there too, so "
+      "the breaking is not an L = 8 artefact; the values are finite-size numbers and carry no "
+      "infinite-volume statement"
+      % (" ".join("%.6f" % x for x in W1), " ".join("%.6f" % x for x in W4)),
+      all(close(a, b, 1e-6) for a, b in zip(W1, [0.762517, 0.594051]))
+      and all(close(a, b, 1e-6) for a, b in zip(W4, [2.271118, 2.169659]))
+      and s1[0][1] == 26)
+
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache joining this session's gauge-coupling lane with the sister session's light lane: **the emergent fermion's charge couples exactly to a compact U(1) link (integer flux) at every coordination, the electric term is dynamical, the Wilson plaquette term commutes with Gauss's law and lies in the sister lane's quadratic basin (open PR #7884), static charges on a ring confine with the exact linear potential `(g^2/2) d`, and the string breaks by pair creation once the matter is present.** The structure is the Kogut-Susskind U(1) Hamiltonian with staggered fermions, said plainly; the "designed" status is unchanged. **One premise carried into the computation was wrong and is reported as such:** integer flux does not make the neutral-sea and bulk conventions coincide. It removes the coordination dependence of PR #7893's parity condition (`z_v` drops out) but selects the staggered background half-charge universally: `rho = n - 1/2` has a Gauss sector of dimension exactly zero on every block, coordination and truncation tested, while `rho = n - (1 - eps_v)/2` is solvable everywhere; the two differ on balanced blocks by an explicit `+-1/2` background link field, and on the open `3x3x3` block no such field exists. The link record is multi-valued (`log2(2S+1)` bits) and needs a collective role of several physical sites, named as an interface. **No photon is shown.**

- `docs/THE_FERMION_ON_COMPACT_U1_LINKS_THE_INTEGER_FLUX_SELECTS_THE_STAGGERED_GAUSS_LAW_AND_JOINS_THE_MAXWELL_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md` (329 lines)
- `scripts/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.py` (`TOTAL: PASS=28 FAIL=0`, 2.4 s; exact hybrid Pauli-link algebra; the cube counted by three independent methods, never diagonalised; no seeds)
- `logs/runner-cache/fermion_compact_u1_links_staggered_gauss_law_join_check_2026_09_03.txt`

## Theorems

- **T1** the coupling `(T_ij C_e + K_ij S_e)/2` on all 140 bond checks (plaquette, cube, open `3x3x3`; `S = 1, 2`), reducing to PR #7893's form at spin 1/2; `[G_v, H^g] = 0` at every coordination 2 to 6.
- **T2** the census: plaquette 26 / 50, cube 102304 / 1477920, ring 234 (staggered convention); 0 everywhere for the sea convention; all 2240 half-filled fermion patterns admit, in eight multiplicity classes identical at both `S`; `dim(Gauss ∩ code) = 13, 25`; PR #7893's 14400 is the sea convention at spin 1/2.
- **T3** the electric spectrum `{0, 1}`, `{0, 1, 4}`; `[P_f, G_v] = 0` on all face-corner pairs; zero leaked amplitude from the Gauss sector; `V''(0) = 1/g^2 > 0`.
- **T4** plaquette numerics at `g^2 = 1, 2, 4` with and without the magnetic term; `<rho_v>` not zero by symmetry (`0.426, 0.305, 0.181` at `S = 1`).
- **T5** the ring (`L = 8` main, `L = 4` cross-check; `L = 0 mod 4` forced by the encoding's even-`N` realisation): `V(d) = (g^2/2) d` exactly without matter; with matter the string breaks (`2.27, 2.38, 4.30, 2.82` against `2, 4, 6, 8` at `g^2 = 4`), the flux localising on the sources with a hole at one and a fermion at the other.

## Boundary

- Coarse lattice; named finite blocks and rings; truncations `S = 1, 2` for every numerical item (the untruncated Gauss sectors are infinite); designed link role and declared dynamics; the sister-lane PR cited as an open pointer, not authority; nothing derived from the axioms; no photon. Executor corrections kept: 140 bond checks (not 36); the ring numbers are `L = 8`; `<rho_v> = 0.181` is the `g^2 = 4` value; two source bugs in the scratch census and Gauss assembly found and fixed.

## Context

- Parents: PR #7893 (the spin-1/2 coupling and its convention tension, resolved here in one direction), PR #7892 (the current), PR #7899 (the glued level, whose breakable counterpart the string exhibits), PR #7834. Sister lane: PR #7884, #7886, #7887 (open).
- Part of the owner-authorised 24-hour matter-to-TOE campaign (2026-09-02/03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
