### PR TITLE
feat(matter): record-time domain wall on an open interval, partner mode forced

### DIFF
--- a/docs/THE_RECORD_TIME_DOMAIN_WALL_ON_AN_OPEN_INTERVAL_WHERE_THE_PARTNER_WEYL_MODE_LIVES_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_RECORD_TIME_DOMAIN_WALL_ON_AN_OPEN_INTERVAL_WHERE_THE_PARTNER_WEYL_MODE_LIVES_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,302 @@
+---
+claim_id: record_time_domain_wall_open_interval_partner_weyl_mode
+claim_type: bounded_theorem
+claim_scope: "In the free-field one-particle sector, on the named finite sizes only, with record time treated throughout as a SUPPLIED extra coordinate -- an ordered chain of N_s sites with nearest-neighbour adjacency, a hermitian momentum K_s, a Wilson Laplacian r_s L_s, a fifth Clifford generator Gamma_s in the four-component embedding Gamma_i = tau_1 (x) sigma_i, Gamma_s = tau_2 (x) I, Gamma_m = tau_3 (x) I with chi = i Gamma_s Gamma_m, a supplied mass field m(s), a supplied length L_5 = N_s and a supplied boundary condition, none of which is derived from any axiom: (T1) the landed periodic construction of DOMAIN_WALL_CHIRAL_EDGE_FROM_ACHIRAL_CL3_BULK_..._2026-07-04 reproduces digit for digit at N_s = 64, M = 0.8, r = r_s = 1 -- four light states at p = 0 with max|E| = 4.557e-09 and next gap 0.801204, wall window top-2 0.798565653 twice at peak s = 15 with xi_L = 0.621335 and xi_R = 1.701298, <chi> = +1.000000000000 and handedness -1, anti-wall top-2 0.880610823 twice at peak s = 48 with the two lengths interchanged, <chi> = -1.000000000000 and handedness +1, light counts [4,0,0,0,0,0,0,0] at the eight Brillouin-zone corners, chirality density +1.999950592685 in the wall zone against -1.999950592685 in the anti-wall zone at residual 0.0 and net +0.000000000000 on the circle. (T2) On an OPEN record-time interval at N_s = 64 the wall/anti-wall pairing survives: with one wall at the middle and hard (Dirichlet-completed) ends there are four EXACT zero modes, max|E| = 5.93e-16 against a next |E| of 0.801213, the <chi> = +1.000000000 doublet on the wall at peak s = 31 with handedness -1 and the <chi> = -1.000000000 doublet at the left end at peak s = 0 with IPR 0.9231 and handedness +1, the right end carrying no rank-2 light doublet, zone chiralities -2.000000000 / +1.999999996 / +0.000000004 and net +0.000000000000; free (Neumann) ends give the identical count with max|E| = 1.04e-15 and a less tightly bound partner (IPR 0.8427); a mirrored mass puts the partner on the other end (peak s = 63, IPR 0.9231, <chi> = +1.000000000); pinning the Wilson mass to the trivial sign m = +4.0 on the four end sites leaves the partner in the spectrum at s = 4, the inner edge of the pinned region, with IPR 0.8548, <chi> = -1.000000000 and zone chirality -1.996923274; a uniform topological mass with NO wall gives the same -1 / +1 pair on the two boundaries with max|E| = 9.19e-16; a uniform trivial mass gives zero light states; the Callan-Harvey inflow with one non-dynamical U(1) flux quantum through an L_x = L_y = 3 torus at N_s = 16, L_z = 7 and 15 twist steps is +1 on the wall branch, -1 on its partner and 0 in total in all four geometries flowed; and the light branch is an exact Weyl cone, |E| = |sin q| to eight decimals at q/pi = 0.05, 0.10, 0.20 on the interval and on the circle alike, with Brillouin-corner counts [4,0,0,0,0,0,0,0]. (T3) On a DECLARED family -- the complete enumeration of piecewise-constant profiles on N_s = 32 with breakpoints on the coarse grid {8, 16, 24}, adjacent segment values distinct, drawn from the alphabet {-3.0, -1.5, -0.5, +0.5, +1.5, +3.0}, giving 1296 profiles by transition count [6, 90, 450, 750], each taken on the open interval and on the circle, 2592 members with no randomness and no seed anywhere -- the number of localized chiral species equals the tau-transition count of the band-inversion sequence bracketed by the trivial vacuum, with 0 mismatches, and the net chirality is zero on every member at worst |net| = 6.661e-15; the band-inversion window of a uniform open slab at N_s = 48 is exactly -2 r_s < m < 0 at eight declared masses. (T4) The wall's local chirality inside a half-width-W window at N_s = 128 is +2 with deficit 4.941e-05, 4.068e-09, 3.366e-13 and 1.776e-15 at W = 8, 16, 24 and 32, and the wall/partner splitting decays exponentially in L_5 on both geometries, the interval reaching machine zero by L_5 = 48: the species is EXPONENTIALLY unpaired and never exactly unpaired. (T5) [statement] The diagnostic is a function of exactly seven supplied items -- the ordered coordinate, K_s, r_s L_s, Gamma_s, m(s), an unbounded L_5 and a boundary condition -- rebuilt from them alone it reproduces the operator at residual 0.0, none of them is redundant, and with all of them withdrawn what is left is the achiral spatial operator D(p) = i sum_i sigma_i sin(p_i) with eight zeros of winding signs four positive and four negative; record time is a supplied extra dimension and not a re-reading of a per-site record stack, because Record / Fixed Reality says a site never carries more than one record, so the per-site record set is a singleton; and the spatial wall of RECORD_WALLS_IN_THE_STAGGERED_MASS_..._2026-09-03 is a different construction -- a stacking fault in a mass the lattice has, eps_{v+e_x} = -eps_v at residual 0.0 with min|m(x)| = m -- reaching the same bottom line. The counting rule of T3 is VERIFIED ON A DECLARED FINITE FAMILY, not proved, and is not stated as a general no-go. Higher-dimensional and branching record time, smooth mass fronts, interactions, gauge coupling beyond the single non-dynamical flux quantum, dynamics and any fermion measure are out of scope. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py
+---
+
+# The record-time domain wall on an open interval: where the partner Weyl mode lives
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py`](../scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.txt`](../logs/runner-cache/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note; the landed note it extends is reproduced from scratch by the runner, not imported.
+
+A landed free-field diagnostic puts a domain wall in a mass along a supplied record-time direction and finds one handed Weyl species bound on the wall and its mirror
+image on the anti-wall. That construction lives on a **circle**, so the two interfaces come as a pair by construction. This note asks the obvious next question: **is
+the wall/anti-wall pairing forced, or is it an artefact of the periodic record time?** Cut the circle open and see where the partner goes.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite free-field linear-algebra theorems about one declared object: a sign change of a supplied mass along a supplied one-dimensional record-time coordinate. The operator identities of T5 and the interface counts are zero-residual or integer statements; the spectra, localisation lengths, chirality densities and spectral flows are floating-point cross-checks at the stated tolerance; the counting rule of T3 is a verification on a declared finite family, not a proof."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-size theorem, and route to its owner the question this note does not decide: whether a record-time direction of the kind the construction needs -- ordered, metrized, kinetic, unbounded -- can come from the law rather than being supplied."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`E`. The zero-residual and integer items are exact; the items tagged
+`[numerical]` are floating-point cross-checks at the stated tolerance. `T3` is a **verification on a declared finite family**, and is labelled as such wherever it appears.
+
+1. `T1` (`A`). The landed periodic construction, reproduced digit for digit.
+2. `T2` (`B`). The open interval: where the partner is bound, under every end convention computed.
+3. `T3` (`C`). The counting rule on the declared family, and the band-inversion window.
+4. `T4` (`D`). How unpaired the wall's species is: exponentially, never exactly.
+5. `T5` (`E`). The seven supplied items, and the coordinate itself as one of them.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. Jackiw-Rebbi zero modes, the Kaplan/Shamir domain-wall and slab constructions, the Callan-Harvey anomaly-inflow
+argument and the Nielsen-Ninomiya counting are standard methodology; every object is redeclared here and the runner recomputes every statement from scratch. No
+observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight:
+
+- [`DOMAIN_WALL_CHIRAL_EDGE_FROM_ACHIRAL_CL3_BULK_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-04.md`](DOMAIN_WALL_CHIRAL_EDGE_FROM_ACHIRAL_CL3_BULK_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-04.md):
+  the periodic construction this note extends, reproduced by group `A`.
+- [`DOMAIN_WALL_EDGE_ANOMALY_INFLOW_SPECTRAL_FLOW_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md`](DOMAIN_WALL_EDGE_ANOMALY_INFLOW_SPECTRAL_FLOW_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md):
+  the Callan-Harvey flow whose open-interval analogue is group `B`'s last check.
+- [`RECORD_FORMATION_FRONT_IS_THE_DOMAIN_WALL_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md`](RECORD_FORMATION_FRONT_IS_THE_DOMAIN_WALL_FREE_FIELD_BOUNDED_THEOREM_NOTE_2026-07-05.md):
+  the occupancy-to-mass bridge, in its own words "a motivated model/bridge, not a derivation"; its smooth `tanh` front is **not** covered here.
+- `RECORD_WALLS_IN_THE_STAGGERED_MASS_CARRY_LOCALIZED_2P1D_DIRAC_MATTER_VECTOR_LIKE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open branch): the spatial wall, contrasted in `T5`.
+- [`NO_PER_SITE_CHIRALITY_THEOREM_NOTE_2026-05-02.md`](NO_PER_SITE_CHIRALITY_THEOREM_NOTE_2026-05-02.md): there is no `gamma_5` inside the one-site algebra.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md): the axioms quoted in "Setting". No grade of theirs is cited and no hypothesis is adopted.
+
+## Setting
+
+The framework axioms are quoted, not amended. **Lattice / Physical Locality**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+adjacency, standard translations, and proper cubic rotations about each site." The lattice is physical. **Qubit / Site Possibility**: "Each site has a domain of local
+possibilities", whose "full one-site possibility domain has algebraic presentation `M_2(C)`". **Admissibility / Local Constraint**: "There is one fixed nearest-neighbor
+admissibility rule, covariant under lattice translations and proper cubic rotations", and "For each site, the probability distribution over the possibilities is
+determined by, and varies with, the nearest-neighbor conditions". **Record / Fixed Reality**: "Records form."; "When present, a record locks exactly one admissible local
+possibility. **A site never carries more than one record; records are permanent.**"; "Only records are readable."
+
+That last clause is load-bearing for `T5`. The per-site record set is a **singleton**: a site registers one record and it is permanent. So there is no per-site stack to
+index, and record time is not obtainable by re-reading one. The memo's **Open Gates Outside The Axioms** list says as much from the other side, naming "arrow,
+record-production dynamics, physical persistence dynamics, time metric, and local observability of records" as outside axiom content. Every record-time structure used
+below is therefore **supplied data**, declared in "Definitions" and nowhere derived.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the four-component embedding, the supplied
+record-time coordinate with its `K_s`, `r_s L_s`, `Gamma_s`, `m(s)`, `L_5` and boundary condition, and the Hamiltonian built from them. `P1` (`A`) is the reproduction of
+the periodic circle, which fixes the conventions and the localisation lengths every later group reads; `P2` (`B`) the open-interval spectra, zone decomposition,
+per-interface Weyl data, dispersion and spectral flow; `P3` (`C`) the counting rule on the declared family and the band-inversion window; `P4` (`D`) the window chirality
+and the `L_5` scaling, which uses `P1`'s measured `xi_L` and `xi_R`; `P5` (`E`) the supplied-item decomposition and the two contrasts. The strongest supported scope is
+precisely `P0`-`P5`.
+
+## Definitions
+
+```text
+embedding     Gamma_i = tau_1 (x) sigma_i,  Gamma_s = tau_2 (x) I,  Gamma_m = tau_3 (x) I
+chirality     chi = i Gamma_s Gamma_m = -tau_1 (x) I                     A SPECIES LABEL
+handedness    Tr(V_1 V_2 V_3) / 2i on the projected spatial velocities   THE WEYL SIGN
+H(p)          sum_i sin(p_i) Gamma_i + K_s (x) Gamma_s
+              + [ diag(m(s)) + r_s L_s + r sum_i (1 - cos p_i) ] (x) Gamma_m
+K_s           hermitian nearest-neighbour momentum on record time        SUPPLIED
+L_s           Wilson Laplacian on record time; 'hard' ends hold the diagonal at 1.0
+              (a psi = 0 ghost site outside), 'free' ends at 0.5         SUPPLIED
+m(s)          the record-time mass field; L_5 = N_s its length           SUPPLIED
+circle        m = -M outside [N_s/4, 3N_s/4), +M inside: one wall, one anti-wall
+interval      m = -M for s < N_s/2, +M above: ONE wall, two ends
+tau(m)        1D band-inversion index: 1 iff -2 r_s < m < 0, else 0
+chi(s)        sum over the light subspace of <psi_k| Pi_s chi |psi_k>    BASIS-FREE
+IPR           sum_s p(s)^2 on the normalised site profile
+xi            from rho(d) ~ exp(-2 d / xi), the landed runner's convention
+```
+
+Sizes: `M = 0.8`, `r = r_s = 1` throughout; `N_s = 64` for `T1` and `T2`, `N_s ∈ {16, 24, 32, 48, 64, 128}` for the scaling, `N_s = 48` for the window scan, `N_s = 32`
+for the declared family, and `L_x = L_y = 3`, `L_z = 7`, `N_s = 16`, 15 twist steps for the flow. The spatial directions are Fourier-transformed at fixed transverse
+momentum `p`, so the largest matrix is `576 x 576`.
+
+## Theorem 1 -- the landed periodic circle, reproduced digit for digit
+
+**Conclusion.** At `N_s = 64`, `M = 0.8`, `r = r_s = 1` there are four light states at `p = 0` with `max|E| = 4.557e-09` against a next gap of `0.801204`. The wall's
+localisation window has top-2 eigenvalues `0.798565653` twice at peak `s = 15`, with `xi_L = 0.621335`, `xi_R = 1.701298`, `<chi> = +1.000000000000` and handedness `-1`;
+the anti-wall's are `0.880610823` twice at peak `s = 48` with the two lengths interchanged, `<chi> = -1.000000000000` and handedness `+1`. The light counts at the eight
+Brillouin-zone corners are `[4,0,0,0,0,0,0,0]`. The basis-free chirality density puts `+1.999950592685` in the wall zone and `-1.999950592685` in the anti-wall zone at
+residual `0.0`, with net `+0.000000000000` on the circle. Every printed figure of the landed note reproduces.
+
+**Method.** Group `A` rebuilds the operator from the definitions above, diagonalises it, and reads the localisation windows inside the computed light subspace. The
+chirality **density** `chi(s)` is added here and is not in the landed runner: it localises the chirality without any window step, so the zone numbers do not depend on the
+window width. `<chi>` and handedness are two different quantities and are reported separately; they are anti-correlated in every geometry computed here, and `<chi>` is a
+species label rather than the physical Weyl sign.
+
+## Theorem 2 -- the open interval: the partner is bound at an end, not absent
+
+**Conclusion.** Replace the circle by an interval with **one** wall at the middle. (1) With hard ends there are four **exact** zero modes, `max|E| = 5.93e-16` against a
+next `|E|` of `0.801213`: the `<chi> = +1.000000000` doublet on the wall at peak `s = 31` with handedness `-1`, and the `<chi> = -1.000000000` doublet at the **left end**
+at peak `s = 0` with IPR `0.9231` and handedness `+1`. The right end carries no rank-2 light doublet; the zone chiralities are `-2.000000000`, `+1.999999996`,
+`+0.000000004` and the net is `+0.000000000000`. (2) Free (Neumann) ends give the identical count with `max|E| = 1.04e-15`; only the binding differs (IPR `0.8427`
+against `0.9231`). (3) A **mirrored** mass puts the partner on the other end (peak `s = 63`, IPR `0.9231`, `<chi> = +1.000000000`, zone `+2.000000000`): the hosting end
+is fixed by the mass profile, not by the end convention. (4) Pinning the Wilson mass to the **trivial** sign `m = +4.0` on the four end sites leaves the partner in the
+spectrum at `s = 4`, the inner edge of the pinned region, with IPR `0.8548`, `<chi> = -1.000000000` and zone chirality `-1.996923274`. (5) A **uniform topological** mass
+with no wall anywhere gives the same `-1` / `+1` pair on the two boundaries, `max|E| = 9.19e-16`; a uniform trivial mass gives **zero** light states. (6) The
+Callan-Harvey inflow with one non-dynamical `U(1)` flux quantum is `+1` on the wall branch, `-1` on its partner and `0` in total in all four geometries flowed. (7) The
+light branch is an exact Weyl cone: `|E| = |sin q|` to eight decimals at `q/pi = 0.05, 0.10, 0.20` on the interval and on the circle alike, with Brillouin-corner counts
+`[4,0,0,0,0,0,0,0]` for the one-wall interval and for the uniform topological slab.
+
+**Reading, not theorem.** Opening the circle does not produce a lone handed species. It relocates the partner from the anti-wall to the boundary. Gapping that boundary by
+pinning the mass sign does not delete the partner either; it relocates it inward, to the edge of the pinned region. And the wall is not what does the binding: a uniform
+topological bulk with no wall at all carries the same pair on its two boundaries. What is necessary is a region with `tau = 1` and a boundary.
+
+**Disclosure.** In the pinned geometry the flow tracker's Gaussian windows at `s = 0` and `s = 4` overlap at width 2, so it attributes the pin-edge branch's crossing to
+the `left_end` window. This is a window-overlap artefact of the tracking heuristic, not a crossing at `s = 0`: the zone decomposition of (4) places `-1.996923274` of the
+chirality at `s = 4`. The substance -- `+1` on the wall, `-1` on its partner, `0` in total -- is unaffected.
+
+## Theorem 3 -- the counting rule on a declared family
+
+**Conclusion.** Let the declared family be the **complete enumeration** of piecewise-constant profiles on `N_s = 32` with breakpoints on the coarse grid `{8, 16, 24}`,
+adjacent segment values distinct, drawn from the alphabet `{-3.0, -1.5, -0.5, +0.5, +1.5, +3.0}`: `1296` profiles, `[6, 90, 450, 750]` by transition count, each taken on
+the open interval and on the circle -- `2592` members, with **no randomness and no seed anywhere**. On every member the number of localized chiral species equals the
+number of `tau`-transitions in the sequence bracketed by the trivial vacuum (`[0, tau_1 … tau_k, 0]` on the interval, cyclic on the circle), with **0 mismatches**, and
+the net chirality is zero at worst `|net| = 6.661e-15`. Separately, on a uniform open slab at `N_s = 48` the band-inversion window is exactly `-2 r_s < m < 0`: four light
+states inside it and none outside, at eight declared masses, net zero at each.
+
+**Status of this statement.** This is a **verification on a declared finite family**, not a proof. The elementary bulk-boundary reading -- an interval returns to the
+trivial vacuum at both ends, so `tau` steps up and down equally often -- is stated here as motivation only, and is not established by anything in this note. It is not
+offered as a general no-go, and nothing here bears on record-time geometries outside the declared family.
+
+## Theorem 4 -- exponentially unpaired, never exactly unpaired
+
+**Conclusion.** At `N_s = 128` with one wall at the middle, the chirality inside a window of half-width `W` about the wall is `+2` with deficit `5.940e-02`,
+`5.448e-03`, `4.941e-05`, `4.068e-09`, `3.366e-13` and `1.776e-15` at `W = 2, 4, 8, 16, 24, 32`, while the total over the interval is zero to `1e-12`. The wall/partner
+splitting decays exponentially in `L_5` on both geometries, and the **interval decouples faster** than the circle at the same `L_5` -- its two interfaces face each other
+across the short-`xi` side, `xi_L = 0.621335` against `xi_R = 1.701298` -- reaching machine zero by `L_5 = 48` where the circle is still at `5.02e-07`.
+
+**Reading, not theorem.** A single wall supplies a species whose handedness is exact to `1.8e-15` inside a half-width-32 window and whose partner is `64` sites away. That
+is an **exponentially** unpaired species. It is never an exactly unpaired one at any finite `L_5` computed here, on any geometry computed here.
+
+## Theorem 5 -- the seven supplied items, and the coordinate is one of them
+
+**Conclusion.** (1) The diagnostic is a function of exactly seven supplied items -- an ordered coordinate `s` with nearest-neighbour adjacency, `K_s`, `r_s L_s`,
+`Gamma_s`, `m(s)` with a sign change, an unbounded `L_5`, and a boundary condition -- and rebuilt from those alone it reproduces the operator at residual `0.0`. (2) None
+is redundant: withdrawing `K_s`, `r_s L_s`, `Gamma_s` or `m(s)` changes the operator by `11.225`, `19.545`, `2.000`, `12.800` respectively. (3) With every record-time
+item withdrawn, what is left is the achiral spatial operator `D(p) = i sum_i sigma_i sin(p_i)`, with eight zeros on the Brillouin torus whose winding signs are four
+positive and four negative, net `0`: doubled, and with no handedness anywhere. (4) Record time is a **supplied extra dimension**, not a re-reading of a per-site record
+stack, because a site never carries more than one record and the per-site record set is a singleton. (5) The spatial wall of the companion note is a **different**
+construction: there `eps_{v+e_x} = -eps_v` at residual `0.0`, so a supplied sign flip is a one-site translation of the alternating pattern and `min|m(x)| = m` -- no plane
+carries a vanishing mass -- whereas here `tau` steps `1 -> 0` across the wall and the light states are exact zero modes.
+
+## Corollary -- what a domain wall in record time supplies, on the geometries computed
+
+Within the setting declared above, in the free-field one-particle sector, and on the finite sizes named:
+
+1. **The pairing is forced, not a periodic artefact.** On any one-dimensional record time computed here the partner appears at a wall, at an end of the interval, or at
+   the edge of a pinned region, and the net is zero on every profile in the declared family. Opening the circle changes where the partner is, not whether there is one.
+   The landed note states its zero net as a property of the torus; on the evidence here it is a property of one-dimensional record time, and this note replaces that
+   reading.
+2. **The wall is sufficient for localisation, not necessary.** A uniform topological bulk with no wall anywhere carries the identical pair on its two boundaries, and a
+   uniform trivial bulk carries nothing. What binds a species is a `tau = 1` region with a boundary.
+3. **A single wall supplies an exponentially unpaired species and never an exactly unpaired one.** Its local chirality is exact to `1.8e-15` inside a half-width-32
+   window; the partner is elsewhere in the same spectrum, not out of it.
+4. **The price is seven supplied items, and the coordinate itself is one of them.** Ordered, metrized, kinetic, of a chosen length with a chosen end condition -- all
+   four adjectives sit on the axiom memo's Open Gates list, and the note the construction extends is candid that its regulator is not derived either.
+5. **With the companion spatial-wall note, the bottom line.** A single domain wall does not supply a net handed sector, in space or in record time. In space it fails
+   locally, the wall band gapped and the chirality vanishing identically on it; in record time it succeeds locally -- `<chi> = ±1`, exact zero modes, inflow `±1` -- and
+   the net is zero on every geometry computed. Higher-dimensional or branching record time is **out of scope**, and is where the counting rule could fail.
+
+**Reading, not theorem (this register).** Put a wall in the mass along the history direction and handed matter gathers on it, but its mirror image always gathers
+somewhere else: on a second wall, at the end of the interval, or at the edge of wherever the mass was pinned. Cut the interval open and the partner does not vanish, it
+moves. Counting the walls counts the pairs. So this construction can make handed matter that is very well separated from its partner, but never a lone handed species,
+and the direction it lives along is itself something the lattice has to be given.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms: the record-time coordinate, its operators, its Clifford generator, the mass field, the length and the boundary condition are
+  declared objects, and no coefficient is derived.
+- The four-component chiral embedding is a diagnostic construction, not an axiom, a primitive registration, or a claim about the one-site algebra.
+- The counting rule of `T3` is not promoted to a proof, to a general statement about record time, or to a no-go of any kind.
+
+## Interfaces named for other lanes, not moved here
+
+- **Branching or higher-dimensional record time.** Everything here is a one-dimensional chain. A record time with `d_5 > 1`, or one that branches, is **not computed**,
+  and it is precisely where the counting rule of `T3` could fail. Whether such a geometry is even admissible is a question for the lane that owns record structure.
+- **Interactions.** Only the free operator is treated. A four-fermion term on the wall, or any coupling between the wall species and its partner, is untouched.
+- **The regulator from the law.** The higher-dimensional Wilson-Dirac operator is supplied, as the landed note says of itself. Whether the admissibility rule can supply
+  a regulator -- and an ordered, metrized, kinetic, unbounded record-time direction to hang it on -- belongs to the lane that owns the dynamical clause.
+- **A smooth front.** The occupancy-to-mass bridge's `tanh` profile is not covered: every profile here is piecewise constant. A smooth-front repeat is the obvious
+  follow-on and is not attempted.
+
+## Remaining live routes
+
+1. Larger `L_5` and other alphabets. `N_s ≤ 128` and the six declared segment values are what is computed; nothing is claimed beyond them.
+2. Other end conventions. Hard, free and a trivially pinned end are computed; other completions of the Laplacian at the ends are not.
+3. Gauge coupling. One non-dynamical `U(1)` flux quantum enters the Callan-Harvey check and nothing else; no dynamical gauge field appears anywhere.
+4. The many-body statements. Everything here is one-particle; no sea, no measure, no anomaly matching.
+
+## Executable claim block
+
+```text
+setting: free-field one-particle sector; four-component embedding Gamma_i = tau_1 (x) sigma_i, Gamma_s = tau_2 (x) I, Gamma_m = tau_3 (x) I, chi = i Gamma_s Gamma_m; record time SUPPLIED as an ordered chain with K_s, r_s L_s, Gamma_s, m(s), L_5 and a boundary condition; M = 0.8, r = r_s = 1; axioms quoted from MINIMAL_AXIOMS_2026-06-29.md
+T1 circle: N_s = 64, 4 light states at p = 0, max|E| = 4.557e-09, next gap 0.801204; wall top-2 0.798565653 twice, peak 15, xi_L 0.621335, xi_R 1.701298, <chi> +1.000000000000, handedness -1; anti-wall top-2 0.880610823 twice, peak 48, lengths interchanged, <chi> -1.000000000000, handedness +1; BZ corners [4,0,0,0,0,0,0,0]; chi density +1.999950592685 / -1.999950592685 at residual 0.0; net +0.000000000000
+T2 interval: hard ends, one wall -- 4 EXACT zero modes, max|E| 5.93e-16, next |E| 0.801213, wall <chi> +1.000000000 at peak 31, partner <chi> -1.000000000 at peak 0, IPR 0.9231, right end empty, zones -2.000000000 / +1.999999996 / +0.000000004, net +0.000000000000; free ends identical count, max|E| 1.04e-15, IPR 0.8427; mirrored mass -> partner at peak 63, IPR 0.9231, <chi> +1.000000000; ends pinned trivial (m = +4.0, 4 sites) -> partner at s = 4, IPR 0.8548, <chi> -1.000000000, zone -1.996923274; uniform topological, no wall -> same pair on the two boundaries, max|E| 9.19e-16; uniform trivial -> 0 light states; Callan-Harvey +1 / -1 / 0 in all four geometries (L_x = L_y = 3, N_s = 16, L_z = 7, 15 twist steps); |E| = |sin q| to 8 decimals at q/pi = 0.05, 0.10, 0.20; BZ corners [4,0,0,0,0,0,0,0]
+T3 declared family [verified, not proved]: complete enumeration, N_s = 32, breakpoints on {8,16,24}, adjacent values distinct, alphabet {-3.0,-1.5,-0.5,+0.5,+1.5,+3.0}; 1296 profiles, [6,90,450,750] by transition count, open and circle -> 2592 members, no seed; species count = tau-transitions bracketed by the trivial vacuum, MISMATCHES = 0; worst |net chirality| 6.661e-15; uniform slab window exactly -2 r_s < m < 0 at 8 masses
+T4 unpairing: N_s = 128 window deficits 5.940e-02 / 5.448e-03 / 4.941e-05 / 4.068e-09 / 3.366e-13 / 1.776e-15 at W = 2/4/8/16/24/32; splitting monotone in L_5 on both geometries; interval at machine zero by L_5 = 48 where the circle is 5.02e-07
+T5 supplied items [statement]: seven -- ordered coordinate, K_s, r_s L_s, Gamma_s, m(s), unbounded L_5, boundary condition; rebuild residual 0.0; none redundant (11.225 / 19.545 / 2.000 / 12.800); all withdrawn -> D(p) = i sum_i sigma_i sin(p_i), 8 zeros, 4 positive and 4 negative windings, net 0; per-site record set a singleton; the spatial wall is a stacking fault, eps_{v+e_x} = -eps_v at 0.0, min|m(x)| = m
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=26 FAIL=0
+```
+
+## Proof boundary
+
+Everything is **free field** and **one particle**. There is no interaction, no dynamics, no fermion measure, and no gauge coupling except the **single non-dynamical
+`U(1)` background flux quantum** of the Callan-Harvey check. No anomaly matching is proven and no continuum limit is taken.
+
+All record-time structure is **supplied**: the coordinate, its ordering, its nearest-neighbour adjacency, `K_s`, `r_s L_s`, `Gamma_s`, `m(s)`, `L_5`, and the boundary
+condition. None is derived from the four axioms, and the note the construction extends says the same of its own regulator. The four-component chiral embedding is a
+diagnostic construction, not an axiom and not a primitive registration; `<chi>` is a species label and not the Weyl handedness, which is reported separately throughout.
+
+The sizes are the named finite ones and nothing else: `N_s = 64` for `T1` and `T2`, `N_s ∈ {16, 24, 32, 48, 64, 128}` for the scaling, `N_s = 48` for the window scan,
+`N_s = 32` for the declared family, and `L_x = L_y = 3`, `L_z = 7`, `N_s = 16`, 15 twist steps for the flow. Nothing is claimed at any other size.
+
+`T3` is **verified on a declared finite family, not proved**. The family is exactly the complete enumeration named in Theorem 3 -- 2592 members, deterministic, no seed --
+and mass profiles outside it are not covered: smooth fronts are not covered, breakpoints off the coarse grid are not covered, and values outside the six-element alphabet
+are not covered. The bulk-boundary reading offered as motivation is not a proof, and nothing here is a general no-go. Higher-dimensional record time, curved or branching
+record geometry, and any record-time direction that is not a one-dimensional chain are out of scope and are named above as the place the rule could fail.
+
+Two items deserve their own line because a reader could over-read them. The pinned-ends spectral flow is reported through overlapping tracking windows at `s = 0` and
+`s = 4`, disclosed under Theorem 2; the zone decomposition, which needs no window, is the authority there. And the `1.776e-15` window chirality of `T4` is a statement
+about a half-width-32 window at `N_s = 128`, not about the interval: the total over the interval is zero to `1e-12`, which is the whole point of the theorem.
+
+## Review record
+
+An honest auditor should come away with: the landed periodic construction reproduced digit for digit before anything new is claimed, and then one question answered on
+named finite sizes -- cut the record-time circle open and the handed species on the wall keeps its exact zero mode, its `<chi> = +1`, its Weyl cone and its `+1` of
+Callan-Harvey inflow, while its partner is found at the end of the interval, at the other end if the mass is mirrored, and at the inner edge of a pinned region if the
+end is gapped. A uniform topological bulk with no wall carries the same pair on its two boundaries; a uniform trivial bulk carries nothing. On a declared family of 2592
+piecewise-constant profiles, enumerated completely and without randomness, the species count is the transition count of the band-inversion index bracketed by the trivial
+vacuum, with no mismatch, and the net chirality is zero to `6.661e-15`.
+
+The auditor should also come away with three caveats. The counting rule is a **verification on that declared family**, not a proof and not a general no-go; the family is
+finite, piecewise constant, and one-dimensional, and higher-dimensional or branching record time is untouched. The unpairing is **exponential**, not exact: the wall's
+chirality is `+2` to `1.8e-15` in a half-width-32 window, and the partner remains in the same finite spectrum. And every piece of the record-time direction is supplied
+data -- seven items, the coordinate among them -- so this note bounds what the construction gives, not what the axioms give.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the six context notes in "Imports
+and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at `PASS=26 FAIL=0`, runtime
+under the declared `150` seconds, and passing pipeline and strict-lint gates; independent audit remains a separate lane.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py
+```
+
+Expected terminal summary:
+
+```text
+TOTAL: PASS=26 FAIL=0
+```

--- a/logs/runner-cache/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.txt
+++ b/logs/runner-cache/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.txt
@@ -1,0 +1,48 @@
+===== runner cache v1 =====
+runner: scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py
+runner_sha256: a8499d7704364cc6bd4e6db2e241c8ea121b162e8e8a4f47fb8536127db89971
+timeout_sec: 150
+exit_code: 0
+elapsed_sec: 60.16
+status: ok
+----- stdout -----
+== A  T1  the landed periodic circle, N_s = 64, M = 0.8, r = r_s = 1
+PASS A1 [1e-6] wall s=16, anti-wall s=48: 4 light states at p=0, max|E| 4.557e-09, next gap 0.801204 (landed 0.801204)
+PASS A2 [1e-8] wall: window top-2 0.798565653 0.798565653 (landed 0.798565653), peak 15, xi_L 0.621335, xi_R 1.701298, <chi> +1.000000000000, handedness -1
+PASS A3 [1e-8] anti-wall: window top-2 0.880610823 0.880610823 (landed 0.880610823), peak 48, xi_L 1.701298, xi_R 0.621335, <chi> -1.000000000000, handedness +1
+PASS A4 [exact] light counts at the eight BZ corners [4, 0, 0, 0, 0, 0, 0, 0]: the species sits at the physical p=0 corner alone
+PASS A5 [1e-10] chirality density +1.999950592685 in the wall zone [8,24), -1.999950592685 in the anti-wall zone, residual 0.0e+00, net on the circle +0.000000000000
+== B  T2  the open record-time interval, N_s = 64, light cut |E| < 0.40
+PASS B1 [1e-12] one wall, hard ends: 4 light states, max|E| 5.93e-16 -- EXACT zero modes -- next |E| 0.801213, net chirality +0.000000000000
+PASS B2 [1e-8] the wall doublet (peak s=31) has <chi> +1.000000000, handedness -1, xi_L 0.6213, xi_R 1.7013; the PARTNER doublet sits at the left end (peak s=0, IPR 0.9231), <chi> -1.000000000, handedness +1
+PASS B3 [1e-6] the right end is EMPTY (no rank-2 light doublet): zone chirality -2.000000000 left end, +1.999999996 wall, +0.000000004 right end
+PASS B4 [1e-12] FREE (Neumann) ends give the IDENTICAL count: 4 light states, max|E| 1.04e-15, net -0.000000000000, partner still at s=0, bound less tightly (IPR 0.8427 against 0.9231)
+PASS B5 [1e-8] a MIRRORED mass puts the partner on the other end: peak s=63, IPR 0.9231, <chi> +1.000000000, zone +2.000000000 against the wall's -1.999999987 -- the hosting end is fixed by the profile, not by the end convention
+PASS B6 [1e-8] pinning the Wilson mass to the TRIVIAL sign (m=+4.0) on the 4 end sites leaves the partner in the spectrum at s=4, the inner edge of the pinned region: IPR 0.8548, <chi> -1.000000000, zone -1.996923274, net +0.000000000000
+PASS B7 [1e-12] a UNIFORM topological mass with NO WALL gives the same pair on the two boundaries: 4 light states, max|E| 9.19e-16, <chi> -1.000000000 at s=0 and +1.000000000 at s=63, net +0.000000000000 -- the wall is sufficient for localisation, not necessary
+PASS B8 [exact] a UNIFORM trivial mass gives 0 light states (next |E| 0.802526): the light chirality is an interface effect, not a bulk mode
+   q/pi, open |E|, circle |E|, |sin q|:  0.05 0.15643447 0.15643447 0.15643447 | 0.10 0.30901699 0.30901699 0.30901699 | 0.20 0.58778525 0.58778525 0.58778525
+PASS B9 [5e-9] the light branch is an EXACT Weyl cone: |E| = |sin q| to eight decimals through q = 0.2 pi, identical on the interval and on the circle
+PASS B10 [exact] BZ corner counts [4, 0, 0, 0, 0, 0, 0, 0] (open, one wall) and [4, 0, 0, 0, 0, 0, 0, 0] (open, uniform topological) agree with the circle's
+PASS B11 [integer] Callan-Harvey inflow, one U(1) flux quantum through the x-y torus (L_x=L_y=3, N_s=16, L_z=7, 15 twist steps): circle_2wall wall+1 anti-1 = +0; open_1wall left_end-1 wall+1 right_end+0 = +0; open_pinned left_end-1 pin_edge+0 wall+1 right_end+0 = +0; open_uniform_top left_end-1 right_end+1 = +0 -- +1 on the wall branch, -1 on its partner, 0 in total, in EVERY geometry
+== C  T3  the counting rule on a DECLARED family: complete enumeration, no randomness
+PASS C1 [exact] the declared family is the COMPLETE ENUMERATION of piecewise-constant profiles on N_s=32 with breakpoints on the coarse grid (8, 16, 24), adjacent segment values distinct, from the alphabet (-3.0, -1.5, -0.5, 0.5, 1.5, 3.0): 1296 profiles, [6, 90, 450, 750] by transition count, each on the open interval and on the circle -- 2592 members, no randomness and no seed anywhere
+PASS C2 [exact] on every member the number of localized chiral species equals the tau-transition count of the sequence bracketed by the trivial vacuum ([0, tau_1..tau_k, 0] open, cyclic on the circle): 1296 open and 1296 periodic members, MISMATCHES = 0
+PASS C3 [1e-14] net chirality is zero on EVERY member: worst |net| 6.661e-15 over all 2592 members
+   uniform open slab N_s=48, m/tau/n_light:  -3.0/0/0  -2.5/0/0  -1.5/1/4  -1.0/1/4  -0.5/1/4  +0.5/0/0  +1.5/0/0  +3.0/0/0
+PASS C4 [1e-13] the band-inversion window of a uniform open slab is exactly -2 r_s < m < 0: four light states inside it and none outside, at eight declared masses, net zero at each
+== D  T4  how unpaired the wall's species is
+   half-width W, deficit of the window chirality from +2:  2 5.940e-02  4 5.448e-03  8 4.941e-05  16 4.068e-09  24 3.366e-13  32 1.776e-15
+PASS D1 [1e-14] the wall's local chirality inside a half-width-32 window is +2 to 1.8e-15 (N_s=128), against 4.94e-05 at W=8 and 4.07e-09 at W=16: the species is EXPONENTIALLY unpaired, never exactly unpaired
+   L_5, circle max|E_light|, interval max|E_light|:  16 6.10e-03 2.06e-06  24 5.81e-04 3.29e-09  32 5.53e-05 5.26e-12  48 5.02e-07 3.00e-15  64 4.56e-09 1.86e-15
+PASS D2 [monotone] the wall/partner splitting decays exponentially in L_5 on both geometries, and the interval decouples FASTER -- its two interfaces face each other across the short-xi side (xi_L 0.621335 against xi_R 1.701298) -- reaching machine zero by L_5 = 48
+== E  T5  the seven supplied items, and the coordinate itself is one of them
+PASS E1 [exact] the diagnostic is a function of exactly seven supplied items -- an ordered coordinate s with nearest-neighbour adjacency; K_s; r_s L_s; Gamma_s; m(s) with a sign change; an unbounded L_5; a boundary condition -- and rebuilt from them alone it reproduces group B's open one-wall operator at residual 0.0e+00
+PASS E2 [exact] none is redundant: withdrawing K_s, r_s L_s, Gamma_s, m(s) changes the operator by 11.225, 19.545, 2.000, 12.800
+PASS E3 [exact] with every record-time item withdrawn what is left is the achiral spatial operator D(p) = i sum_i sigma_i sin(p_i): 8 zeros on the Brillouin torus, winding signs 4 positive and 4 negative, net +0.  Record / Fixed Reality reads "A site never carries more than one record; records are permanent", so the per-site record set is a SINGLETON and record time is a supplied extra dimension, not a re-reading of a per-site stack; the axiom memo's Open Gates list puts "arrow, record-production dynamics, physical persistence dynamics, time metric, and local observability of records" outside axiom content
+PASS E4 [exact] the companion spatial-wall note is a DIFFERENT construction with the same bottom line: there eps_{v+e_x} = -eps_v at residual 0.0, so a supplied sign flip is a one-site translation of the alternating pattern and min|m(x)| = 1.0 -- no plane carries a vanishing mass -- while here tau steps 1 -> 0 across the wall and the light states are exact zero modes
+SUMMARY: the landed circle reproduces; on an open record-time interval the partner Weyl mode is bound at an end, at the inner edge of a pinned region, or on the two boundaries of a uniform topological bulk; on the declared family the species count is the tau-transition count and the net is zero; a single wall supplies an exponentially unpaired species, and the coordinate it lives along is supplied.
+TOTAL: PASS=26 FAIL=0
+
+----- stderr -----
+

--- a/scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py
+++ b/scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""The record-time domain wall on an open interval: where the partner Weyl mode lives.
+
+Self-contained free-field one-particle runner.  Record time is a SUPPLIED extra
+coordinate `s`: an ordered chain of `N_s` sites with nearest-neighbour
+adjacency, a hermitian momentum `K_s`, a Wilson Laplacian `r_s L_s`, a fifth
+Clifford generator `Gamma_s`, a supplied mass field `m(s)`, a supplied length
+`L_5 = N_s` and a supplied boundary condition.  The four-component embedding is
+
+    Gamma_i = tau_1 (x) sigma_i,  Gamma_s = tau_2 (x) I,  Gamma_m = tau_3 (x) I,
+    chi = i Gamma_s Gamma_m = -tau_1 (x) I,
+
+    H(p) = sum_i sin(p_i) Gamma_i + K_s (x) Gamma_s
+           + [ diag(m(s)) + r_s L_s + r sum_i (1 - cos p_i) ] (x) Gamma_m.
+
+  A  T1  The landed periodic construction, reproduced digit for digit at
+         N_s = 64, M = 0.8, r = r_s = 1.
+  B  T2  The open interval with hard and with free ends: four exact zero modes,
+         the <chi> = +1 doublet on the wall and the <chi> = -1 doublet at an
+         end, at the inner edge of a pinned region, or on the two boundaries of
+         a uniform topological bulk; net chirality zero in every geometry;
+         Callan-Harvey inflow +1 / -1 / 0; an exact Weyl cone.
+  C  T3  The counting rule on a DECLARED family: the complete enumeration of
+         piecewise-constant profiles with up to three transitions on the coarse
+         grid {8, 16, 24} of a 32-site record time, six declared segment values,
+         open and periodic -- 2592 members, no randomness anywhere.
+  D  T4  The wall's local chirality inside a half-width-W window: the species is
+         exponentially unpaired, never exactly unpaired.
+  E  T5  What the construction is supplied with: seven items, and the coordinate
+         itself is one of them.  Group E also computes the achiral spatial
+         starting point and the staggered stacking-fault identity that makes the
+         companion spatial-wall note a DIFFERENT construction.
+
+The lattice is physical.  Nothing here is derived from any axiom, no axiom is
+amended, no status is set and no registry entry is created.  Group C is a
+verification on a declared finite family, not a proof, and not a general no-go.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import sys
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 150
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ===================================================== the four-component embedding
+
+I2 = np.eye(2, dtype=complex)
+S1 = np.array([[0, 1], [1, 0]], dtype=complex)
+S2 = np.array([[0, -1j], [1j, 0]], dtype=complex)
+S3 = np.array([[1, 0], [0, -1]], dtype=complex)
+SIG = [S1, S2, S3]
+I4 = np.eye(4, dtype=complex)
+G_SP = [np.kron(S1, s) for s in SIG]          # Gamma_i = tau_1 (x) sigma_i
+G_S = np.kron(S2, I2)                          # Gamma_s = tau_2 (x) I
+G_M = np.kron(S3, I2)                          # Gamma_m = tau_3 (x) I
+CHI = 1j * G_S @ G_M                           # chi = -tau_1 (x) I
+
+M_DEF = 0.8
+R_S = 1.0
+R_SPACE = 1.0
+
+
+def nrm(a):
+    return float(np.linalg.norm(a))
+
+
+# =============================================== the supplied record-time coordinate
+
+def record_time_ops(n_s, bc, end_mode="hard"):
+    """SUPPLIED item 1/2/3/7: the ordered chain, K_s, r_s L_s, the end convention.
+
+    bc       'periodic' (a circle) or 'open' (an interval)
+    end_mode 'hard' -- Dirichlet completion, Laplacian diagonal held at 1.0 at
+                       the two ends, as if a psi = 0 ghost site sat outside
+             'free' -- Neumann, diagonal 0.5 at the ends, only existing links
+    """
+    k = np.zeros((n_s, n_s), dtype=complex)
+    lap = np.zeros((n_s, n_s), dtype=complex)
+    if bc == "periodic":
+        for s in range(n_s):
+            k[s, (s + 1) % n_s] += -0.5j
+            k[s, (s - 1) % n_s] += 0.5j
+            lap[s, s] += 1.0
+            lap[s, (s + 1) % n_s] += -0.5
+            lap[s, (s - 1) % n_s] += -0.5
+        return k, lap
+    for s in range(n_s - 1):
+        k[s, s + 1] += -0.5j
+        k[s + 1, s] += 0.5j
+        lap[s, s] += 0.5
+        lap[s + 1, s + 1] += 0.5
+        lap[s, s + 1] += -0.5
+        lap[s + 1, s] += -0.5
+    if end_mode == "hard":
+        lap[0, 0] += 0.5
+        lap[n_s - 1, n_s - 1] += 0.5
+    return k, lap
+
+
+def hamiltonian(n_s, m, bc, end_mode="hard", p=(0.0, 0.0, 0.0)):
+    """The five-dimensional Wilson-Dirac diagnostic at transverse momentum p."""
+    k, lap = record_time_ops(n_s, bc, end_mode)
+    w = R_SPACE * sum(1.0 - math.cos(x) for x in p)
+    mass = np.diag(np.asarray(m, dtype=float) + w) + R_S * lap
+    ham = np.kron(k, G_S) + np.kron(mass, G_M)
+    for i, pi in enumerate(p):
+        ham = ham + np.kron(np.eye(n_s, dtype=complex), math.sin(pi) * G_SP[i])
+    return ham
+
+
+def profile_periodic(n_s, mm=M_DEF):
+    """The landed circle: m = -M outside [n/4, 3n/4), +M inside: one wall, one anti-wall."""
+    w, aw = n_s // 4, n_s // 4 + n_s // 2
+    m = -mm * np.ones(n_s)
+    m[w:aw] = mm
+    return m, w, aw
+
+
+def profile_flip(n_s, mm=M_DEF, left=-1.0):
+    m = left * mm * np.ones(n_s)
+    m[n_s // 2:] = -left * mm
+    return m
+
+
+def dist(n_s, centre, bc):
+    d = np.abs(np.arange(n_s) - centre)
+    return np.minimum(d, n_s - d) if bc == "periodic" else d
+
+
+# ============================================================== analysis primitives
+
+def light_set(ev, cut):
+    idx = np.where(np.abs(ev) < cut)[0]
+    rest = np.abs(ev[np.abs(ev) >= cut])
+    return idx, (float(rest.min()) if rest.size else float("inf"))
+
+
+def chirality_density(evec, idx, n_s):
+    """chi(s) = sum_{k in light} <psi_k| Pi_s chi |psi_k>, basis independent."""
+    v = evec[:, idx].reshape(n_s, 4, -1)
+    return np.einsum("scm,cd,sdm->s", v.conj(), CHI, v).real
+
+
+def window_basis(ham, n_s, centre, bc, cut, width=2.0):
+    """Diagonalize a Gaussian window of the named interface inside the light space."""
+    ev, evec = np.linalg.eigh(ham)
+    idx, _ = light_set(ev, cut)
+    v = evec[:, idx]
+    w = np.exp(-((dist(n_s, centre, bc) / width) ** 2))
+    wv, wvec = np.linalg.eigh(v.conj().T @ np.kron(np.diag(w), I4) @ v)
+    o = np.argsort(wv)[::-1]
+    return wv[o], v @ wvec[:, o]
+
+
+def mode_report(vec, n_s, bc):
+    p = np.sum(np.abs(vec.reshape(n_s, 4)) ** 2, axis=1)
+    p = p / p.sum()
+    peak = int(np.argmax(p))
+    xis = {}
+    for side, step in (("L", -1), ("R", 1)):
+        ds, ys = [], []
+        for d in range(1, min(12, n_s // 2)):
+            j = peak + step * d
+            if bc == "periodic":
+                j %= n_s
+            elif not 0 <= j < n_s:
+                break
+            if p[j] < 1e-15:
+                break
+            ds.append(d)
+            ys.append(math.log(p[j]))
+        sl = np.polyfit(np.array(ds, float), np.array(ys), 1)[0] if len(ds) >= 4 else 0.0
+        xis[side] = -2.0 / sl if sl < 0 else float("nan")
+    return peak, float(np.sum(p ** 2)), xis["L"], xis["R"]
+
+
+def weyl_data(u, n_s, rank=2):
+    """Projected spatial velocities: Weyl cone, handedness Tr(V1V2V3)/2i, <chi>."""
+    proj = u[:, :rank]
+    big = np.eye(n_s, dtype=complex)
+    vs = [proj.conj().T @ np.kron(big, g) @ proj for g in G_SP]
+    sq = max(nrm(v @ v - np.eye(rank, dtype=complex)) for v in vs)
+    ac = max(nrm(vs[i] @ vs[j] + vs[j] @ vs[i]) for i in range(3) for j in range(i + 1, 3))
+    hand = float(np.real(np.trace(vs[0] @ vs[1] @ vs[2]) / 2j))
+    chi = float(np.real(np.trace(proj.conj().T @ np.kron(big, CHI) @ proj)) / rank)
+    return sq, ac, hand, chi
+
+
+def interface_report(ham, n_s, centre, bc, cut=0.40):
+    wv, u = window_basis(ham, n_s, centre, bc, cut)
+    if wv.size < 2 or wv[1] < 0.05:
+        return None
+    peak, ipr, xil, xir = mode_report(u[:, 0], n_s, bc)
+    sq, ac, hand, chi = weyl_data(u, n_s)
+    return dict(top2=wv[:2], peak=peak, ipr=ipr, xiL=xil, xiR=xir,
+                sq=sq, ac=ac, hand=hand, chi=chi)
+
+
+# ================================================================== GROUP A -- T1
+
+print("== A  T1  the landed periodic circle, N_s = 64, M = 0.8, r = r_s = 1")
+NS = 64
+M_PER, W_P, AW_P = profile_periodic(NS)
+H_PER = hamiltonian(NS, M_PER, "periodic")
+EV_P, EVEC_P = np.linalg.eigh(H_PER)
+IDX_P, GAP_P = light_set(EV_P, 1e-5)
+check("A1 [1e-6] wall s=%d, anti-wall s=%d: %d light states at p=0, max|E| %.3e, next gap %.6f "
+      "(landed 0.801204)" % (W_P, AW_P, IDX_P.size, np.abs(EV_P[IDX_P]).max(), GAP_P),
+      IDX_P.size == 4 and np.abs(EV_P[IDX_P]).max() < 1e-6 and abs(GAP_P - 0.801204) < 5e-7)
+
+RW = interface_report(H_PER, NS, W_P, "periodic", cut=1e-5)
+RA = interface_report(H_PER, NS, AW_P, "periodic", cut=1e-5)
+check("A2 [1e-8] wall: window top-2 %.9f %.9f (landed 0.798565653), peak %d, xi_L %.6f, xi_R "
+      "%.6f, <chi> %+.12f, handedness %+.0f"
+      % (RW["top2"][0], RW["top2"][1], RW["peak"], RW["xiL"], RW["xiR"], RW["chi"], RW["hand"]),
+      abs(RW["top2"][0] - 0.798565653) < 5e-9 and abs(RW["top2"][1] - 0.798565653) < 5e-9
+      and RW["peak"] == 15 and abs(RW["xiL"] - 0.621335) < 5e-7
+      and abs(RW["xiR"] - 1.701298) < 5e-7 and abs(RW["chi"] - 1.0) < 1e-9
+      and abs(RW["hand"] + 1.0) < 1e-6 and RW["sq"] < 1e-13 and RW["ac"] < 1e-13)
+check("A3 [1e-8] anti-wall: window top-2 %.9f %.9f (landed 0.880610823), peak %d, xi_L %.6f, "
+      "xi_R %.6f, <chi> %+.12f, handedness %+.0f"
+      % (RA["top2"][0], RA["top2"][1], RA["peak"], RA["xiL"], RA["xiR"], RA["chi"], RA["hand"]),
+      abs(RA["top2"][0] - 0.880610823) < 5e-9 and abs(RA["top2"][1] - 0.880610823) < 5e-9
+      and RA["peak"] == 48 and abs(RA["xiL"] - 1.701298) < 5e-7
+      and abs(RA["xiR"] - 0.621335) < 5e-7 and abs(RA["chi"] + 1.0) < 1e-9
+      and abs(RA["hand"] - 1.0) < 1e-6 and RA["sq"] < 1e-13 and RA["ac"] < 1e-13)
+
+CNT_P = [int(np.sum(np.abs(np.linalg.eigvalsh(hamiltonian(NS, M_PER, "periodic", p=p))) < 1e-5))
+         for p in itertools.product([0.0, math.pi], repeat=3)]
+check("A4 [exact] light counts at the eight BZ corners %s: the species sits at the physical p=0 "
+      "corner alone" % (CNT_P,), CNT_P == [4, 0, 0, 0, 0, 0, 0, 0])
+
+CD_P = chirality_density(EVEC_P, IDX_P, NS)
+ZW = float(CD_P[W_P - 8:W_P + 8].sum())
+ZA = float(CD_P[AW_P - 8:AW_P + 8].sum())
+check("A5 [1e-10] chirality density %+.12f in the wall zone [%d,%d), %+.12f in the anti-wall "
+      "zone, residual %.1e, net on the circle %+.12f"
+      % (ZW, W_P - 8, W_P + 8, ZA, abs(float(CD_P.sum()) - ZW - ZA), float(CD_P.sum())),
+      abs(ZW - 2.0) < 1e-4 and abs(ZA + 2.0) < 1e-4 and abs(float(CD_P.sum())) < 1e-10)
+
+# ================================================================== GROUP B -- T2
+
+print("== B  T2  the open record-time interval, N_s = 64, light cut |E| < 0.40")
+CUT = 0.40
+LAM, NPIN = 4.0, 4
+GEO = {
+    "open_hard_1wall": (profile_flip(NS), "open", "hard", {"left_end": 0, "wall": 32, "right_end": 63}),
+    "open_free_1wall": (profile_flip(NS), "open", "free", {"left_end": 0, "wall": 32, "right_end": 63}),
+    "open_hard_mirror": (profile_flip(NS, left=1.0), "open", "hard", {"left_end": 0, "wall": 32, "right_end": 63}),
+    "open_uniform_topological": (-M_DEF * np.ones(NS), "open", "hard", {"left_end": 0, "right_end": 63}),
+    "open_uniform_trivial": (M_DEF * np.ones(NS), "open", "hard", {"left_end": 0, "right_end": 63}),
+}
+_mp = profile_flip(NS).copy()
+_mp[:NPIN] = LAM
+_mp[-NPIN:] = LAM
+GEO["open_pinned_ends"] = (_mp, "open", "hard",
+                           {"left_end": 0, "pin_edge": NPIN, "wall": 32, "right_end": 63})
+
+RES = {}
+for key, (m, bc, em, ifaces) in GEO.items():
+    ham = hamiltonian(NS, m, bc, em)
+    ev, evec = np.linalg.eigh(ham)
+    idx, gap = light_set(ev, CUT)
+    cd = chirality_density(evec, idx, NS)
+    cs = sorted(set(ifaces.values()))
+    lab = {v: k for k, v in ifaces.items()}
+    zone = {lab[c]: 0.0 for c in cs}
+    for s in range(NS):
+        zone[lab[min(cs, key=lambda c: abs(s - c))]] += cd[s]
+    RES[key] = dict(n=idx.size, mx=float(np.abs(ev[idx]).max()) if idx.size else 0.0, gap=gap,
+                    net=float(cd.sum()), zone=zone,
+                    ifc={k: interface_report(ham, NS, c, bc, CUT) for k, c in ifaces.items()})
+
+B1 = RES["open_hard_1wall"]
+check("B1 [1e-12] one wall, hard ends: %d light states, max|E| %.2e -- EXACT zero modes -- next "
+      "|E| %.6f, net chirality %+.12f" % (B1["n"], B1["mx"], B1["gap"], B1["net"]),
+      B1["n"] == 4 and B1["mx"] < 1e-14 and abs(B1["net"]) < 1e-12)
+check("B2 [1e-8] the wall doublet (peak s=%d) has <chi> %+.9f, handedness %+.0f, xi_L %.4f, xi_R "
+      "%.4f; the PARTNER doublet sits at the left end (peak s=%d, IPR %.4f), <chi> %+.9f, "
+      "handedness %+.0f"
+      % (B1["ifc"]["wall"]["peak"], B1["ifc"]["wall"]["chi"], B1["ifc"]["wall"]["hand"],
+         B1["ifc"]["wall"]["xiL"], B1["ifc"]["wall"]["xiR"], B1["ifc"]["left_end"]["peak"],
+         B1["ifc"]["left_end"]["ipr"], B1["ifc"]["left_end"]["chi"], B1["ifc"]["left_end"]["hand"]),
+      abs(B1["ifc"]["wall"]["chi"] - 1.0) < 1e-8 and abs(B1["ifc"]["wall"]["hand"] + 1.0) < 1e-6
+      and B1["ifc"]["wall"]["peak"] == 31 and abs(B1["ifc"]["left_end"]["chi"] + 1.0) < 1e-8
+      and abs(B1["ifc"]["left_end"]["hand"] - 1.0) < 1e-6
+      and B1["ifc"]["left_end"]["peak"] == 0 and abs(B1["ifc"]["left_end"]["ipr"] - 0.9231) < 5e-5)
+check("B3 [1e-6] the right end is EMPTY (no rank-2 light doublet): zone chirality %+.9f left end, "
+      "%+.9f wall, %+.9f right end"
+      % (B1["zone"]["left_end"], B1["zone"]["wall"], B1["zone"]["right_end"]),
+      B1["ifc"]["right_end"] is None and abs(B1["zone"]["left_end"] + 2.0) < 1e-6
+      and abs(B1["zone"]["wall"] - 2.0) < 1e-6 and abs(B1["zone"]["right_end"]) < 1e-6)
+
+B2 = RES["open_free_1wall"]
+check("B4 [1e-12] FREE (Neumann) ends give the IDENTICAL count: %d light states, max|E| %.2e, net "
+      "%+.12f, partner still at s=%d, bound less tightly (IPR %.4f against %.4f)"
+      % (B2["n"], B2["mx"], B2["net"], B2["ifc"]["left_end"]["peak"], B2["ifc"]["left_end"]["ipr"],
+         B1["ifc"]["left_end"]["ipr"]),
+      B2["n"] == 4 and B2["mx"] < 1e-14 and abs(B2["net"]) < 1e-12
+      and B2["ifc"]["left_end"]["peak"] == 0 and abs(B2["ifc"]["left_end"]["chi"] + 1.0) < 1e-8
+      and abs(B2["ifc"]["left_end"]["ipr"] - 0.8427) < 5e-5)
+
+B3 = RES["open_hard_mirror"]
+check("B5 [1e-8] a MIRRORED mass puts the partner on the other end: peak s=%d, IPR %.4f, <chi> "
+      "%+.9f, zone %+.9f against the wall's %+.9f -- the hosting end is fixed by the profile, not "
+      "by the end convention"
+      % (B3["ifc"]["right_end"]["peak"], B3["ifc"]["right_end"]["ipr"], B3["ifc"]["right_end"]["chi"],
+         B3["zone"]["right_end"], B3["zone"]["wall"]),
+      B3["n"] == 4 and B3["ifc"]["right_end"]["peak"] == 63
+      and abs(B3["ifc"]["right_end"]["chi"] - 1.0) < 1e-8
+      and abs(B3["ifc"]["right_end"]["ipr"] - 0.9231) < 5e-5
+      and abs(B3["zone"]["right_end"] - 2.0) < 1e-6 and abs(B3["net"]) < 1e-12)
+
+B6 = RES["open_pinned_ends"]
+check("B6 [1e-8] pinning the Wilson mass to the TRIVIAL sign (m=+%.1f) on the %d end sites leaves "
+      "the partner in the spectrum at s=%d, the inner edge of the pinned region: IPR %.4f, <chi> "
+      "%+.9f, zone %+.9f, net %+.12f"
+      % (LAM, NPIN, B6["ifc"]["pin_edge"]["peak"], B6["ifc"]["pin_edge"]["ipr"],
+         B6["ifc"]["pin_edge"]["chi"], B6["zone"]["pin_edge"], B6["net"]),
+      B6["n"] == 4 and B6["ifc"]["pin_edge"]["peak"] == NPIN
+      and abs(B6["ifc"]["pin_edge"]["chi"] + 1.0) < 1e-8
+      and abs(B6["ifc"]["pin_edge"]["ipr"] - 0.8548) < 5e-5
+      and abs(B6["zone"]["pin_edge"] + 1.9969) < 5e-4 and abs(B6["net"]) < 1e-12)
+
+B4 = RES["open_uniform_topological"]
+B5 = RES["open_uniform_trivial"]
+check("B7 [1e-12] a UNIFORM topological mass with NO WALL gives the same pair on the two "
+      "boundaries: %d light states, max|E| %.2e, <chi> %+.9f at s=%d and %+.9f at s=%d, net "
+      "%+.12f -- the wall is sufficient for localisation, not necessary"
+      % (B4["n"], B4["mx"], B4["ifc"]["left_end"]["chi"], B4["ifc"]["left_end"]["peak"],
+         B4["ifc"]["right_end"]["chi"], B4["ifc"]["right_end"]["peak"], B4["net"]),
+      B4["n"] == 4 and B4["mx"] < 1e-14 and abs(B4["ifc"]["left_end"]["chi"] + 1.0) < 1e-8
+      and abs(B4["ifc"]["right_end"]["chi"] - 1.0) < 1e-8 and abs(B4["net"]) < 1e-12)
+check("B8 [exact] a UNIFORM trivial mass gives %d light states (next |E| %.6f): the light "
+      "chirality is an interface effect, not a bulk mode" % (B5["n"], B5["gap"]), B5["n"] == 0)
+
+OKC, ROW = True, []
+for f in (0.05, 0.10, 0.20):
+    q = f * math.pi
+    eo = float(np.sort(np.abs(np.linalg.eigvalsh(
+        hamiltonian(NS, GEO["open_hard_1wall"][0], "open", "hard", (q, 0.0, 0.0)))))[0])
+    ep = float(np.sort(np.abs(np.linalg.eigvalsh(hamiltonian(NS, M_PER, "periodic", p=(q, 0.0, 0.0)))))[0])
+    ROW.append("%.2f %.8f %.8f %.8f" % (f, eo, ep, abs(math.sin(q))))
+    OKC = OKC and abs(eo - abs(math.sin(q))) < 5e-9 and abs(ep - abs(math.sin(q))) < 5e-9
+print("   q/pi, open |E|, circle |E|, |sin q|:  " + " | ".join(ROW))
+check("B9 [5e-9] the light branch is an EXACT Weyl cone: |E| = |sin q| to eight decimals through "
+      "q = 0.2 pi, identical on the interval and on the circle", OKC)
+
+CNT_O = [int(np.sum(np.abs(np.linalg.eigvalsh(
+    hamiltonian(NS, GEO["open_hard_1wall"][0], "open", "hard", p))) < CUT))
+    for p in itertools.product([0.0, math.pi], repeat=3)]
+CNT_U = [int(np.sum(np.abs(np.linalg.eigvalsh(
+    hamiltonian(NS, GEO["open_uniform_topological"][0], "open", "hard", p))) < CUT))
+    for p in itertools.product([0.0, math.pi], repeat=3)]
+check("B10 [exact] BZ corner counts %s (open, one wall) and %s (open, uniform topological) agree "
+      "with the circle's" % (CNT_O, CNT_U),
+      CNT_O == [4, 0, 0, 0, 0, 0, 0, 0] and CNT_U == [4, 0, 0, 0, 0, 0, 0, 0])
+
+
+# ------------------------------------------- Callan-Harvey inflow, one flux quantum
+
+def covariant_xy(lx, ly):
+    """Peierls phases for exactly one U(1) flux quantum through the x-y torus."""
+    n = lx * ly
+    b = 2.0 * math.pi / n
+    kx = np.zeros((n, n), dtype=complex)
+    ky = np.zeros((n, n), dtype=complex)
+    lap = np.zeros((n, n), dtype=complex)
+    ix = lambda x, y: (x % lx) * ly + (y % ly)
+    for x in range(lx):
+        for y in range(ly):
+            i = ix(x, y)
+            uy = np.exp(1j * b * x)
+            ux = np.exp(-1j * b * lx * y) if x == lx - 1 else 1.0 + 0j
+            for j, u, k in ((ix(x + 1, y), ux, kx), (ix(x, y + 1), uy, ky)):
+                k[i, j] += -0.5j * u
+                k[j, i] += 0.5j * np.conj(u)
+                lap[i, i] += 0.5
+                lap[j, j] += 0.5
+                lap[i, j] += -0.5 * u
+                lap[j, i] += -0.5 * np.conj(u)
+    return kx, ky, lap
+
+
+def spectral_flow(m, bc, em, ifaces, ns=16, lx=3, ly=3, lz=7, steps=15,
+                  twist=0.31, wcut=0.10, chicut=0.40, ecut=0.30):
+    """Track each localized branch through the twist phi: 0 -> 2 pi and count sign changes."""
+    kx, ky, lapxy = covariant_xy(lx, ly)
+    nxy = lx * ly
+    ixy, isr = np.eye(nxy, dtype=complex), np.eye(ns, dtype=complex)
+    big = np.eye(nxy * ns, dtype=complex)
+    ks, lap = record_time_ops(ns, bc, em)
+    base = (np.kron(np.kron(kx, isr), G_SP[0]) + np.kron(np.kron(ky, isr), G_SP[1])
+            + np.kron(np.kron(ixy, ks), G_S)
+            + np.kron(np.kron(lapxy, isr) + np.kron(ixy, np.diag(m) + lap), G_M))
+    hzw, hzk, chop = np.kron(big, G_M), np.kron(big, G_SP[2]), np.kron(big, CHI)
+    wins = {k: np.exp(-((dist(ns, c, bc) / 2.0) ** 2)) for k, c in ifaces.items()}
+    flow = {k: 0 for k in wins}
+    for zi in range(lz):
+        prev = {k: None for k in wins}
+        hist = {k: [] for k in wins}
+        for phi in np.linspace(0.0, 2 * math.pi, steps):
+            kz = float((2 * math.pi * (zi + twist) / lz - math.pi + phi / lz + math.pi)
+                       % (2 * math.pi) - math.pi)
+            ev, evec = np.linalg.eigh(base + (1 - math.cos(kz)) * hzw + math.sin(kz) * hzk)
+            chis = np.einsum("ij,ij->j", evec.conj(), chop @ evec).real
+            arr = evec.reshape(nxy, ns, 4, -1)
+            for k, win in wins.items():
+                w = np.sum(np.abs(arr) ** 2 * win[None, :, None, None], axis=(0, 1, 2)).real
+                cand = np.where((w > wcut) & (np.abs(chis) > chicut))[0]
+                score = w * np.abs(chis) / (1 + np.abs(ev))
+                if cand.size == 0:
+                    cand = np.argsort(score)[-12:]
+                sc = (score[cand] if prev[k] is None
+                      else np.abs(evec[:, cand].conj().T @ prev[k]) + 1e-3 * score[cand])
+                i = int(cand[int(np.argmax(sc))])
+                prev[k] = evec[:, i]
+                hist[k].append(float(ev[i]))
+        for k in wins:
+            for j in range(steps - 1):
+                e0, e1 = hist[k][j], hist[k][j + 1]
+                if max(abs(e0), abs(e1)) >= ecut:
+                    continue
+                flow[k] += 1 if e0 < 0 < e1 else (-1 if e0 > 0 > e1 else 0)
+    return flow
+
+
+NSF = 16
+FLOW = {}
+for key, ifc in (("circle_2wall", {"wall": 4, "anti": 12}),
+                 ("open_1wall", {"left_end": 0, "wall": 8, "right_end": 15}),
+                 ("open_pinned", {"left_end": 0, "pin_edge": NPIN, "wall": 8, "right_end": 15}),
+                 ("open_uniform_top", {"left_end": 0, "right_end": 15})):
+    if key == "circle_2wall":
+        mf, bcf, emf = profile_periodic(NSF)[0], "periodic", "hard"
+    elif key == "open_uniform_top":
+        mf, bcf, emf = -M_DEF * np.ones(NSF), "open", "hard"
+    elif key == "open_pinned":
+        mf = profile_flip(NSF).copy()
+        mf[:NPIN] = LAM
+        mf[-NPIN:] = LAM
+        bcf, emf = "open", "hard"
+    else:
+        mf, bcf, emf = profile_flip(NSF), "open", "hard"
+    FLOW[key] = spectral_flow(mf, bcf, emf, ifc)
+
+FTXT = "; ".join("%s %s = %+d" % (k, " ".join("%s%+d" % (a, b) for a, b in v.items()), sum(v.values()))
+                 for k, v in FLOW.items())
+check("B11 [integer] Callan-Harvey inflow, one U(1) flux quantum through the x-y torus "
+      "(L_x=L_y=3, N_s=16, L_z=7, 15 twist steps): %s -- +1 on the wall branch, -1 on its "
+      "partner, 0 in total, in EVERY geometry" % FTXT,
+      all(sum(v.values()) == 0 and list(v.values()).count(1) == 1
+          and list(v.values()).count(-1) == 1 and set(v.values()) <= {-1, 0, 1}
+          for v in FLOW.values()))
+
+# ================================================================== GROUP C -- T3
+
+print("== C  T3  the counting rule on a DECLARED family: complete enumeration, no randomness")
+GRID = (8, 16, 24)
+ALPHA = (-3.0, -1.5, -0.5, 0.5, 1.5, 3.0)
+NSC = 32
+
+
+def tau(m, r=R_S):
+    """1D Wilson-Dirac band-inversion index: M(0) = m and M(pi) = m + 2r of opposite sign."""
+    return 1 if -2.0 * r < m < 0.0 else 0
+
+
+def family():
+    """Every piecewise-constant profile with breakpoints on GRID, adjacent values distinct."""
+    for kk in range(4):
+        for cuts in itertools.combinations(GRID, kk):
+            for vals in itertools.product(ALPHA, repeat=kk + 1):
+                if any(a == b for a, b in zip(vals, vals[1:])):
+                    continue
+                yield cuts, vals
+
+
+PROFILES = list(family())
+BY_K = [sum(1 for c, _ in PROFILES if len(c) == j) for j in range(4)]
+check("C1 [exact] the declared family is the COMPLETE ENUMERATION of piecewise-constant profiles "
+      "on N_s=32 with breakpoints on the coarse grid %s, adjacent segment values distinct, from "
+      "the alphabet %s: %d profiles, %s by transition count, each on the open interval and on the "
+      "circle -- %d members, no randomness and no seed anywhere"
+      % (GRID, ALPHA, len(PROFILES), BY_K, 2 * len(PROFILES)),
+      len(PROFILES) == 1296 and BY_K == [6, 90, 450, 750])
+
+WORST = 0.0
+MISM = []
+COUNTS = {"open": 0, "periodic": 0}
+for cuts, vals in PROFILES:
+    edges = (0,) + cuts + (NSC,)
+    m = np.empty(NSC)
+    for j in range(len(vals)):
+        m[edges[j]:edges[j + 1]] = vals[j]
+    taus = [tau(v) for v in vals]
+    for bc in ("open", "periodic"):
+        seq = [0] + taus + [0] if bc == "open" else taus + [taus[0]]
+        pred = 2 * sum(1 for a, b in zip(seq, seq[1:]) if a != b)
+        ev, evec = np.linalg.eigh(hamiltonian(NSC, m, bc, "hard"))
+        idx, gap = light_set(ev, 0.25)
+        net = float(chirality_density(evec, idx, NSC).sum())
+        WORST = max(WORST, abs(net))
+        COUNTS[bc] += 1
+        if idx.size != pred:
+            MISM.append((bc, cuts, vals, pred, int(idx.size), gap))
+
+check("C2 [exact] on every member the number of localized chiral species equals the tau-"
+      "transition count of the sequence bracketed by the trivial vacuum ([0, tau_1..tau_k, 0] "
+      "open, cyclic on the circle): %d open and %d periodic members, MISMATCHES = %d"
+      % (COUNTS["open"], COUNTS["periodic"], len(MISM)), not MISM)
+for row in MISM[:4]:
+    print("   MISMATCH bc=%s cuts=%s vals=%s predicted=%d found=%d next|E|=%.4f" % row)
+check("C3 [1e-14] net chirality is zero on EVERY member: worst |net| %.3e over all %d members"
+      % (WORST, 2 * len(PROFILES)), WORST < 1e-14)
+
+OKW, ROW = True, []
+for m0 in (-3.0, -2.5, -1.5, -1.0, -0.5, 0.5, 1.5, 3.0):
+    ev, evec = np.linalg.eigh(hamiltonian(48, m0 * np.ones(48), "open", "hard"))
+    idx, gap = light_set(ev, 0.30)
+    net = float(chirality_density(evec, idx, 48).sum())
+    ROW.append("%+.1f/%d/%d" % (m0, tau(m0), idx.size))
+    OKW = OKW and idx.size == 4 * tau(m0) and abs(net) < 1e-13
+print("   uniform open slab N_s=48, m/tau/n_light:  " + "  ".join(ROW))
+check("C4 [1e-13] the band-inversion window of a uniform open slab is exactly -2 r_s < m < 0: "
+      "four light states inside it and none outside, at eight declared masses, net zero at each",
+      OKW)
+
+# ================================================================== GROUP D -- T4
+
+print("== D  T4  how unpaired the wall's species is")
+NSD = 128
+MD = -M_DEF * np.ones(NSD)
+MD[NSD // 2:] = M_DEF
+EVD, EVECD = np.linalg.eigh(hamiltonian(NSD, MD, "open", "hard"))
+IDXD, _ = light_set(EVD, 0.30)
+CDD = chirality_density(EVECD, IDXD, NSD)
+DEF = {w: 2.0 - float(CDD[NSD // 2 - w:NSD // 2 + w].sum()) for w in (2, 4, 8, 16, 24, 32)}
+print("   half-width W, deficit of the window chirality from +2:  " +
+      "  ".join("%d %.3e" % (w, d) for w, d in DEF.items()))
+check("D1 [1e-14] the wall's local chirality inside a half-width-32 window is +2 to %.1e "
+      "(N_s=128), against %.2e at W=8 and %.2e at W=16: the species is EXPONENTIALLY unpaired, "
+      "never exactly unpaired" % (abs(DEF[32]), abs(DEF[8]), abs(DEF[16])),
+      abs(DEF[32]) < 1e-14 and abs(DEF[24]) < 1e-12 and abs(DEF[16]) < 1e-8
+      and abs(DEF[8]) > 1e-6 and abs(float(CDD.sum())) < 1e-12)
+
+SPL = []
+for n in (16, 24, 32, 48, 64):
+    mm = -M_DEF * np.ones(n)
+    mm[n // 2:] = M_DEF
+    ep = np.linalg.eigvalsh(hamiltonian(n, profile_periodic(n)[0], "periodic"))
+    eo = np.linalg.eigvalsh(hamiltonian(n, mm, "open", "hard"))
+    SPL.append((n, float(np.abs(ep[light_set(ep, 0.40)[0]]).max()),
+                float(np.abs(eo[light_set(eo, 0.40)[0]]).max())))
+print("   L_5, circle max|E_light|, interval max|E_light|:  " + "  ".join("%d %.2e %.2e" % r for r in SPL))
+check("D2 [monotone] the wall/partner splitting decays exponentially in L_5 on both geometries, "
+      "and the interval decouples FASTER -- its two interfaces face each other across the short-"
+      "xi side (xi_L %.6f against xi_R %.6f) -- reaching machine zero by L_5 = 48"
+      % (RW["xiL"], RW["xiR"]),
+      all(SPL[i][1] > SPL[i + 1][1] for i in range(len(SPL) - 1))
+      and all(SPL[i][2] > SPL[i + 1][2] for i in range(len(SPL) - 1) if SPL[i][2] > 1e-13)
+      and SPL[-1][2] < 1e-14)
+
+# ================================================================== GROUP E -- T5
+
+print("== E  T5  the seven supplied items, and the coordinate itself is one of them")
+SUPPLIED = ("an ordered coordinate s with nearest-neighbour adjacency", "K_s", "r_s L_s",
+            "Gamma_s", "m(s) with a sign change", "an unbounded L_5", "a boundary condition")
+K64, L64 = record_time_ops(NS, "open", "hard")
+H_REBUILT = np.kron(K64, G_S) + np.kron(np.diag(profile_flip(NS)) + R_S * L64, G_M)
+RESID = nrm(H_REBUILT - hamiltonian(NS, profile_flip(NS), "open", "hard"))
+check("E1 [exact] the diagnostic is a function of exactly seven supplied items -- %s -- and "
+      "rebuilt from them alone it reproduces group B's open one-wall operator at residual %.1e"
+      % ("; ".join(SUPPLIED), RESID), RESID == 0.0)
+
+DROP = (nrm(np.kron(K64, G_S)), nrm(np.kron(R_S * L64, G_M)), nrm(G_S),
+        nrm(np.kron(np.diag(profile_flip(NS)), G_M)))
+check("E2 [exact] none is redundant: withdrawing K_s, r_s L_s, Gamma_s, m(s) changes the operator "
+      "by %s" % ", ".join("%.3f" % v for v in DROP), all(v > 1e-9 for v in DROP))
+
+ZEROS = [p for p in itertools.product([0.0, math.pi], repeat=3)
+         if nrm(sum(math.sin(x) * SIG[i] for i, x in enumerate(p))) < 1e-12]
+WIND = [int(np.sign(math.prod(math.cos(x) for x in p))) for p in ZEROS]
+check("E3 [exact] with every record-time item withdrawn what is left is the achiral spatial "
+      "operator D(p) = i sum_i sigma_i sin(p_i): %d zeros on the Brillouin torus, winding signs "
+      "%d positive and %d negative, net %+d.  Record / Fixed Reality reads \"A site never carries "
+      "more than one record; records are permanent\", so the per-site record set is a SINGLETON "
+      "and record time is a supplied extra dimension, not a re-reading of a per-site stack; the "
+      "axiom memo's Open Gates list puts \"arrow, record-production dynamics, physical persistence "
+      "dynamics, time metric, and local observability of records\" outside axiom content"
+      % (len(ZEROS), WIND.count(1), WIND.count(-1), sum(WIND)),
+      len(ZEROS) == 8 and sum(WIND) == 0 and WIND.count(1) == 4)
+
+EPS = np.array([(-1.0) ** (x + y + z) for x in range(8) for y in range(8)
+                for z in range(8)]).reshape(8, 8, 8)
+FAULT = float(np.abs(EPS[1:, :, :] + EPS[:-1, :, :]).max())
+MSTAG = np.where(np.arange(8)[:, None, None] < 4, 1.0, -1.0) * EPS
+check("E4 [exact] the companion spatial-wall note is a DIFFERENT construction with the same "
+      "bottom line: there eps_{v+e_x} = -eps_v at residual %.1f, so a supplied sign flip is a one-"
+      "site translation of the alternating pattern and min|m(x)| = %.1f -- no plane carries a "
+      "vanishing mass -- while here tau steps %d -> %d across the wall and the light states are "
+      "exact zero modes" % (FAULT, float(np.abs(MSTAG).min()), tau(-M_DEF), tau(M_DEF)),
+      FAULT == 0.0 and float(np.abs(MSTAG).min()) == 1.0 and tau(-M_DEF) == 1 and tau(M_DEF) == 0)
+
+print("SUMMARY: the landed circle reproduces; on an open record-time interval the partner Weyl "
+      "mode is bound at an end, at the inner edge of a pinned region, or on the two boundaries of "
+      "a uniform topological bulk; on the declared family the species count is the tau-transition "
+      "count and the net is zero; a single wall supplies an exponentially unpaired species, and "
+      "the coordinate it lives along is supplied.")
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + runner + cache extending the landed record-time domain wall (`DOMAIN_WALL_CHIRAL_EDGE_FROM_ACHIRAL_CL3_BULK_FREE_FIELD`, 2026-07-04) from the periodic circle to an open interval: **the wall/anti-wall pairing is forced, not a periodic-boundary artefact.** The landed construction reproduces digit for digit; on the open interval the partner Weyl mode does not vanish, it moves to an end of the interval (or to the inner edge of a pinned region), a uniform topological mass with no wall at all produces the same pair on the two boundaries, the Callan–Harvey flow is +1/−1/0 in every geometry, and the dispersion is an exact Weyl cone. A counting rule, verified by complete enumeration of a declared family of 2,592 piecewise-constant profiles (no seeds): the number of chiral species equals the transition count bracketed by the trivial vacuum, so the net chirality on any one-dimensional record time is zero (worst 6.7e-15, 0 mismatches). The species is exponentially unpaired (local chirality exact to 1.8e-15 in a half-width-32 window), never exactly. The construction's price is seven supplied items, including the record-time coordinate itself: the Record axiom allows one record per site, so record time is a supplied extra dimension. Together with `RECORD_WALLS_IN_THE_STAGGERED_MASS` (this session, spatial walls): a single domain wall never supplies a net handed sector, in space or in record time.

- `docs/THE_RECORD_TIME_DOMAIN_WALL_ON_AN_OPEN_INTERVAL_WHERE_THE_PARTNER_WEYL_MODE_LIVES_BOUNDED_THEOREM_NOTE_2026-09-03.md` (302 lines)
- `scripts/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.py` (`TOTAL: PASS=26 FAIL=0`, 60 s)
- `logs/runner-cache/record_time_domain_wall_open_interval_partner_mode_check_2026_09_03.txt`

## Boundary

- Free field, one-particle, named finite sizes; supplied regulator and coordinate; the counting rule is a verification on a declared family, not a proof and not a no-go; two-dimensional or branching record time out of scope. Two framing corrections to the landed note carried as corollary items (the zero net is a property of one-dimensional record time, not of the torus; the wall is sufficient, not necessary, for localisation).

## Context

- Parents: the landed domain-wall trio of 2026-07-04/05; this session's spatial-wall note (branch `physics-loop/record-walls-localized-2p1d-matter-vector-like`). Owner-directed full-repository probe wave (2026-09-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
