### PR TITLE
science(light): local auxiliary conditionals realize the gauge measure

### DIFF
--- a/docs/U1_AUXILIARY_FACE_LOCAL_CONDITIONALS_UNCONDITIONAL_GAUGE_MEASURE_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/U1_AUXILIARY_FACE_LOCAL_CONDITIONALS_UNCONDITIONAL_GAUGE_MEASURE_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,595 @@
+# Local Auxiliary-Face Conditionals Realize the Gauge Measure Without Postselection
+
+**Date:** 2026-09-03
+**Claim type:** bounded_theorem
+**Status authority:** independent audit only. This source note sets no audit
+verdict, changes no TOE score, and claims no obligation retirement.
+**Direct parent:**
+[`U1_RECORD_FACE_LIKELIHOOD_SPATIAL_GAUGE_AND_PHOTON_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_RECORD_FACE_LIKELIHOOD_SPATIAL_GAUGE_AND_PHOTON_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+**Overlap parent:**
+[`U1_RECORD_DISTRIBUTION_OVERLAP_POSITIVE_MAXWELL_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_RECORD_DISTRIBUTION_OVERLAP_POSITIVE_MAXWELL_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+**Current axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+**Runner:**
+[`scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py`](../scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py)
+**Cached receipt:**
+[`logs/runner-cache/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.txt`](../logs/runner-cache/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.txt)
+
+## Claim scope
+
+Let `G=Z_N` and let `T:G->R_{>0}` be a strictly positive, even compact
+plaquette weight. The Record-overlap examples of the parents supply such a
+`T` on every finite cyclic refinement. On the doubled cubic incidence pattern,
+put a link possibility `ell_e in G` at every edge-role site. At every face-role
+site put an auxiliary possibility
+
+```text
+h_f in {star} union G^4.
+```
+
+The four entries of a non-universal `h_f` are ordered by the four edge sites
+in that face site's nearest-neighbor star. Choose
+
+```text
+epsilon = (1/2) min_(g in G) T(g),
+```
+
+and define one local nonnegative face factor
+
+```text
+F_f(star; ell_boundary) = epsilon,
+
+F_f(a; ell_boundary)
+ = T(curl a)-epsilon       if a=ell_boundary,
+ = 0                       otherwise.
+```
+
+Then on every finite periodic incidence complex:
+
+1. **Exact unconditional marginal.** Summing the auxiliary at each face gives
+
+   ```text
+   sum_(h_f) F_f(h_f;ell_boundary)=T(Phi_f),
+   ```
+
+   so the normalized joint distribution
+
+   ```text
+   mu(ell,h) proportional to product_f F_f(h_f;ell_boundary)
+   ```
+
+   has link marginal
+
+   ```text
+   mu_link(ell) proportional to product_f T(Phi_f).
+   ```
+
+   No special Record outcome is conditioned on and no auxiliary outcome is
+   discarded before the weight is produced.
+
+2. **Nearest-neighbor full conditionals on support.** At a face, conditional
+   on its four neighboring links, exactly two possibilities have positive
+   probability:
+
+   ```text
+   Pr(star|ell_boundary)=epsilon/T(Phi),
+   Pr(ell_boundary|ell_boundary)=1-epsilon/T(Phi).
+   ```
+
+   At a link, the only relevant conditions are its adjacent face auxiliaries.
+   If all are `star`, the link is uniform on `G`; if any carries a tuple, its
+   incident component fixes the link. All tuple demands agree on the joint
+   support. A conflicting zero-probability neighbor context may be assigned a
+   covariant fallback without changing `mu`.
+
+3. **Compatibility and uniqueness.** The universal state has positive weight.
+   From any supported state, turn every face to `star`, change links one at a
+   time, and turn any desired faces back to their matching tuples. Thus the
+   single-site support graph is connected. The displayed local full
+   conditionals determine `mu` uniquely on that support, and their random-scan
+   heat-bath chain is reversible.
+
+4. **Gauge and cubic covariance.** A gauge transformation acts simultaneously
+   on the links and on every matching tuple; `star` is fixed. Curl and `T` are
+   unchanged. Proper cubic rotations permute faces and tuple slots; orientation
+   reversal sends `Phi` to `-Phi`, which evenness removes.
+
+This is a finite constructive theorem for any strictly positive `T`, not only
+the runner's example. The runner exhausts the parent's `Z_4` Record overlap
+`T=(85,50,40,50)` on a one-face support and on all `65,536` link
+configurations of a `2 x 2` periodic gauge lattice. It also follows a strictly
+positive trigonometric Record density through `Z_N`,
+`N=8,16,32,64,128,256`, and verifies convergence of the discrete curvature to
+the parent's positive `U(1)` curvature.
+
+This removes the direct parent's **postselection and joint-compatibility
+caveat for the finite candidate law**. The plaquette measure is now an
+unconditional marginal of one compatible local-conditional system. It does
+not derive this local rule from the axioms' unspecified distribution, provide
+a Record-production history, or finish the internal role/readout compilation.
+It also does not prove a continuous compact interacting photon or identify the
+field with electromagnetism.
+
+## 1. The two-state decomposition at one face
+
+Fix the four neighboring link values
+
+```text
+a=(a_1,a_2,a_3,a_4) in G^4,
+Phi(a)=a_1+a_2-a_3-a_4.
+```
+
+Only two auxiliary values contribute:
+
+```text
+F(star;a)=epsilon,
+F(a;a)=T(Phi(a))-epsilon.
+```
+
+Because `epsilon=(1/2)min T`, both are strictly positive and every other tuple
+has weight zero. Their sum is exactly `T(Phi(a))`. This is an identity for
+every boundary tuple, not an asymptotic or a fitted normalization.
+
+The half-minimum choice removes a free scalar from this construction. Other
+values `0<epsilon<min T` give the same link marginal but different readable
+auxiliary statistics. The runner checks `epsilon=1`, the canonical value `20`,
+and `39` for `T=(85,50,40,50)`. At `epsilon=0`, the universal state has zero
+weight and cannot connect tuple sectors. At an endpoint
+`epsilon>=min T`, at least one matching state loses strict positivity. These
+are controls on this decomposition, not a claim that every possible auxiliary
+decomposition must use the half-minimum.
+
+For a normalized overlap `q=T/T(0)`, multiplying every local factor by the
+same positive constant changes only the finite-volume partition function.
+The induced link probability and its negative-log action are unchanged.
+
+## 2. Global marginal without a selected outcome
+
+Given the links, different `h_f` variables occur in different factors. Hence
+finite distributivity gives
+
+```text
+sum_h product_f F_f(h_f;ell_boundary)
+ = product_f sum_(h_f) F_f(h_f;ell_boundary)
+ = product_f T(Phi_f).
+```
+
+Unlike the all-success likelihood in the direct parent, this equation sums
+**all** auxiliary possibilities and still leaves the plaquette weight. The
+reason is that `F` is an unnormalized factor of the joint measure, not a
+normalized descendant probability whose outcomes sum to one before the joint
+normalization.
+
+After the global partition function is applied, however, `F` yields ordinary
+normalized local full conditionals. The construction therefore avoids the
+parent's normalization trap without pretending that a normalized binary
+child can reweight its parent when forgotten.
+
+For the `Z_4` Record histogram `(8,4,2,1)/15`, direct pair counting gives
+
+```text
+T=(85,50,40,50),       epsilon=20.
+```
+
+The runner enumerates all `4^8=65,536` link configurations on the `2 x 2`
+periodic lattice. For each it sums all `2^4=16` supported universal/matching
+face masks and obtains exactly the target four-plaquette product. The local
+one-face identity is also checked on all `4^4=256` ordered boundaries for all
+three interior epsilon choices.
+
+## 3. The local full conditionals
+
+### Face site
+
+Condition on the four link neighbors. The normalization is the one-face
+marginal `T(Phi)`, so
+
+```text
+Pr(h=star | a)=epsilon/T(Phi(a)),
+Pr(h=a    | a)=[T(Phi(a))-epsilon]/T(Phi(a)),
+Pr(h=b    | a)=0 for b!=a.
+```
+
+These probabilities depend only on the face site's nearest-neighbor edge
+conditions. They normalize exactly and vary with `Phi` whenever `T` is
+nonconstant.
+
+### Edge site
+
+Condition on every other variable in a supported joint state. A neighboring
+face in state `star` contributes the same factor `epsilon` for every candidate
+link value. A neighboring tuple state contributes only when the candidate
+equals its incident tuple component. Therefore
+
+```text
+Pr(ell_e=g | adjacent h)
+ = 1/N                    if every adjacent h=star,
+ = 1 at the common demand if at least one h is a tuple,
+ = 0 otherwise.
+```
+
+The other three links around an incident face do not enter this conditional
+on support: their equality with the stored tuple is already fixed in the
+conditioning event. If tuple demands conflict, the conditioning event has
+zero `mu` probability and the full conditional is mathematically arbitrary;
+a fixed uniform fallback makes the candidate rule total without changing the
+joint measure.
+
+Thus both nontrivial site roles have distributions determined by their
+nearest-neighbor incidence conditions. This is stronger than merely writing a
+four-link action and declaring it local on a coarse face.
+
+The construction is still conditional on a supplied role sector. Vertex and
+cube roles, genesis of the role pattern, and a single microscopic rule table
+covering every possible malformed role neighborhood are not compiled here.
+
+## 4. Connected support makes the joint law determined
+
+Hard matching constraints can hide arbitrary weights in disconnected support
+components. The positive universal state is included to remove that problem.
+
+Take any supported `(ell,h)`. Each face may change from its matching tuple to
+`star` with positive conditional probability `epsilon/T(Phi)`. Once all faces
+are universal, each link conditional is uniform, so any target link
+configuration can be reached by single-site changes. Finally each target face
+may remain universal or change to its matching tuple with positive
+probability. The support graph is connected.
+
+Now let `mu` and `nu` be two normalized joint distributions on this support
+with the same displayed full conditionals. Along every allowed single-site
+edge `x<->y`, the conditional ratios give
+
+```text
+mu(y)/mu(x)=nu(y)/nu(x).
+```
+
+Connectivity makes `mu/nu` constant on the whole support, and normalization
+makes that constant one. Thus the local full conditionals select the joint
+measure uniquely at finite volume.
+
+On the one-face `Z_4` model the support has `2 x 4^4=512` states. The runner
+builds its entire single-site graph, visits all states, and checks every face
+and link heat-bath balance equation for the three epsilon choices. At
+`epsilon=0`, the 256 matching-tuple sectors cannot communicate, which is the
+explicit disconnected-support control.
+
+The heat-bath chain proves static compatibility and uniqueness. It is not
+identified with physical time or with a process that changes permanent
+Records.
+
+## 5. Gauge and proper-cubic covariance
+
+Around a square with vertices `0,1,2,3`, take positive link orientations
+`a_1:0->1`, `a_2:1->2`, `a_3:3->2`, and `a_4:0->3`. Then
+
+```text
+Phi=a_1+a_2-a_3-a_4.
+```
+
+Under `a_xy -> a_xy+lambda_y-lambda_x`, all four vertex phases cancel from
+`Phi`. Transform a matching auxiliary tuple by the same four link maps;
+`star` remains `star`. Equality and the factor weight are preserved. The
+runner checks all 256 boundary tuples against all 64 based `Z_4` gauge
+transformations.
+
+The eight square relabelings either preserve the oriented sum or reverse it.
+Since the Record overlap is even, `T(-Phi)=T(Phi)`. The runner checks all eight
+images of every boundary tuple. On the three-dimensional incidence complex,
+proper cubic rotations permute these face rules; the direct parent separately
+checks all 24 rotations of the spatial plaquette product.
+
+The tuple slots must transform with their incident edge directions. This is
+an exact abstract covariance rule. Realizing that slot action through a
+specific internal `M_2(C)` automorphism or a spatial composite remains part of
+the microscopic compiler interface.
+
+## 6. Capacity inside the one-site possibility algebra
+
+The full one-site possibility domain has algebraic presentation `M_2(C)`.
+At the level of distinct possibilities, the face alphabet fits explicitly:
+for `zeta=exp(2 pi i/N)`, map
+
+```text
+(a_1,a_2,a_3,a_4)
+ -> [[zeta^a1,zeta^a2],
+     [zeta^a3,zeta^a4]],
+
+star -> [[0,0],[0,0]].
+```
+
+This is injective for every finite `N`, and the same formula embeds
+`U(1)^4` as a subset of `M_2(C)`. The runner verifies distinctness for all
+`1+4^4=257` and `1+8^4=4097` labels.
+
+This algebraic capacity is not an orthogonal-readout theorem. If every
+auxiliary label must be perfectly distinguishable as an orthogonal quantum
+record, a composite needs at least
+
+```text
+ceil(log2(1+N^4))
+```
+
+qubits: `5,9,13,17` at `N=2,4,8,16`. The runner derives those costs. The
+framework may instead use nonorthogonal possibility content in the local law,
+but a physical readable-slot interpretation must decide which standard is
+required.
+
+## 7. Finite cyclic route toward the compact overlap germ
+
+Use the strictly positive density
+
+```text
+p(theta)=1+0.25 cos(theta)+0.15 sin(2 theta).
+```
+
+Sample and normalize it on `Z_N`. Its cyclic autocorrelation is strictly
+positive at every shift, so the auxiliary theorem applies at every tested
+`N`. Normalize the overlap at zero and use
+
+```text
+kappa_N = -2 log q_N(2 pi/N)/(2 pi/N)^2.
+```
+
+The runner verifies monotonically shrinking error through
+`N=8,16,32,64,128,256`, ending below `2e-5` from the parent's analytic
+
+```text
+kappa=||p'||_2^2/||p||_2^2>0.
+```
+
+Thus the exact finite local laws approach the same positive compact curvature.
+This is not yet a theorem interchanging the group refinement, spatial
+continuum, thermodynamic, and quantum limits. It supplies a concrete sequence
+on which that stronger analysis can be run.
+
+## 8. What changes in the TOE route
+
+The action/compatibility stack now has the following constructive sequence:
+
+```text
+neighbor-varying Record distribution on a compact shift orbit
+ -> positive even overlap kernel                         parent #7887
+ -> nearest-neighbor spatial face likelihood             parent #7906
+ -> unconditional gauge marginal from local conditionals this note
+ -> positive magnetic germ and two weak-field modes       parent #7906
+```
+
+The new step is not a synonym for the previous one. Parent #7906 required an
+all-success Record event to turn normalized face probabilities into a
+plaquette posterior. Here every auxiliary outcome is summed and the plaquette
+weight remains, while the resulting joint measure has compatible local full
+conditionals and connected support.
+
+What remains explicit:
+
+- selection of this auxiliary conditional family from the unspecified
+  Admissibility distribution;
+- the full rotation-covariant internal/role compiler on physical sites;
+- the Record formation/history process, if static full conditionals are not
+  taken as the complete probability law;
+- the electric/time law and relative propagation normalization;
+- the physical electromagnetic dictionary; and
+- simultaneous compact, thermodynamic, interacting, and quantum continuum
+  control.
+
+No axiom update is requested. This is a candidate law inside the room the
+minimal axioms deliberately leave for the extensional distribution.
+
+## 9. Executable evidence
+
+The runner reports `TOTAL: PASS=19 FAIL=0`. It verifies:
+
+- reconstruction of the finite Record overlap rather than insertion of its
+  four output weights;
+- all 257 auxiliary values on all 256 face boundaries for three interior
+  epsilon splits;
+- exact marginalization, positivity, normalization, and neighbor variation;
+- every based `Z_4` gauge transformation and every square relabeling;
+- the complete 512-state one-face support graph and all local heat-bath
+  balance equations;
+- every `2 x 2` link configuration and every one of its 16 supported face
+  masks at the canonical split;
+- local edge conditional composition on every incidence mask;
+- the zero-universal and endpoint controls;
+- injective `M_2(C)` labels and orthogonal composite costs; and
+- six cyclic refinements approaching the positive `U(1)` curvature.
+
+The single-face marginal identity, finite distributivity, conditional formulas,
+support path, conditional-ratio uniqueness proof, and covariance equations
+prove the general finite theorem. Exhaustive runs test every element of the
+declared `Z_4` blocks; the refinement sequence is a convergence check, not a
+proof of all simultaneous limits.
+
+## No-Go Discipline Gate
+
+This positive theorem contains three narrowed negative boundaries: normalized
+descendant probabilities cannot reweight a forgotten parent in the no-feedback
+model of #7906; the zero-universal version of this auxiliary construction has
+disconnected support; and the finite cyclic sequence is not itself a proof of
+the full continuous interacting theory. The gate below stress-tests only
+those statements and asserts no permanent impossibility.
+
+### N1 — Alternative route enumeration
+
+| Family | Object / mechanism / terminal obligation | Marker and outcome |
+|---|---|---|
+| `selected_face_event` | Normalized binary face outcomes / condition on all successes / obtain the plaquette posterior. | **ATTEMPTED:** positive in #7906, but retains a selected-event condition. |
+| `forgotten_descendant` | Normalized face outcomes / sum every outcome / obtain an unconditional parent reweighting. | **ATTEMPTED:** fails in the declared no-feedback model because each sum is one. |
+| `matching_only_auxiliary` | Hard matching tuples / exact face marginal / obtain locally connected support. | **ATTEMPTED:** marginal is exact but `epsilon=0` leaves disconnected tuple sectors. |
+| `universal_plus_matching` | One universal plus one matching tuple / positive overlap split / obtain both exact marginal and connected support. | **ATTEMPTED:** positive; this is the theorem. |
+| `full_conditionals` | Supported incidence graph / local conditional ratios / determine a unique finite joint measure. | **ATTEMPTED:** positive; connectivity and every one-face heat-bath equation pass. |
+| `one_site_algebra` | Explicit four-entry matrix label / inject the face alphabet into `M_2(C)` / meet possibility capacity. | **ATTEMPTED:** positive as an algebraic injection; orthogonal readout remains separate. |
+| `cyclic_refinement` | Strictly positive sampled Record densities / `Z_N -> U(1)` curvature / preserve the Maxwell germ. | **ATTEMPTED:** positive through six refinements; simultaneous continuum control remains open. |
+
+The failed matching-only and forgotten-descendant routes are not generalized
+beyond their displayed constructions. Positive feedback, other auxiliary
+factorizations, direct continuum specifications, and spatial composites remain
+live.
+
+### N2 — Wall-independence audit
+
+For promotion from this finite candidate to a physical source-free quantum
+electromagnetic law, the collapsed inputs are:
+
+```text
+W1 = microscopic role and rotation-covariant internal compiler,
+W2 = selection of this auxiliary conditional family,
+W3 = physical formation/history interpretation if static law is insufficient,
+W4 = electric/time dynamics and relative normalization,
+W5 = electromagnetic field/readout dictionary,
+W6 = compact interacting and simultaneous-limit control.
+```
+
+| Pair | `Wi -> Wj`? | `Wj -> Wi`? | Independent? |
+|---|---:|---:|---:|
+| W1, W2 | no | no | yes |
+| W1, W3 | no | no | yes |
+| W1, W4 | no | no | yes |
+| W1, W5 | no | no | yes |
+| W1, W6 | no | no | yes |
+| W2, W3 | no | no | yes |
+| W2, W4 | no | no | yes |
+| W2, W5 | no | no | yes |
+| W2, W6 | no | no | yes |
+| W3, W4 | no | no | yes |
+| W3, W5 | no | no | yes |
+| W3, W6 | no | no | yes |
+| W4, W5 | no | no | yes |
+| W4, W6 | no | no | yes |
+| W5, W6 | no | no | yes |
+
+An internal compiler does not select a probability table; a static table does
+not supply a formation history; electric evolution does not identify a field
+as electromagnetism; and a physical dictionary does not prove a simultaneous
+continuum limit. No pair collapses.
+
+### N3 — Hidden-wall scan
+
+“Supply” and “supplied” mark the cyclic group, role sector, local factor,
+fallback on zero-probability contexts, and any dynamics. The displayed
+`M_2(C)` map is an algebraic injection, not a claim of orthogonal readability.
+“Canonical” appears only in the parent's separately supplied weak-field
+quantization and is not used in this factor theorem. No “as is standard,”
+“the framework provides,” “naturally,” or “obviously” phrase carries a proof
+step. The global normalization, support, and finite-volume condition are
+explicit.
+
+### N4 — Residual matching
+
+| Cited surface | Its residual | Residual treated here | Match and use |
+|---|---|---|---|
+| `U1_RECORD_FACE_LIKELIHOOD_SPATIAL_GAUGE_AND_PHOTON_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md`, lines 90-96 and 375-385 | product joint and postselection are supplied | unconditional auxiliary marginal with connected compatible full conditionals | **yes**, direct target |
+| `U1_RECORD_DISTRIBUTION_OVERLAP_POSITIVE_MAXWELL_GERM_BOUNDED_THEOREM_NOTE_2026-09-03.md`, lines 251-269 and 326-350 | overlap factorization/ownership remains supplied | one explicit finite local joint-law realization | **partial**, candidate ownership but not law selection |
+| `G3_CROSS_EDGE_INDEPENDENCE_IS_A_FORMATION_GATE_ATOM_MARGINAL_IDENTITY_FROM_QUALIFICATION_BOUNDED_THEOREM_NOTE_2026-07-12.md`, lines 1-35 and 190-220 | marginals do not choose a coupling | explicit joint coupling and unique full-conditionals measure | **yes** in mathematical shape; no audit grade imported |
+| open PR #7901 | energy tests on record-shift chains | reversible full-conditionals chain on a gauge factor graph | **partial**, context only |
+| open PR #7903 | finite truncated interacting photon remains uncomputed | static factorization of a magnetic measure | **no**, dropped as witness and not claimed closed |
+
+The proof stands after dropping both open-PR pointers. They route future
+composition only.
+
+### N5 — Rhetoric and resolution audit
+
+“The zero-universal construction has disconnected support” is tested on every
+one-face state; it is not extended to all auxiliary designs. “A forgotten
+normalized child does not reweight its parent” is an exact per-face identity
+and lattice product in #7906's no-feedback model; feedback is explicitly
+outside that sentence. “Finite cyclic convergence is not the full interacting
+continuum” states an unexecuted scope rather than a negative theorem.
+
+The cached stdout carries the five-resolution certificate:
+
+```text
+per_element: every Z4 boundary tuple, auxiliary state, gauge transform, and square relabeling is checked
+per_site: face and edge full conditionals are normalized and depend only on incidence neighbors on support
+per_mode: checked and not executed — this factorization changes no parent Hessian eigenvalue or momentum mode
+per_block: all 512 one-face support states and three epsilon splits are checked for balance and connectivity
+lattice_wide: every 2x2 Z4 link configuration and all 16 auxiliary masks are marginalized exactly
+```
+
+### N6 — Partial-closure paths and primitive check
+
+The current primitive registry and all three source notes were reread. The
+scale-reference primitive supplies units only. The kinetic-isotropy primitive
+supplies structural `c_t=c_s` graining, not this factor, a gauge Hamiltonian,
+or formation. The realized-state primitive supplies pointwise evaluation, not
+a state, measure, probability, or selector. They are premise nodes with their
+declared scopes and are neither walls nor expanded here.
+
+Live partial-closure routes are concrete:
+
+- compile the tuple-slot transformation through an explicit spatial composite
+  or an allowed internal action on the displayed `M_2(C)` injection;
+- prove a direct continuous mixed auxiliary measure instead of approaching it
+  only through `Z_N`;
+- treat the static compatible full-conditionals law as the probability theory
+  and derive predictions without adding a record-changing tick;
+- or build a fresh-site formation history whose event conditionals equal this
+  static law.
+
+Adopting a candidate extensional law would be downstream model selection, not
+a new axiom. Deriving the law from a smaller consistency class would be the
+preferred import-retirement path.
+
+### N7 — Steelman
+
+A hostile reviewer can argue that the supposed microscopic compiler wall is
+nearly gone: `M_2(C)` has four complex entries, this note gives an explicit
+injective `U(1)^4` label, and the face site already has exactly the four edge
+neighbors the tuple describes. The remaining work may be a routine covariant
+slot permutation rather than new physics. That route is credible, so this
+note does not declare a compiler no-go. Its exact terminal obligation is to
+write one proper-cubic-covariant rule on every physical role and show that its
+Record-readable interpretation preserves the abstract full conditionals.
+Likewise, if physical predictions are exhausted by a static conditional
+probability law, no extra formation dynamics may be needed. The theorem leaves
+both stronger positive readings open.
+
+### N8 — Cross-cycle echo
+
+The repository search found the same marginal-versus-joint distinction in
+`G3_CROSS_EDGE_INDEPENDENCE_IS_A_FORMATION_GATE_ATOM_MARGINAL_IDENTITY_FROM_QUALIFICATION_BOUNDED_THEOREM_NOTE_2026-07-12.md`.
+That note isolated the joint coupling as an open formation atom; this theorem
+does not dismiss it, but supplies and uniquely characterizes one coupling for
+the finite gauge model. The Record-occurrence axiom update retired an older
+absence-of-occurrence statement while preserving the concrete formation-rule
+residual; the applicable lesson is to keep the static law/formation distinction
+explicit. Open PRs #7900 and #7902 show that one joint-formation unit succeeds
+on flat-band blocks and fails to generalize automatically, so they motivate a
+compiler test rather than a general negative conclusion.
+
+**Gate result:** PASS for the three scoped boundaries. Seven materially
+different routes were executed, the hard-matching failure was repaired by a
+positive universal state, the wall set was pairwise audited, and both the
+continuous and microscopic steelman routes remain open.
+
+## Falsifiers
+
+The finite theorem fails if any of the following occurs:
+
+- the universal and matching weights do not sum to `T(Phi)` for some boundary;
+- the canonical half-minimum split is not strictly positive;
+- the link marginal differs from `product_f T(Phi_f)` after every auxiliary is
+  summed;
+- a supported face or edge full conditional depends on a non-neighboring site;
+- the positive-universal support graph is disconnected;
+- two distinct normalized measures on that connected support share all the
+  displayed full conditionals;
+- a gauge transformation or square relabeling changes a local factor;
+- the finite auxiliary alphabet does not inject into `M_2(C)` as displayed;
+  or
+- the declared positive-density cyclic sequence fails its stated curvature
+  convergence check.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=19 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15761,
- "node_count": 5563,
+ "edge_count": 15764,
+ "node_count": 5564,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18701,6 +18701,10 @@
   "u0_su2_bivector_irrep_analytic_derivation_narrow_theorem_note_2026-05-17": {
    "deps_hash": "4514c6f97532",
    "out_degree": 1
+  },
+  "u1_auxiliary_face_local_conditionals_unconditional_gauge_measure_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "fff5d03a38f8",
+   "out_degree": 3
   },
   "u1_det_sector_bi_orbit_quotient_step_law_baseline_decomposition_bounded_theorem_note_2026-06-10": {
    "deps_hash": "2c3aa3968ee1",

--- a/logs/runner-cache/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.txt
+++ b/logs/runner-cache/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.txt
@@ -1,0 +1,37 @@
+===== runner cache v1 =====
+runner: scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py
+runner_sha256: f1ea4e913d0046bf98359be319b48177d64de81bff7e773cfe84c1d840f292a5
+input_fingerprint_sha256: 99a3cd5861a594175f4bf5e1a267ff3cd963709e1a6ad02c04c106b1962256ed
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 24.63
+status: ok
+----- stdout -----
+[PASS] 01 the parent finite Record overlap is reconstructed rather than hard-coded as a weight
+[PASS] 02 half the kernel minimum gives a positive parameter-free auxiliary split
+[PASS] 03 universal plus matching auxiliary states marginalize exactly to every face weight
+[PASS] 04 each supported face condition has exactly two strictly positive auxiliary states
+[PASS] 05 three distinct auxiliary splits give the identical physical plaquette marginal
+[PASS] 06 face full conditionals normalize and vary with the four neighboring link values
+[PASS] 07 zero and endpoint auxiliary splits lose strict two-state support
+[PASS] 08 all 16384 boundary tuples and based gauge transformations preserve the face factor
+[PASS] 09 all square rotations and orientation reversals preserve the even auxiliary factor
+[PASS] 10 the 512-state one-face support is connected by single-site conditional moves
+[PASS] 11 face and link heat-bath moves satisfy exact detailed balance for every split
+[PASS] 12 all 65536 link configurations recover the target four-face weight at an interior split
+[PASS] 13 summing all 16 supported auxiliary masks reproduces each global marginal exactly
+[PASS] 14 every supported edge conditional is uniform or fixed by adjacent face states alone
+[PASS] 15 the universal component connects support; zero weight leaves disconnected tuple sectors
+[PASS] 16 the universal state and every finite boundary tuple inject distinctly into M2(C)
+[PASS] 17 an orthogonal auxiliary readout costs 4 log2(N)+1 qubits for power-of-two N
+[PASS] 18 the positive-density cyclic refinements admit the auxiliary split at every N
+[PASS] 19 finite cyclic auxiliary models converge to the parent's positive U1 curvature
+per_element: every Z4 boundary tuple, auxiliary state, gauge transform, and square relabeling is checked
+per_site: face and edge full conditionals are normalized and depend only on incidence neighbors on support
+per_mode: checked and not executed — this factorization changes no parent Hessian eigenvalue or momentum mode
+per_block: all 512 one-face support states and three epsilon splits are checked for balance and connectivity
+lattice_wide: every 2x2 Z4 link configuration and all 16 auxiliary masks are marginalized exactly
+TOTAL: PASS=19 FAIL=0
+
+----- stderr -----
+

--- a/scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py
+++ b/scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""Checks for an auxiliary-face local realization of a plaquette measure.
+
+For a strictly positive finite cyclic plaquette weight T and any
+0 < epsilon < min(T), a face auxiliary has one universal state plus one state
+for each ordered boundary-link tuple.  Its local factor is epsilon in the
+universal state, T(curl)-epsilon for the matching tuple, and zero otherwise.
+Summing the face auxiliary returns T(curl) exactly.  The universal state also
+connects the support under single-site full-conditional moves.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from collections import deque
+from fractions import Fraction
+from typing import Iterable
+
+import numpy as np
+
+from u1_record_distribution_overlap_maxwell_germ_2026_09_03 import (
+    kernel_curvature,
+    overlap_coefficients,
+)
+from u1_record_face_likelihood_spatial_gauge_photon_germ_2026_09_03 import (
+    configuration_weight,
+    decode_configuration,
+    face_terms,
+    flux,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "scripts/u1_record_distribution_overlap_maxwell_germ_2026_09_03.py",
+    "scripts/u1_record_face_likelihood_spatial_gauge_photon_germ_2026_09_03.py",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def encode_tuple(values: tuple[int, ...], group_order: int) -> int:
+    index = 0
+    multiplier = 1
+    for value in values:
+        index += value * multiplier
+        multiplier *= group_order
+    return index
+
+
+def decode_tuple(index: int, length: int, group_order: int) -> tuple[int, ...]:
+    return decode_configuration(index, length, group_order)
+
+
+def tuple_flux(boundary: tuple[int, int, int, int], group_order: int) -> int:
+    first, second, third, fourth = boundary
+    return (first + second - third - fourth) % group_order
+
+
+def face_factor(
+    auxiliary: int,
+    boundary: tuple[int, int, int, int],
+    overlap: tuple[int, ...],
+    epsilon: int,
+) -> int:
+    """Auxiliary zero is universal; 1+encoded tuple is a matching state."""
+
+    if auxiliary == 0:
+        return epsilon
+    encoded = encode_tuple(boundary, len(overlap))
+    if auxiliary != encoded + 1:
+        return 0
+    return overlap[tuple_flux(boundary, len(overlap))] - epsilon
+
+
+def face_marginal(
+    boundary: tuple[int, int, int, int],
+    overlap: tuple[int, ...],
+    epsilon: int,
+) -> int:
+    auxiliary_count = 1 + len(overlap) ** len(boundary)
+    return sum(
+        face_factor(auxiliary, boundary, overlap, epsilon)
+        for auxiliary in range(auxiliary_count)
+    )
+
+
+def face_conditionals(
+    boundary: tuple[int, int, int, int],
+    overlap: tuple[int, ...],
+    epsilon: int,
+) -> tuple[Fraction, Fraction]:
+    total = overlap[tuple_flux(boundary, len(overlap))]
+    return Fraction(epsilon, total), Fraction(total - epsilon, total)
+
+
+def boundary_gauge_transform(
+    boundary: tuple[int, int, int, int],
+    gauge: tuple[int, int, int, int],
+    group_order: int,
+) -> tuple[int, int, int, int]:
+    """Boundary links a:0->1, b:1->2, c:3->2, d:0->3."""
+
+    first, second, third, fourth = boundary
+    lam_0, lam_1, lam_2, lam_3 = gauge
+    return (
+        (first + lam_1 - lam_0) % group_order,
+        (second + lam_2 - lam_1) % group_order,
+        (third + lam_2 - lam_3) % group_order,
+        (fourth + lam_3 - lam_0) % group_order,
+    )
+
+
+def dihedral_boundaries(
+    boundary: tuple[int, int, int, int], group_order: int
+) -> tuple[tuple[int, int, int, int], ...]:
+    """Eight square relabelings, expressed in the fixed a+b-c-d convention."""
+
+    first, second, third, fourth = boundary
+    path_oriented = (first, second, -third, -fourth)
+    transformed: list[tuple[int, int, int, int]] = []
+    for shift in range(4):
+        rotated = path_oriented[shift:] + path_oriented[:shift]
+        for reflected in (False, True):
+            values = rotated
+            if reflected:
+                values = tuple(-value for value in reversed(rotated))
+            transformed.append(
+                (
+                    values[0] % group_order,
+                    values[1] % group_order,
+                    (-values[2]) % group_order,
+                    (-values[3]) % group_order,
+                )
+            )
+    return tuple(transformed)
+
+
+def transformed_auxiliary(
+    auxiliary: int,
+    transform,
+    group_order: int,
+) -> int:
+    """Apply a boundary relabeling to a tuple auxiliary; leave star fixed."""
+
+    if auxiliary == 0:
+        return 0
+    boundary = decode_tuple(auxiliary - 1, 4, group_order)
+    return 1 + encode_tuple(transform(boundary), group_order)
+
+
+def single_face_supported_states(
+    group_order: int,
+) -> tuple[tuple[tuple[int, ...], int], ...]:
+    states = []
+    for boundary_raw in itertools.product(range(group_order), repeat=4):
+        boundary = tuple(boundary_raw)
+        matching = 1 + encode_tuple(boundary, group_order)
+        states.append((boundary, 0))
+        states.append((boundary, matching))
+    return tuple(states)
+
+
+def single_face_weight(
+    state: tuple[tuple[int, ...], int],
+    overlap: tuple[int, ...],
+    epsilon: int,
+) -> int:
+    boundary, auxiliary = state
+    return face_factor(auxiliary, boundary, overlap, epsilon)
+
+
+def single_face_neighbours(
+    state: tuple[tuple[int, ...], int], group_order: int
+) -> Iterable[tuple[tuple[int, ...], int]]:
+    boundary, auxiliary = state
+    matching = 1 + encode_tuple(boundary, group_order)
+    if auxiliary == 0:
+        yield boundary, matching
+        for link in range(4):
+            for value in range(group_order):
+                if value == boundary[link]:
+                    continue
+                candidate = list(boundary)
+                candidate[link] = value
+                yield tuple(candidate), 0
+    else:
+        yield boundary, 0
+
+
+def support_connected(
+    group_order: int, overlap: tuple[int, ...], epsilon: int
+) -> tuple[bool, int]:
+    states = single_face_supported_states(group_order)
+    positive_states = {
+        state for state in states if single_face_weight(state, overlap, epsilon) > 0
+    }
+    unseen = set(positive_states)
+    start = next(iter(positive_states))
+    queue = deque([start])
+    unseen.remove(start)
+    edge_count = 0
+    while queue:
+        state = queue.popleft()
+        for neighbour in single_face_neighbours(state, group_order):
+            if neighbour not in positive_states:
+                continue
+            edge_count += 1
+            if neighbour in unseen:
+                unseen.remove(neighbour)
+                queue.append(neighbour)
+    return not unseen, edge_count
+
+
+def local_heat_bath_balance(
+    overlap: tuple[int, ...], epsilon: int
+) -> tuple[bool, int]:
+    group_order = len(overlap)
+    balanced = True
+    comparisons = 0
+    for boundary_raw in itertools.product(range(group_order), repeat=4):
+        boundary = tuple(boundary_raw)
+        matching = 1 + encode_tuple(boundary, group_order)
+        total = overlap[tuple_flux(boundary, group_order)]
+        star_weight = face_factor(0, boundary, overlap, epsilon)
+        tuple_weight = face_factor(matching, boundary, overlap, epsilon)
+        star_to_tuple = Fraction(tuple_weight, total)
+        tuple_to_star = Fraction(star_weight, total)
+        balanced = balanced and (
+            star_weight * star_to_tuple == tuple_weight * tuple_to_star
+        )
+        comparisons += 1
+
+        for link in range(4):
+            for value in range(group_order):
+                candidate = list(boundary)
+                candidate[link] = value
+                candidate_tuple = tuple(candidate)
+                forward = Fraction(1, group_order)
+                backward = Fraction(1, group_order)
+                balanced = balanced and star_weight * forward == face_factor(
+                    0, candidate_tuple, overlap, epsilon
+                ) * backward
+                comparisons += 1
+                tuple_candidate_weight = face_factor(
+                    matching, candidate_tuple, overlap, epsilon
+                )
+                balanced = balanced and (
+                    (value == boundary[link] and tuple_candidate_weight == tuple_weight)
+                    or (value != boundary[link] and tuple_candidate_weight == 0)
+                )
+                comparisons += 1
+    return balanced, comparisons
+
+
+def incidence_lists(
+    faces: tuple[tuple[tuple[int, int], ...], ...], link_count: int
+) -> tuple[tuple[tuple[int, int], ...], ...]:
+    incidence: list[list[tuple[int, int]]] = [[] for _ in range(link_count)]
+    for face_index, terms in enumerate(faces):
+        for boundary_position, (link, _sign) in enumerate(terms):
+            incidence[link].append((face_index, boundary_position))
+    return tuple(tuple(entries) for entries in incidence)
+
+
+def global_auxiliary_marginal_checks(
+    overlap: tuple[int, ...], epsilon: int
+) -> tuple[bool, bool, bool, int]:
+    group_order = len(overlap)
+    size = 2
+    dimension = 2
+    link_count = dimension * size**dimension
+    faces = face_terms(size, dimension)
+    incidence = incidence_lists(faces, link_count)
+    marginal_ok = True
+    support_weight_ok = True
+    local_edge_ok = True
+    masks = range(1 << len(faces))
+    for state in range(group_order**link_count):
+        configuration = decode_configuration(state, link_count, group_order)
+        boundaries = tuple(
+            tuple(configuration[link] for link, _sign in terms) for terms in faces
+        )
+        target = configuration_weight(configuration, faces, overlap)
+        local_sums = tuple(
+            face_marginal(boundary, overlap, epsilon) for boundary in boundaries
+        )
+        marginal_ok = marginal_ok and math.prod(local_sums) == target
+
+        support_sum = 0
+        for mask in masks:
+            joint_weight = 1
+            for face_index, boundary in enumerate(boundaries):
+                if mask & (1 << face_index):
+                    auxiliary = 1 + encode_tuple(boundary, group_order)
+                else:
+                    auxiliary = 0
+                joint_weight *= face_factor(
+                    auxiliary, boundary, overlap, epsilon
+                )
+            support_sum += joint_weight
+        support_weight_ok = support_weight_ok and support_sum == target
+
+    # On the joint support, a link is uniform iff every incident face is
+    # universal; otherwise the neighboring face tuple fixes it.  Evaluate the
+    # actual incident-factor products for every link and auxiliary mask.  The
+    # conclusion is independent of the chosen supported link configuration,
+    # so one nonuniform deterministic configuration exhausts the incidence
+    # and mask structure without repeating the same identity 4^8 times.
+    reference = tuple(link % group_order for link in range(link_count))
+    reference_boundaries = tuple(
+        tuple(reference[face_link] for face_link, _sign in terms)
+        for terms in faces
+    )
+    checked = 0
+    for link, entries in enumerate(incidence):
+        for mask in masks:
+            candidate_weights = []
+            for candidate_value in range(group_order):
+                candidate_configuration = list(reference)
+                candidate_configuration[link] = candidate_value
+                product = 1
+                for face_index, _position in entries:
+                    terms = faces[face_index]
+                    candidate_boundary = tuple(
+                        candidate_configuration[face_link]
+                        for face_link, _sign in terms
+                    )
+                    if mask & (1 << face_index):
+                        auxiliary = 1 + encode_tuple(
+                            reference_boundaries[face_index], group_order
+                        )
+                    else:
+                        auxiliary = 0
+                    product *= face_factor(
+                        auxiliary, candidate_boundary, overlap, epsilon
+                    )
+                candidate_weights.append(product)
+            tuple_incident = any(
+                mask & (1 << face_index) for face_index, _position in entries
+            )
+            if tuple_incident:
+                local_edge_ok = local_edge_ok and (
+                    candidate_weights[reference[link]] > 0
+                    and sum(weight > 0 for weight in candidate_weights) == 1
+                )
+            else:
+                local_edge_ok = local_edge_ok and (
+                    min(candidate_weights) > 0
+                    and len(set(candidate_weights)) == 1
+                )
+            checked += 1
+    return marginal_ok, support_weight_ok, local_edge_ok, checked
+
+
+def matrix_encoding_is_injective(group_order: int) -> bool:
+    encoded = {((0j, 0j), (0j, 0j))}
+    for boundary in itertools.product(range(group_order), repeat=4):
+        phases = tuple(
+            complex(
+                round(math.cos(2.0 * math.pi * value / group_order), 14),
+                round(math.sin(2.0 * math.pi * value / group_order), 14),
+            )
+            for value in boundary
+        )
+        encoded.add(((phases[0], phases[1]), (phases[2], phases[3])))
+    return len(encoded) == 1 + group_order**4
+
+
+def discretized_overlap_curvature(group_order: int) -> tuple[float, float]:
+    angles = 2.0 * math.pi * np.arange(group_order) / group_order
+    density = 1.0 + 0.25 * np.cos(angles) + 0.15 * np.sin(2.0 * angles)
+    probabilities = density / float(np.sum(density))
+    overlap = np.array(
+        [float(probabilities @ np.roll(probabilities, -shift)) for shift in range(group_order)]
+    )
+    normalized = overlap / overlap[0]
+    step = 2.0 * math.pi / group_order
+    curvature = -2.0 * math.log(normalized[1]) / step**2
+    return curvature, float(np.min(overlap))
+
+
+def main() -> int:
+    checks = Checks()
+    record_counts = (8, 4, 2, 1)
+    overlap = tuple(
+        sum(
+            record_counts[value] * record_counts[(value + shift) % len(record_counts)]
+            for value in range(len(record_counts))
+        )
+        for shift in range(len(record_counts))
+    )
+    checks.check(
+        overlap == (85, 50, 40, 50),
+        "the parent finite Record overlap is reconstructed rather than hard-coded as a weight",
+    )
+
+    factorization_ok = True
+    positive_ok = True
+    epsilon_invariant = True
+    conditionals_ok = True
+    conditional_families = []
+    canonical_epsilon = min(overlap) // 2
+    checks.check(
+        canonical_epsilon == 20 and 0 < canonical_epsilon < min(overlap),
+        "half the kernel minimum gives a positive parameter-free auxiliary split",
+    )
+    for epsilon in (1, canonical_epsilon, 39):
+        marginals = []
+        face_probabilities = set()
+        for boundary_raw in itertools.product(range(len(overlap)), repeat=4):
+            boundary = tuple(boundary_raw)
+            target = overlap[tuple_flux(boundary, len(overlap))]
+            marginal = face_marginal(boundary, overlap, epsilon)
+            marginals.append(marginal)
+            factorization_ok = factorization_ok and marginal == target
+            weights = [
+                face_factor(auxiliary, boundary, overlap, epsilon)
+                for auxiliary in range(1 + len(overlap) ** 4)
+            ]
+            positive_ok = positive_ok and min(weights) >= 0 and sum(
+                weight > 0 for weight in weights
+            ) == 2
+            star_probability, tuple_probability = face_conditionals(
+                boundary, overlap, epsilon
+            )
+            conditionals_ok = conditionals_ok and (
+                star_probability > 0
+                and tuple_probability > 0
+                and star_probability + tuple_probability == 1
+            )
+            face_probabilities.add(star_probability)
+        epsilon_invariant = epsilon_invariant and tuple(marginals) == tuple(
+            overlap[tuple_flux(tuple(boundary), len(overlap))]
+            for boundary in itertools.product(range(len(overlap)), repeat=4)
+        )
+        conditional_families.append(face_probabilities)
+    checks.check(
+        factorization_ok,
+        "universal plus matching auxiliary states marginalize exactly to every face weight",
+    )
+    checks.check(
+        positive_ok,
+        "each supported face condition has exactly two strictly positive auxiliary states",
+    )
+    checks.check(
+        epsilon_invariant,
+        "three distinct auxiliary splits give the identical physical plaquette marginal",
+    )
+    checks.check(
+        conditionals_ok and all(len(family) == 3 for family in conditional_families),
+        "face full conditionals normalize and vary with the four neighboring link values",
+    )
+
+    invalid_splits = []
+    for epsilon in (0, min(overlap), min(overlap) + 1):
+        all_weights = [
+            face_factor(epsilon_state, tuple(boundary), overlap, epsilon)
+            for boundary in itertools.product(range(len(overlap)), repeat=4)
+            for epsilon_state in (0, 1 + encode_tuple(tuple(boundary), len(overlap)))
+        ]
+        invalid_splits.append(
+            epsilon == 0 or min(all_weights) <= 0
+        )
+    checks.check(
+        all(invalid_splits),
+        "zero and endpoint auxiliary splits lose strict two-state support",
+    )
+
+    gauge_covariant = True
+    dihedral_covariant = True
+    auxiliary_count = 1 + len(overlap) ** 4
+    for boundary_raw in itertools.product(range(len(overlap)), repeat=4):
+        boundary = tuple(boundary_raw)
+        original_flux = tuple_flux(boundary, len(overlap))
+        original_weight = overlap[original_flux]
+        for gauge_tail in itertools.product(range(len(overlap)), repeat=3):
+            gauge = (0,) + tuple(gauge_tail)
+            transformed = boundary_gauge_transform(boundary, gauge, len(overlap))
+            gauge_covariant = gauge_covariant and (
+                tuple_flux(transformed, len(overlap)) == original_flux
+                and overlap[tuple_flux(transformed, len(overlap))] == original_weight
+            )
+            gauge_transform = lambda values, gauge=gauge: boundary_gauge_transform(
+                values, gauge, len(overlap)
+            )
+            for auxiliary in range(auxiliary_count):
+                transformed_state = transformed_auxiliary(
+                    auxiliary, gauge_transform, len(overlap)
+                )
+                gauge_covariant = gauge_covariant and face_factor(
+                    auxiliary, boundary, overlap, canonical_epsilon
+                ) == face_factor(
+                    transformed_state,
+                    transformed,
+                    overlap,
+                    canonical_epsilon,
+                )
+        boundary_images = dihedral_boundaries(boundary, len(overlap))
+        for image_index, transformed in enumerate(boundary_images):
+            transformed_flux = tuple_flux(transformed, len(overlap))
+            dihedral_covariant = dihedral_covariant and (
+                transformed_flux in (original_flux, -original_flux % len(overlap))
+                and overlap[transformed_flux] == original_weight
+            )
+            dihedral_transform = (
+                lambda values, image_index=image_index: dihedral_boundaries(
+                    values, len(overlap)
+                )[image_index]
+            )
+            for auxiliary in range(auxiliary_count):
+                transformed_state = transformed_auxiliary(
+                    auxiliary, dihedral_transform, len(overlap)
+                )
+                dihedral_covariant = dihedral_covariant and face_factor(
+                    auxiliary, boundary, overlap, canonical_epsilon
+                ) == face_factor(
+                    transformed_state,
+                    transformed,
+                    overlap,
+                    canonical_epsilon,
+                )
+    checks.check(
+        gauge_covariant,
+        "all 16384 boundary tuples and based gauge transformations preserve the face factor",
+    )
+    checks.check(
+        dihedral_covariant,
+        "all square rotations and orientation reversals preserve the even auxiliary factor",
+    )
+
+    connected, support_edges = support_connected(
+        len(overlap), overlap, canonical_epsilon
+    )
+    checks.check(
+        connected
+        and support_edges
+        == len(overlap) ** 4 * (2 + 4 * (len(overlap) - 1)),
+        "the 512-state one-face support is connected by single-site conditional moves",
+    )
+    balance_ok = True
+    balance_comparisons = 0
+    for epsilon in (1, canonical_epsilon, 39):
+        balanced, comparisons = local_heat_bath_balance(overlap, epsilon)
+        balance_ok = balance_ok and balanced
+        balance_comparisons += comparisons
+    checks.check(
+        balance_ok
+        and balance_comparisons
+        == 3 * len(overlap) ** 4 * (1 + 8 * len(overlap)),
+        "face and link heat-bath moves satisfy exact detailed balance for every split",
+    )
+
+    global_results = [
+        global_auxiliary_marginal_checks(overlap, canonical_epsilon)
+    ]
+    checks.check(
+        all(result[0] for result in global_results),
+        "all 65536 link configurations recover the target four-face weight at an interior split",
+    )
+    checks.check(
+        all(result[1] for result in global_results),
+        "summing all 16 supported auxiliary masks reproduces each global marginal exactly",
+    )
+    checks.check(
+        all(result[2] for result in global_results)
+        and sum(result[3] for result in global_results) == 128,
+        "every supported edge conditional is uniform or fixed by adjacent face states alone",
+    )
+
+    zero_split_connected, _ = support_connected(len(overlap), overlap, 0)
+    checks.check(
+        not zero_split_connected
+        and face_factor(0, (0, 0, 0, 0), overlap, 0) == 0,
+        "the universal component connects support; zero weight leaves disconnected tuple sectors",
+    )
+
+    checks.check(
+        matrix_encoding_is_injective(4) and matrix_encoding_is_injective(8),
+        "the universal state and every finite boundary tuple inject distinctly into M2(C)",
+    )
+    orthogonal_costs = tuple(
+        math.ceil(math.log2(1 + group_order**4))
+        for group_order in (2, 4, 8, 16)
+    )
+    checks.check(
+        orthogonal_costs == (5, 9, 13, 17),
+        "an orthogonal auxiliary readout costs 4 log2(N)+1 qubits for power-of-two N",
+    )
+
+    coefficients = overlap_coefficients((0.25, 0.0), (0.0, 0.15))
+    continuum_kappa = kernel_curvature(coefficients)
+    curvature_errors = []
+    positive_minima = []
+    for group_order in (8, 16, 32, 64, 128, 256):
+        curvature, minimum = discretized_overlap_curvature(group_order)
+        curvature_errors.append(abs(curvature - continuum_kappa))
+        positive_minima.append(minimum)
+    checks.check(
+        all(minimum > 0.0 for minimum in positive_minima),
+        "the positive-density cyclic refinements admit the auxiliary split at every N",
+    )
+    checks.check(
+        all(
+            left > right
+            for left, right in zip(curvature_errors, curvature_errors[1:])
+        )
+        and curvature_errors[-1] < 2.0e-5,
+        "finite cyclic auxiliary models converge to the parent's positive U1 curvature",
+    )
+
+    print(
+        "per_element: every Z4 boundary tuple, auxiliary state, gauge transform, and square relabeling is checked"
+    )
+    print(
+        "per_site: face and edge full conditionals are normalized and depend only on incidence neighbors on support"
+    )
+    print(
+        "per_mode: checked and not executed — this factorization changes no parent Hessian eigenvalue or momentum mode"
+    )
+    print(
+        "per_block: all 512 one-face support states and three epsilon splits are checked for balance and connectivity"
+    )
+    print(
+        "lattice_wide: every 2x2 Z4 link configuration and all 16 auxiliary masks are marginalized exactly"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

- Constructs one unconditional finite joint gauge measure from nearest-neighbor face and link full conditionals.
- Summing every auxiliary face possibility gives the target plaquette product exactly; no selected all-success outcome remains.
- A positive universal auxiliary state connects the hard-constraint support, so the displayed full conditionals determine a unique finite measure.
- Preserves finite gauge covariance and square/proper-cubic covariance, with an explicit one-site M2(C) possibility injection.

## Exact evidence

- New runner: TOTAL: PASS=19 FAIL=0.
- Exhausts all 256 Z4 face boundaries, 257 auxiliary labels, 64 based gauge transformations, eight square relabelings, the complete 512-state one-face support graph, all heat-bath balance equations, all 65,536 link configurations, and all 16 supported face masks on the 2x2 block.
- Parent stack rerun directly: 24/24, 29/29, 30/30, 27/27, and 30/30.
- Cache is source/input-fingerprint fresh; vocabulary lint has zero violations; changed-audit-evidence reports 0 failures; audit lint reports no errors beyond repository baseline warnings/notices.

## Honest boundary

This removes the postselection and joint-compatibility caveat for the finite candidate law. It does not derive the extensional local distribution from the axioms, compile the full physical role/readout rule, provide Record-formation history, supply electric/time dynamics, identify the field with electromagnetism, or prove the simultaneous compact interacting quantum continuum limit. It changes no audit verdict or TOE score.

## Stack

Stacked on #7906 because it directly replaces that PRs selected-event likelihood with an unconditional auxiliary marginal. The full N1-N8 scoped-boundary packet is included in the source note.