### PR TITLE
feat(gravity): 4D Regge second variation carries a native linearised graviton

### DIFF
--- a/docs/THE_REGGE_SECOND_VARIATION_ON_THE_4D_CUBIC_COXETER_COMPLEX_CARRIES_A_NATIVE_LINEARISED_GRAVITON_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_REGGE_SECOND_VARIATION_ON_THE_4D_CUBIC_COXETER_COMPLEX_CARRIES_A_NATIVE_LINEARISED_GRAVITON_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,314 @@
+---
+claim_id: regge_4d_cubic_coxeter_native_linearised_graviton_dispersion
+claim_type: bounded_theorem
+claim_scope: "On the 4D cubic-Coxeter (Kuhn/Freudenthal) path complex T(Z^3 x Z_tau) with flat Euclidean/OS0 background and supplied 0/1-vector edge lengths (l^2 in {1,2,3,4}), the second variation of the Regge action S_R = sum_t A_t delta_t about flat has, at every declared momentum: dim ker Q(k) = 5, namely 4 discrete diffeomorphisms coinciding exactly with the continuum family h_munu = i(k_mu xi_nu + k_nu xi_mu) plus 1 identically flat non-metric branch, with metric-sector kernel exactly 4; exactly 2 propagating modes, doubly degenerate, with no further branch in omega in (0,8] out to the zone boundary; the exact on-shell locus 4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2) under the holomorphic continuation k_tau = i omega, to worst relative residual 3.2e-13 over 32 declared zone points in five directions; the small-momentum expansion omega^2 = k^2 - (k^4/12)(1 + sum_i n_i^4) + O(k^6) with the exact rationals -1/6, -1/8, -1/9, -7/50 on the axis, face, body and (2,1,0) directions; zero lapse and shift kinetic weight on shell; and both propagating polarisations transverse-traceless up to gauge in the small-momentum limit, degrading at the zone corner. The edge-length variables, the selection of S_R, its overall orientation, the Lorentzian signature, the nonlinear completion and the record-to-geometry link are supplied and are not derived here."
+upstream_dependencies:
+  - docs/CUBIC_COXETER_REGGE_3PLUS1_TICK_EXTENSION_SECOND_VARIATION_NARROW_THEOREM_NOTE_2026-06-09.md
+  - docs/CUBIC_COXETER_REGGE_SECOND_VARIATION_EQUALS_LINEARIZED_EH_NARROW_THEOREM_NOTE_2026-06-09.md
+  - docs/CUBIC_COXETER_REGGE_DEFICIT_VANISHING_NARROW_THEOREM_NOTE_2026-05-10.md
+  - docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md
+  - docs/POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md
+runner: scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py
+---
+
+# The Regge second variation on the 4D cubic-Coxeter complex carries a native linearised graviton
+
+**Date:** 2026-09-03
+
+**Type:** bounded_theorem
+
+**Audit:** unset; independent audit remains a separate lane
+
+**Status:** proposed_retained
+
+**Status authority:** independent audit only. This source note writes no audit
+verdict and retags no ledger row.
+
+**Primary runner:**
+[`scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py`](../scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py)
+(PASS=11 FAIL=0)
+
+**Runner cache:**
+[`logs/runner-cache/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.txt`](../logs/runner-cache/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.txt)
+
+**Parents:** the 3D equality row, the 3+1 tick-extension row, and the retained
+spatial complex they both stand on; listed in *Load-bearing inputs* below.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Machine-exact linear-order spectral theorem on one declared complex at declared momenta; the geometric variables and the action remain supplied."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit; the runner re-executes both landed parent runners in-process."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Setting
+
+The Lattice axiom is quoted verbatim from
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md):
+
+> Physical sites are the points of the cubic lattice `Z^3`, with
+> nearest-neighbor adjacency, standard translations, and proper cubic rotations
+> about each site.
+>
+> No site is privileged. Sites are distinguished by the supplied lattice
+> structure alone.
+
+The lattice is physical: `Z^3` is the site set, not a computational scaffold or
+a chart on something else. Space is `Z^3` only; time is the emergent tick at
+which records register. The complex used here is the tick extension
+`T(Z^3 x Z_tau)` of the retained spatial chain, exactly as built by the landed
+3+1 row: per 4-cell, the 24 path (Kuhn/Freudenthal) 4-simplices sharing the main
+diagonal, 15 edge classes (the nonzero `0/1` vectors, flat lengths squared in
+`{1,2,3,4}`), 50 triangle (hinge) classes, and 10 metric components against 15
+edge classes, hence 5 non-metric edge directions. The tick edge is grained on
+the same footing as the spatial edge under the registered
+[`kinetic_isotropy_primitive`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+(`c_t = c_s`, a structural grant); the tick **scale** is not derived, and the
+[`POST_RECORD_CLOCK_RATE_INTERFACE`](POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md)
+boundary is respected.
+
+## The landed rows this one stands on
+
+The 3D row
+[`CUBIC_COXETER_REGGE_SECOND_VARIATION_EQUALS_LINEARIZED_EH`](CUBIC_COXETER_REGGE_SECOND_VARIATION_EQUALS_LINEARIZED_EH_NARROW_THEOREM_NOTE_2026-06-09.md)
+establishes, on the retained six-tetrahedra chain, that the metric-sector Regge
+form equals the 3D Euclidean linearised Einstein-Hilbert pairing with the single
+constant `c = -1/2` in all three directions. The 3+1 row
+[`CUBIC_COXETER_REGGE_3PLUS1_TICK_EXTENSION_SECOND_VARIATION`](CUBIC_COXETER_REGGE_3PLUS1_TICK_EXTENSION_SECOND_VARIATION_NARROW_THEOREM_NOTE_2026-06-09.md)
+extends that to `T(Z^3 x Z_tau)`: the same comparator constant across five
+directions including the tick-mixed ones, the `lambda = 1` kinetic fibre metric,
+the multiplier structure, and the split of the five non-metric directions into
+four massive branches and one identically flat one.
+
+Both rows evaluate `Q(k)` at **real** Euclidean momenta only. Neither extracts a
+frequency. There is no `omega(k)`, no pole and no finite-frequency mode count in
+either runner. That is what this note supplies at linear order.
+
+## The question
+
+Does the second variation of the Regge action, on the framework's own 4D
+complex, carry a propagating spin-two mode with the right dispersion — from the
+action itself, with no continuum operator consumed anywhere in the derivation?
+
+The reading is declared. The signature is Euclidean/OS0, so the dispersion is
+read as the poles of the lattice propagator by the holomorphic continuation of
+the tick momentum, `k_tau = i omega`. `Q(k)` is entire in `k` — every entry is a
+finite sum `c_j exp(i k . a_j)` with real coefficients and real anchors — so the
+continuation is unique. The landed `bloch_Q` writes `conj(x(k))`, which is
+correct only for real `k`; the continuation replaces it by `x(-k)`, and the same
+replacement is made in the line-averaged metric map, whose midpoint phase times
+sinc is written as the entire function `(exp(2iz) - 1) / (2iz)`. The gauge map is
+already entire as landed and is reused verbatim.
+
+**Provenance.** The runner imports
+`scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py` as a
+library and builds every geometric object from that module's own edge classes,
+areas, dihedral derivatives and hinge stars. The complex analysed here is
+therefore provably identical to the landed one, not a re-implementation of it.
+The landed 3D runner is imported the same way. Both are declared to the audit
+lane through `AUDIT_INPUT_PATHS`, so the cache is pinned to their content.
+
+## Theorem (runner-verified; gates named)
+
+**T1 (both parent runners reproduce).** The landed 3D and 3+1 runners, executed
+in-process by this runner, both return `TOTAL: PASS=10 FAIL=0`. The 3D
+comparator is unchanged: `c = -1/2` in all three directions with direction
+spread `7.54e-08`; `TT(yz) = TT(E) = -0.250000` and transverse-trace `+0.250000`
+(raw `S_R` orientation), ratio `-1`.
+
+**T2 (kernel census; numerical tolerance `1e-12`).** On `T(Z^3 x Z_tau)`,
+`dim ker Q(k) = 5` at every declared momentum. Four of the five are the discrete
+diffeomorphisms — one vertex displacement per spacetime direction — annihilated
+to `max|Q Gamma| <= 4.5e-15`. They coincide **exactly**, not approximately, with
+the continuum family `h_munu = i(k_mu xi_nu + k_nu xi_mu)`: the worst
+`max|Q_h Gamma_h| / |Q_h|` over the four declared momenta is `1.8e-13`. The fifth
+lies outside the metric sector: it is the identically flat non-metric branch the
+3+1 row already reports (`non-metric eigenvalues = [-48, -16, -16, -16, 0.0]`),
+and it stays a null direction under continuation, so it never becomes a pole. The
+metric-sector kernel is therefore exactly 4 and the metric-sector rank is
+`10 - 4 = 6`.
+
+**T3 (propagating-mode count).** Exactly two propagating modes, doubly
+degenerate. At the on-shell frequency the null count rises from 5 to 7, with
+`sigma_6` and `sigma_7` at machine zero (`~1e-17`) against a `sigma_8` fourteen
+orders larger. Over twelve declared momenta — axis and body diagonal at
+`|k| = 0.3, 1.0, 2.0, 2.5, 3.0, pi` — a 900-point scan of `omega in (0, 8]` with
+refinement of every interior local minimum finds exactly one branch per momentum,
+out to the zone boundary. No doubler, no spurious propagating branch, no extra
+branch in the window.
+
+**T4 (the exact dispersion).** The on-shell locus is exactly the zero set of the
+standard hypercubic nearest-neighbour lattice d'Alembertian `k-hat^2`, continued
+to `k_tau = i omega`:
+
+> `4 sinh^2(omega/2) = sum_{i=1}^{3} 4 sin^2(k_i/2)`,
+> equivalently `sum_{mu=0}^{3} 4 sin^2(k_mu/2) = 0` at `k_tau = i omega`.
+
+Worst relative residual `3.243e-13` over 32 declared zone points in five
+directions (axis, face, body, `(2,1,0)`, `(3,1,2)`); the residual is
+root-finder limited, `~1e-15` typical. At small momentum,
+
+> `omega^2 = k^2 - (k^4/12)(1 + sum_i n_i^4) + O(k^6)`,  `n = k/|k|`,
+
+with the computed coefficients matching the exact rationals `-1/6` (axis),
+`-1/8` (face), `-1/9` (body), `-7/50` (`(2,1,0)`) — and `(2,1,1)` reproducing
+`-1/8` because it shares the same cubic invariant, so the anisotropy is that
+invariant and nothing else. The mode is therefore massless with light speed
+exactly 1 in tick units (`omega/|k| = 0.999991667` at `|k| = 0.01`), exactly
+isotropic at `O(k^2)` — the relative direction spread over axis, face and body
+is `0.0278 k^2`, constant to four figures from `|k| = 0.02` to `0.2` — and
+anisotropic only at `O(k^4)`. The lapse `h_tautau` and shift `h_i,tau` kinetic
+weights vanish on shell (`4.4e-16`, `3.7e-16`) as well as statically: the
+multiplier structure holds at the pole, not only at zero frequency.
+
+**T5 (polarisation, and the comparator).** Removing the four gauge directions
+from the seven-dimensional on-shell kernel in edge space leaves three; exactly
+two of them lie in the metric slice, and both are transverse-traceless up to
+gauge. The TT fraction is `0.99999999` at `|k| = 0.05`, `0.999` at `0.8`, and
+`0.96 / 0.89` at the zone corner. **This is a small-momentum statement.** TT is a
+continuum notion and the exact lattice polarisation deforms at `O(k^2)`; the mode
+count and the dispersion do not deform, and are machine-exact across the whole
+zone. Separately, `omega = +-k` across the zone is **not** reproduced: `omega* - k`
+is `-0.47` at `|k| = 2` and `-1.24` at `|k| = 3` on the axis.
+
+## Corollary
+
+1. **Yes at linear order.** On the framework's own 4D complex, `delta^2 S_R`
+   carries exactly the diffeomorphism gauge zeros, exactly two propagating modes,
+   no doublers, and the exact lattice dispersion of a massless mode at light
+   speed 1, isotropic to quadratic order. That is the textbook
+   `10 - 4 - 4 = 2` count, realised exactly on the lattice.
+2. **This is a native linearised graviton on supplied edge lengths, not a
+   certificate against a supplied operator.** Nothing in the computation consumes
+   the continuum Einstein-Hilbert operator; the comparator relations are outputs
+   tested against, never inputs.
+3. **What stays supplied is named** — see the section below. The result is a
+   statement about the dynamics of a supplied action on supplied variables.
+4. **The earlier target-operator row's `omega = +-k` across the zone is the same
+   polynomial read in Lorentzian signature, and holds only on axis.** The row
+   [`UNIVERSAL_GR_3PLUS1_CONSTRAINT_MULTIPLIER_STRUCTURE_DERIVED_FIBER_METRIC`](UNIVERSAL_GR_3PLUS1_CONSTRAINT_MULTIPLIER_STRUCTURE_DERIVED_FIBER_METRIC_BOUNDED_THEOREM_NOTE_2026-06-09.md)
+   gives `4 sin^2(omega/2) = 4 sin^2(k/2)`, i.e. `omega = +-k` exactly across the
+   zone, for the written-down continuum-transcribed operator. Both relations are
+   the same on-shell polynomial `sum_mu 4 sin^2(k_mu/2)`: with a real-time tick
+   the timelike slot enters with the opposite sign and one gets
+   `4 sin^2(omega/2) = sum_i 4 sin^2(k_i/2)`, which reduces to `omega = +-k` for
+   **axis** momentum only — along a body diagonal the same relation gives
+   `4 sin^2(omega/2) = 3 * 4 sin^2(k/(2 sqrt 3))`. The geometric complex here is
+   Euclidean/OS0, so the same polynomial is continued instead and gives `sinh`.
+   The two agree at `O(k)` and differ at `O(k^3)`. This is a signature-reading
+   difference, stated both ways; a Lorentzian cubic-Coxeter complex is not built
+   here and is the honest next step if `omega = +-k` across the zone is wanted
+   from the geometry.
+5. **Two superseded gates are recorded.** (a) A first pass gauge-fixed the
+   Hessian against a *fixed* metric-sector complement. That complement degenerates
+   whenever `k_tau -> 0` — the directions `h_xy`, `h_xz` become pure gauge there —
+   and manufactured a spurious `omega/|k| = 4` branch. Mode counting must be
+   basis-free; all results above use the singular values of the full `15 x 15`
+   `Q(k)`, whose kernel is 5 at every momentum, so `sigma_6 -> 0` is the on-shell
+   diagnostic. (b) A metric-slice gate reading `dim ker Q_h = 6` on shell fails,
+   because the two physical null directions of the 15-dimensional edge-space
+   Hessian are not exactly inside `range M(k)` at finite `k` (their principal
+   cosines are `1 - 1e-8` at `|k| = 0.05`). The edge-space polarisation
+   reading of T5 is the correct one and supersedes it.
+
+## Reading, not theorem
+
+Take the lattice's own way of building geometry out of edge lengths, disturb it
+slightly, and ask what waves it carries. It carries exactly two, moving at the
+speed of light with no extra copies, and the four directions of pure relabelling
+do not propagate. That is what a graviton looks like at first order. The lengths
+themselves, the action, and the link from records to lengths are still given by
+hand.
+
+## What stays supplied
+
+| supplied object | status |
+|---|---|
+| edge lengths as the geometric variables | supplied; not derived from the axioms |
+| selection of `S_R` as the action | supplied; the linearised action-selection row narrows the class at quadratic order without selecting |
+| overall action orientation (`S_R` vs `-S_R`) | supplied; the single located sign residual, unchanged here |
+| Lorentzian signature | supplied; this is the Euclidean/OS0 surface read by holomorphic continuation |
+| the nonlinear completion | supplied; every statement here is quadratic order |
+| the record-to-geometry link | supplied; nothing here derives edge lengths from what records register |
+| the tick scale (`c_t = c_s`) | structural grant of the kinetic-isotropy primitive; not derived |
+
+## Interfaces
+
+- **Nonlinear order.** Cubic and higher terms of `S_R` on this complex,
+  including the behaviour of the identically flat non-metric branch beyond
+  quadratic order.
+- **Lorentzian signature.** A Lorentzian cubic-Coxeter complex, which would
+  produce `4 sin^2(omega/2) = sum_i 4 sin^2(k_i/2)` directly rather than by
+  continuation.
+- **The record-to-geometry link.** What fixes the edge lengths from what records
+  register.
+- **The tick scale.** The clock-rate interface, untouched.
+
+## Proof boundary
+
+The theorem proposed here is exactly the linear-order spectral statement of
+T1–T5 on one complex at declared momenta, in the Euclidean/OS0 reading with the
+holomorphic continuation `k_tau = i omega`. Covered: the complete enumeration of
+`ker Q(k)` at four declared 4-momenta; the branch census over `omega in (0, 8]`
+at twelve declared spatial momenta; the dispersion at 32 declared zone points in
+five directions; the small-momentum coefficients in five directions; the
+polarisation at five magnitudes. Every momentum is a declared constant of the
+runner; there are no seeds. Outside this target: any statement at cubic or higher
+order; any other complex; the `O(k^6)` term; the higher-order behaviour of the
+flat non-metric branch; `G_Newton`, the attraction sign, and the equivalence
+principle, all of which are separate targets with their own premises.
+
+## Honest-auditor read
+
+The strongest thing an auditor can take from this note is: *given* the edge
+lengths as the variables and *given* `S_R` as the action, the framework's own 4D
+complex has a linearised graviton with the correct mode count, the correct gauge
+structure, the correct light cone and the correct lattice dispersion — and the
+framework still supplies no reason, from the axioms, for either given. The
+weakest link is not numerical: every gate here is machine-exact, and both parent
+runners re-execute clean in the same process. It is the pair of supplied objects
+named above. An auditor who wants to overturn the note should attack the reading
+(`k_tau = i omega` on a Euclidean complex) or the provenance (that the imported
+complex is the landed one), not the arithmetic. The `omega = +-k` disagreement
+with the target-operator row is stated in the note rather than smoothed over: the
+geometric action gives `sinh`, and that is the honest output of the Euclidean
+reading.
+
+## Load-bearing inputs
+
+- [`CUBIC_COXETER_REGGE_3PLUS1_TICK_EXTENSION_SECOND_VARIATION_NARROW_THEOREM_NOTE_2026-06-09.md`](CUBIC_COXETER_REGGE_3PLUS1_TICK_EXTENSION_SECOND_VARIATION_NARROW_THEOREM_NOTE_2026-06-09.md) — the complex, the Bloch Hessian, the metric and gauge maps; its runner is imported as a library and re-executed here.
+- [`CUBIC_COXETER_REGGE_SECOND_VARIATION_EQUALS_LINEARIZED_EH_NARROW_THEOREM_NOTE_2026-06-09.md`](CUBIC_COXETER_REGGE_SECOND_VARIATION_EQUALS_LINEARIZED_EH_NARROW_THEOREM_NOTE_2026-06-09.md) — the 3D headline; its runner is re-executed here as the spatial comparator.
+- [`CUBIC_COXETER_REGGE_DEFICIT_VANISHING_NARROW_THEOREM_NOTE_2026-05-10.md`](CUBIC_COXETER_REGGE_DEFICIT_VANISHING_NARROW_THEOREM_NOTE_2026-05-10.md) — the retained spatial chain that is the constant-tick slice.
+- [`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md) — the `c_t = c_s` structural grant; nothing beyond its declared grant is consumed.
+- [`POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md`](POST_RECORD_CLOCK_RATE_INTERFACE_2026-06-06.md) — the tick-scale boundary respected by the framing.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) — the Lattice axiom quoted in *Setting*.
+
+Context only, entering no check:
+[`UNIVERSAL_GR_3PLUS1_CONSTRAINT_MULTIPLIER_STRUCTURE_DERIVED_FIBER_METRIC_BOUNDED_THEOREM_NOTE_2026-06-09.md`](UNIVERSAL_GR_3PLUS1_CONSTRAINT_MULTIPLIER_STRUCTURE_DERIVED_FIBER_METRIC_BOUNDED_THEOREM_NOTE_2026-06-09.md)
+(the target-operator row of corollary 4) and
+[`CUBIC_COXETER_REGGE_LINEARIZED_ACTION_SELECTION_EH_CLASS_NARROW_THEOREM_NOTE_2026-06-10.md`](CUBIC_COXETER_REGGE_LINEARIZED_ACTION_SELECTION_EH_CLASS_NARROW_THEOREM_NOTE_2026-06-10.md)
+(the action-selection class).
+
+## Forbidden-imports check
+
+No PDG, fitted or literature value is consumed. The complex, the areas, the
+dihedral angles, the deficits, the Hessian, the gauge and metric maps, the
+continuation, the null-space census, the branch census, the dispersion and its
+small-momentum coefficients are all constructed or derived in-runner. The exact
+rationals `-1/6`, `-1/8`, `-1/9`, `-7/50` and the relation
+`4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2)` are outputs tested against, not
+inputs. Regge (1961), Rocek–Williams and Cheeger–Müller–Schrader appear as
+context only and enter no check.

--- a/logs/runner-cache/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.txt
+++ b/logs/runner-cache/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.txt
@@ -1,0 +1,77 @@
+===== runner cache v1 =====
+runner: scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py
+runner_sha256: d789886cd60c073c9163988a70a92809568517deb625677d8d5b6dbc1832d395
+input_fingerprint_sha256: b374f158c5bd46e231251a054ea6e4a250d897e274c4e425161753b00e1bc77d
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 29.86
+status: ok
+----- stdout -----
+T(Z^3 x Z_tau), Euclidean/OS0: delta^2 S_Regge, propagating modes and dispersion
+  complex imported from the landed 3+1 runner: 24 4-simplices, 15 edge classes, 50 hinge classes per 4-cell; 15x15 Hessian per momentum
+[PASS] T0 continuation provenance: the holomorphic continuation reproduces the landed Bloch Hessian and metric map at real momentum
+       max|Qan-bloch_Q| = 8.9e-16; max|Man-metric_map| = 5.3e-16 at the declared k; the gauge map is entire as landed and reused verbatim
+[PASS] T1a landed 3D row reproduces: the retained spatial comparator is unchanged
+       PASS=10 FAIL=0; c = -1/2, spread/mean 7.54e-08; TT -0.2500 = -0.2500; transverse-trace +0.2500
+[PASS] T1b landed 3+1 row reproduces: the 4D complex and Hessian imported here are the landed ones, re-executed clean
+       PASS=10 FAIL=0
+  kernel census, declared real Euclidean 4-momenta:
+    k=[ 0.410,-0.230, 0.670, 0.310]  ker Q = 5  ker Q_h = 4  max|Q Gamma| = 2.6e-15
+    k=[ 1.100, 0.600,-0.400, 0.200]  ker Q = 5  ker Q_h = 4  max|Q Gamma| = 2.7e-15
+    k=[ 2.300, 1.700,-2.900, 0.830]  ker Q = 5  ker Q_h = 4  max|Q Gamma| = 4.5e-15
+    k=[0.013,0.000,0.000,0.021]      ker Q = 5  ker Q_h = 4  max|Q Gamma| = 1.8e-16
+[PASS] T2a kernel census: dim ker Q(k) = 5 at every declared momentum -- 4 discrete diffeomorphisms plus 1 identically flat non-metric branch that never goes on shell; the metric-sector kernel is exactly 4
+       ker Q = [5], ker Q_h = [4], worst max|Q Gamma| = 4.5e-15
+[PASS] T2b continuum gauge family: the metric-sector kernel coincides exactly with h_munu = i(k_mu xi_nu + k_nu xi_mu) -- the discrete diffeomorphism orbit is the continuum one here, not an approximation to it
+       worst max|Q_h Gamma_h|/|Q_h| = 1.8e-13 over 4 momenta
+  branch hunt, omega in (0,8], 900-point scan then refinement:
+    axis |k|=0.30000 br=1 om*=0.29777489 s6=5.1e-17 s7=1.3e-16 s8=2.8e-03 n=7
+    axis |k|=1.00000 br=1 om*=0.92546834 s6=6.9e-17 s7=7.9e-17 s8=2.6e-02 n=7
+    axis |k|=2.00000 br=1 om*=1.52945031 s6=6.0e-17 s7=9.6e-17 s8=7.2e-02 n=7
+    axis |k|=2.50000 br=1 om*=1.68967272 s6=1.1e-16 s7=1.6e-16 s8=9.1e-02 n=7
+    axis |k|=3.00000 br=1 om*=1.75920233 s6=6.6e-17 s7=1.4e-16 s8=1.0e-01 n=7
+    axis |k|=3.14159 br=1 om*=1.76274717 s6=7.8e-17 s7=2.0e-16 s8=1.0e-01 n=7
+    body |k|=0.30000 br=1 om*=0.29851552 s6=5.8e-17 s7=7.2e-17 s8=2.7e-03 n=7
+    body |k|=1.00000 br=1 om*=0.95003563 s6=5.2e-17 s7=1.1e-16 s8=3.1e-02 n=7
+    body |k|=2.00000 br=1 om*=1.68441404 s6=6.6e-17 s7=9.6e-17 s8=7.5e-02 n=7
+    body |k|=2.50000 br=1 om*=1.95962020 s6=8.6e-17 s7=1.1e-16 s8=7.2e-02 n=7
+    body |k|=3.00000 br=1 om*=2.18045693 s6=9.0e-17 s7=1.1e-16 s8=6.3e-02 n=7
+    body |k|=3.14159 br=1 om*=2.23394278 s6=8.3e-17 s7=1.4e-16 s8=6.1e-02 n=7
+[PASS] T3 propagating-mode count: exactly one on-shell frequency per declared spatial momentum, doubly degenerate -- sigma_6 and sigma_7 at machine zero against a sigma_8 fourteen orders larger; no doubler and no spurious propagating branch in omega in (0,8]
+       branches/momentum [1]; on-shell nulls [7] = 5 kinematic + 2 physical, over 12 declared momenta
+  4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2), worst relative residual per direction:
+    axis(100) 3.2e-13  face(110) 2.5e-13  body(111) 2.7e-14  (2,1,0) 1.3e-13  (3,1,2) 4.9e-14
+[PASS] T4a exact all-zone dispersion: the on-shell locus is exactly the zero set of the standard hypercubic lattice d'Alembertian k-hat^2 continued to k_tau = i omega, 4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2), across the whole zone
+       worst relative residual 3.243e-13 over 32 declared zone points in 5 directions (root-finder limited; ~1e-15 typical)
+  (omega^2-k^2)/k^4 at |k|=0.01, computed/exact rational:
+    axis(100) -0.166664/-0.166667  face(110) -0.124998/-0.125000  body(111) -0.111110/-0.111111  (2,1,0) -0.139998/-0.140000  (2,1,1) -0.124998/-0.125000
+[PASS] T4b small-k expansion, derived not fitted: omega^2 = k^2 - (k^4/12)(1 + sum_i n_i^4) + O(k^6) -- massless, light speed exactly 1 in tick units, the anisotropy the cubic invariant alone: -1/6 axis, -1/8 face, -1/9 body, -7/50 for (2,1,0)
+       pairs above; omega/|k| = 0.999991667 at |k| = 0.01
+  isotropy: spread of omega* over axis/face/body:
+    |k|= 0.02 axis 0.019999333 face 0.019999500 body 0.019999556 spread/k^2 0.0278
+    |k|= 0.05 axis 0.049989587 face 0.049992190 body 0.049993058 spread/k^2 0.0278
+    |k|= 0.10 axis 0.099916771 face 0.099937574 body 0.099944509 spread/k^2 0.0278
+    |k|= 0.20 axis 0.199336642 face 0.199502359 body 0.199557616 spread/k^2 0.0277
+    |k|= 0.80 axis 0.760385333 face 0.770197417 body 0.773481704 spread/k^2 0.0266
+[PASS] T4c isotropy at quadratic order: the relative direction spread of omega scales as k^2, so omega is isotropic at O(k^2) and anisotropic only at O(k^4) -- the lattice-artefact order the landed rows leave uncharacterised
+       spread/k^2 constant at 0.0278 => the anisotropy first enters omega^2 at O(k^4)
+    k=(0.2,0,0) static   TT(yz) -0.00997780 TT(yy-zz) -0.00996671 tr-trace +0.00996671 lapse +6.3e-16 shift +5.1e-16
+    k=(0.2,0,0) on-shell TT(yz) -0.00002208 TT(yy-zz) +0.00002207 tr-trace +0.00002207 lapse +4.4e-16 shift +3.7e-16
+[PASS] T4d multiplier structure on shell: the lapse h_tautau and shift h_i,tau kinetic weights vanish on shell as well as statically -- the constraint multipliers carry no propagating weight
+       lapse 4.4e-16, shift 3.7e-16 on shell, raw S_R orientation; the static row is the landed comparator pair, ratio -1
+  TT fraction of the two propagating modes after gauge removal:
+    |k|= 0.05 TT fraction 1.00000000, 0.99999999
+    |k|= 0.20 TT fraction 0.99999952, 0.99999651
+    |k|= 0.80 TT fraction 0.99976777, 0.99916163
+    |k|= 2.00 TT fraction 0.98942430, 0.97252385
+    |k|= 3.00 TT fraction 0.95665239, 0.89085870
+  omega* - k on axis: |k|=0.1 -0.00, |k|=0.4 -0.01, |k|=1.2 -0.12, |k|=2.0 -0.47, |k|=3.0 -1.24
+[PASS] T5 TT up to gauge is a small-k statement, and the target-operator row's omega = +-k across the zone is not reproduced here: both polarisations are transverse-traceless up to gauge as k -> 0 and deform at the corner, where omega* falls below k by O(1)
+       TT fraction 0.99999999 at |k|=0.05, 0.999 at 0.8, 0.96/0.89 at the corner; omega*-k = -0.47 at |k|=2 and -1.24 at 3 -- the same polynomial read in Lorentzian signature gives omega = +-k, and only on axis
+
+TOTAL: PASS=11 FAIL=0
+SUPPLIED, not derived: the edge lengths, the action selection and its orientation, the
+Lorentzian signature, the nonlinear completion, the record-to-geometry link.
+
+----- stderr -----
+

--- a/scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py
+++ b/scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py
@@ -1,0 +1,491 @@
+"""Native linearised graviton on the 4D cubic-Coxeter complex T(Z^3 x Z_tau): the propagating-mode
+census and the exact lattice dispersion of delta^2 S_Regge, read from the geometric action itself.
+
+PROVENANCE (load-bearing). The complex, the edge classes, the hinge classes, the area and dihedral
+machinery, the Bloch Hessian, the line-averaged metric map and the gauge map are NOT rebuilt here.
+This runner IMPORTS the landed 3+1 runner
+  scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py
+as a library (module R4) and uses its own objects, so the complex analysed here is provably
+identical to the landed one. The landed 3D runner is imported as R3 for the spatial comparator.
+Both landed runners are re-executed in-process (gate T1) and must reproduce PASS=10 FAIL=0.
+
+WHAT IS NEW. The landed 4D runner evaluates Q(k) only at REAL Euclidean momenta and never extracts
+a dispersion: there is no omega(k), no pole and no finite-frequency mode count in it. This runner
+adds exactly that. The signature is Euclidean/OS0, so the dispersion is read as the poles of the
+lattice propagator by the holomorphic continuation of the tick momentum,
+    k_tau = i*omega   (equivalently z = exp(i k_tau) = exp(-omega)).
+Q(k) is entire in k -- every entry is a finite sum c_j exp(i k . a_j) with real c_j and real
+anchors a_j -- so the continuation is unique. The landed bloch_Q writes conj(x(k)), which is valid
+only for real k; the continuation replaces it by x(-k) (Qan below), and the same replacement is
+made in the metric map (Man: the midpoint phase x sinc written as the entire (exp(2iz)-1)/(2iz)).
+Gate T0 pins Qan and Man against the landed bloch_Q and metric_map at a declared real momentum.
+The gauge map is already entire as landed and is used verbatim.
+
+MEMORY. One 15x15 momentum-space Hessian per momentum; no position-space Hessian is built here.
+No random seeds: every momentum is a declared constant of this module.
+
+CHECKS:
+  T0 continuation-provenance check   Qan/Man reproduce the landed bloch_Q/metric_map at a declared
+      real momentum; the complex identity (24 path 4-simplices, 15 edge classes, 50 hinge classes
+      per 4-cell) is read off the imported module.
+  T1a landed-3D-reproduction check   the landed 3D runner reproduces PASS=10 FAIL=0 and its
+      comparator numbers (c = -1/2 with direction spread ~1e-8; TT -0.25; transverse-trace +0.25).
+  T1b landed-4D-reproduction check   the landed 3+1 runner reproduces PASS=10 FAIL=0.
+  T2a kernel-census check            dim ker Q(k) = 5 at every declared momentum = 4 discrete
+      diffeomorphisms + 1 identically flat non-metric branch; the metric-sector kernel is exactly 4.
+  T2b continuum-gauge-family check   the metric-sector kernel is EXACTLY the continuum family
+      h_munu = i(k_mu xi_nu + k_nu xi_mu), not merely approximately.
+  T3  propagating-mode-count check   exactly one on-shell frequency per declared spatial momentum,
+      doubly degenerate (sigma_6 ~ sigma_7 ~ 1e-17 against sigma_8 fourteen orders larger), over
+      omega in (0,8] out to the zone boundary: no doubler, no spurious propagating branch.
+  T4a exact-dispersion check         4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2) over declared zone
+      points in five directions -- the zero set of the standard hypercubic k-hat^2.
+  T4b small-k-expansion check        omega^2 = k^2 - (k^4/12)(1 + sum_i n_i^4) + O(k^6), against the
+      exact rationals -1/6, -1/8, -1/9, -7/50: massless, light speed 1 in tick units.
+  T4c isotropy check                 the direction spread of omega scales as k^2 relative, i.e.
+      omega is isotropic at O(k^2) and anisotropic only at O(k^4).
+  T4d multiplier-structure check     the lapse h_tautau and shift h_i,tau kinetic weights vanish on
+      shell.
+  T5  TT-fraction-and-comparator check  the two propagating polarisations are transverse-traceless
+      up to gauge -- a small-k statement, degrading at the zone corner; and the landed
+      target-operator row's omega = +-k across the zone is NOT reproduced by the geometric action.
+
+SUPPLIED, NOT DERIVED (unchanged by this runner): the edge lengths as the geometric variables, the
+selection of S_R as the action, its overall orientation, the Lorentzian signature, the nonlinear
+completion, and the record-to-geometry link.
+"""
+from __future__ import annotations
+
+AUDIT_TIMEOUT_SEC = 300
+AUDIT_INPUT_PATHS = (
+    "scripts/frontier_cubic_coxeter_regge_second_variation_3d_2026_06_09.py",
+    "scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py",
+)
+
+import contextlib
+import io
+import os
+import re
+import sys
+
+import numpy as np
+
+_SCRIPTS = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import frontier_cubic_coxeter_regge_second_variation_3d_2026_06_09 as R3          # noqa: E402
+import frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09 as R4      # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, detail=""):
+    global PASS, FAIL
+    print(f"[{'PASS' if cond else 'FAIL'}] {name}")
+    if detail:
+        print(f"       {detail}")
+    PASS += int(bool(cond))
+    FAIL += int(not cond)
+    return bool(cond)
+
+
+# ------------------------------------------------------------------ declared momenta (no seeds)
+K_PIN = np.array([0.37, -0.83, 0.51, 0.29])                      # T0 pinning momentum
+K_KERNEL = [np.array([0.410, -0.230, 0.670, 0.310]),             # T2 census momenta
+            np.array([1.100, 0.600, -0.400, 0.200]),
+            np.array([2.300, 1.700, -2.900, 0.830]),
+            np.array([0.013, 0.000, 0.000, 0.021])]
+AXIS = np.array([1.0, 0.0, 0.0])
+FACE = np.array([1.0, 1.0, 0.0]) / np.sqrt(2.0)
+BODY = np.array([1.0, 1.0, 1.0]) / np.sqrt(3.0)
+D210 = np.array([2.0, 1.0, 0.0]) / np.sqrt(5.0)
+D211 = np.array([2.0, 1.0, 1.0]) / np.sqrt(6.0)
+D312 = np.array([3.0, 1.0, 2.0]) / np.sqrt(14.0)
+K_BRANCH = [0.3, 1.0, 2.0, 2.5, 3.0, np.pi]                      # T3 magnitudes, axis and body
+K_ZONE = [0.1, 0.5, 1.0, 2.0, 3.0, np.pi, 4.0]                   # T4a magnitudes
+K_SMALL = [0.05, 0.02, 0.01]                                     # T4b magnitudes
+K_ISO = [0.02, 0.05, 0.10, 0.20, 0.80]                           # T4c magnitudes
+K_POL = [0.05, 0.20, 0.80, 2.00, 3.00]                           # T5 magnitudes
+K_CMP = [0.10, 0.40, 1.20, 2.00, 3.00]                           # T5 comparator magnitudes
+NDIR = {"axis(100)": AXIS, "face(110)": FACE, "body(111)": BODY,
+        "(2,1,0)": D210, "(2,1,1)": D211}
+ZDIR = {"axis(100)": AXIS, "face(110)": FACE, "body(111)": BODY,
+        "(2,1,0)": D210, "(3,1,2)": D312}
+HIDX = {c: i for i, c in enumerate(R4.HCOMPS)}
+NTRI = len(R4.TRI_CLASSES)
+
+
+# ------------------------------------------------------------------ holomorphic continuation
+def precompute_terms():
+    """Each area-gradient and deficit-gradient row of the landed runner is
+    sum_j coef_j exp(i k . anchor_j) e_{class_j} with real coef_j and k-independent anchors.
+    Built here from the imported module's own edge classes, areas and dihedral derivatives."""
+    a_terms, d_terms = [], []
+    for tri in R4.TRI_CLASSES:
+        vts = [np.array(x) for x in tri]
+        qvals, einfo = [], []
+        for (i, j) in [(0, 1), (0, 2), (1, 2)]:
+            cls, anc = R4.edge_class(tuple(vts[i]), tuple(vts[j]))
+            v = np.array(R4.DIRS15[cls])
+            qvals.append(float(v @ v))
+            einfo.append((cls, anc, float(np.sqrt(float(v @ v)))))
+        aout = R4.AREA(*qvals)
+        at = [(cls, np.array(anc, float), 2 * ell * float(aout[1 + n]))
+              for n, (cls, anc, ell) in enumerate(einfo)]
+        dt = []
+        for vs in R4.STARS[tri]:
+            loc = {v: i for i, v in enumerate(vs)}
+            hinge_local = sorted([loc[tri[0]], loc[tri[1]], loc[tri[2]]])
+            miss = tuple(sorted([i for i in range(5) if i not in hinge_local]))
+            qv, edata = [], []
+            for (i, j) in R4.PAIRS5:
+                cls, anc = R4.edge_class(vs[i], vs[j])
+                v = np.array(R4.DIRS15[cls])
+                qv.append(float(v @ v))
+                edata.append((cls, anc, float(np.sqrt(float(v @ v)))))
+            out = R4.THETA[miss](*qv)
+            dt += [(cls, np.array(anc, float), -2 * ell * float(out[1 + n]))
+                   for n, (cls, anc, ell) in enumerate(edata)]
+        for src, dst in ((at, a_terms), (dt, d_terms)):
+            dst.append((np.array([t[0] for t in src], int),
+                        np.array([t[1] for t in src], float),
+                        np.array([t[2] for t in src], float)))
+    return a_terms, d_terms
+
+
+A_TERMS, D_TERMS = precompute_terms()
+
+
+def _row(term, k):
+    cls, anc, coef = term
+    r = np.zeros(15, complex)
+    np.add.at(r, cls, coef * np.exp(1j * (anc @ k)))
+    return r
+
+
+def Qan(k):
+    """Holomorphic continuation of the landed bloch_Q: conj(x(k)) -> x(-k). Valid for complex k."""
+    k = np.asarray(k, complex)
+    Q = np.zeros((15, 15), complex)
+    for t in range(NTRI):
+        ap, am = _row(A_TERMS[t], k), _row(A_TERMS[t], -k)
+        dp, dm = _row(D_TERMS[t], k), _row(D_TERMS[t], -k)
+        Q += 0.5 * (np.outer(am, dp) + np.outer(dm, ap))
+    return Q
+
+
+def _entire_sinc_phase(z):
+    z = complex(z)
+    return 1.0 + 0j if abs(z) < 1e-13 else (np.exp(2j * z) - 1.0) / (2j * z)
+
+
+def Man(k):
+    """Holomorphic continuation of the landed metric_map (midpoint phase x sinc)."""
+    k = np.asarray(k, complex)
+    Mm = np.zeros((15, 10), complex)
+    for ci, v in enumerate(R4.DIRS15):
+        vv = np.array(v, float)
+        ell = float(np.linalg.norm(vv))
+        ph = _entire_sinc_phase((k @ vv) / 2.0)
+        for hj, (a, b) in enumerate(R4.HCOMPS):
+            Hm = np.zeros((4, 4))
+            Hm[a, b] += 1.0
+            if a != b:
+                Hm[b, a] += 1.0
+            Mm[ci, hj] = ph * (vv @ Hm @ vv) / (2 * ell)
+    return Mm
+
+
+def Qh(k):
+    return Man(-np.asarray(k, complex)).T @ Qan(k) @ Man(k)
+
+
+def kvec(kspat, omega):
+    return np.array([kspat[0], kspat[1], kspat[2], 1j * omega], complex)
+
+
+def svals(kspat, omega):
+    s = np.linalg.svd(Qan(kvec(kspat, omega)), compute_uv=False)
+    return np.sort(s) / s.max()
+
+
+def sig6(kspat, omega):
+    return svals(kspat, omega)[5]
+
+
+def refine(kspat, lo, hi, f=sig6):
+    """Golden-section minimisation of sigma_6 in omega; deterministic, no seeds."""
+    gr = (np.sqrt(5.0) - 1.0) / 2.0
+    a, b = lo, hi
+    c, d = b - gr * (b - a), a + gr * (b - a)
+    fc, fd = f(kspat, c), f(kspat, d)
+    for _ in range(200):
+        if fc < fd:
+            b, d, fd = d, c, fc
+            c = b - gr * (b - a)
+            fc = f(kspat, c)
+        else:
+            a, c, fc = c, d, fd
+            d = a + gr * (b - a)
+            fd = f(kspat, d)
+        if b - a < 1e-14:
+            break
+    om = 0.5 * (a + b)
+    return om, f(kspat, om)
+
+
+def on_shell(kspat):
+    km = float(np.linalg.norm(kspat))
+    return refine(kspat, 0.35 * km, 1.05 * km + 1e-3)[0]
+
+
+def gauge_h(k):
+    """The continuum gauge family h_munu = i(k_mu xi_nu + k_nu xi_mu) in metric components."""
+    Gh = np.zeros((10, 4), complex)
+    for j in range(4):
+        for i, (a, b) in enumerate(R4.HCOMPS):
+            Gh[i, j] = (1j * k[a] if b == j else 0.0) + (1j * k[b] if a == j else 0.0)
+    return Gh
+
+
+def kerdim(A, tol=1e-8):
+    s = np.linalg.svd(A, compute_uv=False)
+    return int((s / s.max() < tol).sum())
+
+
+def main() -> int:
+    print("T(Z^3 x Z_tau), Euclidean/OS0: delta^2 S_Regge, propagating modes and dispersion")
+    print(f"  complex imported from the landed 3+1 runner: {len(R4.cell_simplices(np.zeros(4, int)))}"
+          f" 4-simplices, {len(R4.DIRS15)} edge classes, {NTRI} hinge classes per 4-cell;"
+          f" 15x15 Hessian per momentum")
+
+    # ---------------------------------------------------------------- T0
+    dq = float(np.abs(Qan(K_PIN) - R4.bloch_Q(K_PIN)).max())
+    dm = float(np.abs(Man(K_PIN) - R4.metric_map(K_PIN)).max())
+    check("T0 continuation provenance: the holomorphic continuation reproduces the landed Bloch "
+          "Hessian and metric map at real momentum",
+          dq < 1e-12 and dm < 1e-12 and len(R4.DIRS15) == 15 and NTRI == 50,
+          f"max|Qan-bloch_Q| = {dq:.1e}; max|Man-metric_map| = {dm:.1e} at the declared k; "
+          f"the gauge map is entire as landed and reused verbatim")
+
+    # ---------------------------------------------------------------- T1
+    for tag, mod, lbl in (("T1a", R3, "3D"), ("T1b", R4, "3+1")):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            mod.main()
+        txt = buf.getvalue()
+        m = re.search(r"TOTAL: PASS=(\d+) FAIL=(\d+)", txt)
+        npass, nfail = (int(m.group(1)), int(m.group(2))) if m else (-1, -1)
+        if tag == "T1a":
+            sp = re.search(r"spread/mean = ([0-9.eE+-]+)", txt)
+            tt = re.search(r"TT\(yz\)=([-+0-9.]+) = TT\(E\)=([-+0-9.]+); "
+                           r"transverse-trace=([-+0-9.]+)", txt)
+            spread = float(sp.group(1)) if sp else float("nan")
+            tt1, tt2, trt = (float(tt.group(1)), float(tt.group(2)), float(tt.group(3))) \
+                if tt else (float("nan"),) * 3
+            check("T1a landed 3D row reproduces: the retained spatial comparator is unchanged",
+                  npass == 10 and nfail == 0 and spread < 1e-7
+                  and abs(tt1 + 0.25) < 1e-6 and abs(tt2 + 0.25) < 1e-6 and abs(trt - 0.25) < 1e-6,
+                  f"PASS={npass} FAIL={nfail}; c = -1/2, spread/mean {spread:.2e}; "
+                  f"TT {tt1:+.4f} = {tt2:+.4f}; transverse-trace {trt:+.4f}")
+        else:
+            check("T1b landed 3+1 row reproduces: the 4D complex and Hessian imported here are the "
+                  "landed ones, re-executed clean",
+                  npass == 10 and nfail == 0, f"PASS={npass} FAIL={nfail}")
+
+    # ---------------------------------------------------------------- T2
+    print("  kernel census, declared real Euclidean 4-momenta:")
+    ok2, rows = True, []
+    for k in K_KERNEL:
+        Q = Qan(k)
+        d15, d10 = kerdim(Q), kerdim(Qh(k))
+        r = float(np.abs(Q @ R4.gauge_map(k)).max())
+        ok2 &= (d15 == 5 and d10 == 4 and r < 1e-12)
+        rows.append((k, d15, d10, r))
+        print(f"    k={np.array2string(k, precision=3, floatmode='fixed', separator=','):<30s}"
+              f" ker Q = {d15}  ker Q_h = {d10}  max|Q Gamma| = {r:.1e}")
+    check("T2a kernel census: dim ker Q(k) = 5 at every declared momentum -- 4 discrete "
+          "diffeomorphisms plus 1 identically flat non-metric branch that never goes on shell; "
+          "the metric-sector kernel is exactly 4",
+          ok2, f"ker Q = {sorted(set(r[1] for r in rows))}, ker Q_h = "
+               f"{sorted(set(r[2] for r in rows))}, worst max|Q Gamma| = {max(r[3] for r in rows):.1e}")
+    worst_gh = 0.0
+    for k in K_KERNEL:
+        Qm = Qh(k)
+        worst_gh = max(worst_gh, float(np.abs(Qm @ gauge_h(k)).max() / np.abs(Qm).max()))
+    check("T2b continuum gauge family: the metric-sector kernel coincides exactly with "
+          "h_munu = i(k_mu xi_nu + k_nu xi_mu) -- the discrete diffeomorphism orbit is the "
+          "continuum one here, not an approximation to it",
+          worst_gh < 1e-12, f"worst max|Q_h Gamma_h|/|Q_h| = {worst_gh:.1e} over 4 momenta")
+
+    # ---------------------------------------------------------------- T3
+    print("  branch hunt, omega in (0,8], 900-point scan then refinement:")
+    branches, nulls = {}, set()
+    for nm, kh in (("axis", AXIS), ("body", BODY)):
+        for km in K_BRANCH:
+            ks = km * kh
+            ws = np.linspace(1e-5, 8.0, 900)
+            ys = np.array([sig6(ks, w) for w in ws])
+            roots = []
+            for i in range(1, len(ws) - 1):
+                if ys[i] < ys[i - 1] and ys[i] <= ys[i + 1]:
+                    om, y = refine(ks, ws[i - 1], ws[i + 1])
+                    if y < 1e-11:
+                        s = svals(ks, om)
+                        roots.append((om, y, float(s[6]), float(s[7]), int((s < 1e-9).sum())))
+            branches[(nm, km)] = roots
+            for r in roots:
+                nulls.add(r[4])
+            head = roots[0] if roots else None
+            print(f"    {nm:4s} |k|={km:7.5f} br={len(roots)}" + (
+                f" om*={head[0]:.8f} s6={head[1]:.1e} s7={head[2]:.1e} s8={head[3]:.1e} "
+                f"n={head[4]}" if head else ""))
+    check("T3 propagating-mode count: exactly one on-shell frequency per declared spatial "
+          "momentum, doubly degenerate -- sigma_6 and sigma_7 at machine zero against a sigma_8 "
+          "fourteen orders larger; no doubler and no spurious propagating branch in omega in (0,8]",
+          all(len(v) == 1 for v in branches.values()) and nulls == {7},
+          f"branches/momentum {sorted(set(len(v) for v in branches.values()))}; on-shell nulls "
+          f"{sorted(nulls)} = 5 kinematic + 2 physical, over {len(branches)} declared momenta")
+
+    # ---------------------------------------------------------------- T4a
+    worst, npts, per = 0.0, 0, {}
+    for nm, kh in ZDIR.items():
+        for km in K_ZONE:
+            ks = km * kh
+            if float(np.max(np.abs(ks))) > np.pi + 1e-9:
+                continue
+            om = on_shell(ks)
+            lhs = 4 * np.sinh(om / 2) ** 2
+            rhs = float(sum(4 * np.sin(x / 2) ** 2 for x in ks))
+            rel = abs(lhs - rhs) / max(abs(rhs), 1e-30)
+            worst = max(worst, rel)
+            per[nm] = max(per.get(nm, 0.0), rel)
+            npts += 1
+    print("  4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2), worst relative residual per direction:")
+    print("    " + "  ".join(f"{nm} {v:.1e}" for nm, v in per.items()))
+    check("T4a exact all-zone dispersion: the on-shell locus is exactly the zero set of the "
+          "standard hypercubic lattice d'Alembertian k-hat^2 continued to k_tau = i omega, "
+          "4 sinh^2(omega/2) = sum_i 4 sin^2(k_i/2), across the whole zone",
+          worst < 1e-11 and npts == 32,
+          f"worst relative residual {worst:.3e} over {npts} declared zone points in "
+          f"{len(ZDIR)} directions (root-finder limited; ~1e-15 typical)")
+
+    # ---------------------------------------------------------------- T4b
+    print("  (omega^2-k^2)/k^4 at |k|=0.01, computed/exact rational:")
+    ok4b, cells = True, []
+    for nm, kh in NDIR.items():
+        vals = [((on_shell(km * kh)) ** 2 - km ** 2) / km ** 4 for km in K_SMALL]
+        s4 = float(np.sum(kh ** 4))
+        pred = -(1.0 + s4) / 12.0
+        ok4b &= abs(vals[-1] - pred) < 5e-4
+        cells.append(f"{nm} {vals[-1]:+.6f}/{pred:+.6f}")
+    print("    " + "  ".join(cells))
+    kax = 0.01
+    om_ax = on_shell(kax * AXIS)
+    check("T4b small-k expansion, derived not fitted: omega^2 = k^2 - (k^4/12)(1 + sum_i n_i^4) "
+          "+ O(k^6) -- massless, light speed exactly 1 in tick units, the anisotropy the cubic "
+          "invariant alone: -1/6 axis, -1/8 face, -1/9 body, -7/50 for (2,1,0)",
+          ok4b and abs(om_ax / kax - 1.0) < 1e-4,
+          f"pairs above; omega/|k| = {om_ax / kax:.9f} at |k| = {kax}")
+
+    # ---------------------------------------------------------------- T4c
+    print("  isotropy: spread of omega* over axis/face/body:")
+    iso = []
+    for km in K_ISO:
+        a, f_, b = (on_shell(km * AXIS), on_shell(km * FACE), on_shell(km * BODY))
+        rel = (max(a, f_, b) - min(a, f_, b)) / float(np.mean([a, f_, b]))
+        iso.append((km, rel))
+        print(f"    |k|={km:5.2f} axis {a:.9f} face {f_:.9f} body {b:.9f} "
+              f"spread/k^2 {rel / km ** 2:.4f}")
+    base = iso[0][1] / iso[0][0] ** 2
+    check("T4c isotropy at quadratic order: the relative direction spread of omega scales as "
+          "k^2, so omega is isotropic at O(k^2) and anisotropic only at O(k^4) -- the "
+          "lattice-artefact order the landed rows leave uncharacterised",
+          all(abs(r / km ** 2 - base) < 0.06 * base for km, r in iso if km <= 0.2),
+          f"spread/k^2 constant at {base:.4f} => the anisotropy first enters omega^2 at O(k^4)")
+
+    # ---------------------------------------------------------------- T4d
+    ks = 0.2 * AXIS
+    out = []
+    for lbl, om in (("static", 0.0), ("on-shell", on_shell(ks))):
+        Qm = Qh(kvec(ks, om))
+        Qm = (Qm + Qm.conj().T) / 2
+
+        def hq(d):
+            v = np.zeros(10)
+            nrm = 0.0
+            for (a, b), val in d.items():
+                v[HIDX[(min(a, b), max(a, b))]] = val
+                nrm += val ** 2 * (2 if a != b else 1)
+            return float(np.real(v @ Qm @ v)) / nrm
+        out.append((lbl, hq({(1, 2): 1.0}), hq({(1, 1): 1.0, (2, 2): -1.0}),
+                    hq({(1, 1): 1.0, (2, 2): 1.0}), hq({(3, 3): 1.0}), hq({(0, 3): 1.0})))
+    for lbl, t1, t2, tr, la, sh in out:
+        print(f"    k=(0.2,0,0) {lbl:8s} TT(yz) {t1:+.8f} TT(yy-zz) {t2:+.8f} "
+              f"tr-trace {tr:+.8f} lapse {la:+.1e} shift {sh:+.1e}")
+    check("T4d multiplier structure on shell: the lapse h_tautau and shift h_i,tau kinetic "
+          "weights vanish on shell as well as statically -- the constraint multipliers carry no "
+          "propagating weight",
+          max(abs(r[4]) for r in out) < 1e-12 and max(abs(r[5]) for r in out) < 1e-12,
+          f"lapse {out[1][4]:.1e}, shift {out[1][5]:.1e} on shell, raw S_R orientation; the "
+          f"static row is the landed comparator pair, ratio -1")
+
+    # ---------------------------------------------------------------- T5
+    print("  TT fraction of the two propagating modes after gauge removal:")
+    frac_lo, frac_hi = [], []
+    for km in K_POL:
+        ksp = km * AXIS
+        k = kvec(ksp, on_shell(ksp))
+        Q = Qan(k)
+        _, s, Vh = np.linalg.svd(Q)
+        Z = Vh.conj().T[:, s / s.max() < 1e-8]
+        Gq, _ = np.linalg.qr(R4.gauge_map(k))
+        Zr = Z - Gq @ (Gq.conj().T @ Z)
+        Uz, sz, _ = np.linalg.svd(Zr)
+        Bq, _ = np.linalg.qr(Uz[:, :len(sz)][:, sz > 1e-8])
+        M = Man(k)
+        Mq, _ = np.linalg.qr(M)
+        _, _, Vc = np.linalg.svd(Mq.conj().T @ Bq)
+        inB = Bq @ Vc.conj().T[:, :2]
+        Gh = gauge_h(k)
+        tt = np.zeros((10, 2), complex)
+        tt[HIDX[(1, 2)], 0] = 1.0
+        tt[HIDX[(1, 1)], 1] = 1.0
+        tt[HIDX[(2, 2)], 1] = -1.0
+        basis = np.hstack([tt, Gh])
+        fr = []
+        for j in range(2):
+            h, *_ = np.linalg.lstsq(M, inB[:, j], rcond=None)
+            c, *_ = np.linalg.lstsq(basis, h, rcond=None)
+            hg = h - Gh @ c[2:]
+            yy, zz, yz = hg[HIDX[(1, 1)]], hg[HIDX[(2, 2)]], hg[HIDX[(1, 2)]]
+            num = 2 * abs((yy - zz) / 2) ** 2 + 2 * abs(yz) ** 2
+            den = sum(abs(hg[i]) ** 2 * (2 if a != b else 1) for i, (a, b) in enumerate(R4.HCOMPS))
+            fr.append(num / den)
+        fr = sorted(fr)
+        frac_lo.append(fr[0])
+        frac_hi.append(fr[1])
+        print(f"    |k|={km:5.2f} TT fraction {fr[1]:.8f}, {fr[0]:.8f}")
+    dev = [(km, on_shell(km * AXIS) - km) for km in K_CMP]
+    print("  omega* - k on axis: " + ", ".join(f"|k|={km:.1f} {d:+.2f}" for km, d in dev))
+    check("T5 TT up to gauge is a small-k statement, and the target-operator row's omega = +-k "
+          "across the zone is not reproduced here: both polarisations are transverse-traceless up "
+          "to gauge as k -> 0 and deform at the corner, where omega* falls below k by O(1)",
+          min(frac_lo[0], frac_hi[0]) > 0.999999 and frac_lo[-1] < 0.95
+          and abs(dev[-2][1] + 0.47) < 0.05 and abs(dev[-1][1] + 1.24) < 0.05,
+          f"TT fraction {frac_lo[0]:.8f} at |k|={K_POL[0]}, {frac_lo[2]:.3f} at {K_POL[2]}, "
+          f"{frac_hi[-1]:.2f}/{frac_lo[-1]:.2f} at the corner; omega*-k = {dev[-2][1]:+.2f} at "
+          f"|k|=2 and {dev[-1][1]:+.2f} at 3 -- the same polynomial read in Lorentzian signature "
+          f"gives omega = +-k, and only on axis")
+
+    print()
+    print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    print("SUPPLIED, not derived: the edge lengths, the action selection and its orientation, the")
+    print("Lorentzian signature, the nonlinear completion, the record-to-geometry link.")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Bounded theorem note + runner + cache: **the framework's own four-dimensional complex carries a native linearised graviton.** Importing the landed 3+1 runner (`CUBIC_COXETER_REGGE_3PLUS1_TICK_EXTENSION_SECOND_VARIATION`, 2026-06-09) as a library so the complex is provably identical, the Regge second variation on `T(Z³ × Z_τ)` (24 4-simplices, 15 edge classes, 50 hinge classes per cell; Euclidean reading with holomorphic continuation `k_τ = iω`) has, at every declared momentum, a kernel of exactly four gauge modes coinciding with the continuum diffeomorphism family plus one flat non-metric branch; exactly two propagating modes, doubly degenerate, with no doublers anywhere in the zone over 12 declared momenta; the exact all-zone dispersion `4 sinh²(ω/2) = Σ 4 sin²(k_i/2)` (worst relative residual 3.2e-13 over 32 zone points in 5 directions); small-`k` `ω² = k² − (k⁴/12)(1 + Σ n_i⁴)` with exact rationals `−1/6, −1/8, −1/9, −7/50`: massless, `c = 1`, isotropic to quadratic order; lapse and shift kinetic weights zero on shell. The earlier target-operator row's `ω = ±k` across the zone is the same polynomial read in Lorentzian signature and holds only on axis. Still supplied: edge lengths, action selection, orientation, signature, the nonlinear completion, the record-to-geometry link, the tick scale.

- `docs/THE_REGGE_SECOND_VARIATION_ON_THE_4D_CUBIC_COXETER_COMPLEX_CARRIES_A_NATIVE_LINEARISED_GRAVITON_BOUNDED_THEOREM_NOTE_2026-09-03.md` (314 lines)
- `scripts/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.py` (`TOTAL: PASS=11 FAIL=0`, 30 s; 15×15 momentum-space Hessians only; declared momenta, no seeds)
- `logs/runner-cache/regge_4d_complex_native_linearised_graviton_dispersion_check_2026_09_03.txt`

## Boundary

- Linear order; one complex; declared momenta; Euclidean reading; the TT polarisation is a small-`k` statement; two superseded gates from the probe recorded. Not a derivation of the geometric variables or the action from the axioms.

## Context

- Parents: `CUBIC_COXETER_REGGE_SECOND_VARIATION_EQUALS_LINEARIZED_EH` and the 3+1 tick extension (2026-06-09), `UNIVERSAL_GR_3PLUS1_CONSTRAINT_MULTIPLIER_STRUCTURE`. Owner-directed full-repository probe wave (2026-09-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
